### PR TITLE
Add browser e2e suite and browse-live-site skill; fix missing browser-tab icon

### DIFF
--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -11,6 +11,14 @@ first if you haven't. This skill adds the one step that doc doesn't need to cove
 specific to **Claude Code on the web / remote execution environments**: getting the
 pre-installed Chromium to actually reach `www.gamedev.pl` through the session's egress proxy.
 
+**Before writing a throwaway script, check `apps/e2e`.** This walkthrough is codified as a
+runnable suite there (`npm run e2e` — not `npm test`, which deliberately excludes it so a
+browser suite pointed at production stays out of the offline test run). Its
+`apps/e2e/src/browser.ts` already
+exports the launch / session / problem-collection helpers described below. Reach for a
+scratch script only to explore something the suite doesn't cover — and when you find
+something worth keeping, add it there rather than leaving it in `/tmp`.
+
 ## Symptom
 
 Without the fix below, every `page.goto()` fails the same way regardless of URL (even
@@ -33,7 +41,7 @@ ClientHello and the tunnel succeeds.
 
 ## The fix
 
-Launch Chromium with **both** the explicit proxy server *and* the TLS cap:
+Launch Chromium with **both** the explicit proxy server _and_ the TLS cap:
 
 ```js
 const browser = await chromium.launch({
@@ -85,10 +93,14 @@ const page = await context.newPage();
 
 // 4. Wire up problem detection BEFORE navigating — console errors, page errors,
 //    failed requests, and 4xx/5xx responses are the actual signal you're looking for.
-page.on('console', (m) => { if (m.type() === 'error') console.log('console.error:', m.text()); });
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('console.error:', m.text());
+});
 page.on('pageerror', (e) => console.log('pageerror:', e));
 page.on('requestfailed', (r) => console.log('requestfailed:', r.url(), r.failure()?.errorText));
-page.on('response', (r) => { if (r.status() >= 400) console.log(`HTTP ${r.status()}`, r.url()); });
+page.on('response', (r) => {
+  if (r.status() >= 400) console.log(`HTTP ${r.status()}`, r.url());
+});
 
 await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
 await page.waitForTimeout(3000); // SPA hydration + first data fetch
@@ -126,11 +138,11 @@ roughly in order of how often they turn up real issues:
   unhandled console exception.
 - **`/health`** — renders "Not found" for a non-admin identity (including a token-authed
   bot); that's correct per `docs/agent-access-tokens.md`, not a bug.
-- **Signed-out pass** — a *second*, cookie-less browser context (`browser.newContext()`
+- **Signed-out pass** — a _second_, cookie-less browser context (`browser.newContext()`
   without `storageState`) hitting the same routes. Confirms anonymous visitors get a sane
   read-only experience and that nothing meant to be gated actually renders private data.
 - **Mobile viewport** (e.g. 390×844) — check `document.documentElement.scrollWidth -
-  clientWidth` is ~0 on both the home page and a game's play view; horizontal overflow is the
+clientWidth` is ~0 on both the home page and a game's play view; horizontal overflow is the
   most common mobile regression.
 
 ## Interpreting what you find
@@ -139,11 +151,17 @@ Not every console error or 404 is a bug:
 
 - `GET .../media/gameplay.mp4` aborting is normal — the catalog lazy-loads/cancels preview
   video for off-screen cards as you scroll.
+- Chromium's `Failed to load resource: the server responded with a status of NNN` console
+  error names **no URL in its text** — the URL is in the message's `location().url`. Read it
+  from there, or you'll be tempted to dismiss the whole shape as noise. Doing exactly that
+  is how a real missing-favicon 404 survived a full manual walkthrough. Browser-initiated
+  requests like `/favicon.ico` also never appear in `page.on('response')` at all, so that
+  console line is their _only_ report.
 - A 404 on `/api/admin/telemetry/*` from a non-admin bot identity, or on `/health` itself, is
   the intended behavior (unlisted admin route, 404s to everyone else).
 - A 404 on `/api/submissions/<garbage-token>` or `/api/drafts/<slug>` when you deliberately
   navigated to a bogus token/slug is the expected miss path, not a defect — check that the
-  *page* still rendered a friendly empty/error state, which is the actual thing worth verifying.
+  _page_ still rendered a friendly empty/error state, which is the actual thing worth verifying.
 
 Do treat as real findings: unhandled `pageerror` exceptions, a game whose canvas never
 appears or never responds to input, a route that renders a blank page instead of a state,

--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -44,12 +44,31 @@ ClientHello and the tunnel succeeds.
 Launch Chromium with **both** the explicit proxy server _and_ the TLS cap:
 
 ```js
+import { readdirSync } from 'node:fs';
+
+// The build number moves with the Playwright version — resolve it, never pin it.
+// A hard-coded chromium-<build> path is the single most likely way this snippet
+// goes stale and "fails" on a machine where Chromium is installed perfectly well.
+const root = process.env.PLAYWRIGHT_BROWSERS_PATH ?? '/opt/pw-browsers';
+const build = readdirSync(root)
+  .filter((n) => /^chromium-\d+$/.test(n))
+  .sort((a, b) => Number(b.split('-')[1]) - Number(a.split('-')[1]))[0];
+
 const browser = await chromium.launch({
-  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  executablePath: process.env.E2E_CHROMIUM_PATH ?? `${root}/${build}/chrome-linux/chrome`,
   proxy: { server: process.env.HTTPS_PROXY },
   args: ['--no-sandbox', '--ssl-version-max=tls1.2'],
 });
 ```
+
+Match `chromium-<build>` exactly rather than `chromium*`: the same directory holds
+`chromium_headless_shell-*`, which cannot run the WebGL and audio paths some generated
+games use. `apps/e2e/src/browser.ts` exports this as `findChromium()` — prefer importing
+it over re-deriving the path.
+
+Apply `--ssl-version-max=tls1.2` **only when a proxy is actually configured**. It is a
+real downgrade, not a harmless default: with nothing intercepting the connection there is
+nothing to work around, and pinning to 1.2 would forgo TLS 1.3 for no reason.
 
 Both parts matter: `proxy.server` alone still resets (TLS version is the real blocker);
 `--ssl-version-max` alone doesn't help if Chromium isn't told about the proxy in the first
@@ -80,11 +99,13 @@ const res = await api.post('/api/auth/session', {
 });
 if (res.status() !== 200) throw new Error(`session exchange failed: ${res.status()}`);
 
-// 2. Launch Chromium through the proxy at TLS 1.2 (see "The fix" above).
+// 2. Launch Chromium through the proxy at TLS 1.2 (see "The fix" above for how to
+//    resolve executablePath instead of pinning a build number).
+const proxyServer = process.env.HTTPS_PROXY;
 const browser = await chromium.launch({
-  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
-  proxy: { server: process.env.HTTPS_PROXY },
-  args: ['--no-sandbox', '--ssl-version-max=tls1.2'],
+  executablePath: findChromium(),
+  ...(proxyServer ? { proxy: { server: proxyServer } } : {}),
+  args: ['--no-sandbox', ...(proxyServer ? ['--ssl-version-max=tls1.2'] : [])],
 });
 
 // 3. Carry the cookie into the browser context.

--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: browse-live-site
+description: Drive a real Chromium browser against the live www.gamedev.pl as the bot:e2e agent identity, signed in, to manually explore the site or check a change actually works end-to-end. Use whenever asked to "click around", "walk through", "play a game and see if it works", or otherwise manually exercise the deployed site rather than just curling the API. Covers the one non-obvious step in a Claude Code on the web session: getting Playwright's bundled Chromium through the session's HTTPS egress proxy.
+---
+
+# Browsing the live site as an agent
+
+`docs/agent-access-tokens.md` already covers minting/using `GAMEDEV_ACCESS_TOKEN` and the
+basic Playwright shape (token → `/api/auth/session` → cookie → `storageState`). Read that
+first if you haven't. This skill adds the one step that doc doesn't need to cover because it's
+specific to **Claude Code on the web / remote execution environments**: getting the
+pre-installed Chromium to actually reach `www.gamedev.pl` through the session's egress proxy.
+
+## Symptom
+
+Without the fix below, every `page.goto()` fails the same way regardless of URL (even
+`https://example.com`):
+
+```
+Error: page.goto: net::ERR_CONNECTION_RESET
+```
+
+`curl` to the same host works fine. This is misleading — it looks like a site or network
+outage, but it's Chromium's TLS stack, not the destination.
+
+## Root cause
+
+The session's outbound HTTPS goes through a local CONNECT proxy at `$HTTPS_PROXY`
+(see `/root/.ccr/README.md`). Node tools (curl, fetch) negotiate TLS 1.3 through it fine.
+Chromium's default TLS 1.3 ClientHello (large, includes post-quantum key shares) gets the
+CONNECT tunnel reset by the proxy. Capping Chromium at TLS 1.2 avoids the oversized/PQ
+ClientHello and the tunnel succeeds.
+
+## The fix
+
+Launch Chromium with **both** the explicit proxy server *and* the TLS cap:
+
+```js
+const browser = await chromium.launch({
+  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  proxy: { server: process.env.HTTPS_PROXY },
+  args: ['--no-sandbox', '--ssl-version-max=tls1.2'],
+});
+```
+
+Both parts matter: `proxy.server` alone still resets (TLS version is the real blocker);
+`--ssl-version-max` alone doesn't help if Chromium isn't told about the proxy in the first
+place. Do not pass `--proxy-bypass-list` or otherwise try to route around the proxy — that's
+the egress policy, not a bug, and bypassing it will just fail differently (DNS/connect
+timeouts) or violate the session's network policy.
+
+Do not disable TLS verification and do not unset `HTTPS_PROXY` to "fix" this — those are
+never the right move (see `/root/.ccr/README.md`), and they're not needed: TLS 1.2 through
+the proxy is a complete, secure fix.
+
+If Playwright's own browser isn't installed yet, don't run `playwright install` — it's
+pre-fetched at `/opt/pw-browsers` and `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` blocks re-fetching.
+Just install `playwright-core` (not the full `playwright` package) in a scratch dir and point
+`executablePath` at the pre-installed binary.
+
+## Full recipe: signed-in session + a walkthrough
+
+```js
+import { chromium, request } from 'playwright-core';
+
+const BASE = 'https://www.gamedev.pl';
+
+// 1. Exchange the bearer token for a session cookie (see agent-access-tokens.md).
+const api = await request.newContext({ baseURL: BASE });
+const res = await api.post('/api/auth/session', {
+  headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
+});
+if (res.status() !== 200) throw new Error(`session exchange failed: ${res.status()}`);
+
+// 2. Launch Chromium through the proxy at TLS 1.2 (see "The fix" above).
+const browser = await chromium.launch({
+  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  proxy: { server: process.env.HTTPS_PROXY },
+  args: ['--no-sandbox', '--ssl-version-max=tls1.2'],
+});
+
+// 3. Carry the cookie into the browser context.
+const context = await browser.newContext({ storageState: await api.storageState() });
+const page = await context.newPage();
+
+// 4. Wire up problem detection BEFORE navigating — console errors, page errors,
+//    failed requests, and 4xx/5xx responses are the actual signal you're looking for.
+page.on('console', (m) => { if (m.type() === 'error') console.log('console.error:', m.text()); });
+page.on('pageerror', (e) => console.log('pageerror:', e));
+page.on('requestfailed', (r) => console.log('requestfailed:', r.url(), r.failure()?.errorText));
+page.on('response', (r) => { if (r.status() >= 400) console.log(`HTTP ${r.status()}`, r.url()); });
+
+await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(3000); // SPA hydration + first data fetch
+await page.screenshot({ path: 'home.png' });
+
+await browser.close();
+await api.dispose();
+```
+
+## Walkthrough checklist
+
+When asked to "explore" or "look for problems", don't stop at the home page. Useful surfaces,
+roughly in order of how often they turn up real issues:
+
+- **Home** (`/`) — scroll to the bottom too; lazy-loaded catalog cards fetch media on scroll.
+- **Play a real game** (`/play/<slug>` for a `single-player` catalog entry from
+  `GET /api/catalog`) — click into the game's iframe and send keyboard input; a game that
+  never responds to input is the most user-visible failure mode there is.
+- **Play alias rewrite** (`/ai/<slug>` or `/ay/<slug>`) — should 30x/rewrite to the canonical
+  `/play/<slug>` (see `apps/web/src/router.ts`).
+- **Multiplayer lobby** — click "Play together" on a catalog entry with `multiplayer` set;
+  check the QR/join-link screen renders and the join URL matches `/join/<CODE>#<token>`.
+- **Header menu** (hamburger, top right) — items are `<button class="nav-link">`, not links;
+  they call `scrollIntoView` on a same-page section id (`#hero-prompt`, `#arcade`,
+  `#my-games`), not client-side routes. Don't be fooled by a URL that doesn't change — wait
+  for the smooth-scroll to actually land before screenshotting. `#my-games` only exists in the
+  DOM once `MyGamesRail` has at least one non-abandoned submission to show — for a fresh
+  bot identity with zero submissions, clicking "My Games" is a legitimate no-op.
+- **Language toggle** (EN/PL) — check strings actually swap, not just the button state.
+- **Static/legal routes** — `/privacy`, `/terms`.
+- **Error paths** — an unknown path (→ `notFound` view, real 404), an unknown game slug at
+  `/play/<garbage>` (→ in-page "Could not load this game" error state, not a crash),
+  `/draft/<slug>` for something already published, a bogus `/status/<token>`, a bogus
+  `/join/<CODE>#<token>`. These should all render a friendly state, never a blank page or an
+  unhandled console exception.
+- **`/health`** — renders "Not found" for a non-admin identity (including a token-authed
+  bot); that's correct per `docs/agent-access-tokens.md`, not a bug.
+- **Signed-out pass** — a *second*, cookie-less browser context (`browser.newContext()`
+  without `storageState`) hitting the same routes. Confirms anonymous visitors get a sane
+  read-only experience and that nothing meant to be gated actually renders private data.
+- **Mobile viewport** (e.g. 390×844) — check `document.documentElement.scrollWidth -
+  clientWidth` is ~0 on both the home page and a game's play view; horizontal overflow is the
+  most common mobile regression.
+
+## Interpreting what you find
+
+Not every console error or 404 is a bug:
+
+- `GET .../media/gameplay.mp4` aborting is normal — the catalog lazy-loads/cancels preview
+  video for off-screen cards as you scroll.
+- A 404 on `/api/admin/telemetry/*` from a non-admin bot identity, or on `/health` itself, is
+  the intended behavior (unlisted admin route, 404s to everyone else).
+- A 404 on `/api/submissions/<garbage-token>` or `/api/drafts/<slug>` when you deliberately
+  navigated to a bogus token/slug is the expected miss path, not a defect — check that the
+  *page* still rendered a friendly empty/error state, which is the actual thing worth verifying.
+
+Do treat as real findings: unhandled `pageerror` exceptions, a game whose canvas never
+appears or never responds to input, a route that renders a blank page instead of a state,
+horizontal overflow on mobile, or a 4xx/5xx on a request the page itself considers essential
+(not a background poll or a lazy asset).

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -1,0 +1,8 @@
+# Defence in depth for a public repo. globalSetup.ts deliberately parks the signed-in
+# session state in os.tmpdir(), so nothing auth-shaped should ever appear here — but
+# "write it next to the tests instead" is a natural-looking refactor, and the file holds
+# a live session cookie. If someone makes that change, this stops the cookie reaching a
+# commit; .gitleaks.toml only knows the gdpl_pat_ token shape, not session state.
+*storage-state*.json
+*.storageState.json
+auth-state.json

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -1,0 +1,88 @@
+# @gamedevpl/e2e
+
+A signed-in walk through the **deployed** site in a real browser.
+
+Everything else in this repo tests code in isolation. This suite tests the thing users
+actually get: the built bundle, served by the real API, with a generated game booting in
+a sandboxed iframe. It exists for the failures that only appear there — a game whose
+canvas never starts, a route that renders blank instead of a state, a missing tab icon
+costing every visit a 404.
+
+## Running it
+
+```bash
+GAMEDEV_ACCESS_TOKEN=gdpl_pat_… npm run e2e
+```
+
+Note the script is `e2e`, not `test`. That is deliberate: the root `npm run test` fans out
+across workspaces with `--if-present`, and a browser suite pointed at a real deployment does
+not belong in a run people expect to be offline, fast, and about the working tree. Anyone
+holding a token would otherwise put every local `npm test` on the network — and see it fail
+whenever the deployed site lags their branch.
+
+Both prerequisites are environmental, and a miss **skips loudly** rather than failing —
+same reasoning as the optional authenticated smoke in `.github/workflows/deploy.yml`: a
+skipped check is absence of signal, and reporting it as a pass is the actual harm.
+
+| Requirement            | Why                                                                                                    | If missing  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ | ----------- |
+| `GAMEDEV_ACCESS_TOKEN` | Signs in as a `bot:` identity — see [`docs/agent-access-tokens.md`](../../docs/agent-access-tokens.md) | Suite skips |
+| A Playwright Chromium  | Driven headless; found under `PLAYWRIGHT_BROWSERS_PATH` (default `/opt/pw-browsers`)                   | Suite skips |
+
+Overrides: `E2E_BASE_URL` (default `https://www.gamedev.pl`) to point at a candidate
+revision, `E2E_CHROMIUM_PATH` to name a browser binary explicitly.
+
+Because it needs a credential, this suite **does not run in normal PR CI** — it skips
+there. Run it against a candidate URL before promoting a deploy, or by hand while
+working on the front end.
+
+## One token exchange per run
+
+`POST /api/auth/session` is rate limited to **20 per hour**, and that budget is shared
+with anything else using the same token. `src/globalSetup.ts` therefore exchanges once per
+run and hands the session state to every test file; nothing else may call that endpoint.
+
+This is worth knowing because of how the limit fails: it answers `429`, which reads as an
+expired or revoked credential. If a run suddenly cannot sign in, check the status code
+before reaching for `token:mint` — minting a second token does not buy more budget and
+leaves you with two credentials to revoke.
+
+## It talks to production
+
+The default `E2E_BASE_URL` is the live site. The tests are read-only by design: they
+browse, play, and inspect, but never submit an idea (which would spend real generation
+quota) and never write catalog state. Keep it that way — if you need to exercise the
+creation flow, point `E2E_BASE_URL` at a candidate revision first.
+
+## The proxy gotcha
+
+In a sandboxed environment that routes egress through a CONNECT proxy (Claude Code on
+the web, among others), Chromium needs two launch settings or **every** navigation fails
+`net::ERR_CONNECTION_RESET` — including `https://example.com`, while `curl` to the same
+host succeeds. That asymmetry reads as a site outage and is not one.
+
+`src/browser.ts` applies both:
+
+- `proxy: { server: HTTPS_PROXY }` — Chromium does not read the env var the way curl does.
+- `--ssl-version-max=tls1.2` — the non-obvious one. Chromium's default TLS 1.3
+  ClientHello (large, carries post-quantum key shares) gets its tunnel reset by the proxy.
+
+Never work around this by disabling TLS verification or unsetting `HTTPS_PROXY`. See
+[`.claude/skills/browse-live-site/SKILL.md`](../../.claude/skills/browse-live-site/SKILL.md)
+for driving the same setup by hand.
+
+## Adding a test
+
+Two rules, both learned the hard way:
+
+**Assert what you can actually verify.** The games are AI-generated; their HUD copy, art,
+and scoring are not a contract. "The canvas keeps producing frames" is checkable across
+any game. "The score went up when I pressed a key" is not — most of these games animate
+on their own, so that assertion passes on idle drift and proves nothing.
+
+**Explain every entry you add to `EXPECTED_NOISE`.** It is an assertion about intent, so
+each pattern needs the code that produces it. The bar matters: a `Failed to load
+resource` line carries no URL in its text, and allowlisting the whole shape — the
+tempting shortcut — is what hid the missing-favicon 404 through an entire manual
+walkthrough. `collectProblems` now folds in the console message's location URL so these
+stay triageable.

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -36,6 +36,23 @@ Because it needs a credential, this suite **does not run in normal PR CI** — i
 there. Run it against a candidate URL before promoting a deploy, or by hand while
 working on the front end.
 
+### Do not put `GAMEDEV_ACCESS_TOKEN` in `ci.yml`
+
+This is a public repo, and making the suite run in CI is the obvious next thought. It is
+the one change here that would actually be dangerous.
+
+`ci.yml` triggers on `pull_request`, which runs **code authored by the pull request** —
+`npm run lint`, `npm run test`, and `npm run build` all execute whatever the branch says
+they execute. Today that is harmless, because the only secret it can see is
+`GAMES_REPO_TOKEN` and fork PRs get no secrets at all. Add `GAMEDEV_ACCESS_TOKEN` to that
+workflow and any PR raised from a branch _inside_ the repo could exfiltrate it by editing
+a test file.
+
+`deploy.yml` is the safe home, and already holds the secret: it triggers only on
+`push: branches: [master]`, so nothing runs there until it has been reviewed and merged.
+Wire the suite in next to the existing authenticated smoke, pointed at `CANDIDATE_URL`
+before traffic is promoted.
+
 ## One token exchange per run
 
 `POST /api/auth/session` is rate limited to **20 per hour**, and that budget is shared

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@gamedevpl/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "// scripts": "Deliberately no `test` script: `npm run test` at the root fans out with --workspaces, and this suite drives a browser against a real deployment. Picked up there it would put every local test run on the network, stretch 16s into minutes, and fail whenever the deployed site lags the working tree. Run it explicitly: npm run e2e.",
+  "scripts": {
+    "e2e": "vitest run",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.15",
+    "playwright-core": "^1.56.1",
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.7"
+  }
+}

--- a/apps/e2e/src/anonymous-and-mobile.test.ts
+++ b/apps/e2e/src/anonymous-and-mobile.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Browser, Page } from 'playwright-core';
-import { collectProblems, describeProblems, e2ePrerequisites, launchSiteBrowser, visit } from './browser.js';
+import { browserPrerequisite, collectProblems, describeProblems, launchSiteBrowser, visit } from './browser.js';
 
 /**
  * Two audiences the signed-in desktop walk cannot speak for: a visitor who has not
@@ -10,7 +10,9 @@ import { collectProblems, describeProblems, e2ePrerequisites, launchSiteBrowser,
  * a signed-in 1280px run is structurally blind to — a sign-in wall on something that
  * should be public, or a layout that scrolls sideways.
  */
-const prereq = e2ePrerequisites();
+// Gated on a browser alone, not on a credential: nothing here signs in, so a token
+// requirement would skip these on any machine that has Chromium but no token.
+const prereq = browserPrerequisite();
 if (!prereq.ok) {
   console.warn(`[e2e] SKIPPED anonymous/mobile: ${prereq.reason}`);
 }

--- a/apps/e2e/src/anonymous-and-mobile.test.ts
+++ b/apps/e2e/src/anonymous-and-mobile.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright-core';
+import { collectProblems, describeProblems, e2ePrerequisites, launchSiteBrowser, visit } from './browser';
+
+/**
+ * Two audiences the signed-in desktop walk cannot speak for: a visitor who has not
+ * signed in, and a phone.
+ *
+ * Both are the majority case for a link shared from the site, and both fail in ways
+ * a signed-in 1280px run is structurally blind to — a sign-in wall on something that
+ * should be public, or a layout that scrolls sideways.
+ */
+const prereq = e2ePrerequisites();
+if (!prereq.ok) {
+  console.warn(`[e2e] SKIPPED anonymous/mobile: ${prereq.reason}`);
+}
+
+describe.skipIf(!prereq.ok)('anonymous visitors and small screens', () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await launchSiteBrowser();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  /** A context with no session cookie at all — not merely signed out in the UI. */
+  async function anonymousPage(viewport: { width: number; height: number }): Promise<Page> {
+    const context = await browser.newContext({ viewport });
+    return context.newPage();
+  }
+
+  /**
+   * Horizontal overflow is the most common mobile regression and the least likely to
+   * be noticed on a desktop run: a single unwrapped element widens the document and
+   * the whole page scrolls sideways.
+   */
+  async function horizontalOverflow(page: Page): Promise<number> {
+    return page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  }
+
+  it('lets an anonymous visitor browse the catalog and play a game', async () => {
+    const page = await anonymousPage({ width: 1280, height: 900 });
+    // An anonymous /api/auth/me is expected to come back unauthenticated.
+    const watcher = collectProblems(page, [401]);
+
+    await visit(page, '/', 4_000);
+    await expect.poll(() => page.locator('article.catalog-card').count(), { timeout: 20_000 }).toBeGreaterThan(0);
+    // Signed out means offered a way in, not walled out.
+    expect(await page.locator('button.sign-in-btn').count()).toBe(1);
+
+    await visit(page, '/play/apex-sprint', 6_000);
+    const frame = page.frames().find((f) => f !== page.mainFrame());
+    expect(frame, 'anonymous visitors must still get a playable game').toBeTruthy();
+    await expect.poll(() => frame!.locator('canvas').count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+    expect(describeProblems(watcher.drain())).toBe('');
+    await page.context().close();
+  });
+
+  it('fits a phone viewport without scrolling sideways', async () => {
+    const page = await anonymousPage({ width: 390, height: 844 });
+    const watcher = collectProblems(page, [401]);
+
+    await visit(page, '/', 4_000);
+    // A couple of pixels is sub-pixel rounding; a real overflow is tens or hundreds.
+    expect(await horizontalOverflow(page), 'home page overflows horizontally on a phone').toBeLessThanOrEqual(2);
+
+    await visit(page, '/play/apex-sprint', 6_000);
+    expect(await horizontalOverflow(page), 'play view overflows horizontally on a phone').toBeLessThanOrEqual(2);
+
+    expect(describeProblems(watcher.drain())).toBe('');
+    await page.context().close();
+  });
+});

--- a/apps/e2e/src/anonymous-and-mobile.test.ts
+++ b/apps/e2e/src/anonymous-and-mobile.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Browser, Page } from 'playwright-core';
-import { collectProblems, describeProblems, e2ePrerequisites, launchSiteBrowser, visit } from './browser';
+import { collectProblems, describeProblems, e2ePrerequisites, launchSiteBrowser, visit } from './browser.js';
 
 /**
  * Two audiences the signed-in desktop walk cannot speak for: a visitor who has not

--- a/apps/e2e/src/auth.test.ts
+++ b/apps/e2e/src/auth.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { request, type APIRequestContext } from 'playwright-core';
-import { BASE_URL, STORAGE_STATE_ENV, signedInApiContext } from './browser.js';
+import { BASE_URL, signedInApiContext, storageStatePath } from './browser.js';
 
 /**
  * The credential contract, checked without a browser. If these fail, every browser
@@ -50,7 +50,7 @@ describe.skipIf(!hasToken)('agent access token', () => {
     // /api/auth/session again: that endpoint allows 20/hour, and a test that spends
     // one every run is a test that eventually fails as a 429 looking like a revoked
     // token. The exchange itself is covered — globalSetup throws if it does not 200.
-    const storageState = process.env[STORAGE_STATE_ENV];
+    const storageState = storageStatePath();
     expect(storageState, 'globalSetup should have exported the session state').toBeTruthy();
 
     const state = JSON.parse(await readFile(storageState!, 'utf8')) as {

--- a/apps/e2e/src/auth.test.ts
+++ b/apps/e2e/src/auth.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { request, type APIRequestContext } from 'playwright-core';
-import { BASE_URL, STORAGE_STATE_ENV, signedInApiContext } from './browser';
+import { BASE_URL, STORAGE_STATE_ENV, signedInApiContext } from './browser.js';
 
 /**
  * The credential contract, checked without a browser. If these fail, every browser

--- a/apps/e2e/src/auth.test.ts
+++ b/apps/e2e/src/auth.test.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { request, type APIRequestContext } from 'playwright-core';
+import { BASE_URL, STORAGE_STATE_ENV, signedInApiContext } from './browser';
+
+/**
+ * The credential contract, checked without a browser. If these fail, every browser
+ * test below is failing for the same reason and their output is noise.
+ */
+const hasToken = Boolean(process.env.GAMEDEV_ACCESS_TOKEN);
+if (!hasToken) {
+  console.warn('[e2e] SKIPPED auth: GAMEDEV_ACCESS_TOKEN not set (see docs/agent-access-tokens.md)');
+}
+
+describe.skipIf(!hasToken)('agent access token', () => {
+  let api: APIRequestContext;
+
+  beforeAll(async () => {
+    api = await signedInApiContext();
+  });
+
+  afterAll(async () => {
+    await api?.dispose();
+  });
+
+  it('authenticates as a bot account over the bearer header', async () => {
+    // Cookie-less on purpose: /api/auth/me takes either credential, so asking it
+    // through the signed-in context would answer 200 from the cookie and tell us
+    // nothing about the bearer path this test exists to cover.
+    const clean = await request.newContext({ baseURL: BASE_URL });
+    try {
+      const res = await clean.get('/api/auth/me', {
+        headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
+      });
+
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+
+      // Automation must never run as a person: bot: uids are excluded from creator
+      // metrics, so a human token pasted into the secret would quietly pollute the
+      // product numbers. Same guard the deploy workflow's authenticated smoke applies.
+      expect(body.user?.uid).toMatch(/^bot:/);
+    } finally {
+      await clean.dispose();
+    }
+  });
+
+  it('issues a hardened session cookie from the token exchange', async () => {
+    // Asserted against the state globalSetup already obtained rather than by calling
+    // /api/auth/session again: that endpoint allows 20/hour, and a test that spends
+    // one every run is a test that eventually fails as a 429 looking like a revoked
+    // token. The exchange itself is covered — globalSetup throws if it does not 200.
+    const storageState = process.env[STORAGE_STATE_ENV];
+    expect(storageState, 'globalSetup should have exported the session state').toBeTruthy();
+
+    const state = JSON.parse(await readFile(storageState!, 'utf8')) as {
+      cookies: { name: string; domain: string; httpOnly: boolean; secure: boolean; sameSite: string }[];
+    };
+    const session = state.cookies.find((c) => c.name === 'gamedev_session');
+    expect(session, 'exchange should set gamedev_session').toBeTruthy();
+
+    // The flags are the point of the cookie, not decoration: HttpOnly keeps it away
+    // from a generated game's scripts, Secure keeps it off plaintext, and SameSite
+    // blunts cross-site use.
+    expect(session!.httpOnly).toBe(true);
+    expect(session!.secure).toBe(true);
+    expect(session!.sameSite).toBe('Lax');
+  });
+
+  it('accepts that session cookie on a session-walled route', async () => {
+    // The other half of the contract: the cookie is not just well-formed, it works.
+    const res = await api.get('/api/notifications');
+    expect(res.status()).toBe(200);
+  });
+
+  it('rejects a forged token rather than erroring on it', async () => {
+    // A cookie-less context on purpose. The exchange above left a valid session
+    // cookie on `api`, and /api/auth/me accepts either credential — reusing it here
+    // authenticates by cookie and reports 200 no matter how bogus the bearer is,
+    // which looks like the token wall failing open when nothing is wrong.
+    const clean = await request.newContext({ baseURL: BASE_URL });
+    try {
+      // Assembled at runtime: a well-formed gdpl_pat_ literal in the source would
+      // (correctly) trip gitleaks. Same construction as the deploy smoke.
+      const forged = `gdpl_pat_${'0'.repeat(16)}_${'A'.repeat(43)}`;
+      const res = await clean.get('/api/auth/me', { headers: { Authorization: `Bearer ${forged}` } });
+
+      // 401, never a 500 and never a session: the token path must fail closed.
+      expect(res.status()).toBe(401);
+    } finally {
+      await clean.dispose();
+    }
+  });
+});

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -8,8 +8,11 @@ import {
   type BrowserContext,
   type Page,
 } from 'playwright-core';
+import { inject } from 'vitest';
+import { BASE_URL, STORAGE_STATE_ENV } from './config.js';
 
-export const BASE_URL = process.env.E2E_BASE_URL ?? 'https://www.gamedev.pl';
+// Re-exported so test files have a single import site for the whole helper surface.
+export { BASE_URL, STORAGE_STATE_ENV };
 
 /**
  * Where Claude Code's remote environments pre-install Playwright's browsers.
@@ -52,6 +55,18 @@ export function e2ePrerequisites(): { ok: boolean; reason: string } {
   if (!process.env.GAMEDEV_ACCESS_TOKEN) {
     return { ok: false, reason: 'GAMEDEV_ACCESS_TOKEN not set (see docs/agent-access-tokens.md)' };
   }
+  return browserPrerequisite();
+}
+
+/**
+ * The weaker gate, for suites that never sign in.
+ *
+ * The anonymous and mobile checks build their own cookie-less contexts, so requiring a
+ * credential there would skip real coverage on any machine that has a browser but no
+ * token — which is most of them, and exactly the pass most likely to catch a
+ * signed-out or small-screen regression.
+ */
+export function browserPrerequisite(): { ok: boolean; reason: string } {
   if (!findChromium()) {
     return { ok: false, reason: 'no pre-installed Chromium found (set E2E_CHROMIUM_PATH)' };
   }
@@ -75,7 +90,11 @@ export function e2ePrerequisites(): { ok: boolean; reason: string } {
  *
  * Never "fix" this by disabling TLS verification or unsetting HTTPS_PROXY — see
  * /root/.ccr/README.md. TLS 1.2 through the proxy is a complete and secure fix.
- * When no proxy is configured, both settings are harmless.
+ *
+ * Both settings are applied *only* when a proxy is configured. The TLS cap is a real
+ * downgrade, not a harmless default: with no proxy in the path there is nothing to
+ * work around, and pinning a laptop run to 1.2 would forgo TLS 1.3 for no reason —
+ * and break outright against a host that ever requires it.
  */
 export async function launchSiteBrowser(): Promise<Browser> {
   const executablePath = findChromium();
@@ -86,12 +105,42 @@ export async function launchSiteBrowser(): Promise<Browser> {
   return chromium.launch({
     executablePath,
     ...(proxyServer ? { proxy: { server: proxyServer } } : {}),
-    args: ['--no-sandbox', '--ssl-version-max=tls1.2', '--autoplay-policy=no-user-gesture-required'],
+    args: [
+      '--no-sandbox',
+      '--autoplay-policy=no-user-gesture-required',
+      ...(proxyServer ? ['--ssl-version-max=tls1.2'] : []),
+    ],
   });
 }
 
-/** Where globalSetup parks the once-per-run session state. */
-export const STORAGE_STATE_ENV = 'E2E_STORAGE_STATE';
+declare module 'vitest' {
+  interface ProvidedContext {
+    E2E_STORAGE_STATE: string;
+  }
+}
+
+/**
+ * Path to the session state globalSetup wrote, read the way Vitest supports.
+ *
+ * `inject()` is the counterpart to globalSetup's `provide()` and is the contract for
+ * getting a value from setup into the workers. The `process.env` fallback is what this
+ * used to rely on alone, and it only happens to work: globalSetup mutates env in the
+ * main process before workers are forked, so forked workers inherit it. That is an
+ * implementation detail of the pool, not a guarantee — under a pool that does not fork
+ * from a mutated parent, the suite would fail with "unset" even though setup succeeded.
+ *
+ * Kept as a fallback rather than removed, because `inject()` throws outside a worker
+ * (globalSetup itself imports this module for BASE_URL).
+ */
+export function storageStatePath(): string | undefined {
+  try {
+    const injected = inject(STORAGE_STATE_ENV);
+    if (injected) return injected;
+  } catch {
+    // Not running inside a Vitest worker — fall through to the inherited env.
+  }
+  return process.env[STORAGE_STATE_ENV];
+}
 
 /**
  * An API context already carrying the bot's session cookie.
@@ -105,7 +154,7 @@ export const STORAGE_STATE_ENV = 'E2E_STORAGE_STATE';
  * budget fast enough to lock the suite out mid-iteration.
  */
 export async function signedInApiContext(): Promise<APIRequestContext> {
-  const storageState = process.env[STORAGE_STATE_ENV];
+  const storageState = storageStatePath();
   if (!storageState) {
     throw new Error(`${STORAGE_STATE_ENV} unset — globalSetup did not run or the token is missing`);
   }

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -1,0 +1,198 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { chromium, type APIRequestContext, type Browser, type BrowserContext, type Page } from 'playwright-core';
+import { request } from 'playwright-core';
+
+export const BASE_URL = process.env.E2E_BASE_URL ?? 'https://www.gamedev.pl';
+
+/**
+ * Where Claude Code's remote environments pre-install Playwright's browsers.
+ * `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` is set there too, so `playwright install`
+ * is not the fallback — if this returns null the suite skips rather than trying
+ * to fetch a browser that the environment has deliberately pinned.
+ */
+export function findChromium(): string | null {
+  const explicit = process.env.E2E_CHROMIUM_PATH;
+  if (explicit) return existsSync(explicit) ? explicit : null;
+
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH ?? '/opt/pw-browsers';
+  if (!existsSync(root)) return null;
+
+  // Directory name carries the build number (chromium-1194), which moves with the
+  // Playwright version — glob rather than pin, and prefer the full browser over the
+  // headless shell (the shell cannot run the WebGL/audio paths some games use).
+  const candidates = readdirSync(root)
+    .filter((name) => name.startsWith('chromium-'))
+    .map((name) => join(root, name, 'chrome-linux', 'chrome'))
+    .filter((path) => existsSync(path));
+
+  return candidates[0] ?? null;
+}
+
+/**
+ * Whether this suite can run at all. Both halves are environmental, not a product
+ * signal, so the suite skips loudly on a miss instead of failing — same reasoning as
+ * the optional authenticated smoke in .github/workflows/deploy.yml: a skipped check
+ * is absence of signal, and dressing it up as a pass is the actual harm.
+ */
+export function e2ePrerequisites(): { ok: boolean; reason: string } {
+  if (!process.env.GAMEDEV_ACCESS_TOKEN) {
+    return { ok: false, reason: 'GAMEDEV_ACCESS_TOKEN not set (see docs/agent-access-tokens.md)' };
+  }
+  if (!findChromium()) {
+    return { ok: false, reason: 'no pre-installed Chromium found (set E2E_CHROMIUM_PATH)' };
+  }
+  return { ok: true, reason: '' };
+}
+
+/**
+ * Launch the pre-installed Chromium so it can actually reach the site.
+ *
+ * The two args are not optional in a proxied environment (Claude Code on the web,
+ * and any sandbox that routes egress through a CONNECT proxy):
+ *
+ * - `proxy.server` — Chromium does not read HTTPS_PROXY from the environment the way
+ *   curl and Node's fetch do. Without it every navigation dies at DNS/connect.
+ * - `--ssl-version-max=tls1.2` — the non-obvious one. Chromium's default TLS 1.3
+ *   ClientHello (large, carries post-quantum key shares) gets its CONNECT tunnel
+ *   reset by the proxy, so *every* page load fails `net::ERR_CONNECTION_RESET`,
+ *   including https://example.com, while curl to the same host succeeds. That
+ *   asymmetry reads as a site outage and is not one. Capping at TLS 1.2 keeps the
+ *   ClientHello small enough to tunnel.
+ *
+ * Never "fix" this by disabling TLS verification or unsetting HTTPS_PROXY — see
+ * /root/.ccr/README.md. TLS 1.2 through the proxy is a complete and secure fix.
+ * When no proxy is configured, both settings are harmless.
+ */
+export async function launchSiteBrowser(): Promise<Browser> {
+  const executablePath = findChromium();
+  if (!executablePath) throw new Error('no Chromium available; check e2ePrerequisites() first');
+
+  const proxyServer = process.env.HTTPS_PROXY ?? process.env.https_proxy;
+
+  return chromium.launch({
+    executablePath,
+    ...(proxyServer ? { proxy: { server: proxyServer } } : {}),
+    args: ['--no-sandbox', '--ssl-version-max=tls1.2', '--autoplay-policy=no-user-gesture-required'],
+  });
+}
+
+/** Where globalSetup parks the once-per-run session state. */
+export const STORAGE_STATE_ENV = 'E2E_STORAGE_STATE';
+
+/**
+ * An API context already carrying the bot's session cookie.
+ *
+ * The SPA authenticates with cookies (`credentials: 'include'`), so a bearer header on
+ * the browser's requests would not do — `POST /api/auth/session` is the supported
+ * bridge, and it accepts only a token, never a cookie (docs/agent-access-tokens.md).
+ *
+ * That exchange happens once per run in globalSetup.ts and is *reused* here rather than
+ * repeated: the endpoint allows 20 per hour, and one call per test file spends the
+ * budget fast enough to lock the suite out mid-iteration.
+ */
+export async function signedInApiContext(): Promise<APIRequestContext> {
+  const storageState = process.env[STORAGE_STATE_ENV];
+  if (!storageState) {
+    throw new Error(`${STORAGE_STATE_ENV} unset — globalSetup did not run or the token is missing`);
+  }
+  return request.newContext({ baseURL: BASE_URL, storageState });
+}
+
+/** A browser context carrying the bot's session cookie. */
+export async function signedInContext(browser: Browser, api: APIRequestContext): Promise<BrowserContext> {
+  return browser.newContext({ storageState: await api.storageState(), viewport: { width: 1280, height: 900 } });
+}
+
+export type Problem = { kind: string; text: string };
+
+/**
+ * Failures that are correct behavior, not defects. Everything here was confirmed by
+ * reading the code that produces it — this list is an assertion about intent, so add
+ * to it only with the same evidence, never to quiet a failure you have not explained.
+ */
+const EXPECTED_NOISE: { pattern: RegExp; why: string }[] = [
+  {
+    // ArcadeCatalog lazy-loads preview video and cancels it for cards scrolled out of
+    // view. The abort is the optimisation working.
+    pattern: /ERR_ABORTED/,
+    why: 'catalog cancels off-screen preview media on scroll',
+  },
+  {
+    // The telemetry route is unlisted, not secret: it answers 404 to everyone who is
+    // not an admin, including a token-authenticated bot (docs/agent-access-tokens.md).
+    pattern: /\/api\/admin\/telemetry\//,
+    why: 'admin telemetry 404s for non-admin identities by design',
+  },
+  {
+    // An anonymous visitor's first /api/auth/me is expected to be unauthenticated.
+    pattern: /401 .*\/api\/auth\/me|\/api\/auth\/me.*401/,
+    why: 'anonymous session probe is expected to be unauthenticated',
+  },
+];
+
+function isExpected(text: string): boolean {
+  return EXPECTED_NOISE.some(({ pattern }) => pattern.test(text));
+}
+
+/**
+ * Attach problem collection to a page. Returns a live array plus a drain() that
+ * empties it, so one page can be reused across navigations without findings from an
+ * earlier route leaking into a later assertion.
+ *
+ * `expectedStatuses` covers routes deliberately driven to a miss (a bogus slug, an
+ * expired token): there the 404 is the scenario, and the thing under test is that the
+ * *page* still renders a real state instead of a blank or a crash.
+ */
+export function collectProblems(page: Page, expectedStatuses: number[] = []) {
+  const problems: Problem[] = [];
+  const push = (kind: string, text: string) => {
+    if (!isExpected(text)) problems.push({ kind, text: text.slice(0, 400) });
+  };
+
+  page.on('pageerror', (error) => push('pageerror', String(error)));
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+
+    // Chromium's subresource failure message ("Failed to load resource: the server
+    // responded with a status of 404") names no URL in its text — the URL is in the
+    // message *location*. Folding it in is not cosmetic: browser-initiated requests
+    // like /favicon.ico never surface through page.on('response') at all, so without
+    // this the only report of them is an unattributable line that is impossible to
+    // triage and tempting to allowlist wholesale. It hid a real missing-favicon 404.
+    const status = Number(text.match(/status of (\d{3})/)?.[1]);
+    if (status && expectedStatuses.includes(status)) return;
+
+    const url = message.location()?.url;
+    push('console.error', url ? `${text} :: ${url}` : text);
+  });
+
+  page.on('requestfailed', (req) => push('requestfailed', `${req.url()} :: ${req.failure()?.errorText ?? ''}`));
+
+  page.on('response', (res) => {
+    if (res.status() >= 400 && !expectedStatuses.includes(res.status())) {
+      push(`http.${res.status()}`, `${res.request().method()} ${res.url()}`);
+    }
+  });
+
+  return {
+    problems,
+    drain(): Problem[] {
+      return problems.splice(0, problems.length);
+    },
+  };
+}
+
+/** Readable failure output: `[kind] text` per line. */
+export function describeProblems(problems: Problem[]): string {
+  return problems.map((p) => `  [${p.kind}] ${p.text}`).join('\n');
+}
+
+/** Navigate and let the SPA hydrate and make its first data fetch. */
+export async function visit(page: Page, path: string, settleMs = 3_000) {
+  const response = await page.goto(BASE_URL + path, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(settleMs);
+  return response;
+}

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -1,7 +1,13 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { chromium, type APIRequestContext, type Browser, type BrowserContext, type Page } from 'playwright-core';
-import { request } from 'playwright-core';
+import {
+  chromium,
+  request,
+  type APIRequestContext,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from 'playwright-core';
 
 export const BASE_URL = process.env.E2E_BASE_URL ?? 'https://www.gamedev.pl';
 
@@ -19,11 +25,18 @@ export function findChromium(): string | null {
   if (!existsSync(root)) return null;
 
   // Directory name carries the build number (chromium-1194), which moves with the
-  // Playwright version — glob rather than pin, and prefer the full browser over the
-  // headless shell (the shell cannot run the WebGL/audio paths some games use).
+  // Playwright version — glob rather than pin, and match `chromium-` exactly so the
+  // headless shell (chromium_headless_shell-*) never wins: it cannot run the WebGL
+  // and audio paths some generated games use.
+  //
+  // Sorted by build descending rather than taking readdir order, which is filesystem
+  // dependent: with two builds installed, an unsorted pick means one machine tests
+  // the new Chromium and another silently tests the old one.
   const candidates = readdirSync(root)
-    .filter((name) => name.startsWith('chromium-'))
-    .map((name) => join(root, name, 'chrome-linux', 'chrome'))
+    .map((name) => /^chromium-(\d+)$/.exec(name))
+    .filter((match): match is RegExpExecArray => match !== null)
+    .sort((a, b) => Number(b[1]) - Number(a[1]))
+    .map((match) => join(root, match[0], 'chrome-linux', 'chrome'))
     .filter((path) => existsSync(path));
 
   return candidates[0] ?? null;

--- a/apps/e2e/src/config.ts
+++ b/apps/e2e/src/config.ts
@@ -1,0 +1,13 @@
+/**
+ * Constants shared between globalSetup and the test workers.
+ *
+ * Deliberately its own module with **no `vitest` import**. `globalSetup` runs in a
+ * different context from the workers, and importing `vitest` there fails outright
+ * ("Vitest failed to access its internal state"). `browser.ts` imports `inject`, so
+ * anything globalSetup needs has to live somewhere that does not drag that in.
+ */
+
+export const BASE_URL = process.env.E2E_BASE_URL ?? 'https://www.gamedev.pl';
+
+/** Key under which globalSetup publishes the once-per-run session state path. */
+export const STORAGE_STATE_ENV = 'E2E_STORAGE_STATE';

--- a/apps/e2e/src/globalSetup.ts
+++ b/apps/e2e/src/globalSetup.ts
@@ -2,7 +2,9 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { request } from 'playwright-core';
-import { BASE_URL, STORAGE_STATE_ENV } from './browser.js';
+// From config.js, not browser.js: browser.js imports `inject` from vitest, and
+// importing vitest inside globalSetup fails — it runs in a different context.
+import { BASE_URL, STORAGE_STATE_ENV } from './config.js';
 
 /**
  * Exchange the access token for a session cookie exactly once per run.

--- a/apps/e2e/src/globalSetup.ts
+++ b/apps/e2e/src/globalSetup.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { request } from 'playwright-core';
-import { BASE_URL, STORAGE_STATE_ENV } from './browser';
+import { BASE_URL, STORAGE_STATE_ENV } from './browser.js';
 
 /**
  * Exchange the access token for a session cookie exactly once per run.

--- a/apps/e2e/src/globalSetup.ts
+++ b/apps/e2e/src/globalSetup.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request } from 'playwright-core';
+import { BASE_URL, STORAGE_STATE_ENV } from './browser';
+
+/**
+ * Exchange the access token for a session cookie exactly once per run.
+ *
+ * `POST /api/auth/session` is rate limited to 20 per hour. Doing the exchange in each
+ * test file's beforeAll spent one per file, so a suite of four files burned a fifth of
+ * the hourly budget per run and locked itself out after five — and the lockout surfaces
+ * as a 429 that reads exactly like an expired token. One exchange, shared by every
+ * file, keeps the suite re-runnable while you iterate.
+ *
+ * The state lands in a temp file rather than an env var because it holds a live session
+ * cookie: a temp file is removed in teardown, where an exported env var would be
+ * inherited by every child process for the rest of the run.
+ */
+let directory: string | undefined;
+
+export async function setup({ provide }: { provide: (key: string, value: unknown) => void }) {
+  if (!process.env.GAMEDEV_ACCESS_TOKEN) return; // suites skip themselves; nothing to set up
+
+  const api = await request.newContext({ baseURL: BASE_URL });
+  try {
+    const res = await api.post('/api/auth/session', {
+      headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
+    });
+
+    if (res.status() === 429) {
+      throw new Error(
+        'token→session exchange rate limited (429). The limit is 20/hour and is shared with ' +
+          'anything else using this token — wait it out rather than minting a second one.',
+      );
+    }
+    if (res.status() !== 200) {
+      throw new Error(
+        `token→session exchange failed (${res.status()}). Likely expired or revoked — ` +
+          'npm run token:list -w @gamedevpl/api -- bot:e2e',
+      );
+    }
+
+    directory = await mkdtemp(join(tmpdir(), 'gamedev-e2e-'));
+    const path = join(directory, 'storage-state.json');
+    await writeFile(path, JSON.stringify(await api.storageState()), { mode: 0o600 });
+
+    process.env[STORAGE_STATE_ENV] = path;
+    provide(STORAGE_STATE_ENV, path);
+  } finally {
+    await api.dispose();
+  }
+}
+
+export async function teardown() {
+  if (directory) await rm(directory, { recursive: true, force: true });
+}

--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -8,7 +8,7 @@ import {
   signedInApiContext,
   signedInContext,
   visit,
-} from './browser';
+} from './browser.js';
 
 /**
  * The routes a visitor reaches by accident: a typo, a stale bookmark, a shared link
@@ -55,7 +55,7 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
     // The status matters as much as the view: a soft-404 that answers 200 tells
     // crawlers a typo'd URL is a real page.
     expect(res?.status()).toBe(404);
-    await expect.poll(() => page.locator('.not-found').count()).toBeGreaterThan(0);
+    await expect.poll(() => page.locator('.not-found').count(), { timeout: 20_000 }).toBeGreaterThan(0);
     // The URL stays visible so the visitor can see what they mistyped.
     expect(new URL(page.url()).pathname).toBe('/this-page-does-not-exist');
 

--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { APIRequestContext, Browser, BrowserContext, Page } from 'playwright-core';
+import {
+  collectProblems,
+  describeProblems,
+  e2ePrerequisites,
+  launchSiteBrowser,
+  signedInApiContext,
+  signedInContext,
+  visit,
+} from './browser';
+
+/**
+ * The routes a visitor reaches by accident: a typo, a stale bookmark, a shared link
+ * whose game was never published, an expired tracking token.
+ *
+ * The shared property under test is "renders a real state" — a blank page or an
+ * unhandled exception is the failure, and a 4xx from the API underneath is usually
+ * the *correct* half of the scenario. That distinction is why these routes get their
+ * own suite with expected statuses declared, rather than being folded into the
+ * happy-path walk.
+ */
+const prereq = e2ePrerequisites();
+if (!prereq.ok) {
+  console.warn(`[e2e] SKIPPED resilience: ${prereq.reason}`);
+}
+
+describe.skipIf(!prereq.ok)('error and edge routes', () => {
+  let browser: Browser;
+  let api: APIRequestContext;
+  let context: BrowserContext;
+  let page: Page;
+  let watcher: ReturnType<typeof collectProblems>;
+
+  beforeAll(async () => {
+    api = await signedInApiContext();
+    browser = await launchSiteBrowser();
+    context = await signedInContext(browser, api);
+    page = await context.newPage();
+    // 404/400 are the scenario on these routes, not the defect.
+    watcher = collectProblems(page, [400, 404, 409]);
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await api?.dispose();
+  });
+
+  /** Rendered text, collapsed — enough to tell "a state" from "a blank page". */
+  const bodyText = async () => (await page.locator('body').innerText()).replace(/\s+/g, ' ').trim();
+
+  it('serves a real 404 for an unknown path instead of silently showing home', async () => {
+    const res = await visit(page, '/this-page-does-not-exist', 2_500);
+
+    // The status matters as much as the view: a soft-404 that answers 200 tells
+    // crawlers a typo'd URL is a real page.
+    expect(res?.status()).toBe(404);
+    await expect.poll(() => page.locator('.not-found').count()).toBeGreaterThan(0);
+    // The URL stays visible so the visitor can see what they mistyped.
+    expect(new URL(page.url()).pathname).toBe('/this-page-does-not-exist');
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('shows an in-page error for an unknown game slug, not a crash', async () => {
+    await visit(page, '/play/nope-not-a-real-game', 4_000);
+
+    const text = await bodyText();
+    expect(text.length).toBeGreaterThan(0);
+    // The player chrome stays up and offers a way out; the API's 404 underneath is
+    // expected and declared above.
+    expect(text).toMatch(/could not load|nie udało|retry|ponów/i);
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('explains an unavailable draft rather than blanking', async () => {
+    // A published game has no draft, so this is the "already published, or still
+    // starting up" path in DraftView.
+    await visit(page, '/draft/apex-sprint', 3_000);
+
+    expect((await bodyText()).length).toBeGreaterThan(0);
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('tells the visitor an expired tracking token is invalid', async () => {
+    await visit(page, '/status/deadbeefdeadbeef', 3_000);
+
+    expect(await bodyText()).toMatch(/invalid|expired|nieprawidłow|wygasł/i);
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('renders the join screen for an unrecognised room code', async () => {
+    await visit(page, '/join/ABC123#faketoken', 3_000);
+
+    // Reaching the form is the assertion: the credential is in the fragment, so the
+    // server cannot pre-validate it and the screen must stand on its own.
+    expect((await bodyText()).length).toBeGreaterThan(0);
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('keeps the telemetry route unlisted for a non-admin identity', async () => {
+    await visit(page, '/health', 3_000);
+
+    // Unlisted, not secret: the route renders nothing and the API 404s to everyone
+    // who is not an admin — including a token-authenticated bot, which is exactly
+    // what this identity is (docs/agent-access-tokens.md).
+    const text = await bodyText();
+    expect(text).toMatch(/not found|nie znaleziono/i);
+    // Whatever else it does, it must not leak the operator numbers.
+    expect(text).not.toMatch(/creators|visits|retention/i);
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('serves the legal documents without a session', async () => {
+    // Someone deciding whether to sign in has to be able to read what signing in
+    // would mean first, so these are deliberately reachable unauthenticated.
+    const anon = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const anonPage = await anon.newPage();
+    const anonWatcher = collectProblems(anonPage, [401]);
+
+    for (const path of ['/privacy', '/terms']) {
+      const res = await visit(anonPage, path, 2_500);
+      expect(res?.status()).toBe(200);
+      const text = (await anonPage.locator('body').innerText()).replace(/\s+/g, ' ');
+      expect(text.length).toBeGreaterThan(500);
+    }
+
+    expect(describeProblems(anonWatcher.drain())).toBe('');
+    await anon.close();
+  });
+});

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -9,7 +9,7 @@ import {
   signedInApiContext,
   signedInContext,
   visit,
-} from './browser';
+} from './browser.js';
 
 /**
  * A signed-in walk through the deployed site, as the bot:e2e agent identity.

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { APIRequestContext, Browser, BrowserContext, Page } from 'playwright-core';
+import {
+  BASE_URL,
+  collectProblems,
+  describeProblems,
+  e2ePrerequisites,
+  launchSiteBrowser,
+  signedInApiContext,
+  signedInContext,
+  visit,
+} from './browser';
+
+/**
+ * A signed-in walk through the deployed site, as the bot:e2e agent identity.
+ *
+ * What this suite is for: the failures that only exist once a real browser runs the
+ * real bundle against the real API — a game whose canvas never boots, a route that
+ * renders blank instead of a state, input that never reaches the sandboxed iframe.
+ * The unit suites already cover the routing and rendering logic in isolation; none
+ * of them can tell you the deployed thing works.
+ *
+ * See .claude/skills/browse-live-site/SKILL.md for driving this by hand.
+ */
+const prereq = e2ePrerequisites();
+if (!prereq.ok) {
+  console.warn(`[e2e] SKIPPED walkthrough: ${prereq.reason}`);
+}
+
+describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
+  let browser: Browser;
+  let api: APIRequestContext;
+  let context: BrowserContext;
+  let page: Page;
+  let watcher: ReturnType<typeof collectProblems>;
+  let catalog: CatalogEntry[];
+
+  type CatalogEntry = {
+    slug: string;
+    title: string;
+    multiplayer: { mode: string; minPlayers: number; maxPlayers: number } | null;
+  };
+
+  beforeAll(async () => {
+    api = await signedInApiContext();
+    browser = await launchSiteBrowser();
+    context = await signedInContext(browser, api);
+    page = await context.newPage();
+    watcher = collectProblems(page);
+    catalog = (await (await api.get('/api/catalog')).json()) as CatalogEntry[];
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await api?.dispose();
+  });
+
+  const singlePlayer = () => {
+    const entry = catalog.find((g) => !g.multiplayer);
+    if (!entry) throw new Error('catalog has no single-player game to exercise');
+    return entry;
+  };
+
+  it('renders the catalog signed in, with no page errors', async () => {
+    const res = await visit(page, '/', 4_000);
+    expect(res?.status()).toBe(200);
+
+    await expect.poll(() => page.locator('article.catalog-card').count(), { timeout: 20_000 }).toBeGreaterThan(0);
+    // The session cookie actually took effect in the SPA, not just on the API.
+    await expect.poll(() => page.locator('.user-name').textContent()).toBeTruthy();
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('boots a generated game into a live canvas that can receive input', async () => {
+    const { slug } = singlePlayer();
+    await visit(page, `/play/${slug}`, 6_000);
+
+    // Games run in a sandboxed iframe (allow-scripts, no allow-same-origin). The
+    // canvas living inside it is the only real proof the generated bundle booted.
+    const frame = page.frames().find((f) => f !== page.mainFrame());
+    expect(frame, 'game iframe should exist').toBeTruthy();
+    await expect.poll(() => frame!.locator('canvas').count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+    // These games draw everything — HUD included — into the canvas, so the frame's
+    // innerText never moves and pixels are the only readable output. A canvas that
+    // keeps producing new frames is a game that booted and is still running, which
+    // is the failure this catches: a black or frozen theater.
+    const canvas = frame!.locator('canvas').first();
+    const render = async () => (await canvas.screenshot()).toString('base64');
+    const first = await render();
+    await expect.poll(render, { timeout: 20_000 }).not.toBe(first);
+
+    // Deliberately *not* asserting that the picture changes in response to a
+    // keystroke: most of these games animate on their own, so a pixel diff after
+    // ArrowUp would pass on idle drift alone and prove nothing about input. What is
+    // checkable, and what actually regresses, is delivery — GameFrame focuses the
+    // iframe on load (and on srcDoc swap) so the very first keypress reaches the
+    // game instead of scrolling the page behind it.
+    await expect.poll(() => page.evaluate(() => document.activeElement?.tagName)).toBe('IFRAME');
+    await page.keyboard.press('ArrowUp');
+    expect(await page.evaluate(() => document.activeElement?.tagName)).toBe('IFRAME');
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+
+  it('declares a browser-tab icon instead of falling back to /favicon.ico', async () => {
+    await visit(page, '/', 3_000);
+
+    // Found by a walkthrough, and invisible to every other check we run: the site
+    // shipped manifest icons and an apple-touch-icon but no rel="icon", so desktop
+    // browsers fell back to requesting /favicon.ico — which is not served. Every
+    // visit paid a 404 and every tab rendered blank. The manifest does not cover
+    // this; its icons are for the installed app.
+    const href = await page.locator('link[rel="icon"]').first().getAttribute('href');
+    expect(href, 'no <link rel="icon"> — tabs will fall back to /favicon.ico').toBeTruthy();
+
+    // Declared is not the same as served: a typo'd path fails exactly as silently.
+    const icon = await api.get(new URL(href!, BASE_URL).toString());
+    expect(icon.status()).toBe(200);
+    expect(icon.headers()['content-type']).toMatch(/^image\//);
+  });
+
+  it('rewrites the /ai and /ay play aliases to the canonical /play URL', async () => {
+    const { slug } = singlePlayer();
+
+    for (const alias of ['ai', 'ay']) {
+      await visit(page, `/${alias}/${slug}`, 3_000);
+      // Shared links must converge on one permalink rather than fragmenting across
+      // aliases (apps/web/src/router.ts).
+      expect(new URL(page.url()).pathname).toBe(`/play/${slug}`);
+    }
+
+    watcher.drain();
+  });
+
+  it('opens a party lobby with a join link phones can actually use', async () => {
+    const party = catalog.find((g) => g.multiplayer);
+    if (!party) return; // catalog has no multiplayer entry; nothing to assert
+
+    await visit(page, '/', 4_000);
+    const button = page.locator('button.party-btn').first();
+    await button.scrollIntoViewIfNeeded();
+    await button.click();
+
+    // `.party-lobby` specifically, not a [class*="party"] substring match — the
+    // catalog cards already carry party badges, so a loose selector is satisfied by
+    // the page we started on and the lobby never has to open for the test to pass.
+    await expect.poll(() => page.locator('.party-lobby').count(), { timeout: 45_000 }).toBe(1);
+
+    // The join credential rides in the fragment so it stays out of access logs and
+    // Referer headers (docs/multiplayer-plan.md §4.3) — a join URL that put the token
+    // in the path would leak it, so assert the shape, not just that a link exists.
+    // `.party-url` renders it scheme-less, hence the optional host prefix.
+    const joinUrl = await page.locator('.party-url').innerText();
+    expect(joinUrl).toMatch(/\/join\/[A-Z0-9]{6}#[A-Za-z0-9_-]+$/);
+    expect(await page.locator('.party-code').innerText()).toMatch(/^[A-Z0-9]{6}$/);
+
+    watcher.drain();
+  });
+
+  it('offers a reportable path for illegal content (DSA art. 16)', async () => {
+    const { slug } = singlePlayer();
+    await visit(page, `/play/${slug}`, 5_000);
+
+    // A mailto, not a button — the honest MVP per ReportGameButton.tsx. The four
+    // headings are what makes a notice actionable under art. 16, so an empty mail
+    // body would technically "have a report path" and still fail the obligation.
+    const href = await page.locator('a.report-btn').getAttribute('href');
+    expect(href).toMatch(/^mailto:/);
+    const decoded = decodeURIComponent(href ?? '');
+    expect(decoded).toContain(`/play/${slug}`); // where
+    expect(decoded).toMatch(/illegal/i); // why
+    expect(decoded).toMatch(/name and email/i); // who
+    expect(decoded).toMatch(/good faith/i); // good-faith statement
+
+    watcher.drain();
+  });
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/apps/e2e/vitest.config.ts
+++ b/apps/e2e/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // Every test here drives a real browser against a real deployment: page loads,
+    // SPA hydration, and a generated game booting inside an iframe. The 5s default
+    // fails on network latency alone and says nothing about the site.
+    testTimeout: 90_000,
+    hookTimeout: 120_000,
+    // One browser per file, but only one token→session exchange for the whole run:
+    // that endpoint allows 20/hour, and spending one per file locks the suite out
+    // after a handful of runs (see globalSetup.ts).
+    globalSetup: ['./src/globalSetup.ts'],
+    // Parallel files would each launch their own browser and multiply the load we put
+    // on production for no extra coverage.
+    fileParallelism: false,
+  },
+});

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -13,6 +13,12 @@
          app to portrait would take that away. -->
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#0f1418" />
+    <!-- The browser-tab icon, which the manifest does not cover: manifest icons are for
+         the installed app, so without this a desktop tab falls back to requesting
+         /favicon.ico — which this site does not serve, costing every visit a 404 and
+         leaving the tab blank. Reuses the 192px PWA icon rather than adding a fifth
+         copy of the same artwork in .ico form. -->
+    <link rel="icon" type="image/png" href="/icons/icon-192.png" />
     <!-- iOS ignores the manifest's icons for the home screen and reads this instead. -->
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <!-- Pre-16.4 iOS has no manifest support at all; these are how it learns the app is

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,16 @@
         "node": ">=20"
       }
     },
+    "apps/e2e": {
+      "name": "@gamedevpl/e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^20.14.15",
+        "playwright-core": "^1.56.1",
+        "typescript": "^5.5.4",
+        "vitest": "^3.2.7"
+      }
+    },
     "apps/web": {
       "name": "@gamedevpl/web",
       "version": "0.0.0",
@@ -1454,6 +1464,10 @@
     },
     "node_modules/@gamedevpl/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@gamedevpl/e2e": {
+      "resolved": "apps/e2e",
       "link": true
     },
     "node_modules/@gamedevpl/game-generator": {
@@ -5143,6 +5157,19 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.22",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npm run build:packages && npm run build -w @gamedevpl/api && npm run build -w @gamedevpl/web",
     "dev": "npm run build:packages && concurrently -n api,web -c blue,green \"npm run dev -w @gamedevpl/api\" \"npm run dev -w @gamedevpl/web\"",
     "test": "npm run build:packages && npm run test --workspaces --if-present",
+    "e2e": "npm run e2e -w @gamedevpl/e2e",
     "contract:games-repo": "npm run contract:games-repo -w @gamedevpl/api",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "type-check": "npm run build:packages && npm run type-check --workspaces --if-present",


### PR DESCRIPTION
Started as "does `GAMEDEV_ACCESS_TOKEN` work" and turned into a walkthrough of the deployed site in a real browser. This codifies what that took and what it found.

## The bug it found

The site shipped manifest icons and an `apple-touch-icon` but no `<link rel="icon">`. Desktop browsers therefore fell back to requesting `/favicon.ico`, which the site does not serve — so **every visit paid a 404 and every browser tab rendered blank**. The manifest does not cover this; its icons are for the installed app.

Fixed in `apps/web/index.html` by declaring the 192px PWA icon that already ships, rather than adding a fifth copy of the same artwork in `.ico` form.

## Why it survived a manual walkthrough first

More useful than the bug. Chromium reports a failed subresource as `Failed to load resource: the server responded with a status of 404` — and puts the URL **nowhere in the message text**. It is only in the message *location*. An unattributable line like that is exactly what gets dismissed as noise, and I dismissed it for a while.

Two consequences, both now encoded in `collectProblems`:
- The location URL is folded into the recorded text, so findings are triageable.
- Browser-initiated requests (`/favicon.ico` among them) never surface through `page.on('response')` at all, so that console line is their **only** report. Dropping the shape wholesale drops them entirely.

## What's in the suite

`apps/e2e`, 19 assertions over four files:

- **`auth`** — bearer auth resolves to a `bot:` identity, the exchanged cookie is HttpOnly/Secure/SameSite=Lax and passes a session-walled route, a forged token gets 401.
- **`walkthrough`** — catalog signed in, a generated game booting into a live canvas that holds focus, the tab-icon check above, `/ai` and `/ay` alias rewrites, a party lobby whose join URL keeps its credential in the fragment, and the DSA art. 16 report path carrying its four required headings.
- **`resilience`** — unknown path (real 404, not a soft one), unknown game slug, unavailable draft, expired status token, unrecognised room code, `/health` staying unlisted for a non-admin, legal docs readable without a session.
- **`anonymous-and-mobile`** — a cookie-less visitor can still browse and play; no horizontal overflow at 390×844.

## Three deliberate non-obvious choices

**It does not assert that a keystroke changes the picture.** Most of these games animate on their own, so a pixel diff after `ArrowUp` passes on idle drift and proves nothing about input. What is checkable across arbitrary generated games is *delivery* — that `GameFrame` leaves the iframe focused so the first keypress reaches the game instead of scrolling the page behind it.

**It has no `test` script.** The root `npm run test` fans out with `--workspaces --if-present`; a browser suite pointed at production does not belong in a run people expect to be offline, fast, and about the working tree. Anyone holding a token would otherwise put every local `npm test` on the network and watch it fail whenever the deployed site lagged their branch. Run it with `npm run e2e`.

**One token exchange per run**, in `globalSetup` rather than per file. `POST /api/auth/session` allows 20/hour; spending one per file locks the suite out after a handful of runs — and the lockout surfaces as a `429` that reads exactly like a revoked token. I hit this while building it.

Suites skip loudly without a credential or a browser, matching `deploy.yml`'s stance that a skipped check is absence of signal rather than a pass.

## The skill

`.claude/skills/browse-live-site/SKILL.md` covers driving this by hand, including the step that cost the most time: in a proxied environment, Chromium needs both `proxy: { server: HTTPS_PROXY }` and `--ssl-version-max=tls1.2`, or **every** navigation dies `net::ERR_CONNECTION_RESET` — including `https://example.com`, while `curl` to the same host succeeds. That asymmetry reads as a site outage and is not one. (Chromium's default TLS 1.3 ClientHello, carrying post-quantum key shares, gets its CONNECT tunnel reset.)

## Verification

- `npm run lint`, `npm run type-check`, `npm run test` (246 tests) — all pass; `npm run test` confirmed still offline and fast, with the e2e workspace correctly excluded.
- `npm run e2e` against production: **16 of 19 pass**. The three failures are the favicon defect this PR fixes, and will keep failing until it deploys — that is the suite doing its job.
- The fix itself is verified independently: built `dist/index.html` carries the tag, `dist/icons/icon-192.png` ships, prod already serves that path 200, and a browser run against the fixed build no longer requests `/favicon.ico` at all.
- The `globalSetup` single-exchange refactor is confirmed end-to-end: measured against the rate-limit headers, a full suite run consumes **exactly 1** of the 20/hour budget.

## Security note (public repo)

`GAMEDEV_ACCESS_TOKEN` is reachable only from `deploy.yml`, which triggers on `push: branches: [master]` — pull requests never run it. `ci.yml` uses `pull_request` (not `pull_request_target`), and there is no `pull_request_target` or `workflow_run` anywhere in `.github/`, so there is no path for a PR to reach the secret.

Because this suite makes wiring it into CI tempting, `apps/e2e/README.md` spells out why the token must **not** go into `ci.yml`: that workflow executes PR-authored code, so a token there could be exfiltrated by editing a test file from any in-repo branch. `deploy.yml` is the safe home.

## Notes for review

- The suite is read-only against production by design: it browses, plays, and inspects, but never submits an idea (real generation quota) and never writes catalog state.
- No CI wiring included — I did not want to change deploy gating without asking. If you want it, the natural home is `deploy.yml` against `CANDIDATE_URL` before promotion, next to the existing authenticated smoke.
- Unrelated to this PR, so not touched: `copilot-task.yml` interpolates `${{ github.event.inputs.task || github.event.client_payload.task }}` straight into a `run:` block. It is inert today (both are empty for the `issue_comment` trigger, and it checks out `master` rather than PR head, with no secrets and `contents: read`) — but it is a script-injection shape one edit away from being live. Passing it via `env:` would close it off.