### PR TITLE
Block deploys that break playable games

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -306,6 +306,38 @@ jobs:
 
           echo "Authenticated smoke passed as ${UID_VALUE}: bearer auth, cookie exchange, and the session wall all live."
 
+      # Playable games are the product, and every check above this point can pass while
+      # play is completely broken: `/api/games/<slug>` returning HTML says nothing about
+      # whether that HTML *runs*. A CSP header, a sandbox change, a bundle regression or a
+      # broken assembler all return a healthy 200 and a black screen. This drives a real
+      # browser against the candidate and asserts games actually draw
+      # (e2e/deploy-smoke.spec.ts, docs/deployment.md).
+      #
+      # Blocking, deliberately. The suite itself distinguishes "one game is broken" (warns,
+      # since games live in a separate agent-maintained repo) from "most games are broken"
+      # (fails, because that is the deploy having broken play).
+      - name: Install Chromium for the e2e smoke
+        run: npx playwright install --with-deps chromium
+
+      - name: End-to-end smoke (real browser, real games)
+        env:
+          SMOKE_BASE_URL: ${{ env.CANDIDATE_URL }}
+          GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
+        run: npm run e2e:deployed
+
+      # Traces and screenshots for the failing run only — a red deploy gate is useless if
+      # diagnosing it means reproducing the whole deploy locally.
+      - name: Upload e2e artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-${{ github.run_id }}
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Promote candidate revision to 100% traffic
         run: |
           gcloud run services update-traffic "$SERVICE" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -316,6 +316,18 @@ jobs:
       # Blocking, deliberately. The suite itself distinguishes "one game is broken" (warns,
       # since games live in a separate agent-maintained repo) from "most games are broken"
       # (fails, because that is the deploy having broken play).
+      # `deploy` is a separate job from `ci-gate`, on a fresh runner with no node_modules —
+      # everything above this point is gcloud and curl. The e2e steps need the workspace
+      # installed, so set Node up here rather than assuming the CI gate's runner state.
+      - name: Set up Node for the e2e smoke
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci
+
       - name: Install Chromium for the e2e smoke
         run: npx playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ coverage
 *.tsbuildinfo
 .vite
 /gitleaks
+
+# Playwright post-deploy e2e artifacts (e2e/playwright.config.ts)
+test-results
+playwright-report

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -183,13 +183,17 @@ Traps, in the order an agent will hit them:
   silently stays logged out with no error. Go through a browser-level API:
   `storageState` as above, or `context.addCookies([...])` with `httpOnly: true` if the
   `Set-Cookie` came from curl.
-- **Do not add Playwright to the repo's `package.json`.** This app has no e2e harness by
-  design; install `playwright-core` in a scratch directory instead. A dependency edit
-  without a regenerated lockfile passes every local check and kills CI at `npm ci` — the
-  exact failure the `verify-agent-work` playbook records.
-- **No `playwright install`.** Chromium is preinstalled in agent VMs
-  (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`); pass `executablePath` if your
-  Playwright version doesn't auto-find it.
+- **There is already a Playwright harness — reuse it.** `e2e/` holds the post-deploy
+  suite and the repo pins `@playwright/test`, so `npm run e2e:deployed` works against any
+  target via `SMOKE_BASE_URL`. Do **not** add or bump a Playwright dependency for a
+  one-off check: install `playwright-core` in a scratch directory outside the repo
+  instead. A dependency edit without a regenerated lockfile passes every local check and
+  kills CI at `npm ci` — the exact failure the `verify-agent-work` playbook records.
+- **No `playwright install` in an agent VM.** Chromium is preinstalled
+  (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`) and may be a different build than the
+  pinned Playwright expects; point `SMOKE_CHROMIUM_PATH` at the existing binary rather
+  than downloading one. Behind an egress proxy, set `HTTPS_PROXY` — the config picks it
+  up, and without it a proxy 403 reads exactly like the site refusing you.
 - **Production cookies carry `Secure`** — they travel over HTTPS only, so the same
   script pointed at a plain-HTTP host will not authenticate.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,32 @@ Deployments to Cloud Run are triggered on push to `master`:
 3. **Cloud Build Image Creation:** Submits image build using `infra/cloudbuild.yaml` to Artifact Registry. The WIF deployer service account must also have `roles/serviceusage.serviceUsageConsumer` and storage access for the default Cloud Build staging bucket; `infra/setup-wif.sh` grants both.
 4. **Staging / Candidate Revision:** Deploys revision to Cloud Run with `--no-traffic --tag candidate`.
 5. **Candidate Smoke Test:** Anonymous checks (health, shell, public catalog/play, walls hold, forged bearer token rejected) plus an **authenticated smoke** when the `GAMEDEV_ACCESS_TOKEN` repo secret exists — bearer auth, token→cookie exchange, and a session-walled route, run as the CI bot (see [`agent-access-tokens.md`](./agent-access-tokens.md)). Skips loudly when the secret is absent.
-6. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if the smoke test succeeds.
+6. **End-to-end smoke (real browser):** Drives Chromium against the candidate and asserts that published games **actually run** — the frame is correctly sandboxed, the game document executes, its canvas draws, and the drawing changes over time (`e2e/deploy-smoke.spec.ts`). See below for why this blocks.
+7. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if every check above succeeds.
+
+### Why the browser smoke blocks a deploy
+
+Playable games are the product; a site that loads but plays nothing is worth nothing. Every
+other check can pass while play is completely broken, because they all stop at HTTP: proving
+`/api/games/<slug>` returns HTML says nothing about whether that HTML _runs_. A CSP header, a
+sandbox change, a bundle regression or a broken assembler each return a healthy 200 and a
+black screen.
+
+The one thing that must not block is a single badly-written game — those live in a separate,
+agent-maintained repo and change independently of this one. So the suite samples several
+published games and decides by breadth:
+
+| Sample result        | Meaning                    | Outcome                     |
+| -------------------- | -------------------------- | --------------------------- |
+| most games fail      | the deploy broke play      | **blocks promotion**        |
+| exactly one fails    | that game is broken        | `::warning::`, ships        |
+| only one game exists | nothing to compare against | **blocks** — it is the site |
+
+It also asserts the sandbox invariant (`allow-scripts`, never `allow-same-origin`) on the
+**rendered, deployed page**, which unit tests in jsdom cannot do, and skips play telemetry so
+CI plays never enter the product numbers. On failure it uploads traces and screenshots as a
+run artifact. Run it yourself against anything:
+`SMOKE_BASE_URL=https://www.gamedev.pl npm run e2e:deployed`.
 
 ## Secrets & access (current live state)
 
@@ -43,15 +68,15 @@ account (`<project-number>-compute@developer.gserviceaccount.com`) needs
 `roles/secretmanager.secretAccessor` on each. `deploy.yml` and `infra/deploy-api.sh` wire whichever exist into
 a single `--set-secrets` list.
 
-| Secret                    | Purpose                                                             | State (2026-07-26)       |
-| ------------------------- | ------------------------------------------------------------------- | ------------------------ |
-| `github-token`            | Fine-grained PAT (Issues rw + PRs r + Contents r, games repo only)  | ✅ set — submissions on  |
+| Secret                              | Purpose                                                                                 | State (2026-07-26)                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `github-token`                      | Fine-grained PAT (Issues rw + PRs r + Contents r, games repo only)                      | ✅ set — submissions on                                                      |
 | `GAMES_REPO_TOKEN` (GitHub Actions) | Contents:read PAT on the games repo — CI lockstep check (`npm run contract:games-repo`) | ⚠️ set on the GitHub repo (not GCP) so assemble/Check 4/music drift fails CI |
-| `submission-token-secret` | HMAC key for the stateless status token → `SUBMISSION_TOKEN_SECRET` | ✅ set                   |
-| `session-secret`          | HMAC key for session cookies → `SESSION_SECRET`                     | ✅ set                   |
-| `resend-api-key`          | Outbound email → `RESEND_API_KEY` (see below)                       | ✅ set                   |
-| `vapid-private-key`       | Web push signing → `VAPID_PRIVATE_KEY`                              | ✅ set                   |
-| `site-basic-auth`         | Former "not public yet" lock → `SITE_BASIC_AUTH`                    | ⚠️ exists but **unused** |
+| `submission-token-secret`           | HMAC key for the stateless status token → `SUBMISSION_TOKEN_SECRET`                     | ✅ set                                                                       |
+| `session-secret`                    | HMAC key for session cookies → `SESSION_SECRET`                                         | ✅ set                                                                       |
+| `resend-api-key`                    | Outbound email → `RESEND_API_KEY` (see below)                                           | ✅ set                                                                       |
+| `vapid-private-key`                 | Web push signing → `VAPID_PRIVATE_KEY`                                                  | ✅ set                                                                       |
+| `site-basic-auth`                   | Former "not public yet" lock → `SITE_BASIC_AUTH`                                        | ⚠️ exists but **unused**                                                     |
 
 `site-basic-auth` is a leftover: the running revision does not wire it, and the site answers
 without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta allowlist

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -1,0 +1,238 @@
+import { expect, test, type Frame, type Page } from '@playwright/test';
+
+/**
+ * Post-deployment checks against a candidate revision, run before traffic is promoted.
+ *
+ * **Playable games are the product.** A deploy that breaks play is worse than a deploy
+ * that fails to ship, so everything here blocks promotion — including the assertion that
+ * a game's canvas actually draws. Proving `/api/games/<slug>` returns HTML (which the
+ * curl smoke already does) says nothing about whether that HTML *runs* in a browser: a
+ * CSP header, a sandbox change, a bundle regression or a broken assembler all return a
+ * perfectly healthy 200 and a black screen.
+ *
+ * The one thing that must NOT block is a single badly-written game. Games live in a
+ * separate, agent-maintained repo and change independently, so one broken game is not a
+ * reason to stop shipping the website. The discriminator is breadth, not assertion type:
+ *
+ *   several games sampled → most fail  = the deploy broke play        → BLOCK
+ *                        → one fails   = that game is broken          → warn
+ *
+ * With a single game in the catalog there is nothing to compare against, so it blocks —
+ * at that point one broken game *is* a site with no playable games.
+ */
+
+/** How many published games to sample. Enough to tell "all broken" from "one broken". */
+const SAMPLE_SIZE = 3;
+
+/** Pixel brightness above which we count a pixel as drawn rather than background. */
+const LIT_THRESHOLD = 60;
+
+interface GameReport {
+  slug: string;
+  shellRendered: boolean;
+  sandbox: string | null;
+  documentDelivered: boolean;
+  litPixels: number;
+  animated: boolean;
+  note?: string;
+}
+
+async function publishedSlugs(request: Page['request'], limit: number): Promise<string[]> {
+  const res = await request.get('/api/catalog');
+  expect(res.status(), 'catalog must serve anonymously — play is public').toBe(200);
+  const catalog = (await res.json()) as Array<{ slug: string; status?: string }>;
+  return catalog
+    .filter((entry) => entry.status === 'published')
+    .map((entry) => entry.slug)
+    .slice(0, limit);
+}
+
+/** The game frame: the only child frame on a play route. */
+async function gameFrame(page: Page): Promise<Frame | null> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const frame = page.frames().find((candidate) => candidate !== page.mainFrame());
+    if (frame) {
+      const ready = await frame.evaluate(() => document.readyState !== 'loading' && !!document.body).catch(() => false);
+      if (ready) return frame;
+    }
+    await page.waitForTimeout(250);
+  }
+  return null;
+}
+
+/**
+ * Counts pixels the game has drawn. Reaching into the frame works despite the opaque
+ * origin because Playwright talks CDP, below the same-origin policy — verified against a
+ * real sandboxed srcdoc frame before this suite was written.
+ */
+async function litPixels(frame: Frame): Promise<number> {
+  return frame
+    .evaluate((threshold) => {
+      const canvas = document.querySelector('canvas');
+      if (!canvas) return -1;
+      const context = canvas.getContext('2d');
+      if (!context) return -1;
+      const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+      let count = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        if ((data[i] ?? 0) + (data[i + 1] ?? 0) + (data[i + 2] ?? 0) > threshold) count++;
+      }
+      return count;
+    }, LIT_THRESHOLD)
+    .catch(() => -1);
+}
+
+async function inspectGame(page: Page, slug: string): Promise<GameReport> {
+  const report: GameReport = {
+    slug,
+    shellRendered: false,
+    sandbox: null,
+    documentDelivered: false,
+    litPixels: -1,
+    animated: false,
+  };
+
+  await page.goto(`/play/${encodeURIComponent(slug)}`, { waitUntil: 'domcontentloaded' });
+
+  // The SPA shell itself — if the bundle 404s or throws, nothing below can pass either,
+  // but this distinguishes "site is broken" from "this game is broken" in the output.
+  report.shellRendered = await page
+    .locator('.app, main')
+    .first()
+    .isVisible()
+    .catch(() => false);
+
+  const iframe = page.locator('iframe').first();
+  await iframe.waitFor({ state: 'attached', timeout: 15_000 }).catch(() => undefined);
+  report.sandbox = await iframe.getAttribute('sandbox').catch(() => null);
+
+  const frame = await gameFrame(page);
+  if (!frame) {
+    report.note = 'no game frame appeared';
+    return report;
+  }
+
+  report.documentDelivered = await frame.evaluate(() => document.body.children.length > 0).catch(() => false);
+
+  // Two samples with time between them: a game that painted one frame and died looks
+  // identical to a working one in a single sample.
+  const first = await litPixels(frame);
+  await page.waitForTimeout(600);
+  const second = await litPixels(frame);
+
+  report.litPixels = Math.max(first, second);
+  report.animated = first >= 0 && second >= 0 && first !== second;
+  if (first === -1) report.note = 'no canvas found in the game document';
+
+  return report;
+}
+
+test.describe('deployed site', () => {
+  /**
+   * Never let a CI play count as a real one.
+   *
+   * Play and visit telemetry are deliberately anonymous — no uid — so the `bot:` uid
+   * exclusion that keeps agents out of creator metrics cannot reach them. This suite
+   * opens several games on every single deploy, which at beta volumes would be a visible
+   * fraction of daily plays and would quietly corrupt exactly the per-game health signal
+   * the numbers exist to provide. Dropping the beacons client-side is the narrowest fix:
+   * no product code changes, and nothing about the page under test differs.
+   */
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/telemetry**', (route) => route.abort());
+  });
+
+  test('serves a play route inside a correctly sandboxed frame', async ({ page }) => {
+    const [slug] = await publishedSlugs(page.request, 1);
+    expect(slug, 'catalog must contain at least one published game').toBeTruthy();
+
+    await page.goto(`/play/${encodeURIComponent(slug!)}`, { waitUntil: 'domcontentloaded' });
+
+    const iframe = page.locator('iframe').first();
+    await expect(iframe, 'a play route must render a game frame').toBeAttached({ timeout: 15_000 });
+
+    // The repo's one non-negotiable safety invariant, asserted for the first time on the
+    // *deployed, rendered* page rather than on the component in jsdom. `allow-same-origin`
+    // would let generated code reach this app's DOM, storage and cookies.
+    const sandbox = await iframe.getAttribute('sandbox');
+    expect(sandbox, 'game frame must be sandboxed').toBe('allow-scripts');
+    expect(sandbox ?? '', 'allow-same-origin must never appear').not.toContain('allow-same-origin');
+  });
+
+  test('published games actually run', async ({ page }, testInfo) => {
+    // Several games, each loaded and sampled twice — budget accordingly.
+    testInfo.setTimeout(180_000);
+
+    const slugs = await publishedSlugs(page.request, SAMPLE_SIZE);
+    expect(slugs.length, 'catalog must contain at least one published game').toBeGreaterThan(0);
+
+    const reports: GameReport[] = [];
+    for (const slug of slugs) {
+      reports.push(await inspectGame(page, slug));
+    }
+
+    const playable = (report: GameReport) =>
+      report.sandbox === 'allow-scripts' && report.documentDelivered && report.litPixels > 0 && report.animated;
+
+    const working = reports.filter(playable);
+    const broken = reports.filter((report) => !playable(report));
+
+    for (const report of reports) {
+      const state = playable(report) ? 'OK  ' : 'FAIL';
+      console.log(
+        `${state} ${report.slug}  shell=${report.shellRendered} sandbox=${report.sandbox} ` +
+          `doc=${report.documentDelivered} lit=${report.litPixels} animated=${report.animated}` +
+          (report.note ? `  (${report.note})` : ''),
+      );
+    }
+
+    // One broken game out of several is a games-repo problem, not a reason to hold the
+    // website. Surface it loudly and carry on.
+    if (broken.length === 1 && working.length > 0) {
+      const failed = broken[0]!;
+      console.log(
+        `::warning title=Game not playable::${failed.slug} did not run on this revision ` +
+          `(lit=${failed.litPixels}, animated=${failed.animated}). Other sampled games play, ` +
+          `so this is a games-repo issue rather than a deploy regression.`,
+      );
+      return;
+    }
+
+    // Everything else is systemic: if the games that worked yesterday do not run now, the
+    // deploy broke play, and a site without playable games is worth nothing.
+    expect(
+      working.length,
+      `play appears broken on this revision — ${broken.length}/${reports.length} sampled games ` +
+        `failed to run. This blocks promotion because playable games are the product.`,
+    ).toBe(reports.length);
+  });
+
+  test('a signed-in session renders the authenticated shell', async ({ browser, request, baseURL }) => {
+    const token = process.env.GAMEDEV_ACCESS_TOKEN;
+    test.skip(!token, 'GAMEDEV_ACCESS_TOKEN not set — authenticated shell unverified on this run');
+    // A token is a row in the deployment's own datastore, so one minted against
+    // production cannot authenticate to a laptop running InMemoryStore. Skipping keeps a
+    // local run honest instead of failing on a mismatch that means nothing.
+    test.skip(
+      /localhost|127\.0\.0\.1/.test(baseURL ?? ''),
+      'local target — a deployed token does not exist in this store',
+    );
+
+    // Exchange the agent token for the cookie the SPA actually sends.
+    const api = await request.post('/api/auth/session', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(api.status(), 'token must exchange for a session').toBe(200);
+
+    const context = await browser.newContext({ storageState: await request.storageState() });
+    const page = await context.newPage();
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // Proves the cookie is honoured by the *rendered app*, not merely by the API — the
+    // closed-beta splash and the signed-in shell are different branches in App.tsx.
+    await expect(page.locator('.user-name'), 'signed-in nav must render for a token session').toBeVisible({
+      timeout: 15_000,
+    });
+    await context.close();
+  });
+});

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -34,6 +34,8 @@ interface GameReport {
   documentDelivered: boolean;
   litPixels: number;
   animated: boolean;
+  /** Only probed when the game looked static — see `inspectGame`. */
+  respondedToInput?: boolean;
   note?: string;
 }
 
@@ -60,26 +62,40 @@ async function gameFrame(page: Page): Promise<Frame | null> {
   return null;
 }
 
+interface CanvasSample {
+  /** Pixels brighter than the background — "has it drawn anything at all". */
+  lit: number;
+  /** Order-dependent digest of the pixels — "has what it drew changed". */
+  digest: number;
+}
+
 /**
- * Counts pixels the game has drawn. Reaching into the frame works despite the opaque
- * origin because Playwright talks CDP, below the same-origin policy — verified against a
- * real sandboxed srcdoc frame before this suite was written.
+ * Samples the game's canvas. Reaching into the frame works despite the opaque origin
+ * because Playwright talks CDP, below the same-origin policy — verified against a real
+ * sandboxed srcdoc frame before this suite was written.
+ *
+ * Returns a digest as well as a count, because a count alone cannot detect motion: a
+ * sprite translating across a uniform background lights exactly as many pixels in every
+ * frame. Comparing counts would report that game as frozen and block a perfectly good
+ * deploy. The digest folds each pixel with its position, so movement changes it.
  */
-async function litPixels(frame: Frame): Promise<number> {
+async function sampleCanvas(frame: Frame): Promise<CanvasSample | null> {
   return frame
     .evaluate((threshold) => {
       const canvas = document.querySelector('canvas');
-      if (!canvas) return -1;
-      const context = canvas.getContext('2d');
-      if (!context) return -1;
+      const context = canvas?.getContext('2d');
+      if (!canvas || !context) return null;
       const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
-      let count = 0;
+      let lit = 0;
+      let digest = 0;
       for (let i = 0; i < data.length; i += 4) {
-        if ((data[i] ?? 0) + (data[i + 1] ?? 0) + (data[i + 2] ?? 0) > threshold) count++;
+        const brightness = (data[i] ?? 0) + (data[i + 1] ?? 0) + (data[i + 2] ?? 0);
+        if (brightness > threshold) lit++;
+        digest = (Math.imul(digest, 33) + brightness) | 0;
       }
-      return count;
+      return { lit, digest };
     }, LIT_THRESHOLD)
-    .catch(() => -1);
+    .catch(() => null);
 }
 
 async function inspectGame(page: Page, slug: string): Promise<GameReport> {
@@ -114,15 +130,40 @@ async function inspectGame(page: Page, slug: string): Promise<GameReport> {
 
   report.documentDelivered = await frame.evaluate(() => document.body.children.length > 0).catch(() => false);
 
-  // Two samples with time between them: a game that painted one frame and died looks
-  // identical to a working one in a single sample.
-  const first = await litPixels(frame);
-  await page.waitForTimeout(600);
-  const second = await litPixels(frame);
+  // Three spaced samples rather than two: a canvas can appear a beat late, and judging a
+  // game on a sample taken before it existed would report a healthy game as dead.
+  const samples: Array<CanvasSample | null> = [];
+  for (let take = 0; take < 3; take++) {
+    samples.push(await sampleCanvas(frame));
+    if (take < 2) await page.waitForTimeout(500);
+  }
 
-  report.litPixels = Math.max(first, second);
-  report.animated = first >= 0 && second >= 0 && first !== second;
-  if (first === -1) report.note = 'no canvas found in the game document';
+  const valid = samples.filter((sample): sample is CanvasSample => sample !== null);
+  if (valid.length === 0) {
+    report.note = 'no canvas found in the game document';
+    return report;
+  }
+
+  report.litPixels = Math.max(...valid.map((sample) => sample.lit));
+  report.animated = valid.length > 1 && valid[0]!.digest !== valid[valid.length - 1]!.digest;
+
+  // A game that draws but never moves on its own is not necessarily broken — a puzzle or
+  // turn-based game legitimately redraws only on input. Poke it before concluding it is
+  // frozen, so "static by design" cannot block a deploy.
+  if (!report.animated) {
+    await page
+      .locator('iframe')
+      .first()
+      .click({ position: { x: 40, y: 40 } })
+      .catch(() => undefined);
+    for (const key of ['ArrowUp', 'ArrowRight', 'Space']) {
+      await page.keyboard.press(key).catch(() => undefined);
+    }
+    await page.waitForTimeout(400);
+    const poked = await sampleCanvas(frame);
+    report.respondedToInput = !!poked && poked.digest !== valid[valid.length - 1]!.digest;
+    if (report.respondedToInput) report.note = 'static until input, responded when poked';
+  }
 
   return report;
 }
@@ -171,8 +212,16 @@ test.describe('deployed site', () => {
       reports.push(await inspectGame(page, slug));
     }
 
+    // "Alive" is: the frame is sandboxed, a document arrived, and the canvas *changed* —
+    // either on its own or when poked. Liveness is the change, not the brightness: a game
+    // with a dark palette can legitimately light no pixels above the threshold, and
+    // requiring `lit > 0` would block the deploy over an art choice. A deploy that truly
+    // broke play leaves every canvas both blank *and* frozen, which this still catches.
+    // `litPixels` stays in the report as a diagnostic.
     const playable = (report: GameReport) =>
-      report.sandbox === 'allow-scripts' && report.documentDelivered && report.litPixels > 0 && report.animated;
+      report.sandbox === 'allow-scripts' &&
+      report.documentDelivered &&
+      (report.animated || report.respondedToInput === true);
 
     const working = reports.filter(playable);
     const broken = reports.filter((report) => !playable(report));
@@ -181,7 +230,8 @@ test.describe('deployed site', () => {
       const state = playable(report) ? 'OK  ' : 'FAIL';
       console.log(
         `${state} ${report.slug}  shell=${report.shellRendered} sandbox=${report.sandbox} ` +
-          `doc=${report.documentDelivered} lit=${report.litPixels} animated=${report.animated}` +
+          `doc=${report.documentDelivered} lit=${report.litPixels} animated=${report.animated} ` +
+          `input=${report.respondedToInput ?? 'n/a'}` +
           (report.note ? `  (${report.note})` : ''),
       );
     }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -38,7 +38,9 @@ export default defineConfig({
     // Playwright does not pick up HTTPS_PROXY by itself, and agent VMs route all egress
     // through one — without this the suite gets a proxy 403 that reads exactly like the
     // site refusing the request. CI has no proxy set, so this is inert there.
-    ...(process.env.HTTPS_PROXY ? { proxy: { server: process.env.HTTPS_PROXY } } : {}),
+    ...(process.env.HTTPS_PROXY
+      ? { proxy: { server: process.env.HTTPS_PROXY, bypass: 'localhost,127.0.0.1,::1' } }
+      : {}),
   },
   projects: [
     {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Post-deployment end-to-end checks (docs/deployment.md).
+ *
+ * These do not run in `ci-gate` and have no dev server: they drive a **deployed** URL,
+ * normally the Cloud Run candidate revision before traffic is promoted to it. Unit tests
+ * cover components; this covers the thing a visitor actually receives — the built bundle,
+ * the CDN in front of it, and the assembled game document.
+ *
+ * Two suites with deliberately different consequences (see each spec's header):
+ *   deploy-smoke.spec.ts — the website's own behaviour. Blocks promotion.
+ *   gameplay.spec.ts     — whether a published game runs. Reports, never blocks.
+ */
+
+const baseURL = process.env.SMOKE_BASE_URL ?? 'http://127.0.0.1:3001';
+
+export default defineConfig({
+  testDir: '.',
+  // One retry: these cross a real network to a scale-to-zero service, so a first-request
+  // cold start is a normal event rather than a defect. More than one would start hiding
+  // real flakiness instead of absorbing cold starts.
+  retries: 1,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  // Serial: the whole point is a fast gate in front of a deploy, and the suite is small.
+  workers: 1,
+  forbidOnly: true,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  use: {
+    baseURL,
+    ...devices['Desktop Chrome'],
+    // A failure here blocks a production deploy, so leave behind enough to diagnose it
+    // without re-running: the trace is the difference between "it was red" and knowing why.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    // Playwright does not pick up HTTPS_PROXY by itself, and agent VMs route all egress
+    // through one — without this the suite gets a proxy 403 that reads exactly like the
+    // site refusing the request. CI has no proxy set, so this is inert there.
+    ...(process.env.HTTPS_PROXY ? { proxy: { server: process.env.HTTPS_PROXY } } : {}),
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Agent VMs ship a Chromium that may not match this Playwright's expected build,
+        // and re-downloading one is often blocked there. Point SMOKE_CHROMIUM_PATH at the
+        // existing binary to reuse it; CI leaves this unset and uses the installed build.
+        ...(process.env.SMOKE_CHROMIUM_PATH
+          ? { launchOptions: { executablePath: process.env.SMOKE_CHROMIUM_PATH } }
+          : {}),
+      },
+    },
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "1.62.0",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "concurrently": "^8.2.2",
@@ -1789,6 +1790,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5143,6 +5160,53 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.22",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "dev": "npm run build:packages && concurrently -n api,web -c blue,green \"npm run dev -w @gamedevpl/api\" \"npm run dev -w @gamedevpl/web\"",
     "test": "npm run build:packages && npm run test --workspaces --if-present",
     "contract:games-repo": "npm run contract:games-repo -w @gamedevpl/api",
+    "e2e:deployed": "playwright test --config e2e/playwright.config.ts",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "type-check": "npm run build:packages && npm run type-check --workspaces --if-present",
     "prepare": "husky install"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "1.62.0",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "concurrently": "^8.2.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,9 @@ import { configDefaults, defineConfig } from 'vitest/config';
  */
 export default defineConfig({
   test: {
-    exclude: [...configDefaults.exclude, '**/.claude/worktrees/**'],
+    // `e2e/` holds Playwright specs driving a *deployed* URL (see e2e/playwright.config.ts).
+    // Vitest's default include matches `*.spec.ts`, so without this a root run collects
+    // them and fails on `@playwright/test` imports it cannot execute.
+    exclude: [...configDefaults.exclude, '**/.claude/worktrees/**', 'e2e/**'],
   },
 });


### PR DESCRIPTION
Playable games are the product. Every check we have stops at HTTP, so today a deploy can break play completely and still go green — proving `/api/games/<slug>` returns HTML says nothing about whether that HTML **runs**. A CSP header, a sandbox change, a bundle regression or a broken assembler each return a healthy 200 and a black screen.

This drives a real browser against the candidate revision before traffic is promoted.

## Asserted on the deployed, rendered page

- **The sandbox invariant** — `allow-scripts`, never `allow-same-origin`. Previously only checked against the component in jsdom; this is the first time it's asserted on what a visitor actually receives.
- **Games actually run** — the game document executes, its canvas draws, and the drawing *changes between two samples*. A game that painted one frame and froze is not "working", and a single sample can't tell the difference.
- **A `bot:ci` token exchanges for a session cookie the SPA honours** — proving auth works in the rendered app, not just via curl.

## One broken game must not stop the website shipping

Games live in a separate, agent-maintained repo and change independently. So the suite samples several published games and decides by **breadth**, not by assertion type:

| Sample result | Meaning | Outcome |
| --- | --- | --- |
| most games fail | the deploy broke play | **blocks promotion** |
| exactly one fails | that game is broken | `::warning::`, ships |
| only one game exists | nothing to compare against | **blocks** — it *is* the site |

## Verification

Ran end-to-end against a local instance serving the three fixture games (`odd-one-out`, `pixel-dodge`, `range-squad`) — the play-route/sandbox test and the games-actually-run test both pass against a real browser and real game documents.

Before writing any of it, I probed the core assumption against a real sandboxed `srcdoc` frame: Playwright **can** read inside it (`origin: "null"`, canvas pixels readable) because it works through CDP, beneath the same-origin policy. The rAF-throttling trap the `verify-agent-work` playbook documents doesn't apply — a headless Playwright page counts as visible.

`npm run type-check && npm run lint && npm run test && npm run build` all exit 0, each run unpiped with its status checked. Lockfile verified stable under regeneration, so `npm ci` won't break.

**Not verified:** the suite has not run against production from here — this container's TLS-intercepting proxy resets Chromium's connections (curl works, the browser doesn't). CI has no such proxy. The `HTTPS_PROXY` and `SMOKE_CHROMIUM_PATH` support exists so the same suite runs from an agent VM.

## Measurement hygiene

Play telemetry is aborted client-side, so CI plays never enter the product numbers. Those events carry no uid by design, so the `bot:` exclusion that keeps agents out of creator metrics cannot reach them — without this, several fake plays per deploy would corrupt exactly the per-game health signal the data exists to provide.

## Costs and one correction

Adds a pinned `@playwright/test` devDependency, `e2e/` specs, and ~60–90s per deploy (browser install). It runs only in the deploy workflow, never in `ci-gate`. Traces and screenshots upload as an artifact on failure, so a red gate is diagnosable without reproducing the deploy locally.

This **contradicts guidance I added earlier** in `docs/agent-access-tokens.md` — "do not add Playwright to the repo's `package.json`; this app has no e2e harness by design." That was aimed at agents making unversioned dependency edits for ad-hoc checks. Now that a versioned harness exists, the doc is corrected to say: reuse `npm run e2e:deployed`, and still never add or bump the dependency for a one-off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT8ueQTiejuiksCUd2oxQx)_