### PR TITLE
Fix a shell injection in copilot-task.yml and enforce the ESM import convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,9 @@ See [`docs/architecture.md`](../docs/architecture.md#sandboxed-game-execution).
 ## Conventions
 
 - **ESM only** — every package is `"type": "module"`; use `.js` extensions in relative TS
-  imports (e.g. `import { x } from './mock.js'`).
+  imports (e.g. `import { x } from './mock.js'`). Enforced by the
+  `gamedev/relative-import-extensions` lint rule, so `npm run lint -- --fix` will write the
+  correct specifier for you — including `./dir/index.js` where `./dir` is a directory.
 - **TypeScript strict** — `strict`, `noUnusedLocals`, `noUnusedParameters`,
   `noFallthroughCasesInSwitch`. Prefix intentionally-unused args with `_`.
 - **Small, focused files**; comment _why_, not _what_.

--- a/.github/workflows/copilot-task.yml
+++ b/.github/workflows/copilot-task.yml
@@ -7,8 +7,10 @@ on:
         description: 'Task description for Copilot'
         required: true
         type: string
-  issue_comment:
-    types: [created]
+  # No issue_comment trigger: this workflow reads its task from inputs.task or
+  # client_payload.task, neither of which a comment event carries. It used to fire
+  # on every comment created anywhere in the repo, running the full npm ci +
+  # type-check + lint + test + build gate to echo an empty string.
   repository_dispatch:
     types: [copilot-task]
 
@@ -39,6 +41,14 @@ jobs:
       - name: Verify Baseline (Green Gate)
         run: npm run type-check && npm run lint && npm run test && npm run build
 
+      # The task text is attacker-influenced (anyone who can fire workflow_dispatch or
+      # repository_dispatch picks it). Interpolating ${{ }} directly into `run:` splices
+      # it into the script *before* bash parses it, so a payload containing $(...) or a
+      # newline executes as code. Passing it through the environment instead means bash
+      # only ever sees it as a variable's value, never as script text — hence the env
+      # block plus a quoted expansion rather than a bare ${{ }} inside the script.
       - name: Echo Task Payload
+        env:
+          TASK: ${{ github.event.inputs.task || github.event.client_payload.task }}
         run: |
-          echo "Executing task: ${{ github.event.inputs.task || github.event.client_payload.task }}"
+          echo "Executing task: ${TASK}"

--- a/apps/web/src/App.anonymousPlay.test.ts
+++ b/apps/web/src/App.anonymousPlay.test.ts
@@ -3,9 +3,9 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
-import { AuthProvider } from './AuthContext';
-import i18n from './i18n';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
 
 /**
  * Closed beta: anonymous visitors see the splash, not the arcade.

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -3,10 +3,10 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
-import { AuthProvider } from './AuthContext';
-import { NAVIGATE_EVENT, type NavigateEventDetail } from './router';
-import i18n from './i18n';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import { NAVIGATE_EVENT, type NavigateEventDetail } from './router.js';
+import i18n from './i18n/index.js';
 
 async function flushEffects() {
   await Promise.resolve();

--- a/apps/web/src/App.documentTitle.test.ts
+++ b/apps/web/src/App.documentTitle.test.ts
@@ -3,9 +3,9 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
-import { AuthProvider } from './AuthContext';
-import i18n from './i18n';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
 
 async function flushEffects() {
   await Promise.resolve();

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -3,9 +3,9 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { App } from './App';
-import { AuthProvider } from './AuthContext';
-import i18n from './i18n';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
 
 /**
  * The QA gate as the creator meets it: type an idea, get questions, answer them.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,23 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { generateGame, type GeneratedGame, type GenerateGameApiError } from './api';
-import { fetchCatalog, type CatalogEntry } from './catalog';
-import { GameTheater } from './GameTheater';
-import { NavHeader } from './NavHeader';
-import { HeroPromptSection } from './HeroPromptSection';
-import { ArcadeCatalog } from './ArcadeCatalog';
-import { MyGamesRail } from './MyGamesRail';
-import { DraftView } from './DraftView';
-import { GameHealthView } from './GameHealthView';
-import { PixelIcon } from './PixelIcon';
-import { SubmissionStatusView } from './SubmissionStatusView';
-import { CreatorQA, type QAQuestion } from './CreatorQA';
-import { canonicalPlayPath, NAVIGATE_EVENT, parsePathRoute, statusPath, playPath, type AppRoute } from './router';
-import { LegalPage } from './LegalPage';
-import { NotFoundPage } from './NotFoundPage';
-import { SiteFooter } from './SiteFooter';
-import { resolveDocumentTitle } from './pageTitle';
-import { useDocumentTitle } from './useDocumentTitle';
+import { generateGame, type GeneratedGame, type GenerateGameApiError } from './api.js';
+import { fetchCatalog, type CatalogEntry } from './catalog.js';
+import { GameTheater } from './GameTheater.js';
+import { NavHeader } from './NavHeader.js';
+import { HeroPromptSection } from './HeroPromptSection.js';
+import { ArcadeCatalog } from './ArcadeCatalog.js';
+import { MyGamesRail } from './MyGamesRail.js';
+import { DraftView } from './DraftView.js';
+import { GameHealthView } from './GameHealthView.js';
+import { PixelIcon } from './PixelIcon.js';
+import { SubmissionStatusView } from './SubmissionStatusView.js';
+import { CreatorQA, type QAQuestion } from './CreatorQA.js';
+import { canonicalPlayPath, NAVIGATE_EVENT, parsePathRoute, statusPath, playPath, type AppRoute } from './router.js';
+import { LegalPage } from './LegalPage.js';
+import { NotFoundPage } from './NotFoundPage.js';
+import { SiteFooter } from './SiteFooter.js';
+import { resolveDocumentTitle } from './pageTitle.js';
+import { useDocumentTitle } from './useDocumentTitle.js';
 
 /** Read the current URL into an AppRoute, rewriting `/ay|/ai/<slug>` → `/play/<slug>`. */
 function readLocationRoute(): AppRoute {
@@ -27,17 +27,17 @@ function readLocationRoute(): AppRoute {
   }
   return parsePathRoute(window.location.pathname, window.location.hash);
 }
-import { submitSpec, refineSpec, type SubmissionApiError } from './submissionApi';
-import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs';
-import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa';
-import { useAuth } from './AuthContext';
-import { AuthModal } from './AuthModal';
-import { recordCreateStep } from './visitTelemetry';
-import { ClosedBetaSplash } from './ClosedBetaSplash';
-import { AppLoadingScreen } from './AppLoadingScreen';
-import { ControllerView } from './mp/ControllerView';
-import { PartyStage } from './mp/PartyStage';
-import { createPartySession, type PartySession } from './mp/mpApi';
+import { submitSpec, refineSpec, type SubmissionApiError } from './submissionApi.js';
+import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs.js';
+import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa.js';
+import { useAuth } from './AuthContext.js';
+import { AuthModal } from './AuthModal.js';
+import { recordCreateStep } from './visitTelemetry.js';
+import { ClosedBetaSplash } from './ClosedBetaSplash.js';
+import { AppLoadingScreen } from './AppLoadingScreen.js';
+import { ControllerView } from './mp/ControllerView.js';
+import { PartyStage } from './mp/PartyStage.js';
+import { createPartySession, type PartySession } from './mp/mpApi.js';
 
 type StageContent =
   | { type: 'catalog'; game: CatalogEntry }

--- a/apps/web/src/AppLoadingScreen.tsx
+++ b/apps/web/src/AppLoadingScreen.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Mascot } from './Mascot';
+import { Mascot } from './Mascot.js';
 
 export function AppLoadingScreen() {
   const { t } = useTranslation();

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -3,9 +3,9 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArcadeCatalog } from './ArcadeCatalog';
-import type { CatalogEntry } from './catalog';
-import i18n from './i18n';
+import { ArcadeCatalog } from './ArcadeCatalog.js';
+import type { CatalogEntry } from './catalog.js';
+import i18n from './i18n/index.js';
 
 type ObserverInstance = {
   callback: IntersectionObserverCallback;

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog';
-import { MascotMoment } from './Mascot';
-import { PixelIcon } from './PixelIcon';
-import { useInView } from './useInView';
+import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
+import { MascotMoment } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
+import { useInView } from './useInView.js';
 
 type ArcadeCatalogProps = {
   catalogStatus: 'loading' | 'ready' | 'error';

--- a/apps/web/src/AuthModal.tsx
+++ b/apps/web/src/AuthModal.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { GoogleSignInButton } from './GoogleSignInButton';
-import { Mascot } from './Mascot';
-import { PixelIcon } from './PixelIcon';
+import { GoogleSignInButton } from './GoogleSignInButton.js';
+import { Mascot } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
 
 interface AuthModalProps {
   isOpen: boolean;

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -3,11 +3,11 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
-import { ClosedBetaSplash } from './ClosedBetaSplash';
-import i18n from './i18n';
+import { AuthProvider } from './AuthContext.js';
+import { ClosedBetaSplash } from './ClosedBetaSplash.js';
+import i18n from './i18n/index.js';
 
-import { AppLoadingScreen } from './AppLoadingScreen';
+import { AppLoadingScreen } from './AppLoadingScreen.js';
 
 async function flushEffects() {
   await Promise.resolve();

--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from './AuthContext';
-import { GoogleSignInButton } from './GoogleSignInButton';
-import { Mascot } from './Mascot';
+import { useAuth } from './AuthContext.js';
+import { GoogleSignInButton } from './GoogleSignInButton.js';
+import { Mascot } from './Mascot.js';
 
 type WaitlistState = 'idle' | 'joining' | 'joined' | 'error';
 

--- a/apps/web/src/CreatorMetricsPanel.test.tsx
+++ b/apps/web/src/CreatorMetricsPanel.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it } from 'vitest';
-import { CreatorMetricsPanel } from './CreatorMetricsPanel';
-import type { CreatorMetrics, CreatorsResponse } from './healthApi';
+import { CreatorMetricsPanel } from './CreatorMetricsPanel.js';
+import type { CreatorMetrics, CreatorsResponse } from './healthApi.js';
 
 /**
  * The Stage 0 gate is a real decision made on the number this panel renders, so the

--- a/apps/web/src/CreatorMetricsPanel.tsx
+++ b/apps/web/src/CreatorMetricsPanel.tsx
@@ -1,4 +1,4 @@
-import type { CreatorsResponse } from './healthApi';
+import type { CreatorsResponse } from './healthApi.js';
 
 /**
  * Creator return and build economics — the two figures docs/gtm-plan.md gates Stage 0 on.
@@ -66,15 +66,14 @@ export function CreatorMetricsPanel({ data }: { data: CreatorsResponse }) {
         */}
         {rate === null ? (
           <>
-            No creator has had a full 7 days since publishing yet, so the return rate is not
-            measurable — {metrics.published} game{metrics.published === 1 ? '' : 's'} published so
-            far, from {data.sampled} sampled.
+            No creator has had a full 7 days since publishing yet, so the return rate is not measurable —{' '}
+            {metrics.published} game{metrics.published === 1 ? '' : 's'} published so far, from {data.sampled} sampled.
           </>
         ) : (
           <>
             {metrics.returnedWithin7Days} of {metrics.eligibleForReturn} creator
-            {metrics.eligibleForReturn === 1 ? '' : 's'} whose 7 days have elapsed. Creators who
-            published more recently are excluded rather than counted as not returning.
+            {metrics.eligibleForReturn === 1 ? '' : 's'} whose 7 days have elapsed. Creators who published more recently
+            are excluded rather than counted as not returning.
           </>
         )}
       </p>

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CreatorQA, type QAQuestion } from './CreatorQA';
-import i18n from './i18n';
+import { CreatorQA, type QAQuestion } from './CreatorQA.js';
+import i18n from './i18n/index.js';
 
 async function flushEffects() {
   await Promise.resolve();

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PixelIcon } from './PixelIcon';
-import type { PendingQaAnswers } from './pendingQa';
+import { PixelIcon } from './PixelIcon.js';
+import type { PendingQaAnswers } from './pendingQa.js';
 
 export interface QAOption {
   label: string;

--- a/apps/web/src/DraftView.tsx
+++ b/apps/web/src/DraftView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GameTheater } from './GameTheater';
-import { getDraftBySlug, type SubmissionApiError, type SubmissionPreview } from './submissionApi';
+import { GameTheater } from './GameTheater.js';
+import { getDraftBySlug, type SubmissionApiError, type SubmissionPreview } from './submissionApi.js';
 
 type DraftViewProps = {
   slug: string;

--- a/apps/web/src/GameFrame.sandbox.test.ts
+++ b/apps/web/src/GameFrame.sandbox.test.ts
@@ -3,7 +3,7 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { describe, expect, it } from 'vitest';
-import { GameFrame } from './GameFrame';
+import { GameFrame } from './GameFrame.js';
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/apps/web/src/GameFrame.tsx
+++ b/apps/web/src/GameFrame.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
-import i18n from './i18n';
-import { embedGameHtml, withGameLocale } from './gamePlayer';
+import i18n from './i18n/index.js';
+import { embedGameHtml, withGameLocale } from './gamePlayer.js';
 
 type GameFrameSource = { title: string; html: string; src?: never } | { title: string; src: string; html?: never };
 

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 
-import { GameHealthView } from './GameHealthView';
+import { GameHealthView } from './GameHealthView.js';
 import type {
   GameHealth,
   HealthResponse,
@@ -12,7 +12,7 @@ import type {
   VisitsResponse,
   CreatorsResponse,
   ScorecardsResponse,
-} from './healthApi';
+} from './healthApi.js';
 
 /**
  * The operator view's job is to make one thing obvious: which published game is broken.

--- a/apps/web/src/GameHealthView.tsx
+++ b/apps/web/src/GameHealthView.tsx
@@ -9,10 +9,10 @@ import {
   type VisitsResponse,
   type CreatorsResponse,
   type ScorecardsResponse,
-} from './healthApi';
-import { VisitFunnelPanel } from './VisitFunnelPanel';
-import { CreatorMetricsPanel } from './CreatorMetricsPanel';
-import { ScorecardPanel } from './ScorecardPanel';
+} from './healthApi.js';
+import { VisitFunnelPanel } from './VisitFunnelPanel.js';
+import { CreatorMetricsPanel } from './CreatorMetricsPanel.js';
+import { ScorecardPanel } from './ScorecardPanel.js';
 
 /**
  * Operator view over play telemetry (docs/improvement-loop-plan.md IL-2).

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -3,7 +3,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
+import i18n from './i18n/index.js';
 
 vi.mock('./AuthContext', () => ({
   useAuth: () => ({ user: null, signInWithGoogleToken: vi.fn(), logout: vi.fn() }),
@@ -35,7 +35,7 @@ vi.mock('./useScreenWakeLock', () => ({
   useScreenWakeLock: () => undefined,
 }));
 
-import { GameTheater } from './GameTheater';
+import { GameTheater } from './GameTheater.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isPlatformAuthor } from './catalog';
-import { GameFrame } from './GameFrame';
-import { PublishedGameFrame } from './PublishedGameFrame';
-import { PixelIcon, type PixelIconName } from './PixelIcon';
-import { PlayerFeedbackWidget } from './PlayerFeedbackWidget';
-import { ReportGameButton } from './ReportGameButton';
-import { ShareGameButton } from './ShareGameButton';
-import { VoteWidget } from './VoteWidget';
-import { useGamePlayer } from './gamePlayer';
-import { useScreenWakeLock } from './useScreenWakeLock';
+import { isPlatformAuthor } from './catalog.js';
+import { GameFrame } from './GameFrame.js';
+import { PublishedGameFrame } from './PublishedGameFrame.js';
+import { PixelIcon, type PixelIconName } from './PixelIcon.js';
+import { PlayerFeedbackWidget } from './PlayerFeedbackWidget.js';
+import { ReportGameButton } from './ReportGameButton.js';
+import { ShareGameButton } from './ShareGameButton.js';
+import { VoteWidget } from './VoteWidget.js';
+import { useGamePlayer } from './gamePlayer.js';
+import { useScreenWakeLock } from './useScreenWakeLock.js';
 
 /** A game to run, sourced either from raw assembled HTML or a published slug. */
 export type GameTheaterSource = { html: string } | { slug: string };

--- a/apps/web/src/GoogleSignInButton.tsx
+++ b/apps/web/src/GoogleSignInButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useAuth } from './AuthContext';
+import { useAuth } from './AuthContext.js';
 
 declare global {
   interface Window {

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { HeroPromptSection } from './HeroPromptSection';
-import i18n from './i18n';
+import { HeroPromptSection } from './HeroPromptSection.js';
+import i18n from './i18n/index.js';
 
 async function flushEffects() {
   await Promise.resolve();

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { recordCreateStep } from './visitTelemetry';
+import { recordCreateStep } from './visitTelemetry.js';
 import type { CatalogEntry } from './catalog.js';
 import { SketchModal } from './SketchModal.js';
 import { PixelIcon } from './PixelIcon.js';

--- a/apps/web/src/LanguageSwitcher.tsx
+++ b/apps/web/src/LanguageSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { SUPPORTED_LANGUAGES } from './i18n';
+import { SUPPORTED_LANGUAGES } from './i18n/index.js';
 
 const LABELS: Record<string, string> = { en: 'EN', pl: 'PL' };
 

--- a/apps/web/src/LegalPage.tsx
+++ b/apps/web/src/LegalPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { legalDocument, type LegalBlock, type LegalDocId } from './legal';
-import { renderInline } from './legal/inline';
-import { OPERATOR_LEGAL_NAME } from './legal/operator';
-import { legalAnchor, legalPath } from './router';
-import { PixelIcon } from './PixelIcon';
+import { legalDocument, type LegalBlock, type LegalDocId } from './legal/index.js';
+import { renderInline } from './legal/inline.js';
+import { OPERATOR_LEGAL_NAME } from './legal/operator.js';
+import { legalAnchor, legalPath } from './router.js';
+import { PixelIcon } from './PixelIcon.js';
 
 function Block({ block }: { block: LegalBlock }) {
   if (block.kind === 'p') return <p>{renderInline(block.text)}</p>;

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Mascot, MascotMoment, type MascotEmotion } from './Mascot';
-import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans';
+import { Mascot, MascotMoment, type MascotEmotion } from './Mascot.js';
+import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans.js';
 
 const EMOTIONS: MascotEmotion[] = [
   'idle',

--- a/apps/web/src/MyGamesRail.test.ts
+++ b/apps/web/src/MyGamesRail.test.ts
@@ -3,9 +3,9 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
-import { MyGamesRail } from './MyGamesRail';
-import { getSubmissionStatus, listMySubmissions } from './submissionApi';
+import i18n from './i18n/index.js';
+import { MyGamesRail } from './MyGamesRail.js';
+import { getSubmissionStatus, listMySubmissions } from './submissionApi.js';
 
 vi.mock('./submissionApi', async () => {
   const actual = await vi.importActual<typeof import('./submissionApi')>('./submissionApi');

--- a/apps/web/src/MyGamesRail.tsx
+++ b/apps/web/src/MyGamesRail.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PixelIcon, type PixelIconName } from './PixelIcon';
-import { getSavedSpecs } from './mySpecs';
-import { formatRelativeTime } from './relativeTime';
-import { getSubmissionStatus, listMySubmissions, type SubmissionState } from './submissionApi';
+import { PixelIcon, type PixelIconName } from './PixelIcon.js';
+import { getSavedSpecs } from './mySpecs.js';
+import { formatRelativeTime } from './relativeTime.js';
+import { getSubmissionStatus, listMySubmissions, type SubmissionState } from './submissionApi.js';
 
 /**
  * "Your games" on the home page. Before this existed, a creator who closed the tab

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -1,11 +1,11 @@
 import { useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from './AuthContext';
-import { AuthModal } from './AuthModal';
-import { LanguageSwitcher } from './LanguageSwitcher';
-import { Mascot } from './Mascot';
-import { NotificationBell } from './NotificationBell';
-import { PixelIcon } from './PixelIcon';
+import { useAuth } from './AuthContext.js';
+import { AuthModal } from './AuthModal.js';
+import { LanguageSwitcher } from './LanguageSwitcher.js';
+import { Mascot } from './Mascot.js';
+import { NotificationBell } from './NotificationBell.js';
+import { PixelIcon } from './PixelIcon.js';
 import githubIcon from './assets/github-mark-white.svg';
 
 type NavHeaderProps = {

--- a/apps/web/src/NotFoundPage.test.tsx
+++ b/apps/web/src/NotFoundPage.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
-import { NotFoundPage } from './NotFoundPage';
+import i18n from './i18n/index.js';
+import { NotFoundPage } from './NotFoundPage.js';
 
 describe('NotFoundPage', () => {
   afterEach(() => {

--- a/apps/web/src/NotFoundPage.tsx
+++ b/apps/web/src/NotFoundPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { MascotMoment } from './Mascot';
-import { PixelIcon } from './PixelIcon';
+import { MascotMoment } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
 
 type NotFoundPageProps = {
   onHome: () => void;

--- a/apps/web/src/NotificationBell.tsx
+++ b/apps/web/src/NotificationBell.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from './AuthContext';
+import { useAuth } from './AuthContext.js';
 import {
   clearNotifications,
   fetchNotifications,
   markNotificationsRead,
   type AppNotification,
   type NotificationType,
-} from './notificationsApi';
-import { pushUiState, subscribeToPush, unsubscribeFromPush, type PushUiState } from './pushApi';
+} from './notificationsApi.js';
+import { pushUiState, subscribeToPush, unsubscribeFromPush, type PushUiState } from './pushApi.js';
 import './NotificationBell.css';
 
 const POLL_MS = 60_000;

--- a/apps/web/src/PlayerFeedbackWidget.test.tsx
+++ b/apps/web/src/PlayerFeedbackWidget.test.tsx
@@ -3,7 +3,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
+import i18n from './i18n/index.js';
 
 const authState = vi.hoisted(() => ({ user: null as { uid: string } | null }));
 vi.mock('./AuthContext', () => ({
@@ -15,7 +15,7 @@ const feedbackApi = vi.hoisted(() => ({
 }));
 vi.mock('./playerFeedbackApi', () => feedbackApi);
 
-import { PlayerFeedbackWidget } from './PlayerFeedbackWidget';
+import { PlayerFeedbackWidget } from './PlayerFeedbackWidget.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;

--- a/apps/web/src/PlayerFeedbackWidget.tsx
+++ b/apps/web/src/PlayerFeedbackWidget.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AuthModal } from './AuthModal';
-import { useAuth } from './AuthContext';
-import { PixelIcon } from './PixelIcon';
-import { submitPlayerFeedback, type PlayerFeedbackError } from './playerFeedbackApi';
+import { AuthModal } from './AuthModal.js';
+import { useAuth } from './AuthContext.js';
+import { PixelIcon } from './PixelIcon.js';
+import { submitPlayerFeedback, type PlayerFeedbackError } from './playerFeedbackApi.js';
 
 /**
  * Written player feedback (docs/improvement-loop-plan.md, signal source #1) — the

--- a/apps/web/src/PublishedGameFrame.retry.test.tsx
+++ b/apps/web/src/PublishedGameFrame.retry.test.tsx
@@ -8,9 +8,9 @@ vi.mock('./catalog', () => ({
   fetchPublishedGame: vi.fn(),
 }));
 
-import { PublishedGameFrame } from './PublishedGameFrame';
-import { fetchPublishedGame } from './catalog';
-import i18n from './i18n';
+import { PublishedGameFrame } from './PublishedGameFrame.js';
+import { fetchPublishedGame } from './catalog.js';
+import i18n from './i18n/index.js';
 
 describe('PublishedGameFrame retry', () => {
   let container: HTMLDivElement;
@@ -28,13 +28,11 @@ describe('PublishedGameFrame retry', () => {
   });
 
   it('offers Retry after a failed load and fetches again when clicked', async () => {
-    vi.mocked(fetchPublishedGame)
-      .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce({
-        slug: 'solo-cards',
-        title: 'Solo Cards',
-        html: '<!doctype html><title>Solo Cards</title>',
-      });
+    vi.mocked(fetchPublishedGame).mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({
+      slug: 'solo-cards',
+      title: 'Solo Cards',
+      html: '<!doctype html><title>Solo Cards</title>',
+    });
 
     const root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/PublishedGameFrame.telemetry.test.tsx
+++ b/apps/web/src/PublishedGameFrame.telemetry.test.tsx
@@ -12,8 +12,8 @@ vi.mock('./catalog', () => ({
   })),
 }));
 
-import { PublishedGameFrame } from './PublishedGameFrame';
-import type { PublishedGame } from './catalog';
+import { PublishedGameFrame } from './PublishedGameFrame.js';
+import type { PublishedGame } from './catalog.js';
 
 /**
  * The wiring test: a real play of a published game must report itself.
@@ -94,7 +94,7 @@ describe('PublishedGameFrame telemetry', () => {
   });
 
   it('reports nothing before the game document arrives — a click is not a play', async () => {
-    const { fetchPublishedGame } = await import('./catalog');
+    const { fetchPublishedGame } = await import('./catalog.js');
     let release: (game: PublishedGame) => void = () => {};
     vi.mocked(fetchPublishedGame).mockReturnValue(new Promise((resolve) => (release = resolve)));
 

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, type MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GameFrame } from './GameFrame';
-import { fetchPublishedGame } from './catalog';
-import { PixelIcon } from './PixelIcon';
-import { useGameTelemetry } from './gamePlayer';
+import { GameFrame } from './GameFrame.js';
+import { fetchPublishedGame } from './catalog.js';
+import { PixelIcon } from './PixelIcon.js';
+import { useGameTelemetry } from './gamePlayer.js';
 
 type PublishedGameFrameProps = {
   slug: string;

--- a/apps/web/src/ReportGameButton.test.tsx
+++ b/apps/web/src/ReportGameButton.test.tsx
@@ -4,9 +4,9 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { ReportGameButton } from './ReportGameButton';
-import { CONTACT_EMAIL } from './legal/operator';
-import i18n from './i18n';
+import { ReportGameButton } from './ReportGameButton.js';
+import { CONTACT_EMAIL } from './legal/operator.js';
+import i18n from './i18n/index.js';
 
 /**
  * This control is our DSA art. 16 notice-and-action mechanism. A notice only obliges

--- a/apps/web/src/ReportGameButton.tsx
+++ b/apps/web/src/ReportGameButton.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { CONTACT_EMAIL, SERVICE_URL } from './legal/operator';
-import { PixelIcon } from './PixelIcon';
+import { CONTACT_EMAIL, SERVICE_URL } from './legal/operator.js';
+import { PixelIcon } from './PixelIcon.js';
 
 /**
  * Notice-and-action, minimum viable (DSA art. 16).

--- a/apps/web/src/ScorecardPanel.test.tsx
+++ b/apps/web/src/ScorecardPanel.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { describe, expect, it } from 'vitest';
-import { ScorecardPanel } from './ScorecardPanel';
-import type { Scorecard, ScorecardsResponse } from './healthApi';
+import { ScorecardPanel } from './ScorecardPanel.js';
+import type { Scorecard, ScorecardsResponse } from './healthApi.js';
 
 /**
  * This panel is the only place a stopped sweep is visible — the game-health table beside

--- a/apps/web/src/ScorecardPanel.tsx
+++ b/apps/web/src/ScorecardPanel.tsx
@@ -1,4 +1,4 @@
-import type { Scorecard, ScorecardsResponse } from './healthApi';
+import type { Scorecard, ScorecardsResponse } from './healthApi.js';
 
 /**
  * What the nightly scorecard sweep last produced (docs/improvement-loop-plan.md IL-2).

--- a/apps/web/src/ShareGameButton.test.tsx
+++ b/apps/web/src/ShareGameButton.test.tsx
@@ -3,8 +3,8 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
-import { ShareGameButton } from './ShareGameButton';
+import i18n from './i18n/index.js';
+import { ShareGameButton } from './ShareGameButton.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;

--- a/apps/web/src/ShareGameButton.tsx
+++ b/apps/web/src/ShareGameButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PixelIcon } from './PixelIcon';
+import { PixelIcon } from './PixelIcon.js';
 
 /**
  * One-tap share of a published game's `/play/<slug>` permalink.
@@ -19,8 +19,7 @@ export function ShareGameButton({ slug, title }: { slug: string; title: string }
   const share = async () => {
     const url = playUrl();
     const canShare =
-      typeof navigator.share === 'function' &&
-      (!navigator.canShare || navigator.canShare({ url, title, text: title }));
+      typeof navigator.share === 'function' && (!navigator.canShare || navigator.canShare({ url, title, text: title }));
 
     if (canShare) {
       try {

--- a/apps/web/src/SiteFooter.test.tsx
+++ b/apps/web/src/SiteFooter.test.tsx
@@ -4,9 +4,9 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { SiteFooter } from './SiteFooter';
-import i18n from './i18n';
-import { setVisitSessionForTesting, VisitSession } from './visitTelemetry';
+import { SiteFooter } from './SiteFooter.js';
+import i18n from './i18n/index.js';
+import { setVisitSessionForTesting, VisitSession } from './visitTelemetry.js';
 
 /**
  * The footer carries two different reporting routes that look alike and must not be

--- a/apps/web/src/SiteFooter.tsx
+++ b/apps/web/src/SiteFooter.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
-import { bugReportUrl, ISSUES_URL, REPO_URL } from './github';
-import { OPERATOR_LEGAL_NAME } from './legal/operator';
-import { legalPath } from './router';
-import { currentVisitId } from './visitTelemetry';
+import { bugReportUrl, ISSUES_URL, REPO_URL } from './github.js';
+import { OPERATOR_LEGAL_NAME } from './legal/operator.js';
+import { legalPath } from './router.js';
+import { currentVisitId } from './visitTelemetry.js';
 
 /**
  * The site footer, and the one legally load-bearing piece of chrome on the page.

--- a/apps/web/src/SketchModal.tsx
+++ b/apps/web/src/SketchModal.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PixelIcon } from './PixelIcon';
+import { PixelIcon } from './PixelIcon.js';
 
 type SketchModalProps = {
   isOpen: boolean;

--- a/apps/web/src/SplitHero.tsx
+++ b/apps/web/src/SplitHero.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { CatalogEntry } from './catalog';
+import type { CatalogEntry } from './catalog.js';
 
 type SplitHeroProps = {
   featuredGame: CatalogEntry | null;

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -3,15 +3,15 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
-import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView';
+import i18n from './i18n/index.js';
+import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView.js';
 import {
   abandonSubmission,
   getBuildStats,
   getSubmissionPreview,
   getSubmissionStatus,
   submitFeedback,
-} from './submissionApi';
+} from './submissionApi.js';
 
 vi.mock('./submissionApi', async () => {
   const actual = await vi.importActual<typeof import('./submissionApi')>('./submissionApi');

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GameTheater } from './GameTheater';
-import { PixelIcon, type PixelIconName } from './PixelIcon';
+import { GameTheater } from './GameTheater.js';
+import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
   abandonSubmission,
   getBuildStats,
@@ -17,9 +17,9 @@ import {
   type SubmissionApiError,
   type SubmissionPreview,
   type SubmissionStatus,
-} from './submissionApi';
-import { draftPath, playPath, statusPath } from './router';
-import { formatDuration, formatRelativeTime } from './relativeTime';
+} from './submissionApi.js';
+import { draftPath, playPath, statusPath } from './router.js';
+import { formatDuration, formatRelativeTime } from './relativeTime.js';
 
 const TERMINAL_STATUSES = new Set<SubmissionStatus['status']>(['published', 'needs_changes', 'abandoned']);
 /** Statuses that halt the linear timeline rather than sitting on a step of it. */

--- a/apps/web/src/TransparencySection.tsx
+++ b/apps/web/src/TransparencySection.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import githubIcon from './assets/github-mark-white.svg';
-import { PixelIcon } from './PixelIcon';
+import { PixelIcon } from './PixelIcon.js';
 
 export function TransparencySection() {
   const { t } = useTranslation();

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -3,8 +3,8 @@
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it } from 'vitest';
-import { VisitFunnelPanel } from './VisitFunnelPanel';
-import type { VisitFunnel, VisitsResponse } from './healthApi';
+import { VisitFunnelPanel } from './VisitFunnelPanel.js';
+import type { VisitFunnel, VisitsResponse } from './healthApi.js';
 
 /**
  * Renders the operator funnel panel.

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -1,4 +1,4 @@
-import { type VisitFunnel, type VisitsResponse } from './healthApi';
+import { type VisitFunnel, type VisitsResponse } from './healthApi.js';
 
 /**
  * The visit funnel, rendered beside game health on the operator page.

--- a/apps/web/src/VoteWidget.test.tsx
+++ b/apps/web/src/VoteWidget.test.tsx
@@ -3,7 +3,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import i18n from './i18n';
+import i18n from './i18n/index.js';
 
 /**
  * The widget's whole job is: show the up-count to anyone, and only let a signed-in
@@ -24,7 +24,7 @@ const votesApi = vi.hoisted(() => ({
 }));
 vi.mock('./votesApi', () => votesApi);
 
-import { VoteWidget } from './VoteWidget';
+import { VoteWidget } from './VoteWidget.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;

--- a/apps/web/src/VoteWidget.tsx
+++ b/apps/web/src/VoteWidget.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AuthModal } from './AuthModal';
-import { useAuth } from './AuthContext';
-import { PixelIcon } from './PixelIcon';
-import { castVote, clearVote, fetchVotes, type VoteCounts } from './votesApi';
+import { AuthModal } from './AuthModal.js';
+import { useAuth } from './AuthContext.js';
+import { PixelIcon } from './PixelIcon.js';
+import { castVote, clearVote, fetchVotes, type VoteCounts } from './votesApi.js';
 
 /**
  * Thumbs-up on a played game (docs/improvement-loop-plan.md, signal source #2).

--- a/apps/web/src/catalog.test.ts
+++ b/apps/web/src/catalog.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { catalogMediaUrl, fetchCatalog } from './catalog';
+import { catalogMediaUrl, fetchCatalog } from './catalog.js';
 
 describe('catalog helpers', () => {
   afterEach(() => {

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { embedGameHtml } from './gamePlayer';
+import { embedGameHtml } from './gamePlayer.js';
 
 /**
  * Runs the injected bridge for real rather than grepping its source.

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { embedGameHtml, withGameLocale } from './gamePlayer';
+import { embedGameHtml, withGameLocale } from './gamePlayer.js';
 
 describe('embedGameHtml', () => {
   it('injects the hide-chrome style and bridge script before </body>', () => {

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
-import { isPlayTimeAccruing, TelemetrySession } from './telemetry';
-import { recordVisitEvent } from './visitTelemetry';
+import { isPlayTimeAccruing, TelemetrySession } from './telemetry.js';
+import { recordVisitEvent } from './visitTelemetry.js';
 
 // Message envelope tags. The host is the app; the player is the bridge script
 // that runs inside the sandboxed game iframe.

--- a/apps/web/src/github.test.ts
+++ b/apps/web/src/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bugReportUrl, ISSUES_URL, REPO_URL } from './github';
+import { bugReportUrl, ISSUES_URL, REPO_URL } from './github.js';
 
 describe('github links', () => {
   it('points the issues list at the same repo', () => {

--- a/apps/web/src/legal/index.ts
+++ b/apps/web/src/legal/index.ts
@@ -1,10 +1,10 @@
-import { privacyEn } from './privacy.en';
-import { privacyPl } from './privacy.pl';
-import { termsEn } from './terms.en';
-import { termsPl } from './terms.pl';
-import type { LegalDocId, LegalDocument } from './types';
+import { privacyEn } from './privacy.en.js';
+import { privacyPl } from './privacy.pl.js';
+import { termsEn } from './terms.en.js';
+import { termsPl } from './terms.pl.js';
+import type { LegalDocId, LegalDocument } from './types.js';
 
-export type { LegalBlock, LegalDocId, LegalDocument, LegalSection } from './types';
+export type { LegalBlock, LegalDocId, LegalDocument, LegalSection } from './types.js';
 
 const DOCUMENTS: Record<'en' | 'pl', Record<LegalDocId, LegalDocument>> = {
   en: { privacy: privacyEn, terms: termsEn },

--- a/apps/web/src/legal/inline.test.tsx
+++ b/apps/web/src/legal/inline.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { renderInline } from './inline';
+import { renderInline } from './inline.js';
 
 /**
  * The documents promise contact addresses and cross-references in several places. If

--- a/apps/web/src/legal/legal.test.ts
+++ b/apps/web/src/legal/legal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { ALL_LEGAL_DOCUMENTS, legalDocument, type LegalDocument } from './index';
-import { CONTACT_EMAIL } from './operator';
+import { ALL_LEGAL_DOCUMENTS, legalDocument, type LegalDocument } from './index.js';
+import { CONTACT_EMAIL } from './operator.js';
 
 const DOC_IDS = ['privacy', 'terms'] as const;
 

--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -1,5 +1,5 @@
-import type { LegalDocument } from './types';
-import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN } from './operator';
+import type { LegalDocument } from './types.js';
+import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN } from './operator.js';
 
 /**
  * Privacy policy — English translation. The Polish text in `privacy.pl.ts` is the

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -1,5 +1,5 @@
-import type { LegalDocument } from './types';
-import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN } from './operator';
+import type { LegalDocument } from './types.js';
+import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN } from './operator.js';
 
 /**
  * Polityka prywatności — wersja polska (wiążąca).

--- a/apps/web/src/legal/terms.en.ts
+++ b/apps/web/src/legal/terms.en.ts
@@ -1,5 +1,5 @@
-import type { LegalDocument } from './types';
-import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN, SERVICE_URL } from './operator';
+import type { LegalDocument } from './types.js';
+import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN, SERVICE_URL } from './operator.js';
 
 /**
  * Terms of Service — English translation. The Polish text in `terms.pl.ts` is the

--- a/apps/web/src/legal/terms.pl.ts
+++ b/apps/web/src/legal/terms.pl.ts
@@ -1,5 +1,5 @@
-import type { LegalDocument } from './types';
-import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN, SERVICE_URL } from './operator';
+import type { LegalDocument } from './types.js';
+import { CONTACT_EMAIL, LEGAL_EFFECTIVE_DATE, OPERATOR_LEGAL_NAME, SERVICE_DOMAIN, SERVICE_URL } from './operator.js';
 
 /**
  * Regulamin — wersja polska (wiążąca).

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App';
-import { AuthProvider } from './AuthContext';
-import { startVisitTracking } from './visitTelemetry';
-import './i18n';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import { startVisitTracking } from './visitTelemetry.js';
+import './i18n/index.js';
 import './styles.css';
 
 // Started before the first render: the visit has to be recorded as it lands, and a tree

--- a/apps/web/src/mp/ControllerView.tsx
+++ b/apps/web/src/mp/ControllerView.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RoomClient, type RoomStatus } from './roomClient';
-import { useScreenWakeLock } from '../useScreenWakeLock';
-import type { InputKey, RoomPhase } from './protocol';
+import { RoomClient, type RoomStatus } from './roomClient.js';
+import { useScreenWakeLock } from '../useScreenWakeLock.js';
+import type { InputKey, RoomPhase } from './protocol.js';
 
 type ControllerViewProps = { code: string; token: string };
 

--- a/apps/web/src/mp/PartyStage.tsx
+++ b/apps/web/src/mp/PartyStage.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { CatalogEntry } from '../catalog';
-import { PublishedGameFrame } from '../PublishedGameFrame';
-import { joinUrl, type PartySession } from './mpApi';
-import { QrCode } from './QrCode';
-import { RoomClient, type RoomStatus } from './roomClient';
-import { BRIDGE_NAMESPACE, parseGameBridgeMessage, PROTOCOL_VERSION, type RosterSlot } from './protocol';
+import type { CatalogEntry } from '../catalog.js';
+import { PublishedGameFrame } from '../PublishedGameFrame.js';
+import { joinUrl, type PartySession } from './mpApi.js';
+import { QrCode } from './QrCode.js';
+import { RoomClient, type RoomStatus } from './roomClient.js';
+import { BRIDGE_NAMESPACE, parseGameBridgeMessage, PROTOCOL_VERSION, type RosterSlot } from './protocol.js';
 
 type PartyStageProps = {
   game: CatalogEntry;

--- a/apps/web/src/mp/protocol.test.ts
+++ b/apps/web/src/mp/protocol.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { parseGameBridgeMessage, parseServerFrame, PROTOCOL_VERSION } from './protocol';
-import { parsePathRoute } from '../router';
+import { parseGameBridgeMessage, parseServerFrame, PROTOCOL_VERSION } from './protocol.js';
+import { parsePathRoute } from '../router.js';
 
 describe('parseServerFrame', () => {
   it('accepts a well-formed roster', () => {

--- a/apps/web/src/mp/roomClient.ts
+++ b/apps/web/src/mp/roomClient.ts
@@ -1,4 +1,4 @@
-import { parseServerFrame, PROTOCOL_VERSION, roomSocketUrl, type InputKey, type ServerFrame } from './protocol';
+import { parseServerFrame, PROTOCOL_VERSION, roomSocketUrl, type InputKey, type ServerFrame } from './protocol.js';
 
 export type RoomStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed';
 

--- a/apps/web/src/notificationsApi.test.ts
+++ b/apps/web/src/notificationsApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchNotifications, markNotificationsRead } from './notificationsApi';
+import { fetchNotifications, markNotificationsRead } from './notificationsApi.js';
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -5,7 +5,7 @@ import {
   humanizeSlug,
   resolveDocumentTitle,
   type DocumentTitleCopy,
-} from './pageTitle';
+} from './pageTitle.js';
 
 const copy: DocumentTitleCopy = {
   home: 'Gamedev.pl — Describe a game, play it',

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -1,4 +1,4 @@
-import type { AppRoute } from './router';
+import type { AppRoute } from './router.js';
 
 /** Brand suffix used on every non-home tab title. */
 export const SITE_BRAND = 'Gamedev.pl';

--- a/apps/web/src/pendingQa.test.ts
+++ b/apps/web/src/pendingQa.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { clearPendingQa, loadPendingQa, savePendingQa } from './pendingQa';
+import { clearPendingQa, loadPendingQa, savePendingQa } from './pendingQa.js';
 
 const session = {
   spec: { title: 'Kosmiczny listonosz', concept: 'Deliver parcels between planets', displayName: 'Greg' },

--- a/apps/web/src/pendingQa.ts
+++ b/apps/web/src/pendingQa.ts
@@ -1,4 +1,4 @@
-import type { QAQuestion } from './CreatorQA';
+import type { QAQuestion } from './CreatorQA.js';
 
 /**
  * The clarifying-questions session, parked in localStorage.

--- a/apps/web/src/playerFeedbackApi.test.ts
+++ b/apps/web/src/playerFeedbackApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { submitPlayerFeedback } from './playerFeedbackApi';
+import { submitPlayerFeedback } from './playerFeedbackApi.js';
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -8,7 +8,7 @@ import {
   parsePathRoute,
   playPath,
   statusPath,
-} from './router';
+} from './router.js';
 
 describe('parsePathRoute', () => {
   it('maps empty and root paths to home', () => {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,4 +1,4 @@
-import type { LegalDocId } from './legal/types';
+import type { LegalDocId } from './legal/types.js';
 
 export type AppRoute =
   | { view: 'home' }

--- a/apps/web/src/submissionApi.test.ts
+++ b/apps/web/src/submissionApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getSubmissionStatus, submitSpec } from './submissionApi';
+import { getSubmissionStatus, submitSpec } from './submissionApi.js';
 
 describe('submissionApi', () => {
   afterEach(() => {

--- a/apps/web/src/telemetry.test.ts
+++ b/apps/web/src/telemetry.test.ts
@@ -5,7 +5,7 @@ import {
   type TelemetryEvent,
   type TelemetrySend,
   type WireEvent,
-} from './telemetry';
+} from './telemetry.js';
 
 type Batch = { slug: string; sessionId: string; flushMsSinceOpen: number; events: WireEvent[] };
 
@@ -184,7 +184,7 @@ describe('isPlayTimeAccruing', () => {
 describe('sendTelemetry', () => {
   it('posts with keepalive so the final flush survives the page closing', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
-    const { sendTelemetry } = await import('./telemetry');
+    const { sendTelemetry } = await import('./telemetry.js');
 
     sendTelemetry({
       slug: 'space-hop',
@@ -202,7 +202,7 @@ describe('sendTelemetry', () => {
 
   it('swallows a rejected request — telemetry never surfaces to the player', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
-    const { sendTelemetry } = await import('./telemetry');
+    const { sendTelemetry } = await import('./telemetry.js');
 
     expect(() =>
       sendTelemetry({

--- a/apps/web/src/useInView.test.ts
+++ b/apps/web/src/useInView.test.ts
@@ -3,7 +3,7 @@
 import { act, createElement, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useInView } from './useInView';
+import { useInView } from './useInView.js';
 
 type ObserverInstance = {
   callback: IntersectionObserverCallback;
@@ -41,13 +41,7 @@ function installIntersectionObserverMock() {
   vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
 }
 
-function Probe({
-  onChange,
-  once,
-}: {
-  onChange: (inView: boolean) => void;
-  once?: boolean;
-}) {
+function Probe({ onChange, once }: { onChange: (inView: boolean) => void; once?: boolean }) {
   const { ref, inView } = useInView({ once });
   useEffect(() => {
     onChange(inView);

--- a/apps/web/src/visitTelemetry.dom.test.ts
+++ b/apps/web/src/visitTelemetry.dom.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest';
-import { NAVIGATE_EVENT, type NavigateEventDetail } from './router';
-import { startVisitTracking, type WireVisitEvent } from './visitTelemetry';
+import { NAVIGATE_EVENT, type NavigateEventDetail } from './router.js';
+import { startVisitTracking, type WireVisitEvent } from './visitTelemetry.js';
 
 /**
  * The wiring half of visit tracking, which the pure-function tests cannot reach.

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -1,6 +1,6 @@
 import { webcrypto } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
-import { parsePathRoute } from './router';
+import { parsePathRoute } from './router.js';
 
 // vitest's node environment does not expose the webcrypto global that a real browser
 // (and plain Node) provides, and `readVisitIdentity` relies on `crypto.randomUUID()`
@@ -18,7 +18,7 @@ import {
   utmFields,
   VisitSession,
   type WireVisitEvent,
-} from './visitTelemetry';
+} from './visitTelemetry.js';
 
 function capture() {
   const batches: { visitId: string; flushMsSinceStart: number; events: WireVisitEvent[] }[] = [];
@@ -296,7 +296,7 @@ describe('sendVisitTelemetry', () => {
   it('swallows a rejected request so telemetry never surfaces as a failure', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error('offline'));
     vi.stubGlobal('fetch', fetchMock);
-    const { sendVisitTelemetry } = await import('./visitTelemetry');
+    const { sendVisitTelemetry } = await import('./visitTelemetry.js');
     expect(() => sendVisitTelemetry({ visitId: 'v1', flushMsSinceStart: 0, events: [] })).not.toThrow();
     vi.unstubAllGlobals();
   });

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -1,4 +1,4 @@
-import { NAVIGATE_EVENT, parsePathRoute } from './router';
+import { NAVIGATE_EVENT, parsePathRoute } from './router.js';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 

--- a/apps/web/src/votesApi.test.ts
+++ b/apps/web/src/votesApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { castVote, clearVote, fetchVotes } from './votesApi';
+import { castVote, clearVote, fetchVotes } from './votesApi.js';
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,7 +2,7 @@ import react from '@vitejs/plugin-react';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
-import { isKnownSpaShellPath, looksLikeStaticAsset } from '../api/src/spa-paths.ts';
+import { isKnownSpaShellPath, looksLikeStaticAsset } from '../api/src/spa-paths.js';
 
 const apiTarget = process.env.VITE_API_TARGET ?? 'http://127.0.0.1:3001';
 

--- a/eslint-rules/relative-import-extensions.mjs
+++ b/eslint-rules/relative-import-extensions.mjs
@@ -1,0 +1,155 @@
+/**
+ * Require an explicit `.js` extension on every relative import.
+ *
+ * Every package here is `"type": "module"`, which is why .github/copilot-instructions.md
+ * asks for `import { x } from './mock.js'`. The convention was documented but unenforced,
+ * so it held in apps/api and drifted in apps/web — and the difference is not cosmetic:
+ *
+ * - apps/api compiles to dist/ and is run directly by Node. Node's ESM resolver does no
+ *   extension guessing, so an extensionless relative import there is a runtime crash.
+ * - apps/web is bundled by Vite, which resolves extensionless specifiers happily. Nothing
+ *   breaks, so nothing pushed back, so it drifted to ~210 violations.
+ *
+ * Enforcing it repo-wide keeps a file from acquiring a hidden dependency on the bundler
+ * the day it moves — and stops reviewers (human or Copilot) having to flag it by hand.
+ *
+ * Written as a local rule rather than pulling in eslint-plugin-import(-x): the whole need
+ * is one check, and those plugins bring their own TypeScript resolver stack to do it.
+ *
+ * The fix resolves against the filesystem instead of appending '.js' to whatever is
+ * written. `./foo` may mean `foo.ts` *or* `foo/index.ts`, and a blind append silently
+ * turns the second one into a broken import that Vite would no longer save.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Extensions that already state what they are — an asset import is not our business. */
+const SETTLED_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+  '.css',
+  '.scss',
+  '.svg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.mp3',
+  '.wav',
+  '.ogg',
+  '.woff',
+  '.woff2',
+  '.wasm',
+  '.txt',
+  '.md',
+]);
+
+/** What a specifier may resolve to on disk, and what it should be written as. */
+const SOURCE_EXTENSIONS = ['.ts', '.tsx'];
+
+function isFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The specifier this one should have been written as, or undefined when nothing on disk
+ * matches. Unresolvable specifiers are reported without a fix rather than guessed at.
+ */
+function resolveSpecifier(fromDirectory, specifier) {
+  const bare = specifier.replace(/\/+$/, '');
+  const target = path.resolve(fromDirectory, bare);
+
+  for (const extension of SOURCE_EXTENSIONS) {
+    if (isFile(`${target}${extension}`)) return `${bare}.js`;
+  }
+  for (const extension of SOURCE_EXTENSIONS) {
+    if (isFile(path.join(target, `index${extension}`))) return `${bare}/index.js`;
+  }
+  return undefined;
+}
+
+export const relativeImportExtensions = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require an explicit .js extension on relative imports (ESM packages).',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missing:
+        "Relative import '{{specifier}}' has no extension — write '{{fixed}}'. Every package is \"type\": \"module\", and Node's ESM resolver does not guess extensions.",
+      unresolved:
+        "Relative import '{{specifier}}' has no extension and resolves to no .ts/.tsx file — add the right extension by hand.",
+      typescript:
+        "Relative import '{{specifier}}' points at TypeScript source — write '{{fixed}}'. The specifier has to name the file that exists after compilation, not before.",
+    },
+  },
+
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    // <input> and <text> stand in for piped source, where there is no directory to
+    // resolve against and every specifier would look unresolvable.
+    if (!filename || !path.isAbsolute(filename)) return {};
+    const directory = path.dirname(filename);
+
+    function check(source) {
+      if (!source || source.type !== 'Literal' || typeof source.value !== 'string') return;
+
+      const specifier = source.value;
+      if (!specifier.startsWith('./') && !specifier.startsWith('../')) return;
+
+      const quote = source.raw[0];
+      const extension = path.extname(specifier);
+
+      // `allowImportingTsExtensions` lets apps/web write './x.ts'; it still compiles to
+      // a './x.js' on disk, so the specifier is wrong for anything but the bundler.
+      if (SOURCE_EXTENSIONS.includes(extension)) {
+        const fixed = `${specifier.slice(0, -extension.length)}.js`;
+        context.report({
+          node: source,
+          messageId: 'typescript',
+          data: { specifier, fixed },
+          fix: (fixer) => fixer.replaceText(source, `${quote}${fixed}${quote}`),
+        });
+        return;
+      }
+
+      if (SETTLED_EXTENSIONS.has(extension)) return;
+
+      const fixed = resolveSpecifier(directory, specifier);
+      if (!fixed) {
+        context.report({ node: source, messageId: 'unresolved', data: { specifier } });
+        return;
+      }
+
+      context.report({
+        node: source,
+        messageId: 'missing',
+        data: { specifier, fixed },
+        fix: (fixer) => fixer.replaceText(source, `${quote}${fixed}${quote}`),
+      });
+    }
+
+    return {
+      ImportDeclaration: (node) => check(node.source),
+      ExportNamedDeclaration: (node) => check(node.source),
+      ExportAllDeclaration: (node) => check(node.source),
+      // `await import('./x')` — a literal argument is checkable, a computed one is not.
+      ImportExpression: (node) => check(node.source),
+    };
+  },
+};
+
+export default {
+  rules: { 'relative-import-extensions': relativeImportExtensions },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
+import gamedevRules from './eslint-rules/relative-import-extensions.mjs';
 
 // Flat config lints a file only when some block's `files` pattern matches it, so the
 // ts/tsx blocks below are what define the lint surface — the same one `--ext ts,tsx` gave.
@@ -23,6 +24,11 @@ export default [
       '**/*.js',
       '**/*.cjs',
       '**/*.mjs',
+      // Game sources standing in for the *external* games repo, not code this repo
+      // authors. They exist to pin the assembler's contract, so they must keep whatever
+      // shape real published games have — normalising them to local convention would
+      // quietly stop testing the thing they were checked in to test.
+      'apps/api/fixtures/**',
     ],
   },
   { ...js.configs.recommended, files: TS_FILES },
@@ -37,8 +43,13 @@ export default [
       parserOptions: { ecmaFeatures: { jsx: true } },
       globals: { ...globals.node, ...globals.browser },
     },
+    plugins: { gamedev: gamedevRules },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      // The ESM convention copilot-instructions.md documents. Unenforced it held in
+      // apps/api (where Node would crash without it) and drifted in apps/web (where
+      // Vite covers for it), which left reviewers flagging it by hand forever.
+      'gamedev/relative-import-extensions': 'error',
     },
   },
   {


### PR DESCRIPTION
Two hardening follow-ups from #257. Neither changes product behaviour.

> **Scope changed after opening.** This PR originally also wired the browser e2e suite into `deploy.yml`. While I was working, #261 and #263 landed that on `master` — and did it better: `E2E_REQUIRED=1` turns "cannot run" into a failed deploy rather than a silent skip, and #263 resolves the installed Chromium binary explicitly after the path heuristic missed it on the first real run. I dropped my version entirely. Nothing of that part remains here; `deploy.yml` is untouched.
>
> Rebuilt on current `master` four times since (through #260, #262, #265, #266, #268, #269, #271 and others). The import rewrite is regenerated with `eslint --fix` on each rebase rather than merged, so the diff always reflects the current tree rather than a hand-resolved conflict.

## 1. `copilot-task.yml` no longer splices a payload into a shell script

The task text is attacker-influenced — anyone who can fire `workflow_dispatch` or `repository_dispatch` chooses it — and interpolating `${{ }}` into `run:` inserts it *before* bash parses the script, so `$(...)` in a payload executes. It now travels through the environment, where bash only ever sees it as a value.

Inert today (the step only echoes), but it's one edit away from being live, and the fix costs three lines.

I also **dropped the `issue_comment` trigger**, which is the one behavioural change here and the thing to push back on if you disagree. The workflow reads its task from `inputs.task` or `client_payload.task`, neither of which a comment event carries — so every comment created anywhere in the repo was running the full `type-check && lint && test && build` gate in order to echo an empty string. Nothing references the workflow by comment.

## 2. The `.js` import convention is enforced rather than documented

It was in `copilot-instructions.md` but nothing checked it, so it held in `apps/api` and drifted to ~240 violations in `apps/web` — leaving reviewers to flag it by hand and reasonably conclude the convention didn't exist.

The split isn't arbitrary, and it's why this is worth enforcing rather than deleting from the docs:

| | runtime | extensionless import |
|---|---|---|
| `apps/api` | Node runs `dist/` directly | **crashes** — Node's ESM resolver does no extension guessing |
| `apps/web` | Vite bundles | resolves fine, so nothing ever pushed back |

Adds a local `gamedev/relative-import-extensions` rule and fixes every violation via `--fix`.

**The rule resolves each specifier against the filesystem** rather than appending `.js` to whatever is written, which is what makes the autofix trustworthy: **22 of the fixes are directories** that had to become `./dir/index.js`, where a blind append would have produced a broken `./dir.js`. Unresolvable specifiers are reported without a fix rather than guessed at.

Local rather than `eslint-plugin-import(-x)` because the whole need is one check and those bring their own TypeScript resolver stack to do it.

`apps/api/fixtures/**` is excluded: those files stand in for the *external* games repo and have to keep whatever shape real published games have. The autofix did rewrite one fixture before I caught it — normalising it would have quietly stopped testing the contract it was checked in to pin.

### On the `vite.config.ts` line

Copilot flagged `../api/src/spa-paths.js` as broken, since only `spa-paths.ts` exists. The premise is right, the conclusion isn't — [refuted in thread](https://github.com/gamedevpl/www.gamedev.pl/pull/264#discussion_r3660078880) with a live dev-server run: Vite starts, and the middleware built on the imported helpers still discriminates correctly (`/play/foo` 200, `/catalog` 404, `/nonexistent.png` 200). Both esbuild (which loads the config) and `tsc` map a `.js` specifier to the `.ts` source under `moduleResolution: "bundler"`. `.ts` was the odd one out here, legal only because `allowImportingTsExtensions` is on in `apps/web`.

## Verification

Full gate green locally on this branch: lint, type-check, **984 unit tests**, build.

## Worth knowing before you review

This has now been rebased four times in ~4 hours without review, and every conflict has come from the import rewrite — most recently `Mascot.test.tsx`, where new code on `master` added `./Mascot` and `./mascotSpans` extensionless. That is exactly the drift the rule exists to stop, and also the reason this PR is expensive to keep open. **Merging it soon is materially cheaper than merging it later.** If you'd rather not carry it, the clean alternative is to take the three-line `copilot-task.yml` fix on its own and drop the rewrite — the rule can't land without the bulk fix, since it would fail CI on the existing violations.

## What I did not do

No unit test for the lint rule itself — it lives at the repo root, outside any workspace, so testing it means standing up a root vitest config. The empirical evidence is decent (it rewrites the whole repo cleanly with the build and every test green, including the directory cases a naive rule would have broken, and it has survived four regenerations against a moving `master`), but an untested lint rule in a PR about unenforced conventions is a fair thing to call out, and I'd rather flag it than have it pass unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Der9k8dNBjJAmuXp4i2CS