### PR TITLE
Fix the browser gate: hand it the Chromium that was actually installed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,16 +328,31 @@ jobs:
       # searches PLAYWRIGHT_BROWSERS_PATH (default /opt/pw-browsers). Unpinned, the
       # browser lands where the suite never looks, every suite skips, and the job exits 0
       # having verified nothing — a green deploy behind a gate that never ran.
+      # `npx playwright install` resolves the *latest* playwright CLI — the workspace has
+      # playwright-core, which ships no CLI — so the directory layout it produces is not
+      # something to assume. findChromium()'s `chromium-<build>/chrome-linux/chrome` guess
+      # missed it on the first real run and the gate refused to run at all. Locate the
+      # binary that was actually installed and hand it over explicitly; E2E_CHROMIUM_PATH
+      # takes priority over every heuristic in findChromium().
       - name: Install Chromium
         env:
           PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          npx playwright install --with-deps chromium
+
+          BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -name chrome -perm -u+x 2>/dev/null | sort | tail -1)
+          if [ -z "$BIN" ]; then
+            echo "::error::no chromium binary under $PLAYWRIGHT_BROWSERS_PATH — layout below"
+            find "$PLAYWRIGHT_BROWSERS_PATH" -maxdepth 3 | head -50
+            exit 1
+          fi
+          echo "Chromium: $BIN"
+          echo "E2E_CHROMIUM_PATH=$BIN" >> "$GITHUB_ENV"
 
       - name: Browser gate against the candidate
         env:
           E2E_BASE_URL: ${{ env.CANDIDATE_URL }}
           GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
-          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
           # Turns "cannot run" into a failed deploy instead of a silent skip
           # (apps/e2e/src/gate-prerequisites.test.ts).
           E2E_REQUIRED: '1'


### PR DESCRIPTION
**Master cannot deploy until this lands.** The first real run of the browser gate (#261) refused to run and blocked promotion:

```
E2E_REQUIRED=1 but this suite cannot run: no pre-installed Chromium found.
The gate would have skipped and let the deploy promote unverified.
→ Promote candidate revision: SKIPPED
```

The live revision kept serving 100% of traffic throughout, so there is no site impact — but every subsequent deploy fails at the same step.

## Cause

Pinning `PLAYWRIGHT_BROWSERS_PATH` wasn't enough. `npx playwright install` resolves the **latest** `playwright` CLI — the workspace carries `playwright-core`, which ships no CLI — so the directory layout it produces isn't something `findChromium()`'s `chromium-<build>/chrome-linux/chrome` pattern can assume.

## Fix

Stop guessing. Locate the binary that was actually installed and export `E2E_CHROMIUM_PATH`, which `findChromium()` already honours ahead of every heuristic:

```bash
BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -name chrome -perm -u+x | sort | tail -1)
```

If nothing is found, the step fails with the directory tree printed — so the next diagnosis takes one look rather than another deploy cycle.

## Verification

Ran the suite locally through exactly the path CI now uses — `E2E_CHROMIUM_PATH` pointing at a real Playwright chromium:

```
OK   apex-sprint    sandbox=allow-scripts frame=true lit=256000 animated=true
OK   beat-teacher   sandbox=allow-scripts frame=true lit=256000 animated=true
OK   block-cascade  sandbox=allow-scripts frame=true lit=105238 animated=true
Test Files  6 passed (6)   Tests  22 passed (22)
```

And confirmed the negative: a bad `E2E_CHROMIUM_PATH` fails the prerequisite test rather than skipping.

## Worth noting

The gate behaved **correctly** on its first outing. It refused to certify a revision it had not actually checked, promotion was skipped, and production was never touched. A silent skip here would have shipped an unverified revision while reporting success — which is precisely the failure `gate-prerequisites.test.ts` was added to prevent. It caught its own harness.

The remaining unknown is unchanged and unavoidable: `deploy.yml` cannot run from a PR, so this fix is also proven only on merge. The difference is that a failure now prints the browser layout instead of just saying it found nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT8ueQTiejuiksCUd2oxQx)_