### PR TITLE
Set up dev environment + add Cursor Cloud notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,26 @@ autonomous agents here. Read them directly:
 Both carry a **mandatory self-improvement clause**: if you use one and it turns out to be
 wrong, stale, or missing something that cost you time, update it in the same session. That
 applies regardless of which agent you are.
+
+## Cursor Cloud specific instructions
+
+Setup is just `npm install` (see the "Green gate" and `docs/contributing-for-agents.md` for the
+standard commands). Everything runs offline with the `mock` generator — no cloud, keys, or
+secrets. Non-obvious caveats for running/testing locally:
+
+- **Open the web app at `http://localhost:5173`, not `http://127.0.0.1:5173`.** `npm run dev`
+  (Vite) binds to `localhost` (IPv6 `::1`) only, so `127.0.0.1` refuses the connection. The API
+  is at `127.0.0.1:3001`; Vite proxies `/api` → the API (`apps/web/vite.config.ts`).
+- **`GET /api/catalog` returns 503 ("catalog is not configured") locally, and the home page
+  shows a red "Could not load the catalog" error — this is expected.** The catalog is served
+  from the separate games repo, which isn't wired up in local dev.
+- **The generate/create loop is gated behind Google sign-in in the UI** — clicking "Build My
+  Game" opens a "Sign in with Google" modal, and `POST /api/generate-game` returns 401 without a
+  session. Real Google OAuth isn't available locally. To exercise the authenticated
+  generate→assemble loop without Google, do what the tests do: `InMemoryStore.upsertUser(...)` +
+  `mintSessionToken(uid, 'dev-session-secret-change-me')` and send it as the `gamedev_session`
+  cookie (see `apps/api/src/app.test.ts`). Dev uses `InMemoryStore` and that default session
+  secret (`apps/api/src/server.ts`, `auth.ts`).
+- Generated games render only in `<iframe sandbox="allow-scripts">` with no `allow-same-origin`
+  (`apps/web/src/GameFrame.tsx`) — the safety invariant. A produced game document is a
+  self-contained `<!doctype html>` with inlined `<style>`/`<script>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the local development environment for the gamedev.pl monorepo and captures durable, non-obvious run/test caveats for future cloud agents in `AGENTS.md`.

The only code/docs change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No product code was modified.

## Environment setup

- `npm install` (single, self-contained npm-workspaces install) is the entire update script. Everything runs offline with the `mock` generator — no cloud, keys, or secrets.
- Verified the full green gate from the repo root:

| Step | Command | Result |
| --- | --- | --- |
| Type-check | `npm run type-check` | pass |
| Lint | `npm run lint` | pass (0 warnings) |
| Test | `npm run test` | pass (API 351, web 99) |
| Build | `npm run build` | pass |
| Run | `npm run dev` | API `127.0.0.1:3001`, web `http://localhost:5173` |

## Hello-world verification

- **Web + API integration:** loaded the home page, typed a game idea, and clicked "Build My Game" — the app correctly surfaces the Google sign-in modal (generation is auth-gated).
- **Core generate → sandbox loop:** drove the real `POST /api/generate-game` route (moderation → quota → mock generator → HTML assembly → hygiene) to produce a genuine self-contained game document, then rendered it in an `<iframe sandbox="allow-scripts">` (no `allow-same-origin`) matching `GameFrame`. The game runs and responds to input (score/miss counters update, game-over triggers).

[gamedevpl_home_prompt_signin_flow.mp4](https://cursor.com/agents/bc-0e72b783-faf7-4c29-ad88-2efc85883e15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgamedevpl_home_prompt_signin_flow.mp4)

[gamedevpl_sandboxed_game_player.mp4](https://cursor.com/agents/bc-0e72b783-faf7-4c29-ad88-2efc85883e15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgamedevpl_sandboxed_game_player.mp4)

[Sign-in modal after clicking Build My Game](https://cursor.com/agents/bc-0e72b783-faf7-4c29-ad88-2efc85883e15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgamedevpl_signin_modal.webp)

[Generated game running in the sandboxed player](https://cursor.com/agents/bc-0e72b783-faf7-4c29-ad88-2efc85883e15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgamedevpl_game_running.webp)

## Notes captured in AGENTS.md

- Open the web app at `http://localhost:5173` (Vite binds to `localhost`/IPv6 only; `127.0.0.1:5173` refuses).
- `GET /api/catalog` returns 503 locally ("catalog is not configured") — expected; the catalog lives in the separate games repo.
- The generate loop is gated behind Google sign-in; to exercise it locally without OAuth, seed `InMemoryStore.upsertUser` + `mintSessionToken(uid, 'dev-session-secret-change-me')` as the `gamedev_session` cookie (see `apps/api/src/app.test.ts`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e72b783-faf7-4c29-ad88-2efc85883e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e72b783-faf7-4c29-ad88-2efc85883e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

