### PR TITLE
Gate deploys on the browser suite, and decide play by breadth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -306,6 +306,32 @@ jobs:
 
           echo "Authenticated smoke passed as ${UID_VALUE}: bearer auth, cookie exchange, and the session wall all live."
 
+      # The browser gate. Everything above stops at HTTP, so play can be completely broken
+      # while every check is green: `/api/games/<slug>` returning HTML says nothing about
+      # whether that HTML runs. A CSP header, a sandbox change, a bundle regression or a
+      # broken assembler each return a healthy 200 and a black screen — and a site without
+      # playable games is worth nothing (apps/e2e, docs/deployment.md).
+      #
+      # `deploy` is a separate job from `ci-gate`, on a fresh runner with no node_modules —
+      # everything before this point is gcloud and curl — so Node is set up here.
+      - name: Set up Node for the browser gate
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser gate against the candidate
+        env:
+          E2E_BASE_URL: ${{ env.CANDIDATE_URL }}
+          GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
+        run: npm run e2e
+
       - name: Promote candidate revision to 100% traffic
         run: |
           gcloud run services update-traffic "$SERVICE" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,13 +323,24 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci
 
+      # PLAYWRIGHT_BROWSERS_PATH must be set for BOTH steps and must match: `install`
+      # writes to ~/.cache/ms-playwright by default, while the suite's findChromium()
+      # searches PLAYWRIGHT_BROWSERS_PATH (default /opt/pw-browsers). Unpinned, the
+      # browser lands where the suite never looks, every suite skips, and the job exits 0
+      # having verified nothing — a green deploy behind a gate that never ran.
       - name: Install Chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
         run: npx playwright install --with-deps chromium
 
       - name: Browser gate against the candidate
         env:
           E2E_BASE_URL: ${{ env.CANDIDATE_URL }}
           GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
+          # Turns "cannot run" into a failed deploy instead of a silent skip
+          # (apps/e2e/src/gate-prerequisites.test.ts).
+          E2E_REQUIRED: '1'
         run: npm run e2e
 
       - name: Promote candidate revision to 100% traffic

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ coverage
 *.tsbuildinfo
 .vite
 /gitleaks
+
+# Playwright/browser run artifacts (apps/e2e)
+test-results
+playwright-report

--- a/apps/e2e/src/auth.test.ts
+++ b/apps/e2e/src/auth.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { request, type APIRequestContext } from 'playwright-core';
-import { BASE_URL, signedInApiContext, storageStatePath } from './browser.js';
+import { BASE_URL, proxyOptions, signedInApiContext, storageStatePath } from './browser.js';
 
 /**
  * The credential contract, checked without a browser. If these fail, every browser
@@ -27,7 +27,7 @@ describe.skipIf(!hasToken)('agent access token', () => {
     // Cookie-less on purpose: /api/auth/me takes either credential, so asking it
     // through the signed-in context would answer 200 from the cookie and tell us
     // nothing about the bearer path this test exists to cover.
-    const clean = await request.newContext({ baseURL: BASE_URL });
+    const clean = await request.newContext({ baseURL: BASE_URL, ...proxyOptions() });
     try {
       const res = await clean.get('/api/auth/me', {
         headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
@@ -78,7 +78,7 @@ describe.skipIf(!hasToken)('agent access token', () => {
     // cookie on `api`, and /api/auth/me accepts either credential — reusing it here
     // authenticates by cookie and reports 200 no matter how bogus the bearer is,
     // which looks like the token wall failing open when nothing is wrong.
-    const clean = await request.newContext({ baseURL: BASE_URL });
+    const clean = await request.newContext({ baseURL: BASE_URL, ...proxyOptions() });
     try {
       // Assembled at runtime: a well-formed gdpl_pat_ literal in the source would
       // (correctly) trip gitleaks. Same construction as the deploy smoke.

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -9,10 +9,10 @@ import {
   type Page,
 } from 'playwright-core';
 import { inject } from 'vitest';
-import { BASE_URL, STORAGE_STATE_ENV } from './config.js';
+import { BASE_URL, proxyOptions, STORAGE_STATE_ENV } from './config.js';
 
 // Re-exported so test files have a single import site for the whole helper surface.
-export { BASE_URL, STORAGE_STATE_ENV };
+export { BASE_URL, proxyOptions, STORAGE_STATE_ENV };
 
 /**
  * Where Claude Code's remote environments pre-install Playwright's browsers.
@@ -158,7 +158,7 @@ export async function signedInApiContext(): Promise<APIRequestContext> {
   if (!storageState) {
     throw new Error(`${STORAGE_STATE_ENV} unset — globalSetup did not run or the token is missing`);
   }
-  return request.newContext({ baseURL: BASE_URL, storageState });
+  return request.newContext({ baseURL: BASE_URL, storageState, ...proxyOptions() });
 }
 
 /** A browser context carrying the bot's session cookie. */

--- a/apps/e2e/src/config.ts
+++ b/apps/e2e/src/config.ts
@@ -11,3 +11,21 @@ export const BASE_URL = process.env.E2E_BASE_URL ?? 'https://www.gamedev.pl';
 
 /** Key under which globalSetup publishes the once-per-run session state path. */
 export const STORAGE_STATE_ENV = 'E2E_STORAGE_STATE';
+
+/**
+ * Proxy options for `request.newContext`, when egress goes through a CONNECT proxy.
+ *
+ * `launchSiteBrowser` already does this for Chromium, but Playwright's **API** contexts
+ * need it too and are easy to miss: they do not read `HTTPS_PROXY` from the environment
+ * either, so in a proxied sandbox they bypass it, get a proxy `403`, and the failure
+ * reads as the site rejecting the credential. Lives here rather than in `browser.ts`
+ * because `globalSetup` runs in a context where importing that module (and through it,
+ * vitest) fails outright.
+ *
+ * No TLS cap needed here, unlike the browser: that workaround exists for Chromium's
+ * TLS 1.3 ClientHello, and Node's HTTP client does not trip it.
+ */
+export function proxyOptions(): { proxy?: { server: string } } {
+  const server = process.env.HTTPS_PROXY ?? process.env.https_proxy;
+  return server ? { proxy: { server } } : {};
+}

--- a/apps/e2e/src/games-playable.test.ts
+++ b/apps/e2e/src/games-playable.test.ts
@@ -1,0 +1,236 @@
+import type { APIRequestContext, Browser, BrowserContext, Frame, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { e2ePrerequisites, launchSiteBrowser, signedInApiContext, signedInContext, visit } from './browser.js';
+
+/**
+ * Are published games actually playable on this deployment?
+ *
+ * `walkthrough.test.ts` boots one game to prove the *player* works — the frame, the
+ * canvas, focus delivery. This asks the different question the deploy gate needs
+ * answered: is play broken **across the catalog**, which is what a bad deploy looks
+ * like. Every other check in `deploy.yml` stops at HTTP, and proving
+ * `/api/games/<slug>` returns HTML says nothing about whether that HTML runs — a CSP
+ * header, a sandbox change, a bundle regression or a broken assembler each return a
+ * healthy 200 and a black screen.
+ *
+ * The verdict is by **breadth**, and that is the whole point of this file existing
+ * separately. Games live in a separate, agent-maintained repo and change independently
+ * of this one, so a single broken game must not stop the website shipping — including
+ * the deploy that would fix it:
+ *
+ *   most sampled games fail → the deploy broke play → fail (blocks promotion)
+ *   exactly one fails       → that game is broken   → pass, with a loud warning
+ *   only one game exists    → nothing to compare    → fail; it *is* the site
+ */
+
+/** Enough games to tell "all broken" from "one broken" without lengthening the gate much. */
+const SAMPLE_SIZE = 3;
+
+/** Summed-RGB brightness above which a pixel counts as drawn rather than background. */
+const LIT_THRESHOLD = 60;
+
+interface CanvasSample {
+  /** Pixels brighter than the background — "did it draw anything at all". */
+  lit: number;
+  /** Order-dependent digest of the pixel data — "did what it drew change". */
+  digest: number;
+}
+
+interface GameReport {
+  slug: string;
+  frameAppeared: boolean;
+  sandbox: string | null;
+  litPixels: number;
+  animated: boolean;
+  /** Only probed when the game looked static; see below. */
+  respondedToInput?: boolean;
+  note?: string;
+}
+
+const prereq = e2ePrerequisites();
+
+/**
+ * Reads the canvas from inside the game's frame.
+ *
+ * Works despite the frame's opaque origin (`allow-scripts` with no `allow-same-origin`)
+ * because Playwright drives CDP, below the same-origin policy — verified against a real
+ * sandboxed `srcdoc` frame before this was written.
+ *
+ * Returns a digest as well as a count because a count alone cannot see motion: a sprite
+ * translating across a uniform background lights exactly as many pixels every frame, so
+ * comparing counts would report a healthy game as frozen and block a good deploy. Reading
+ * pixels in-frame rather than screenshotting also keeps repeated sampling cheap enough to
+ * do across several games.
+ */
+async function sampleCanvas(frame: Frame): Promise<CanvasSample | null> {
+  return frame
+    .evaluate((threshold) => {
+      const canvas = document.querySelector('canvas');
+      const context = canvas?.getContext('2d');
+      if (!canvas || !context) return null;
+      const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+      let lit = 0;
+      let digest = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        const brightness = (data[i] ?? 0) + (data[i + 1] ?? 0) + (data[i + 2] ?? 0);
+        if (brightness > threshold) lit++;
+        digest = (Math.imul(digest, 33) + brightness) | 0;
+      }
+      return { lit, digest };
+    }, LIT_THRESHOLD)
+    .catch(() => null);
+}
+
+async function inspectGame(page: Page, slug: string): Promise<GameReport> {
+  const report: GameReport = { slug, frameAppeared: false, sandbox: null, litPixels: -1, animated: false };
+
+  await visit(page, `/play/${encodeURIComponent(slug)}`, 4_000);
+
+  const iframe = page.locator('iframe').first();
+  report.sandbox = await iframe.getAttribute('sandbox').catch(() => null);
+
+  const frame = page.frames().find((candidate) => candidate !== page.mainFrame());
+  if (!frame) {
+    report.note = 'no game frame appeared';
+    return report;
+  }
+  report.frameAppeared = true;
+
+  // Three spaced samples, not two: a canvas can appear a beat late, and judging a game on
+  // a sample taken before it existed reports a healthy game as dead.
+  const samples: Array<CanvasSample | null> = [];
+  for (let take = 0; take < 3; take++) {
+    samples.push(await sampleCanvas(frame));
+    if (take < 2) await page.waitForTimeout(500);
+  }
+
+  const valid = samples.filter((sample): sample is CanvasSample => sample !== null);
+  if (valid.length === 0) {
+    report.note = 'no canvas in the game document';
+    return report;
+  }
+
+  report.litPixels = Math.max(...valid.map((sample) => sample.lit));
+  report.animated = valid.length > 1 && valid[0]!.digest !== valid[valid.length - 1]!.digest;
+
+  // A game that draws but never moves on its own is not necessarily broken — a puzzle or
+  // turn-based game legitimately redraws only on input. Poke it before calling it frozen,
+  // so "static by design" cannot block a deploy.
+  if (!report.animated) {
+    await page.keyboard.press('ArrowUp').catch(() => undefined);
+    await page.keyboard.press('Space').catch(() => undefined);
+    await page.waitForTimeout(400);
+    const poked = await sampleCanvas(frame);
+    report.respondedToInput = !!poked && poked.digest !== valid[valid.length - 1]!.digest;
+    if (report.respondedToInput) report.note = 'static until input, responded when poked';
+  }
+
+  return report;
+}
+
+/**
+ * Alive = sandboxed, a frame arrived, and the canvas *changed* — on its own or when poked.
+ *
+ * Liveness is the change, not the brightness: a dark palette can legitimately light
+ * nothing above the threshold, and requiring `lit > 0` would block a deploy over an art
+ * choice. A deploy that genuinely broke play leaves every canvas blank *and* frozen, which
+ * this still catches. `litPixels` stays in the report purely as a diagnostic.
+ */
+function playable(report: GameReport): boolean {
+  return (
+    report.sandbox === 'allow-scripts' && report.frameAppeared && (report.animated || report.respondedToInput === true)
+  );
+}
+
+describe.skipIf(!prereq.ok)('published games are playable', () => {
+  let browser: Browser;
+  let api: APIRequestContext;
+  let context: BrowserContext;
+  let page: Page;
+  let slugs: string[];
+
+  beforeAll(async () => {
+    api = await signedInApiContext();
+    browser = await launchSiteBrowser();
+    context = await signedInContext(browser, api);
+    page = await context.newPage();
+
+    // CI opens these games on every deploy. Play telemetry carries no uid by design, so
+    // the `bot:` exclusion that keeps agents out of creator metrics cannot reach it —
+    // dropping the beacons is the only way these plays stay out of per-game health.
+    await context.route('**/api/telemetry**', (route) => route.abort());
+
+    const catalog = (await (await api.get('/api/catalog')).json()) as Array<{
+      slug: string;
+      multiplayer: unknown | null;
+    }>;
+    // Single-player only: a party game needs a second participant to leave its lobby, so
+    // a solo browser would report it dead for reasons that have nothing to do with play.
+    slugs = catalog
+      .filter((entry) => !entry.multiplayer)
+      .map((entry) => entry.slug)
+      .slice(0, SAMPLE_SIZE);
+  }, 120_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await api?.dispose();
+  });
+
+  it('play works across the catalog, not just for one game', async () => {
+    expect(slugs.length, 'catalog must contain at least one single-player game').toBeGreaterThan(0);
+
+    const reports: GameReport[] = [];
+    for (const slug of slugs) {
+      reports.push(await inspectGame(page, slug));
+    }
+
+    for (const report of reports) {
+      console.log(
+        `${playable(report) ? 'OK  ' : 'FAIL'} ${report.slug}  sandbox=${report.sandbox} ` +
+          `frame=${report.frameAppeared} lit=${report.litPixels} animated=${report.animated} ` +
+          `input=${report.respondedToInput ?? 'n/a'}${report.note ? `  (${report.note})` : ''}`,
+      );
+    }
+
+    const broken = reports.filter((report) => !playable(report));
+    const working = reports.filter(playable);
+
+    // One broken game out of several is a games-repo problem. Say so loudly and let the
+    // website ship — holding the deploy would punish this repo for another's content.
+    if (broken.length === 1 && working.length > 0) {
+      const failed = broken[0]!;
+      console.warn(
+        `::warning title=Game not playable::${failed.slug} did not run on this revision ` +
+          `(lit=${failed.litPixels}, animated=${failed.animated}). The other sampled games play, ` +
+          `so this is a games-repo issue rather than a deploy regression.`,
+      );
+      return;
+    }
+
+    expect(
+      broken.map((report) => report.slug),
+      `play looks broken on this revision — ${broken.length}/${reports.length} sampled games failed to run. ` +
+        `Blocking promotion: a site without playable games is worth nothing.`,
+    ).toEqual([]);
+  }, 240_000);
+
+  it('runs every game in a frame that cannot reach the app', async () => {
+    // The repo's one non-negotiable safety invariant, asserted on the *deployed, rendered*
+    // page rather than on the component in jsdom. `allow-same-origin` would hand generated
+    // code this app's DOM, storage and cookies.
+    const sandboxes = new Set<string | null>();
+    for (const slug of slugs) {
+      await visit(page, `/play/${encodeURIComponent(slug)}`, 2_000);
+      sandboxes.add(
+        await page
+          .locator('iframe')
+          .first()
+          .getAttribute('sandbox')
+          .catch(() => null),
+      );
+    }
+
+    expect([...sandboxes], 'every game frame must be exactly allow-scripts').toEqual(['allow-scripts']);
+  }, 180_000);
+});

--- a/apps/e2e/src/games-playable.test.ts
+++ b/apps/e2e/src/games-playable.test.ts
@@ -20,7 +20,7 @@ import { e2ePrerequisites, launchSiteBrowser, signedInApiContext, signedInContex
  *
  *   most sampled games fail → the deploy broke play → fail (blocks promotion)
  *   exactly one fails       → that game is broken   → pass, with a loud warning
- *   only one game exists    → nothing to compare    → fail; it *is* the site
+ *   only one game exists    → no warn path at all   → its failure blocks; it *is* the site
  */
 
 /** Enough games to tell "all broken" from "one broken" without lengthening the gate much. */
@@ -222,13 +222,13 @@ describe.skipIf(!prereq.ok)('published games are playable', () => {
     const sandboxes = new Set<string | null>();
     for (const slug of slugs) {
       await visit(page, `/play/${encodeURIComponent(slug)}`, 2_000);
-      sandboxes.add(
-        await page
-          .locator('iframe')
-          .first()
-          .getAttribute('sandbox')
-          .catch(() => null),
-      );
+      // Wait for attachment before reading. On a cold start the frame arrives a moment
+      // after the settle, and `getAttribute` on a not-yet-present element returns null —
+      // which would read as "sandbox missing" and block promotion over a slow revision
+      // rather than a real defect.
+      const iframe = page.locator('iframe').first();
+      await iframe.waitFor({ state: 'attached', timeout: 30_000 });
+      sandboxes.add(await iframe.getAttribute('sandbox'));
     }
 
     expect([...sandboxes], 'every game frame must be exactly allow-scripts').toEqual(['allow-scripts']);

--- a/apps/e2e/src/gate-prerequisites.test.ts
+++ b/apps/e2e/src/gate-prerequisites.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { e2ePrerequisites } from './browser.js';
+
+/**
+ * A gate that can silently skip is not a gate.
+ *
+ * Every other suite here is `describe.skipIf(!prereq.ok)`, which is right locally — a
+ * contributor without a token should not get failures they cannot act on. But that same
+ * behaviour, running as a deploy gate, produces the worst possible outcome: a missing
+ * token or an unresolvable browser makes the whole suite skip, the job exits 0, and the
+ * deploy promotes having verified nothing. Green, and meaningless.
+ *
+ * This file deliberately does **not** skip. When `E2E_REQUIRED=1` — which
+ * `.github/workflows/deploy.yml` sets — an unusable environment is a hard failure that
+ * stops promotion, in exactly the situation where absence of signal would otherwise be
+ * mistaken for a pass.
+ *
+ * The failure this was written for: `findChromium()` searches `PLAYWRIGHT_BROWSERS_PATH`
+ * (default `/opt/pw-browsers`), while `npx playwright install` on a GitHub runner writes
+ * to `~/.cache/ms-playwright`. Without the workflow pinning that variable, the browser is
+ * installed somewhere the suite never looks, everything skips, and the gate is decorative.
+ */
+describe('deploy gate prerequisites', () => {
+  it('can actually run when the environment claims to be gating', () => {
+    if (process.env.E2E_REQUIRED !== '1') {
+      // Local run: skipping is legitimate and the other suites explain themselves.
+      expect(true).toBe(true);
+      return;
+    }
+
+    const prereq = e2ePrerequisites();
+    expect(
+      prereq.ok,
+      `E2E_REQUIRED=1 but this suite cannot run: ${prereq.reason}. ` +
+        'The gate would have skipped and let the deploy promote unverified.',
+    ).toBe(true);
+  });
+});

--- a/apps/e2e/src/globalSetup.ts
+++ b/apps/e2e/src/globalSetup.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { request } from 'playwright-core';
 // From config.js, not browser.js: browser.js imports `inject` from vitest, and
 // importing vitest inside globalSetup fails — it runs in a different context.
-import { BASE_URL, STORAGE_STATE_ENV } from './config.js';
+import { BASE_URL, proxyOptions, STORAGE_STATE_ENV } from './config.js';
 
 /**
  * Exchange the access token for a session cookie exactly once per run.
@@ -24,7 +24,7 @@ let directory: string | undefined;
 export async function setup({ provide }: { provide: (key: string, value: unknown) => void }) {
   if (!process.env.GAMEDEV_ACCESS_TOKEN) return; // suites skip themselves; nothing to set up
 
-  const api = await request.newContext({ baseURL: BASE_URL });
+  const api = await request.newContext({ baseURL: BASE_URL, ...proxyOptions() });
   try {
     const res = await api.post('/api/auth/session', {
       headers: { Authorization: `Bearer ${process.env.GAMEDEV_ACCESS_TOKEN}` },
@@ -38,7 +38,9 @@ export async function setup({ provide }: { provide: (key: string, value: unknown
     }
     if (res.status() !== 200) {
       throw new Error(
-        `token→session exchange failed (${res.status()}). Likely expired or revoked — ` +
+        `token→session exchange failed (${res.status()}). If 403 from a sandbox, suspect the ` +
+          'egress proxy before the token — HTTPS_PROXY must reach ' +
+          `${BASE_URL}. Otherwise it is expired or revoked: ` +
           'npm run token:list -w @gamedevpl/api -- bot:e2e',
       );
     }

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { APIRequestContext, Browser, BrowserContext, Page } from 'playwright-core';
+import type { APIRequestContext, Browser, BrowserContext, Frame, Page } from 'playwright-core';
 import {
   BASE_URL,
   collectProblems,
@@ -73,14 +73,35 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
   });
 
   it('boots a generated game into a live canvas that can receive input', async () => {
-    const { slug } = singlePlayer();
-    await visit(page, `/play/${slug}`, 6_000);
+    // Try a few games rather than pinning whichever sorts first. This test is about the
+    // *player* — frame, canvas, focus delivery — and games live in a separate,
+    // agent-maintained repo. Now that this suite gates deploys, letting one broken game
+    // fail it would hold the website hostage to another repo's content. Whether the
+    // catalog at large is broken is games-playable.test.ts's question, and it is the one
+    // that blocks.
+    const candidates = catalog.filter((g) => !g.multiplayer).slice(0, 3);
+    expect(candidates.length, 'catalog has no single-player game to exercise').toBeGreaterThan(0);
 
-    // Games run in a sandboxed iframe (allow-scripts, no allow-same-origin). The
-    // canvas living inside it is the only real proof the generated bundle booted.
-    const frame = page.frames().find((f) => f !== page.mainFrame());
-    expect(frame, 'game iframe should exist').toBeTruthy();
-    await expect.poll(() => frame!.locator('canvas').count(), { timeout: 30_000 }).toBeGreaterThan(0);
+    let frame: Frame | undefined;
+    for (const candidate of candidates) {
+      await visit(page, `/play/${candidate.slug}`, 6_000);
+      const found = page.frames().find((f) => f !== page.mainFrame());
+      if (!found) continue;
+      // Games run in a sandboxed iframe (allow-scripts, no allow-same-origin). The
+      // canvas living inside it is the only real proof the generated bundle booted.
+      const booted = await found
+        .locator('canvas')
+        .first()
+        .waitFor({ state: 'attached', timeout: 20_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (booted) {
+        frame = found;
+        break;
+      }
+      watcher.drain(); // a candidate that never booted leaves noise that is not this test's finding
+    }
+    expect(frame, 'no sampled single-player game booted a canvas').toBeTruthy();
 
     // These games draw everything — HUD included — into the canvas, so the frame's
     // innerText never moves and pixels are the only readable output. A canvas that

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,7 +35,7 @@ Deployments to Cloud Run are triggered on push to `master`:
 4. **Staging / Candidate Revision:** Deploys revision to Cloud Run with `--no-traffic --tag candidate`.
 5. **Candidate Smoke Test:** Anonymous checks (health, shell, public catalog/play, walls hold, forged bearer token rejected) plus an **authenticated smoke** when the `GAMEDEV_ACCESS_TOKEN` repo secret exists — bearer auth, token→cookie exchange, and a session-walled route, run as the CI bot (see [`agent-access-tokens.md`](./agent-access-tokens.md)). Skips loudly when the secret is absent.
 6. **Browser gate (`apps/e2e`):** Drives real Chromium against the candidate and asserts the site works where HTTP checks cannot see — most importantly that **published games actually run**. See below for why this blocks.
-7. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if the smoke test succeeds.
+7. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if **both** the curl smoke checks and the browser gate succeed.
 
 ### Why the browser gate blocks a deploy
 
@@ -49,11 +49,11 @@ The one thing that must not block is a single badly-written game — those live 
 agent-maintained repo and change independently of this one. So `games-playable.test.ts`
 samples several single-player games and decides by breadth:
 
-| Sample result        | Meaning                    | Outcome                     |
-| -------------------- | -------------------------- | --------------------------- |
-| most games fail      | the deploy broke play      | **blocks promotion**        |
-| exactly one fails    | that game is broken        | `::warning::`, ships        |
-| only one game exists | nothing to compare against | **blocks** — it is the site |
+| Sample result        | Meaning                      | Outcome                                 |
+| -------------------- | ---------------------------- | --------------------------------------- |
+| most games fail      | the deploy broke play        | **blocks promotion**                    |
+| exactly one fails    | that game is broken          | `::warning::`, ships                    |
+| only one game exists | no warn path to fall back on | its failure **blocks** — it is the site |
 
 Liveness is _change_, not brightness: the canvas is read in-frame and digested, so a sprite
 moving across a uniform background still counts as alive, and a dark palette is not mistaken
@@ -61,8 +61,15 @@ for a black screen. A game that never moves on its own is poked with input befor
 called frozen. The sandbox invariant (`allow-scripts`, never `allow-same-origin`) is asserted
 on every sampled game's rendered frame — something jsdom unit tests cannot do.
 
-Without `GAMEDEV_ACCESS_TOKEN` the suite skips loudly rather than passing silently. Run it
-yourself against anything: `E2E_BASE_URL=https://www.gamedev.pl npm run e2e`.
+Locally, the suite skips without a token or a browser — a contributor should not get
+failures they cannot act on. **In CI that would be the worst outcome**: a skipped suite
+exits 0 and the deploy promotes having verified nothing. So the workflow sets
+`E2E_REQUIRED=1`, and `gate-prerequisites.test.ts` (which never skips) turns an unusable
+environment into a failed deploy. It also pins `PLAYWRIGHT_BROWSERS_PATH` for both the
+install and the run: unpinned, `playwright install` writes to `~/.cache/ms-playwright`
+while the suite looks in `/opt/pw-browsers`, and the gate skips itself into uselessness.
+
+Run it yourself against anything: `E2E_BASE_URL=https://www.gamedev.pl npm run e2e`.
 
 ## Secrets & access (current live state)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,35 @@ Deployments to Cloud Run are triggered on push to `master`:
 3. **Cloud Build Image Creation:** Submits image build using `infra/cloudbuild.yaml` to Artifact Registry. The WIF deployer service account must also have `roles/serviceusage.serviceUsageConsumer` and storage access for the default Cloud Build staging bucket; `infra/setup-wif.sh` grants both.
 4. **Staging / Candidate Revision:** Deploys revision to Cloud Run with `--no-traffic --tag candidate`.
 5. **Candidate Smoke Test:** Anonymous checks (health, shell, public catalog/play, walls hold, forged bearer token rejected) plus an **authenticated smoke** when the `GAMEDEV_ACCESS_TOKEN` repo secret exists — bearer auth, token→cookie exchange, and a session-walled route, run as the CI bot (see [`agent-access-tokens.md`](./agent-access-tokens.md)). Skips loudly when the secret is absent.
-6. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if the smoke test succeeds.
+6. **Browser gate (`apps/e2e`):** Drives real Chromium against the candidate and asserts the site works where HTTP checks cannot see — most importantly that **published games actually run**. See below for why this blocks.
+7. **Traffic Promotion & Tag Cleanup:** Promotes traffic to the latest revision (`--to-latest`) and removes the candidate tag (`--remove-tags candidate`) only if the smoke test succeeds.
+
+### Why the browser gate blocks a deploy
+
+Playable games are the product; a site that loads but plays nothing is worth nothing. Every
+other check stops at HTTP, so play can be completely broken while the deploy is green:
+proving `/api/games/<slug>` returns HTML says nothing about whether that HTML _runs_. A CSP
+header, a sandbox change, a bundle regression or a broken assembler each return a healthy
+200 and a black screen.
+
+The one thing that must not block is a single badly-written game — those live in a separate,
+agent-maintained repo and change independently of this one. So `games-playable.test.ts`
+samples several single-player games and decides by breadth:
+
+| Sample result        | Meaning                    | Outcome                     |
+| -------------------- | -------------------------- | --------------------------- |
+| most games fail      | the deploy broke play      | **blocks promotion**        |
+| exactly one fails    | that game is broken        | `::warning::`, ships        |
+| only one game exists | nothing to compare against | **blocks** — it is the site |
+
+Liveness is _change_, not brightness: the canvas is read in-frame and digested, so a sprite
+moving across a uniform background still counts as alive, and a dark palette is not mistaken
+for a black screen. A game that never moves on its own is poked with input before being
+called frozen. The sandbox invariant (`allow-scripts`, never `allow-same-origin`) is asserted
+on every sampled game's rendered frame — something jsdom unit tests cannot do.
+
+Without `GAMEDEV_ACCESS_TOKEN` the suite skips loudly rather than passing silently. Run it
+yourself against anything: `E2E_BASE_URL=https://www.gamedev.pl npm run e2e`.
 
 ## Secrets & access (current live state)
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Builds on #257 rather than duplicating it. That suite can prove the deployed site works; nothing yet *stops a deploy* when it doesn't. This closes the two gaps it deliberately left open, and supersedes #255 (which I'm closing — same goal, worse foundation).

## 1. The gate

`npm run e2e` now runs in `deploy.yml` against `CANDIDATE_URL`, before promotion. #257 identified this as the natural home but didn't want to change gating unasked.

The `deploy` job is separate from `ci-gate`, on a fresh runner with no `node_modules` — everything before this point is gcloud and curl — so it sets Node up itself. Worth stating because the omission is invisible on a PR: `deploy.yml` only runs on push to master, so no PR check can catch a broken deploy job.

## 2. Play is decided by breadth

`games-playable.test.ts` samples several single-player games:

| Sample result | Meaning | Outcome |
| --- | --- | --- |
| most games fail | the deploy broke play | **blocks promotion** |
| exactly one fails | that game is broken | `::warning::`, ships |
| only one game exists | nothing to compare against | **blocks** — it *is* the site |

This rule is why the file exists separately. Games live in a separate, agent-maintained repo and change independently, so without it one bad game would hold the website hostage — including the deploy that would fix it.

**Liveness is change, not brightness.** The canvas is read in-frame and digested rather than screenshotted, so a sprite crossing a uniform background still counts as alive — a lit-pixel count would call it frozen and block a good deploy — and a dark palette isn't mistaken for a black screen. A game that never moves on its own is poked with input before being called dead. Reading pixels in-frame instead of screenshotting also keeps sampling cheap enough to do across several games.

`walkthrough.test.ts`'s boot test now tries a few candidates instead of pinning whichever game sorts first. It's about the *player* — frame, canvas, focus delivery — and once the suite gates deploys, one broken game must not fail it.

## 3. A gap that blocked the suite entirely in a proxied sandbox

`launchSiteBrowser` configures the proxy, but **all three `APIRequestContext`s did not** — `globalSetup`, `signedInApiContext`, and two in `auth.test.ts`. They bypassed `HTTPS_PROXY`, got a proxy `403`, and it surfaced as:

```
token→session exchange failed (403). Likely expired or revoked
```

Which sends you to check a perfectly good token. Shared `proxyOptions()` now lives in `config.ts` — the module that deliberately avoids importing vitest, so `globalSetup` can use it — and the error message names the proxy as the first suspect.

## Verification

**21/21 against live production**, sampling `apex-sprint`, `beat-teacher` and `block-cascade` — all animating:

```
OK   apex-sprint    sandbox=allow-scripts frame=true lit=256000 animated=true
OK   beat-teacher   sandbox=allow-scripts frame=true lit=256000 animated=true
OK   block-cascade  sandbox=allow-scripts frame=true lit=105238 animated=true
Test Files  5 passed (5)   Tests  21 passed (21)
```

`type-check`, `lint`, `test`, `build` all exit 0, each run unpiped with its status checked. `npm run test` confirmed still offline and e2e-free.

Play telemetry is aborted in the games suite: those events carry no uid, so the `bot:` exclusion can't reach them, and several CI plays per deploy would otherwise corrupt per-game health.

## Not verified

The gate itself has never executed as a workflow — `deploy.yml` can't run from a PR, so its first real run is on merge. The steps are YAML-validated and every command in them has been run by hand here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT8ueQTiejuiksCUd2oxQx)_