### PR TITLE
feat(api): read the committed catalog.json, falling back to the GraphQL fan-out

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -15,6 +15,10 @@ function specMd(frontmatter: Record<string, string>): string {
 function catalogFetchImpl(dirs: string[], files: Record<string, string | null>): typeof fetch {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
+    if (url.includes('/contents/catalog.json')) {
+      // No committed artifact on this ref — exercises the GraphQL fallback below.
+      return new Response('not found', { status: 404 });
+    }
     if (url.includes('/contents/games?')) {
       return new Response(
         JSON.stringify([
@@ -89,9 +93,10 @@ describe('getCatalog', () => {
         orientation: 'any',
       },
     ]);
-    // One directory listing + one GraphQL chunk — not one Contents read per file.
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(String(vi.mocked(fetchImpl).mock.calls[1]?.[0])).toContain('/graphql');
+    // Artifact probe + one directory listing + one GraphQL chunk — not one
+    // Contents read per file.
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(String(vi.mocked(fetchImpl).mock.calls[2]?.[0])).toContain('/graphql');
   });
 
   it('strips quotes from frontmatter values and skips games without a title', async () => {
@@ -210,10 +215,153 @@ describe('getCatalog', () => {
 
     const catalog = await client.getCatalog('main');
     expect(catalog).toHaveLength(35);
-    // 1 listing + 2 GraphQL chunks (chunk size 30).
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    // 1 artifact probe + 1 listing + 2 GraphQL chunks (chunk size 30).
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     const graphqlCalls = vi.mocked(fetchImpl).mock.calls.filter((call) => String(call[0]).includes('/graphql'));
     expect(graphqlCalls).toHaveLength(2);
+  });
+
+  it('serves the committed catalog.json in a single request when present', async () => {
+    const committed = [
+      {
+        slug: 'bubble-pop',
+        title: 'Bubble Pop Rush',
+        genre: 'arcade',
+        controls: 'Mouse to aim and pop',
+        status: 'published',
+        touch: 'gamekit',
+        orientation: 'portrait',
+        multiplayer: null,
+        media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+      },
+      {
+        slug: 'arena-tag',
+        title: 'Arena Tag',
+        genre: 'party',
+        controls: 'D-pad',
+        status: 'draft',
+        touch: 'controllers',
+        orientation: 'any',
+        multiplayer: { mode: 'controllers', minPlayers: 2, maxPlayers: 4 },
+        media: null,
+      },
+    ];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/contents/catalog.json')) {
+        return new Response(JSON.stringify(committed), { status: 200 });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    const catalog = await client.getCatalog('main');
+
+    // The whole point: no listing, no GraphQL, no per-game reads.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(catalog).toEqual([
+      {
+        slug: 'bubble-pop',
+        title: 'Bubble Pop Rush',
+        genre: 'arcade',
+        controls: 'Mouse to aim and pop',
+        status: 'published',
+        touch: 'gamekit',
+        orientation: 'portrait',
+        multiplayer: null,
+        media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+      },
+      {
+        slug: 'arena-tag',
+        title: 'Arena Tag',
+        genre: 'party',
+        controls: 'D-pad',
+        // draft coerces exactly like the GraphQL path: merged means visible.
+        status: 'published',
+        touch: 'controllers',
+        orientation: 'any',
+        multiplayer: { mode: 'controllers', minPlayers: 2, maxPlayers: 4 },
+        media: null,
+      },
+    ]);
+  });
+
+  it('carries touch, which no SPEC-derived path can produce', async () => {
+    // The regression this guards: touch is computed from each game's code by the
+    // games repo. Losing it here silently tells phone visitors nothing.
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response(
+          JSON.stringify([{ slug: 'thumbly', title: 'Thumbly', status: 'published', touch: 'native' }]),
+          { status: 200 },
+        );
+      }
+      throw new Error('unexpected request');
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    expect((await client.getCatalog('main'))[0]?.touch).toBe('native');
+  });
+
+  it('re-validates committed entries instead of trusting the artifact', async () => {
+    const committed = [
+      // Unsafe media filename, unknown touch class, out-of-range player bounds and
+      // a bogus orientation: each must be dropped without dropping the game.
+      {
+        slug: 'sneaky',
+        title: 'Sneaky',
+        status: 'published',
+        touch: 'telepathy',
+        orientation: 'SIDEWAYS',
+        multiplayer: { mode: 'controllers', minPlayers: 2, maxPlayers: 99 },
+        media: { screenshots: [{ name: 'opening', file: '../../etc/passwd.png' }], video: null },
+      },
+      // Not a game entry at all.
+      { slug: 'No Slug!', title: 'Bad' },
+      'garbage',
+    ];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response(JSON.stringify(committed), { status: 200 });
+      }
+      throw new Error('unexpected request');
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    const catalog = await client.getCatalog('main');
+
+    expect(catalog).toEqual([
+      {
+        slug: 'sneaky',
+        title: 'Sneaky',
+        genre: '',
+        controls: '',
+        status: 'published',
+        orientation: 'any',
+        multiplayer: null,
+        media: null,
+      },
+    ]);
+  });
+
+  it('falls back to the GraphQL fan-out when catalog.json is not valid JSON', async () => {
+    const base = catalogFetchImpl(['bubble-pop'], {
+      'games/bubble-pop/SPEC.md': specMd({ title: 'Bubble Pop Rush', status: 'published' }),
+      'games/bubble-pop/media/metadata.json': null,
+    });
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response('<<not json>>', { status: 200 });
+      }
+      return base(input, init);
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    const catalog = await client.getCatalog('main');
+
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0].slug).toBe('bubble-pop');
+    expect(catalog[0].touch).toBeUndefined();
   });
 });
 

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -344,6 +344,41 @@ describe('getCatalog', () => {
     ]);
   });
 
+  it('falls back rather than blanking the site when no committed entry is usable', async () => {
+    // A schema change in the games repo (a renamed field, say) would leave a valid
+    // JSON array whose every row fails validation. Serving that as an empty catalog
+    // would hide all games; the fan-out must take over instead.
+    const base = catalogFetchImpl(['bubble-pop'], {
+      'games/bubble-pop/SPEC.md': specMd({ title: 'Bubble Pop Rush', status: 'published' }),
+      'games/bubble-pop/media/metadata.json': null,
+    });
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response(JSON.stringify([{ id: 'renamed-field' }, 'garbage']), { status: 200 });
+      }
+      return base(input, init);
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    const catalog = await client.getCatalog('main');
+
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0].slug).toBe('bubble-pop');
+  });
+
+  it('treats a genuinely empty artifact as an empty catalog, not a failure', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response('[]', { status: 200 });
+      }
+      throw new Error('unexpected request: the fan-out must not run');
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    expect(await client.getCatalog('main')).toEqual([]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it('falls back to the GraphQL fan-out when catalog.json is not valid JSON', async () => {
     const base = catalogFetchImpl(['bubble-pop'], {
       'games/bubble-pop/SPEC.md': specMd({ title: 'Bubble Pop Rush', status: 'published' }),

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -898,7 +898,7 @@ const CATALOG_TOUCH_VALUES = new Set<CatalogGameTouch>(['gamekit', 'native', 'co
  * media filenames it vouches for become servable URLs, and this process must
  * not extend more trust to a repo file than to any other remote input.
  * Returns null when the payload is not a catalog at all (fall back to the
- * SPEC-derived fan-out); individual malformed entries are just skipped.
+ * GraphQL fan-out); individual malformed entries are just skipped.
  */
 function parseCommittedCatalog(raw: string): CatalogGameEntry[] | null {
   let body: unknown;
@@ -942,6 +942,14 @@ function parseCommittedCatalog(raw: string): CatalogGameEntry[] | null {
         ? { touch: touch as CatalogGameTouch }
         : {}),
     });
+  }
+
+  // Rows present but none usable means this is not the schema we understand — a
+  // field rename in the games repo, say. Serving the resulting empty array would
+  // blank every game on the site; fall through to the fan-out instead. An
+  // artifact that is genuinely `[]` still returns an empty catalog, as it should.
+  if (body.length > 0 && entries.length === 0) {
+    return null;
   }
   return entries;
 }

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -141,7 +141,16 @@ export interface CatalogGameEntry {
    * uses it to nudge a phone that is held the wrong way round.
    */
   orientation: CatalogGameOrientation;
+  /**
+   * Touch playability class, derived from each game's *code* by the games repo's
+   * own build (it runs inferTouchSupport over the sources). Nothing readable from
+   * SPEC.md can reproduce it, so it is present only when the catalog came from the
+   * committed catalog.json artifact — the GraphQL fallback below leaves it absent.
+   */
+  touch?: CatalogGameTouch;
 }
+
+export type CatalogGameTouch = 'gamekit' | 'native' | 'controllers' | 'none';
 
 export type CatalogGameOrientation = 'any' | 'portrait' | 'landscape';
 
@@ -769,6 +778,20 @@ ${gameJs}`;
         throw new Error(`invalid published ref "${ref}"`);
       }
 
+      // Fast path: the games repo commits a website-ready catalog.json at its root,
+      // held fresh by its own validate gate. One read answers the whole catalog, and
+      // it is the only source that can carry `touch` — a value derived from each
+      // game's code, which no amount of SPEC.md reading here can reproduce.
+      // The GraphQL fan-out below stays as the fallback for refs without the
+      // artifact (older commits, and PR branches during a build).
+      const committed = await readRawFile('catalog.json', ref);
+      if (committed !== null) {
+        const entries = parseCommittedCatalog(committed);
+        if (entries !== null) {
+          return entries;
+        }
+      }
+
       const listing = await requestJson<Array<{ name: string; type: string }>>(
         `https://api.github.com/repos/${repo}/contents/games?ref=${encodeURIComponent(ref)}`,
       );
@@ -862,6 +885,111 @@ ${gameJs}`;
       return entries;
     },
   };
+}
+
+const SAFE_MEDIA_NAME = /^[a-z0-9][a-z0-9-]*$/;
+const SAFE_MEDIA_PNG = /^[a-z0-9][a-z0-9-]*\.png$/;
+const SAFE_MEDIA_MP4 = /^[a-z0-9][a-z0-9-]*\.mp4$/;
+const CATALOG_TOUCH_VALUES = new Set<CatalogGameTouch>(['gamekit', 'native', 'controllers', 'none']);
+
+/**
+ * Parses the games repo's committed catalog.json into catalog entries. The file
+ * is CI-validated at the source, but everything is still re-checked here — the
+ * media filenames it vouches for become servable URLs, and this process must
+ * not extend more trust to a repo file than to any other remote input.
+ * Returns null when the payload is not a catalog at all (fall back to the
+ * SPEC-derived fan-out); individual malformed entries are just skipped.
+ */
+function parseCommittedCatalog(raw: string): CatalogGameEntry[] | null {
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(body)) {
+    return null;
+  }
+
+  const entries: CatalogGameEntry[] = [];
+  for (const item of body) {
+    if (typeof item !== 'object' || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+    if (typeof candidate.slug !== 'string' || !SAFE_MEDIA_NAME.test(candidate.slug)) continue;
+    if (typeof candidate.title !== 'string' || candidate.title.length === 0) continue;
+
+    // Same status coercion as the SPEC-derived path: the games repo uses
+    // draft/in-progress/published, and only an explicit archived/disabled
+    // takes a merged game off the site.
+    const rawStatus = typeof candidate.status === 'string' ? candidate.status : '';
+    const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
+
+    const orientationRaw = typeof candidate.orientation === 'string' ? candidate.orientation.trim().toLowerCase() : '';
+    const touch = candidate.touch;
+
+    entries.push({
+      slug: candidate.slug,
+      title: candidate.title,
+      genre: typeof candidate.genre === 'string' ? candidate.genre : '',
+      controls: typeof candidate.controls === 'string' ? candidate.controls : '',
+      status,
+      media: parseCommittedMedia(candidate.media),
+      multiplayer: parseCommittedMultiplayer(candidate.multiplayer),
+      orientation: GAME_ORIENTATIONS.has(orientationRaw as CatalogGameOrientation)
+        ? (orientationRaw as CatalogGameOrientation)
+        : 'any',
+      ...(typeof touch === 'string' && CATALOG_TOUCH_VALUES.has(touch as CatalogGameTouch)
+        ? { touch: touch as CatalogGameTouch }
+        : {}),
+    });
+  }
+  return entries;
+}
+
+/** The committed catalog carries media already in website shape, unlike per-game metadata.json. */
+function parseCommittedMedia(value: unknown): CatalogGameMedia | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+  const media = value as { screenshots?: unknown; video?: unknown };
+  const screenshots = (Array.isArray(media.screenshots) ? media.screenshots : [])
+    .filter(
+      (shot): shot is { name: string; file: string } =>
+        typeof shot === 'object' &&
+        shot !== null &&
+        typeof (shot as { name?: unknown }).name === 'string' &&
+        SAFE_MEDIA_NAME.test((shot as { name: string }).name) &&
+        typeof (shot as { file?: unknown }).file === 'string' &&
+        SAFE_MEDIA_PNG.test((shot as { file: string }).file),
+    )
+    .slice(0, 8)
+    .map((shot) => ({ name: shot.name, file: shot.file }));
+  const video = typeof media.video === 'string' && SAFE_MEDIA_MP4.test(media.video) ? media.video : null;
+  return screenshots.length > 0 || video ? { screenshots, video } : null;
+}
+
+function parseCommittedMultiplayer(value: unknown): CatalogGameMultiplayer | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+  const multiplayer = value as { mode?: unknown; minPlayers?: unknown; maxPlayers?: unknown };
+  if (
+    multiplayer.mode !== 'controllers' ||
+    typeof multiplayer.minPlayers !== 'number' ||
+    typeof multiplayer.maxPlayers !== 'number' ||
+    !Number.isInteger(multiplayer.minPlayers) ||
+    !Number.isInteger(multiplayer.maxPlayers)
+  ) {
+    return null;
+  }
+  if (
+    multiplayer.minPlayers < 2 ||
+    multiplayer.maxPlayers < multiplayer.minPlayers ||
+    multiplayer.maxPlayers > MAX_MULTIPLAYER_SLOTS
+  ) {
+    return null;
+  }
+  return { mode: 'controllers', minPlayers: multiplayer.minPlayers, maxPlayers: multiplayer.maxPlayers };
 }
 
 function parseGameMedia(metadataJson: string | null): CatalogGameMedia | null {


### PR DESCRIPTION
## Status: rebased onto #234, now composes with it

This PR originally carried two changes. The first (resilient catalog cache — request coalescing + stale-on-error) is **already on master** as 6d019fdb and survived #234's rewrite intact. What remains here is the single-read fast path, rebased so it *builds on* #234 rather than competing with it.

## Why this is still worth landing after #234

#234 cut catalog rebuilds from ~167 Contents reads to `1 + ceil(N/30)` requests. That fixed the outage. Two things it structurally cannot do:

1. **`touch` never reaches visitors.** It is derived from each game's *code* by the games repo's `inferTouchSupport`. No amount of SPEC.md frontmatter reading can reproduce it. That field exists specifically so the site can tell a phone visitor what they can actually play — today it is computed, committed, and silently dropped at the API boundary.
2. **It grows with the catalog.** `1 + ceil(N/30)` is 4 requests at 83 games, 11 at 300. The games repo went 73 → 83 in a single day.

The games repo now commits a website-ready `catalog.json` (gamedevpl/www.gamedev.pl-games#56, **merged**), held fresh by validate Check 14. Reading it answers the whole catalog in **one request, constant in N**, and carries `touch`. Right now that artifact is maintained but unconsumed — this PR is what makes it pay for itself.

## How

Fast path reads `catalog.json`; **#234's chunked GraphQL fan-out stays as the fallback** for refs predating the artifact and for PR branches mid-build. Nothing is removed.

The artifact is re-validated on the way in — slug and media-filename regexes, player bounds, orientation and touch enumerations — because the filenames it vouches for become servable URLs, and a repo file earns no more trust than any other remote input. Malformed entries are skipped individually; a payload that is not a catalog at all falls through to the fan-out. Status coercion unchanged: only `archived`/`disabled` hide a merged game.

## Verified

- Against the **real 83-game artifact**: every entry parses, all carry `touch` (68 gamekit, 12 controllers, 3 native), in a single request.
- github-client 17/17 (4 new: fast path, touch preservation, hostile-artifact re-validation, malformed-JSON fallback). Existing GraphQL tests retained and still exercising the fallback.
- Full API suite 437/437; lint and type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Catalog loading behavior changes at the API boundary (new primary data source) with security-sensitive media filename validation; fallback limits blast radius if the artifact is wrong or missing.
> 
> **Overview**
> **`getCatalog`** now tries a **one-request fast path** by reading root **`catalog.json`** from the games repo when present, instead of always listing `games/` and batching GraphQL reads.
> 
> The committed file is parsed with **`parseCommittedCatalog`** and strict re-validation (slugs, media paths, orientation/touch enums, multiplayer bounds) because those filenames become servable URLs. Malformed rows are skipped; invalid JSON, non-arrays, or arrays where every row fails validation trigger **fallback** to the existing SPEC/GraphQL path so a bad artifact does not empty the site. A valid **`[]`** still means an empty catalog.
> 
> **`CatalogGameEntry`** gains optional **`touch`** (`gamekit` | `native` | `controllers` | `none`), which only the committed artifact can supply—the fallback path leaves it unset.
> 
> Tests mock a **`catalog.json`** probe on the fallback path, bump expected fetch counts, and add coverage for the fast path, **`touch`** preservation, hostile payloads, schema-mismatch fallback, empty artifact, and non-JSON fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21f615add8de5a30b51e67612c5f6e0c0c628bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->