### PR TITLE
Serve published games from a Cloud Storage snapshot instead of rebuilding per request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,10 @@ jobs:
       SERVICE: 'gamedev-app'
       REPO: 'gamedev'
       GAMES_REPO: 'gamedevpl/www.gamedev.pl-games'
+      # Pre-assembled published games (apps/api/src/game-snapshot.ts), written by
+      # publish-games.yml. Unset would simply mean every play rebuilds from GitHub
+      # again — serving treats the snapshot as a fast path, never a requirement.
+      GAMES_SNAPSHOT_BUCKET: 'gamedevpl-games-snapshots'
       WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
       WIF_SERVICE_ACCOUNT: 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com'
 
@@ -131,7 +135,7 @@ jobs:
             --min-instances 0 \
             --max-instances 1 \
             --port 8080 \
-            --set-env-vars "^|^GAMES_REPO=${GAMES_REPO}|GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }}|WEB_ORIGIN=https://gamedev-app-334141807880.europe-west1.run.app,https://www.gamedev.pl,https://gamedev.pl|CANONICAL_HOST=www.gamedev.pl|PRIVATE_BETA=true|BETA_ALLOWED_UIDS=${{ vars.BETA_ALLOWED_UIDS }}|BETA_ALLOWED_EMAILS=${{ vars.BETA_ALLOWED_EMAILS }}|ADMIN_UIDS=${{ vars.ADMIN_UIDS }}|NOTIFY_SWEEP_AUDIENCE=${{ vars.NOTIFY_SWEEP_AUDIENCE }}|NOTIFY_SWEEP_SA=${{ vars.NOTIFY_SWEEP_SA }}|SCORECARD_SWEEP_AUDIENCE=${{ vars.SCORECARD_SWEEP_AUDIENCE }}|VAPID_PUBLIC_KEY=${{ vars.VAPID_PUBLIC_KEY }}|VAPID_SUBJECT=${{ vars.VAPID_SUBJECT }}" \
+            --set-env-vars "^|^GAMES_REPO=${GAMES_REPO}|GAMES_SNAPSHOT_BUCKET=${GAMES_SNAPSHOT_BUCKET}|GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }}|WEB_ORIGIN=https://gamedev-app-334141807880.europe-west1.run.app,https://www.gamedev.pl,https://gamedev.pl|CANONICAL_HOST=www.gamedev.pl|PRIVATE_BETA=true|BETA_ALLOWED_UIDS=${{ vars.BETA_ALLOWED_UIDS }}|BETA_ALLOWED_EMAILS=${{ vars.BETA_ALLOWED_EMAILS }}|ADMIN_UIDS=${{ vars.ADMIN_UIDS }}|NOTIFY_SWEEP_AUDIENCE=${{ vars.NOTIFY_SWEEP_AUDIENCE }}|NOTIFY_SWEEP_SA=${{ vars.NOTIFY_SWEEP_SA }}|SCORECARD_SWEEP_AUDIENCE=${{ vars.SCORECARD_SWEEP_AUDIENCE }}|VAPID_PUBLIC_KEY=${{ vars.VAPID_PUBLIC_KEY }}|VAPID_SUBJECT=${{ vars.VAPID_SUBJECT }}" \
             "${SECRET_FLAGS[@]}"
 
       - name: Smoke test candidate revision

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -1,0 +1,140 @@
+name: Publish games snapshot
+
+# Bakes every published game into the snapshot bucket so the play route serves
+# pre-assembled documents instead of rebuilding each game from GitHub + esbuild on
+# the request path (apps/api/src/game-snapshot.ts).
+#
+# Fires on a repository_dispatch from the games repo's validate workflow, right
+# after a merge to main regenerates catalog.json — see
+# gamedevpl/www.gamedev.pl-games/.github/workflows/validate.yml. The
+# workflow_dispatch entry point is the manual escape hatch: re-baking after an
+# assembler change here, or recovering from a failed publish.
+#
+# Nothing needs to be redeployed afterwards. Running instances re-read the pointer
+# on its short TTL, so a publish becomes visible on its own within about a minute.
+
+on:
+  repository_dispatch:
+    types: [games-published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Games-repo ref to bake from'
+        required: false
+        default: 'main'
+      dry_run:
+        description: 'Report what would be baked without writing to the bucket'
+        type: boolean
+        required: false
+        default: false
+
+# Two publishes racing would interleave their pointer writes, and the loser could
+# leave `current.json` addressing the older snapshot. Queue them instead — the
+# snapshot prefixes are immutable, so a queued run is simply the newer truth.
+concurrency:
+  group: games-snapshot-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: 'gamedevpl'
+      GAMES_REPO: 'gamedevpl/www.gamedev.pl-games'
+      GAMES_SNAPSHOT_BUCKET: 'gamedevpl-games-snapshots'
+      WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+      WIF_SERVICE_ACCOUNT: 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Resolve games-repo ref
+        env:
+          DISPATCH_REF: ${{ github.event.client_payload.ref }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          # Payload values come from another repository's workflow, so they are
+          # treated as data: passed through the environment (never interpolated
+          # into the script) and constrained before use.
+          REF="${DISPATCH_REF:-${INPUT_REF:-main}}"
+          case "$REF" in
+            *[!A-Za-z0-9._/-]*)
+              echo "Error: refusing to bake from a ref with unexpected characters"
+              exit 1
+              ;;
+          esac
+          echo "SNAPSHOT_REF=${REF}" >> "$GITHUB_ENV"
+          case "$DISPATCH_SHA" in
+            "" ) ;;
+            *[!0-9a-fA-F]* )
+              echo "::warning::ignoring malformed commit sha in dispatch payload"
+              ;;
+            * ) echo "SNAPSHOT_SHA=${DISPATCH_SHA}" >> "$GITHUB_ENV" ;;
+          esac
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+
+      - name: Bake and publish the snapshot
+        env:
+          # Same fine-grained PAT the contract check uses: contents:read on the
+          # games repo. The default GITHUB_TOKEN cannot read another repository.
+          GAMES_REPO_TOKEN: ${{ secrets.GAMES_REPO_TOKEN }}
+          GAMES_PUBLISHED_REF: ${{ env.SNAPSHOT_REF }}
+        run: |
+          if [ -z "$GAMES_REPO_TOKEN" ]; then
+            echo "Error: GAMES_REPO_TOKEN secret is required to read the games repo"
+            exit 1
+          fi
+
+          ARGS=(--ref "$SNAPSHOT_REF")
+          if [ -n "${SNAPSHOT_SHA:-}" ]; then
+            ARGS+=(--commit-sha "$SNAPSHOT_SHA")
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          npm run snapshot:publish -- "${ARGS[@]}"
+
+      - name: Verify the live site serves the new snapshot
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          # A green publish that the site cannot read is the failure mode worth
+          # catching here: the bucket is written by this job but read by Cloud Run
+          # under a different identity, so permissions can be wrong in one
+          # direction only. Serving falls back to GitHub either way, which is
+          # precisely why this would otherwise go unnoticed.
+          BASE_URL="https://www.gamedev.pl"
+          STATUS_CODE=$(curl -s -o /tmp/publish-catalog.json -w "%{http_code}" "${BASE_URL}/api/catalog")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "::warning::catalog returned ${STATUS_CODE} after publish; snapshot may not be live yet"
+            exit 0
+          fi
+          PLAY_SLUG=$(jq -r '([.[] | select(.status == "published") | .slug] | first) // empty' /tmp/publish-catalog.json)
+          if [ -z "$PLAY_SLUG" ]; then
+            echo "::warning::no published slug to verify"
+            exit 0
+          fi
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/games/${PLAY_SLUG}")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Error: /api/games/${PLAY_SLUG} returned ${STATUS_CODE} after publish"
+            exit 1
+          fi
+          echo "Play route healthy after publish (${PLAY_SLUG})."

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "contract:games-repo": "tsx scripts/check-games-repo-contract.ts",
+    "snapshot:publish": "tsx scripts/publish-snapshot.ts",
     "beta:approve": "tsx scripts/beta-approve.ts",
     "beta:invite": "tsx scripts/beta-invite.ts",
     "token:mint": "tsx scripts/access-token.ts mint",

--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -1,0 +1,105 @@
+/**
+ * Bakes the published games into the snapshot bucket and flips the pointer.
+ *
+ * This moves game assembly off the request path: instead of every cache-cold play
+ * rebuilding a game from a fan-out of GitHub reads plus an esbuild bundle, a merge
+ * to the games repo's default branch bakes every published game once and the site
+ * serves the result. GitHub stays in the picture only for unmerged PR previews and
+ * as the fallback when a game is missing from the snapshot.
+ *
+ * Run by .github/workflows/publish-games.yml on a repository_dispatch from the
+ * games repo (and manually via workflow_dispatch). Safe to re-run: each run writes
+ * a fresh immutable snapshot prefix and only then moves `current.json`.
+ *
+ * Environment:
+ *   GAMES_SNAPSHOT_BUCKET  target GCS bucket (required unless --dry-run)
+ *   GAMES_REPO_TOKEN       contents:read PAT on the games repo (or GITHUB_TOKEN)
+ *   GAMES_REPO             defaults to gamedevpl/www.gamedev.pl-games
+ *   GAMES_PUBLISHED_REF    defaults to main
+ *
+ * Usage:
+ *   npm run snapshot:publish -w @gamedevpl/api
+ *   npm run snapshot:publish -w @gamedevpl/api -- --dry-run
+ *   npm run snapshot:publish -w @gamedevpl/api -- --ref <sha> --commit-sha <sha>
+ */
+
+import { publishSnapshot } from '../src/game-snapshot-publish.js';
+import { createGcsSnapshotStore, type GameSnapshotWriter, type SnapshotPointer } from '../src/game-snapshot.js';
+import { createGitHubClient } from '../src/github-client.js';
+
+function readFlag(name: string): string | null {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? (process.argv[index + 1] ?? null) : null;
+}
+
+const dryRun = process.argv.includes('--dry-run');
+const repo = (process.env.GAMES_REPO ?? 'gamedevpl/www.gamedev.pl-games').trim();
+const ref = (readFlag('ref') ?? process.env.GAMES_PUBLISHED_REF ?? 'main').trim();
+const commitSha = readFlag('commit-sha');
+const bucket = (process.env.GAMES_SNAPSHOT_BUCKET ?? '').trim();
+const token = (process.env.GAMES_REPO_TOKEN ?? process.env.GITHUB_TOKEN ?? '').trim();
+
+function fail(message: string): never {
+  console.error(`snapshot publish: ${message}`);
+  process.exit(1);
+}
+
+/** Counts what a real run would write, without touching the bucket. */
+function createDryRunWriter(): GameSnapshotWriter & { pointer: SnapshotPointer | null } {
+  return {
+    pointer: null,
+    async putCatalog() {},
+    async putGame() {},
+    async putMedia() {},
+    async putPointer(pointer) {
+      this.pointer = pointer;
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  if (!token) {
+    fail('GAMES_REPO_TOKEN (or GITHUB_TOKEN) is required to read the games repo');
+  }
+  if (!bucket && !dryRun) {
+    fail('GAMES_SNAPSHOT_BUCKET is required (or pass --dry-run)');
+  }
+
+  const client = createGitHubClient({ token, repo });
+  const writer = dryRun ? createDryRunWriter() : createGcsSnapshotStore({ bucket });
+
+  console.log(`snapshot publish: ${repo}@${ref} → ${dryRun ? '(dry run, nothing written)' : `gs://${bucket}`}`);
+
+  const result = await publishSnapshot({
+    client,
+    writer,
+    ref,
+    commitSha,
+    log: (message) => console.log(message),
+  });
+
+  console.log('');
+  console.log(`  snapshot id : ${result.snapshotId}`);
+  console.log(`  games       : ${result.published}`);
+  console.log(`  media files : ${result.mediaFiles}`);
+  console.log(`  failures    : ${result.failures.length}`);
+
+  if (result.failures.length > 0) {
+    // The pointer has already moved — a game that fails to bake falls back to the
+    // GitHub path and keeps working, so a partial snapshot is better than none.
+    // But a failure means a published game is no longer being served the cheap
+    // way, and the games repo's own gate should have caught it, so end red.
+    console.error('');
+    console.error('games that could not be baked (serving falls back to GitHub for these):');
+    for (const failure of result.failures) {
+      console.error(`  - ${failure.slug}: ${failure.reason}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('snapshot publish: ok');
+}
+
+main().catch((error: unknown) => {
+  fail(error instanceof Error ? (error.stack ?? error.message) : String(error));
+});

--- a/apps/api/src/game-snapshot-publish.test.ts
+++ b/apps/api/src/game-snapshot-publish.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest';
+import { publishSnapshot } from './game-snapshot-publish.js';
+import type { GameSnapshotWriter, SnapshotGame, SnapshotMedia, SnapshotPointer } from './game-snapshot.js';
+import type { CatalogGameEntry, GameSources, GitHubClient } from './github-client.js';
+
+const ref = 'main';
+
+function catalogEntry(slug: string, overrides: Partial<CatalogGameEntry> = {}): CatalogGameEntry {
+  return {
+    slug,
+    title: slug,
+    genre: 'arcade',
+    controls: 'arrows',
+    status: 'published',
+    media: null,
+    multiplayer: null,
+    ...overrides,
+  };
+}
+
+function gameSources(overrides: Partial<GameSources> = {}): GameSources {
+  return {
+    indexHtml: '<canvas id="game"></canvas>',
+    gameJs: 'console.log("play")',
+    styleCss: 'body{margin:0}',
+    title: null,
+    ...overrides,
+  };
+}
+
+function createClientStub(params: {
+  catalog: CatalogGameEntry[];
+  sourcesBySlug?: Record<string, GameSources | null>;
+  mediaBySlug?: Record<string, Uint8Array | null>;
+}) {
+  const getCatalog = vi.fn(async () => params.catalog);
+  const getGameSources = vi.fn(async (_ref: string, slug: string) =>
+    params.sourcesBySlug ? (params.sourcesBySlug[slug] ?? null) : gameSources(),
+  );
+  const getGameMedia = vi.fn(async (_ref: string, slug: string) =>
+    params.mediaBySlug ? (params.mediaBySlug[slug] ?? null) : new Uint8Array([1, 2, 3]),
+  );
+  const client = {
+    getCatalog,
+    getGameSources,
+    getGameMedia,
+  } as unknown as GitHubClient;
+  return { client, getCatalog, getGameSources, getGameMedia };
+}
+
+function createWriterSpy() {
+  const order: string[] = [];
+  const games = new Map<string, SnapshotGame>();
+  const media = new Map<string, SnapshotMedia>();
+  let catalog: CatalogGameEntry[] | null = null;
+  let pointer: SnapshotPointer | null = null;
+
+  const writer: GameSnapshotWriter = {
+    async putCatalog(_id, entries) {
+      order.push('catalog');
+      catalog = entries;
+    },
+    async putGame(_id, game) {
+      order.push(`game:${game.slug}`);
+      games.set(game.slug, game);
+    },
+    async putMedia(_id, slug, filename, value) {
+      order.push(`media:${slug}/${filename}`);
+      media.set(`${slug}/${filename}`, value);
+    },
+    async putPointer(value) {
+      order.push('pointer');
+      pointer = value;
+    },
+  };
+
+  return {
+    writer,
+    order,
+    games,
+    media,
+    get catalog() {
+      return catalog;
+    },
+    get pointer() {
+      return pointer;
+    },
+  };
+}
+
+const fixedNow = () => new Date('2026-07-27T10:15:00.000Z');
+
+describe('publishSnapshot', () => {
+  it('bakes each published game into a self-contained document', async () => {
+    const { client } = createClientStub({ catalog: [catalogEntry('bubble-pop')] });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    const baked = spy.games.get('bubble-pop');
+    expect(baked?.html).toContain('<!doctype html>');
+    expect(baked?.html).toContain('console.log("play")');
+  });
+
+  it('applies the same serve-time policy the play route would have applied', async () => {
+    const { client } = createClientStub({ catalog: [catalogEntry('bubble-pop')] });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    const html = spy.games.get('bubble-pop')?.html ?? '';
+    // Baking must not quietly drop the network lockdown or the AI Act art. 50(2)
+    // provenance marking — that is the whole reason this reuses assembleGameHtml.
+    expect(html).toContain("default-src 'none'");
+    expect(html).toContain('name="ai-generated"');
+  });
+
+  it('prefers the SPEC.md title and falls back to the catalog title', async () => {
+    const { client } = createClientStub({
+      catalog: [catalogEntry('a', { title: 'Catalog Title' }), catalogEntry('b')],
+      sourcesBySlug: { a: gameSources({ title: 'Spec Title' }), b: gameSources() },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(spy.games.get('a')?.title).toBe('Spec Title');
+    expect(spy.games.get('b')?.title).toBe('b');
+  });
+
+  it('skips games the catalog does not publish', async () => {
+    const { client, getGameSources } = createClientStub({
+      catalog: [catalogEntry('live'), catalogEntry('gone', { status: 'archived' })],
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    expect(spy.games.has('gone')).toBe(false);
+    expect(getGameSources).not.toHaveBeenCalledWith(ref, 'gone');
+  });
+
+  it('copies the media the catalog vouches for', async () => {
+    const { client } = createClientStub({
+      catalog: [
+        catalogEntry('bubble-pop', {
+          media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+        }),
+      ],
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.mediaFiles).toBe(2);
+    expect(spy.media.get('bubble-pop/opening.png')?.contentType).toBe('image/png');
+    expect(spy.media.get('bubble-pop/gameplay.mp4')?.contentType).toBe('video/mp4');
+  });
+
+  it('moves the pointer only after every object is durable', async () => {
+    const { client } = createClientStub({
+      catalog: [
+        catalogEntry('bubble-pop', { media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null } }),
+      ],
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    // Until the pointer moves a half-written snapshot is invisible, so publishing
+    // is atomic and the site keeps serving the previous snapshot throughout.
+    expect(spy.order.at(-1)).toBe('pointer');
+    expect(spy.order).toContain('game:bubble-pop');
+    expect(spy.order).toContain('media:bubble-pop/opening.png');
+    expect(spy.order).toContain('catalog');
+  });
+
+  it('records the ref commit in the pointer for traceability', async () => {
+    const { client } = createClientStub({ catalog: [catalogEntry('bubble-pop')] });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, commitSha: 'cafe1234', now: fixedNow });
+
+    expect(spy.pointer).toEqual({
+      snapshotId: result.snapshotId,
+      commitSha: 'cafe1234',
+      publishedAt: '2026-07-27T10:15:00.000Z',
+      gameCount: 1,
+    });
+  });
+});
+
+describe('publishSnapshot failure handling', () => {
+  it('reports a game it could not bake without failing the whole publish', async () => {
+    const { client } = createClientStub({
+      catalog: [catalogEntry('good'), catalogEntry('broken')],
+      sourcesBySlug: { good: gameSources(), broken: null },
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    expect(result.failures).toEqual([{ slug: 'broken', reason: 'game sources not found on ref' }]);
+    expect(spy.pointer).not.toBeNull();
+  });
+
+  it('keeps an unbakeable game in the snapshot catalog so it is not silently unpublished', async () => {
+    const { client } = createClientStub({
+      catalog: [catalogEntry('good'), catalogEntry('broken')],
+      sourcesBySlug: { good: gameSources(), broken: null },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    // Catalog membership is the games repo's decision, not this job's. The game
+    // stays listed and its play route falls back to GitHub — exactly what it did
+    // before the snapshot existed.
+    expect(spy.catalog?.map((entry) => entry.slug)).toEqual(['good', 'broken']);
+    expect(spy.games.has('broken')).toBe(false);
+  });
+
+  it('treats a game that fails the hygiene gate as a failure, not a bad snapshot', async () => {
+    const { client } = createClientStub({
+      catalog: [catalogEntry('empty')],
+      sourcesBySlug: { empty: gameSources({ gameJs: '   ' }) },
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(0);
+    expect(result.failures[0]?.slug).toBe('empty');
+    expect(spy.pointer?.gameCount).toBe(0);
+  });
+
+  it('carries on when one game is missing a declared media file', async () => {
+    const { client } = createClientStub({
+      catalog: [
+        catalogEntry('bubble-pop', { media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null } }),
+      ],
+      mediaBySlug: { 'bubble-pop': null },
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    expect(result.mediaFiles).toBe(0);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('bakes an empty catalog without writing a broken pointer', async () => {
+    const { client } = createClientStub({ catalog: [] });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(0);
+    expect(spy.catalog).toEqual([]);
+    expect(spy.pointer?.gameCount).toBe(0);
+  });
+});

--- a/apps/api/src/game-snapshot-publish.ts
+++ b/apps/api/src/game-snapshot-publish.ts
@@ -1,0 +1,167 @@
+import type { GameProject } from '@gamedevpl/game-generator';
+import { assembleGameHtml } from './assemble.js';
+import {
+  generateSnapshotId,
+  mediaContentType,
+  type GameSnapshotWriter,
+  type SnapshotPointer,
+} from './game-snapshot.js';
+import type { CatalogGameEntry, GitHubClient } from './github-client.js';
+
+/**
+ * Bakes every published game into the snapshot bucket.
+ *
+ * This is the one place the expensive work still happens — the same GitHub reads
+ * and esbuild bundle the play route used to do per request — and it deliberately
+ * reuses `assembleGameHtml` rather than the games repo's own `tools/build.ts`.
+ * That assembler is where the restrictive CSP, the AI Act art. 50(2) provenance
+ * meta and the credential scan are applied, so baking through it keeps one
+ * authoritative definition of "what a served game is". A second implementation on
+ * the games-repo side would be a serve-time policy that could drift out of the
+ * repo that owns the policy.
+ */
+
+export interface PublishSnapshotOptions {
+  client: GitHubClient;
+  writer: GameSnapshotWriter;
+  /** Games-repo ref to bake from. */
+  ref: string;
+  /** Recorded in the pointer for traceability; not used to address objects. */
+  commitSha?: string | null;
+  /** Bounds concurrent bake work (GitHub reads plus an esbuild bundle each). */
+  concurrency?: number;
+  now?: () => Date;
+  random?: () => number;
+  log?: (message: string) => void;
+}
+
+export interface PublishSnapshotFailure {
+  slug: string;
+  reason: string;
+}
+
+export interface PublishSnapshotResult {
+  snapshotId: string;
+  /** Games written to the snapshot. */
+  published: number;
+  /** Games in the catalog that could not be baked; these fall back to GitHub. */
+  failures: PublishSnapshotFailure[];
+  mediaFiles: number;
+  pointer: SnapshotPointer;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+
+export async function publishSnapshot(options: PublishSnapshotOptions): Promise<PublishSnapshotResult> {
+  const { client, writer, ref } = options;
+  const now = options.now ?? (() => new Date());
+  const log = options.log ?? (() => {});
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+
+  const snapshotId = generateSnapshotId(now(), options.random);
+  log(`baking snapshot ${snapshotId} from ${ref}`);
+
+  const catalog = await client.getCatalog(ref);
+  const published = catalog.filter((entry) => entry.status === 'published');
+  log(`catalog: ${catalog.length} entries, ${published.length} published`);
+
+  const failures: PublishSnapshotFailure[] = [];
+  let publishedCount = 0;
+  let mediaFiles = 0;
+
+  await mapWithConcurrency(published, concurrency, async (entry) => {
+    try {
+      const written = await bakeGame({ client, writer, ref, snapshotId, entry });
+      publishedCount += 1;
+      mediaFiles += written.mediaFiles;
+      log(`  ✓ ${entry.slug} (${written.mediaFiles} media)`);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message.replace(/\s+/g, ' ').trim().slice(0, 200) : 'unknown error';
+      failures.push({ slug: entry.slug, reason });
+      log(`  ✗ ${entry.slug}: ${reason}`);
+    }
+  });
+
+  // The catalog is written whole, including games that failed to bake. Catalog
+  // membership is the games repo's decision, not this job's: dropping a game
+  // here would silently unpublish it because one bake failed. A game with no
+  // snapshot object simply falls back to the GitHub path at serve time, which is
+  // exactly what it did before this job existed.
+  await writer.putCatalog(snapshotId, published);
+
+  const pointer: SnapshotPointer = {
+    snapshotId,
+    commitSha: options.commitSha ?? null,
+    publishedAt: now().toISOString(),
+    gameCount: publishedCount,
+  };
+
+  // Last, and only after every object is durable: until the pointer moves, the
+  // half-written snapshot is invisible and the site keeps serving the previous one.
+  await writer.putPointer(pointer);
+  log(`published snapshot ${snapshotId}: ${publishedCount} games, ${mediaFiles} media, ${failures.length} failed`);
+
+  return { snapshotId, published: publishedCount, failures, mediaFiles, pointer };
+}
+
+async function bakeGame(args: {
+  client: GitHubClient;
+  writer: GameSnapshotWriter;
+  ref: string;
+  snapshotId: string;
+  entry: CatalogGameEntry;
+}): Promise<{ mediaFiles: number }> {
+  const { client, writer, ref, snapshotId, entry } = args;
+
+  const sources = await client.getGameSources(ref, entry.slug);
+  if (!sources) {
+    throw new Error('game sources not found on ref');
+  }
+
+  const project: GameProject = {
+    title: sources.title ?? entry.title ?? entry.slug,
+    description: '',
+    html: sources.indexHtml,
+    js: sources.gameJs,
+    css: sources.styleCss,
+  };
+
+  // restrictNetwork mirrors the play route exactly: published games are
+  // self-contained by repo policy, so they are locked to their own inline assets.
+  const html = assembleGameHtml(project, { restrictNetwork: true });
+  await writer.putGame(snapshotId, { slug: entry.slug, title: project.title, html });
+
+  const mediaNames = [
+    ...(entry.media?.screenshots.map((screenshot) => screenshot.file) ?? []),
+    ...(entry.media?.video ? [entry.media.video] : []),
+  ];
+
+  let mediaFiles = 0;
+  for (const filename of mediaNames) {
+    const bytes = await client.getGameMedia(ref, entry.slug, filename);
+    if (!bytes) {
+      // Catalog metadata is generated from what is committed, so a gap here is
+      // odd but not fatal — the media route falls back to GitHub for this file.
+      continue;
+    }
+    await writer.putMedia(snapshotId, entry.slug, filename, {
+      body: Buffer.from(bytes),
+      contentType: mediaContentType(filename),
+    });
+    mediaFiles += 1;
+  }
+
+  return { mediaFiles };
+}
+
+/** Runs `worker` over `items` with at most `limit` in flight. */
+async function mapWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    while (cursor < items.length) {
+      const item = items[cursor++];
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -1,0 +1,302 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildApp } from './app.js';
+import type { GameSnapshotReader, SnapshotGame } from './game-snapshot.js';
+import type { CatalogGameEntry, GameSources, GitHubClient } from './github-client.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+/**
+ * The serve half of the snapshot: published games are read from the bucket, and
+ * every way that can fail falls back to the GitHub path the site used before.
+ */
+
+const sessionSecret = 'dev-session-secret-change-me';
+const repo = 'gamedevpl/www.gamedev.pl-games';
+
+function catalogEntry(slug: string, overrides: Partial<CatalogGameEntry> = {}): CatalogGameEntry {
+  return {
+    slug,
+    title: slug,
+    genre: 'arcade',
+    controls: 'arrows',
+    status: 'published',
+    media: null,
+    multiplayer: null,
+    ...overrides,
+  };
+}
+
+function gameSources(): GameSources {
+  return {
+    indexHtml: '<canvas id="game"></canvas>',
+    gameJs: 'console.log("from github")',
+    styleCss: 'body{margin:0}',
+    title: 'From GitHub',
+  };
+}
+
+function createGithubStub(catalog: CatalogGameEntry[]) {
+  const getCatalog = vi.fn(async () => catalog);
+  const getGameSources = vi.fn(async () => gameSources());
+  const getGameMedia = vi.fn(async () => new Uint8Array([0x67, 0x69, 0x74]));
+  const githubClient = {
+    createIssue: vi.fn(async () => ({ number: 1 })),
+    getIssueState: vi.fn(async () => ({ state: 'open' as const })),
+    findLinkedPR: vi.fn(async () => null),
+    createIssueComment: vi.fn(async () => ({ id: 1 })),
+    updateIssueBody: vi.fn(async () => {}),
+    closeIssue: vi.fn(async () => {}),
+    closePullRequest: vi.fn(async () => {}),
+    getGameSources,
+    getGameMedia,
+    getCatalog,
+    getProgressNotes: vi.fn(async () => null),
+  } as unknown as GitHubClient;
+  return { githubClient, getCatalog, getGameSources, getGameMedia };
+}
+
+function createSnapshotStub(params: {
+  catalog?: CatalogGameEntry[] | null;
+  games?: Record<string, SnapshotGame>;
+  media?: Record<string, Buffer>;
+  failWith?: Error;
+}) {
+  const fail = <T>(): Promise<T> => Promise.reject(params.failWith);
+  const getCatalog = vi.fn(async () =>
+    params.failWith ? fail<CatalogGameEntry[] | null>() : (params.catalog ?? null),
+  );
+  const getGame = vi.fn(async (slug: string) =>
+    params.failWith ? fail<SnapshotGame | null>() : (params.games?.[slug] ?? null),
+  );
+  const getMedia = vi.fn(async (slug: string, filename: string) => {
+    if (params.failWith) return fail<{ body: Buffer; contentType: string } | null>();
+    const body = params.media?.[`${slug}/${filename}`];
+    return body ? { body, contentType: 'image/png' } : null;
+  });
+  const reader: GameSnapshotReader = {
+    getPointer: vi.fn(async () => null),
+    getCatalog,
+    getGame,
+    getMedia,
+  };
+  return { reader, getCatalog, getGame, getMedia };
+}
+
+async function createApp(params: {
+  githubClient: GitHubClient;
+  snapshotReader?: GameSnapshotReader | null;
+}): Promise<FastifyInstance> {
+  const store = new InMemoryStore();
+  await store.upsertUser({ uid: 'g:test-user' });
+  return buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      githubToken: 'token',
+      submissionTokenSecret: 'submission-secret',
+      gamesRepo: repo,
+      githubClient: params.githubClient,
+      snapshotReader: params.snapshotReader ?? null,
+      translator: new NoopTranslator(),
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('playing a published game', () => {
+  it('serves the baked document without touching GitHub', async () => {
+    const { githubClient, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
+    const snapshot = createSnapshotStub({
+      catalog: [catalogEntry('bubble-pop')],
+      games: { 'bubble-pop': { slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html><p>baked</p>' } },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html><p>baked</p>' });
+    // The point of the whole change: no source fan-out, no esbuild bundle.
+    expect(getGameSources).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('falls back to GitHub for a game that is not in the snapshot', async () => {
+    const { githubClient, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
+    const snapshot = createSnapshotStub({ catalog: [catalogEntry('bubble-pop')], games: {} });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().html).toContain('from github');
+    expect(getGameSources).toHaveBeenCalledWith('main', 'bubble-pop');
+    await app.close();
+  });
+
+  it('falls back to GitHub when the snapshot bucket is unreachable', async () => {
+    const { githubClient, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
+    const snapshot = createSnapshotStub({ failWith: new Error('storage 503') });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+
+    // A Storage outage must degrade to the old behaviour, not to a broken site.
+    expect(response.statusCode).toBe(200);
+    expect(response.json().html).toContain('from github');
+    expect(getGameSources).toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('still refuses a slug the catalog does not publish', async () => {
+    const { githubClient } = createGithubStub([]);
+    const snapshot = createSnapshotStub({
+      catalog: [],
+      games: { sneaky: { slug: 'sneaky', title: 'Sneaky', html: '<!doctype html>' } },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/sneaky' });
+
+    // Publication is decided by the catalog, not by what happens to sit in the
+    // bucket — a stale object must never resurrect an unpublished game.
+    expect(response.statusCode).toBe(404);
+    await app.close();
+  });
+
+  it('reads a given game from the snapshot once, then from the in-process cache', async () => {
+    const { githubClient } = createGithubStub([catalogEntry('bubble-pop')]);
+    const snapshot = createSnapshotStub({
+      catalog: [catalogEntry('bubble-pop')],
+      games: { 'bubble-pop': { slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html>' } },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+    await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+
+    expect(snapshot.getGame).toHaveBeenCalledTimes(1);
+    await app.close();
+  });
+});
+
+describe('the catalog', () => {
+  it('comes from the snapshot when one is published', async () => {
+    const { githubClient, getCatalog } = createGithubStub([catalogEntry('from-github')]);
+    const snapshot = createSnapshotStub({ catalog: [catalogEntry('from-snapshot')] });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.json().map((entry: CatalogGameEntry) => entry.slug)).toEqual(['from-snapshot']);
+    expect(getCatalog).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('falls back to GitHub before any snapshot has been published', async () => {
+    const { githubClient, getCatalog } = createGithubStub([catalogEntry('from-github')]);
+    const snapshot = createSnapshotStub({ catalog: null });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.json().map((entry: CatalogGameEntry) => entry.slug)).toEqual(['from-github']);
+    expect(getCatalog).toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('falls back to GitHub when the snapshot read fails', async () => {
+    const { githubClient, getCatalog } = createGithubStub([catalogEntry('from-github')]);
+    const snapshot = createSnapshotStub({ failWith: new Error('storage 503') });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    expect(getCatalog).toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('still hides entries the snapshot lists as not published', async () => {
+    const { githubClient } = createGithubStub([]);
+    const snapshot = createSnapshotStub({
+      catalog: [catalogEntry('live'), catalogEntry('archived-game', { status: 'archived' })],
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.json().map((entry: CatalogGameEntry) => entry.slug)).toEqual(['live']);
+    await app.close();
+  });
+});
+
+describe('gallery media', () => {
+  const withMedia = catalogEntry('bubble-pop', {
+    media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null },
+  });
+
+  it('is served from the snapshot when it is baked', async () => {
+    const { githubClient, getGameMedia } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: { 'bubble-pop/opening.png': Buffer.from('baked-bytes') },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawPayload.toString()).toBe('baked-bytes');
+    expect(getGameMedia).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('falls back to GitHub when the file is not in the snapshot', async () => {
+    const { githubClient, getGameMedia } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({ catalog: [withMedia], media: {} });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
+
+    expect(response.statusCode).toBe(200);
+    expect(getGameMedia).toHaveBeenCalledWith('main', 'bubble-pop', 'opening.png');
+    await app.close();
+  });
+
+  it('still rejects a filename the catalog does not vouch for', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: { 'bubble-pop/secret.png': Buffer.from('should-not-be-served') },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/secret.png' });
+
+    // The catalog allowlist runs before the snapshot is consulted, so a stray
+    // object in the bucket cannot widen what the API will serve.
+    expect(response.statusCode).toBe(404);
+    await app.close();
+  });
+});
+
+describe('with no snapshot configured', () => {
+  it('serves games and catalog entirely from GitHub', async () => {
+    const { githubClient, getCatalog, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
+    const app = await createApp({ githubClient, snapshotReader: null });
+
+    const catalog = await app.inject({ method: 'GET', url: '/api/catalog' });
+    const game = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
+
+    expect(catalog.statusCode).toBe(200);
+    expect(game.statusCode).toBe(200);
+    expect(getCatalog).toHaveBeenCalled();
+    expect(getGameSources).toHaveBeenCalled();
+    await app.close();
+  });
+});

--- a/apps/api/src/game-snapshot.test.ts
+++ b/apps/api/src/game-snapshot.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  catalogObject,
+  createGcsSnapshotStore,
+  createSnapshotReaderFromEnv,
+  gameObject,
+  generateSnapshotId,
+  mediaContentType,
+  mediaObject,
+  POINTER_OBJECT,
+  type SnapshotPointer,
+} from './game-snapshot.js';
+
+const bucket = 'gamedev-snapshots';
+
+function pointer(overrides: Partial<SnapshotPointer> = {}): SnapshotPointer {
+  return {
+    snapshotId: '20260727T101500Z-abcd',
+    commitSha: 'deadbeef',
+    publishedAt: '2026-07-27T10:15:00.000Z',
+    gameCount: 2,
+    ...overrides,
+  };
+}
+
+interface FakeCall {
+  method: string;
+  name: string;
+  cacheControl?: string;
+  contentType?: string;
+  body?: Buffer;
+}
+
+/**
+ * Fakes Cloud Storage at the `fetch` boundary — the same seam local-games-repo.ts
+ * uses for GitHub, so there is no second client implementation to keep honest.
+ */
+function createFakeStorage(objects: Record<string, { body: Buffer; contentType?: string }> = {}) {
+  const calls: FakeCall[] = [];
+  const store = new Map(Object.entries(objects));
+
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+
+    if (url.pathname.startsWith('/upload/')) {
+      const name = url.searchParams.get('name') ?? '';
+      const body = Buffer.from(init?.body as Uint8Array);
+      calls.push({
+        method: 'PUT',
+        name,
+        cacheControl: headers['cache-control'],
+        contentType: headers['content-type'],
+        body,
+      });
+      store.set(name, { body, contentType: headers['content-type'] });
+      return new Response('{}', { status: 200 });
+    }
+
+    // Read: /storage/v1/b/<bucket>/o/<encoded name>
+    const name = decodeURIComponent(url.pathname.split('/o/')[1] ?? '');
+    calls.push({ method: 'GET', name });
+    const found = store.get(name);
+    if (!found) return new Response('Not Found', { status: 404 });
+    return new Response(found.body, { status: 200 });
+  });
+
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls, store, raw: fetchImpl };
+}
+
+function createStore(fake: ReturnType<typeof createFakeStorage>, now = () => 1_000) {
+  return createGcsSnapshotStore({
+    bucket,
+    fetchImpl: fake.fetchImpl,
+    getAccessToken: async () => 'fake-token',
+    now,
+  });
+}
+
+describe('snapshot object layout', () => {
+  it('addresses every object under an immutable per-snapshot prefix', () => {
+    expect(catalogObject('snap1')).toBe('snapshots/snap1/catalog.json');
+    expect(gameObject('snap1', 'bubble-pop')).toBe('snapshots/snap1/games/bubble-pop.json');
+    expect(mediaObject('snap1', 'bubble-pop', 'opening.png')).toBe('snapshots/snap1/media/bubble-pop/opening.png');
+    // The pointer is the only mutable object, and it lives outside the prefixes.
+    expect(POINTER_OBJECT).toBe('current.json');
+  });
+
+  it('derives media content types from the extension', () => {
+    expect(mediaContentType('opening.png')).toBe('image/png');
+    expect(mediaContentType('gameplay.mp4')).toBe('video/mp4');
+  });
+
+  it('generates ids that sort in publish order', () => {
+    const first = generateSnapshotId(new Date('2026-07-27T10:15:00.000Z'), () => 0.1);
+    const second = generateSnapshotId(new Date('2026-07-27T11:15:00.000Z'), () => 0.1);
+    expect(first).toMatch(/^\d{8}T\d{6}Z-[0-9a-f]{4}$/);
+    expect([second, first].sort()).toEqual([first, second]);
+  });
+
+  it('gives two publishes in the same second distinct ids', () => {
+    const at = new Date('2026-07-27T10:15:00.000Z');
+    expect(generateSnapshotId(at, () => 0.1)).not.toBe(generateSnapshotId(at, () => 0.9));
+  });
+});
+
+describe('snapshot reads', () => {
+  it('resolves the catalog through the pointer', async () => {
+    const fake = createFakeStorage({
+      [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) },
+      [catalogObject(pointer().snapshotId)]: { body: Buffer.from(JSON.stringify([{ slug: 'bubble-pop' }])) },
+    });
+
+    const catalog = await createStore(fake).getCatalog();
+
+    expect(catalog).toEqual([{ slug: 'bubble-pop' }]);
+  });
+
+  it('returns null when no snapshot has been published yet', async () => {
+    const fake = createFakeStorage();
+    const store = createStore(fake);
+
+    expect(await store.getPointer()).toBeNull();
+    expect(await store.getCatalog()).toBeNull();
+    expect(await store.getGame('bubble-pop')).toBeNull();
+    expect(await store.getMedia('bubble-pop', 'opening.png')).toBeNull();
+  });
+
+  it('returns null for a game that is not in the snapshot, so serving can fall back', async () => {
+    const fake = createFakeStorage({ [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) } });
+
+    expect(await createStore(fake).getGame('never-baked')).toBeNull();
+  });
+
+  it('reads media bytes with a content type derived from the filename', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const fake = createFakeStorage({
+      [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) },
+      [mediaObject(pointer().snapshotId, 'bubble-pop', 'opening.png')]: { body: bytes },
+    });
+
+    const media = await createStore(fake).getMedia('bubble-pop', 'opening.png');
+
+    expect(media?.contentType).toBe('image/png');
+    expect(media?.body.equals(bytes)).toBe(true);
+  });
+
+  it('throws on transport failure rather than reporting a miss', async () => {
+    const fake = createFakeStorage();
+    fake.raw.mockResolvedValueOnce(new Response('nope', { status: 500 }));
+
+    // A 500 must not look like "not published" — serving tells the two apart to
+    // decide between falling back to GitHub and answering 404.
+    await expect(createStore(fake).getPointer()).rejects.toThrow(/500/);
+  });
+
+  it('rejects slugs and filenames that could escape the snapshot prefix', async () => {
+    const store = createStore(createFakeStorage());
+
+    await expect(store.getGame('../../etc/passwd')).rejects.toThrow(/unsafe slug/);
+    await expect(store.getMedia('bubble-pop', '../secret.png')).rejects.toThrow(/unsafe media filename/);
+    await expect(store.getMedia('bubble-pop', 'opening.svg')).rejects.toThrow(/unsafe media filename/);
+  });
+});
+
+describe('pointer caching', () => {
+  it('reads the pointer once for a burst of lookups', async () => {
+    const fake = createFakeStorage({
+      [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) },
+      [gameObject(pointer().snapshotId, 'a')]: { body: Buffer.from(JSON.stringify({ slug: 'a' })) },
+      [gameObject(pointer().snapshotId, 'b')]: { body: Buffer.from(JSON.stringify({ slug: 'b' })) },
+    });
+    const store = createStore(fake);
+
+    // A cold instance takes a page load's worth of requests at once; they all
+    // need the same pointer and must coalesce into one read.
+    await Promise.all([store.getGame('a'), store.getGame('b'), store.getPointer()]);
+
+    expect(fake.calls.filter((call) => call.name === POINTER_OBJECT)).toHaveLength(1);
+  });
+
+  it('re-reads the pointer once its TTL lapses', async () => {
+    const fake = createFakeStorage({ [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) } });
+    let clock = 1_000;
+    const store = createGcsSnapshotStore({
+      bucket,
+      fetchImpl: fake.fetchImpl,
+      getAccessToken: async () => 'fake-token',
+      pointerTtlMs: 60_000,
+      now: () => clock,
+    });
+
+    await store.getPointer();
+    clock += 61_000;
+    await store.getPointer();
+
+    expect(fake.calls.filter((call) => call.name === POINTER_OBJECT)).toHaveLength(2);
+  });
+
+  it('keeps serving the last known pointer when a refresh fails', async () => {
+    const fake = createFakeStorage({ [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) } });
+    let clock = 1_000;
+    const store = createGcsSnapshotStore({
+      bucket,
+      fetchImpl: fake.fetchImpl,
+      getAccessToken: async () => 'fake-token',
+      pointerTtlMs: 60_000,
+      now: () => clock,
+    });
+
+    await store.getPointer();
+    clock += 61_000;
+    fake.raw.mockResolvedValueOnce(new Response('boom', { status: 503 }));
+
+    // Snapshot prefixes are immutable, so a stale pointer still serves correct
+    // games — briefly-old beats an outage.
+    expect(await store.getPointer()).toEqual(pointer());
+  });
+});
+
+describe('snapshot writes', () => {
+  it('marks snapshot objects immutable and the pointer uncacheable', async () => {
+    const fake = createFakeStorage();
+    const store = createStore(fake);
+
+    await store.putGame('snap1', { slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html>' });
+    await store.putPointer(pointer({ snapshotId: 'snap1' }));
+
+    const gameWrite = fake.calls.find((call) => call.name === gameObject('snap1', 'bubble-pop'));
+    const pointerWrite = fake.calls.find((call) => call.name === POINTER_OBJECT);
+    // This is what makes putting a CDN in front a config change rather than a redesign.
+    expect(gameWrite?.cacheControl).toBe('public, max-age=31536000, immutable');
+    // A cached pointer would make a publish take an unbounded time to become visible.
+    expect(pointerWrite?.cacheControl).toBe('no-cache');
+  });
+
+  it('round-trips a written game', async () => {
+    const fake = createFakeStorage();
+    const store = createStore(fake);
+    const game = { slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html><p>hi</p>' };
+
+    await store.putGame('snap1', game);
+    await store.putPointer(pointer({ snapshotId: 'snap1' }));
+
+    expect(await store.getGame('bubble-pop')).toEqual(game);
+  });
+
+  it('refuses to write outside a well-formed snapshot prefix', async () => {
+    const store = createStore(createFakeStorage());
+
+    await expect(store.putGame('../evil', { slug: 'a', title: 'a', html: 'x' })).rejects.toThrow(/unsafe snapshot id/);
+    await expect(store.putGame('snap1', { slug: '../evil', title: 'a', html: 'x' })).rejects.toThrow(/unsafe slug/);
+  });
+});
+
+describe('createSnapshotReaderFromEnv', () => {
+  it('is null without a bucket, so local dev and tests keep the GitHub path', () => {
+    expect(createSnapshotReaderFromEnv({})).toBeNull();
+    expect(createSnapshotReaderFromEnv({ GAMES_SNAPSHOT_BUCKET: '  ' })).toBeNull();
+  });
+
+  it('builds a reader when a bucket is configured', () => {
+    expect(createSnapshotReaderFromEnv({ GAMES_SNAPSHOT_BUCKET: bucket })).not.toBeNull();
+  });
+});

--- a/apps/api/src/game-snapshot.ts
+++ b/apps/api/src/game-snapshot.ts
@@ -1,0 +1,327 @@
+import { GoogleAuth } from 'google-auth-library';
+import type { CatalogGameEntry } from './github-client.js';
+
+/**
+ * Published games as immutable, pre-assembled objects in Cloud Storage.
+ *
+ * Until now every play of a published game rebuilt it from scratch on the request
+ * path: a fan-out of authenticated GitHub reads for the game's sources and the
+ * GameKit modules it selects, an esbuild bundle, then assembly. That made GitHub
+ * API availability and quota a hard dependency of the *play* route — the one route
+ * that must never be down — and it had already cost one rate-limit outage (the
+ * reason `getCatalog` moved to batched GraphQL, see github-client.ts).
+ *
+ * The work is the same either way; the question is only whether it happens once per
+ * merge or once per cache miss per instance. This module makes it once per merge:
+ * `publishSnapshot` bakes every published game into a self-contained document and
+ * writes it here, and the serve routes read the result.
+ *
+ * ## Layout
+ *
+ *   current.json                              → the pointer (small, mutable)
+ *   snapshots/<id>/catalog.json               → CatalogGameEntry[]
+ *   snapshots/<id>/games/<slug>.json          → { slug, title, html }
+ *   snapshots/<id>/media/<slug>/<filename>    → screenshot / video bytes
+ *
+ * Snapshot prefixes are immutable and content-addressed by publish; only
+ * `current.json` is ever overwritten. Three things fall out of that:
+ * publishing is atomic (a half-uploaded snapshot is invisible until the pointer
+ * moves), rollback is a pointer rewrite rather than a rebuild, and every object
+ * under `snapshots/` is safe to cache forever — so putting a CDN in front later
+ * is a configuration change, not a redesign.
+ */
+
+/** Points at the snapshot the site should currently serve. */
+export interface SnapshotPointer {
+  snapshotId: string;
+  /** Games-repo commit the snapshot was baked from, for traceability. */
+  commitSha: string | null;
+  publishedAt: string;
+  gameCount: number;
+}
+
+/** A pre-assembled game, shaped exactly like the play route's response body. */
+export interface SnapshotGame {
+  slug: string;
+  title: string;
+  html: string;
+}
+
+export interface SnapshotMedia {
+  body: Buffer;
+  contentType: string;
+}
+
+/**
+ * The read side, used by the serve routes. Every method throws on transport
+ * failure and resolves to null on a genuine miss, so callers can tell "snapshot
+ * is unreachable, fall back to GitHub" apart from "this game isn't published".
+ */
+export interface GameSnapshotReader {
+  getPointer(): Promise<SnapshotPointer | null>;
+  getCatalog(): Promise<CatalogGameEntry[] | null>;
+  getGame(slug: string): Promise<SnapshotGame | null>;
+  getMedia(slug: string, filename: string): Promise<SnapshotMedia | null>;
+}
+
+/** The write side, used by the publish job. */
+export interface GameSnapshotWriter {
+  putCatalog(snapshotId: string, entries: CatalogGameEntry[]): Promise<void>;
+  putGame(snapshotId: string, game: SnapshotGame): Promise<void>;
+  putMedia(snapshotId: string, slug: string, filename: string, media: SnapshotMedia): Promise<void>;
+  putPointer(pointer: SnapshotPointer): Promise<void>;
+}
+
+export type GameSnapshotStore = GameSnapshotReader & GameSnapshotWriter;
+
+export const POINTER_OBJECT = 'current.json';
+
+export function catalogObject(snapshotId: string): string {
+  return `snapshots/${snapshotId}/catalog.json`;
+}
+
+export function gameObject(snapshotId: string, slug: string): string {
+  return `snapshots/${snapshotId}/games/${slug}.json`;
+}
+
+export function mediaObject(snapshotId: string, slug: string, filename: string): string {
+  return `snapshots/${snapshotId}/media/${slug}/${filename}`;
+}
+
+export function mediaContentType(filename: string): string {
+  return filename.endsWith('.mp4') ? 'video/mp4' : 'image/png';
+}
+
+/**
+ * Snapshot ids sort lexicographically in publish order, so listing the bucket
+ * shows history newest-last and old snapshots are trivially identifiable for
+ * lifecycle deletion. The random suffix keeps two publishes in the same second
+ * from colliding.
+ */
+export function generateSnapshotId(now: Date, random: () => number = Math.random): string {
+  const stamp = now
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d+Z$/, 'Z');
+  const suffix = Math.floor(random() * 0x10000)
+    .toString(16)
+    .padStart(4, '0');
+  return `${stamp}-${suffix}`;
+}
+
+/** Rejects anything that could escape its prefix or forge an object path. */
+const SAFE_SLUG = /^[a-z0-9][a-z0-9-]*$/;
+const SAFE_MEDIA_FILENAME = /^[a-z0-9][a-z0-9-]*\.(?:png|mp4)$/;
+const SAFE_SNAPSHOT_ID = /^[0-9A-Za-z-]+$/;
+
+function assertSafeSlug(slug: string): void {
+  if (!SAFE_SLUG.test(slug)) throw new Error(`unsafe slug "${slug}"`);
+}
+
+function assertSafeMediaFilename(filename: string): void {
+  if (!SAFE_MEDIA_FILENAME.test(filename)) throw new Error(`unsafe media filename "${filename}"`);
+}
+
+function assertSafeSnapshotId(snapshotId: string): void {
+  if (!SAFE_SNAPSHOT_ID.test(snapshotId)) throw new Error(`unsafe snapshot id "${snapshotId}"`);
+}
+
+export interface GcsSnapshotStoreOptions {
+  bucket: string;
+  fetchImpl?: typeof fetch;
+  /**
+   * Resolves a bearer token for the Storage JSON API. Defaults to Application
+   * Default Credentials, which on Cloud Run is the service account already
+   * attached to the revision — no key material anywhere.
+   */
+  getAccessToken?: () => Promise<string>;
+  /** How long a resolved pointer is trusted before re-reading it. */
+  pointerTtlMs?: number;
+  now?: () => number;
+}
+
+/**
+ * We talk to the Storage JSON API over `fetch` with an ADC bearer token rather
+ * than pulling in `@google-cloud/storage`. The API surface we need is three verbs,
+ * the auth library is already a dependency (it backs Google sign-in), and keeping
+ * the transport at the `fetch` boundary means tests fake it the same way
+ * local-games-repo.ts fakes GitHub — no second client implementation to keep honest.
+ */
+export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSnapshotStore {
+  const { bucket } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const pointerTtlMs = options.pointerTtlMs ?? 60_000;
+
+  let auth: GoogleAuth | null = null;
+  const getAccessToken =
+    options.getAccessToken ??
+    (async () => {
+      auth ??= new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/devstorage.read_write'] });
+      const token = await auth.getAccessToken();
+      if (!token) throw new Error('could not obtain a Google access token for the snapshot bucket');
+      return token;
+    });
+
+  async function authHeaders(): Promise<Record<string, string>> {
+    return { authorization: `Bearer ${await getAccessToken()}` };
+  }
+
+  async function readObject(name: string): Promise<Buffer | null> {
+    const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(name)}?alt=media`;
+    const response = await fetchImpl(url, { headers: await authHeaders() });
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(`snapshot read of ${name} failed: ${response.status} ${await safeBodyText(response)}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async function readJson<T>(name: string): Promise<T | null> {
+    const body = await readObject(name);
+    if (!body) return null;
+    try {
+      return JSON.parse(body.toString('utf8')) as T;
+    } catch (error) {
+      throw new Error(`snapshot object ${name} is not valid JSON`, { cause: error });
+    }
+  }
+
+  async function writeObject(name: string, body: Buffer, contentType: string, cacheControl: string): Promise<void> {
+    const url =
+      `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(bucket)}/o` +
+      `?uploadType=media&name=${encodeURIComponent(name)}`;
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        ...(await authHeaders()),
+        'content-type': contentType,
+        'cache-control': cacheControl,
+      },
+      body: new Uint8Array(body),
+    });
+    if (!response.ok) {
+      throw new Error(`snapshot write of ${name} failed: ${response.status} ${await safeBodyText(response)}`);
+    }
+  }
+
+  // Objects under snapshots/ never change, so they are safe to cache hard —
+  // this is what a CDN in front of the bucket would honour. The pointer is the
+  // one mutable object and must not be cached, or a publish would take an
+  // unbounded time to become visible.
+  const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable';
+  const POINTER_CACHE = 'no-cache';
+
+  let pointerCache: { value: SnapshotPointer | null; expiresAt: number } | null = null;
+  let pointerRefresh: Promise<SnapshotPointer | null> | null = null;
+
+  return {
+    async getPointer() {
+      if (pointerCache && pointerCache.expiresAt > now()) {
+        return pointerCache.value;
+      }
+      // Misses coalesce: a cold instance takes a page load's worth of catalog,
+      // game and media requests at once, and they all need the same pointer.
+      pointerRefresh ??= readJson<SnapshotPointer>(POINTER_OBJECT)
+        .then((value) => {
+          pointerCache = { value, expiresAt: now() + pointerTtlMs };
+          return value;
+        })
+        .finally(() => {
+          pointerRefresh = null;
+        });
+      try {
+        return await pointerRefresh;
+      } catch (error) {
+        // A pointer we already resolved stays usable: snapshot objects are
+        // immutable, so a stale pointer serves correct (if not newest) games.
+        if (pointerCache) return pointerCache.value;
+        throw error;
+      }
+    },
+
+    async getCatalog() {
+      const pointer = await this.getPointer();
+      if (!pointer) return null;
+      return readJson<CatalogGameEntry[]>(catalogObject(pointer.snapshotId));
+    },
+
+    async getGame(slug) {
+      assertSafeSlug(slug);
+      const pointer = await this.getPointer();
+      if (!pointer) return null;
+      return readJson<SnapshotGame>(gameObject(pointer.snapshotId, slug));
+    },
+
+    async getMedia(slug, filename) {
+      assertSafeSlug(slug);
+      assertSafeMediaFilename(filename);
+      const pointer = await this.getPointer();
+      if (!pointer) return null;
+      const body = await readObject(mediaObject(pointer.snapshotId, slug, filename));
+      if (!body) return null;
+      return { body, contentType: mediaContentType(filename) };
+    },
+
+    async putCatalog(snapshotId, entries) {
+      assertSafeSnapshotId(snapshotId);
+      await writeObject(
+        catalogObject(snapshotId),
+        Buffer.from(JSON.stringify(entries), 'utf8'),
+        'application/json',
+        IMMUTABLE_CACHE,
+      );
+    },
+
+    async putGame(snapshotId, game) {
+      assertSafeSnapshotId(snapshotId);
+      assertSafeSlug(game.slug);
+      await writeObject(
+        gameObject(snapshotId, game.slug),
+        Buffer.from(JSON.stringify(game), 'utf8'),
+        'application/json',
+        IMMUTABLE_CACHE,
+      );
+    },
+
+    async putMedia(snapshotId, slug, filename, media) {
+      assertSafeSnapshotId(snapshotId);
+      assertSafeSlug(slug);
+      assertSafeMediaFilename(filename);
+      await writeObject(mediaObject(snapshotId, slug, filename), media.body, media.contentType, IMMUTABLE_CACHE);
+    },
+
+    async putPointer(pointer) {
+      assertSafeSnapshotId(pointer.snapshotId);
+      await writeObject(
+        POINTER_OBJECT,
+        Buffer.from(JSON.stringify(pointer), 'utf8'),
+        'application/json',
+        POINTER_CACHE,
+      );
+      pointerCache = { value: pointer, expiresAt: now() + pointerTtlMs };
+    },
+  };
+}
+
+async function safeBodyText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).replace(/\s+/g, ' ').trim().slice(0, 200);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Builds the reader the serve routes use, or null when no bucket is configured.
+ *
+ * Absent configuration is a supported state, not an error: local development and
+ * tests run without a bucket, and production keeps working from GitHub if the
+ * snapshot is switched off. Serving is written so the snapshot is a fast path,
+ * never a requirement.
+ */
+export function createSnapshotReaderFromEnv(env: NodeJS.ProcessEnv = process.env): GameSnapshotReader | null {
+  const bucket = env.GAMES_SNAPSHOT_BUCKET?.trim();
+  if (!bucket) return null;
+  return createGcsSnapshotStore({ bucket });
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -12,6 +12,7 @@ import {
   type GitHubClient,
   type LinkedPullRequest,
 } from './github-client.js';
+import { createSnapshotReaderFromEnv, type GameSnapshotReader } from './game-snapshot.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
@@ -83,6 +84,12 @@ export interface SubmissionRoutesOptions {
   translator?: Translator;
   /** Caps and seams for the agent build channel; see registerAgentChannelRoutes. */
   agentChannel?: Pick<AgentChannelOptions, 'maxEventsPerBuild' | 'maxEventsPerWindow'>;
+  /**
+   * Pre-assembled published games. Defaults to the bucket in
+   * GAMES_SNAPSHOT_BUCKET, or null when unset. Always a fast path in front of
+   * GitHub, never a requirement — see game-snapshot.ts.
+   */
+  snapshotReader?: GameSnapshotReader | null;
 }
 
 function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {
@@ -276,6 +283,14 @@ export async function registerSubmissionRoutes(
 
   // Published games live on the games repo's default branch.
   const publishedRef = process.env.GAMES_PUBLISHED_REF ?? 'main';
+
+  // Pre-assembled published games, baked on merge by scripts/publish-snapshot.ts.
+  // `undefined` means "read the environment"; an explicit null disables it (tests
+  // that assert the GitHub-backed behaviour pass null).
+  const snapshotReader = options.snapshotReader === undefined ? createSnapshotReaderFromEnv() : options.snapshotReader;
+  if (snapshotReader) {
+    app.log.info('serving published games from the snapshot bucket, with GitHub as fallback');
+  }
 
   const githubClient =
     githubToken && submissionTokenSecret
@@ -512,13 +527,63 @@ export async function registerSubmissionRoutes(
   // reads), but misses still coalesce into one in-flight refresh, and a failed
   // refresh falls back to the last catalog this instance built — for data that
   // changes only on a merge, briefly stale beats a visitor-facing 502.
+  /**
+   * Where a catalog read actually comes from.
+   *
+   * `forceFresh` deliberately skips the snapshot. It is only set by
+   * isSlugPublished for the publishing→published transition, and that is exactly
+   * the window where the snapshot is the stale source (it is baked a minute or
+   * two after the merge) and GitHub is the fresh one.
+   */
+  async function loadCatalog(client: GitHubClient, forceFresh: boolean): Promise<CatalogGameEntry[]> {
+    if (!forceFresh && snapshotReader) {
+      try {
+        const entries = await snapshotReader.getCatalog();
+        if (entries) {
+          return entries;
+        }
+      } catch (error) {
+        app.log.warn({ err: error }, 'snapshot catalog unavailable; falling back to GitHub');
+      }
+    }
+    return client.getCatalog(publishedRef);
+  }
+
+  /**
+   * Snapshot lookups never fail a request. A miss (game not in this snapshot) and
+   * a transport error both fall back to the GitHub path, so switching the bucket
+   * off, an unbaked game, and a Storage outage all degrade to exactly the
+   * behaviour the site had before the snapshot existed.
+   */
+  async function readSnapshotGame(slug: string): Promise<{ slug: string; title: string; html: string } | null> {
+    if (!snapshotReader) return null;
+    try {
+      return await snapshotReader.getGame(slug);
+    } catch (error) {
+      app.log.warn({ err: error, slug }, 'snapshot game unavailable; falling back to GitHub');
+      return null;
+    }
+  }
+
+  async function readSnapshotMedia(
+    slug: string,
+    filename: string,
+  ): Promise<{ body: Buffer; contentType: string } | null> {
+    if (!snapshotReader) return null;
+    try {
+      return await snapshotReader.getMedia(slug, filename);
+    } catch (error) {
+      app.log.warn({ err: error, slug, filename }, 'snapshot media unavailable; falling back to GitHub');
+      return null;
+    }
+  }
+
   async function getCatalogEntries(client: GitHubClient, forceFresh = false): Promise<CatalogGameEntry[]> {
     if (!forceFresh && catalogCache && catalogCache.expiresAt > now()) {
       return catalogCache.entries;
     }
 
-    catalogRefresh ??= client
-      .getCatalog(publishedRef)
+    catalogRefresh ??= loadCatalog(client, forceFresh)
       .then((entries) => {
         catalogCache = { entries, expiresAt: now() + catalogTtlMs };
         return entries;
@@ -1507,12 +1572,20 @@ export async function registerSubmissionRoutes(
         return reply.status(404).send({ error: 'media not found' });
       }
 
-      const media = await githubClient.getGameMedia(publishedRef, parsedParams.data.slug, parsedParams.data.filename);
-      if (!media) {
-        return reply.status(404).send({ error: 'media not found' });
+      // The catalog allowlist above still gates every read, so the snapshot can
+      // only ever answer for a filename the validated metadata already vouches for.
+      const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
+      let body: Buffer;
+      if (snapshotMedia) {
+        body = snapshotMedia.body;
+      } else {
+        const media = await githubClient.getGameMedia(publishedRef, parsedParams.data.slug, parsedParams.data.filename);
+        if (!media) {
+          return reply.status(404).send({ error: 'media not found' });
+        }
+        body = Buffer.from(media);
       }
 
-      const body = Buffer.from(media);
       const cacheEntry = {
         expiresAt: currentTime + mediaTtlMs,
         etag: `"${createHash('sha256').update(body).digest('base64url').slice(0, 27)}"`,
@@ -1557,6 +1630,15 @@ export async function registerSubmissionRoutes(
     try {
       if (!(await isSlugPublished(githubClient, slug))) {
         return reply.status(404).send({ error: 'game not found' });
+      }
+
+      // Baked at merge time by the same assembler this route would use, with the
+      // same CSP, provenance meta and credential scan already applied — so a hit
+      // skips the GitHub fan-out and the esbuild bundle entirely.
+      const snapshotGame = await readSnapshotGame(slug);
+      if (snapshotGame) {
+        gameCache.set(slug, { value: snapshotGame, expiresAt: currentTime + gameTtlMs });
+        return reply.send(snapshotGame);
       }
 
       const sources = await githubClient.getGameSources(publishedRef, slug);

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ survives only in this repo's early history.
 | [`roadmap.md`](./roadmap.md)                                       | Phased milestones with goals, deliverables, dependencies, open questions                               |
 | [`games-repo.md`](./games-repo.md)                                 | **The current architecture — games will live in a repo maintained by coding agents. Read this first.** |
 | [`games-repo-blueprint.md`](./games-repo-blueprint.md)             | Concrete layout, validation, publishing, and issue-first implementation plan                           |
+| [`games-snapshot.md`](./games-snapshot.md)                         | Published games are baked to Cloud Storage on merge, so playing no longer rebuilds them from GitHub    |
 | [`security-model.md`](./security-model.md)                         | Threat model. The credential-exfiltration finding is **dissolved** by the games-repo pivot             |
 | [`agent-adapters.md`](./agent-adapters.md)                         | Common repository contract for Claude Code / Codex / agy / Copilot                                     |
 | [`deployment.md`](./deployment.md)                                 | Minimal delivery shape for the app, games origin, and submission API                                   |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,15 +43,16 @@ account (`<project-number>-compute@developer.gserviceaccount.com`) needs
 `roles/secretmanager.secretAccessor` on each. `deploy.yml` and `infra/deploy-api.sh` wire whichever exist into
 a single `--set-secrets` list.
 
-| Secret                              | Purpose                                                                                 | State (2026-07-26)                                                           |
-| ----------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `github-token`                      | Fine-grained PAT (Issues rw + PRs r + Contents r, games repo only)                      | ✅ set — submissions on                                                      |
-| `GAMES_REPO_TOKEN` (GitHub Actions) | Contents:read PAT on the games repo — CI lockstep check (`npm run contract:games-repo`) | ⚠️ set on the GitHub repo (not GCP) so assemble/Check 4/music drift fails CI |
-| `submission-token-secret`           | HMAC key for the stateless status token → `SUBMISSION_TOKEN_SECRET`                     | ✅ set                                                                       |
-| `session-secret`                    | HMAC key for session cookies → `SESSION_SECRET`                                         | ✅ set                                                                       |
-| `resend-api-key`                    | Outbound email → `RESEND_API_KEY` (see below)                                           | ✅ set                                                                       |
-| `vapid-private-key`                 | Web push signing → `VAPID_PRIVATE_KEY`                                                  | ✅ set                                                                       |
-| `site-basic-auth`                   | Former "not public yet" lock → `SITE_BASIC_AUTH`                                        | ⚠️ exists but **unused**                                                     |
+| Secret                                 | Purpose                                                                                                                                  | State (2026-07-26)                                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `github-token`                         | Fine-grained PAT (Issues rw + PRs r + Contents r, games repo only)                                                                       | ✅ set — submissions on                                                                             |
+| `GAMES_REPO_TOKEN` (GitHub Actions)    | Contents:read PAT on the games repo — CI lockstep check (`npm run contract:games-repo`) and the snapshot bake (`publish-games.yml`)      | ⚠️ set on the GitHub repo (not GCP) so assemble/Check 4/music drift fails CI                        |
+| `SITE_DISPATCH_TOKEN` (GitHub Actions) | Fine-grained PAT that lets the **games repo** dispatch `games-published` into this repo — see [`games-snapshot.md`](./games-snapshot.md) | ⚠️ set on the _games_ repo; without it the site serves the previous snapshot until a manual publish |
+| `submission-token-secret`              | HMAC key for the stateless status token → `SUBMISSION_TOKEN_SECRET`                                                                      | ✅ set                                                                                              |
+| `session-secret`                       | HMAC key for session cookies → `SESSION_SECRET`                                                                                          | ✅ set                                                                                              |
+| `resend-api-key`                       | Outbound email → `RESEND_API_KEY` (see below)                                                                                            | ✅ set                                                                                              |
+| `vapid-private-key`                    | Web push signing → `VAPID_PRIVATE_KEY`                                                                                                   | ✅ set                                                                                              |
+| `site-basic-auth`                      | Former "not public yet" lock → `SITE_BASIC_AUTH`                                                                                         | ⚠️ exists but **unused**                                                                            |
 
 `site-basic-auth` is a leftover: the running revision does not wire it, and the site answers
 without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta allowlist

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -1,0 +1,156 @@
+# Published-game snapshots
+
+**Status: ✅ built.** Serving reads the snapshot with a GitHub fallback; the bake runs
+on every merge to the games repo's `main`.
+
+## The problem
+
+Every play of a published game used to rebuild it on the request path:
+
+1. `getGameSources` fans out into authenticated GitHub reads — the game's own files,
+   plus each GameKit module its `GAME.json` selects, plus the shared shell and audio.
+2. `bundleGameTypeScript` runs esbuild over the result.
+3. `assembleGameHtml` produces the self-contained document.
+
+Cached for five minutes per slug, per instance. With `--min-instances 0`, a cold
+instance did that work for whichever games the visitor happened to open.
+
+Three things follow from that, and all three are avoidable:
+
+- **GitHub API availability and quota became a dependency of the play route** — the one
+  route that must never be down. A per-file Contents fan-out for the _catalog_ had
+  already caused a rate-limit outage once; that is why `getCatalog` batches through
+  GraphQL (see the comment at `github-client.ts:919`). Game assembly kept the same
+  shape.
+- **The work is identical every time.** A published game changes only when someone
+  merges to the games repo's `main`. Rebuilding it per cache miss recomputes a
+  constant.
+- **The cost lands on the visitor**, in a service pinned to `--max-instances 1` while
+  the multiplayer relay keeps room state in one process's memory.
+
+Baking moves the same work to merge time. Nothing about the work changes — only how
+often it happens.
+
+## Shape
+
+```
+current.json                              ← the pointer (small, mutable)
+snapshots/<id>/catalog.json               ← CatalogGameEntry[]
+snapshots/<id>/games/<slug>.json          ← { slug, title, html }
+snapshots/<id>/media/<slug>/<filename>    ← screenshots and gameplay video
+```
+
+Snapshot prefixes are immutable; only `current.json` is ever overwritten. Three
+properties fall out of that:
+
+- **Publishing is atomic.** Objects are written first and the pointer moves last, so a
+  half-written snapshot is invisible and the site serves the previous one throughout.
+- **Rollback is a pointer rewrite**, not a rebuild.
+- **Everything under `snapshots/` is safe to cache forever**, which is what makes
+  putting a CDN in front of the bucket a configuration change rather than a redesign.
+
+## Who bakes, and why it is this side
+
+`scripts/publish-snapshot.ts` runs in _this_ repo and reuses `assembleGameHtml` — the
+same function the play route calls.
+
+The games repo has its own `tools/build.ts` that emits standalone HTML, and uploading
+that instead would have removed GitHub from the loop entirely. It was the wrong trade:
+the restrictive CSP, the AI Act art. 50(2) provenance meta and the credential scan are
+applied _here_, at serve time. Baking on the games-repo side would move serve-time
+policy into a repo that does not own it, and would invert the drift problem that
+`games-repo-contract.ts` exists to prevent. It would also mean giving the games repo
+GCP credentials.
+
+So: the games repo stays the source of truth for _content_, this repo stays the source
+of truth for _what a served game is_, and the bake is where the two meet.
+
+## Serving
+
+`apps/api/src/submissions.ts` consults the snapshot first on three routes:
+
+| Route                              | Snapshot hit                  | Snapshot miss or error     |
+| ---------------------------------- | ----------------------------- | -------------------------- |
+| `GET /api/catalog`                 | `snapshots/<id>/catalog.json` | `client.getCatalog(ref)`   |
+| `GET /api/games/:slug`             | pre-assembled document        | GitHub sources + esbuild   |
+| `GET /api/games/:slug/media/:file` | snapshot bytes                | `client.getGameMedia(...)` |
+
+**The snapshot is a fast path, never a requirement.** An unset `GAMES_SNAPSHOT_BUCKET`,
+a game that failed to bake, an unbaked media file and a Cloud Storage outage all
+degrade to exactly the behaviour the site had before this existed. That is deliberate:
+the fallback is the reason this change is safe to ship in one step.
+
+Two invariants survive unchanged, and are tested:
+
+- **Publication is still decided by the catalog**, not by what happens to sit in the
+  bucket. A stale object cannot resurrect an unpublished game.
+- **Media is still gated by the catalog allowlist** before the snapshot is consulted, so
+  a stray object cannot widen what the API will serve.
+
+One deliberate exception: `isSlugPublished` skips the snapshot when it forces a
+refresh. That only happens during the publishing→published transition, which is
+precisely the window where the snapshot is the stale source and GitHub is the fresh
+one.
+
+## The publish path
+
+```
+merge to games-repo main
+  → validate.yml: npm run check
+  → validate.yml: regenerate + commit catalog.json
+  → validate.yml: repository_dispatch → this repo
+  → publish-games.yml: npm run snapshot:publish
+  → objects written, then current.json moves
+  → running instances pick it up within the pointer TTL (~1 min)
+```
+
+No redeploy is needed — instances re-read the pointer on its own TTL.
+
+Manual publish (after an assembler change here, or to recover a failed run): run
+**Publish games snapshot** via `workflow_dispatch`. It takes a `ref` and a `dry_run`
+that reports what would be baked without writing.
+
+Locally:
+
+```bash
+GAMES_REPO_TOKEN=... npm run snapshot:publish -- --dry-run
+GAMES_REPO_TOKEN=... GAMES_SNAPSHOT_BUCKET=... npm run snapshot:publish
+```
+
+### A game that fails to bake
+
+It stays in the snapshot catalog and simply gets no game object, so its play route
+falls back to GitHub — exactly what it did before. Dropping it from the catalog would
+silently unpublish a game because of a transient build failure, and catalog membership
+is the games repo's decision, not the bake job's.
+
+The job still exits non-zero, because the games repo's own gate should have caught it.
+
+## Configuration
+
+| Name                    | Where                      | Purpose                                                |
+| ----------------------- | -------------------------- | ------------------------------------------------------ |
+| `GAMES_SNAPSHOT_BUCKET` | Cloud Run env var          | Bucket to read snapshots from; unset disables the path |
+| `GAMES_REPO_TOKEN`      | this repo, Actions secret  | Contents:read PAT on the games repo, for the bake      |
+| `SITE_DISPATCH_TOKEN`   | games repo, Actions secret | Fine-grained PAT that may dispatch into this repo      |
+
+IAM is split by direction: the deploy service account has `storage.objectAdmin` (it
+writes), the Cloud Run runtime SA has `storage.objectViewer` (it reads). A compromised
+runtime cannot rewrite what it serves. `infra/setup-gcp.sh` step 7 provisions all of it,
+including a 90-day lifecycle rule on `snapshots/`.
+
+If the games repo ever goes 90 days without a merge, the live snapshot ages out and
+serving falls back to GitHub — degraded, not broken, which is the right way for a cost
+control to fail.
+
+## What this does not solve
+
+- **Bytes still flow through Cloud Run.** The API remains the games origin, which is
+  what keeps `PRIVATE_BETA` and the rate limits meaningful. Serving the bucket to
+  browsers directly would be faster and would take Cloud Run out of the byte path, but
+  it makes published games publicly reachable URLs and bypasses the beta gate. The
+  object layout is already CDN-shaped for when that trade becomes worth making.
+- **Preview and draft routes still read GitHub live**, and should — an unmerged PR head
+  has no snapshot, and that immediacy is the point of the creator's build channel.
+- **`--max-instances 1`** remains the scaling ceiling (see `docs/roadmap.md`). This
+  removes work from each request; it does not add instances.

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -37,7 +37,7 @@
 # Then run:
 #   PROJECT_ID=my-proj ./infra/deploy-api.sh
 #
-# Override any of these via env: REGION, SERVICE, REPO, GAMES_REPO.
+# Override any of these via env: REGION, SERVICE, REPO, GAMES_REPO, GAMES_SNAPSHOT_BUCKET.
 set -euo pipefail
 
 : "${PROJECT_ID:?set PROJECT_ID to your GCP project id}"
@@ -47,6 +47,9 @@ REGION="${REGION:-europe-west1}"
 SERVICE="${SERVICE:-gamedev-app}"
 REPO="${REPO:-gamedev}"
 GAMES_REPO="${GAMES_REPO:-gamedevpl/www.gamedev.pl-games}"
+# Pre-assembled published games, baked by .github/workflows/publish-games.yml.
+# Leave empty to serve every game from GitHub the way the site did before.
+GAMES_SNAPSHOT_BUCKET="${GAMES_SNAPSHOT_BUCKET:-${PROJECT_ID}-games-snapshots}"
 GOOGLE_OAUTH_CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-334141807880-t8qsj5n6p3g9imbs3jfut82cecvr87pu.apps.googleusercontent.com}"
 WEB_ORIGIN="${WEB_ORIGIN:-https://gamedev-app-334141807880.europe-west1.run.app,https://www.gamedev.pl,https://gamedev.pl}"
 # Apex → www 301 canonicalization (app-side; Cloud Run mappings can't redirect).
@@ -122,6 +125,9 @@ fi
 # ^|^ switches gcloud's env-var separator to | (pipe) so values may contain
 # commas (WEB_ORIGIN list) and @ signs (BETA_ALLOWED_EMAILS).
 ENV_VARS="^|^GAMES_REPO=${GAMES_REPO}|WEB_ORIGIN=${WEB_ORIGIN}|PRIVATE_BETA=${PRIVATE_BETA}"
+if [ -n "${GAMES_SNAPSHOT_BUCKET:-}" ]; then
+  ENV_VARS="${ENV_VARS}|GAMES_SNAPSHOT_BUCKET=${GAMES_SNAPSHOT_BUCKET}"
+fi
 if [ -n "${CANONICAL_HOST:-}" ]; then
   ENV_VARS="${ENV_VARS}|CANONICAL_HOST=${CANONICAL_HOST}"
 fi

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -48,8 +48,11 @@ SERVICE="${SERVICE:-gamedev-app}"
 REPO="${REPO:-gamedev}"
 GAMES_REPO="${GAMES_REPO:-gamedevpl/www.gamedev.pl-games}"
 # Pre-assembled published games, baked by .github/workflows/publish-games.yml.
-# Leave empty to serve every game from GitHub the way the site did before.
-GAMES_SNAPSHOT_BUCKET="${GAMES_SNAPSHOT_BUCKET:-${PROJECT_ID}-games-snapshots}"
+# Set GAMES_SNAPSHOT_BUCKET='' to serve every game from GitHub the way the site
+# did before. Note the `-` rather than `:-`: an explicit empty value has to survive
+# for that opt-out to work at all, and it is what makes the `-n` guard below mean
+# something instead of being always true.
+GAMES_SNAPSHOT_BUCKET="${GAMES_SNAPSHOT_BUCKET-${PROJECT_ID}-games-snapshots}"
 GOOGLE_OAUTH_CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-334141807880-t8qsj5n6p3g9imbs3jfut82cecvr87pu.apps.googleusercontent.com}"
 WEB_ORIGIN="${WEB_ORIGIN:-https://gamedev-app-334141807880.europe-west1.run.app,https://www.gamedev.pl,https://gamedev.pl}"
 # Apex → www 301 canonicalization (app-side; Cloud Run mappings can't redirect).

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -13,27 +13,27 @@ PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 REGION="${REGION:-europe-central2}"
 DEPLOYER_SA="${SA_NAME:-github-actions-deployer}@${PROJECT_ID}.iam.gserviceaccount.com"
 
-echo "==> 1/6 Enabling required GCP APIs"
+echo "==> 1/7 Enabling required GCP APIs"
 gcloud services enable run.googleapis.com cloudbuild.googleapis.com \
   artifactregistry.googleapis.com secretmanager.googleapis.com firestore.googleapis.com \
   aiplatform.googleapis.com \
   --project "$PROJECT_ID"
 
-echo "==> 2/6 Provisioning Firestore (Native Mode) in ${REGION}"
+echo "==> 2/7 Provisioning Firestore (Native Mode) in ${REGION}"
 if gcloud firestore databases describe --project "$PROJECT_ID" >/dev/null 2>&1; then
   echo "    Firestore database already exists."
 else
   gcloud firestore databases create --location="$REGION" --type=firestore-native --project="$PROJECT_ID"
 fi
 
-echo "==> 3/6 Granting datastore.user role to Deployer SA (${DEPLOYER_SA})"
+echo "==> 3/7 Granting datastore.user role to Deployer SA (${DEPLOYER_SA})"
 gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${DEPLOYER_SA}" \
   --role="roles/datastore.user" \
   --condition=None \
   >/dev/null
 
-echo "==> 4/6 Ensuring Cloud Run runtime SA has datastore.user and aiplatform.user roles"
+echo "==> 4/7 Ensuring Cloud Run runtime SA has datastore.user and aiplatform.user roles"
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
 RUN_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
 gcloud projects add-iam-policy-binding "$PROJECT_ID" \
@@ -48,7 +48,7 @@ gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --condition=None \
   >/dev/null
 
-echo "==> 5/6 Ensuring session-secret exists in Secret Manager and granting secretAccessor"
+echo "==> 5/7 Ensuring session-secret exists in Secret Manager and granting secretAccessor"
 if gcloud secrets describe session-secret --project "$PROJECT_ID" >/dev/null 2>&1; then
   echo "    Secret 'session-secret' already exists."
 else
@@ -80,7 +80,7 @@ gcloud secrets add-iam-policy-binding session-secret \
 # `ttls list` reports only fields that already have a policy, so a name match is the
 # existence check. Verified against the live ACTIVE playEvents policy on 2026-07-25.
 TELEMETRY_GROUPS="playEvents visitEvents"
-echo "==> 6/6 Ensuring the 90-day TTL policy on each telemetry collection group"
+echo "==> 6/7 Ensuring the 90-day TTL policy on each telemetry collection group"
 EXISTING_TTLS="$(gcloud firestore fields ttls list --project="$PROJECT_ID" --format="value(name)" 2>/dev/null || true)"
 for GROUP in $TELEMETRY_GROUPS; do
   if printf '%s\n' "$EXISTING_TTLS" | grep -q "collectionGroups/${GROUP}/fields/expiresAt"; then
@@ -98,5 +98,63 @@ for GROUP in $TELEMETRY_GROUPS; do
   fi
 done
 
+# Pre-assembled published games (apps/api/src/game-snapshot.ts). The bucket sits in
+# the Cloud Run region, not the Firestore one: it is read on the play path, and a
+# cross-region read would put the latency back that baking was meant to remove.
+SNAPSHOT_BUCKET="${GAMES_SNAPSHOT_BUCKET:-${PROJECT_ID}-games-snapshots}"
+SNAPSHOT_BUCKET_REGION="${SNAPSHOT_BUCKET_REGION:-europe-west1}"
+echo "==> 7/7 Ensuring the games snapshot bucket gs://${SNAPSHOT_BUCKET} exists"
+if gcloud storage buckets describe "gs://${SNAPSHOT_BUCKET}" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    Bucket already exists."
+else
+  # Uniform access: the objects are reached through the API, which applies the
+  # catalog allowlist and the beta gate. Per-object ACLs would be a second,
+  # weaker access model for the same bytes.
+  gcloud storage buckets create "gs://${SNAPSHOT_BUCKET}" \
+    --location="$SNAPSHOT_BUCKET_REGION" \
+    --uniform-bucket-level-access \
+    --project="$PROJECT_ID"
+  echo "    Created bucket in ${SNAPSHOT_BUCKET_REGION}."
+fi
+
+# The publish job (github-actions-deployer via WIF) writes; Cloud Run only reads.
+# Splitting the two means a compromised runtime cannot rewrite what it serves.
+gcloud storage buckets add-iam-policy-binding "gs://${SNAPSHOT_BUCKET}" \
+  --member="serviceAccount:${DEPLOYER_SA}" \
+  --role="roles/storage.objectAdmin" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+
+gcloud storage buckets add-iam-policy-binding "gs://${SNAPSHOT_BUCKET}" \
+  --member="serviceAccount:${RUN_SA}" \
+  --role="roles/storage.objectViewer" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+
+# Old snapshots are dead weight once the pointer moves past them, but they are
+# also the rollback path, so they are kept for a quarter rather than a day. If the
+# games repo ever goes 90 days without a merge the live snapshot ages out and
+# serving falls back to GitHub — degraded, not broken, which is the right way for
+# a cost control to fail.
+LIFECYCLE_FILE="$(mktemp)"
+cat > "$LIFECYCLE_FILE" <<'EOF'
+{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": { "type": "Delete" },
+        "condition": { "age": 90, "matchesPrefix": ["snapshots/"] }
+      }
+    ]
+  }
+}
+EOF
+gcloud storage buckets update "gs://${SNAPSHOT_BUCKET}" \
+  --lifecycle-file="$LIFECYCLE_FILE" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+rm -f "$LIFECYCLE_FILE"
+echo "    IAM (deployer: write, Cloud Run: read) and 90-day lifecycle applied."
+
 echo ""
-echo "==> Done. Firestore database, IAM roles (datastore.user, aiplatform.user), session-secret, and telemetry TTL configured for project ${PROJECT_ID}."
+echo "==> Done. Firestore database, snapshot bucket, IAM roles (datastore.user, aiplatform.user), session-secret, and telemetry TTL configured for project ${PROJECT_ID}."

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -14,9 +14,12 @@ REGION="${REGION:-europe-central2}"
 DEPLOYER_SA="${SA_NAME:-github-actions-deployer}@${PROJECT_ID}.iam.gserviceaccount.com"
 
 echo "==> 1/7 Enabling required GCP APIs"
+# storage.googleapis.com is needed by step 7 (the snapshot bucket) and by the Cloud
+# Run runtime that reads it. It is already on in most projects, but not guaranteed
+# on a fresh one — and without it step 7 fails after everything before it succeeded.
 gcloud services enable run.googleapis.com cloudbuild.googleapis.com \
   artifactregistry.googleapis.com secretmanager.googleapis.com firestore.googleapis.com \
-  aiplatform.googleapis.com \
+  aiplatform.googleapis.com storage.googleapis.com \
   --project "$PROJECT_ID"
 
 echo "==> 2/7 Provisioning Firestore (Native Mode) in ${REGION}"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "npm run build:packages && npm run test --workspaces --if-present",
     "e2e": "npm run e2e -w @gamedevpl/e2e",
     "contract:games-repo": "npm run contract:games-repo -w @gamedevpl/api",
+    "snapshot:publish": "npm run snapshot:publish -w @gamedevpl/api",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "type-check": "npm run build:packages && npm run type-check --workspaces --if-present",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run build:packages && npm run test --workspaces --if-present",
     "e2e": "npm run e2e -w @gamedevpl/e2e",
     "contract:games-repo": "npm run contract:games-repo -w @gamedevpl/api",
-    "snapshot:publish": "npm run snapshot:publish -w @gamedevpl/api",
+    "snapshot:publish": "npm run snapshot:publish -w @gamedevpl/api --",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "type-check": "npm run build:packages && npm run type-check --workspaces --if-present",
     "prepare": "husky install"


### PR DESCRIPTION
Paired with gamedevpl/www.gamedev.pl-games#74 — that PR adds the dispatch that triggers the bake. Neither changes behaviour without the other plus the setup steps below.

## The problem

Every play of a published game rebuilt it on the request path:

1. `getGameSources` fans out into authenticated GitHub reads — the game's own files, plus each GameKit module its `GAME.json` selects, plus the shared shell and audio.
2. `bundleGameTypeScript` runs esbuild over the result.
3. `assembleGameHtml` produces the self-contained document.

Cached five minutes per slug, per instance, with `--min-instances 0`.

Three consequences, all avoidable:

- **GitHub API availability and quota became a dependency of the play route** — the one route that must never be down. The per-file Contents fan-out for the *catalog* had already caused a rate-limit outage once; that is why `getCatalog` batches through GraphQL (`github-client.ts:919`). Game assembly kept the same shape.
- **The work is identical every time.** A published game changes only on a merge to the games repo's `main`. Rebuilding per cache miss recomputes a constant.
- **The cost lands on the visitor**, in a service pinned to `--max-instances 1`.

Baking moves the same work to merge time. The work itself doesn't change — only how often it happens.

## What changed

- **`apps/api/src/game-snapshot.ts`** — the store. Immutable `snapshots/<id>/` prefixes plus a small mutable `current.json` pointer. Objects are written first and the pointer last, so publishing is atomic, rollback is a pointer rewrite, and every snapshot object is cacheable forever. Talks to the Storage JSON API over `fetch` with an ADC bearer token rather than adding `@google-cloud/storage`: the surface needed is three verbs, `google-auth-library` was already a dependency, and keeping transport at the `fetch` boundary lets tests fake it the way `local-games-repo.ts` fakes GitHub.
- **`apps/api/src/game-snapshot-publish.ts`** — the bake.
- **`apps/api/scripts/publish-snapshot.ts`** — CLI with `--dry-run`, `--ref`, `--commit-sha`.
- **`apps/api/src/submissions.ts`** — catalog, play and media routes prefer the snapshot.
- **`.github/workflows/publish-games.yml`** — runs on `repository_dispatch` from the games repo, plus `workflow_dispatch` for manual re-bakes.
- **Infra** — bucket, split IAM and lifecycle rule in `setup-gcp.sh` (now step 7/7); `GAMES_SNAPSHOT_BUCKET` wired through `deploy.yml` and `deploy-api.sh`.
- **`docs/games-snapshot.md`** — design, publish path, configuration, and what this deliberately does not solve.

## Two decisions worth reviewing

**Assembly stayed on this side.** The games repo has its own `tools/build.ts` that emits standalone HTML, and uploading that instead would have removed GitHub from the loop entirely. It was the wrong trade: the restrictive CSP, the AI Act art. 50(2) provenance meta and the credential scan are serve-time policy owned by *this* repo. Baking on the games-repo side would move that policy into a repo that does not own it, invert the drift problem `games-repo-contract.ts` exists to prevent, and require giving the games repo GCP credentials.

**The snapshot is a fast path, never a requirement.** An unset `GAMES_SNAPSHOT_BUCKET`, a game that failed to bake, an unbaked media file, and a Cloud Storage outage all degrade to exactly the behaviour the site has today. That fallback is why this is safe to ship in one step rather than behind a flag.

A game that fails to bake stays in the snapshot catalog and gets no game object, so its play route falls back to GitHub. Dropping it would silently unpublish a game over a transient build failure, and catalog membership is the games repo's decision. The job still exits non-zero, since the games repo's own gate should have caught it.

## Invariants that survive, and are tested

- **Publication is still decided by the catalog**, not by what sits in the bucket — a stale object cannot resurrect an unpublished game.
- **Media is still gated by the catalog allowlist** *before* the snapshot is consulted, so a stray object cannot widen what the API serves.

One deliberate exception: `isSlugPublished` skips the snapshot when it forces a refresh. That only happens during the publishing→published transition, which is precisely the window where the snapshot is stale and GitHub is fresh.

## Verification

Lint, type-check and build clean. **677 API tests pass, 43 of them new** — 18 covering the store (object layout, pointer caching/coalescing/stale-on-error, path safety, cache headers), 12 the bake (policy reapplied, pointer written last, failure handling), 13 the serve path (snapshot hit avoids GitHub; miss, error and unset bucket all fall back; both allowlist invariants). Web (254) and generator (12) suites unaffected. Publish-script guard rails exercised directly; shell and YAML syntax checked.

## Note on the diff

The pre-commit prettier hook reformats `submissions.ts` wholesale on any commit that touches it, because master's copy was never prettier-clean. That buried the ~90-line change in an 806-line diff, so the untouched lines were restored to master's formatting and only the real edits kept — `submissions.ts` is now 88 insertions / 6 deletions. The file is left exactly as formatted as it is on master, and CI runs eslint rather than `prettier --check`, so nothing regresses. Worth fixing repo-wide separately, not here.

Both findings from the Copilot review are addressed in the second commit: `deploy-api.sh` now honours an explicitly empty `GAMES_SNAPSHOT_BUCKET` as the documented opt-out (`-` rather than `:-`, which also makes the `-n` guard below it meaningful), and `setup-gcp.sh` enables the Cloud Storage API that step 7 and the Cloud Run runtime both depend on.

## Before this does anything in production

Owner-run, none of which I could do from here:

1. `./infra/setup-gcp.sh` — provisions the bucket, split IAM (deploy SA writes, Cloud Run SA reads), and the 90-day lifecycle rule.
2. `SITE_DISPATCH_TOKEN` on the **games** repo — fine-grained PAT that may dispatch into this repo. Until it exists that step warns and skips.
3. Confirm the bucket name/region — I defaulted to `gamedevpl-games-snapshots` in `europe-west1` (co-located with Cloud Run); change in `deploy.yml`, `publish-games.yml` and `setup-gcp.sh` if you'd rather.

Worth a `--dry-run` via `workflow_dispatch` first to see the bake report against the real 83-game catalog before anything is written.

## Not addressed

Bytes still flow through Cloud Run — the API stays the games origin, which is what keeps `PRIVATE_BETA` and the rate limits meaningful. Serving the bucket to browsers directly would be faster but makes published games publicly reachable URLs. The object layout is already CDN-shaped for when that trade is worth making. Preview and draft routes still read GitHub live, and should. `--max-instances 1` remains the scaling ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01858DHfkaq7psPoJbveLkAk