### PR TITLE
Add SPA 404 page for unknown paths

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -22,6 +22,7 @@ import { registerTelemetryRoutes, type TelemetryRoutesOptions } from './telemetr
 import { registerVisitTelemetryRoutes } from './visit-telemetry.js';
 import { createPublishedSlugGateFromEnv } from './published-slugs.js';
 import { registerRateLimit } from './rate-limit.js';
+import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -301,13 +302,19 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
         }
       },
     });
-    // SPA fallback: any non-/api GET that isn't a real file returns index.html
-    // so path deep links (`/play/<slug>`, `/status/<token>`, …) survive refresh.
+    // SPA shell: known deep links (`/play/<slug>`, …) keep HTTP 200 so refresh
+    // works; everything else gets a *proper* HTTP 404 with the same `index.html`
+    // so crawlers/tools see a real miss while the client can still render NotFound.
+    // Missing extension-bearing files stay hard 404s (never the HTML shell).
     app.setNotFoundHandler((request, reply) => {
       if (request.method !== 'GET' || request.url.startsWith('/api')) {
         return reply.status(404).send({ error: 'not found' });
       }
-      return reply.sendFile('index.html');
+      if (looksLikeStaticAsset(request.url)) {
+        return reply.status(404).send({ error: 'not found' });
+      }
+      const status = isKnownSpaShellPath(request.url) ? 200 : 404;
+      return reply.status(status).type('text/html').sendFile('index.html');
     });
   }
 

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { isKnownSpaShellPath, looksLikeStaticAsset, normalizePathname } from './spa-paths.js';
+
+describe('normalizePathname', () => {
+  it('strips query strings and trailing slashes', () => {
+    expect(normalizePathname('/play/sky-dodge?x=1')).toBe('/play/sky-dodge');
+    expect(normalizePathname('/privacy/')).toBe('/privacy');
+    expect(normalizePathname('/')).toBe('/');
+  });
+});
+
+describe('looksLikeStaticAsset', () => {
+  it('detects extension-bearing paths', () => {
+    expect(looksLikeStaticAsset('/sw.js')).toBe(true);
+    expect(looksLikeStaticAsset('/assets/index-AbCd.js')).toBe(true);
+    expect(looksLikeStaticAsset('/icons/foo.png')).toBe(true);
+    expect(looksLikeStaticAsset('/offline.html')).toBe(true);
+  });
+
+  it('does not treat SPA paths as assets', () => {
+    expect(looksLikeStaticAsset('/play/sky-dodge')).toBe(false);
+    expect(looksLikeStaticAsset('/nope')).toBe(false);
+    expect(looksLikeStaticAsset('/')).toBe(false);
+  });
+});
+
+describe('isKnownSpaShellPath', () => {
+  it.each([
+    '/',
+    '/privacy',
+    '/terms',
+    '/health',
+    '/play/sky-dodge',
+    '/ay/sky-dodge',
+    '/ai/sky-dodge',
+    '/draft/space-runner',
+    '/status/tok-abc',
+    '/join/K7M3QP',
+  ])('treats %s as a known shell path (HTTP 200)', (path) => {
+    expect(isKnownSpaShellPath(path)).toBe(true);
+  });
+
+  it.each([
+    '/nope',
+    '/this/does/not/exist',
+    '/play/',
+    '/play/-bad',
+    '/play/Kotek%20W%20Cyrku',
+    '/draft/',
+    '/draft/..%2Fadmin',
+    '/health/brick-storm',
+    '/join/lower1',
+    '/join/TOOLONG9',
+    '/join/K7M3QP/extra',
+  ])('treats %s as unknown (HTTP 404)', (path) => {
+    expect(isKnownSpaShellPath(path)).toBe(false);
+  });
+});

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -1,0 +1,74 @@
+/**
+ * Which request paths are real SPA deep links (serve `index.html` with 200) vs
+ * unknown (serve `index.html` with **404**).
+ *
+ * Kept as a pure pathname check so the Cloud Run static fallback and Vite's
+ * dev server can share the same grammar. Must stay aligned with
+ * `apps/web/src/router.ts` (`parsePathRoute`) — except `/join/<code>`, which is
+ * treated as known here even without a fragment: the join token lives in the
+ * hash and never reaches the server (see docs/path-routing-plan.md § Join).
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
+const DRAFT_PATTERN = /^\/draft\/([^/]+)$/;
+const STATUS_PATTERN = /^\/status\/([^/]+)$/;
+const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
+/** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
+const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
+
+export function normalizePathname(urlOrPath: string): string {
+  const withoutQuery = urlOrPath.split('?')[0] ?? urlOrPath;
+  const pathname = withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+  // Trailing slash (other than `/`) is not a known route shape.
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+/**
+ * True when a missing static file should stay a hard JSON/plain 404 rather than
+ * the HTML shell. `/play/foo` has no extension; `/assets/missing.js` does.
+ */
+export function looksLikeStaticAsset(urlOrPath: string): boolean {
+  return STATIC_ASSET_PATTERN.test(normalizePathname(urlOrPath));
+}
+
+/**
+ * True when this path is a first-class SPA route that should boot with HTTP 200.
+ * Everything else that still wants the shell boots with HTTP 404 (proper 404,
+ * not a soft 200).
+ */
+export function isKnownSpaShellPath(urlOrPath: string): boolean {
+  const pathname = normalizePathname(urlOrPath);
+
+  if (pathname === '/') return true;
+  if (pathname === '/privacy' || pathname === '/terms' || pathname === '/health') return true;
+
+  const statusMatch = pathname.match(STATUS_PATTERN);
+  if (statusMatch?.[1]) return true;
+
+  const playMatch = pathname.match(PLAY_PREFIX_PATTERN);
+  if (playMatch?.[2]) {
+    try {
+      return SLUG_PATTERN.test(decodeURIComponent(playMatch[2]));
+    } catch {
+      return false;
+    }
+  }
+
+  const draftMatch = pathname.match(DRAFT_PATTERN);
+  if (draftMatch?.[1]) {
+    try {
+      return SLUG_PATTERN.test(decodeURIComponent(draftMatch[1]));
+    } catch {
+      return false;
+    }
+  }
+
+  // Fragment is not on the request line; `/join/ABC123` alone must still 200.
+  if (JOIN_PATTERN.test(pathname)) return true;
+
+  return false;
+}

--- a/apps/api/src/static-serving.test.ts
+++ b/apps/api/src/static-serving.test.ts
@@ -71,10 +71,25 @@ describe('static web serving', () => {
     expect(res.headers['cache-control']).toBe('no-cache');
   });
 
-  it('SPA fallback serves index.html with no-cache for unknown paths', async () => {
-    const res = await app.inject({ method: 'GET', url: '/some/spa/route' });
+  it('serves known SPA deep links as 200 + index.html', async () => {
+    const res = await app.inject({ method: 'GET', url: '/play/sky-dodge' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['cache-control']).toBe('no-cache');
+    expect(res.headers['content-type']).toMatch(/text\/html/);
     expect(res.body).toContain('gamedev.pl shell');
+  });
+
+  it('serves unknown paths as a proper HTTP 404 with the SPA shell', async () => {
+    const res = await app.inject({ method: 'GET', url: '/some/spa/route' });
+    expect(res.statusCode).toBe(404);
+    expect(res.headers['cache-control']).toBe('no-cache');
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.body).toContain('gamedev.pl shell');
+  });
+
+  it('keeps missing static assets as hard 404s, not the HTML shell', async () => {
+    const res = await app.inject({ method: 'GET', url: '/assets/missing-AbCd.js' });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).not.toContain('gamedev.pl shell');
   });
 });

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -116,6 +116,22 @@ describe('POST /api/telemetry/visit', () => {
     expect(response.statusCode).toBe(400);
   });
 
+  it('accepts the SPA notFound route kind', async () => {
+    const response = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [
+        { type: 'visit_started', entry: 'notFound', msSinceStart: 0 },
+        { type: 'route_viewed', route: 'notFound', msSinceStart: 10 },
+      ],
+    });
+    expect(response.statusCode).toBe(204);
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events.map((event) => event.type)).toEqual(['visit_started', 'route_viewed']);
+    expect(events[0]).toMatchObject({ type: 'visit_started', entry: 'notFound' });
+    expect(events[1]).toMatchObject({ type: 'route_viewed', route: 'notFound' });
+  });
+
   it('rejects acquisition values that could carry personal data', async () => {
     const response = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -125,7 +125,7 @@ describe('POST /api/telemetry/visit', () => {
         { type: 'route_viewed', route: 'notFound', msSinceStart: 10 },
       ],
     });
-    expect(response.statusCode).toBe(204);
+    expect(response.statusCode).toBe(202);
     const events = await store.listVisitEvents(today(), { visitId });
     expect(events.map((event) => event.type)).toEqual(['visit_started', 'route_viewed']);
     expect(events[0]).toMatchObject({ type: 'visit_started', entry: 'notFound' });

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -30,7 +30,7 @@ const MAX_VISIT_MS = 24 * 60 * 60 * 1000;
 /** How far back an event may be dated from its flush — bounds client-supplied offsets. */
 const MAX_BACKDATE_MS = 6 * 60 * 60 * 1000;
 
-const RouteKindSchema = z.enum(['home', 'play', 'draft', 'status', 'join', 'legal', 'health']);
+const RouteKindSchema = z.enum(['home', 'play', 'draft', 'status', 'join', 'legal', 'health', 'notFound']);
 /**
  * Creation-funnel steps. A closed enum rather than a free string, for the same reason
  * every other field here is bounded: this reaches a grouping key, and the endpoint is

--- a/apps/web/src/App.documentTitle.test.ts
+++ b/apps/web/src/App.documentTitle.test.ts
@@ -101,6 +101,13 @@ describe('document title follows navigation', () => {
     expect(document.title).toBe('Telemetry — Gamedev.pl');
 
     await act(async () => {
+      window.history.pushState(null, '', '/this-page-does-not-exist');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await flushEffects();
+    });
+    expect(document.title).toBe('Page not found — Gamedev.pl');
+
+    await act(async () => {
       window.history.pushState(null, '', '/');
       window.dispatchEvent(new PopStateEvent('popstate'));
       await flushEffects();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { SubmissionStatusView } from './SubmissionStatusView';
 import { CreatorQA, type QAQuestion } from './CreatorQA';
 import { canonicalPlayPath, NAVIGATE_EVENT, parsePathRoute, statusPath, playPath, type AppRoute } from './router';
 import { LegalPage } from './LegalPage';
+import { NotFoundPage } from './NotFoundPage';
 import { SiteFooter } from './SiteFooter';
 import { resolveDocumentTitle } from './pageTitle';
 import { useDocumentTitle } from './useDocumentTitle';
@@ -120,6 +121,7 @@ export function App() {
         health: t('pageTitle.health'),
         privacy: t('legal.privacy'),
         terms: t('legal.terms'),
+        notFound: t('pageTitle.notFound'),
         playNamed: t('pageTitle.playNamed'),
         draftNamed: t('pageTitle.draftNamed'),
         statusNamed: t('pageTitle.statusNamed'),
@@ -492,6 +494,24 @@ export function App() {
         />
         <main className="content">
           <LegalPage doc={route.doc} onBack={() => navigate('/')} />
+        </main>
+        <SiteFooter />
+      </div>
+    );
+  }
+
+  // Same early exit as legal: a typo'd URL should not bounce anonymous visitors into
+  // the closed-beta splash (or the home catalog) and pretend the path was valid.
+  if (route.view === 'notFound') {
+    return (
+      <div className="app app--not-found">
+        <NavHeader
+          activeSpecsCount={savedSpecs.length}
+          onNavigate={handleNavigateSection}
+          onHome={() => navigate('/')}
+        />
+        <main className="content">
+          <NotFoundPage onHome={() => navigate('/')} />
         </main>
         <SiteFooter />
       </div>

--- a/apps/web/src/NotFoundPage.test.tsx
+++ b/apps/web/src/NotFoundPage.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n';
+import { NotFoundPage } from './NotFoundPage';
+
+describe('NotFoundPage', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders the 404 copy and calls onHome from the CTA', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const onHome = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(NotFoundPage, { onHome }));
+    });
+
+    expect(container.querySelector('#not-found-title')?.textContent).toBe('Page not found');
+    expect(container.textContent).toContain("That link doesn't go anywhere on gamedev.pl");
+
+    const button = container.querySelector('button.not-found__home');
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onHome).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/NotFoundPage.tsx
+++ b/apps/web/src/NotFoundPage.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon';
+
+type NotFoundPageProps = {
+  onHome: () => void;
+};
+
+/**
+ * SPA catch-all for unknown / invalid paths. The API still serves `index.html` for
+ * these URLs (so refresh works); this is the client view that replaces the old
+ * silent fall-through to home.
+ */
+export function NotFoundPage({ onHome }: NotFoundPageProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section className="not-found" aria-labelledby="not-found-title">
+      <p className="not-found__code" aria-hidden="true">
+        404
+      </p>
+      <h1 id="not-found-title" className="not-found__title">
+        {t('notFound.title')}
+      </h1>
+      <p className="not-found__copy">{t('notFound.copy')}</p>
+      <button type="button" className="primary-btn not-found__home" onClick={onHome}>
+        <PixelIcon name="arrowRight" size={12} /> {t('notFound.home')}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -336,6 +336,11 @@
     "contents": "Contents",
     "effective": "In effect since {{date}}"
   },
+  "notFound": {
+    "title": "Page not found",
+    "copy": "That link doesn't go anywhere on gamedev.pl. It may be mistyped, or the page may have moved.",
+    "home": "Back to the catalog"
+  },
   "footer": {
     "legalNav": "Legal information",
     "reportIllegal": "Report illegal content",
@@ -410,6 +415,7 @@
     "draft": "A game in the making",
     "join": "Join the game",
     "health": "Telemetry",
+    "notFound": "Page not found",
     "playNamed": "Play {{title}}",
     "draftNamed": "Draft {{title}}",
     "statusNamed": "Status · {{title}}"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -336,6 +336,11 @@
     "contents": "Spis treści",
     "effective": "Obowiązuje od {{date}}"
   },
+  "notFound": {
+    "title": "Nie znaleziono strony",
+    "copy": "Ten link nie prowadzi nigdzie na gamedev.pl. Może być literówka, albo strona została przeniesiona.",
+    "home": "Wróć do katalogu"
+  },
   "footer": {
     "legalNav": "Informacje prawne",
     "reportIllegal": "Zgłoś nielegalne treści",
@@ -410,6 +415,7 @@
     "draft": "Gra w trakcie tworzenia",
     "join": "Dołącz do gry",
     "health": "Telemetria",
+    "notFound": "Nie znaleziono strony",
     "playNamed": "Graj: {{title}}",
     "draftNamed": "Szkic: {{title}}",
     "statusNamed": "Status · {{title}}"

--- a/apps/web/src/mp/protocol.test.ts
+++ b/apps/web/src/mp/protocol.test.ts
@@ -73,11 +73,11 @@ describe('join route', () => {
     });
   });
 
-  it('falls back home for malformed join links', () => {
-    expect(parsePathRoute('/join/lower1', '#token')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/TOOLONG9', '#token')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/K7M3QP')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/K7M3QP/tok/en')).toEqual({ view: 'home' });
+  it('maps malformed join links to notFound', () => {
+    expect(parsePathRoute('/join/lower1', '#token')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/TOOLONG9', '#token')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/K7M3QP')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/K7M3QP/tok/en')).toEqual({ view: 'notFound' });
   });
 
   it('still parses the existing routes', () => {

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -15,6 +15,7 @@ const copy: DocumentTitleCopy = {
   health: 'Telemetry',
   privacy: 'Privacy Policy',
   terms: 'Terms of Service',
+  notFound: 'Page not found',
   playNamed: 'Play {{title}}',
   draftNamed: 'Draft {{title}}',
   statusNamed: 'Status · {{title}}',
@@ -86,5 +87,6 @@ describe('resolveDocumentTitle', () => {
     expect(resolveDocumentTitle({ view: 'health' }, { copy })).toBe('Telemetry — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'legal', doc: 'privacy' }, { copy })).toBe('Privacy Policy — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'legal', doc: 'terms' }, { copy })).toBe('Terms of Service — Gamedev.pl');
+    expect(resolveDocumentTitle({ view: 'notFound' }, { copy })).toBe('Page not found — Gamedev.pl');
   });
 });

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -32,6 +32,7 @@ export type DocumentTitleCopy = {
   health: string;
   privacy: string;
   terms: string;
+  notFound: string;
   /** Prefixed template for a playable game name, e.g. "Play {{title}}". */
   playNamed: string;
   /** Prefixed template for a draft's real name, e.g. "Draft {{title}}". */
@@ -76,6 +77,8 @@ export function resolveDocumentTitle(route: AppRoute, ctx: DocumentTitleContext)
       return brandedPageTitle(ctx.copy.health);
     case 'legal':
       return brandedPageTitle(route.doc === 'privacy' ? ctx.copy.privacy : ctx.copy.terms);
+    case 'notFound':
+      return brandedPageTitle(ctx.copy.notFound);
   }
 }
 

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -28,22 +28,22 @@ describe('parsePathRoute', () => {
   it('accepts /ay and /ai as play aliases', () => {
     expect(parsePathRoute('/ay/sky-dodge')).toEqual({ view: 'play', slug: 'sky-dodge' });
     expect(parsePathRoute('/ai/sky-dodge')).toEqual({ view: 'play', slug: 'sky-dodge' });
-    expect(parsePathRoute('/ay/-bad')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/ai/')).toEqual({ view: 'home' });
+    expect(parsePathRoute('/ay/-bad')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/ai/')).toEqual({ view: 'notFound' });
   });
 
   it('rejects non-slug play paths', () => {
-    expect(parsePathRoute('/play/Kotek W Cyrku')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/play/..%2Fadmin')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/play/a/b')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/play/-bad')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/play/')).toEqual({ view: 'home' });
+    expect(parsePathRoute('/play/Kotek W Cyrku')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/play/..%2Fadmin')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/play/a/b')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/play/-bad')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/play/')).toEqual({ view: 'notFound' });
   });
 
   it('parses a draft permalink and rejects non-slugs', () => {
     expect(parsePathRoute('/draft/space-runner')).toEqual({ view: 'draft', slug: 'space-runner' });
-    expect(parsePathRoute('/draft/..%2Fadmin')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/draft/')).toEqual({ view: 'home' });
+    expect(parsePathRoute('/draft/..%2Fadmin')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/draft/')).toEqual({ view: 'notFound' });
   });
 
   it('parses a hybrid join link (code in path, token in fragment)', () => {
@@ -59,22 +59,23 @@ describe('parsePathRoute', () => {
     });
   });
 
-  it('falls back home for malformed join links', () => {
-    expect(parsePathRoute('/join/lower1', '#token')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/TOOLONG9', '#token')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/K7M3QP')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/K7M3QP/tok/en')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/join/K7M3QP/abc-DEF_123')).toEqual({ view: 'home' });
+  it('maps malformed join links to notFound', () => {
+    expect(parsePathRoute('/join/lower1', '#token')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/TOOLONG9', '#token')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/K7M3QP')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/K7M3QP/tok/en')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/join/K7M3QP/abc-DEF_123')).toEqual({ view: 'notFound' });
   });
 
   it('parses the unlisted health route', () => {
     expect(parsePathRoute('/health')).toEqual({ view: 'health' });
     // Trailing segments are not the health view.
-    expect(parsePathRoute('/health/brick-storm')).toEqual({ view: 'home' });
+    expect(parsePathRoute('/health/brick-storm')).toEqual({ view: 'notFound' });
   });
 
-  it('falls back to home for unknown paths', () => {
-    expect(parsePathRoute('/nope')).toEqual({ view: 'home' });
+  it('maps unknown paths to notFound', () => {
+    expect(parsePathRoute('/nope')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/this/does/not/exist')).toEqual({ view: 'notFound' });
   });
 
   it('parses the legal routes', () => {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -22,7 +22,10 @@ export type AppRoute =
   | { view: 'health' }
   // Privacy policy and terms. Reachable without a session — someone deciding whether
   // to sign in has to be able to read what signing in would mean first.
-  | { view: 'legal'; doc: LegalDocId };
+  | { view: 'legal'; doc: LegalDocId }
+  // Unknown / invalid path. Kept as its own view so a typo or stale bookmark shows a
+  // real 404 instead of silently dumping the visitor on the home catalog.
+  | { view: 'notFound' };
 
 // Game slugs are lowercase kebab-case (matches the games-repo catalog); keep the
 // route pattern strict so arbitrary path segments can't masquerade as a play route.
@@ -34,7 +37,7 @@ const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
 
 /**
  * Parse the SPA route from pathname (+ optional hash for the join credential).
- * Unknown / invalid paths fall back to home.
+ * Unknown / invalid paths become `notFound` (not home) so the URL stays visible.
  */
 export function parsePathRoute(pathname: string, hash = ''): AppRoute {
   const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
@@ -83,7 +86,7 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     return { view: 'join', code: joinMatch[1], token: fragment };
   }
 
-  return { view: 'home' };
+  return { view: 'notFound' };
 }
 
 export function statusPath(token: string): string {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3848,6 +3848,47 @@ body.player-open {
 
 /* Legal documents ---------------------------------------------------------- */
 
+.not-found {
+  max-width: 28rem;
+  margin: 4rem auto 2rem;
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.not-found__code {
+  margin: 0 0 0.5rem;
+  font-size: clamp(3.5rem, 12vw, 5.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--turquoise);
+  opacity: 0.85;
+}
+
+.not-found__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 4vw, 1.85rem);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.not-found__copy {
+  margin: 0 0 1.75rem;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.not-found__home {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.7rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .legal-page {
   max-width: 52rem;
   margin: 0 auto;

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -113,6 +113,7 @@ describe('route kinds follow the real router', () => {
     ['/terms', 'legal'],
     ['/status/some-token', 'status'],
     ['/health', 'health'],
+    ['/nope', 'notFound'],
   ])('reads %s as %s', (pathname, expected) => {
     expect(routeKind(parsePathRoute(pathname, '').view)).toBe(expected);
   });

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -26,7 +26,7 @@ const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
  */
 
 /** Where a visit is, coarsely. Route parameters (tokens, slugs) never travel. */
-export type VisitRouteKind = 'home' | 'play' | 'draft' | 'status' | 'join' | 'legal' | 'health';
+export type VisitRouteKind = 'home' | 'play' | 'draft' | 'status' | 'join' | 'legal' | 'health' | 'notFound';
 
 export type VisitEvent =
   | {
@@ -165,6 +165,7 @@ export function routeKind(view: string): VisitRouteKind {
     case 'join':
     case 'legal':
     case 'health':
+    case 'notFound':
       return view;
     default:
       return 'home';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,72 @@
 import react from '@vitejs/plugin-react';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
+import { isKnownSpaShellPath, looksLikeStaticAsset } from '../api/src/spa-paths.ts';
 
 const apiTarget = process.env.VITE_API_TARGET ?? 'http://127.0.0.1:3001';
 
+type WriteHead = ServerResponse['writeHead'];
+
+/**
+ * Vite's default SPA fallback always answers 200. Mirror production: known deep
+ * links stay 200, unknown paths get a proper HTTP 404 while still serving the
+ * transformed `index.html` so the client NotFound page boots.
+ *
+ * Implemented by forcing the status on the response for unknown document
+ * navigations — Vite still rewrites the URL to `/index.html` and transforms it.
+ */
+function spaProper404(): Plugin {
+  return {
+    name: 'spa-proper-404',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.method !== 'GET' && req.method !== 'HEAD') {
+          next();
+          return;
+        }
+
+        const pathname = pathnameOf(req);
+        if (isViteInternal(pathname) || looksLikeStaticAsset(pathname) || isKnownSpaShellPath(pathname)) {
+          next();
+          return;
+        }
+
+        forceStatus(res, 404);
+        next();
+      });
+    },
+  };
+}
+
+function pathnameOf(req: IncomingMessage): string {
+  return (req.url ?? '/').split('?')[0] ?? '/';
+}
+
+function isViteInternal(pathname: string): boolean {
+  return (
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/@') ||
+    pathname.startsWith('/node_modules') ||
+    pathname.startsWith('/src') ||
+    pathname.startsWith('/__') ||
+    pathname === '/index.html'
+  );
+}
+
+/** Ensure later `writeHead(200)` / default 200 from the HTML middleware become 404. */
+function forceStatus(res: ServerResponse, status: number): void {
+  res.statusCode = status;
+
+  const originalWriteHead = res.writeHead.bind(res) as WriteHead;
+  res.writeHead = ((code: number, ...rest: unknown[]) => {
+    const forced = code === 200 ? status : code;
+    return (originalWriteHead as (...args: unknown[]) => ServerResponse)(forced, ...rest);
+  }) as WriteHead;
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), spaProper404()],
   server: {
     port: 5173,
     proxy: {

--- a/docs/path-routing-plan.md
+++ b/docs/path-routing-plan.md
@@ -75,7 +75,8 @@ No `/game/` segment — everything playable is a game; `/play` (and the `/ay` /
 `/ai` aliases) is enough. Emitters always write `/play/<slug>`.
 
 Slug validation stays as today: lowercase kebab-case only
-(`^[a-z0-9]+(?:-[a-z0-9]+)*$`). Unknown / invalid paths → home (same as today).
+(`^[a-z0-9]+(?:-[a-z0-9]+)*$`). Unknown / invalid paths → `{ view: 'notFound' }`
+(a dedicated 404 page — not a silent redirect to home).
 
 **Reserved:** anything under `/api/*` is the API. Do not add SPA routes that collide with
 static files (`/assets/*`, `/icons/*`, `/sw.js`, `/offline.html`, …).

--- a/docs/path-routing-plan.md
+++ b/docs/path-routing-plan.md
@@ -78,6 +78,13 @@ Slug validation stays as today: lowercase kebab-case only
 (`^[a-z0-9]+(?:-[a-z0-9]+)*$`). Unknown / invalid paths → `{ view: 'notFound' }`
 (a dedicated 404 page — not a silent redirect to home).
 
+**HTTP status (proper 404, not soft):** the document request for an unknown path
+answers **404** while still serving `index.html`, so crawlers and `curl -I` see a
+real miss and the SPA can still render `NotFoundPage`. Known deep links
+(`/play/<slug>`, `/status/<token>`, `/join/<code>`, …) stay **200**. Missing
+extension-bearing files (`/assets/…`, `/sw.js`) stay hard 404s without the HTML
+shell. See `apps/api/src/spa-paths.ts` (also wired into Vite for local dev).
+
 **Reserved:** anything under `/api/*` is the API. Do not add SPA routes that collide with
 static files (`/assets/*`, `/icons/*`, `/sw.js`, `/offline.html`, …).
 
@@ -102,9 +109,11 @@ This keeps the existing `AppRoute` type and all the stage/theater effects that k
 
 ### Vite / Cloud Run
 
-- **Dev:** Vite already serves `index.html` for unmatched paths; no config change expected.
-- **Prod:** SPA fallback already exists. Update the comment that claims the app is
-  hash-routed; behaviour stays "non-`/api` GET → `index.html`".
+- **Dev:** Vite plugin `spa-proper-404` mirrors production status codes (known deep
+  links → 200, unknown → 404 + shell).
+- **Prod:** Fastify `setNotFoundHandler` uses `isKnownSpaShellPath` /
+  `looksLikeStaticAsset` (`apps/api/src/spa-paths.ts`) so unknown paths are proper
+  HTTP 404s with `index.html`, not soft 200s.
 - **Canonical host redirect** already preserves path + query (`canonical-host.test.ts`).
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Unknown and invalid SPA paths resolve to a dedicated `notFound` view (EN/PL) instead of silently falling through to home.
- **Proper HTTP 404** (not soft): document requests for unknown paths answer **404** while still serving `index.html`, so crawlers/`curl -I` see a real miss and the SPA can render `NotFoundPage`. Known deep links stay **200**.
- Shared path grammar in `apps/api/src/spa-paths.ts`, wired into Fastify’s SPA fallback and Vite’s dev server. Missing extension-bearing assets stay hard 404s (no HTML shell).
- Visit-telemetry accepts the `notFound` route kind.

## Test plan
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5173/nope` → `404` (HTML body still the shell)
- [x] `curl … /play/sky-dodge` → `200`; `/privacy` → `200`; `/play/-bad` → `404`
- [x] Manual: `/nope` shows the 404 page; home CTA works; `/privacy` unchanged

[404 page at /nope](https://cursor.com/agents/bc-019f9e91-3097-75c0-8186-9836bbfadcf1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F404-page-nope.webp)
[404 for invalid play slug](https://cursor.com/agents/bc-019f9e91-3097-75c0-8186-9836bbfadcf1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F404-page-invalid-play.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9e91-3097-75c0-8186-9836bbfadcf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9e91-3097-75c0-8186-9836bbfadcf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

