### PR TITLE
docs(api): reflect that the games repo retired SPEC status

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -344,6 +344,36 @@ describe('getCatalog', () => {
     ]);
   });
 
+  it('publishes a game whose entry claims no status, and honours a withdrawal', async () => {
+    // The games repo stopped authoring `status` — merging a game publishes it, and a
+    // spec speaks up only to withdraw itself. An entry with no status must therefore
+    // reach visitors, or retiring the field would empty the site. `/api/catalog` keeps
+    // only `published`, so `archived` surviving verbatim is what takes a game off it.
+    const committed = [
+      { slug: 'silent', title: 'Silent' },
+      { slug: 'retired', title: 'Retired', status: 'archived' },
+      { slug: 'off', title: 'Off', status: 'disabled' },
+      // A stale artifact written before the change still carries the old default.
+      { slug: 'legacy', title: 'Legacy', status: 'draft' },
+    ];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/contents/catalog.json')) {
+        return new Response(JSON.stringify(committed), { status: 200 });
+      }
+      throw new Error('unexpected request');
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+    const catalog = await client.getCatalog('main');
+
+    expect(catalog.map((entry) => [entry.slug, entry.status])).toEqual([
+      ['silent', 'published'],
+      ['retired', 'archived'],
+      ['off', 'disabled'],
+      ['legacy', 'published'],
+    ]);
+  });
+
   it('falls back rather than blanking the site when no committed entry is usable', async () => {
     // A schema change in the games repo (a renamed field, say) would leave a valid
     // JSON array whose every row fails validation. Serving that as an empty catalog

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -347,8 +347,13 @@ describe('getCatalog', () => {
   it('publishes a game whose entry claims no status, and honours a withdrawal', async () => {
     // The games repo stopped authoring `status` — merging a game publishes it, and a
     // spec speaks up only to withdraw itself. An entry with no status must therefore
-    // reach visitors, or retiring the field would empty the site. `/api/catalog` keeps
-    // only `published`, so `archived` surviving verbatim is what takes a game off it.
+    // resolve to `published`, or retiring the field would empty the site.
+    //
+    // Withdrawal is decided one layer up, not here: `getCatalog` reports every game
+    // it read, and the `/api/catalog` route is what keeps only `published`. So
+    // `archived`/`disabled` surviving this call *verbatim* is exactly what lets that
+    // filter drop them — flattening them to `published` here would put them back on
+    // the site. Hence the assertions below expect all four entries back.
     const committed = [
       { slug: 'silent', title: 'Silent' },
       { slug: 'retired', title: 'Retired', status: 'archived' },

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -867,6 +867,8 @@ ${gameJs}`;
         if (!title) {
           continue;
         }
+        // A spec with no status is published — merging it is what publishes it.
+        // Only an explicit archived/disabled withdraws a game from the site.
         const rawStatus = frontmatter.status ?? '';
         const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
         const mediaMetadata = status === 'published' ? (files.get(`games/${slug}/media/metadata.json`) ?? null) : null;
@@ -918,9 +920,10 @@ function parseCommittedCatalog(raw: string): CatalogGameEntry[] | null {
     if (typeof candidate.slug !== 'string' || !SAFE_MEDIA_NAME.test(candidate.slug)) continue;
     if (typeof candidate.title !== 'string' || candidate.title.length === 0) continue;
 
-    // Same status coercion as the SPEC-derived path: the games repo uses
-    // draft/in-progress/published, and only an explicit archived/disabled
-    // takes a merged game off the site.
+    // Same status coercion as the SPEC-derived path. The games repo now emits only
+    // `published`/`archived`/`disabled`, so this is a no-op for a current artifact —
+    // kept because it also has to read artifacts written before that change, where
+    // the value was a `draft` the field's own repo never acted on.
     const rawStatus = typeof candidate.status === 'string' ? candidate.status : '';
     const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
 

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -920,10 +920,12 @@ function parseCommittedCatalog(raw: string): CatalogGameEntry[] | null {
     if (typeof candidate.slug !== 'string' || !SAFE_MEDIA_NAME.test(candidate.slug)) continue;
     if (typeof candidate.title !== 'string' || candidate.title.length === 0) continue;
 
-    // Same status coercion as the SPEC-derived path. The games repo now emits only
-    // `published`/`archived`/`disabled`, so this is a no-op for a current artifact —
-    // kept because it also has to read artifacts written before that change, where
-    // the value was a `draft` the field's own repo never acted on.
+    // Same status coercion as the SPEC-derived path, and a no-op for a current
+    // artifact: it is SPEC.md that made `status` optional, while the generator still
+    // writes one of `published`/`archived`/`disabled` onto every row. The coercion
+    // stays because this also reads artifacts it did not just generate — ones written
+    // before that change, carrying a `draft` the field's own repo never acted on, and
+    // ones with the key absent entirely, which must publish rather than vanish.
     const rawStatus = typeof candidate.status === 'string' ? candidate.status : '';
     const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
 


### PR DESCRIPTION
## Summary
Companion to [gamedevpl/www.gamedev.pl-games#66](https://github.com/gamedevpl/www.gamedev.pl-games/pull/66), which retires the games repo's `status` field from a required `draft|in-progress|published` value down to an optional withdrawal-only flag (`archived`/`disabled`). A spec with no status is now published by virtue of being merged.

This side needed no behavior change — the existing coercion already treated anything other than `archived`/`disabled` as `published` — but two comments described the old three-value vocabulary as still current. Updated them, and added a test that locks in the new semantics: an entry with no status publishes, `archived`/`disabled` still withdraw, and a stale pre-change artifact carrying the old `draft` default still publishes correctly.

## Test plan
- [x] `npx vitest run apps/api/src/github-client.test.ts` passes, including the new test
- [x] No behavior change confirmed: existing coercion logic untouched, only comments and a test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)