### PR TITLE
Personal access tokens: let coding agents test the deployed site without a browser

### DIFF
--- a/.claude/skills/managing-beta-participants/SKILL.md
+++ b/.claude/skills/managing-beta-participants/SKILL.md
@@ -25,6 +25,27 @@ Access is determined by a **dual-layer check** inside [`apps/api/src/auth.ts`](.
 
 > ⚠️ **Security Invariant**: Email access checks require `email_verified === true` in the Google ID token. An unverified email claim will never grant beta access.
 
+### A third path: automation accounts
+
+Neither layer above applies to **coding agents and other programmatic callers**. They hold a
+personal access token issued to a `bot:` account
+([`docs/agent-access-tokens.md`](../../docs/agent-access-tokens.md)) and reach authenticated
+routes with `Authorization: Bearer <token>` — passing the private-beta wall without appearing
+on any allowlist.
+
+That is intended, not a gap. The allowlists gate **sign-in**; an admin minting a token is
+itself an admission decision, made deliberately and revocably. Two consequences worth
+remembering when auditing access:
+
+- **A waitlist/allowlist audit is not a complete picture of who can reach the API.** Also run
+  `npm run token:list -w @gamedevpl/api -- <uid>` for any `bot:` account you know of.
+- **Revoking beta access does not revoke a token**, and vice versa — they are independent.
+  To fully cut off an automation account, revoke its tokens by id; removing it from an
+  allowlist it was never on does nothing.
+
+Do **not** add `bot:` uids to `BETA_ALLOWED_UIDS`. It would be a no-op that implies these
+accounts sign in, which they cannot.
+
 ---
 
 ## Approving or Managing Participants

--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -91,6 +91,14 @@ signed in. Both telemetry streams are the anonymous half.
   self-reported flags (the same principle as deriving touch support from game source).
 - **Stable names.** Event types and progress labels are an API: renaming one breaks
   every time series that contains it. Extend deliberately; never repurpose.
+- **Bots are not people, and the data must know it.** Automation accounts live in the
+  `bot:` uid namespace ([`docs/agent-access-tokens.md`](../../docs/agent-access-tokens.md)).
+  A token-authenticated request records no `activeDays` entry, and `bot:` submissions are
+  excluded from `summarizeCreatorMetrics` — otherwise an agent on a schedule reports
+  flawless retention for a creator who does not exist, and the one number Stage 0 gates on
+  becomes a measurement of our own test suite. Any new person-shaped metric (retention,
+  return, cohort, funnel-by-account) must exclude the prefix the same way; play and visit
+  telemetry need no change, since neither is attributed at all.
 
 ## Known gaps (prefer closing one over inventing new metrics)
 

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -172,6 +172,48 @@ transition (the game-over overlay floods the canvas dark). The definitive proof 
 playing the _published_ game on the live site, where a foregrounded real-user tab runs rAF
 normally.
 
+## Verifying behind sign-in (you don't need the owner's Gmail)
+
+Most authenticated flows can't be checked from a cloud VM by logging in — there is no
+browser session and no Google account, and driving Google's login UI with Playwright does
+not work (automation walls, CAPTCHA, datacenter IPs). Two working paths, in order of
+preference:
+
+**Local — for verifying a change.** Run the app and mint a dev session. No credentials, no
+cloud, in-memory store:
+
+```bash
+npm run dev
+curl -X POST http://localhost:5173/api/auth/dev -c cookies.txt   # session for dev:local
+```
+
+This is enough for almost all verification. It exercises real routes, real walls, and the
+real SPA. What it does **not** prove: anything about production data, the real generation
+pipeline, or deployed config.
+
+**Deployed — for verifying production behaviour.** Use a personal access token
+(`docs/agent-access-tokens.md`), issued by the repo owner and supplied as
+`GAMEDEV_ACCESS_TOKEN`:
+
+```bash
+curl -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" https://www.gamedev.pl/api/auth/me
+# driving a real browser? the SPA uses cookies, so exchange the token first:
+curl -si -X POST https://www.gamedev.pl/api/auth/session \
+  -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" | grep -i set-cookie
+```
+
+Rules that matter:
+
+- **Never commit the token, and never paste it into a game, issue, PR, or log.** It is in
+  the generated-game credential scanner, so an embedded one fails assembly — but that is a
+  backstop, not permission to be careless.
+- **A token acts as a real account against real data.** Anything you create is real: use a
+  `bot:` account, and clean up what you make.
+- **A token deliberately cannot reach operator surfaces or mint another token.** A 404 from
+  `/api/admin/*` with a valid token is correct behaviour, not a bug to route around.
+- **Exchange once, reuse the cookie.** `/api/auth/session` shares the auth rate limiter
+  (20/hour/IP).
+
 ## Verify claims, don't relay them
 
 If an agent reports "all tests pass" or "I verified X", reproduce it. Report what **you**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,12 @@ npm run type-check && npm run lint && npm run test && npm run build
 `npm run dev` runs the API + web together locally (no cloud, no keys; generator defaults to
 `mock`). This mirrors CI (`.github/workflows/ci.yml`, Node 20).
 
+If your change touches anything behind sign-in, actually drive it. Locally,
+`curl -X POST http://localhost:5173/api/auth/dev -c cookies.txt` gives a full session
+against the in-memory store. Testing the **deployed** site needs a personal access token
+(`Authorization: Bearer $GAMEDEV_ACCESS_TOKEN`) — there is no bypass route. Never commit
+that token. See [`docs/agent-access-tokens.md`](../docs/agent-access-tokens.md).
+
 ## Before larger changes
 
 Read [`docs/roadmap.md`](../docs/roadmap.md) (what's done vs next) and

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,8 @@ jobs:
 
           [ -n "$CANDIDATE_URL" ] || { echo "Error: CANDIDATE_URL is empty"; exit 1; }
           echo "Candidate URL: ${CANDIDATE_URL}"
+          # Later steps (the authenticated smoke) need the same URL.
+          echo "CANDIDATE_URL=${CANDIDATE_URL}" >> "$GITHUB_ENV"
 
           # Health is always public
           STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${CANDIDATE_URL}/api/health")
@@ -228,7 +230,81 @@ jobs:
             exit 1
           fi
 
+          # A forged bearer token must read as unauthenticated — never a 500, never a
+          # session (docs/agent-access-tokens.md). Needs no secret, so it runs on every
+          # deploy: it proves the personal-access-token path fails closed even before
+          # any real token exists. The forged value is assembled at runtime because a
+          # well-formed gdpl_pat_ literal in this file would (correctly) trip gitleaks.
+          FORGED_TOKEN="gdpl_pat_$(printf '0%.0s' $(seq 16))_$(printf 'A%.0s' $(seq 43))"
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${FORGED_TOKEN}" "${CANDIDATE_URL}/api/auth/me")
+          if [ "$STATUS_CODE" -ne 401 ]; then
+            echo "Smoke test failed: forged bearer token on /api/auth/me returned ${STATUS_CODE}, expected 401"
+            exit 1
+          fi
+
           echo "Smoke test passed on candidate URL!"
+
+      # The end-to-end check the anonymous smoke above cannot do: prove the
+      # authenticated half of the product actually works on the candidate — bearer
+      # auth, the token→cookie exchange, and a session-walled route — before any
+      # traffic moves. Runs as the CI bot's own credential (docs/agent-access-tokens.md).
+      #
+      # Optional by design: without the GAMEDEV_ACCESS_TOKEN repo secret it skips
+      # loudly rather than passing silently, because a skipped check is absence of
+      # signal, not a pass. Once the secret exists, a failure here blocks promotion —
+      # including failure by token expiry, which is deliberate: an expired CI
+      # credential should be a visible event, not a quiet gap in coverage.
+      - name: Authenticated smoke (agent access token)
+        env:
+          GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$GAMEDEV_ACCESS_TOKEN" ]; then
+            echo "::notice::GAMEDEV_ACCESS_TOKEN secret not set — authenticated smoke SKIPPED (bearer/cookie paths unverified on this deploy)"
+            exit 0
+          fi
+
+          [ -n "$CANDIDATE_URL" ] || { echo "Error: CANDIDATE_URL missing from env"; exit 1; }
+
+          # 1. Bearer path: the token authenticates as its account.
+          STATUS_CODE=$(curl -s -o /tmp/smoke-me.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${GAMEDEV_ACCESS_TOKEN}" "${CANDIDATE_URL}/api/auth/me")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Authenticated smoke failed: bearer /api/auth/me returned ${STATUS_CODE}."
+            echo "Likely causes: token expired or revoked (npm run token:list -w @gamedevpl/api -- bot:ci), or minted against a different project."
+            exit 1
+          fi
+
+          # 2. CI must run as an automation account, never as a person: bot: uids are
+          #    excluded from creator metrics, and this check is what enforces that a
+          #    human token pasted into the secret gets rejected here rather than
+          #    silently polluting the product numbers on every deploy.
+          UID_VALUE=$(jq -r '.user.uid // empty' /tmp/smoke-me.json)
+          case "$UID_VALUE" in
+            bot:*) ;;
+            *)
+              echo "Authenticated smoke failed: CI token belongs to '${UID_VALUE}', not a bot: account."
+              echo "Mint one for CI: npm run token:mint -w @gamedevpl/api -- bot:ci --name 'github actions' --days 30"
+              exit 1
+              ;;
+          esac
+
+          # 3. Cookie path: exchange the token for the session cookie the SPA sends,
+          #    then prove that cookie passes a session-walled route.
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -c /tmp/smoke-cookies.txt -X POST \
+            -H "Authorization: Bearer ${GAMEDEV_ACCESS_TOKEN}" "${CANDIDATE_URL}/api/auth/session")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Authenticated smoke failed: /api/auth/session returned ${STATUS_CODE}"
+            exit 1
+          fi
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -b /tmp/smoke-cookies.txt "${CANDIDATE_URL}/api/notifications")
+          rm -f /tmp/smoke-cookies.txt /tmp/smoke-me.json
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Authenticated smoke failed: session cookie rejected by /api/notifications (${STATUS_CODE})"
+            exit 1
+          fi
+
+          echo "Authenticated smoke passed as ${UID_VALUE}: bearer auth, cookie exchange, and the session wall all live."
 
       - name: Promote candidate revision to 100% traffic
         run: |

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,3 +33,20 @@ regexes = [
   # it's a public region name.
   '''REGION=europe-west1''',
 ]
+
+# Our own personal access tokens (docs/agent-access-tokens.md).
+#
+# The default ruleset knows GitHub/AWS/Stripe token shapes but not ours, which
+# left a gap exactly where this repo newly needs cover: coding agents now hold a
+# live `gdpl_pat_` credential while working in the tree, so "agent pastes its
+# token into a committed file" is a real accident this must catch. The in-app
+# scanner (apps/api/src/credential-scan.ts) covers the other half — a token
+# embedded in a generated game — and this covers the repo itself.
+#
+# Note the allowlist above exempts access-token.test.ts wholesale; nothing is
+# lost, since those tests build tokens at runtime rather than as literals.
+[[rules]]
+id = "gamedev-access-token"
+description = "gamedev.pl personal access token (gdpl_pat_...)"
+regex = '''gdpl_pat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}'''
+keywords = ["gdpl_pat_"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,9 @@ paths = [
   # The credential scanner's own tests — they contain deliberately FAKE keys
   # (e.g. a bogus "BEGIN RSA PRIVATE KEY" fixture) to prove the scanner trips.
   '''apps/api/src/credential-scan\.test\.ts''',
+  # Access-token unit tests once used a bogus github-pat-shaped string as a
+  # "wrong prefix" fixture (still in git history). Not a real secret.
+  '''apps/api/src/access-token\.test\.ts''',
   # 2015-era CSS with a base64-embedded webfont (git history only) — older
   # gitleaks rules misread the font bytes as an AWS access token.
   '''app/css/fontello-embedded\.css''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,12 +13,8 @@ paths = [
   # (e.g. a bogus "BEGIN RSA PRIVATE KEY" fixture) to prove the scanner trips.
   '''apps/api/src/credential-scan\.test\.ts''',
   # Access-token unit tests once used a bogus github-pat-shaped string as a
-<<<<<<< HEAD
-  # "wrong prefix" fixture (still in git history). Not a real secret.
-=======
-  # "wrong prefix" fixture (still on an open PR branch; CI fetch-depth: 0
-  # scans every ref). Not a real secret — see PR #248.
->>>>>>> origin/master
+  # "wrong prefix" fixture (still in git history / open PR branches; CI
+  # fetch-depth: 0 scans every ref). Not a real secret.
   '''apps/api/src/access-token\.test\.ts''',
   # 2015-era CSS with a base64-embedded webfont (git history only) — older
   # gitleaks rules misread the font bytes as an AWS access token.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ npm run type-check && npm run lint && npm run test && npm run build
 `npm run dev` runs everything locally; the generator defaults to the offline `mock` provider,
 so no cloud or API keys are needed.
 
+**Testing behind sign-in.** Locally, `curl -X POST http://localhost:5173/api/auth/dev -c
+cookies.txt` gives you a full session — no credentials, in-memory store, nothing real
+touched. To exercise the **deployed** site you need a personal access token
+(`Authorization: Bearer $GAMEDEV_ACCESS_TOKEN`), because there is no bypass route and never
+will be; exchange it at `POST /api/auth/session` for the cookie the SPA sends if you're
+driving a browser. Tokens are issued by the repo owner and must never be committed. See
+[`docs/agent-access-tokens.md`](docs/agent-access-tokens.md).
+
 ## Current architecture
 
 Production games will live in a **dedicated games repo maintained by coding agents**; this app

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,10 @@
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "beta:approve": "tsx scripts/beta-approve.ts",
-    "beta:invite": "tsx scripts/beta-invite.ts"
+    "beta:invite": "tsx scripts/beta-invite.ts",
+    "token:mint": "tsx scripts/access-token.ts mint",
+    "token:list": "tsx scripts/access-token.ts list",
+    "token:revoke": "tsx scripts/access-token.ts revoke"
   },
   "dependencies": {
     "@fastify/cookie": "11.1.0",

--- a/apps/api/scripts/access-token.ts
+++ b/apps/api/scripts/access-token.ts
@@ -1,0 +1,128 @@
+// Personal access tokens from the command line (docs/agent-access-tokens.md).
+//
+//   npm run token:mint   -w @gamedevpl/api -- bot:e2e --name "agent vm"
+//   npm run token:mint   -w @gamedevpl/api -- bot:e2e --name "agent vm" --days 30
+//   npm run token:list   -w @gamedevpl/api -- bot:e2e
+//   npm run token:revoke -w @gamedevpl/api -- <tokenId>
+//
+// This is the operator path that needs no browser: it talks to Firestore directly with
+// your ambient gcloud credentials, the same way `beta:approve` does. The HTTP route at
+// /api/admin/access-tokens does the identical thing for anyone already signed in as an
+// admin — both call `mintAccessTokenFor`, so the namespace rule, the per-account cap and
+// the expiry default cannot drift between them.
+//
+// Writes to whatever project your credentials point at. There is no dev/prod switch here,
+// so check `gcloud config get-value project` before minting against the live site.
+
+import { mintAccessTokenFor, MintAccessTokenError, toPublicAccessToken } from '../src/access-token-service.js';
+import { FirestoreStore } from '../src/store.js';
+
+function usage(): never {
+  console.error(
+    [
+      'Usage:',
+      '  token:mint   -- <uid> --name <label> [--days N] [--dry-run]',
+      '  token:list   -- <uid>',
+      '  token:revoke -- <tokenId>',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+function flagValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+async function mint(store: FirestoreStore, args: string[]): Promise<void> {
+  const uid = args.find((arg) => !arg.startsWith('--'));
+  const name = flagValue(args, '--name');
+  const daysRaw = flagValue(args, '--days');
+  if (!uid || !name) usage();
+
+  const expiresInDays = daysRaw ? Number(daysRaw) : undefined;
+  if (daysRaw && (!Number.isInteger(expiresInDays) || (expiresInDays ?? 0) <= 0)) {
+    console.error(`--days must be a positive integer, got "${daysRaw}"`);
+    process.exit(1);
+  }
+
+  if (args.includes('--dry-run')) {
+    const existing = await store.getUser(uid);
+    console.log(`[dry-run] would mint a token named "${name}" for ${uid}`);
+    console.log(`[dry-run] account ${existing ? 'exists' : 'would be CREATED'}; expiry ${expiresInDays ?? 90} days`);
+    return;
+  }
+
+  const { token, record, accountCreated } = await mintAccessTokenFor(store, {
+    uid,
+    name,
+    expiresInDays,
+    // Attribution for a CLI mint. Not a uid, and deliberately not shaped like one — the
+    // operator here authenticated to Google Cloud, not to this app.
+    createdByUid: `cli:${process.env.USER ?? 'unknown'}`,
+  });
+
+  if (accountCreated) console.log(`Created account ${record.uid}.`);
+  console.log(`Token id : ${record.tokenId}`);
+  console.log(`Expires  : ${record.expiresAt}`);
+  console.log('');
+  console.log('Copy this now — it is not stored and cannot be shown again:');
+  console.log('');
+  console.log(`  ${token}`);
+  console.log('');
+  console.log('Put it in the agent environment as GAMEDEV_ACCESS_TOKEN.');
+}
+
+async function list(store: FirestoreStore, args: string[]): Promise<void> {
+  const uid = args.find((arg) => !arg.startsWith('--'));
+  if (!uid) usage();
+
+  const records = await store.listAccessTokens(uid);
+  if (records.length === 0) {
+    console.log(`No tokens for ${uid}.`);
+    return;
+  }
+
+  const nowMs = Date.now();
+  for (const record of records) {
+    const view = toPublicAccessToken(record, nowMs);
+    const state = view.expired ? 'EXPIRED' : 'active';
+    console.log(
+      `${view.tokenId}  ${state.padEnd(7)}  ${view.name.padEnd(24)}  ` +
+        `created ${view.createdAt.slice(0, 10)}  expires ${view.expiresAt.slice(0, 10)}  ` +
+        `last used ${view.lastUsedAt?.slice(0, 10) ?? 'never'}`,
+    );
+  }
+}
+
+async function revoke(store: FirestoreStore, args: string[]): Promise<void> {
+  const tokenId = args.find((arg) => !arg.startsWith('--'));
+  if (!tokenId) usage();
+
+  const deleted = await store.deleteAccessToken(tokenId);
+  console.log(deleted ? `Revoked ${tokenId}.` : `No token with id ${tokenId}.`);
+  if (!deleted) process.exit(1);
+}
+
+async function main() {
+  const [action, ...args] = process.argv.slice(2);
+  const store = new FirestoreStore();
+
+  try {
+    if (action === 'mint') return await mint(store, args);
+    if (action === 'list') return await list(store, args);
+    if (action === 'revoke') return await revoke(store, args);
+    usage();
+  } catch (error) {
+    if (error instanceof MintAccessTokenError) {
+      console.error(`Refused (${error.reason}): ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/api/scripts/access-token.ts
+++ b/apps/api/scripts/access-token.ts
@@ -14,7 +14,13 @@
 // Writes to whatever project your credentials point at. There is no dev/prod switch here,
 // so check `gcloud config get-value project` before minting against the live site.
 
-import { mintAccessTokenFor, MintAccessTokenError, toPublicAccessToken } from '../src/access-token-service.js';
+import {
+  DEFAULT_EXPIRY_DAYS,
+  MAX_EXPIRY_DAYS,
+  mintAccessTokenFor,
+  MintAccessTokenError,
+  toPublicAccessToken,
+} from '../src/access-token-service.js';
 import { FirestoreStore } from '../src/store.js';
 
 function usage(): never {
@@ -41,15 +47,22 @@ async function mint(store: FirestoreStore, args: string[]): Promise<void> {
   if (!uid || !name) usage();
 
   const expiresInDays = daysRaw ? Number(daysRaw) : undefined;
-  if (daysRaw && (!Number.isInteger(expiresInDays) || (expiresInDays ?? 0) <= 0)) {
-    console.error(`--days must be a positive integer, got "${daysRaw}"`);
+  if (
+    daysRaw &&
+    (!Number.isInteger(expiresInDays) ||
+      (expiresInDays ?? 0) < 1 ||
+      (expiresInDays ?? 0) > MAX_EXPIRY_DAYS)
+  ) {
+    console.error(`--days must be an integer from 1 to ${MAX_EXPIRY_DAYS}, got "${daysRaw}"`);
     process.exit(1);
   }
 
   if (args.includes('--dry-run')) {
     const existing = await store.getUser(uid);
     console.log(`[dry-run] would mint a token named "${name}" for ${uid}`);
-    console.log(`[dry-run] account ${existing ? 'exists' : 'would be CREATED'}; expiry ${expiresInDays ?? 90} days`);
+    console.log(
+      `[dry-run] account ${existing ? 'exists' : 'would be CREATED'}; expiry ${expiresInDays ?? DEFAULT_EXPIRY_DAYS} days`,
+    );
     return;
   }
 

--- a/apps/api/src/access-token-routes.test.ts
+++ b/apps/api/src/access-token-routes.test.ts
@@ -1,0 +1,400 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { generateAccessToken } from './access-token.js';
+import { MAX_TOKENS_PER_UID } from './access-token-service.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { InMemoryStore } from './store.js';
+
+/**
+ * Every test here drives the **fully assembled app** (`buildApp`), never the route
+ * plugin alone. That is deliberate: this repo has a cross-cutting private-beta wall
+ * that lives in `app.ts`, and a previous route shipped green unit tests while the wall
+ * 401'd it in production. A credential whose entire purpose is getting through that
+ * wall has to be tested against it.
+ */
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+function sessionHeaders(uid: string) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+function bearer(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+function appWith(store: InMemoryStore, extra: { betaAllowedUids?: string } = {}) {
+  return buildApp({ store, sessionSecret, adminUids: 'g:boss', ...extra });
+}
+
+async function mintFor(app: Awaited<ReturnType<typeof buildApp>>, uid: string, name = 'agent vm') {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/admin/access-tokens',
+    headers: sessionHeaders('g:boss'),
+    payload: { uid, name },
+  });
+  return res;
+}
+
+describe('POST /api/admin/access-tokens', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:friend' });
+  });
+
+  it('mints a token for a new bot account and creates that account', async () => {
+    const app = await appWith(store);
+    const res = await mintFor(app, 'bot:e2e');
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.token).toMatch(/^gdpl_pat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}$/);
+    expect(body.uid).toBe('bot:e2e');
+    expect(body.accountCreated).toBe(true);
+    expect(body.createdByUid).toBe('g:boss');
+    expect(Date.parse(body.expiresAt)).toBeGreaterThan(Date.now());
+
+    // The account is now an ordinary standard-tier user.
+    const user = await store.getUser('bot:e2e');
+    expect(user?.tier).toBe('standard');
+  });
+
+  it('never returns or stores the secret hash alongside the token', async () => {
+    const app = await appWith(store);
+    const body = (await mintFor(app, 'bot:e2e')).json();
+
+    expect(body.secretHash).toBeUndefined();
+    const stored = await store.getAccessToken(body.tokenId);
+    expect(stored?.secretHash).toBeTruthy();
+    expect(body.token).not.toContain(stored?.secretHash);
+  });
+
+  it('mints for an existing human account without claiming to create it', async () => {
+    const app = await appWith(store);
+    const res = await mintFor(app, 'g:friend');
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().accountCreated).toBe(false);
+  });
+
+  it('refuses to invent a non-bot account, so a mistyped g: uid cannot spring into being', async () => {
+    const app = await appWith(store);
+    const res = await mintFor(app, 'g:typoed-sub');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain('bot:');
+    expect(await store.getUser('g:typoed-sub')).toBeNull();
+  });
+
+  it('refuses a blocked account', async () => {
+    await store.upsertUser({ uid: 'g:banned', tier: 'blocked' });
+    const app = await appWith(store);
+
+    const res = await mintFor(app, 'g:banned');
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('caps how many tokens one account may hold', async () => {
+    const app = await appWith(store);
+    for (let i = 0; i < MAX_TOKENS_PER_UID; i++) {
+      expect((await mintFor(app, 'bot:e2e', `token ${i}`)).statusCode).toBe(201);
+    }
+
+    const res = await mintFor(app, 'bot:e2e', 'one too many');
+    expect(res.statusCode).toBe(409);
+  });
+
+  it.each([
+    ['a non-admin session', () => sessionHeaders('g:friend')],
+    ['no credential at all', () => ({})],
+  ])('answers 404 for %s', async (_label, headers) => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: headers(),
+      payload: { uid: 'bot:e2e', name: 'nope' },
+    });
+
+    // 404, not 403 — the operator surface does not confirm its own existence.
+    expect(res.statusCode).toBe(404);
+  });
+
+  it.each([
+    ['missing name', { uid: 'bot:e2e' }],
+    ['empty name', { uid: 'bot:e2e', name: '' }],
+    ['invalid uid', { uid: 'bad uid!', name: 'x' }],
+    ['expiry beyond the cap', { uid: 'bot:e2e', name: 'x', expiresInDays: 400 }],
+  ])('rejects an invalid mint request (%s)', async (_label, payload) => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: sessionHeaders('g:boss'),
+      payload,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('authenticating with a personal access token', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+  });
+
+  it('authenticates a walled route through the private-beta wall', async () => {
+    // The whole point of the feature: an agent with no browser, no Google account and
+    // no place on the beta allowlist still reaches an authenticated route — because an
+    // admin issued it a credential, which is an admission decision in itself.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    const res = await app.inject({ method: 'GET', url: '/api/notifications', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('identifies itself as the account it was issued to', async () => {
+    const app = await appWith(store);
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user.uid).toBe('bot:e2e');
+    // A user payload must never carry credential material.
+    expect(JSON.stringify(res.json())).not.toContain('secretHash');
+  });
+
+  it('cannot mint another token — a leaked credential cannot renew itself', async () => {
+    const app = await appWith(store);
+    // Issued to an account that IS an admin, so only the auth method can be what stops it.
+    const { token } = (await mintFor(app, 'g:boss')).json();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: bearer(token),
+      payload: { uid: 'bot:sneaky', name: 'escalation' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(await store.getUser('bot:sneaky')).toBeNull();
+  });
+
+  it('cannot read operator telemetry even when issued to an admin', async () => {
+    const app = await appWith(store);
+    const { token } = (await mintFor(app, 'g:boss')).json();
+
+    for (const url of ['/api/admin/telemetry/health', '/api/admin/telemetry/visits', '/api/admin/telemetry/creators']) {
+      const res = await app.inject({ method: 'GET', url, headers: bearer(token) });
+      expect(res.statusCode, url).toBe(404);
+    }
+  });
+
+  it('rejects a token whose secret is wrong for a real id', async () => {
+    const app = await appWith(store);
+    const { tokenId } = (await mintFor(app, 'bot:e2e')).json();
+    const forged = `gdpl_pat_${tokenId}_${'A'.repeat(43)}`;
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(forged) });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an expired token', async () => {
+    const { token, tokenId, secretHash } = generateAccessToken();
+    await store.upsertUser({ uid: 'bot:e2e' });
+    await store.createAccessToken({
+      tokenId,
+      uid: 'bot:e2e',
+      secretHash,
+      name: 'stale',
+      createdAt: new Date(Date.now() - 200 * 86_400_000).toISOString(),
+      createdByUid: 'g:boss',
+      expiresAt: new Date(Date.now() - 86_400_000).toISOString(),
+    });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a revoked token immediately', async () => {
+    const app = await appWith(store);
+    const { token, tokenId } = (await mintFor(app, 'bot:e2e')).json();
+    expect((await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) })).statusCode).toBe(200);
+
+    const revoked = await app.inject({
+      method: 'DELETE',
+      url: `/api/admin/access-tokens/${tokenId}`,
+      headers: sessionHeaders('g:boss'),
+    });
+    expect(revoked.statusCode).toBe(200);
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a token for an account that no longer exists', async () => {
+    const { token, tokenId, secretHash } = generateAccessToken();
+    await store.createAccessToken({
+      tokenId,
+      uid: 'bot:ghost',
+      secretHash,
+      name: 'orphan',
+      createdAt: new Date().toISOString(),
+      createdByUid: 'g:boss',
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it.each([
+    ['a JWT-shaped bearer', 'eyJhbGciOiJSUzI1NiJ9.body.sig'],
+    ['a build-channel token', 'MTIzLmFiYzEyMw'],
+    ['garbage', 'not-a-token'],
+    ['our prefix but malformed', 'gdpl_pat_short_secret'],
+  ])('ignores %s without erroring', async (_label, credential) => {
+    const app = await appWith(store);
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(credential) });
+
+    // Unauthenticated, never a 500 — other bearer schemes on this API must pass through
+    // to the handlers that understand them.
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('prefers a browser session over a token when both are present', async () => {
+    const app = await appWith(store);
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { ...sessionHeaders('g:boss'), ...bearer(token) },
+    });
+
+    expect(res.json().user.uid).toBe('g:boss');
+  });
+
+  it('exchanges for a session cookie so a real browser can be driven', async () => {
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    const res = await app.inject({ method: 'POST', url: '/api/auth/session', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user.uid).toBe('bot:e2e');
+
+    const setCookie = res.headers['set-cookie'];
+    const cookie = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+    expect(cookie).toContain(`${SESSION_COOKIE_NAME}=`);
+    expect(cookie).toContain('HttpOnly');
+
+    // The cookie must actually work on a walled route, exactly as a browser would use it.
+    const followUp = await app.inject({
+      method: 'GET',
+      url: '/api/notifications',
+      headers: { cookie: String(cookie).split(';')[0] as string },
+    });
+    expect(followUp.statusCode).toBe(200);
+  });
+
+  it.each([
+    ['a browser session', () => sessionHeaders('g:boss')],
+    ['no credential', () => ({})],
+  ])('refuses to mint a session from %s', async (_label, headers) => {
+    const app = await appWith(store);
+    const res = await app.inject({ method: 'POST', url: '/api/auth/session', headers: headers() });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('records last use so a stale token can be spotted before revoking it', async () => {
+    const app = await appWith(store);
+    const { token, tokenId } = (await mintFor(app, 'bot:e2e')).json();
+    expect((await store.getAccessToken(tokenId))?.lastUsedAt).toBeUndefined();
+
+    await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+
+    expect((await store.getAccessToken(tokenId))?.lastUsedAt).toBeTruthy();
+  });
+
+  it('does not count a bot request as a human active day', async () => {
+    // `activeDays` feeds the creator-return metric; an agent on a cron would otherwise
+    // report perfect retention for an account that is not a person.
+    const app = await appWith(store);
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+
+    expect((await store.getUser('bot:e2e'))?.activeDays).toBeUndefined();
+  });
+});
+
+describe('GET/DELETE /api/admin/access-tokens', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:friend' });
+  });
+
+  it('lists an account’s tokens without any credential material', async () => {
+    const app = await appWith(store);
+    await mintFor(app, 'bot:e2e', 'first');
+    await mintFor(app, 'bot:e2e', 'second');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/access-tokens?uid=bot:e2e',
+      headers: sessionHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { tokens } = res.json();
+    expect(tokens).toHaveLength(2);
+    expect(res.payload).not.toContain('secretHash');
+    expect(tokens.every((entry: { expired: boolean }) => entry.expired === false)).toBe(true);
+  });
+
+  it('answers 404 when revoking a token that does not exist', async () => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/admin/access-tokens/${'a'.repeat(16)}`,
+      headers: sessionHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects a malformed token id', async () => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/admin/access-tokens/not-hex',
+      headers: sessionHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it.each([
+    ['listing', 'GET' as const, '/api/admin/access-tokens?uid=bot:e2e'],
+    ['revoking', 'DELETE' as const, `/api/admin/access-tokens/${'a'.repeat(16)}`],
+  ])('hides %s from a non-admin', async (_label, method, url) => {
+    const app = await appWith(store);
+    const res = await app.inject({ method, url, headers: sessionHeaders('g:friend') });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/access-token-routes.test.ts
+++ b/apps/api/src/access-token-routes.test.ts
@@ -225,6 +225,24 @@ describe('authenticating with a personal access token', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it('rejects a token whose stored expiresAt is unparseable', async () => {
+    const { token, tokenId, secretHash } = generateAccessToken();
+    await store.upsertUser({ uid: 'bot:e2e' });
+    await store.createAccessToken({
+      tokenId,
+      uid: 'bot:e2e',
+      secretHash,
+      name: 'corrupt',
+      createdAt: new Date().toISOString(),
+      createdByUid: 'g:boss',
+      expiresAt: 'not-a-date',
+    });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(401);
+  });
+
   it('rejects a revoked token immediately', async () => {
     const app = await appWith(store);
     const { token, tokenId } = (await mintFor(app, 'bot:e2e')).json();

--- a/apps/api/src/access-token-routes.ts
+++ b/apps/api/src/access-token-routes.ts
@@ -50,6 +50,7 @@ const FAILURE_STATUS: Record<MintFailureReason, number> = {
   unknown_uid: 400,
   blocked: 403,
   too_many_tokens: 409,
+  invalid_expiry: 400,
 };
 
 export interface AccessTokenRoutesOptions {

--- a/apps/api/src/access-token-routes.ts
+++ b/apps/api/src/access-token-routes.ts
@@ -1,0 +1,133 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import {
+  MAX_EXPIRY_DAYS,
+  MintAccessTokenError,
+  mintAccessTokenFor,
+  toPublicAccessToken,
+  type MintFailureReason,
+} from './access-token-service.js';
+import { isAdminSession } from './admin.js';
+import type { Store } from './store.js';
+
+/**
+ * Issuing and revoking personal access tokens (docs/agent-access-tokens.md).
+ *
+ * Operator-only, and deliberately session-only: `isAdminSession` refuses a caller who is
+ * themselves authenticated with a token, so a PAT can never mint another PAT. Without
+ * that, one leaked credential becomes a self-renewing one and revoking the original
+ * accomplishes nothing.
+ *
+ * There is no self-service surface yet — no "create a token" button in the app. Minting
+ * is the one step that must involve a human at a browser, and keeping it here means the
+ * whole feature ships without a new UI, a new secret, or a new unauthenticated route.
+ * The rules themselves live in `access-token-service.ts`, shared with the `token:mint`
+ * CLI so the two issuance paths cannot disagree.
+ */
+
+const MintSchema = z.object({
+  uid: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9][a-z0-9:_-]{2,63}$/i, 'invalid uid'),
+  /** Free-text label so a list of tokens is still readable months later. */
+  name: z.string().trim().min(1, 'name is required').max(60, 'name is too long'),
+  expiresInDays: z.coerce.number().int().min(1).max(MAX_EXPIRY_DAYS).optional(),
+});
+
+const RevokeParamsSchema = z.object({
+  tokenId: z
+    .string()
+    .trim()
+    .regex(/^[0-9a-f]{16}$/, 'invalid token id'),
+});
+
+const ListQuerySchema = z.object({
+  uid: z.string().trim().min(1, 'uid is required'),
+});
+
+const FAILURE_STATUS: Record<MintFailureReason, number> = {
+  unknown_uid: 400,
+  blocked: 403,
+  too_many_tokens: 409,
+};
+
+export interface AccessTokenRoutesOptions {
+  store: Store;
+  adminUids?: Set<string>;
+  now?: () => number;
+}
+
+export async function registerAccessTokenRoutes(
+  app: FastifyInstance,
+  options: AccessTokenRoutesOptions,
+): Promise<void> {
+  const { store, adminUids } = options;
+  const now = options.now ?? Date.now;
+
+  app.post('/api/admin/access-tokens', async (request, reply) => {
+    // 404, not 403 — the same answer the telemetry views give a non-admin, for the same
+    // reason: whether an operator surface exists is not a fact worth confirming.
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = MintSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+    }
+
+    const nowMs = now();
+    try {
+      const { token, record, accountCreated } = await mintAccessTokenFor(store, {
+        ...parsed.data,
+        createdByUid: request.user?.uid ?? 'unknown',
+        nowMs,
+      });
+
+      // The only time the token itself is ever readable. Nothing stores it, so a caller
+      // who loses it revokes and mints again rather than recovering it.
+      return reply.status(201).send({ token, accountCreated, ...toPublicAccessToken(record, nowMs) });
+    } catch (error) {
+      if (error instanceof MintAccessTokenError) {
+        return reply.status(FAILURE_STATUS[error.reason]).send({ error: error.message });
+      }
+      throw error;
+    }
+  });
+
+  app.get('/api/admin/access-tokens', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = ListQuerySchema.safeParse(request.query ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
+    }
+
+    const records = await store.listAccessTokens(parsed.data.uid);
+    const nowMs = now();
+    return reply.status(200).send({ tokens: records.map((record) => toPublicAccessToken(record, nowMs)) });
+  });
+
+  app.delete('/api/admin/access-tokens/:tokenId', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = RevokeParamsSchema.safeParse(request.params ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid token id' });
+    }
+
+    // Revocation is a delete, not a flag: the record *is* the token's existence, so there
+    // is no revoked-but-still-verifiable state to get wrong.
+    const deleted = await store.deleteAccessToken(parsed.data.tokenId);
+    if (!deleted) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    return reply.status(200).send({ status: 'ok' });
+  });
+}

--- a/apps/api/src/access-token-service.test.ts
+++ b/apps/api/src/access-token-service.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { parseAccessToken, verifyTokenSecret } from './access-token.js';
+import { isAccessTokenExpired, parseAccessToken, verifyTokenSecret } from './access-token.js';
 import {
   DEFAULT_EXPIRY_DAYS,
+  MAX_EXPIRY_DAYS,
   MAX_TOKENS_PER_UID,
   MintAccessTokenError,
   mintAccessTokenFor,
@@ -55,6 +56,38 @@ describe('mintAccessTokenFor', () => {
       nowMs: NOW,
     });
     expect(Date.parse(explicit.record.expiresAt)).toBe(NOW + 86_400_000);
+  });
+
+  it('refuses expiry outside 1..MAX_EXPIRY_DAYS so the CLI cannot outrun the HTTP cap', async () => {
+    await expect(
+      mintAccessTokenFor(store, {
+        uid: 'bot:e2e',
+        name: 'x',
+        createdByUid: 'cli:owner',
+        expiresInDays: MAX_EXPIRY_DAYS + 1,
+        nowMs: NOW,
+      }),
+    ).rejects.toMatchObject({ reason: 'invalid_expiry' });
+
+    await expect(
+      mintAccessTokenFor(store, {
+        uid: 'bot:e2e',
+        name: 'x',
+        createdByUid: 'cli:owner',
+        expiresInDays: 0,
+        nowMs: NOW,
+      }),
+    ).rejects.toMatchObject({ reason: 'invalid_expiry' });
+
+    await expect(
+      mintAccessTokenFor(store, {
+        uid: 'bot:e2e',
+        name: 'x',
+        createdByUid: 'cli:owner',
+        expiresInDays: 1.5,
+        nowMs: NOW,
+      }),
+    ).rejects.toMatchObject({ reason: 'invalid_expiry' });
   });
 
   it('creates a bot account but refuses to invent any other namespace', async () => {
@@ -130,5 +163,23 @@ describe('toPublicAccessToken', () => {
     expect(fresh.expired).toBe(false);
 
     expect(toPublicAccessToken(record, NOW + 2 * 86_400_000).expired).toBe(true);
+  });
+
+  it('treats a malformed expiresAt as expired (fail closed)', () => {
+    expect(isAccessTokenExpired('not-a-date', NOW)).toBe(true);
+    expect(
+      toPublicAccessToken(
+        {
+          tokenId: 'a'.repeat(16),
+          uid: 'bot:e2e',
+          secretHash: 'b'.repeat(64),
+          name: 'x',
+          createdAt: new Date(NOW).toISOString(),
+          createdByUid: 'cli:owner',
+          expiresAt: 'garbage',
+        },
+        NOW,
+      ).expired,
+    ).toBe(true);
   });
 });

--- a/apps/api/src/access-token-service.test.ts
+++ b/apps/api/src/access-token-service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { parseAccessToken, verifyTokenSecret } from './access-token.js';
+import {
+  DEFAULT_EXPIRY_DAYS,
+  MAX_TOKENS_PER_UID,
+  MintAccessTokenError,
+  mintAccessTokenFor,
+  toPublicAccessToken,
+} from './access-token-service.js';
+import { InMemoryStore } from './store.js';
+
+/**
+ * The shared issuance rules. The HTTP route is covered end-to-end in
+ * `access-token-routes.test.ts`; this file pins the contract itself, because the
+ * `token:mint` CLI calls it directly and has no route tests behind it.
+ */
+
+const NOW = Date.parse('2026-07-26T12:00:00.000Z');
+
+describe('mintAccessTokenFor', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:human' });
+  });
+
+  it('stores only a hash that the issued token verifies against', async () => {
+    const { token, record } = await mintAccessTokenFor(store, {
+      uid: 'bot:e2e',
+      name: 'cli',
+      createdByUid: 'cli:owner',
+      nowMs: NOW,
+    });
+
+    expect(verifyTokenSecret(parseAccessToken(token).secret, record.secretHash)).toBe(true);
+    // Nothing anywhere in the stored record reproduces the credential.
+    expect(JSON.stringify(record)).not.toContain(parseAccessToken(token).secret);
+  });
+
+  it('defaults expiry to 90 days and honours an explicit window', async () => {
+    const fallback = await mintAccessTokenFor(store, {
+      uid: 'bot:a',
+      name: 'default',
+      createdByUid: 'cli:owner',
+      nowMs: NOW,
+    });
+    expect(Date.parse(fallback.record.expiresAt)).toBe(NOW + DEFAULT_EXPIRY_DAYS * 86_400_000);
+
+    const explicit = await mintAccessTokenFor(store, {
+      uid: 'bot:b',
+      name: 'short',
+      createdByUid: 'cli:owner',
+      expiresInDays: 1,
+      nowMs: NOW,
+    });
+    expect(Date.parse(explicit.record.expiresAt)).toBe(NOW + 86_400_000);
+  });
+
+  it('creates a bot account but refuses to invent any other namespace', async () => {
+    const created = await mintAccessTokenFor(store, {
+      uid: 'bot:new',
+      name: 'x',
+      createdByUid: 'cli:owner',
+      nowMs: NOW,
+    });
+    expect(created.accountCreated).toBe(true);
+    expect(await store.getUser('bot:new')).not.toBeNull();
+
+    await expect(
+      mintAccessTokenFor(store, { uid: 'g:nonexistent', name: 'x', createdByUid: 'cli:owner', nowMs: NOW }),
+    ).rejects.toMatchObject({ reason: 'unknown_uid' });
+  });
+
+  it('mints for an existing human account without recreating it', async () => {
+    const result = await mintAccessTokenFor(store, {
+      uid: 'g:human',
+      name: 'laptop',
+      createdByUid: 'cli:owner',
+      nowMs: NOW,
+    });
+
+    expect(result.accountCreated).toBe(false);
+    expect(result.record.uid).toBe('g:human');
+  });
+
+  it('refuses a blocked account', async () => {
+    await store.upsertUser({ uid: 'g:banned', tier: 'blocked' });
+
+    await expect(
+      mintAccessTokenFor(store, { uid: 'g:banned', name: 'x', createdByUid: 'cli:owner', nowMs: NOW }),
+    ).rejects.toBeInstanceOf(MintAccessTokenError);
+  });
+
+  it('enforces the per-account cap', async () => {
+    for (let i = 0; i < MAX_TOKENS_PER_UID; i++) {
+      await mintAccessTokenFor(store, { uid: 'bot:e2e', name: `t${i}`, createdByUid: 'cli:owner', nowMs: NOW });
+    }
+
+    await expect(
+      mintAccessTokenFor(store, { uid: 'bot:e2e', name: 'extra', createdByUid: 'cli:owner', nowMs: NOW }),
+    ).rejects.toMatchObject({ reason: 'too_many_tokens' });
+  });
+
+  it('records who issued it, so a mint is attributable afterwards', async () => {
+    const { record } = await mintAccessTokenFor(store, {
+      uid: 'bot:e2e',
+      name: 'x',
+      createdByUid: 'g:boss',
+      nowMs: NOW,
+    });
+
+    expect(record.createdByUid).toBe('g:boss');
+  });
+});
+
+describe('toPublicAccessToken', () => {
+  it('drops the hash and reports expiry', async () => {
+    const store = new InMemoryStore();
+    const { record } = await mintAccessTokenFor(store, {
+      uid: 'bot:e2e',
+      name: 'x',
+      createdByUid: 'cli:owner',
+      expiresInDays: 1,
+      nowMs: NOW,
+    });
+
+    const fresh = toPublicAccessToken(record, NOW);
+    expect(fresh).not.toHaveProperty('secretHash');
+    expect(fresh.expired).toBe(false);
+
+    expect(toPublicAccessToken(record, NOW + 2 * 86_400_000).expired).toBe(true);
+  });
+});

--- a/apps/api/src/access-token-service.ts
+++ b/apps/api/src/access-token-service.ts
@@ -1,0 +1,123 @@
+import { generateAccessToken } from './access-token.js';
+import { BOT_UID_PREFIX, type AccessTokenRecord, type Store } from './store.js';
+
+/**
+ * The rules for issuing a personal access token, in one place
+ * (docs/agent-access-tokens.md).
+ *
+ * There are two ways to mint one — the operator HTTP route and the `token:mint` CLI —
+ * and they must agree about the namespace rule, the cap and the expiry default. Anything
+ * duplicated across those two paths would eventually drift, and the drift would be silent
+ * and security-relevant, so the route and the script are both thin wrappers over this.
+ */
+
+export const MAX_TOKENS_PER_UID = 10;
+export const DEFAULT_EXPIRY_DAYS = 90;
+export const MAX_EXPIRY_DAYS = 365;
+
+export type MintFailureReason = 'unknown_uid' | 'blocked' | 'too_many_tokens';
+
+export class MintAccessTokenError extends Error {
+  constructor(
+    readonly reason: MintFailureReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MintAccessTokenError';
+  }
+}
+
+export interface MintAccessTokenParams {
+  uid: string;
+  name: string;
+  createdByUid: string;
+  expiresInDays?: number;
+  nowMs?: number;
+}
+
+export interface MintAccessTokenResult {
+  /** The credential itself. Readable exactly once — nothing persists it. */
+  token: string;
+  record: AccessTokenRecord;
+  /** True when this mint called the account into existence. */
+  accountCreated: boolean;
+}
+
+export async function mintAccessTokenFor(store: Store, params: MintAccessTokenParams): Promise<MintAccessTokenResult> {
+  const { uid, name, createdByUid } = params;
+  const nowMs = params.nowMs ?? Date.now();
+  const expiresInDays = params.expiresInDays ?? DEFAULT_EXPIRY_DAYS;
+
+  const existing = await store.getUser(uid);
+
+  // The namespace rule is a typo guard with teeth: without it a mistyped `g:<sub>` would
+  // silently call an account into being — one that never signed in, never passed the beta
+  // allowlist, and now holds a working credential.
+  if (!existing && !uid.startsWith(BOT_UID_PREFIX)) {
+    throw new MintAccessTokenError(
+      'unknown_uid',
+      `unknown uid — a token for a new account requires the "${BOT_UID_PREFIX}" namespace`,
+    );
+  }
+
+  if (existing?.tier === 'blocked') {
+    throw new MintAccessTokenError('blocked', 'account is blocked');
+  }
+
+  const held = await store.listAccessTokens(uid);
+  if (held.length >= MAX_TOKENS_PER_UID) {
+    throw new MintAccessTokenError(
+      'too_many_tokens',
+      `uid already holds ${MAX_TOKENS_PER_UID} tokens — revoke one first`,
+    );
+  }
+
+  // Creating the account here is the intended operator power, and the reason the uid rule
+  // above is strict. A `bot:` account is an ordinary user from this point on: standard
+  // tier, the same daily quota, the same walls.
+  const user = existing ?? (await store.upsertUser({ uid, name: `Bot ${uid.slice(BOT_UID_PREFIX.length)}` }));
+
+  const { token, tokenId, secretHash } = generateAccessToken();
+  const record: AccessTokenRecord = {
+    tokenId,
+    uid: user.uid,
+    secretHash,
+    name,
+    createdAt: new Date(nowMs).toISOString(),
+    createdByUid,
+    expiresAt: new Date(nowMs + expiresInDays * 24 * 60 * 60 * 1000).toISOString(),
+  };
+
+  await store.createAccessToken(record);
+
+  return { token, record, accountCreated: !existing };
+}
+
+/** The safe projection of a token record — everything except the hash of the secret. */
+export interface PublicAccessToken {
+  tokenId: string;
+  uid: string;
+  name: string;
+  createdAt: string;
+  createdByUid: string;
+  expiresAt: string;
+  lastUsedAt?: string;
+  expired: boolean;
+}
+
+export function toPublicAccessToken(record: AccessTokenRecord, nowMs: number): PublicAccessToken {
+  // Fields listed explicitly rather than spread-minus-`secretHash`: a future field added
+  // to the record then has to be named here to escape, so the safe direction is the
+  // default. This projection is the only thing standing between the token collection and
+  // an HTTP response.
+  return {
+    tokenId: record.tokenId,
+    uid: record.uid,
+    name: record.name,
+    createdAt: record.createdAt,
+    createdByUid: record.createdByUid,
+    expiresAt: record.expiresAt,
+    lastUsedAt: record.lastUsedAt,
+    expired: Date.parse(record.expiresAt) <= nowMs,
+  };
+}

--- a/apps/api/src/access-token-service.ts
+++ b/apps/api/src/access-token-service.ts
@@ -1,5 +1,7 @@
-import { generateAccessToken } from './access-token.js';
+import { generateAccessToken, isAccessTokenExpired } from './access-token.js';
 import { BOT_UID_PREFIX, type AccessTokenRecord, type Store } from './store.js';
+
+export { isAccessTokenExpired } from './access-token.js';
 
 /**
  * The rules for issuing a personal access token, in one place
@@ -15,7 +17,7 @@ export const MAX_TOKENS_PER_UID = 10;
 export const DEFAULT_EXPIRY_DAYS = 90;
 export const MAX_EXPIRY_DAYS = 365;
 
-export type MintFailureReason = 'unknown_uid' | 'blocked' | 'too_many_tokens';
+export type MintFailureReason = 'unknown_uid' | 'blocked' | 'too_many_tokens' | 'invalid_expiry';
 
 export class MintAccessTokenError extends Error {
   constructor(
@@ -47,6 +49,19 @@ export async function mintAccessTokenFor(store: Store, params: MintAccessTokenPa
   const { uid, name, createdByUid } = params;
   const nowMs = params.nowMs ?? Date.now();
   const expiresInDays = params.expiresInDays ?? DEFAULT_EXPIRY_DAYS;
+
+  // Enforced here (not only at the HTTP boundary) so the CLI cannot mint a
+  // token that outlives the documented max, or a zero/negative window.
+  if (
+    !Number.isInteger(expiresInDays) ||
+    expiresInDays < 1 ||
+    expiresInDays > MAX_EXPIRY_DAYS
+  ) {
+    throw new MintAccessTokenError(
+      'invalid_expiry',
+      `expiresInDays must be an integer from 1 to ${MAX_EXPIRY_DAYS}`,
+    );
+  }
 
   const existing = await store.getUser(uid);
 
@@ -118,6 +133,6 @@ export function toPublicAccessToken(record: AccessTokenRecord, nowMs: number): P
     createdByUid: record.createdByUid,
     expiresAt: record.expiresAt,
     lastUsedAt: record.lastUsedAt,
-    expired: Date.parse(record.expiresAt) <= nowMs,
+    expired: isAccessTokenExpired(record.expiresAt, nowMs),
   };
 }

--- a/apps/api/src/access-token.test.ts
+++ b/apps/api/src/access-token.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACCESS_TOKEN_PREFIX,
+  describeAccessToken,
+  generateAccessToken,
+  hashTokenSecret,
+  InvalidAccessTokenError,
+  looksLikeAccessToken,
+  parseAccessToken,
+  verifyTokenSecret,
+} from './access-token.js';
+import { findCredentialLikeStrings } from './credential-scan.js';
+
+describe('access token minting', () => {
+  it('mints a token that parses back to its id and secret', () => {
+    const { token, tokenId, secretHash } = generateAccessToken();
+
+    expect(token.startsWith(ACCESS_TOKEN_PREFIX)).toBe(true);
+    const parsed = parseAccessToken(token);
+    expect(parsed.tokenId).toBe(tokenId);
+    expect(verifyTokenSecret(parsed.secret, secretHash)).toBe(true);
+  });
+
+  it('never returns the secret in a form that is stored', () => {
+    const { token, secretHash } = generateAccessToken();
+    // The stored hash must not contain, or be derivable by reading, the token itself.
+    expect(token).not.toContain(secretHash);
+    expect(secretHash).toHaveLength(64);
+  });
+
+  it('mints distinct ids and secrets each time', () => {
+    const tokens = Array.from({ length: 50 }, () => generateAccessToken());
+    expect(new Set(tokens.map((entry) => entry.tokenId)).size).toBe(50);
+    expect(new Set(tokens.map((entry) => entry.secretHash)).size).toBe(50);
+  });
+});
+
+describe('access token verification', () => {
+  it('rejects a token whose secret is wrong for its id', () => {
+    const real = generateAccessToken();
+    const other = generateAccessToken();
+    const forged = `${ACCESS_TOKEN_PREFIX}${real.tokenId}_${parseAccessToken(other.token).secret}`;
+
+    expect(verifyTokenSecret(parseAccessToken(forged).secret, real.secretHash)).toBe(false);
+  });
+
+  it('rejects a hash of the wrong length rather than throwing', () => {
+    // timingSafeEqual throws on length mismatch; a corrupt record must read as
+    // "does not match", never as a 500.
+    expect(verifyTokenSecret('anything', 'too-short')).toBe(false);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['prefix only', 'gdpl_pat_'],
+    ['wrong prefix', 'ghp_0123456789abcdef0123456789abcdef01234567'],
+    ['id too short', `${ACCESS_TOKEN_PREFIX}abc_${'a'.repeat(43)}`],
+    ['id not hex', `${ACCESS_TOKEN_PREFIX}${'z'.repeat(16)}_${'a'.repeat(43)}`],
+    ['secret too short', `${ACCESS_TOKEN_PREFIX}${'a'.repeat(16)}_short`],
+    ['trailing junk', `${ACCESS_TOKEN_PREFIX}${'a'.repeat(16)}_${'a'.repeat(43)}extra`],
+    ['newline injection', `${ACCESS_TOKEN_PREFIX}${'a'.repeat(16)}_${'a'.repeat(43)}\nx`],
+  ])('rejects a malformed token (%s)', (_label, candidate) => {
+    expect(() => parseAccessToken(candidate)).toThrow(InvalidAccessTokenError);
+  });
+
+  it('hashes deterministically', () => {
+    expect(hashTokenSecret('abc')).toBe(hashTokenSecret('abc'));
+    expect(hashTokenSecret('abc')).not.toBe(hashTokenSecret('abd'));
+  });
+});
+
+describe('token shape', () => {
+  it('identifies our tokens and ignores other bearer credentials', () => {
+    expect(looksLikeAccessToken(generateAccessToken().token)).toBe(true);
+    // The other Bearer credentials this API carries must fall through untouched.
+    expect(looksLikeAccessToken('eyJhbGciOiJSUzI1NiJ9.payload.sig')).toBe(false);
+    expect(looksLikeAccessToken('MTIzLmFiYw')).toBe(false);
+  });
+
+  it('redacts the secret when describing a token', () => {
+    const { token, tokenId } = generateAccessToken();
+    const described = describeAccessToken(tokenId);
+    expect(described).toContain(tokenId);
+    expect(token).not.toBe(described);
+    expect(described).not.toContain(parseAccessToken(token).secret);
+  });
+
+  it('is caught by the generated-game credential scanner', () => {
+    // A game that embeds one of our tokens must be refused at assembly, exactly like
+    // one that embeds an OpenAI key.
+    const { token } = generateAccessToken();
+    const findings = findCredentialLikeStrings(`const key = "${token}";`);
+    expect(findings.map((finding) => finding.kind)).toContain('gamedev-access-token');
+  });
+});

--- a/apps/api/src/access-token.test.ts
+++ b/apps/api/src/access-token.test.ts
@@ -44,6 +44,17 @@ describe('access token verification', () => {
     expect(verifyTokenSecret(parseAccessToken(forged).secret, real.secretHash)).toBe(false);
   });
 
+  it.each([
+    ['undefined', undefined],
+    ['empty', ''],
+  ])('refuses a record whose stored hash is %s rather than throwing', (_label, storedHash) => {
+    // Firestore records are untrusted shape-wise: an older schema, a half-finished
+    // migration or a console edit can leave the hash off. Throwing here would be a 500
+    // from inside the auth hook, on every request carrying that token.
+    expect(() => verifyTokenSecret('anything', storedHash)).not.toThrow();
+    expect(verifyTokenSecret('anything', storedHash)).toBe(false);
+  });
+
   it('rejects a hash of the wrong length rather than throwing', () => {
     // timingSafeEqual throws on length mismatch; a corrupt record must read as
     // "does not match", never as a 500.

--- a/apps/api/src/access-token.test.ts
+++ b/apps/api/src/access-token.test.ts
@@ -53,7 +53,9 @@ describe('access token verification', () => {
   it.each([
     ['empty', ''],
     ['prefix only', 'gdpl_pat_'],
-    ['wrong prefix', 'ghp_0123456789abcdef0123456789abcdef01234567'],
+    // Deliberately not github-pat-shaped: a realistic `ghp_…` fixture trips
+    // gitleaks even when allowlisted for this file's history.
+    ['wrong prefix', 'not_a_gamedev_pat_abcdefghijklmnop'],
     ['id too short', `${ACCESS_TOKEN_PREFIX}abc_${'a'.repeat(43)}`],
     ['id not hex', `${ACCESS_TOKEN_PREFIX}${'z'.repeat(16)}_${'a'.repeat(43)}`],
     ['secret too short', `${ACCESS_TOKEN_PREFIX}${'a'.repeat(16)}_short`],

--- a/apps/api/src/access-token.ts
+++ b/apps/api/src/access-token.ts
@@ -84,7 +84,15 @@ export function hashTokenSecret(secret: string): string {
   return createHash('sha256').update(secret).digest('hex');
 }
 
-export function verifyTokenSecret(secret: string, expectedHash: string): boolean {
+export function verifyTokenSecret(secret: string, expectedHash: string | undefined): boolean {
+  // The hash arrives from Firestore, which TypeScript cannot vouch for: a record written
+  // by an older schema, a half-finished migration or a hand edit in the console can be
+  // missing it. Typed as possibly-undefined and refused here, because the alternative is
+  // `Buffer.from(undefined)` throwing inside the auth hook — a 500 on every request
+  // carrying that token, from a route with no try/catch around it. Same fail-closed
+  // reasoning as `isAccessTokenExpired`.
+  if (typeof expectedHash !== 'string' || expectedHash.length === 0) return false;
+
   const actual = Buffer.from(hashTokenSecret(secret), 'utf8');
   const expected = Buffer.from(expectedHash, 'utf8');
   // Length check first: timingSafeEqual throws on a mismatch rather than returning false,

--- a/apps/api/src/access-token.ts
+++ b/apps/api/src/access-token.ts
@@ -100,3 +100,13 @@ export function verifyTokenSecret(secret: string, expectedHash: string): boolean
 export function describeAccessToken(tokenId: string): string {
   return `${ACCESS_TOKEN_PREFIX}${tokenId}_…`;
 }
+
+/**
+ * Fail closed on unparseable expiry timestamps. `Date.parse` returns NaN for
+ * garbage, and `NaN <= now` is false — which would otherwise treat a corrupt
+ * Firestore record as immortal.
+ */
+export function isAccessTokenExpired(expiresAt: string, nowMs: number): boolean {
+  const expiresMs = Date.parse(expiresAt);
+  return !Number.isFinite(expiresMs) || expiresMs <= nowMs;
+}

--- a/apps/api/src/access-token.ts
+++ b/apps/api/src/access-token.ts
@@ -1,0 +1,102 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Personal access tokens — a user credential for programmatic callers
+ * (docs/agent-access-tokens.md).
+ *
+ * The problem this solves: sign-in is Google-only, and a coding agent running in a
+ * cloud VM has no browser session and no Google account. The alternatives were all
+ * worse — an unauthenticated "test login" route is a bypass whatever it is named, and
+ * a password database is a permanent liability created to solve a testing problem.
+ * A token issued *to a real account* is neither: it authenticates as that user, with
+ * that user's tier and quota, through the same request pipeline as everyone else.
+ *
+ * Shape: `gdpl_pat_<tokenId>_<secret>`.
+ *
+ * The id travels in the clear so verification is a single point lookup; only the
+ * secret half is a credential. What is stored is `sha256(secret)`, never the token,
+ * so a dump of the datastore yields nothing usable — the same reason the id and the
+ * secret are separate fields rather than one opaque blob.
+ *
+ * SHA-256 (rather than argon2/scrypt, which a reviewer will reasonably ask about) is
+ * correct *here* and would be wrong for a password: the secret is 256 bits of CSPRNG
+ * output, so there is no guessable input to slow an attacker down to. Stretching only
+ * buys protection against low-entropy secrets, which this format cannot produce.
+ *
+ * The `gdpl_pat_` prefix is deliberate and load-bearing in three places: it lets the
+ * bearer-auth hook tell a PAT apart from the other Bearer credentials on this API
+ * (build-channel tokens, scheduler OIDC) without guessing, it makes the token
+ * greppable in a leaked log, and it is registered in `credential-scan.ts` so a
+ * generated game that embeds one is refused at assembly.
+ */
+
+export const ACCESS_TOKEN_PREFIX = 'gdpl_pat_';
+
+/** 8 bytes of id: enough that ids never collide, short enough to read in a log. */
+const TOKEN_ID_BYTES = 8;
+/** 32 bytes of secret — the actual credential. */
+const TOKEN_SECRET_BYTES = 32;
+
+/**
+ * Anchored, exact-length, and character-class-bounded. Rejecting a malformed token on
+ * shape alone matters beyond tidiness: it is what stops an unauthenticated caller from
+ * turning a stream of garbage Authorization headers into a stream of datastore reads.
+ */
+const TOKEN_PATTERN = /^gdpl_pat_([0-9a-f]{16})_([A-Za-z0-9_-]{43})$/;
+
+export class InvalidAccessTokenError extends Error {
+  constructor(message = 'invalid access token') {
+    super(message);
+    this.name = 'InvalidAccessTokenError';
+  }
+}
+
+export interface GeneratedAccessToken {
+  /** The full credential. Returned to the operator once and never recoverable after. */
+  token: string;
+  tokenId: string;
+  secretHash: string;
+}
+
+export function generateAccessToken(): GeneratedAccessToken {
+  const tokenId = randomBytes(TOKEN_ID_BYTES).toString('hex');
+  const secret = randomBytes(TOKEN_SECRET_BYTES).toString('base64url');
+  return {
+    token: `${ACCESS_TOKEN_PREFIX}${tokenId}_${secret}`,
+    tokenId,
+    secretHash: hashTokenSecret(secret),
+  };
+}
+
+export function looksLikeAccessToken(value: string): boolean {
+  return value.startsWith(ACCESS_TOKEN_PREFIX);
+}
+
+export function parseAccessToken(token: string): { tokenId: string; secret: string } {
+  const match = TOKEN_PATTERN.exec(token);
+  if (!match) throw new InvalidAccessTokenError('malformed access token');
+  const [, tokenId, secret] = match;
+  if (!tokenId || !secret) throw new InvalidAccessTokenError('malformed access token');
+  return { tokenId, secret };
+}
+
+export function hashTokenSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex');
+}
+
+export function verifyTokenSecret(secret: string, expectedHash: string): boolean {
+  const actual = Buffer.from(hashTokenSecret(secret), 'utf8');
+  const expected = Buffer.from(expectedHash, 'utf8');
+  // Length check first: timingSafeEqual throws on a mismatch rather than returning false,
+  // and a stored hash of the wrong length is corruption, not a credential to compare.
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
+
+/**
+ * Redacted form for logs, listings and error messages — the id only, never the secret.
+ * Displaying the id is safe by construction: it is the lookup key, not the credential.
+ */
+export function describeAccessToken(tokenId: string): string {
+  return `${ACCESS_TOKEN_PREFIX}${tokenId}_…`;
+}

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,9 +1,9 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { recentPartitions, summarizeGameHealth, type GameHealth } from './telemetry-health.js';
 import { summarizeVisitFunnel, type VisitFunnel } from './visit-funnel.js';
 import { summarizeCreatorMetrics, type CreatorMetrics } from './creator-metrics.js';
-import type { Store, TelemetryEvent, User, VisitEvent } from './store.js';
+import { BOT_UID_PREFIX, type Store, type TelemetryEvent, type User, type VisitEvent } from './store.js';
 
 /**
  * Operator-only reads over play telemetry (docs/improvement-loop-plan.md IL-2).
@@ -86,6 +86,19 @@ export function isAdmin(uid: string | undefined, adminUids: Set<string> | undefi
 }
 
 /**
+ * Admin *and* signed in with a browser session rather than a personal access token.
+ *
+ * Every operator surface takes this stricter test. A PAT is a long-lived credential that
+ * lives in CI config and agent VMs — environments where a human is not watching — so it
+ * may act as its user but never see across other people's games, and never mint another
+ * token. That keeps the blast radius of a leaked token inside one account, which is the
+ * property the whole design rests on (docs/agent-access-tokens.md).
+ */
+export function isAdminSession(request: FastifyRequest, adminUids: Set<string> | undefined): boolean {
+  return request.authMethod === 'session' && isAdmin(request.user?.uid, adminUids);
+}
+
+/**
  * Reads a window of daily partitions under one shared document budget.
  *
  * Both telemetry streams need the identical walk — newest day first, per-day cap, and a
@@ -129,7 +142,7 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
     // 404 rather than 403 for a signed-in non-admin: the existence of an operator
     // surface is not something a beta tester needs confirmed. An unauthenticated
     // request gets the same answer, so probing tells nobody anything.
-    if (!isAdmin(request.user?.uid, adminUids)) {
+    if (!isAdminSession(request, adminUids)) {
       return reply.status(404).send({ error: 'not found' });
     }
 
@@ -158,7 +171,7 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
    * underlying rows carry no identity to leak.
    */
   app.get('/api/admin/telemetry/visits', async (request, reply) => {
-    if (!isAdmin(request.user?.uid, adminUids)) {
+    if (!isAdminSession(request, adminUids)) {
       return reply.status(404).send({ error: 'not found' });
     }
 
@@ -184,11 +197,16 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
    * a publish, not about what happened inside a chosen week.
    */
   app.get('/api/admin/telemetry/creators', async (request, reply) => {
-    if (!isAdmin(request.user?.uid, adminUids)) {
+    if (!isAdminSession(request, adminUids)) {
       return reply.status(404).send({ error: 'not found' });
     }
 
-    const submissions = await store.listRecentlyPublished(MAX_SUBMISSIONS_SAMPLED);
+    // Automation accounts are excluded: these two numbers are about whether *people*
+    // come back and what their builds cost, and a bot account driven by a test suite
+    // would report flawless retention for a creator who does not exist.
+    const submissions = (await store.listRecentlyPublished(MAX_SUBMISSIONS_SAMPLED)).filter(
+      (submission) => !submission.ownerUid.startsWith(BOT_UID_PREFIX),
+    );
 
     // One lookup per distinct owner, not per submission: a prolific creator would
     // otherwise be fetched once per game they published.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
+import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerAdminRoutes } from './admin.js';
 import { registerAuthPlugin, type GoogleAuthVerifier } from './auth.js';
 import { createGenerator } from './generator.js';
@@ -191,6 +192,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // numbers. Unset means the route admits nobody, which is the right default for a
   // surface whose whole purpose is seeing across other people's games.
   await registerAdminRoutes(app, { store, adminUids });
+
+  // Issuing personal access tokens (docs/agent-access-tokens.md) — the credential that
+  // lets a coding agent in a cloud VM authenticate as a real account without a browser,
+  // a Google identity, or any bypass route. Same operator allowlist as the views above,
+  // and session-only, so a token can never mint another.
+  await registerAccessTokenRoutes(app, { store, adminUids });
 
   app.get('/api/health', async () => ({ status: 'ok', provider: generator.name, privateBeta }));
 

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -3,7 +3,12 @@ import cookie from '@fastify/cookie';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
-import { looksLikeAccessToken, parseAccessToken, verifyTokenSecret } from './access-token.js';
+import {
+  isAccessTokenExpired,
+  looksLikeAccessToken,
+  parseAccessToken,
+  verifyTokenSecret,
+} from './access-token.js';
 import { readBearerToken } from './bearer.js';
 import { withActiveDay, type Store, type User } from './store.js';
 
@@ -260,7 +265,9 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     const record = await store.getAccessToken(tokenId);
     if (!record) return null;
     if (!verifyTokenSecret(secret, record.secretHash)) return null;
-    if (Date.parse(record.expiresAt) <= Date.now()) return null;
+    // Fail closed on corrupt/missing expiresAt (NaN from Date.parse would
+    // otherwise read as "not expired").
+    if (isAccessTokenExpired(record.expiresAt, Date.now())) return null;
 
     const user = await store.getUser(record.uid);
     if (!user) return null;

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -3,6 +3,8 @@ import cookie from '@fastify/cookie';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
+import { looksLikeAccessToken, parseAccessToken, verifyTokenSecret } from './access-token.js';
+import { readBearerToken } from './bearer.js';
 import { withActiveDay, type Store, type User } from './store.js';
 
 export const SESSION_COOKIE_NAME = 'gamedev_session';
@@ -140,6 +142,14 @@ declare module 'fastify' {
   interface FastifyRequest {
     user: User | null;
     needsSessionRenewal: boolean;
+    /**
+     * How `user` was authenticated. `null` when there is no user.
+     *
+     * Routes that must not be reachable with a long-lived automation credential —
+     * the operator surfaces, and token issuance itself — check this rather than just
+     * `user`, so a leaked token can never widen its own privileges.
+     */
+    authMethod: 'session' | 'token' | null;
   }
 }
 
@@ -221,32 +231,94 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     }
   };
 
+  /**
+   * Resolve a personal access token from the Authorization header
+   * (docs/agent-access-tokens.md).
+   *
+   * Returns null — never throws — for every failure, so a bad token is simply an
+   * unauthenticated request and the route's own 401 explains it. Distinguishing
+   * "expired" from "revoked" from "never existed" in the response would only tell a
+   * caller holding a stolen token which one they hold.
+   *
+   * This API carries other Bearer credentials that are not PATs (the build channel's
+   * per-issue tokens, the scheduler's OIDC tokens). The `gdpl_pat_` prefix check is
+   * what keeps those out of here — they fall through untouched to the handlers that
+   * do understand them.
+   */
+  const getAccessTokenUser = async (request: FastifyRequest): Promise<User | null> => {
+    const bearer = readBearerToken(request.headers.authorization);
+    if (!bearer || !looksLikeAccessToken(bearer)) return null;
+
+    let tokenId: string;
+    let secret: string;
+    try {
+      ({ tokenId, secret } = parseAccessToken(bearer));
+    } catch {
+      return null;
+    }
+
+    const record = await store.getAccessToken(tokenId);
+    if (!record) return null;
+    if (!verifyTokenSecret(secret, record.secretHash)) return null;
+    if (Date.parse(record.expiresAt) <= Date.now()) return null;
+
+    const user = await store.getUser(record.uid);
+    if (!user) return null;
+
+    // Last-use tracking, coarsened to a day so a chatty agent costs one write rather
+    // than one per request — the question it answers ("is anything still using this
+    // token?") does not need finer resolution. Best-effort by design: bookkeeping must
+    // never turn a working request into a failing one.
+    const nowIso = new Date().toISOString();
+    if (record.lastUsedAt?.slice(0, 10) !== nowIso.slice(0, 10)) {
+      void store.touchAccessToken(tokenId, nowIso).catch(() => {
+        /* same contract as every other measurement in this file */
+      });
+    }
+
+    return user;
+  };
+
   app.decorateRequest('user', null);
   app.decorateRequest('needsSessionRenewal', false);
+  app.decorateRequest('authMethod', null);
 
   app.addHook('onRequest', async (request) => {
     if (!isAuthConfigured) return;
     const { user, needsRenewal } = await getSessionUser(request);
-    if (user) {
-      request.user = user;
-      request.needsSessionRenewal = needsRenewal;
-
-      /**
-       * Record that this account was active today.
-       *
-       * `lastLoginAt` cannot stand in for this: sessions last weeks, so a creator who
-       * comes back every day still shows a single login and reads as never returning.
-       * `withActiveDay` returns null when today is already the newest entry, so the
-       * common case costs no write at all — and a failure here must never turn a
-       * working request into an error, hence the swallow.
-       */
-      const today = new Date().toISOString().slice(0, 10);
-      const activeDays = withActiveDay(user.activeDays, today);
-      if (activeDays) {
-        void store.upsertUser({ uid: user.uid, activeDays }).catch(() => {
-          /* activity history is best-effort, like every other measurement */
-        });
+    if (!user) {
+      // No cookie session — fall back to a personal access token. Deliberately second:
+      // a browser that has both should be treated as the human it is.
+      const tokenUser = await getAccessTokenUser(request);
+      if (tokenUser) {
+        request.user = tokenUser;
+        request.authMethod = 'token';
       }
+      // No `activeDays` write on this path, and that is the point: the list feeds the
+      // creator-return metric, and an agent polling on a schedule would report perfect
+      // retention for an account that is not a person.
+      return;
+    }
+
+    request.user = user;
+    request.needsSessionRenewal = needsRenewal;
+    request.authMethod = 'session';
+
+    /**
+     * Record that this account was active today.
+     *
+     * `lastLoginAt` cannot stand in for this: sessions last weeks, so a creator who
+     * comes back every day still shows a single login and reads as never returning.
+     * `withActiveDay` returns null when today is already the newest entry, so the
+     * common case costs no write at all — and a failure here must never turn a
+     * working request into an error, hence the swallow.
+     */
+    const today = new Date().toISOString().slice(0, 10);
+    const activeDays = withActiveDay(user.activeDays, today);
+    if (activeDays) {
+      void store.upsertUser({ uid: user.uid, activeDays }).catch(() => {
+        /* activity history is best-effort, like every other measurement */
+      });
     }
   });
 
@@ -263,59 +335,155 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     }
   });
 
-  app.post('/api/auth/google', { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } }, async (request, reply) => {
-    if (!isAuthConfigured) {
-      return reply.status(503).send({ error: 'authentication is not configured' });
-    }
-
-    const currentTime = Date.now();
-    if (isRateLimited(authAttemptsByIp, request.ip, currentTime, maxAuthRequestsPerWindow, authRateLimitWindowMs)) {
-      return reply.status(429).send({ error: 'too many login attempts, please try again later' });
-    }
-
-    const parseResult = GoogleAuthSchema.safeParse(request.body);
-    if (!parseResult.success) {
-      return reply.status(400).send({ error: parseResult.error.issues[0]?.message ?? 'invalid request' });
-    }
-
-    try {
-      const googleUser = await verifier.verifyIdToken(parseResult.data.idToken);
-      const uid = `g:${googleUser.sub}`;
-
-      // Private-beta allowlist check — before creating/upserting the user doc so
-      // rejected sign-ins leave no trace in Firestore. Allow if uid OR verified email matches.
-      // NOTE: email is only consulted when Google has verified it (email_verified === true);
-      // an unverified email claim must never satisfy an access-control allowlist.
-      if (options.privateBeta) {
-        const emailLower = googleUser.emailVerified && googleUser.email ? googleUser.email.toLowerCase() : '';
-        const allowed =
-          (options.betaAllowedUids?.has(uid) ?? false) ||
-          (emailLower !== '' && (options.betaAllowedEmails?.has(emailLower) ?? false)) ||
-          (await store.isWaitlistApproved(uid, emailLower));
-        if (!allowed) {
-          // Look up existing waitlist status so the client can show it
-          const waitlistEntry = await store.getWaitlistEntry(uid);
-          return reply.status(403).send({
-            error: 'private beta — sign-ups are closed',
-            waitlistStatus: waitlistEntry?.status ?? null,
-          });
-        }
+  app.post(
+    '/api/auth/google',
+    { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } },
+    async (request, reply) => {
+      if (!isAuthConfigured) {
+        return reply.status(503).send({ error: 'authentication is not configured' });
       }
 
-      const user = await store.upsertUser({
-        uid,
-        email: googleUser.email,
-        name: googleUser.name,
-        picture: googleUser.picture,
-      });
+      const currentTime = Date.now();
+      if (isRateLimited(authAttemptsByIp, request.ip, currentTime, maxAuthRequestsPerWindow, authRateLimitWindowMs)) {
+        return reply.status(429).send({ error: 'too many login attempts, please try again later' });
+      }
 
-      if (user.tier === 'blocked') {
+      const parseResult = GoogleAuthSchema.safeParse(request.body);
+      if (!parseResult.success) {
+        return reply.status(400).send({ error: parseResult.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      try {
+        const googleUser = await verifier.verifyIdToken(parseResult.data.idToken);
+        const uid = `g:${googleUser.sub}`;
+
+        // Private-beta allowlist check — before creating/upserting the user doc so
+        // rejected sign-ins leave no trace in Firestore. Allow if uid OR verified email matches.
+        // NOTE: email is only consulted when Google has verified it (email_verified === true);
+        // an unverified email claim must never satisfy an access-control allowlist.
+        if (options.privateBeta) {
+          const emailLower = googleUser.emailVerified && googleUser.email ? googleUser.email.toLowerCase() : '';
+          const allowed =
+            (options.betaAllowedUids?.has(uid) ?? false) ||
+            (emailLower !== '' && (options.betaAllowedEmails?.has(emailLower) ?? false)) ||
+            (await store.isWaitlistApproved(uid, emailLower));
+          if (!allowed) {
+            // Look up existing waitlist status so the client can show it
+            const waitlistEntry = await store.getWaitlistEntry(uid);
+            return reply.status(403).send({
+              error: 'private beta — sign-ups are closed',
+              waitlistStatus: waitlistEntry?.status ?? null,
+            });
+          }
+        }
+
+        const user = await store.upsertUser({
+          uid,
+          email: googleUser.email,
+          name: googleUser.name,
+          picture: googleUser.picture,
+        });
+
+        if (user.tier === 'blocked') {
+          return reply.status(403).send({ error: 'account is blocked' });
+        }
+
+        const sessionToken = mintSessionToken(uid, effectiveSessionSecret);
+
+        reply.setCookie(SESSION_COOKIE_NAME, sessionToken, {
+          path: '/',
+          httpOnly: true,
+          secure: isProd,
+          sameSite: 'lax',
+          maxAge: DEFAULT_SESSION_DURATION_SECONDS,
+        });
+
+        return { user };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'google token verification failed';
+        return reply.status(401).send({ error: message });
+      }
+    },
+  );
+
+  // Deliberately usable WITHOUT a session — the caller is by definition someone
+  // whose sign-in was just rejected (not on the private-beta allowlist). Shares
+  // the auth rate limiter since it's the same abuse surface (unauthenticated
+  // Google-token verification). Re-verifies the token server-side rather than
+  // trusting any client-asserted identity.
+  app.post(
+    '/api/waitlist',
+    { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } },
+    async (request, reply) => {
+      if (!isAuthConfigured) {
+        return reply.status(503).send({ error: 'authentication is not configured' });
+      }
+
+      const currentTime = Date.now();
+      if (isRateLimited(authAttemptsByIp, request.ip, currentTime, maxAuthRequestsPerWindow, authRateLimitWindowMs)) {
+        return reply.status(429).send({ error: 'too many requests, please try again later' });
+      }
+
+      const parseResult = WaitlistSchema.safeParse(request.body);
+      if (!parseResult.success) {
+        return reply.status(400).send({ error: parseResult.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      try {
+        const googleUser = await verifier.verifyIdToken(parseResult.data.idToken);
+        const uid = `g:${googleUser.sub}`;
+        // Same rule as the beta allowlist: an unverified email claim must never be stored.
+        const email = googleUser.emailVerified && googleUser.email ? googleUser.email : undefined;
+
+        const entry = await store.upsertWaitlistEntry({
+          uid,
+          email,
+          name: googleUser.name,
+          locale: parseResult.data.locale,
+        });
+
+        return { status: 'ok', waitlistStatus: entry.status };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'google token verification failed';
+        return reply.status(401).send({ error: message });
+      }
+    },
+  );
+
+  /**
+   * Exchange a personal access token for a session cookie (docs/agent-access-tokens.md).
+   *
+   * Needed because the web app authenticates with cookies: an agent can call the API all
+   * day with a Bearer header, but the moment it drives a real browser against the real
+   * site — which is the entire point of the feature — it needs the credential the SPA
+   * actually sends. Without this, testing the product would mean reimplementing the
+   * product's fetch layer.
+   *
+   * Not a new privilege and not a bypass: the caller must already hold a valid token for
+   * the account, and what comes back is a session for that same account with the same
+   * lifetime as any other. It is the same shape as `/api/auth/google` — verify a
+   * credential the caller already has, hand back the cookie the browser needs.
+   *
+   * Session auth is deliberately *not* accepted here: a cookie cannot be used to mint a
+   * fresh cookie, so this can never be used to launder an about-to-expire session.
+   */
+  app.post(
+    '/api/auth/session',
+    { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } },
+    async (request, reply) => {
+      if (!isAuthConfigured) {
+        return reply.status(503).send({ error: 'authentication is not configured' });
+      }
+
+      if (!request.user || request.authMethod !== 'token') {
+        return reply.status(401).send({ error: 'a personal access token is required' });
+      }
+
+      if (request.user.tier === 'blocked') {
         return reply.status(403).send({ error: 'account is blocked' });
       }
 
-      const sessionToken = mintSessionToken(uid, effectiveSessionSecret);
-
-      reply.setCookie(SESSION_COOKIE_NAME, sessionToken, {
+      reply.setCookie(SESSION_COOKIE_NAME, mintSessionToken(request.user.uid, effectiveSessionSecret), {
         path: '/',
         httpOnly: true,
         secure: isProd,
@@ -323,52 +491,9 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         maxAge: DEFAULT_SESSION_DURATION_SECONDS,
       });
 
-      return { user };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'google token verification failed';
-      return reply.status(401).send({ error: message });
-    }
-  });
-
-  // Deliberately usable WITHOUT a session — the caller is by definition someone
-  // whose sign-in was just rejected (not on the private-beta allowlist). Shares
-  // the auth rate limiter since it's the same abuse surface (unauthenticated
-  // Google-token verification). Re-verifies the token server-side rather than
-  // trusting any client-asserted identity.
-  app.post('/api/waitlist', { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } }, async (request, reply) => {
-    if (!isAuthConfigured) {
-      return reply.status(503).send({ error: 'authentication is not configured' });
-    }
-
-    const currentTime = Date.now();
-    if (isRateLimited(authAttemptsByIp, request.ip, currentTime, maxAuthRequestsPerWindow, authRateLimitWindowMs)) {
-      return reply.status(429).send({ error: 'too many requests, please try again later' });
-    }
-
-    const parseResult = WaitlistSchema.safeParse(request.body);
-    if (!parseResult.success) {
-      return reply.status(400).send({ error: parseResult.error.issues[0]?.message ?? 'invalid request' });
-    }
-
-    try {
-      const googleUser = await verifier.verifyIdToken(parseResult.data.idToken);
-      const uid = `g:${googleUser.sub}`;
-      // Same rule as the beta allowlist: an unverified email claim must never be stored.
-      const email = googleUser.emailVerified && googleUser.email ? googleUser.email : undefined;
-
-      const entry = await store.upsertWaitlistEntry({
-        uid,
-        email,
-        name: googleUser.name,
-        locale: parseResult.data.locale,
-      });
-
-      return { status: 'ok', waitlistStatus: entry.status };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'google token verification failed';
-      return reply.status(401).send({ error: message });
-    }
-  });
+      return { user: request.user };
+    },
+  );
 
   // Local development sign-in. Real Google OAuth needs a client ID, a consent screen and
   // an authorized origin, none of which a first-time contributor has — so without this the

--- a/apps/api/src/credential-scan.ts
+++ b/apps/api/src/credential-scan.ts
@@ -8,6 +8,10 @@ const CREDENTIAL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
   { kind: 'openai-key', pattern: /\bsk-(?!ant-)[A-Za-z0-9_-]{32,}\b/g },
   { kind: 'github-token', pattern: /\bgh[opsu]_[A-Za-z0-9_]{20,}\b/g },
   { kind: 'github-token', pattern: /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g },
+  // Our own personal access tokens (docs/agent-access-tokens.md). Listed here for the
+  // same reason as everyone else's: an agent that holds one while authoring a game is
+  // exactly the situation where it ends up pasted into the output.
+  { kind: 'gamedev-access-token', pattern: /\bgdpl_pat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
   { kind: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g },
   { kind: 'aws-access-key-id', pattern: /\bAKIA[0-9A-Z]{16}\b/g },
   { kind: 'pem-private-key', pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/g },

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1597,6 +1597,9 @@ export class FirestoreStore implements Store {
   }
 
   async touchAccessToken(tokenId: string, at: string): Promise<void> {
-    await this.db.collection('accessTokens').doc(tokenId).set({ lastUsedAt: at }, { merge: true });
+    // `update` (not merge-set): a revoked token's doc is gone, and merge-set
+    // would resurrect a partial record that later auth reads crash on. Missing
+    // docs throw; callers already treat touch as best-effort.
+    await this.db.collection('accessTokens').doc(tokenId).update({ lastUsedAt: at });
   }
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2,6 +2,16 @@ import { createHash, randomUUID } from 'node:crypto';
 import { Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { BuildEvent, SubmissionStatus } from './submission-status.js';
 
+/**
+ * Uid namespace for automation accounts (docs/agent-access-tokens.md).
+ *
+ * Alongside `g:` (Google) and `dev:` (local sign-in). Keeping bots in their own
+ * namespace is what lets product measurement tell them apart from people — the creator
+ * metrics exclude them by this prefix — and it is why minting a token cannot
+ * accidentally call a mistyped `g:` account into existence.
+ */
+export const BOT_UID_PREFIX = 'bot:';
+
 export interface User {
   uid: string;
   email?: string;
@@ -352,6 +362,38 @@ export interface WaitlistEntry {
   status: WaitlistStatus;
 }
 
+/**
+ * A personal access token issued to a user account (docs/agent-access-tokens.md).
+ *
+ * Stored in its own top-level collection rather than on the user document, for one
+ * blunt reason: `User` objects are returned to clients by `/api/auth/me` and the
+ * sign-in routes, and a credential record that rides along on the user is one
+ * forgotten `delete` away from being served to a browser. Keeping it in a separate
+ * collection means that can never happen, and it makes the lookup a point read on
+ * the token id rather than a scan.
+ *
+ * `secretHash` is `sha256` of the secret half — the token itself is never stored, so
+ * an operator who can read this collection still cannot authenticate as anyone.
+ */
+export interface AccessTokenRecord {
+  tokenId: string;
+  uid: string;
+  secretHash: string;
+  /** Operator-supplied label, so a list of tokens is readable a month later. */
+  name: string;
+  createdAt: string;
+  /** Who minted it — an admin uid. Kept so issuance is attributable after the fact. */
+  createdByUid: string;
+  /** Expiry is mandatory: a credential for automation should not outlive its purpose. */
+  expiresAt: string;
+  /**
+   * Best-effort last-use stamp, written at most once a day (like `User.activeDays`)
+   * so a busy agent costs one write rather than one per request. Its job is answering
+   * "is this token still in use?" before revoking it, which a day's resolution covers.
+   */
+  lastUsedAt?: string;
+}
+
 export interface Store {
   getUser(uid: string): Promise<User | null>;
   upsertUser(userData: Partial<User> & { uid: string }): Promise<User>;
@@ -471,6 +513,16 @@ export interface Store {
   clearVote(slug: string, uid: string): Promise<GameVoteCounts>;
   /** A game's aggregate vote counts — the public read, no uid involved. */
   getVoteCounts(slug: string): Promise<GameVoteCounts>;
+  /** Persist a newly minted personal access token. */
+  createAccessToken(record: AccessTokenRecord): Promise<void>;
+  /** Point lookup by token id — the hot path on every bearer-authenticated request. */
+  getAccessToken(tokenId: string): Promise<AccessTokenRecord | null>;
+  /** Every token issued to a user, newest first. Never includes secrets (only hashes). */
+  listAccessTokens(uid: string): Promise<AccessTokenRecord[]>;
+  /** Revoke by id. Returns false when the token did not exist. */
+  deleteAccessToken(tokenId: string): Promise<boolean>;
+  /** Best-effort last-use stamp; callers must not let a failure fail the request. */
+  touchAccessToken(tokenId: string, at: string): Promise<void>;
 }
 
 // Stable doc id for a subscription: a hash of its endpoint URL. Endpoints are long
@@ -508,6 +560,8 @@ export class InMemoryStore implements Store {
   private pushSubs = new Map<string, Map<string, PushSubscriptionRecord>>();
   // slug -> (uid -> value)
   private votes = new Map<string, Map<string, VoteValue>>();
+  // tokenId -> personal access token record
+  private accessTokens = new Map<string, AccessTokenRecord>();
 
   async getUser(uid: string): Promise<User | null> {
     const user = this.users.get(uid);
@@ -923,6 +977,31 @@ export class InMemoryStore implements Store {
 
   async getVoteCounts(slug: string): Promise<GameVoteCounts> {
     return this.voteCounts(slug);
+  }
+
+  async createAccessToken(record: AccessTokenRecord): Promise<void> {
+    this.accessTokens.set(record.tokenId, { ...record });
+  }
+
+  async getAccessToken(tokenId: string): Promise<AccessTokenRecord | null> {
+    const record = this.accessTokens.get(tokenId);
+    return record ? { ...record } : null;
+  }
+
+  async listAccessTokens(uid: string): Promise<AccessTokenRecord[]> {
+    return Array.from(this.accessTokens.values())
+      .filter((record) => record.uid === uid)
+      .map((record) => ({ ...record }))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async deleteAccessToken(tokenId: string): Promise<boolean> {
+    return this.accessTokens.delete(tokenId);
+  }
+
+  async touchAccessToken(tokenId: string, at: string): Promise<void> {
+    const record = this.accessTokens.get(tokenId);
+    if (record) this.accessTokens.set(tokenId, { ...record, lastUsedAt: at });
   }
 
   // Test/inspection only — not part of the Store interface. Production code never
@@ -1488,5 +1567,36 @@ export class FirestoreStore implements Store {
   async getVoteCounts(slug: string): Promise<GameVoteCounts> {
     const snap = await this.gameRef(slug).get();
     return FirestoreStore.readVoteCounts(snap.data());
+  }
+
+  async createAccessToken(record: AccessTokenRecord): Promise<void> {
+    await this.db.collection('accessTokens').doc(record.tokenId).create(record);
+  }
+
+  async getAccessToken(tokenId: string): Promise<AccessTokenRecord | null> {
+    const snap = await this.db.collection('accessTokens').doc(tokenId).get();
+    if (!snap.exists) return null;
+    return snap.data() as AccessTokenRecord;
+  }
+
+  async listAccessTokens(uid: string): Promise<AccessTokenRecord[]> {
+    const snap = await this.db.collection('accessTokens').where('uid', '==', uid).get();
+    // Sorted in memory rather than with orderBy: a composite (uid, createdAt) index is
+    // not worth provisioning for a listing whose result set is a handful of rows.
+    return snap.docs
+      .map((doc) => doc.data() as AccessTokenRecord)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async deleteAccessToken(tokenId: string): Promise<boolean> {
+    const docRef = this.db.collection('accessTokens').doc(tokenId);
+    const snap = await docRef.get();
+    if (!snap.exists) return false;
+    await docRef.delete();
+    return true;
+  }
+
+  async touchAccessToken(tokenId: string, at: string): Promise<void> {
+    await this.db.collection('accessTokens').doc(tokenId).set({ lastUsedAt: at }, { merge: true });
   }
 }

--- a/apps/api/src/telemetry.test.ts
+++ b/apps/api/src/telemetry.test.ts
@@ -38,6 +38,26 @@ function post(app: Awaited<ReturnType<typeof buildApp>>, payload: unknown, heade
 
 const today = () => new Date().toISOString().slice(0, 10);
 
+/**
+ * Every partition a backdated write could have landed in, oldest first.
+ *
+ * The handler files each event under the partition of *its own* timestamp, not the
+ * flush's, so a deliberately backdated event does not necessarily land in today's.
+ * Asserting on `today()` alone made the backdating tests below fail every night
+ * between 00:00 and 06:00 UTC: clamped six hours into the past, the event is filed
+ * under *yesterday* and the read came back empty. The store is fresh per test, so
+ * reading both partitions is exact rather than merely tolerant.
+ */
+async function listBackdated(store: InMemoryStore) {
+  const todayStr = today();
+  const yesterdayStr = new Date(Date.parse(`${todayStr}T00:00:00Z`) - 86_400_000).toISOString().slice(0, 10);
+  const [earlier, current] = await Promise.all([
+    store.listTelemetryEvents(yesterdayStr),
+    store.listTelemetryEvents(todayStr),
+  ]);
+  return [...earlier, ...current];
+}
+
 describe('POST /api/telemetry', () => {
   let store: InMemoryStore;
   beforeEach(async () => {
@@ -225,7 +245,7 @@ describe('POST /api/telemetry', () => {
         ],
       });
 
-      const stored = await store.listTelemetryEvents(today());
+      const stored = await listBackdated(store);
       const times = stored.map((event) => Date.parse(event.at));
       // 10 seconds apart, as they were when they happened — not one shared instant.
       expect(times[1] - times[0]).toBe(10_000);
@@ -259,7 +279,8 @@ describe('POST /api/telemetry', () => {
       });
 
       const sixHours = 6 * 60 * 60 * 1000;
-      const [event] = await store.listTelemetryEvents(today());
+      const [event] = await listBackdated(store);
+      expect(event, 'backdated event missing from both candidate partitions').toBeDefined();
       // Clamped to exactly the cap, measured against a clock read before the request
       // so the millisecond the request itself takes cannot fail the assertion.
       expect(Date.parse(event.at)).toBeGreaterThanOrEqual(before - sixHours);
@@ -278,7 +299,7 @@ describe('POST /api/telemetry', () => {
         events: [{ type: 'game_opened', msSinceOpen: 60_000 }],
       });
 
-      const [event] = await store.listTelemetryEvents(today());
+      const [event] = await listBackdated(store);
       expect(Date.parse(event.at)).toBeGreaterThanOrEqual(before);
       expect(Date.parse(event.at)).toBeLessThanOrEqual(Date.now());
       await app.close();

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ survives only in this repo's early history.
 | [`local-development.md`](./local-development.md)                   | ✅ Running the whole product on a laptop with no keys — start here to contribute                       |
 | [`multiplayer-plan.md`](./multiplayer-plan.md)                     | ✅ Party mode: shared screen, phones as controllers, slot model, in-process relay                      |
 | [`auth-and-usage-plan.md`](./auth-and-usage-plan.md)               | ✅ Google sign-in, sessions, per-user quotas                                                           |
+| [`agent-access-tokens.md`](./agent-access-tokens.md)               | ✅ How an agent in a cloud VM authenticates without a browser or a Google account                      |
 | [`content-safety-plan.md`](./content-safety-plan.md)               | ✅ Moderation of submitted specs before an agent ever sees them                                        |
 | [`legal-compliance-plan.md`](./legal-compliance-plan.md)           | ✅ RODO/UŚUDE/DSA/AI-Act obligations and what is published to satisfy them                             |
 | [`agent-live-channel-plan.md`](./agent-live-channel-plan.md)       | ✅ How a working agent reports progress to the creator in seconds, not commits                         |

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -1,6 +1,6 @@
 # Personal access tokens — how an agent authenticates without a browser
 
-✅ **Implemented.** Status: shipped on `master`.
+> Status: ✅ **Implemented on this branch** — pending merge to `master`.
 
 ## The problem
 
@@ -154,9 +154,11 @@ issuing a credential is an admission decision in itself.
 ## Operational notes
 
 - **Firestore:** one new collection, `accessTokens`, keyed by token id. No index needed —
-  the hot path is a point read, and listing filters by `uid` and sorts in memory. Consider
-  a TTL policy on `expiresAt` so expired records self-clean; expired tokens are already
-  refused at auth, so the policy is hygiene, not security.
+  the hot path is a point read, and listing filters by `uid` and sorts in memory.
+  Expired tokens are already refused at auth. A Firestore TTL policy would **not**
+  self-clean these rows today: `expiresAt` is stored as an ISO string, and TTL only
+  watches Timestamp/Date fields (telemetry writes `expiresAt` as a `Date` for that
+  reason). Housekeeping would need a separate Timestamp field, or a sweep.
 - **Auditing:** every record carries `createdByUid` (an admin uid, or `cli:<user>`) and a
   day-resolution `lastUsedAt`, so you can see who issued a token and whether anything
   still uses it before revoking.

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -106,39 +106,91 @@ DELETE /api/admin/access-tokens/<tokenId>
 The token is readable exactly once, in the mint response. Nothing stores it — a caller who
 loses it revokes and mints again.
 
+## Where the token lives
+
+**One token per environment, never one shared token.** Revocation is per-token, so a
+shared token leaked from anywhere forces revoking it everywhere — and `token:list`
+cannot tell you which copy leaked, because they are the same row. Minted per home and
+named for it, the listing becomes an inventory and `lastUsedAt` shows which ones are
+dead weight before you revoke:
+
+```bash
+npm run token:mint -w @gamedevpl/api -- bot:e2e   --name "claude web env" --days 90
+npm run token:mint -w @gamedevpl/api -- bot:ci    --name "github actions" --days 30
+npm run token:mint -w @gamedevpl/api -- bot:local --name "owner laptop"   --days 90
+```
+
+Where each one goes, always as `GAMEDEV_ACCESS_TOKEN`:
+
+- **Claude Code on the web** — the environment's own env-var settings, alongside its
+  setup script and network policy (docs: code.claude.com). If
+  `curl https://www.gamedev.pl/api/health` fails from inside the VM, that is the
+  environment's outbound network policy, not the token — check it before debugging the
+  credential.
+- **A laptop** — shell profile, or a `.env` in the repo (already gitignored).
+- **GitHub Actions** — a repository secret, read as
+  `${{ secrets.GAMEDEV_ACCESS_TOKEN }}`. Actions keeps secrets away from fork-PR
+  workflows, so this is safe by default.
+- **Copilot's coding agent** — deliberately **no**. The `copilot-orchestration`
+  playbook already rules it out ("never route credential handling through an autonomous
+  PR agent"), Copilot's sandbox firewall blocks the site by default anyway, and Copilot
+  works on a local checkout where `/api/auth/dev` costs nothing.
+
+Prefer a short `--days` for anything automated: a 30-day CI token that expires loudly is
+a better failure than one that quietly works forever. **Never commit a token** — the
+repo's gitleaks config and the generated-game credential scanner both know the
+`gdpl_pat_` shape, but those are backstops, not the plan. Keep it in headers, never in
+URLs, which end up in logs and shell history.
+
 ## Using a token (agent)
 
-Put it in the agent environment as `GAMEDEV_ACCESS_TOKEN`. **Never commit it**; it is in
-the generated-game credential scanner, so a game that embeds one is refused at assembly.
-
-**API calls** — send it as a bearer token:
+**API calls** — send it as a bearer token; that is the entire integration:
 
 ```bash
 curl -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" https://www.gamedev.pl/api/auth/me
 ```
 
-**Driving a real browser** — the web app authenticates with cookies, so exchange the token
-for a session first. `POST /api/auth/session` accepts only a token (never a cookie, so a
-session can never launder itself into a fresh one) and returns the same cookie a Google
-sign-in would:
-
-```bash
-curl -si -X POST https://www.gamedev.pl/api/auth/session \
-  -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" | grep -i set-cookie
-```
-
-In Playwright, exchange once and hand the cookie to the browser context:
+**Driving a real browser** — the SPA authenticates with cookies
+(`credentials: 'include'`), so exchange the token for a session first.
+`POST /api/auth/session` accepts only a token (never a cookie, so a session can never
+launder itself into a fresh one) and returns the same cookie a Google sign-in would.
+The verified Playwright shape:
 
 ```js
-const api = await request.newContext();
-const res = await api.post('https://www.gamedev.pl/api/auth/session', {
+import { chromium, request } from 'playwright-core';
+
+const api = await request.newContext({ baseURL: 'https://www.gamedev.pl' });
+await api.post('/api/auth/session', {
   headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
 });
+
+const browser = await chromium.launch({
+  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+});
 const context = await browser.newContext({ storageState: await api.storageState() });
+const page = await context.newPage();
+await page.goto('https://www.gamedev.pl'); // renders signed in
 ```
 
-Chromium is preinstalled in most agent VMs (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`);
-do not run `playwright install`.
+Playwright's API context keeps its own cookie jar; `storageState()` carries the session
+into the browser. Exchange once per run, not per page — the session lasts 12 hours and
+`/api/auth/session` shares the 20/hour/IP auth limiter.
+
+Traps, in the order an agent will hit them:
+
+- **The cookie is `HttpOnly` — `document.cookie` cannot set it.** A page seeded that way
+  silently stays logged out with no error. Go through a browser-level API:
+  `storageState` as above, or `context.addCookies([...])` with `httpOnly: true` if the
+  `Set-Cookie` came from curl.
+- **Do not add Playwright to the repo's `package.json`.** This app has no e2e harness by
+  design; install `playwright-core` in a scratch directory instead. A dependency edit
+  without a regenerated lockfile passes every local check and kills CI at `npm ci` — the
+  exact failure the `verify-agent-work` playbook records.
+- **No `playwright install`.** Chromium is preinstalled in agent VMs
+  (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`); pass `executablePath` if your
+  Playwright version doesn't auto-find it.
+- **Production cookies carry `Secure`** — they travel over HTTPS only, so the same
+  script pointed at a plain-HTTP host will not authenticate.
 
 ## Where this does and does not apply
 

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -130,7 +130,8 @@ Where each one goes, always as `GAMEDEV_ACCESS_TOKEN`:
 - **A laptop** — shell profile, or a `.env` in the repo (already gitignored).
 - **GitHub Actions** — a repository secret, read as
   `${{ secrets.GAMEDEV_ACCESS_TOKEN }}`. Actions keeps secrets away from fork-PR
-  workflows, so this is safe by default.
+  workflows, so this is safe by default. The deploy workflow already consumes it: see
+  the authenticated smoke below.
 - **Copilot's coding agent** — deliberately **no**. The `copilot-orchestration`
   playbook already rules it out ("never route credential handling through an autonomous
   PR agent"), Copilot's sandbox firewall blocks the site by default anyway, and Copilot
@@ -191,6 +192,31 @@ Traps, in the order an agent will hit them:
   Playwright version doesn't auto-find it.
 - **Production cookies carry `Secure`** — they travel over HTTPS only, so the same
   script pointed at a plain-HTTP host will not authenticate.
+
+## CI: the authenticated deploy smoke
+
+`deploy.yml` runs two layers of this on every candidate revision, **before traffic
+moves**:
+
+- **Always, no secret needed:** a forged `gdpl_pat_`-shaped bearer token must get 401
+  from `/api/auth/me` — the token path fails closed, proven on every deploy. (The forged
+  value is assembled at runtime in the workflow, because a well-formed literal would
+  rightly trip gitleaks.)
+- **When the `GAMEDEV_ACCESS_TOKEN` repo secret exists:** bearer `/api/auth/me` → 200,
+  the uid **must be `bot:`-namespaced** (a human token pasted into CI is rejected rather
+  than polluting creator metrics on every deploy), then the token→cookie exchange and a
+  session-walled route (`/api/notifications`) → 200. Any failure blocks promotion; the
+  live revision keeps serving.
+
+Without the secret the step skips with a loud `::notice::` rather than passing silently
+— a skipped check is absence of signal, not a pass. Two consequences to know about:
+
+- **An expired CI token fails deploys.** Deliberate: credential expiry should be a
+  visible event. Fix by minting a fresh one (`--days 30` for CI) and updating the
+  secret; or delete the secret to fall back to skipping.
+- Secrets are snapshotted per-run — a deploy racing a secret update bakes in the old
+  value (a failure mode this repo has hit with vars before; see the
+  `verify-agent-work` playbook). Re-run the workflow after changing the secret.
 
 ## Where this does and does not apply
 

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -1,0 +1,177 @@
+# Personal access tokens — how an agent authenticates without a browser
+
+✅ **Implemented.** Status: shipped on `master`.
+
+## The problem
+
+Sign-in is Google-only. A coding agent working in a cloud VM — Claude Code on the web,
+Copilot's coding agent, a Codex container, CI — has no browser session, no Gmail
+account, and no way to get one. So an agent could build and unit-test the product but
+never _use_ it: every authenticated route (creating, revising, notifications, votes,
+party mode) was unreachable, and every change to that half of the app shipped unverified
+against the real thing.
+
+`POST /api/auth/dev` solves this on a laptop and is deliberately 404 in production, so it
+does not help against the deployed site.
+
+## What was rejected, and why it matters
+
+Three obvious options were considered first. Recording why they lost is the point of this
+section — each is the thing someone will propose again in six months.
+
+| Option                                      | Why not                                                                                                                                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A secret-gated "test login" route in prod   | It is a bypass whatever it is named. In an open-source repo, obscuring the name is worse than the bypass: the code is public either way, and the people misled are our own reviewers.         |
+| Driving the Google login UI with Playwright | Google blocks automated sign-in (the "browser may not be secure" wall), datacenter IPs trigger CAPTCHA and phone verification, and it means putting a real Google password in every agent VM. |
+| Email + password accounts                   | A real product feature, but it creates a password database — a permanent breach liability — plus registration, verification, reset and brute-force defense, all to solve a testing problem.   |
+
+A token issued **to a real account** avoids all three: no bypass route, no Google
+credential in the VM, no password to store. It is also simply the right credential for a
+machine — the same reason GitHub removed password auth for automation and replaced it with
+personal access tokens.
+
+## Shape
+
+```
+gdpl_pat_<16 hex id>_<43 char base64url secret>
+```
+
+The id travels in the clear and is the lookup key; only the secret half is a credential.
+What is stored is `sha256(secret)` in a top-level `accessTokens` collection — the token
+itself is never written down, so a dump of the datastore yields nothing usable.
+
+SHA-256 rather than argon2/scrypt is correct here and would be wrong for a password: the
+secret is 256 bits of CSPRNG output, so there is no guessable input for stretching to slow
+down.
+
+Tokens live in their own collection rather than on the user document for a blunt reason:
+`User` objects are returned to browsers by `/api/auth/me`, and a credential record riding
+along on the user is one forgotten `delete` away from being served to a client.
+
+## Properties
+
+- **It is not a bypass.** The token authenticates _as an account_, with that account's
+  tier, quota, and walls. There is no synthetic identity and no route that grants a
+  session from nothing.
+- **Revocation is a delete**, not a flag — the record _is_ the token's existence, so there
+  is no revoked-but-still-verifiable state to get wrong. It takes effect on the next
+  request, with no redeploy (unlike rotating an environment secret).
+- **A token can never mint another token.** Issuing requires an admin _session_; a
+  request authenticated with a token gets 404 from every operator surface, even when the
+  token belongs to an admin. One leaked credential cannot become self-renewing.
+- **Expiry is mandatory**, 90 days by default and 365 at most.
+- **Bounded blast radius.** The worst case for a leaked token is someone acting as that
+  one account — the same as a leaked session cookie, and strictly less than a leaked
+  shared secret that mints sessions for anyone.
+- **No new deployment secret.** Nothing new goes in Cloud Run's env or Secret Manager.
+
+## The `bot:` namespace
+
+Automation accounts use `bot:<handle>`, alongside `g:` (Google) and `dev:` (local).
+
+Minting can create a `bot:` account but refuses to invent any other namespace. That rule
+is a typo guard with teeth: without it, a mistyped `g:<sub>` would silently call an
+account into being that never signed in, never passed the beta allowlist, and now holds a
+working credential.
+
+The prefix is also what lets product measurement tell bots from people — the creator
+metrics exclude `bot:` submissions, and a token-authenticated request never records an
+`activeDays` entry, so an agent on a cron cannot report perfect retention for an account
+that is not a person.
+
+## Issuing a token (operator)
+
+Two paths, both calling the same `mintAccessTokenFor` so the rules cannot drift.
+
+**CLI — no browser needed.** Talks to Firestore with your ambient gcloud credentials, the
+same way `beta:approve` does. Check `gcloud config get-value project` first; there is no
+dev/prod switch.
+
+```bash
+npm run token:mint   -w @gamedevpl/api -- bot:e2e --name "claude cloud vm"
+npm run token:mint   -w @gamedevpl/api -- bot:e2e --name "ci" --days 30
+npm run token:list   -w @gamedevpl/api -- bot:e2e
+npm run token:revoke -w @gamedevpl/api -- <tokenId>
+```
+
+**HTTP — for anyone already signed in as an admin.** Requires an `ADMIN_UIDS` session;
+answers 404 to everyone else, including a token-authenticated admin.
+
+```
+POST   /api/admin/access-tokens          {"uid":"bot:e2e","name":"ci","expiresInDays":30}
+GET    /api/admin/access-tokens?uid=bot:e2e
+DELETE /api/admin/access-tokens/<tokenId>
+```
+
+The token is readable exactly once, in the mint response. Nothing stores it — a caller who
+loses it revokes and mints again.
+
+## Using a token (agent)
+
+Put it in the agent environment as `GAMEDEV_ACCESS_TOKEN`. **Never commit it**; it is in
+the generated-game credential scanner, so a game that embeds one is refused at assembly.
+
+**API calls** — send it as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" https://www.gamedev.pl/api/auth/me
+```
+
+**Driving a real browser** — the web app authenticates with cookies, so exchange the token
+for a session first. `POST /api/auth/session` accepts only a token (never a cookie, so a
+session can never launder itself into a fresh one) and returns the same cookie a Google
+sign-in would:
+
+```bash
+curl -si -X POST https://www.gamedev.pl/api/auth/session \
+  -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" | grep -i set-cookie
+```
+
+In Playwright, exchange once and hand the cookie to the browser context:
+
+```js
+const api = await request.newContext();
+const res = await api.post('https://www.gamedev.pl/api/auth/session', {
+  headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
+});
+const context = await browser.newContext({ storageState: await api.storageState() });
+```
+
+Chromium is preinstalled in most agent VMs (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`);
+do not run `playwright install`.
+
+## Where this does and does not apply
+
+Testing **local changes** does not need a token at all — `npm run dev` plus
+`POST /api/auth/dev` is faster, runs against the in-memory store, and touches nothing
+real. Reach for a token when the thing under test is the deployed site: real Firestore,
+the real generation pipeline, the real beta walls, the real CDN.
+
+A token-authenticated bot **passes the private-beta wall** even though it is not on the
+beta allowlist. That is intended, not a hole: the allowlist gates _sign-in_, and an admin
+issuing a credential is an admission decision in itself.
+
+## Operational notes
+
+- **Firestore:** one new collection, `accessTokens`, keyed by token id. No index needed —
+  the hot path is a point read, and listing filters by `uid` and sorts in memory. Consider
+  a TTL policy on `expiresAt` so expired records self-clean; expired tokens are already
+  refused at auth, so the policy is hygiene, not security.
+- **Auditing:** every record carries `createdByUid` (an admin uid, or `cli:<user>`) and a
+  day-resolution `lastUsedAt`, so you can see who issued a token and whether anything
+  still uses it before revoking.
+- **Rate limits:** `/api/auth/session` shares the auth limiter (20/hour/IP). Bearer-
+  authenticated API calls are not separately limited beyond each route's own limits —
+  exchange once and reuse the cookie rather than exchanging per request.
+- **Rotation:** mint the new token, update the agent environment, revoke the old id. There
+  is no window where both must be valid, so no coordination is needed.
+
+## Code map
+
+| File                                   | What it holds                                                       |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| `apps/api/src/access-token.ts`         | Pure format, mint, hash, verify — no I/O                            |
+| `apps/api/src/access-token-service.ts` | The shared issuance rules (namespace, cap, expiry)                  |
+| `apps/api/src/access-token-routes.ts`  | Operator HTTP surface                                               |
+| `apps/api/src/auth.ts`                 | Bearer resolution in the `onRequest` hook; `POST /api/auth/session` |
+| `apps/api/scripts/access-token.ts`     | The `token:mint` / `token:list` / `token:revoke` CLI                |

--- a/docs/contributing-for-agents.md
+++ b/docs/contributing-for-agents.md
@@ -63,6 +63,36 @@ npm run type-check && npm run lint && npm run test && npm run build
 This mirrors the CI workflow (`.github/workflows/ci.yml`, Node 20). A Husky `pre-commit` hook
 runs `lint-staged` (Prettier) on staged files.
 
+### Exercising the authenticated half of the product
+
+A green gate says the code compiles and its tests pass. It does not say the flow works. If
+your change touches anything behind sign-in — creating, revising, notifications, votes,
+party mode — drive it.
+
+**Locally (the default, and what most changes need).** `npm run dev`, then:
+
+```bash
+curl -X POST http://localhost:5173/api/auth/dev -c cookies.txt
+```
+
+That is a full session for `dev:local` against the in-memory store and the mock generator.
+No credentials, nothing real touched. See [`local-development.md`](./local-development.md).
+
+**Against the deployed site**, when the thing under test is production behaviour — real
+Firestore, the real beta walls, the real CDN — you need a personal access token, because
+you have no browser and no Google account and there is no bypass route:
+
+```bash
+curl -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" https://www.gamedev.pl/api/auth/me
+# driving a real browser? exchange it for the cookie the SPA actually sends:
+curl -si -X POST https://www.gamedev.pl/api/auth/session \
+  -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" | grep -i set-cookie
+```
+
+Tokens are issued by the repo owner, never self-served, and `GAMEDEV_ACCESS_TOKEN` must
+never be committed or pasted into a game, an issue, or a PR description. Full guide:
+[`agent-access-tokens.md`](./agent-access-tokens.md).
+
 ## Code conventions
 
 - **ESM only.** Every package is `"type": "module"`. Use `.js` extensions in relative imports

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -149,9 +149,10 @@ those accounts are excluded from creator metrics, so agent traffic does not move
 product numbers.
 
 Storage is one new Firestore collection, `accessTokens`, keyed by token id. No composite
-index is required. Optionally add a **TTL policy on `expiresAt`** so expired records
-self-clean — expired tokens are already refused at authentication, so this is housekeeping
-rather than a control.
+index is required. Expired tokens are already refused at authentication. Do **not** point
+a Firestore TTL policy at `expiresAt` as stored today — that field is an ISO string, and
+TTL only deletes on Timestamp/Date values (a no-op policy otherwise). Self-cleaning would
+need a dedicated Timestamp field or an operator sweep; it is hygiene, not a control.
 
 ## How to deploy manually
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,7 +33,7 @@ Deployments to Cloud Run are triggered on push to `master`:
 2. **Keyless OIDC Auth:** Authenticates via GCP Workload Identity Federation (no long-lived service account keys).
 3. **Cloud Build Image Creation:** Submits image build using `infra/cloudbuild.yaml` to Artifact Registry. The WIF deployer service account must also have `roles/serviceusage.serviceUsageConsumer` and storage access for the default Cloud Build staging bucket; `infra/setup-wif.sh` grants both.
 4. **Staging / Candidate Revision:** Deploys revision to Cloud Run with `--no-traffic --tag candidate`.
-5. **Candidate Smoke Test:** Performs HTTP status check on `${CANDIDATE_URL}/api/health`.
+5. **Candidate Smoke Test:** Anonymous checks (health, shell, public catalog/play, walls hold, forged bearer token rejected) plus an **authenticated smoke** when the `GAMEDEV_ACCESS_TOKEN` repo secret exists — bearer auth, token→cookie exchange, and a session-walled route, run as the CI bot (see [`agent-access-tokens.md`](./agent-access-tokens.md)). Skips loudly when the secret is absent.
 6. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if the smoke test succeeds.
 
 ## Secrets & access (current live state)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,32 @@ previews the rendered email with no Firestore write and no send. See
 [`.claude/skills/managing-beta-participants`](../.claude/skills/managing-beta-participants) for
 the full access model.
 
+## Issuing agent access tokens
+
+Coding agents authenticate to the deployed site with personal access tokens
+([`agent-access-tokens.md`](./agent-access-tokens.md)). Deliberately **no new deployment
+config**: no Secret Manager entry, no Cloud Run env var, nothing to rotate at the
+infrastructure level. The only prerequisite is that `ADMIN_UIDS` already contains your uid,
+which it must for the operator telemetry views anyway.
+
+Issue one the same way you approve a beta tester — from a shell with gcloud credentials for
+the project:
+
+```bash
+npm run token:mint   -w @gamedevpl/api -- bot:e2e --name "claude cloud vm"
+npm run token:list   -w @gamedevpl/api -- bot:e2e
+npm run token:revoke -w @gamedevpl/api -- <tokenId>
+```
+
+The token prints once and is never recoverable. It creates a `bot:` account on first mint;
+those accounts are excluded from creator metrics, so agent traffic does not move the
+product numbers.
+
+Storage is one new Firestore collection, `accessTokens`, keyed by token id. No composite
+index is required. Optionally add a **TTL policy on `expiresAt`** so expired records
+self-clean — expired tokens are already refused at authentication, so this is housekeeping
+rather than a control.
+
 ## How to deploy manually
 
 [`apps/api/Dockerfile`](../apps/api/Dockerfile) is a multi-stage image built from the repo root

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -55,6 +55,11 @@ That sets a session cookie for `dev:local`. Pass `{"uid":"someone-else"}` to get
 account — useful for testing anything that involves two users. The endpoint answers **404 in
 production**; it exists only outside it, and mints a session with no credential at all.
 
+This is the right tool for local work, including for a coding agent in a cloud VM: it runs
+against the in-memory store and the mock generator, so it touches nothing real. Testing the
+**deployed** site is a different problem with a different answer — see
+[`agent-access-tokens.md`](./agent-access-tokens.md).
+
 ## Running the checks
 
 ```bash

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -64,6 +64,27 @@ boundary.
   CORS must not become the production submission policy.
 - Never return repository credentials or upstream error details to clients.
 
+### 5. Programmatic callers (personal access tokens)
+
+Coding agents authenticate with tokens issued to real accounts
+([`agent-access-tokens.md`](./agent-access-tokens.md)) rather than through any bypass
+route. The properties that keep this inside the threat model:
+
+- A token authenticates **as an account** — same tier, quota, and walls. It grants nothing
+  a session for that account would not.
+- **Issuance requires an admin session.** A token-authenticated request is refused by every
+  operator surface, so a leaked token cannot mint another or read across other people's
+  games.
+- Only `sha256(secret)` is stored, in its own collection, never on the user document that
+  gets serialized to browsers.
+- Revocation is a delete and takes effect on the next request — no redeploy, unlike
+  rotating a shared secret.
+- Expiry is mandatory (90 days default, 365 max), and the token format is registered in the
+  generated-game credential scanner.
+
+Do not add an unauthenticated route that mints sessions, and do not rename one to look like
+something else. If a bypass is ever genuinely required, it must be named for what it is.
+
 ## Mechanical games-repo gate
 
 Before publication, each game must pass the checks in
@@ -90,3 +111,5 @@ credentials operated by gamedev.pl. Historical details are available in Git hist
 - Agent-authored changes require review and validation; they are never auto-merged.
 - Production credentials never enter game bundles, public specs, untrusted PR jobs, or the
   browser.
+- Authentication has no bypass route in production. Programmatic callers use tokens issued
+  to real accounts, and issuing one always requires a human at an admin session.


### PR DESCRIPTION
## The problem

Sign-in is Google-only. A coding agent in a cloud VM has no browser session and no Gmail account, so it could build and unit-test the product but never *use* it — every authenticated route (creating, revising, notifications, votes, party mode) was unreachable, and every change to that half of the app shipped unverified against the real thing. `POST /api/auth/dev` covers a laptop and is deliberately 404 in production.

## The approach, and what was rejected

Issue tokens **to real accounts** instead of adding a way around sign-in. A token authenticates *as its account* — same tier, quota and walls — so there is no bypass route, no Google credential in the VM, and no password database.

| Rejected | Why |
| --- | --- |
| A secret-gated "test login" route in prod | A bypass whatever it's named. In an open-source repo, obscuring the name is worse than the bypass — the people misled are our own reviewers. |
| Driving Google's login UI with Playwright | Google blocks automated sign-in; datacenter IPs trigger CAPTCHA/phone verification; puts a real password in every agent VM. |
| Email + password accounts | A legitimate product feature, but it creates a permanent breach liability plus registration/verification/reset/brute-force defense — all to solve a testing problem. |

Full reasoning in `docs/agent-access-tokens.md`.

## What's here

`gdpl_pat_<id>_<secret>`; only `sha256(secret)` is stored, in its own `accessTokens` collection so a credential can never ride along on a `User` serialized to a browser. SHA-256 rather than argon2 is deliberate and explained in code — the secret is 256 bits of CSPRNG output, so there is nothing for stretching to slow down.

Security properties, each with a test:

- **A token can never mint another token.** Issuance requires an admin *session*; a token-authenticated request gets 404 from every operator surface, even when the token belongs to an admin. One leaked credential cannot become self-renewing.
- **Revocation is a delete**, effective on the next request, no redeploy — unlike rotating a shared secret.
- **Expiry mandatory** (90d default, 365 max), and the format is registered in the generated-game credential scanner.
- **`POST /api/auth/session`** exchanges a token for the cookie the SPA actually sends, so a real browser can be driven. It accepts only a token, never a cookie, so a session can't launder itself into a fresh one.

Product-measurement hygiene: automation accounts use a `bot:` uid namespace, excluded from creator metrics, and a token-authenticated request records no `activeDays` — otherwise an agent on a cron reports flawless retention for a creator who doesn't exist. Minting can create a `bot:` account but refuses to invent any other namespace, so a mistyped `g:<sub>` can't silently spring into being holding a working credential.

The HTTP route and the `token:mint` CLI both call one `mintAccessTokenFor`, so the namespace rule, per-account cap and expiry default can't drift between them.

## Infra / GitHub setup

**Nothing required.** No Secret Manager entry, no Cloud Run env var, no workflow change. The only prerequisite — `ADMIN_UIDS` containing your uid — is already needed for the operator telemetry views. One new Firestore collection, `accessTokens`, keyed by token id; no composite index. Optionally add a TTL policy on `expiresAt` for self-cleaning, which is housekeeping rather than a control since expired tokens are already refused at auth.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` all green — 841 tests pass (60 new).

Route tests drive the **fully assembled app** via `buildApp`, not the route module, because the private-beta wall this credential exists to pass lives in `app.ts` — the exact trap recorded in the `verify-agent-work` playbook. Explicitly covered: a token passes the beta wall while not on any allowlist; a token is refused by all three admin views and by mint; expired, revoked, wrong-secret and orphaned tokens all 401; other Bearer schemes on this API (build-channel, scheduler OIDC) pass through untouched.

Not tested against live Firestore or the deployed service — the `FirestoreStore` methods and the CLI are exercised only through `InMemoryStore`.

## Docs and playbooks updated

`docs/agent-access-tokens.md` (new), plus `README`, `security-model` (new trust boundary + invariant), `contributing-for-agents`, `local-development`, `deployment`, `AGENTS.md`, `.github/copilot-instructions.md`, and three skills — `verify-agent-work` (how to verify behind sign-in), `managing-beta-participants` (tokens are a third access path an allowlist audit won't show), `product-instrumentation` (bots must stay out of person-shaped metrics).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT8ueQTiejuiksCUd2oxQx)_