### PR TITLE
feat(legal): grant creators a licence to their generated game, and stop suggesting Mario

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -42,7 +42,7 @@
   "hero": {
     "mainTitle": "Turn any idea into a playable web game",
     "mainSubtitle": "Type what you want to play or build. AI agents code, test, and host it live.",
-    "bigPromptPlaceholder": "Type what you want to play or build... (e.g. mario, space shooter, dodge falling rocks, cyberpunk rhythm game)",
+    "bigPromptPlaceholder": "Type what you want to play or build... (e.g. a platformer, space shooter, dodge falling rocks, cyberpunk rhythm game)",
     "buildGameButton": "Build My Game",
     "instantMockButton": "Quick Local Mock",
     "smartFoundTitle": "Found matching game: {{title}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -42,7 +42,7 @@
   "hero": {
     "mainTitle": "Zamień dowolny pomysł w grywalną grę",
     "mainSubtitle": "Wpisz w co chcesz zagrać lub co stworzyć. Agenty AI napiszą kod, przetestują i opublikują grę na żywo.",
-    "bigPromptPlaceholder": "Wpisz w co chcesz zagrać lub co stworzyć... (np. mario, strzelanka kosmiczna, unikaj spadających skał)",
+    "bigPromptPlaceholder": "Wpisz w co chcesz zagrać lub co stworzyć... (np. platformówka, strzelanka kosmiczna, unikaj spadających skał)",
     "buildGameButton": "Stwórz Moją Grę",
     "instantMockButton": "Szybki Lokalny Podgląd",
     "smartFoundTitle": "Znaleziono pasującą grę: {{title}}",

--- a/apps/web/src/legal/operator.ts
+++ b/apps/web/src/legal/operator.ts
@@ -68,4 +68,4 @@ export const SERVICE_URL = 'https://www.gamedev.pl';
  * Date both documents took effect. Bump on any substantive change, and tell users
  * before it takes effect (the terms promise 14 days' notice).
  */
-export const LEGAL_EFFECTIVE_DATE = '2026-07-25';
+export const LEGAL_EFFECTIVE_DATE = '2026-07-26';

--- a/apps/web/src/legal/terms.en.ts
+++ b/apps/web/src/legal/terms.en.ts
@@ -252,6 +252,14 @@ export const termsEn: LegalDocument = {
         {
           kind: 'p',
           text:
+            'Regardless of the above: to the extent the Provider holds any rights in the game code generated from ' +
+            'your description, the Provider grants you a free, non-exclusive, worldwide and perpetual licence to ' +
+            'use that code for any purpose, including commercially, together with the right to modify it and pass ' +
+            'it on. This licence does not cover the gamedev.pl name or logo, or third-party material.',
+        },
+        {
+          kind: 'p',
+          text:
             'You may play games published in the Service for your own use. The games repository is not currently ' +
             'public; should the Provider release it under an open licence, it will announce this in the Service.',
         },

--- a/apps/web/src/legal/terms.pl.ts
+++ b/apps/web/src/legal/terms.pl.ts
@@ -264,6 +264,15 @@ export const termsPl: LegalDocument = {
         {
           kind: 'p',
           text:
+            'Niezależnie od powyższego: w zakresie, w jakim Usługodawcy przysługują jakiekolwiek prawa do kodu gry ' +
+            'wygenerowanego na podstawie Twojego opisu, Usługodawca udziela Ci nieodpłatnej, niewyłącznej, ' +
+            'nieograniczonej terytorialnie i bezterminowej licencji na korzystanie z tego kodu w dowolnym celu, ' +
+            'w tym komercyjnym, wraz z prawem do jego modyfikowania i dalszego udostępniania. Licencja ta nie ' +
+            'obejmuje nazwy ani logo gamedev.pl, a także treści pochodzących od osób trzecich.',
+        },
+        {
+          kind: 'p',
+          text:
             'Możesz grać w gry opublikowane w Serwisie na własny użytek. Repozytorium gier nie jest obecnie ' +
             'publiczne; jeśli Usługodawca udostępni je na licencji otwartej, poinformuje o tym w Serwisie.',
         },


### PR DESCRIPTION
Two gaps between what the product promises and what the terms actually grant, both found while auditing authorship/copyright coverage.

## 1. Creators had no rights in "their" game

The UI says **Stwórz Moją Grę** and files results under **Twoje gry**, but section 9 granted the creator nothing in the generated code — not to download, reuse, port, or take it elsewhere. On paper they had permission to play it here and nothing more. That gap between marketing language and the regulamin is the classic route into Poland's abusive-clause register.

Section 9 now grants a free, non-exclusive, worldwide, perpetual licence to use the generated code for any purpose including commercially, with rights to modify and redistribute.

Phrased as *"to the extent the Provider holds any rights"* deliberately: the paragraph directly above refuses to say who owns AI output, because Polish law protects only human creative activity (art. 1 pr. aut.) and the question is unsettled. A flat grant would contradict that by implying rights we may not have. The conditional form gives away everything we might hold without asserting we hold it. The gamedev.pl name/logo and third-party material stay carved out.

## 2. The prompt placeholder suggested "mario"

Both locales shipped `np. mario, …`. The terms forbid *users* from submitting infringing content, while the operator's own UI proposed the infringing prompt and published the result on the operator's domain. Moderation screens `profanity, adult, violence, pii, injection` — nothing looks at third-party IP. Now suggests a platformer / platformówka.

**Left alone deliberately:** the `mario` → `plumber` alias in `findMatchingGame`. It steers that query to an existing catalog game rather than generating a lookalike, so removing it would make the outcome worse.

## Notes

- Effective date moves to 2026-07-26. The amendment is **purely in the user's favour**, so the 14-day notice in section 13 — which exists to protect users from adverse change — is not engaged. Worth a look if you disagree.
- Still outstanding from the earlier audit, unchanged by this PR: no allocation of infringement risk if generated output reproduces protected material. Suggest folding into the pending lawyer review.

## Verification

223 web tests pass (including the PL/EN structural parity guard), type-check clean, Prettier clean. Both documents rendered and read in-browser in Polish and English; new clause and placeholder confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)