### PR TITLE
perf(web): lazy-load catalog preview media below the fold

### DIFF
--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArcadeCatalog } from './ArcadeCatalog';
+import type { CatalogEntry } from './catalog';
+import i18n from './i18n';
+
+type ObserverInstance = {
+  callback: IntersectionObserverCallback;
+  observe: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  targets: Element[];
+};
+
+let observers: ObserverInstance[];
+
+function installIntersectionObserverMock() {
+  observers = [];
+  class MockIntersectionObserver {
+    callback: IntersectionObserverCallback;
+    observe = vi.fn((target: Element) => {
+      this.targets.push(target);
+    });
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    targets: Element[] = [];
+    root = null;
+    rootMargin = '';
+    thresholds = [];
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+}
+
+function intersect(observer: ObserverInstance, target: Element, isIntersecting: boolean) {
+  observer.callback(
+    [
+      {
+        isIntersecting,
+        target,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        time: 0,
+        boundingClientRect: {} as DOMRectReadOnly,
+        intersectionRect: {} as DOMRectReadOnly,
+        rootBounds: null,
+      },
+    ],
+    observer as unknown as IntersectionObserver,
+  );
+}
+
+const entries: CatalogEntry[] = [
+  {
+    slug: 'above-fold',
+    title: 'Above Fold',
+    genre: 'Arcade',
+    controls: 'Arrow keys',
+    status: 'published',
+    media: {
+      screenshots: [
+        { name: 'opening', file: 'opening.png' },
+        { name: 'mid', file: 'mid.png' },
+      ],
+      video: 'gameplay.mp4',
+    },
+    multiplayer: null,
+    orientation: 'any',
+  },
+  {
+    slug: 'below-fold',
+    title: 'Below Fold',
+    genre: 'Puzzle',
+    controls: 'Mouse',
+    status: 'published',
+    media: {
+      screenshots: [
+        { name: 'opening', file: 'opening.png' },
+        { name: 'win', file: 'win.png' },
+      ],
+      video: 'preview.mp4',
+    },
+    multiplayer: null,
+    orientation: 'any',
+  },
+];
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('ArcadeCatalog lazy media', () => {
+  beforeEach(async () => {
+    installIntersectionObserverMock();
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not attach image or video sources until a card enters the viewport', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelectorAll('video')).toHaveLength(0);
+    expect(container.querySelectorAll('img.catalog-preview')).toHaveLength(0);
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
+    expect(observers).toHaveLength(2);
+
+    const firstMedia = container.querySelectorAll('.catalog-media')[0]!;
+    await act(async () => {
+      intersect(observers[0]!, firstMedia, true);
+      await flushEffects();
+    });
+
+    const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
+    expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/opening.png');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+
+    // The second card still has no media srcs — it never intersected.
+    expect(container.querySelectorAll('video')).toHaveLength(1);
+    expect(container.querySelectorAll('.catalog-moment img')).toHaveLength(2);
+    const momentSrcs = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')].map((img) => img.src);
+    expect(momentSrcs.every((src) => src.includes('/api/games/above-fold/'))).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { catalogMediaUrl, type CatalogEntry } from './catalog';
 import { PixelIcon } from './PixelIcon';
+import { useInView } from './useInView';
 
 type ArcadeCatalogProps = {
   catalogStatus: 'loading' | 'ready' | 'error';
@@ -30,13 +31,17 @@ function CatalogCard({
 }) {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
+  // Defer preview media until the card is near the viewport — below-fold cards
+  // must not fetch posters/videos on initial home load.
+  const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '200px 0px', once: true });
   const [selectedScreenshot, setSelectedScreenshot] = useState(0);
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const [isPreviewPinned, setIsPreviewPinned] = useState(false);
   const screenshots = entry.media?.screenshots ?? [];
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
-  const posterUrl = selected ? catalogMediaUrl(entry.slug, selected.file) : undefined;
-  const videoUrl = entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
+  const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
+  const videoUrl = entry.media?.video && inView ? catalogMediaUrl(entry.slug, entry.media.video) : null;
+  const hasVideo = Boolean(entry.media?.video);
 
   function playPreview() {
     const video = videoRef.current;
@@ -76,31 +81,32 @@ function CatalogCard({
   return (
     <article className="catalog-card">
       <div
+        ref={mediaRef}
         className="catalog-media"
-        tabIndex={videoUrl ? 0 : undefined}
+        tabIndex={hasVideo ? 0 : undefined}
         onPointerEnter={
-          videoUrl
+          hasVideo
             ? (event) => {
                 if (event.pointerType === 'mouse') playPreview();
               }
             : undefined
         }
         onPointerLeave={
-          videoUrl
+          hasVideo
             ? (event) => {
                 if (event.pointerType === 'mouse' && !isPreviewPinned) pausePreview(true);
               }
             : undefined
         }
         onFocus={
-          videoUrl
+          hasVideo
             ? (event) => {
                 if (event.target === event.currentTarget) playPreview();
               }
             : undefined
         }
         onBlur={
-          videoUrl
+          hasVideo
             ? (event) => {
                 if (!event.currentTarget.contains(event.relatedTarget)) {
                   setIsPreviewPinned(false);
@@ -126,7 +132,13 @@ function CatalogCard({
             onPause={() => setIsPreviewPlaying(false)}
           />
         ) : posterUrl ? (
-          <img className="catalog-preview" src={posterUrl} alt={t('catalog.previewImage', { title: entry.title })} />
+          <img
+            className="catalog-preview"
+            src={posterUrl}
+            alt={t('catalog.previewImage', { title: entry.title })}
+            loading="lazy"
+            decoding="async"
+          />
         ) : (
           <div className="catalog-preview-fallback" aria-hidden="true">
             <span>{entry.title.charAt(0)}</span>
@@ -142,8 +154,14 @@ function CatalogCard({
             one and can wrap; a magic number here would work in one locale and not
             the other. */}
         <div className="catalog-badges-top-left">
-          {videoUrl && (
-            <button type="button" className="preview-toggle" aria-pressed={isPreviewPlaying} onClick={togglePreview}>
+          {hasVideo && (
+            <button
+              type="button"
+              className="preview-toggle"
+              aria-pressed={isPreviewPlaying}
+              disabled={!inView}
+              onClick={togglePreview}
+            >
               {isPreviewPlaying ? (
                 <>
                   <PixelIcon name="pause" size={11} /> {t('catalog.pausePreview')}
@@ -167,7 +185,7 @@ function CatalogCard({
 
         <span className="genre-pill">{entry.genre}</span>
 
-        {screenshots.length > 1 && (
+        {inView && screenshots.length > 1 && (
           <div className="catalog-moments" aria-label={t('catalog.gameMoments', { title: entry.title })}>
             {screenshots.slice(0, 4).map((screenshot, index) => (
               <button
@@ -178,7 +196,7 @@ function CatalogCard({
                 aria-pressed={index === selectedScreenshot}
                 onClick={() => selectScreenshot(index)}
               >
-                <img src={catalogMediaUrl(entry.slug, screenshot.file)} alt="" loading="lazy" />
+                <img src={catalogMediaUrl(entry.slug, screenshot.file)} alt="" loading="lazy" decoding="async" />
               </button>
             ))}
           </div>

--- a/apps/web/src/useInView.test.ts
+++ b/apps/web/src/useInView.test.ts
@@ -133,4 +133,66 @@ describe('useInView', () => {
       root.unmount();
     });
   });
+
+  it('keeps a single observer alive when once is false and visibility toggles', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, once: false }));
+      await flushEffects();
+    });
+
+    expect(observers).toHaveLength(1);
+    const target = container.querySelector('[data-testid="target"]')!;
+    const observer = observers[0]!;
+
+    await act(async () => {
+      observer.callback(
+        [
+          {
+            isIntersecting: true,
+            target,
+            intersectionRatio: 1,
+            time: 0,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+          },
+        ],
+        observer as unknown as IntersectionObserver,
+      );
+      await flushEffects();
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+    expect(observers).toHaveLength(1);
+    expect(observer.disconnect).not.toHaveBeenCalled();
+
+    await act(async () => {
+      observer.callback(
+        [
+          {
+            isIntersecting: false,
+            target,
+            intersectionRatio: 0,
+            time: 0,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+          },
+        ],
+        observer as unknown as IntersectionObserver,
+      );
+      await flushEffects();
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    expect(observers).toHaveLength(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/apps/web/src/useInView.test.ts
+++ b/apps/web/src/useInView.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useInView } from './useInView';
+
+type ObserverInstance = {
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  observe: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  unobserve: ReturnType<typeof vi.fn>;
+};
+
+let observers: ObserverInstance[];
+
+function installIntersectionObserverMock() {
+  observers = [];
+  class MockIntersectionObserver {
+    callback: IntersectionObserverCallback;
+    options?: IntersectionObserverInit;
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    root = null;
+    rootMargin = '';
+    thresholds = [];
+
+    constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+      this.callback = callback;
+      this.options = options;
+      observers.push(this);
+    }
+
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+}
+
+function Probe({
+  onChange,
+  once,
+}: {
+  onChange: (inView: boolean) => void;
+  once?: boolean;
+}) {
+  const { ref, inView } = useInView({ once });
+  useEffect(() => {
+    onChange(inView);
+  }, [inView, onChange]);
+  return createElement('div', { ref, 'data-testid': 'target' });
+}
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('useInView', () => {
+  beforeEach(() => {
+    installIntersectionObserverMock();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('starts false and becomes true when the observed element intersects', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange }));
+      await flushEffects();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.options?.rootMargin).toBe('200px 0px');
+    expect(observers[0]?.observe).toHaveBeenCalled();
+
+    await act(async () => {
+      observers[0]?.callback(
+        [
+          {
+            isIntersecting: true,
+            target: container.querySelector('[data-testid="target"]')!,
+            intersectionRatio: 1,
+            time: 0,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+          },
+        ],
+        observers[0] as unknown as IntersectionObserver,
+      );
+      await flushEffects();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(true);
+    expect(observers[0]?.disconnect).toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('falls back to inView when IntersectionObserver is missing', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange }));
+      await flushEffects();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/useInView.ts
+++ b/apps/web/src/useInView.ts
@@ -20,7 +20,7 @@ export function useInView<T extends Element = HTMLElement>(
 
   useEffect(() => {
     const el = ref.current;
-    if (!el || (once && inView)) return;
+    if (!el) return;
 
     // jsdom and very old browsers: load eagerly rather than strand media forever.
     if (typeof IntersectionObserver === 'undefined') {
@@ -36,6 +36,8 @@ export function useInView<T extends Element = HTMLElement>(
             continue;
           }
           setInView(true);
+          // Sticky mode: stop observing after the first hit so we don't churn
+          // and don't unload media when the card scrolls away.
           if (once) observer.disconnect();
         }
       },
@@ -44,7 +46,10 @@ export function useInView<T extends Element = HTMLElement>(
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [rootMargin, once, inView]);
+    // Intentionally omit `inView`: the observer callback owns that state. Putting
+    // it in deps would tear down and recreate the observer on every toggle when
+    // `once` is false.
+  }, [rootMargin, once]);
 
   return { ref, inView };
 }

--- a/apps/web/src/useInView.ts
+++ b/apps/web/src/useInView.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+export type UseInViewOptions = {
+  /** Expand the root intersection box so media can prefetch before it enters view. */
+  rootMargin?: string;
+  /** Once true, stay true — catalog media should not unload after scrolling away. */
+  once?: boolean;
+};
+
+/**
+ * Observe whether an element intersects the viewport (or is about to).
+ * Used to defer catalog preview images/videos until a card is near the fold.
+ */
+export function useInView<T extends Element = HTMLElement>(
+  options: UseInViewOptions = {},
+): { ref: RefObject<T>; inView: boolean } {
+  const { rootMargin = '200px 0px', once = true } = options;
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || (once && inView)) return;
+
+    // jsdom and very old browsers: load eagerly rather than strand media forever.
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) {
+            if (!once) setInView(false);
+            continue;
+          }
+          setInView(true);
+          if (once) observer.disconnect();
+        }
+      },
+      { rootMargin, threshold: 0 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootMargin, once, inView]);
+
+  return { ref, inView };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Home catalog cards were attaching every game’s preview `video`/`img` sources on first paint, so below-the-fold media competed with above-the-fold load.

- Add a small `useInView` IntersectionObserver hook (200px root margin, sticky once visible)
- Catalog cards only set poster/video/moment `src` after the card is near the viewport
- Placeholder fallback keeps card layout until media loads
- No new dependency — keeps the web package lean vs. pulling in `react-intersection-observer`

## Follow-up

Addressed Copilot review: `inView` is no longer an effect dependency, so `once: false` keeps a single observer across visibility toggles.

## Test plan

- [x] Unit: `useInView` intersects / missing-IO fallback
- [x] Unit: `useInView` keeps one observer when `once: false` toggles
- [x] Unit: ArcadeCatalog does not attach media until intersect
- [x] Existing App catalog playback tests still pass
- [x] Green gate: type-check, lint, test (relevant suites)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39612984-4b53-46dc-93dc-3e99c407950b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39612984-4b53-46dc-93dc-3e99c407950b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

