### PR TITLE
Fix three FirestoreStore defects surfaced by the first real token mint

### DIFF
--- a/apps/api/src/access-token-routes.test.ts
+++ b/apps/api/src/access-token-routes.test.ts
@@ -348,12 +348,18 @@ describe('authenticating with a personal access token', () => {
   it('does not count a bot request as a human active day', async () => {
     // `activeDays` feeds the creator-return metric; an agent on a cron would otherwise
     // report perfect retention for an account that is not a person.
+    //
+    // Asserted as a *contrast* against the session path deliberately: until the stores
+    // were fixed to persist `activeDays` at all, checking only the token path passed for
+    // the wrong reason — the field was undefined for everybody.
     const app = await appWith(store);
     const { token } = (await mintFor(app, 'bot:e2e')).json();
 
     await app.inject({ method: 'GET', url: '/api/auth/me', headers: bearer(token) });
+    await app.inject({ method: 'GET', url: '/api/auth/me', headers: sessionHeaders('g:boss') });
 
     expect((await store.getUser('bot:e2e'))?.activeDays).toBeUndefined();
+    expect((await store.getUser('g:boss'))?.activeDays).toEqual([new Date().toISOString().slice(0, 10)]);
   });
 });
 

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -1,0 +1,165 @@
+import type { Firestore } from '@google-cloud/firestore';
+import { describe, expect, it } from 'vitest';
+import { FirestoreStore, stripUndefined } from './store.js';
+
+/**
+ * Firestore-shaped tests for `FirestoreStore`.
+ *
+ * These exist because of a production incident: the first `bot:` account could not be
+ * created at all, because `upsertUser` handed Firestore `email: undefined` and Firestore
+ * rejects `undefined` rather than treating it as an absent field. Every existing test
+ * ran against `InMemoryStore`, which happily stores whatever it is given — so the whole
+ * suite was green while the real store could not write the document.
+ *
+ * The fake below is deliberately strict in exactly the one way that matters: it refuses
+ * `undefined` values with the same error the real client raises. Anything that passes
+ * here would have been writable for real.
+ */
+
+class UndefinedValueError extends Error {
+  constructor(field: string) {
+    super(
+      `Value for argument "data" is not a valid Firestore document. Cannot use "undefined" as a Firestore value (found in field "${field}").`,
+    );
+  }
+}
+
+function rejectUndefined(data: Record<string, unknown>, path = ''): void {
+  for (const [key, value] of Object.entries(data)) {
+    const field = path ? `${path}.${key}` : key;
+    if (value === undefined) throw new UndefinedValueError(field);
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      rejectUndefined(value as Record<string, unknown>, field);
+    }
+  }
+}
+
+/** Minimal Firestore stand-in: enough surface for the user and waitlist writes. */
+function fakeFirestore() {
+  const docs = new Map<string, Record<string, unknown>>();
+  const key = (collection: string, id: string) => `${collection}/${id}`;
+
+  const makeRef = (collection: string, id: string) => ({
+    id,
+    get: async () => ({
+      get exists() {
+        return docs.has(key(collection, id));
+      },
+      data: () => docs.get(key(collection, id)),
+    }),
+    set: async (data: Record<string, unknown>, options?: { merge?: boolean }) => {
+      rejectUndefined(data);
+      const previous = options?.merge ? (docs.get(key(collection, id)) ?? {}) : {};
+      docs.set(key(collection, id), { ...previous, ...data });
+    },
+  });
+
+  const db = {
+    collection: (collection: string) => ({ doc: (id: string) => makeRef(collection, id) }),
+    runTransaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+      const tx = {
+        get: (ref: ReturnType<typeof makeRef>) => ref.get(),
+        set: (ref: ReturnType<typeof makeRef>, data: Record<string, unknown>, options?: { merge?: boolean }) => {
+          rejectUndefined(data);
+          const previous = options?.merge ? (docs.get(key('users', ref.id)) ?? {}) : {};
+          docs.set(key('users', ref.id), { ...previous, ...data });
+        },
+      };
+      return fn(tx);
+    },
+  };
+
+  return { db: db as unknown as Firestore, docs, key };
+}
+
+describe('stripUndefined', () => {
+  it('drops undefined keys and keeps every other falsy value', () => {
+    expect(stripUndefined({ a: undefined, b: null, c: 0, d: '', e: false, f: 'x' })).toEqual({
+      b: null,
+      c: 0,
+      d: '',
+      e: false,
+      f: 'x',
+    });
+  });
+});
+
+describe('FirestoreStore.upsertUser', () => {
+  it('creates an account that has no email or picture — the bot: case that broke in production', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    const user = await store.upsertUser({ uid: 'bot:e2e', name: 'Bot e2e' });
+
+    expect(user.uid).toBe('bot:e2e');
+    expect(user.tier).toBe('standard');
+    const stored = docs.get(key('users', 'bot:e2e'))!;
+    // Absent, not present-and-undefined: that distinction is the whole bug.
+    expect('email' in stored).toBe(false);
+    expect('picture' in stored).toBe(false);
+    expect(stored.name).toBe('Bot e2e');
+  });
+
+  it('creates a fully-populated Google account unchanged', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.upsertUser({ uid: 'g:1', email: 'a@b.c', name: 'A', picture: 'https://p' });
+
+    expect(docs.get(key('users', 'g:1'))).toMatchObject({ email: 'a@b.c', name: 'A', picture: 'https://p' });
+  });
+
+  it('updates an existing account without erasing fields the caller omitted', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.upsertUser({ uid: 'g:1', email: 'a@b.c', name: 'A' });
+    await store.upsertUser({ uid: 'g:1', activeDays: ['2026-07-27'] });
+
+    const stored = docs.get(key('users', 'g:1'))!;
+    expect(stored.email).toBe('a@b.c');
+    expect(stored.activeDays).toEqual(['2026-07-27']);
+  });
+});
+
+describe('FirestoreStore.upsertWaitlistEntry', () => {
+  it('accepts an entry with no email — the unverified-Google-email case', async () => {
+    // auth.ts deliberately passes undefined rather than store an unverified claim, so
+    // this path was a 500 waiting for the first such sign-up.
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    const entry = await store.upsertWaitlistEntry({ uid: 'g:2', name: 'No Email' });
+
+    expect(entry.status).toBe('pending');
+    const stored = docs.get(key('waitlist', 'g:2'))!;
+    expect('email' in stored).toBe(false);
+    expect('locale' in stored).toBe(false);
+    expect(stored.name).toBe('No Email');
+  });
+
+  it('keeps an approved status across a re-submission', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.upsertWaitlistEntry({ uid: 'g:3', email: 'a@b.c' });
+    docs.set(key('waitlist', 'g:3'), { ...docs.get(key('waitlist', 'g:3'))!, status: 'approved' });
+
+    const entry = await store.upsertWaitlistEntry({ uid: 'g:3', email: 'a@b.c' });
+    expect(entry.status).toBe('approved');
+  });
+});
+
+describe('the fake itself', () => {
+  it('rejects undefined the way the real client does, so these tests can fail', () => {
+    // Guards against the fake quietly accepting everything, which would make every
+    // assertion above meaningless.
+    const { db } = fakeFirestore();
+    return expect(
+      db
+        .collection('users')
+        .doc('x')
+        .set({ email: undefined } as never),
+    ).rejects.toThrow(/Cannot use "undefined" as a Firestore value/);
+  });
+});

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -548,7 +548,10 @@ export function pushSubscriptionId(endpoint: string): string {
  * Applied at the write boundary rather than at each call site so a record can be built
  * naturally, with optional fields left off.
  */
-export function stripUndefined<T extends Record<string, unknown>>(value: T): T {
+export function stripUndefined<T extends object>(value: T): T {
+  // `T extends object`, not `Record<string, unknown>`: interfaces (`User`,
+  // `WaitlistEntry`) have no implicit index signature, so the stricter bound rejects
+  // every real caller.
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
 }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -532,6 +532,26 @@ export function pushSubscriptionId(endpoint: string): string {
   return createHash('sha256').update(endpoint).digest('hex');
 }
 
+/**
+ * Drop keys whose value is `undefined` before a Firestore write.
+ *
+ * Firestore rejects `undefined` outright ("Cannot use 'undefined' as a Firestore
+ * value") rather than treating it as an absent field, which collides head-on with the
+ * TypeScript optional fields (`email?`, `name?`, `picture?`, `locale?`) that this
+ * codebase builds records from. The mismatch is invisible in tests because
+ * `InMemoryStore` stores whatever it is handed, so it only ever surfaces as a 500 in
+ * production — which is exactly how it surfaced: the first `bot:` account (no email, no
+ * picture) could not be created, and the waitlist has the same latent fault for anyone
+ * whose Google email is unverified, since `auth.ts` deliberately passes `undefined`
+ * there rather than store an unverified claim.
+ *
+ * Applied at the write boundary rather than at each call site so a record can be built
+ * naturally, with optional fields left off.
+ */
+export function stripUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}
+
 /** A zeroed counter set — the shape every usage read falls back to. */
 function emptyUsageCounters(): UsageCounters {
   return { submissions: 0, previews: 0, mocks: 0, refines: 0, feedback: 0 };
@@ -583,6 +603,9 @@ export class InMemoryStore implements Store {
       // Preserve email prefs across logins — a re-login must not resubscribe.
       locale: userData.locale ?? existing?.locale,
       emailUnsubscribedAt: existing?.emailUnsubscribedAt ?? null,
+      // Carried explicitly. Omitting it silently discarded every write from the
+      // activity hook in `auth.ts`, whose only purpose is to persist this field.
+      activeDays: userData.activeDays ?? existing?.activeDays,
     };
 
     this.users.set(userData.uid, updated);
@@ -1042,6 +1065,8 @@ export class FirestoreStore implements Store {
           createdAt: now,
           lastLoginAt: now,
           tier: userData.tier ?? 'standard',
+          locale: userData.locale,
+          activeDays: userData.activeDays,
         };
       } else {
         const existing = snap.data() as User;
@@ -1052,10 +1077,15 @@ export class FirestoreStore implements Store {
           picture: userData.picture ?? existing.picture,
           lastLoginAt: now,
           tier: userData.tier ?? existing.tier,
+          // `...existing` carries the *stored* value, so an incoming update to either of
+          // these was dropped on the floor for every account that already existed —
+          // which, for `activeDays`, is every account the activity hook ever touched.
+          locale: userData.locale ?? existing.locale,
+          activeDays: userData.activeDays ?? existing.activeDays,
         };
       }
 
-      transaction.set(docRef, user, { merge: true });
+      transaction.set(docRef, stripUndefined(user), { merge: true });
       return user;
     });
   }
@@ -1374,7 +1404,7 @@ export class FirestoreStore implements Store {
       locale: entry.locale,
       status: existing?.status ?? 'pending',
     };
-    await docRef.set(record, { merge: true });
+    await docRef.set(stripUndefined(record), { merge: true });
     return record;
   }
 


### PR DESCRIPTION
Found by running `npm run token:mint` against real Firestore for the first time. All three were invisible to the test suite because **nothing ever constructed a `FirestoreStore`** — every test ran against `InMemoryStore`, which stores whatever it is handed.

## 1. `undefined` reaches Firestore (the reported failure)

Firestore rejects `undefined` rather than treating it as an absent field. `upsertUser` builds `email`/`picture` straight from optional inputs, so it could not create an account that has neither — i.e. **every `bot:` account**:

```
Error: Cannot use "undefined" as a Firestore value (found in field "email")
    at FirestoreStore.upsertUser (store.ts:1032)
```

`upsertWaitlistEntry` has the identical fault, and that one is **live in production right now**: `auth.ts:443` deliberately passes `email: undefined` rather than store an unverified Google email claim, so a waitlist sign-up from an account with an unverified email 500s today. Unrelated to access tokens; it just needed someone to hit it.

Fixed by stripping undefined keys at the write boundary, so records can keep being built naturally with optional fields left off.

## 2. `activeDays` was never persisted — by either store

`InMemoryStore.upsertUser` omitted the field from the object it builds. `FirestoreStore.upsertUser` spread the *stored* document on the existing-user branch and never read the incoming value. The activity hook in `auth.ts` exists for the sole purpose of writing this field, so every one of those writes was discarded.

The consequence is a measurement one: `summarizeCreatorMetrics` computes creator return (D7) from `User.activeDays`, which was always absent — so the metric has been reporting "nobody ever returns" regardless of actual behaviour. `product-instrumentation` records this gap as closed on 2026-07-26; it wasn't.

## 3. `locale` dropped on the same branch

Same root cause as #2 — an incoming `locale` update was discarded for any account that already existed.

## Tests

New `store-firestore.test.ts` drives `FirestoreStore` through its injectable `db` with a fake that refuses `undefined` exactly as the real client does — including a test asserting the fake still rejects, so the suite can't quietly become vacuous.

The bot-exclusion test in `access-token-routes.test.ts` is now a **contrast** (a session request records an active day, a token request does not). It previously passed for the wrong reason: `activeDays` was undefined for every account, so it proved nothing.

`npm run type-check && npm run lint && npm run test && npm run build` green — 872 tests.

## Not covered

The fake is a stand-in, not Firestore. It reproduces the `undefined` rejection because that is the defect at hand, but it does not model transactions, merge semantics, or query behaviour. The real proof is a successful `token:mint` after this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT8ueQTiejuiksCUd2oxQx)_