### PR TITLE
M5: deploy the app (web + API) as one Cloud Run service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/dist
+.git
+**/.env
+**/.env.local
+**/*.log
+apps/web/dist
+coverage
+.husky

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,40 @@
+# Multi-stage image for the gamedev.pl submission API.
+# Build context is the repo ROOT (this is a npm-workspaces monorepo):
+#   docker build -f apps/api/Dockerfile -t gamedev-api .
+#
+# The API depends on the @gamedevpl/game-generator workspace package, which reads
+# its template files at runtime, so the runtime stage carries that package's dist
+# AND templates, plus prod node_modules (fastify, @fastify/cors, zod).
+
+# ---- builder: install everything and compile TS -> dist ----
+FROM node:20-slim AS builder
+WORKDIR /app
+
+COPY . .
+# --ignore-scripts: skip the repo's `prepare`/husky hook (dev-only) during image builds.
+RUN npm ci --ignore-scripts
+RUN npm run build -w @gamedevpl/game-generator \
+ && npm run build -w @gamedevpl/api
+
+# ---- runtime: prod deps only + built output ----
+FROM node:20-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    HOST=0.0.0.0
+
+# Workspace package manifests must all be present for `npm ci` to resolve the tree.
+COPY package.json package-lock.json ./
+COPY packages/game-generator/package.json packages/game-generator/
+COPY apps/api/package.json apps/api/
+COPY apps/web/package.json apps/web/
+RUN npm ci --omit=dev --ignore-scripts
+
+# Built output + the runtime template files the mock generator reads.
+COPY --from=builder /app/packages/game-generator/dist packages/game-generator/dist
+COPY --from=builder /app/packages/game-generator/templates packages/game-generator/templates
+COPY --from=builder /app/apps/api/dist apps/api/dist
+
+# Cloud Run sets $PORT (default 8080); server.ts reads PORT and HOST from env.
+EXPOSE 8080
+USER node
+CMD ["node", "apps/api/dist/server.js"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,26 +1,36 @@
-# Multi-stage image for the gamedev.pl submission API.
+# Multi-stage image for the gamedev.pl app: one service that serves BOTH the static
+# web build and the submission API from the same origin (so the live www.gamedev.pl
+# Pages site is never touched, and the browser makes only same-origin requests).
 # Build context is the repo ROOT (this is a npm-workspaces monorepo):
-#   docker build -f apps/api/Dockerfile -t gamedev-api .
+#   docker build -f apps/api/Dockerfile -t gamedev-app .
 #
 # The API depends on the @gamedevpl/game-generator workspace package, which reads
 # its template files at runtime, so the runtime stage carries that package's dist
-# AND templates, plus prod node_modules (fastify, @fastify/cors, zod).
+# AND templates, plus prod node_modules (fastify, @fastify/cors, @fastify/static, zod).
 
-# ---- builder: install everything and compile TS -> dist ----
+# ---- builder: install everything and compile TS + build the web app ----
 FROM node:20-slim AS builder
 WORKDIR /app
+
+# Web build-time config (baked into the static bundle). Same-origin API, so no base URL.
+ARG VITE_GAMES_ORIGIN=https://gamedevpl.github.io/www.gamedev.pl-games
+ARG VITE_API_BASE_URL=
+ENV VITE_GAMES_ORIGIN=$VITE_GAMES_ORIGIN \
+    VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 COPY . .
 # --ignore-scripts: skip the repo's `prepare`/husky hook (dev-only) during image builds.
 RUN npm ci --ignore-scripts
 RUN npm run build -w @gamedevpl/game-generator \
- && npm run build -w @gamedevpl/api
+ && npm run build -w @gamedevpl/api \
+ && npm run build -w @gamedevpl/web
 
 # ---- runtime: prod deps only + built output ----
 FROM node:20-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production \
-    HOST=0.0.0.0
+    HOST=0.0.0.0 \
+    WEB_DIST_DIR=/app/apps/web/dist
 
 # Workspace package manifests must all be present for `npm ci` to resolve the tree.
 COPY package.json package-lock.json ./
@@ -29,10 +39,11 @@ COPY apps/api/package.json apps/api/
 COPY apps/web/package.json apps/web/
 RUN npm ci --omit=dev --ignore-scripts
 
-# Built output + the runtime template files the mock generator reads.
+# Built output: API dist, game-generator dist + runtime templates, and the static web bundle.
 COPY --from=builder /app/packages/game-generator/dist packages/game-generator/dist
 COPY --from=builder /app/packages/game-generator/templates packages/game-generator/templates
 COPY --from=builder /app/apps/api/dist apps/api/dist
+COPY --from=builder /app/apps/web/dist apps/web/dist
 
 # Cloud Run sets $PORT (default 8080); server.ts reads PORT and HOST from env.
 EXPOSE 8080

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
+    "@fastify/static": "^7.0.4",
     "@gamedevpl/game-generator": "*",
     "fastify": "^4.28.1",
     "zod": "^3.23.8"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,7 @@
 import cors from '@fastify/cors';
+import fastifyStatic from '@fastify/static';
 import type { GameGenerator } from '@gamedevpl/game-generator';
+import { existsSync } from 'node:fs';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
@@ -58,6 +60,22 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
       throw error;
     }
   });
+
+  // In production (single Cloud Run service) the API also serves the built web app from the
+  // same origin, so the browser makes only same-origin requests and no CORS is involved.
+  // WEB_DIST_DIR points at apps/web/dist; unset in local dev, where Vite serves the app.
+  const webDistDir = process.env.WEB_DIST_DIR?.trim();
+  if (webDistDir && existsSync(webDistDir)) {
+    await app.register(fastifyStatic, { root: webDistDir, wildcard: false });
+    // SPA fallback: any non-/api GET that isn't a real file returns index.html
+    // (the app is hash-routed, so this mainly covers a hard refresh on any path).
+    app.setNotFoundHandler((request, reply) => {
+      if (request.method !== 'GET' || request.url.startsWith('/api')) {
+        return reply.status(404).send({ error: 'not found' });
+      }
+      return reply.sendFile('index.html');
+    });
+  }
 
   return app;
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,7 +20,13 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   const generator = options.generator ?? createGenerator();
   const app = Fastify({ logger: options.logger ?? false });
 
-  await app.register(cors, { origin: true });
+  // In production, WEB_ORIGIN pins CORS to the deployed site (e.g. https://www.gamedev.pl);
+  // a comma-separated list is allowed. Unset (local dev) reflects any origin so the Vite
+  // dev server and same-origin proxy both work.
+  const webOrigin = process.env.WEB_ORIGIN?.trim();
+  await app.register(cors, {
+    origin: webOrigin ? webOrigin.split(',').map((entry) => entry.trim()) : true,
+  });
   await registerSubmissionRoutes(app, options.submissionRoutes);
 
   app.get('/api/health', async () => ({ status: 'ok', provider: generator.name }));

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,32 @@
 # Deployment
 
-> **Status: 📋 Not selected or built.** `infra/` is intentionally non-deployable until the
-> games repository defines its catalog and bundle publishing contract.
+> **Status: 🚧 M5 in progress (2026-07-22).** Hosts are chosen and the API deploy is built:
+> the web app publishes to `www.gamedev.pl/next/` (Pages `gh-pages` branch) and the submission
+> API runs on Cloud Run (scale-to-zero) via [`infra/deploy-api.sh`](../infra/deploy-api.sh).
+> See [`steel-thread-plan.md`](./steel-thread-plan.md) §M5 for the acceptance scenario.
+
+## How to deploy (concrete)
+
+### Submission API → Cloud Run (owner-run)
+
+[`apps/api/Dockerfile`](../apps/api/Dockerfile) is a multi-stage image built from the repo root
+(monorepo context). [`infra/deploy-api.sh`](../infra/deploy-api.sh) builds it via Cloud Build,
+pushes to Artifact Registry, and deploys to Cloud Run with `--min-instances 0`. Two secrets live
+in Secret Manager (never in the repo): `github-token` (a fine-grained PAT — Issues read/write,
+Pull requests read, Contents read, scoped to the games repo only) and `submission-token-secret`
+(`openssl rand -hex 32`). Non-secret config (`GAMES_REPO`, `CATALOG_URL`, `WEB_ORIGIN`) is passed
+as plain env. `WEB_ORIGIN=https://www.gamedev.pl` pins CORS to the site. See the header comment
+in the script for the one-time secret-creation commands.
+
+If the owner prefers another host (Fly.io, a VPS), nothing in `apps/api` assumes Cloud Run — it
+reads `PORT`/`HOST` from env and needs only the four env vars plus two secrets above.
+
+### Web app → `www.gamedev.pl/next/` (CI)
+
+A workflow in this repo builds `apps/web` with `base: '/next/'`, `VITE_GAMES_ORIGIN`, and
+`VITE_API_BASE_URL` (the Cloud Run URL), then publishes the output into the `next/` directory of
+the `gh-pages` branch **without touching the root** (the old site stays live). Flipping the root
+to the new app is a separate owner decision after the thread works end-to-end.
 
 ## What production needs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,32 +1,35 @@
 # Deployment
 
-> **Status: 🚧 M5 in progress (2026-07-22).** Hosts are chosen and the API deploy is built:
-> the web app publishes to `www.gamedev.pl/next/` (Pages `gh-pages` branch) and the submission
-> API runs on Cloud Run (scale-to-zero) via [`infra/deploy-api.sh`](../infra/deploy-api.sh).
-> See [`steel-thread-plan.md`](./steel-thread-plan.md) §M5 for the acceptance scenario.
+> **Status: 🚧 M5 in progress (2026-07-22).** The new app (web + API) deploys as **one
+> Cloud Run service**, on its own `*.run.app` URL. The live `www.gamedev.pl` GitHub Pages
+> site is **not touched** — the new app is entirely separate until an owner decides to point
+> a domain at it. See [`steel-thread-plan.md`](./steel-thread-plan.md) §M5 for the acceptance
+> scenario.
 
 ## How to deploy (concrete)
 
-### Submission API → Cloud Run (owner-run)
+### The app → Cloud Run, single same-origin service (owner-run)
 
 [`apps/api/Dockerfile`](../apps/api/Dockerfile) is a multi-stage image built from the repo root
-(monorepo context). [`infra/deploy-api.sh`](../infra/deploy-api.sh) builds it via Cloud Build,
-pushes to Artifact Registry, and deploys to Cloud Run with `--min-instances 0`. Two secrets live
-in Secret Manager (never in the repo): `github-token` (a fine-grained PAT — Issues read/write,
-Pull requests read, Contents read, scoped to the games repo only) and `submission-token-secret`
-(`openssl rand -hex 32`). Non-secret config (`GAMES_REPO`, `CATALOG_URL`, `WEB_ORIGIN`) is passed
-as plain env. `WEB_ORIGIN=https://www.gamedev.pl` pins CORS to the site. See the header comment
-in the script for the one-time secret-creation commands.
+(monorepo context). It builds both the API and the static web bundle, and the Fastify server
+serves that bundle from the same origin (`WEB_DIST_DIR`), so the browser makes only same-origin
+requests to `/api` — no CORS, no second service, and the Pages site is never involved.
+
+[`infra/deploy-api.sh`](../infra/deploy-api.sh) builds the image via Cloud Build, pushes it to
+Artifact Registry, and deploys to Cloud Run with `--min-instances 0` (scale-to-zero). Two secrets
+live in Secret Manager (never in the repo): `github-token` (a fine-grained PAT — Issues
+read/write, Pull requests read, Contents read, scoped to the games repo only) and
+`submission-token-secret` (`openssl rand -hex 32`). Non-secret config (`GAMES_REPO`,
+`CATALOG_URL`) is plain env. The script wires the secrets **only if both exist**, so a first
+deploy without them is browse/play-only (submission routes return 503); add the secrets and
+redeploy to enable submissions. See the header comment in the script for the one-time
+secret-creation commands.
 
 If the owner prefers another host (Fly.io, a VPS), nothing in `apps/api` assumes Cloud Run — it
-reads `PORT`/`HOST` from env and needs only the four env vars plus two secrets above.
+reads `PORT`/`HOST`/`WEB_DIST_DIR` from env.
 
-### Web app → `www.gamedev.pl/next/` (CI)
-
-A workflow in this repo builds `apps/web` with `base: '/next/'`, `VITE_GAMES_ORIGIN`, and
-`VITE_API_BASE_URL` (the Cloud Run URL), then publishes the output into the `next/` directory of
-the `gh-pages` branch **without touching the root** (the old site stays live). Flipping the root
-to the new app is a separate owner decision after the thread works end-to-end.
+Pointing a domain (e.g. `next.gamedev.pl`) at the Cloud Run service, and eventually replacing
+the old Pages site, are separate owner decisions after the thread works end-to-end.
 
 ## What production needs
 

--- a/docs/steel-thread-plan.md
+++ b/docs/steel-thread-plan.md
@@ -49,12 +49,16 @@ bundle + catalog to the games origin, and the app picked it up. The creator saw 
 3. **No database.** The tracking token is stateless:
    `base64url(issueNumber + "." + HMAC-SHA256(SUBMISSION_TOKEN_SECRET, issueNumber))`.
    Status is derived live from the GitHub API on each request.
-4. **The web app deploys to the existing Pages site under `/next/`** (i.e.
-   `www.gamedev.pl/next/`), leaving the old site at the root untouched. Flipping the root is
-   an owner decision after the thread works.
-5. **The API deploys as one small container, scale-to-zero** (Cloud Run; `infra/` is already
-   GCP-oriented). It is the only component holding a secret. If the owner prefers another
-   host (Fly.io, a VPS), nothing in the code may assume Cloud Run specifics.
+4. **The new app deploys as ONE Cloud Run service (web + API, same origin)**, on its own
+   `*.run.app` URL — **the live `www.gamedev.pl` Pages site is not touched at all.** _(Revised
+   2026-07-22 from the earlier "publish web to `www.gamedev.pl/next/`" idea, at the owner's
+   direction: keep the live site entirely separate rather than sharing its `gh-pages` branch.)_
+   Pointing a domain at the service, and eventually replacing the old site, are later owner
+   decisions. Same origin means no CORS and `VITE_API_BASE_URL=''`.
+5. **That service is one small container, scale-to-zero** (Cloud Run; `infra/` is already
+   GCP-oriented). The Fastify server serves the static web bundle (`WEB_DIST_DIR`) and is the
+   only component holding a secret. If the owner prefers another host (Fly.io, a VPS), nothing
+   in the code assumes Cloud Run specifics — it reads `PORT`/`HOST`/`WEB_DIST_DIR` from env.
 6. **The mock generator path stays** (`POST /api/generate-game`) as a local-dev toy; it is
    not part of the thread and must not be wired into the catalog.
 
@@ -218,25 +222,26 @@ assigned and a PR appearing, hands-off.
 
 ---
 
-### M5 — Deploy to www.gamedev.pl
+### M5 — Deploy the app to Cloud Run (live site untouched)
 
-**Goal:** the thread runs on the real domain, not localhost.
+**Goal:** the thread runs on a real deployed URL, not localhost — **without touching the live
+`www.gamedev.pl` Pages site.**
 
-- **Web:** a workflow in the app repo builds `apps/web` with
-  `VITE_GAMES_ORIGIN` + `VITE_API_BASE_URL` set, Vite `base: '/next/'`, and publishes the
-  output into the `next/` directory of the `gh-pages` branch **without touching anything
-  else on that branch** (the old site stays at the root). Result:
-  `https://www.gamedev.pl/next/`.
-- **API:** containerize `apps/api` (multi-stage Dockerfile, non-root, `PORT` env) and
-  deploy to Cloud Run, scale-to-zero, min instances 0, with the three secrets from M2 in
-  Secret Manager. 🔑 Owner provisions the GCP project + secrets (or chooses an alternate
-  host). CORS on the API allows origin `https://www.gamedev.pl` only.
-- Set `VITE_API_BASE_URL` to the Cloud Run URL for the web build (an `api.gamedev.pl`
-  CNAME can come later).
+- **One service (web + API, same origin).** The multi-stage `apps/api/Dockerfile` (built from
+  the repo root, non-root, `PORT`/`HOST` from env) builds both `apps/api` and `apps/web` and
+  the Fastify server serves the static bundle via `@fastify/static` (`WEB_DIST_DIR`) with an
+  SPA fallback. No CORS (same origin), `VITE_API_BASE_URL=''`, no gh-pages involvement.
+- Deploy with [`infra/deploy-api.sh`](../infra/deploy-api.sh) (Cloud Build → Artifact Registry
+  → Cloud Run, scale-to-zero, min instances 0). Submission secrets (`GITHUB_TOKEN`,
+  `SUBMISSION_TOKEN_SECRET`) come from Secret Manager and are wired **only if both exist** —
+  a first deploy without them is browse/play-only (submissions 503). 🔑 Owner provisions the
+  GCP project (+ optional secrets), then runs the script.
+- Status/verification of the container is done in real Docker before deploy (image builds,
+  boots, `/` serves the app, `/api/*` works same-origin, a seed game plays sandboxed).
 
-**Acceptance — the steel thread itself:** on `https://www.gamedev.pl/next/`, run the §0
-scenario end-to-end: play a seed game; submit a real spec; watch the status page; operator
-verifies + merges Copilot's PR; status flips to `published`; play the new game. Done.
+**Acceptance — the steel thread itself:** on the Cloud Run URL, run the §0 scenario
+end-to-end: play a seed game; submit a real spec; watch the status page; operator verifies +
+merges Copilot's PR; status flips to `published`; play the new game. Done.
 
 ---
 

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -1,0 +1,12 @@
+# Builds the submission API image from the repo root using apps/api/Dockerfile
+# and pushes it to Artifact Registry. Invoked by infra/deploy-api.sh via
+# `gcloud builds submit --config infra/cloudbuild.yaml`.
+substitutions:
+  _IMAGE: '' # e.g. europe-central2-docker.pkg.dev/PROJECT/gamedev/api:latest
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '-f', 'apps/api/Dockerfile', '-t', '${_IMAGE}', '.']
+images:
+  - '${_IMAGE}'
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -1,6 +1,6 @@
-# Builds the submission API image from the repo root using apps/api/Dockerfile
-# and pushes it to Artifact Registry. Invoked by infra/deploy-api.sh via
-# `gcloud builds submit --config infra/cloudbuild.yaml`.
+# Builds the gamedev.pl app image (static web + API) from the repo root using
+# apps/api/Dockerfile and pushes it to Artifact Registry. Invoked by
+# infra/deploy-api.sh via `gcloud builds submit --config infra/cloudbuild.yaml`.
 substitutions:
   _IMAGE: '' # e.g. europe-central2-docker.pkg.dev/PROJECT/gamedev/api:latest
 steps:

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Deploy the gamedev.pl submission API to Cloud Run (scale-to-zero).
+# Deploy the gamedev.pl app (static web + submission API, one same-origin service)
+# to Cloud Run (scale-to-zero). This never touches the live www.gamedev.pl Pages site.
 # OWNER-RUN: needs a GCP project with billing, and `gcloud` authenticated
 # (`gcloud auth login` + `gcloud config set project <id>`).
 #
@@ -10,22 +11,23 @@
 #   openssl rand -hex 32 \
 #     | gcloud secrets create submission-token-secret --data-file=- --replication-policy=automatic
 # (To rotate later: `gcloud secrets versions add <name> --data-file=-`.)
+# The API boots without these; submission routes just return 503 until they exist,
+# so browsing/playing works on a secret-less first deploy.
 #
 # Then run:
 #   PROJECT_ID=my-proj ./infra/deploy-api.sh
 #
-# Override any of these via env: REGION, SERVICE, REPO, GAMES_REPO, WEB_ORIGIN, CATALOG_URL.
+# Override any of these via env: REGION, SERVICE, REPO, GAMES_REPO, CATALOG_URL.
 set -euo pipefail
 
 : "${PROJECT_ID:?set PROJECT_ID to your GCP project id}"
 REGION="${REGION:-europe-central2}"
-SERVICE="${SERVICE:-gamedev-api}"
+SERVICE="${SERVICE:-gamedev-app}"
 REPO="${REPO:-gamedev}"
 GAMES_REPO="${GAMES_REPO:-gamedevpl/www.gamedev.pl-games}"
 CATALOG_URL="${CATALOG_URL:-https://gamedevpl.github.io/www.gamedev.pl-games/catalog.json}"
-WEB_ORIGIN="${WEB_ORIGIN:-https://www.gamedev.pl}"
 
-IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/api:$(date +%Y%m%d-%H%M%S)"
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:$(date +%Y%m%d-%H%M%S)"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 echo "==> Enabling required services"
@@ -41,6 +43,17 @@ echo "==> Building image via Cloud Build: ${IMAGE}"
 gcloud builds submit "$REPO_ROOT" --config "$REPO_ROOT/infra/cloudbuild.yaml" \
   --substitutions "_IMAGE=${IMAGE}" --project "$PROJECT_ID"
 
+# Wire the submission secrets only if BOTH exist; otherwise deploy browse/play-only
+# (the API returns 503 on submission routes until the secrets are added and it is redeployed).
+SECRET_FLAGS=()
+if gcloud secrets describe github-token --project "$PROJECT_ID" >/dev/null 2>&1 \
+   && gcloud secrets describe submission-token-secret --project "$PROJECT_ID" >/dev/null 2>&1; then
+  SECRET_FLAGS=(--set-secrets "GITHUB_TOKEN=github-token:latest,SUBMISSION_TOKEN_SECRET=submission-token-secret:latest")
+  echo "==> Submission secrets found; submissions will be enabled."
+else
+  echo "==> Submission secrets not found; deploying browse/play-only (submissions return 503)."
+fi
+
 echo "==> Deploying to Cloud Run (scale-to-zero)"
 gcloud run deploy "$SERVICE" \
   --image "$IMAGE" \
@@ -51,10 +64,9 @@ gcloud run deploy "$SERVICE" \
   --min-instances 0 \
   --max-instances 4 \
   --port 8080 \
-  --set-env-vars "GAMES_REPO=${GAMES_REPO},CATALOG_URL=${CATALOG_URL},WEB_ORIGIN=${WEB_ORIGIN}" \
-  --set-secrets "GITHUB_TOKEN=github-token:latest,SUBMISSION_TOKEN_SECRET=submission-token-secret:latest"
+  --set-env-vars "GAMES_REPO=${GAMES_REPO},CATALOG_URL=${CATALOG_URL}" \
+  "${SECRET_FLAGS[@]}"
 
-echo "==> Done. Service URL:"
+echo "==> Done. The app (web + API) is live at:"
 gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
   --format 'value(status.url)'
-echo "Set VITE_API_BASE_URL to that URL for the web build (M5a), then rebuild the site."

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Deploy the gamedev.pl submission API to Cloud Run (scale-to-zero).
+# OWNER-RUN: needs a GCP project with billing, and `gcloud` authenticated
+# (`gcloud auth login` + `gcloud config set project <id>`).
+#
+# One-time secret setup (values never live in this repo):
+#   printf '%s' "<fine-grained PAT: Issues rw + PRs r + Contents r on the games repo>" \
+#     | gcloud secrets create github-token --data-file=- --replication-policy=automatic
+#   openssl rand -hex 32 \
+#     | gcloud secrets create submission-token-secret --data-file=- --replication-policy=automatic
+# (To rotate later: `gcloud secrets versions add <name> --data-file=-`.)
+#
+# Then run:
+#   PROJECT_ID=my-proj ./infra/deploy-api.sh
+#
+# Override any of these via env: REGION, SERVICE, REPO, GAMES_REPO, WEB_ORIGIN, CATALOG_URL.
+set -euo pipefail
+
+: "${PROJECT_ID:?set PROJECT_ID to your GCP project id}"
+REGION="${REGION:-europe-central2}"
+SERVICE="${SERVICE:-gamedev-api}"
+REPO="${REPO:-gamedev}"
+GAMES_REPO="${GAMES_REPO:-gamedevpl/www.gamedev.pl-games}"
+CATALOG_URL="${CATALOG_URL:-https://gamedevpl.github.io/www.gamedev.pl-games/catalog.json}"
+WEB_ORIGIN="${WEB_ORIGIN:-https://www.gamedev.pl}"
+
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/api:$(date +%Y%m%d-%H%M%S)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "==> Enabling required services"
+gcloud services enable run.googleapis.com cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com secretmanager.googleapis.com --project "$PROJECT_ID"
+
+echo "==> Ensuring Artifact Registry repo '${REPO}' exists in ${REGION}"
+gcloud artifacts repositories describe "$REPO" --location "$REGION" --project "$PROJECT_ID" >/dev/null 2>&1 \
+  || gcloud artifacts repositories create "$REPO" --repository-format=docker \
+       --location "$REGION" --project "$PROJECT_ID" --description "gamedev.pl images"
+
+echo "==> Building image via Cloud Build: ${IMAGE}"
+gcloud builds submit "$REPO_ROOT" --config "$REPO_ROOT/infra/cloudbuild.yaml" \
+  --substitutions "_IMAGE=${IMAGE}" --project "$PROJECT_ID"
+
+echo "==> Deploying to Cloud Run (scale-to-zero)"
+gcloud run deploy "$SERVICE" \
+  --image "$IMAGE" \
+  --region "$REGION" \
+  --project "$PROJECT_ID" \
+  --platform managed \
+  --allow-unauthenticated \
+  --min-instances 0 \
+  --max-instances 4 \
+  --port 8080 \
+  --set-env-vars "GAMES_REPO=${GAMES_REPO},CATALOG_URL=${CATALOG_URL},WEB_ORIGIN=${WEB_ORIGIN}" \
+  --set-secrets "GITHUB_TOKEN=github-token:latest,SUBMISSION_TOKEN_SECRET=submission-token-secret:latest"
+
+echo "==> Done. Service URL:"
+gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format 'value(status.url)'
+echo "Set VITE_API_BASE_URL to that URL for the web build (M5a), then rebuild the site."

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
+        "@fastify/static": "^7.0.4",
         "@gamedevpl/game-generator": "*",
         "fastify": "^4.28.1",
         "zod": "^3.23.8"
@@ -1122,6 +1123,15 @@
         }
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
@@ -1205,6 +1215,54 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/@fastify/send": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-2.1.0.tgz",
+      "integrity": "sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.1",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "2.0.0",
+        "mime": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-7.0.4.tgz",
+      "integrity": "sha512-p2uKtaf8BMOZWLs6wu+Ihg7bWNBdjNgCwDza4MJtTqg+5ovKmcbgbR9Xs5/smZ1YISfzKOCNYmZV8LaCj+eJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^1.0.0",
+        "@fastify/send": "^2.0.0",
+        "content-disposition": "^0.5.3",
+        "fastify-plugin": "^4.0.0",
+        "fastq": "^1.17.0",
+        "glob": "^10.3.4"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@gamedevpl/api": {
       "resolved": "apps/api",
       "link": true
@@ -1279,6 +1337,102 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1329,6 +1483,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1372,6 +1535,16 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2259,7 +2432,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2269,7 +2441,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2331,7 +2502,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2361,7 +2531,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2531,7 +2700,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2544,7 +2712,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2582,6 +2749,18 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2602,7 +2781,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2707,6 +2885,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2733,6 +2920,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.393",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
@@ -2744,7 +2937,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -2818,6 +3010,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3325,6 +3523,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3511,6 +3725,22 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -3612,7 +3842,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3638,7 +3867,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3688,8 +3916,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3962,11 +4204,22 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -3976,6 +4229,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mnemonist": {
@@ -4105,6 +4367,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4155,11 +4423,32 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4592,6 +4881,26 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex2": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
@@ -4656,11 +4965,16 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4673,7 +4987,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4698,6 +5011,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -4750,6 +5075,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -4761,7 +5095,21 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4776,7 +5124,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4921,6 +5281,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tough-cookie": {
@@ -5736,7 +6105,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5780,6 +6148,24 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",


### PR DESCRIPTION
Implements **M5** from `docs/steel-thread-plan.md`, revised per owner direction: **do not touch the live www.gamedev.pl Pages site.** Instead of publishing the web build into `gh-pages:/next/`, the whole new app ships as **one Cloud Run service** that serves the static web bundle and the API from the **same origin**, on its own `*.run.app` URL. The old site is never involved.

## Why single same-origin service
- The live Pages site stays completely untouched — the concern that motivated this change.
- Same origin ⇒ no CORS, no second service, `VITE_API_BASE_URL=''`.
- One image, one deploy, scale-to-zero.

## What's here
- **`apps/api/src/app.ts`** — when `WEB_DIST_DIR` is set, `@fastify/static` serves the web bundle + an SPA fallback (non-`/api` GET → index.html; unknown `/api` stays JSON 404). Unset in local dev (Vite serves the app). CORS `WEB_ORIGIN` env kept as optional defense.
- **`apps/api/Dockerfile`** — multi-stage, built from repo root; now also builds `@gamedevpl/web` and copies its `dist` into the runtime, non-root, `HOST=0.0.0.0`, reads `PORT`.
- **`infra/deploy-api.sh` + `cloudbuild.yaml`** — owner-run Cloud Run deploy (`gamedev-app`, min-instances 0). Wires `GITHUB_TOKEN` + `SUBMISSION_TOKEN_SECRET` from Secret Manager **only if both exist** — a first deploy without them is browse/play-only (submissions 503). One-time secret setup documented in the script header.
- **`docs/deployment.md`** — documents the single same-origin service.

## Verified locally (real Docker + browser)
- Image builds; container boots as Cloud Run would (`PORT` injected).
- `GET /` serves the app; hashed JS asset returns 200 `application/javascript`.
- `GET /api/health` works same-origin; unknown `/api/*` → JSON 404; deep non-API path → index.html (SPA fallback).
- In the browser: catalog loads all 3 seed games cross-origin from the games Pages origin; clicking Play loads the game in an iframe that is exactly `sandbox="allow-scripts"` (no `allow-same-origin`) with a cross-origin `src`.
- Root gate green: type-check, lint, 44 tests, build.

## Owner actions to go live (🔑)
1. GCP project with billing; `gcloud` authenticated.
2. (For submissions) two Secret Manager secrets — `github-token` (fine-grained PAT: Issues rw + PRs r + Contents r, games repo only) and `submission-token-secret` (`openssl rand -hex 32`).
3. `PROJECT_ID=… ./infra/deploy-api.sh` — deploys browse/play-only without the secrets, full loop with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)