### PR TITLE
M5c: optional Basic Auth access gate + deploy-script fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,15 @@ catalog, player, and spec-submission surface. Self-hosted agent execution was **
 legal reasons** and is not a future phase. Read [`games-repo.md`](../docs/games-repo.md) before
 making architectural assumptions.
 
+## Deployment status (2026-07-22)
+
+Built and **deployed** (M0–M5 merged). The app (web + API, one same-origin service) is **live on
+Cloud Run** at `https://gamedev-app-334141807880.europe-central2.run.app` (project `gamedevpl`);
+the live `www.gamedev.pl` Pages site is untouched. The deployed app is **locked behind HTTP Basic
+Auth** (temporary). Browse/play is live; **submissions are pending the `github-token` secret** and
+return 503 until it exists. Deploy is imperative `gcloud` via `infra/deploy-api.sh` (not Terraform).
+Full state and secret table: [`docs/deployment.md`](../docs/deployment.md).
+
 ## Reviewing or verifying work you didn't write
 
 If your task involves reviewing, verifying, or merging someone else's changes, read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,24 @@ agent-runner container, auth proxy, job tokens, and orchestrator) was **removed 
 reasons** and is not a future phase. Read
 [`games-repo.md`](docs/games-repo.md) before making architectural assumptions.
 
+## Deployment status (2026-07-22)
+
+The steel thread is **built and deployed** — all milestones M0–M5 merged. The app (web + API,
+one same-origin service) is **live on Cloud Run** at
+`https://gamedev-app-334141807880.europe-central2.run.app` (GCP project `gamedevpl`); the live
+`www.gamedev.pl` GitHub Pages site is untouched.
+
+- **The deployed app is locked behind HTTP Basic Auth** (`site-basic-auth` secret) — a
+  temporary "not public yet" gate. Browse/play is live and verified in production.
+- **Submissions are pending one owner secret** (`github-token`, a games-repo-scoped PAT); until
+  it exists, submission routes return 503 by design.
+- **M4 auto-assign requires the `COPILOT_ASSIGN_TOKEN` PAT** on the games repo — the default
+  Actions `GITHUB_TOKEN` cannot assign the Copilot bot (empirically verified).
+- Deploy via [`infra/deploy-api.sh`](infra/deploy-api.sh) (imperative `gcloud`, **not**
+  Terraform — the `infra/*.tf` files are an intentional no-op placeholder). Full deploy state,
+  the secret table, and how to enable submissions / remove the lock are in
+  [`docs/deployment.md`](docs/deployment.md).
+
 ## Shared playbooks (read these — they apply to you too)
 
 These live under `.claude/skills/` because that path makes them auto-loadable for Claude Code,

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,5 +1,5 @@
 import type { GameGenerator, GameProject } from '@gamedevpl/game-generator';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import packageJson from '../../../package.json';
 import { buildApp } from './app.js';
@@ -99,5 +99,66 @@ describe('api', () => {
     expect(res.statusCode).toBe(502);
     expect(res.body).not.toContain(fakeKey);
     await leaky.close();
+  });
+});
+
+describe('site basic auth gate', () => {
+  const creds = 'gamedev:s3cret';
+  const authHeader = `Basic ${Buffer.from(creds).toString('base64')}`;
+
+  afterEach(() => {
+    delete process.env.SITE_BASIC_AUTH;
+  });
+
+  it('is open when SITE_BASIC_AUTH is unset', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('rejects requests without credentials when configured', async () => {
+    process.env.SITE_BASIC_AUTH = creds;
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(401);
+    expect(res.headers['www-authenticate']).toContain('Basic');
+    await app.close();
+  });
+
+  it('rejects wrong credentials', async () => {
+    process.env.SITE_BASIC_AUTH = creds;
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+      headers: { authorization: `Basic ${Buffer.from('gamedev:wrong').toString('base64')}` },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('accepts correct credentials', async () => {
+    process.env.SITE_BASIC_AUTH = creds;
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+      headers: { authorization: authHeader },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('exempts CORS preflight (OPTIONS) from the auth gate', async () => {
+    process.env.SITE_BASIC_AUTH = creds;
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://example.com', 'access-control-request-method': 'GET' },
+    });
+    expect(res.statusCode).not.toBe(401);
+    await app.close();
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import cors from '@fastify/cors';
 import fastifyStatic from '@fastify/static';
 import type { GameGenerator } from '@gamedevpl/game-generator';
+import { timingSafeEqual } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { z } from 'zod';
@@ -29,6 +30,25 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(cors, {
     origin: webOrigin ? webOrigin.split(',').map((entry) => entry.trim()) : true,
   });
+
+  // Optional site-wide HTTP Basic Auth gate. When SITE_BASIC_AUTH ("user:password")
+  // is set, every request must carry matching credentials — a lightweight "not public
+  // yet" lock over the whole app (web + API). Unset (local dev, tests) leaves it open.
+  // CORS preflight (OPTIONS) is exempt: browsers never send credentials on preflight.
+  const basicAuth = process.env.SITE_BASIC_AUTH?.trim();
+  if (basicAuth) {
+    const expected = Buffer.from(`Basic ${Buffer.from(basicAuth).toString('base64')}`);
+    app.addHook('onRequest', async (request, reply) => {
+      if (request.method === 'OPTIONS') return;
+      const provided = Buffer.from(request.headers.authorization ?? '');
+      const ok = provided.length === expected.length && timingSafeEqual(provided, expected);
+      if (!ok) {
+        reply.header('WWW-Authenticate', 'Basic realm="gamedev.pl (private)"');
+        return reply.status(401).send({ error: 'authentication required' });
+      }
+    });
+  }
+
   await registerSubmissionRoutes(app, options.submissionRoutes);
 
   app.get('/api/health', async () => ({ status: 'ok', provider: generator.name }));

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -114,7 +114,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
                             merged
                             isDraft
                             title
-                            files(first: 200) {
+                            files(first: 100) {
                               nodes {
                                 path
                               }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,14 +38,13 @@ serves that bundle from the same origin (`WEB_DIST_DIR`), so the browser makes o
 requests to `/api` — no CORS, no second service, and the Pages site is never involved.
 
 [`infra/deploy-api.sh`](../infra/deploy-api.sh) builds the image via Cloud Build, pushes it to
-Artifact Registry, and deploys to Cloud Run with `--min-instances 0` (scale-to-zero). Two secrets
-live in Secret Manager (never in the repo): `github-token` (a fine-grained PAT — Issues
-read/write, Pull requests read, Contents read, scoped to the games repo only) and
-`submission-token-secret` (`openssl rand -hex 32`). Non-secret config (`GAMES_REPO`,
-`CATALOG_URL`) is plain env. The script wires the secrets **only if both exist**, so a first
-deploy without them is browse/play-only (submission routes return 503); add the secrets and
-redeploy to enable submissions. See the header comment in the script for the one-time
-secret-creation commands.
+Artifact Registry, and deploys to Cloud Run with `--min-instances 0` (scale-to-zero). It reads
+its secrets from Secret Manager (never the repo) and wires whichever exist — see the
+**Secrets & access** table above for the three (`github-token`, `submission-token-secret`,
+optional `site-basic-auth`) and their current state. Submissions require **both**
+`github-token` and `submission-token-secret`, so a first deploy without them is browse/play-only
+(submission routes return 503). Non-secret config (`GAMES_REPO`, `CATALOG_URL`) is plain env.
+See the header comment in the script for the one-time secret-creation commands.
 
 If the owner prefers another host (Fly.io, a VPS), nothing in `apps/api` assumes Cloud Run — it
 reads `PORT`/`HOST`/`WEB_DIST_DIR` from env.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,10 +1,32 @@
 # Deployment
 
-> **Status: 🚧 M5 in progress (2026-07-22).** The new app (web + API) deploys as **one
-> Cloud Run service**, on its own `*.run.app` URL. The live `www.gamedev.pl` GitHub Pages
-> site is **not touched** — the new app is entirely separate until an owner decides to point
-> a domain at it. See [`steel-thread-plan.md`](./steel-thread-plan.md) §M5 for the acceptance
-> scenario.
+> **Status: ✅ Deployed & live (2026-07-22).** The app (web + API) runs as **one Cloud Run
+> service** at `https://gamedev-app-334141807880.europe-central2.run.app` (GCP project
+> `gamedevpl`, region `europe-central2`, service `gamedev-app`, scale-to-zero). The live
+> `www.gamedev.pl` GitHub Pages site is **not touched**. **The app is currently locked behind
+> HTTP Basic Auth** (a temporary "not public yet" gate — see below). Browse/play is live;
+> **submissions are pending the `github-token` secret** (submission routes return 503 until
+> it is added — see below). See [`steel-thread-plan.md`](./steel-thread-plan.md) §M5.
+
+## Secrets & access (current live state)
+
+Secrets live only in GCP Secret Manager (never in the repo); the Cloud Run runtime service
+account (`<project-number>-compute@developer.gserviceaccount.com`) needs
+`roles/secretmanager.secretAccessor` on each. `infra/deploy-api.sh` wires whichever exist into
+a single `--set-secrets` list.
+
+| Secret                    | Purpose                                                                | State (2026-07-22)      |
+| ------------------------- | ---------------------------------------------------------------------- | ----------------------- |
+| `site-basic-auth`         | `"user:password"` → `SITE_BASIC_AUTH`; locks the whole app (web + API) | ✅ set (app is private) |
+| `submission-token-secret` | HMAC key for the stateless status token → `SUBMISSION_TOKEN_SECRET`    | ✅ set                  |
+| `github-token`            | Fine-grained PAT (Issues rw + PRs r + Contents r, games repo only)     | ❌ **not yet created**  |
+
+- **Enable submissions:** create `github-token`, grant the runtime SA accessor on it, and
+  redeploy. Both `github-token` and `submission-token-secret` must be present for submissions
+  to leave 503.
+- **Remove the access lock (make public):** `gcloud secrets delete site-basic-auth` and
+  redeploy (or deploy without wiring it). Basic Auth over HTTPS is a stopgap; a domain +
+  proper auth is a later decision.
 
 ## How to deploy (concrete)
 

--- a/docs/steel-thread-plan.md
+++ b/docs/steel-thread-plan.md
@@ -1,9 +1,23 @@
 # Steel thread plan — from current state to a working loop on www.gamedev.pl
 
-> **Status: 📋 Plan of record, 2026-07-22.** Written to be executed by a coding agent
-> milestone-by-milestone. Read [`games-repo.md`](./games-repo.md) for the architecture's
+> **Status: ✅ Executed — the thread is deployed and live, 2026-07-22.** All milestones
+> M0–M5 are merged; M4 and M5 are verified in production. Written to be executed by a coding
+> agent milestone-by-milestone. Read [`games-repo.md`](./games-repo.md) for the architecture's
 > _why_ and [`games-repo-blueprint.md`](./games-repo-blueprint.md) for the games repo's
 > internal contract. This document is the _how do we ship it_.
+>
+> **Live deployment (as of 2026-07-22):**
+>
+> - **URL:** `https://gamedev-app-334141807880.europe-central2.run.app` (GCP project
+>   `gamedevpl`, region `europe-central2`, Cloud Run service `gamedev-app`, scale-to-zero).
+>   The live `www.gamedev.pl` GitHub Pages site is **not** touched.
+> - **Access is locked** behind HTTP Basic Auth (`SITE_BASIC_AUTH` secret) as a temporary
+>   "not public yet" gate — see [`deployment.md`](./deployment.md).
+> - **Browse/play is fully live**; games play sandboxed from the games origin. **Submissions
+>   go live once the `github-token` secret is added** (see M5 below) — until then submission
+>   routes return 503 by design.
+> - **M4 auto-assign works but requires the `COPILOT_ASSIGN_TOKEN` PAT** (the default Actions
+>   `GITHUB_TOKEN` cannot assign the Copilot bot). That secret is set on the games repo.
 
 ## 0. Definition of done — the steel thread
 
@@ -203,7 +217,7 @@ the game plays.
 
 ---
 
-### M4 — Auto-assign Copilot in the games repo
+### M4 — Auto-assign Copilot in the games repo ✅ _done & verified_
 
 **Goal:** an issue labeled `new-game` gets assigned to Copilot with no operator.
 
@@ -213,16 +227,18 @@ In `www.gamedev.pl-games`:
   `new-game`: resolve the bot via GraphQL `suggestedActors(capabilities: [CAN_BE_ASSIGNED])`
   (login `copilot-swe-agent`), then `replaceActorsForAssignable`, preserving existing
   assignees.
-- ⚠️ **Unverified:** the default `GITHUB_TOKEN` may not be allowed to assign the Copilot
-  bot. Try it first; if it fails, 🔑 owner adds a PAT secret (`COPILOT_ASSIGN_TOKEN`) and
-  the workflow uses that. Record the outcome in the workflow file as a comment.
+- ✅ **Empirical outcome (verified 2026-07-22):** the default `GITHUB_TOKEN` is
+  **insufficient** — it returns an empty `suggestedActors` set and cannot assign the Copilot
+  bot. A repo-secret PAT **`COPILOT_ASSIGN_TOKEN`** (fine-grained, Issues: read/write) is
+  **required** and is set on the games repo; the workflow uses it via
+  `${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}`.
 
-**Acceptance:** filing a labeled test issue (manually or via M2) results in Copilot
-assigned and a PR appearing, hands-off.
+**Acceptance ✅:** a labeled test issue was assigned to `copilot-swe-agent` hands-off and
+Copilot opened a PR from it (verified with throwaway issues, since closed).
 
 ---
 
-### M5 — Deploy the app to Cloud Run (live site untouched)
+### M5 — Deploy the app to Cloud Run (live site untouched) ✅ _deployed 2026-07-22_
 
 **Goal:** the thread runs on a real deployed URL, not localhost — **without touching the live
 `www.gamedev.pl` Pages site.**
@@ -232,16 +248,25 @@ assigned and a PR appearing, hands-off.
   the Fastify server serves the static bundle via `@fastify/static` (`WEB_DIST_DIR`) with an
   SPA fallback. No CORS (same origin), `VITE_API_BASE_URL=''`, no gh-pages involvement.
 - Deploy with [`infra/deploy-api.sh`](../infra/deploy-api.sh) (Cloud Build → Artifact Registry
-  → Cloud Run, scale-to-zero, min instances 0). Submission secrets (`GITHUB_TOKEN`,
-  `SUBMISSION_TOKEN_SECRET`) come from Secret Manager and are wired **only if both exist** —
-  a first deploy without them is browse/play-only (submissions 503). 🔑 Owner provisions the
-  GCP project (+ optional secrets), then runs the script.
-- Status/verification of the container is done in real Docker before deploy (image builds,
-  boots, `/` serves the app, `/api/*` works same-origin, a seed game plays sandboxed).
+  → Cloud Run, scale-to-zero, min instances 0). Secrets come from Secret Manager and are wired
+  into one `--set-secrets` list when present: submission needs **both** `github-token` and
+  `submission-token-secret`; the optional `site-basic-auth` locks the whole app.
+- ✅ **Live at** `https://gamedev-app-334141807880.europe-central2.run.app` (project
+  `gamedevpl`). Verified in production: app serves in house style, catalog loads the 3 seed
+  games cross-origin, a seed game plays in an `iframe sandbox="allow-scripts"`, `/api/health`
+  works same-origin. **Access is gated by HTTP Basic Auth** (`site-basic-auth` secret) as a
+  temporary lock; credentials are held by the owner (not in the repo).
+- 🟡 **Submissions pending one secret:** `submission-token-secret` (HMAC) is set, but
+  `github-token` (a fine-grained PAT — Issues rw + PRs r + Contents r on the games repo) is
+  **not** yet created, so submission routes still return 503. Add it and redeploy to enable
+  the full loop:
+  `printf '%s' "<PAT>" | gcloud secrets create github-token --data-file=- --replication-policy=automatic --project gamedevpl`
+  then grant the runtime SA `roles/secretmanager.secretAccessor` on it and rerun the deploy.
 
 **Acceptance — the steel thread itself:** on the Cloud Run URL, run the §0 scenario
 end-to-end: play a seed game; submit a real spec; watch the status page; operator verifies +
-merges Copilot's PR; status flips to `published`; play the new game. Done.
+merges Copilot's PR; status flips to `published`; play the new game. _Browse/play verified;
+the submit→publish half unlocks once `github-token` is added (above)._
 
 ---
 

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -14,6 +14,12 @@
 # The API boots without these; submission routes just return 503 until they exist,
 # so browsing/playing works on a secret-less first deploy.
 #
+# Optional access lock (make the whole app private "for now"):
+#   printf '%s' "myuser:mypassword" \
+#     | gcloud secrets create site-basic-auth --data-file=- --replication-policy=automatic
+# When present, every request needs those HTTP Basic Auth credentials. Remove the lock
+# by deleting the secret (`gcloud secrets delete site-basic-auth`) and redeploying.
+#
 # Then run:
 #   PROJECT_ID=my-proj ./infra/deploy-api.sh
 #
@@ -43,15 +49,31 @@ echo "==> Building image via Cloud Build: ${IMAGE}"
 gcloud builds submit "$REPO_ROOT" --config "$REPO_ROOT/infra/cloudbuild.yaml" \
   --substitutions "_IMAGE=${IMAGE}" --project "$PROJECT_ID"
 
-# Wire the submission secrets only if BOTH exist; otherwise deploy browse/play-only
-# (the API returns 503 on submission routes until the secrets are added and it is redeployed).
-SECRET_FLAGS=()
+# Wire whichever secrets exist into one --set-secrets list (multiple --set-secrets
+# flags overwrite each other, so mappings must be joined). Submissions need BOTH
+# github-token and submission-token-secret; without them the app is browse/play-only
+# (submission routes return 503). site-basic-auth is optional and locks the whole app
+# (web + API) behind HTTP Basic Auth ("user:password").
+SECRET_MAPPINGS=()
 if gcloud secrets describe github-token --project "$PROJECT_ID" >/dev/null 2>&1 \
    && gcloud secrets describe submission-token-secret --project "$PROJECT_ID" >/dev/null 2>&1; then
-  SECRET_FLAGS=(--set-secrets "GITHUB_TOKEN=github-token:latest,SUBMISSION_TOKEN_SECRET=submission-token-secret:latest")
+  SECRET_MAPPINGS+=("GITHUB_TOKEN=github-token:latest" "SUBMISSION_TOKEN_SECRET=submission-token-secret:latest")
   echo "==> Submission secrets found; submissions will be enabled."
 else
   echo "==> Submission secrets not found; deploying browse/play-only (submissions return 503)."
+fi
+
+if gcloud secrets describe site-basic-auth --project "$PROJECT_ID" >/dev/null 2>&1; then
+  SECRET_MAPPINGS+=("SITE_BASIC_AUTH=site-basic-auth:latest")
+  echo "==> site-basic-auth found; the app will be locked behind HTTP Basic Auth."
+else
+  echo "==> site-basic-auth not found; the app will be publicly reachable."
+fi
+
+SECRET_FLAGS=()
+if [ ${#SECRET_MAPPINGS[@]} -gt 0 ]; then
+  joined=$(IFS=,; echo "${SECRET_MAPPINGS[*]}")
+  SECRET_FLAGS=(--set-secrets "$joined")
 fi
 
 echo "==> Deploying to Cloud Run (scale-to-zero)"
@@ -65,7 +87,7 @@ gcloud run deploy "$SERVICE" \
   --max-instances 4 \
   --port 8080 \
   --set-env-vars "GAMES_REPO=${GAMES_REPO},CATALOG_URL=${CATALOG_URL}" \
-  "${SECRET_FLAGS[@]}"
+  ${SECRET_FLAGS[@]+"${SECRET_FLAGS[@]}"}
 
 echo "==> Done. The app (web + API) is live at:"
 gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \


### PR DESCRIPTION
Follow-up to the M5 Cloud Run deploy (#223). Two changes, both surfaced while taking the app live.

## 1. Optional site-wide HTTP Basic Auth (`apps/api`)
Adds a `SITE_BASIC_AUTH` env var (`"user:password"`). When set, an `onRequest` hook requires matching HTTP Basic credentials on every request (web + API); unset (local dev, tests) leaves the app open. CORS preflight (`OPTIONS`) is exempt since browsers never send credentials on preflight. Timing-safe comparison. This is a lightweight "not public yet" lock — removable by dropping the secret and redeploying. +5 tests (401 without/with wrong creds, 200 with correct, OPTIONS bypass, open-when-unset).

## 2. Deploy-script fix (`infra/deploy-api.sh`)
- Fixes `SECRET_FLAGS[@]: unbound variable` on macOS system bash 3.2 — expanding an empty array under `set -u` errored, so the very first (secret-less) deploy failed at `gcloud run deploy`.
- Joins all present secrets into a single `--set-secrets` list (multiple flags overwrite), and wires the new optional `site-basic-auth` secret.
- Documents the access-lock setup in the header.

Gate green: type-check, lint, 39 API tests, build. Verified live on the Cloud Run deploy.