### PR TITLE
fix(api): sync GameKit modules / music / serve budget (#247)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,13 +161,33 @@ jobs:
           # means the beta wall regressed and every shared game link now leads strangers to
           # a sign-in screen; anything else non-200 means we are about to promote a revision
           # that cannot show the arcade at all. Both are worth failing the deploy for.
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${CANDIDATE_URL}/api/catalog")
+          STATUS_CODE=$(curl -s -o /tmp/smoke-catalog.json -w "%{http_code}" "${CANDIDATE_URL}/api/catalog")
           if [ "$STATUS_CODE" -eq 401 ]; then
             echo "Smoke test failed: /api/catalog answered 401 — play must stay public to anonymous visitors"
             exit 1
           fi
           if [ "$STATUS_CODE" -ne 200 ]; then
             echo "Smoke test failed: expected 200 for anonymous /api/catalog (got ${STATUS_CODE})"
+            exit 1
+          fi
+
+          # Catalog can be green while every play route 502s (the assembler fans out into
+          # GitHub + esbuild; catalog.json is one Contents read). Fail the deploy if a
+          # published game cannot actually be assembled — that is the product.
+          PLAY_SLUG=$(jq -r '([.[] | select(.status == "published") | .slug] | first) // empty' /tmp/smoke-catalog.json)
+          if [ -z "$PLAY_SLUG" ]; then
+            echo "Smoke test failed: catalog has no published slug to play-test"
+            exit 1
+          fi
+          STATUS_CODE=$(curl -s -o /tmp/smoke-game.json -w "%{http_code}" "${CANDIDATE_URL}/api/games/${PLAY_SLUG}")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Smoke test failed: /api/games/${PLAY_SLUG} returned ${STATUS_CODE}"
+            head -c 500 /tmp/smoke-game.json; echo
+            exit 1
+          fi
+          if ! jq -e '.html | type == "string" and length > 0' /tmp/smoke-game.json >/dev/null; then
+            echo "Smoke test failed: /api/games/${PLAY_SLUG} response missing html"
+            head -c 500 /tmp/smoke-game.json; echo
             exit 1
           fi
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,10 @@ paths = [
   # The credential scanner's own tests — they contain deliberately FAKE keys
   # (e.g. a bogus "BEGIN RSA PRIVATE KEY" fixture) to prove the scanner trips.
   '''apps/api/src/credential-scan\.test\.ts''',
+  # Access-token unit tests once used a bogus github-pat-shaped string as a
+  # "wrong prefix" fixture (still on an open PR branch; CI fetch-depth: 0
+  # scans every ref). Not a real secret — see PR #248.
+  '''apps/api/src/access-token\.test\.ts''',
   # 2015-era CSS with a base64-embedded webfont (git history only) — older
   # gitleaks rules misread the font bytes as an AWS access token.
   '''app/css/fontello-embedded\.css''',

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -17,7 +17,10 @@ describe('the size cap', () => {
    * assertion.
    */
   it('matches the budget the games repo enforces in Check 4', () => {
-    const gamesRepoCap = 200 * 1024 + 7_501;
+    // 200 KiB author budget + 42 KiB GameKit platform allowances (touch, restart,
+    // music, touch hint, progress, universal input, pointer poll, draw surface) —
+    // see issue #247. If this fails because the games repo moved, move this to match.
+    const gamesRepoCap = 242 * 1024;
     expect(MAX_PROJECT_BYTES).toBe(gamesRepoCap);
   });
 

--- a/apps/api/src/assemble.ts
+++ b/apps/api/src/assemble.ts
@@ -10,19 +10,18 @@ import { findCredentialLikeStrings } from './credential-scan.js';
 const GAME_BUDGET_BYTES = 200 * 1024;
 
 /**
- * The GameKit touch layer — on-screen pad plus its shell CSS — is inlined into every
- * assembled game whether the game asked for it or not, and costs 7,501 bytes. The games
- * repo added exactly this allowance on top of the budget (`GAMEKIT_TOUCH_BYTES` in
- * tools/validate.ts) rather than charging a platform feature to each author.
+ * Sum of the GameKit platform allowances charged outside the author's budget in the
+ * games repo's `tools/validate.ts` Check 4: `GAMEKIT_TOUCH` (7,501 — on-screen pad),
+ * plus restart chrome, music runtime, touch hint, progress, universal input, pointer
+ * poll, and draw surface. Together they raise the serve cap to 242 KiB (issue #247).
  *
- * Keep the two numbers equal. When only the games repo was raised, block-cascade and
- * rooftop-dash passed CI, merged, and then 422'd on the play route, and a build sitting
- * at 208,001 bytes could not be previewed by the creator watching it being made.
+ * Keep this equal to the games repo. When only one side moves, games pass CI, merge,
+ * and then 422 on the play route.
  */
-const GAMEKIT_TOUCH_BYTES = 7_501;
+const GAMEKIT_PLATFORM_BYTES = 42 * 1024;
 
 /** Combined html+js+css size cap. Generated code is served, not stored, so keep it modest. */
-export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_TOUCH_BYTES;
+export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
 
 export class ProjectTooLargeError extends Error {}
 export class EmptyProjectError extends Error {}

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createGitHubClient } from './github-client.js';
+import { createGitHubClient, resolveGameTypeScriptPath } from './github-client.js';
+
+describe('resolveGameTypeScriptPath', () => {
+  it.each([
+    ['./runtime.ts', '/games/foo/game/runtime.ts'],
+    ['./runtime.js', '/games/foo/game/runtime.ts'],
+    ['./runtime', '/games/foo/game/runtime.ts'],
+    ['../util.js', '/games/foo/util.ts'],
+  ])('maps %s under the game directory', (specifier, expected) => {
+    expect(resolveGameTypeScriptPath('/games/foo/game', specifier)).toBe(expected);
+  });
+
+  it('rejects bare package imports and non-TS assets', () => {
+    expect(resolveGameTypeScriptPath('/games/foo', 'lodash')).toBeNull();
+    expect(resolveGameTypeScriptPath('/games/foo', './levels.json')).toBeNull();
+    expect(resolveGameTypeScriptPath('/games/foo', './sprite.png')).toBeNull();
+  });
+});
 
 const repo = 'gamedevpl/www.gamedev.pl-games';
 
@@ -449,7 +466,7 @@ describe('getGameMedia', () => {
 });
 
 describe('getGameSources', () => {
-  it('bundles selected GameKit modules, audio assets, and shared shell styles before the game', async () => {
+  it('bundles selected GameKit modules, audio assets, music catalog, and shared shell styles', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/coin-catcher/index.html', '<canvas id="game"></canvas>'],
       ['games/coin-catcher/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
@@ -457,7 +474,10 @@ describe('getGameSources', () => {
       ['games/coin-catcher/SPEC.md', specMd({ title: 'Coin Catcher' })],
       [
         'games/coin-catcher/GAME.json',
-        JSON.stringify({ engine: { modules: ['input', 'audio'] }, audio: { sounds: ['ui-toggle', 'coin'] } }),
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle', 'coin'], music: ['menu-theme'] },
+        }),
       ],
       ['shared/game-shell.css', '.shell { display: grid; }'],
       ['shared/modules/core.ts', 'const version: number = 1; window.GameKit = { mount() {} };'],
@@ -465,6 +485,13 @@ describe('getGameSources', () => {
       ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
       ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
       ['shared/audio/assets/coin.wav', new Uint8Array([3, 4])],
+      [
+        'shared/audio/music.json',
+        JSON.stringify({
+          music: { 'menu-theme': 'data:audio/mpeg;base64,AAA=' },
+          tracks: { 'menu-theme': { loop: true } },
+        }),
+      ],
     ]);
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const pathname = new URL(String(input)).pathname;
@@ -481,6 +508,10 @@ describe('getGameSources', () => {
     expect(sources?.styleCss).toBe('.shell { display: grid; }\n.game { color: gold; }');
     expect(sources?.gameJs).toContain('"ui-toggle":"data:audio/wav;base64,AQI="');
     expect(sources?.gameJs).toContain('"coin":"data:audio/wav;base64,AwQ="');
+    expect(sources?.gameJs).toContain('window.__GAME_AUDIO_MUSIC__');
+    expect(sources?.gameJs).toContain('window.__GAME_MUSIC_TRACKS__');
+    expect(sources?.gameJs).toContain('"menu-theme":"data:audio/mpeg;base64,AAA="');
+    expect(sources?.gameJs).toContain('"loop":true');
     expect(sources?.gameJs.indexOf('window.GameKit =')).toBeLessThan(
       sources?.gameJs.indexOf('GameKit.createInput') ?? 0,
     );
@@ -495,14 +526,101 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
-  it('bundles a game-local TypeScript module graph from GitHub', async () => {
+  it('accepts the post-draw-surface module order including gfx and actors', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/squad/index.html', '<canvas id="game"></canvas>'],
+      ['games/squad/game.ts', 'GameKit.mount({ ok: true });'],
+      ['games/squad/style.css', '.game {}'],
+      ['games/squad/SPEC.md', specMd({ title: 'Squad' })],
+      [
+        'games/squad/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'collision', 'world', 'drawing', 'actors', 'gfx', 'effects', 'audio'] },
+          audio: { sounds: ['shot'], music: [] },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell {}'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.input = true;'],
+      ['shared/modules/collision.ts', 'GameKit.collision = true;'],
+      ['shared/modules/world.ts', 'GameKit.world = true;'],
+      ['shared/modules/drawing.ts', 'GameKit.drawing = true;'],
+      ['shared/modules/actors.ts', 'GameKit.actors = true;'],
+      ['shared/modules/gfx.ts', 'GameKit.gfx = true;'],
+      ['shared/modules/effects.ts', 'GameKit.effects = true;'],
+      ['shared/modules/audio.ts', 'GameKit.audio = true;'],
+      ['shared/audio/assets/shot.wav', new Uint8Array([9])],
+      ['shared/audio/music.json', JSON.stringify({ music: {}, tracks: {} })],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const requestedPath = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(requestedPath);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'squad');
+
+    expect(sources?.gameJs).toContain('GameKit.gfx = true');
+    expect(sources?.gameJs).toContain('GameKit.actors = true');
+    expect(sources?.gameJs).toContain('GameKit.world = true');
+    expect(sources?.gameJs.indexOf('GameKit.world = true')).toBeLessThan(sources?.gameJs.indexOf('GameKit.gfx = true') ?? 0);
+    expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
+  });
+
+  it('rejects a GAME.json that still uses a pre-draw-surface module list as incomplete order', async () => {
+    // modules that omit required ordering relative to the canonical list are fine
+    // as a subset — but unknown names must throw (the live 502 root cause).
+    const files = new Map<string, string>([
+      ['games/legacy/index.html', '<canvas></canvas>'],
+      ['games/legacy/game.ts', 'GameKit.mount({});'],
+      ['games/legacy/style.css', '.g{}'],
+      ['games/legacy/SPEC.md', specMd({ title: 'Legacy' })],
+      [
+        'games/legacy/GAME.json',
+        // "sprite" is not in GAME_KIT_MODULES — this is what production was throwing on
+        // when games selected `gfx` against a stale allow-list.
+        JSON.stringify({ engine: { modules: ['input', 'sprite', 'audio'] }, audio: { sounds: ['a'], music: [] } }),
+      ],
+      ['shared/game-shell.css', '.shell{}'],
+      ['shared/modules/core.ts', 'window.GameKit = {};'],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const requestedPath = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(requestedPath);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    await expect(client.getGameSources('main', 'legacy')).rejects.toThrow('invalid engine modules');
+  });
+
+  it.each([
+    {
+      label: '.ts suffix',
+      entry: "import { startGame } from './game/runtime.ts'; startGame();",
+      runtimeImport: "import type { Score } from './model.ts'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+    },
+    {
+      // TypeScript's Node ESM convention — import path says .js, source file is .ts.
+      label: '.js suffix',
+      entry: "import { startGame } from './game/runtime.js'; startGame();",
+      runtimeImport: "import type { Score } from './model.js'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+    },
+    {
+      label: 'extensionless',
+      entry: "import { startGame } from './game/runtime'; startGame();",
+      runtimeImport: "import type { Score } from './model'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+    },
+  ])('bundles a game-local TypeScript module graph from GitHub ($label)', async ({ entry, runtimeImport }) => {
     const files = new Map<string, string | Uint8Array>([
       ['games/modular/index.html', '<canvas id="game"></canvas>'],
-      ['games/modular/game.ts', "import { startGame } from './game/runtime.ts'; startGame();"],
-      [
-        'games/modular/game/runtime.ts',
-        "import type { Score } from './model.ts'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
-      ],
+      ['games/modular/game.ts', entry],
+      ['games/modular/game/runtime.ts', runtimeImport],
       ['games/modular/game/model.ts', 'export type Score = { value: number };'],
       ['games/modular/style.css', '.game { color: gold; }'],
       ['games/modular/SPEC.md', specMd({ title: 'Modular Game' })],
@@ -529,9 +647,37 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
+  it('resolves an extensionless directory import to index.ts', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/modular/index.html', '<canvas id="game"></canvas>'],
+      // Import a subdirectory (not `./game`, which would collide with this entry file).
+      ['games/modular/game.ts', "import { startGame } from './lib'; startGame();"],
+      ['games/modular/lib/index.ts', 'export function startGame(): void { GameKit.mount({ ok: true }); }'],
+      ['games/modular/style.css', '.game { color: gold; }'],
+      ['games/modular/SPEC.md', specMd({ title: 'Modular Game' })],
+      ['games/modular/GAME.json', JSON.stringify({ engine: { modules: [] } })],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const requestedPath = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(requestedPath);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'modular');
+
+    expect(sources?.gameJs).toContain('ok: true');
+    expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
+  });
+
   it.each([
     ["import '../other-game/runtime.ts';", 'game imports must be TypeScript files inside'],
     ["import 'some-package';", 'game runtime dependency is forbidden'],
+    ["import './levels.json';", 'game imports must be TypeScript files inside'],
   ])('rejects an unsafe game import: %s', async (entrySource, expectedError) => {
     const files = new Map<string, string>([
       ['games/unsafe/index.html', '<canvas id="game"></canvas>'],

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -476,7 +476,7 @@ describe('getGameSources', () => {
         'games/coin-catcher/GAME.json',
         JSON.stringify({
           engine: { modules: ['input', 'audio'] },
-          audio: { sounds: ['ui-toggle', 'coin'], music: ['menu-theme'] },
+          audio: { sounds: ['ui-toggle', 'coin'], music: 'menu-theme' },
         }),
       ],
       ['shared/game-shell.css', '.shell { display: grid; }'],
@@ -488,8 +488,10 @@ describe('getGameSources', () => {
       [
         'shared/audio/music.json',
         JSON.stringify({
-          music: { 'menu-theme': 'data:audio/mpeg;base64,AAA=' },
-          tracks: { 'menu-theme': { loop: true } },
+          tracks: {
+            'menu-theme': { loop: true, data: 'data:audio/mpeg;base64,AAA=' },
+            'other-theme': { loop: false, data: 'data:audio/mpeg;base64,BBB=' },
+          },
         }),
       ],
     ]);
@@ -508,10 +510,10 @@ describe('getGameSources', () => {
     expect(sources?.styleCss).toBe('.shell { display: grid; }\n.game { color: gold; }');
     expect(sources?.gameJs).toContain('"ui-toggle":"data:audio/wav;base64,AQI="');
     expect(sources?.gameJs).toContain('"coin":"data:audio/wav;base64,AwQ="');
-    expect(sources?.gameJs).toContain('window.__GAME_AUDIO_MUSIC__');
-    expect(sources?.gameJs).toContain('window.__GAME_MUSIC_TRACKS__');
-    expect(sources?.gameJs).toContain('"menu-theme":"data:audio/mpeg;base64,AAA="');
-    expect(sources?.gameJs).toContain('"loop":true');
+    // Games-repo contract: selected name as a string, plus a one-entry tracks map.
+    expect(sources?.gameJs).toContain('window.__GAME_AUDIO_MUSIC__ = "menu-theme";');
+    expect(sources?.gameJs).toContain('window.__GAME_MUSIC_TRACKS__ = Object.freeze({"menu-theme":{"loop":true,"data":"data:audio/mpeg;base64,AAA="}});');
+    expect(sources?.gameJs).not.toContain('other-theme');
     expect(sources?.gameJs.indexOf('window.GameKit =')).toBeLessThan(
       sources?.gameJs.indexOf('GameKit.createInput') ?? 0,
     );
@@ -536,7 +538,7 @@ describe('getGameSources', () => {
         'games/squad/GAME.json',
         JSON.stringify({
           engine: { modules: ['input', 'collision', 'world', 'drawing', 'actors', 'gfx', 'effects', 'audio'] },
-          audio: { sounds: ['shot'], music: [] },
+          audio: { sounds: ['shot'], music: 'battle' },
         }),
       ],
       ['shared/game-shell.css', '.shell {}'],
@@ -550,7 +552,7 @@ describe('getGameSources', () => {
       ['shared/modules/effects.ts', 'GameKit.effects = true;'],
       ['shared/modules/audio.ts', 'GameKit.audio = true;'],
       ['shared/audio/assets/shot.wav', new Uint8Array([9])],
-      ['shared/audio/music.json', JSON.stringify({ music: {}, tracks: {} })],
+      ['shared/audio/music.json', JSON.stringify({ tracks: { battle: { loop: true } } })],
     ]);
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const pathname = new URL(String(input)).pathname;
@@ -582,7 +584,7 @@ describe('getGameSources', () => {
         'games/legacy/GAME.json',
         // "sprite" is not in GAME_KIT_MODULES — this is what production was throwing on
         // when games selected `gfx` against a stale allow-list.
-        JSON.stringify({ engine: { modules: ['input', 'sprite', 'audio'] }, audio: { sounds: ['a'], music: [] } }),
+        JSON.stringify({ engine: { modules: ['input', 'sprite', 'audio'] }, audio: { sounds: ['a'], music: 'x' } }),
       ],
       ['shared/game-shell.css', '.shell{}'],
       ['shared/modules/core.ts', 'window.GameKit = {};'],

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -539,14 +539,11 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
               errors: [{ text: `game runtime dependency is forbidden: "${args.path}"` }],
             }));
             builder.onLoad({ filter: /.*/, namespace: 'github-game-source' }, async (args) => {
-              if (!loadedPaths.has(args.path)) {
-                if (loadedPaths.size >= MAX_GAME_MODULES) {
-                  return { errors: [{ text: `game exceeds ${MAX_GAME_MODULES} TypeScript modules` }] };
-                }
-                loadedPaths.add(args.path);
-              }
               // Prefer the resolved file; if an extensionless import pointed at a
               // directory, fall back to its index.ts (same rule TypeScript uses).
+              // Count the *actual* source path once — not the synthetic `dir.ts`
+              // plus `dir/index.ts` — so directory imports don't burn two slots
+              // toward MAX_GAME_MODULES.
               let loadedPath = args.path;
               let source = await readRawFile(loadedPath.slice(1), ref);
               if (source === null && loadedPath.endsWith('.ts')) {
@@ -556,16 +553,21 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
                   if (indexSource !== null) {
                     loadedPath = indexPath;
                     source = indexSource;
-                    loadedPaths.add(indexPath);
                   }
                 }
               }
               if (source === null) {
                 return { errors: [{ text: `game module not found: ${args.path}` }] };
               }
-              sourceBytes += Buffer.byteLength(source, 'utf8');
-              if (sourceBytes > MAX_GAME_SOURCE_BYTES) {
-                return { errors: [{ text: `game TypeScript exceeds ${MAX_GAME_SOURCE_BYTES} bytes` }] };
+              if (!loadedPaths.has(loadedPath)) {
+                if (loadedPaths.size >= MAX_GAME_MODULES) {
+                  return { errors: [{ text: `game exceeds ${MAX_GAME_MODULES} TypeScript modules` }] };
+                }
+                loadedPaths.add(loadedPath);
+                sourceBytes += Buffer.byteLength(source, 'utf8');
+                if (sourceBytes > MAX_GAME_SOURCE_BYTES) {
+                  return { errors: [{ text: `game TypeScript exceeds ${MAX_GAME_SOURCE_BYTES} bytes` }] };
+                }
               }
               return {
                 contents: source,

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -63,17 +63,69 @@ export interface GameSources {
 }
 
 // Canonical order must match the games repo's tools/lib/assemble.ts — the two
-// lists are independent copies and a mismatch silently breaks bundling.
-const GAME_KIT_MODULES = ['input', 'collision', 'drawing', 'effects', 'audio', 'party'] as const;
+// lists are independent copies and a mismatch silently breaks bundling
+// (issue #247: a stale list 502s every published game at serve time).
+const GAME_KIT_MODULES = [
+  'input',
+  'collision',
+  'world',
+  'ai',
+  'gameplay',
+  'drawing',
+  'actors',
+  'gfx',
+  'effects',
+  'audio',
+  'party',
+] as const;
 const MAX_GAME_MODULES = 64;
 const MAX_GAME_SOURCE_BYTES = 200 * 1024;
 
-interface GameManifest {
-  engine?: { modules?: unknown };
-  audio?: { sounds?: unknown };
+/**
+ * Maps a relative import specifier onto a `.ts` source path.
+ *
+ * The games repo authors TypeScript the way TypeScript ESM projects do: an import
+ * may write `./foo.ts`, `./foo.js` (emit path — source is still `foo.ts`), or `./foo`.
+ * The play-time bundler has to accept all three or every modular game 502s while the
+ * games repo's own assemble (which resolves the same way) stays green.
+ *
+ * Returns null when the specifier is not a relative TypeScript module path.
+ */
+export function resolveGameTypeScriptPath(resolveDir: string, specifier: string): string | null {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return null;
+  }
+  const resolvedPath = path.posix.resolve(resolveDir, specifier);
+  if (resolvedPath.endsWith('.ts')) {
+    return resolvedPath;
+  }
+  if (resolvedPath.endsWith('.js')) {
+    return `${resolvedPath.slice(0, -'.js'.length)}.ts`;
+  }
+  // Extensionless — only accept bare paths (no other extension). `./foo.json` stays rejected.
+  if (path.posix.extname(resolvedPath) !== '') {
+    return null;
+  }
+  return `${resolvedPath}.ts`;
 }
 
-function parseGameManifest(source: string): { modules: string[]; sounds: string[] } {
+interface GameManifest {
+  engine?: { modules?: unknown };
+  audio?: { sounds?: unknown; music?: unknown };
+}
+
+interface ParsedGameManifest {
+  modules: string[];
+  sounds: string[];
+  /** Track ids from GAME.json; only populated when the audio module is selected. */
+  music: string[];
+}
+
+function isKebabCaseName(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-z0-9][a-z0-9-]*$/.test(value);
+}
+
+function parseGameManifest(source: string): ParsedGameManifest {
   const manifest = JSON.parse(source) as GameManifest;
   const modules = manifest.engine?.modules;
   if (
@@ -91,19 +143,50 @@ function parseGameManifest(source: string): { modules: string[]; sounds: string[
     throw new Error('game manifest engine modules are duplicated or out of order');
   }
 
-  const sounds = manifest.audio?.sounds;
   if (!modules.includes('audio')) {
-    return { modules, sounds: [] };
+    return { modules, sounds: [], music: [] };
   }
+
+  const sounds = manifest.audio?.sounds;
   if (
     !Array.isArray(sounds) ||
     sounds.length === 0 ||
     new Set(sounds).size !== sounds.length ||
-    sounds.some((soundName) => typeof soundName !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(soundName))
+    !sounds.every(isKebabCaseName)
   ) {
     throw new Error('game manifest contains invalid audio sounds');
   }
-  return { modules, sounds };
+
+  // Games-repo assemble requires `audio.music` whenever the audio module is on —
+  // the shared catalog is embedded as __GAME_AUDIO_MUSIC__ / __GAME_MUSIC_TRACKS__.
+  const music = manifest.audio?.music;
+  if (!Array.isArray(music) || new Set(music).size !== music.length || !music.every(isKebabCaseName)) {
+    throw new Error('game manifest contains invalid audio music');
+  }
+
+  return { modules, sounds, music };
+}
+
+/**
+ * Shared music catalog (`shared/audio/music.json`). Shape mirrors the games repo
+ * assembler: a `music` map of embeddable assets plus a `tracks` map of playback
+ * descriptors. Both are frozen onto `window` for GameKit.audio.
+ */
+function parseMusicCatalog(source: string): { music: unknown; tracks: unknown } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    throw new Error('shared audio music catalog is not valid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('shared audio music catalog is invalid');
+  }
+  const catalog = parsed as { music?: unknown; tracks?: unknown };
+  if (catalog.music === undefined || catalog.tracks === undefined) {
+    throw new Error('shared audio music catalog is missing music or tracks');
+  }
+  return { music: catalog.music, tracks: catalog.tracks };
 }
 
 export interface CatalogMediaScreenshot {
@@ -437,13 +520,18 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
           name: 'github-game-modules',
           setup(builder) {
             builder.onResolve({ filter: /^\./ }, (args) => {
-              const resolvedPath = path.posix.resolve(args.resolveDir, args.path);
-              if (!resolvedPath.startsWith(`${gameRoot}/`) || !resolvedPath.endsWith('.ts')) {
+              // Games-repo TypeScript follows normal ESM habits: relative imports may
+              // carry a `.ts` suffix, a `.js` suffix (TypeScript's Node ESM convention
+              // — the source file is still `.ts`), or no suffix at all. Map all three
+              // onto a path under the game directory before the sandbox check; anything
+              // that escapes the game root is rejected.
+              const sourcePath = resolveGameTypeScriptPath(args.resolveDir, args.path);
+              if (!sourcePath || !sourcePath.startsWith(`${gameRoot}/`)) {
                 return {
                   errors: [{ text: `game imports must be TypeScript files inside ${gameRoot}` }],
                 };
               }
-              return { path: resolvedPath, namespace: 'github-game-source' };
+              return { path: sourcePath, namespace: 'github-game-source' };
             });
             builder.onResolve({ filter: /^[^.]/ }, (args) => ({
               errors: [{ text: `game runtime dependency is forbidden: "${args.path}"` }],
@@ -455,7 +543,21 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
                 }
                 loadedPaths.add(args.path);
               }
-              const source = await readRawFile(args.path.slice(1), ref);
+              // Prefer the resolved file; if an extensionless import pointed at a
+              // directory, fall back to its index.ts (same rule TypeScript uses).
+              let loadedPath = args.path;
+              let source = await readRawFile(loadedPath.slice(1), ref);
+              if (source === null && loadedPath.endsWith('.ts')) {
+                const indexPath = `${loadedPath.slice(0, -'.ts'.length)}/index.ts`;
+                if (indexPath.startsWith(`${gameRoot}/`)) {
+                  const indexSource = await readRawFile(indexPath.slice(1), ref);
+                  if (indexSource !== null) {
+                    loadedPath = indexPath;
+                    source = indexSource;
+                    loadedPaths.add(indexPath);
+                  }
+                }
+              }
               if (source === null) {
                 return { errors: [{ text: `game module not found: ${args.path}` }] };
               }
@@ -466,7 +568,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
               return {
                 contents: source,
                 loader: 'ts',
-                resolveDir: path.posix.dirname(args.path),
+                resolveDir: path.posix.dirname(loadedPath),
               };
             });
           },
@@ -728,10 +830,38 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       }
 
       const assetEntries = audioAssets.filter((asset): asset is [string, string] => asset !== null);
-      const assetsJs =
-        assetEntries.length > 0
-          ? `window.__GAME_AUDIO_ASSETS__ = Object.freeze(${JSON.stringify(Object.fromEntries(assetEntries))});\n`
-          : '';
+      const assetChunks: string[] = [];
+      if (assetEntries.length > 0) {
+        assetChunks.push(
+          `window.__GAME_AUDIO_ASSETS__ = Object.freeze(${JSON.stringify(Object.fromEntries(assetEntries))});`,
+        );
+      }
+
+      // Music lives in one shared catalog (not per-game WAV reads). Embed it whenever
+      // the audio module is on — same contract as tools/lib/assemble.ts.
+      if (manifest.modules.includes('audio')) {
+        const musicSource = await readRawFile('shared/audio/music.json', ref);
+        if (musicSource === null) {
+          return null;
+        }
+        const musicCatalog = parseMusicCatalog(musicSource);
+        if (
+          musicCatalog.tracks &&
+          typeof musicCatalog.tracks === 'object' &&
+          !Array.isArray(musicCatalog.tracks)
+        ) {
+          const trackIds = new Set(Object.keys(musicCatalog.tracks as Record<string, unknown>));
+          for (const trackId of manifest.music) {
+            if (!trackIds.has(trackId)) {
+              throw new Error(`game manifest music track not in catalog: ${trackId}`);
+            }
+          }
+        }
+        assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = Object.freeze(${JSON.stringify(musicCatalog.music)});`);
+        assetChunks.push(`window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify(musicCatalog.tracks)});`);
+      }
+
+      const assetsJs = assetChunks.length > 0 ? `${assetChunks.join('\n')}\n` : '';
       const transpiledSources = await Promise.all(
         [coreTs, ...availableModuleSources].map(async (source) => {
           const result = await transform(source, {

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -117,8 +117,11 @@ interface GameManifest {
 interface ParsedGameManifest {
   modules: string[];
   sounds: string[];
-  /** Track ids from GAME.json; only populated when the audio module is selected. */
-  music: string[];
+  /**
+   * Selected BGM track id from GAME.json (`audio.music` string). Null when the
+   * audio module is off. Matches games-repo `tools/lib/assemble.ts`.
+   */
+  music: string | null;
 }
 
 function isKebabCaseName(value: unknown): value is string {
@@ -144,7 +147,7 @@ function parseGameManifest(source: string): ParsedGameManifest {
   }
 
   if (!modules.includes('audio')) {
-    return { modules, sounds: [], music: [] };
+    return { modules, sounds: [], music: null };
   }
 
   const sounds = manifest.audio?.sounds;
@@ -157,10 +160,10 @@ function parseGameManifest(source: string): ParsedGameManifest {
     throw new Error('game manifest contains invalid audio sounds');
   }
 
-  // Games-repo assemble requires `audio.music` whenever the audio module is on —
-  // the shared catalog is embedded as __GAME_AUDIO_MUSIC__ / __GAME_MUSIC_TRACKS__.
+  // Games-repo assemble: `audio.music` is a single track name string. Injected as
+  // `window.__GAME_AUDIO_MUSIC__ = "<name>"` with only that entry from music.json.
   const music = manifest.audio?.music;
-  if (!Array.isArray(music) || new Set(music).size !== music.length || !music.every(isKebabCaseName)) {
+  if (!isKebabCaseName(music)) {
     throw new Error('game manifest contains invalid audio music');
   }
 
@@ -168,25 +171,24 @@ function parseGameManifest(source: string): ParsedGameManifest {
 }
 
 /**
- * Shared music catalog (`shared/audio/music.json`). Shape mirrors the games repo
- * assembler: a `music` map of embeddable assets plus a `tracks` map of playback
- * descriptors. Both are frozen onto `window` for GameKit.audio.
+ * Shared music catalog (`shared/audio/music.json`). The games-repo assembler only
+ * reads the `tracks` map — each value is the playback descriptor for one BGM id.
  */
-function parseMusicCatalog(source: string): { music: unknown; tracks: unknown } {
+function parseMusicTracks(source: string): Record<string, unknown> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(source);
   } catch {
     throw new Error('shared audio music catalog is not valid JSON');
   }
-  if (!parsed || typeof parsed !== 'object') {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('shared audio music catalog is invalid');
   }
-  const catalog = parsed as { music?: unknown; tracks?: unknown };
-  if (catalog.music === undefined || catalog.tracks === undefined) {
-    throw new Error('shared audio music catalog is missing music or tracks');
+  const tracks = (parsed as { tracks?: unknown }).tracks;
+  if (!tracks || typeof tracks !== 'object' || Array.isArray(tracks)) {
+    throw new Error('shared audio music catalog is missing tracks');
   }
-  return { music: catalog.music, tracks: catalog.tracks };
+  return tracks as Record<string, unknown>;
 }
 
 export interface CatalogMediaScreenshot {
@@ -837,28 +839,22 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
         );
       }
 
-      // Music lives in one shared catalog (not per-game WAV reads). Embed it whenever
-      // the audio module is on — same contract as tools/lib/assemble.ts.
-      if (manifest.modules.includes('audio')) {
+      // Music: games-repo assemble reads only `tracks` from music.json, then injects
+      // the selected name plus a one-entry map — not the whole catalog.
+      if (manifest.music !== null) {
         const musicSource = await readRawFile('shared/audio/music.json', ref);
         if (musicSource === null) {
           return null;
         }
-        const musicCatalog = parseMusicCatalog(musicSource);
-        if (
-          musicCatalog.tracks &&
-          typeof musicCatalog.tracks === 'object' &&
-          !Array.isArray(musicCatalog.tracks)
-        ) {
-          const trackIds = new Set(Object.keys(musicCatalog.tracks as Record<string, unknown>));
-          for (const trackId of manifest.music) {
-            if (!trackIds.has(trackId)) {
-              throw new Error(`game manifest music track not in catalog: ${trackId}`);
-            }
-          }
+        const tracks = parseMusicTracks(musicSource);
+        const track = tracks[manifest.music];
+        if (track === undefined) {
+          throw new Error(`game manifest music track not in catalog: ${manifest.music}`);
         }
-        assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = Object.freeze(${JSON.stringify(musicCatalog.music)});`);
-        assetChunks.push(`window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify(musicCatalog.tracks)});`);
+        assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = ${JSON.stringify(manifest.music)};`);
+        assetChunks.push(
+          `window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify({ [manifest.music]: track })});`,
+        );
       }
 
       const assetsJs = assetChunks.length > 0 ? `${assetChunks.join('\n')}\n` : '';

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1207,8 +1207,10 @@ export async function registerSubmissionRoutes(
     try {
       sources = await githubClient!.getGameSources(linkedPr.headRefName, slug);
     } catch (error) {
-      request.log.error({ err: error }, 'failed to fetch preview sources');
-      return reply.status(502).send({ error: 'failed to load preview' });
+      request.log.error({ err: error, slug }, 'failed to fetch preview sources');
+      const detail =
+        error instanceof Error ? error.message.replace(/\s+/g, ' ').trim().slice(0, 240) : 'unknown error';
+      return reply.status(502).send({ error: 'failed to load preview', detail });
     }
 
     if (!sources) {
@@ -1585,8 +1587,13 @@ export async function registerSubmissionRoutes(
         request.log.warn({ err: error, slug }, 'published game failed hygiene checks');
         return reply.status(422).send({ error: 'this game could not be served' });
       }
-      request.log.error({ err: error }, 'failed to serve game');
-      return reply.status(502).send({ error: 'failed to load game' });
+      request.log.error({ err: error, slug }, 'failed to serve game');
+      // Surface a short, non-sensitive reason so a broken play route is diagnosable
+      // from the response body (and from the deploy smoke test) without scraping
+      // Cloud Run logs. Truncate — esbuild messages can be long.
+      const detail =
+        error instanceof Error ? error.message.replace(/\s+/g, ' ').trim().slice(0, 240) : 'unknown error';
+      return reply.status(502).send({ error: 'failed to load game', detail });
     }
   });
 

--- a/docs/multiplayer-plan.md
+++ b/docs/multiplayer-plan.md
@@ -275,8 +275,9 @@ max_players: 4
   select the `party` module, and `game.js` must call `createParty(`. Conversely, selecting
   `party` without the frontmatter fails. The offline-only rule is **unchanged** — no new
   network allowances of any kind.
-- `GAME_KIT_MODULES` gains `party` (canonical order: `input, collision, drawing, effects,
-audio, party`) in both `tools/lib/assemble.mjs` and the API's `github-client.ts`, which
+- `GAME_KIT_MODULES` gains `party` (canonical order today: `input, collision, world, ai,
+gameplay, drawing, actors, gfx, effects, audio, party`) in both `tools/lib/assemble.ts`
+and the API's `github-client.ts`, which
   keep independent copies of that list.
 - The catalog carries `multiplayer`, `minPlayers`, `maxPlayers` through `CatalogGameEntry` →
   `/api/catalog` → the web `CatalogEntry`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #247 — every published game and draft preview was 502ing with `failed to load game` / `failed to load preview` while catalog and media still worked.

**Root cause:** `GAME_KIT_MODULES` in `github-client.ts` was stale after the games-repo draw-surface work. `parseGameManifest` threw `invalid engine modules` for any game selecting `gfx` / `actors` / `world` / etc., and that exception became the 502.

### Changes

1. Expand `GAME_KIT_MODULES` to the canonical games-repo order: `input, collision, world, ai, gameplay, drawing, actors, gfx, effects, audio, party`
2. **Music contract (matches `tools/lib/assemble.ts`):**
   - `audio.music` is a **string** (track name), not an array
   - Read only `tracks` from `shared/audio/music.json`
   - Inject `window.__GAME_AUDIO_MUSIC__ = "<name>"` and `window.__GAME_MUSIC_TRACKS__ = { "<name>": track }`
3. Raise `MAX_PROJECT_BYTES` to **242 KiB** (200 KiB author budget + 42 KiB GameKit platform allowances) to match Check 4
4. Harden relative TS imports (`.js` / extensionless / `index.ts`) and surface a short `detail` on 502s
5. Deploy smoke test now assembles a published `/api/games/:slug` so this class of outage cannot ship dark again

Note: Secret Scanning on the PR is unrelated (fixture `ghp_…` from PR #248 history).

## Test plan

- [x] `npm run type-check && npm run lint && npm run test && npm run build` (pre-music-fix revision)
- [x] Music-contract unit tests updated and green
- [ ] After merge/deploy: `curl -sS https://www.gamedev.pl/api/games/cannon-fodder-squad` returns 200 with `html`
- [ ] Draft preview for an in-progress build loads again
- [ ] A game with music has non-silent BGM in the player
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ca01549-8063-4907-893c-87c695432071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ca01549-8063-4907-893c-87c695432071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

