### PR TITLE
Make the privacy notice's deletion promise executable

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "beta:invite": "tsx scripts/beta-invite.ts",
     "token:mint": "tsx scripts/access-token.ts mint",
     "token:list": "tsx scripts/access-token.ts list",
-    "token:revoke": "tsx scripts/access-token.ts revoke"
+    "token:revoke": "tsx scripts/access-token.ts revoke",
+    "player:erase": "tsx scripts/erase-player-signals.ts"
   },
   "dependencies": {
     "@fastify/cookie": "11.1.0",

--- a/apps/api/scripts/erase-player-signals.ts
+++ b/apps/api/scripts/erase-player-signals.ts
@@ -1,0 +1,63 @@
+// Erase a person's player-side contributions — votes and written feedback.
+//
+//   npm run player:erase -w @gamedevpl/api -- g:12345 --dry-run
+//   npm run player:erase -w @gamedevpl/api -- g:12345 --confirm
+//
+// This is the executable half of the promise in the privacy notice (§8, "Deleting your
+// account"): account deletion removes the votes and feedback a person left on games.
+// Deletion is requested by email, so this is an operator command rather than an HTTP
+// route — a destructive, uid-targeted endpoint is attack surface that buys nothing when
+// the request already arrives out of band and a human has to verify it anyway.
+//
+// Talks to Firestore with your ambient gcloud credentials, like `beta:approve` and
+// `token:mint`. There is no dev/prod switch — check `gcloud config get-value project`
+// before running against the live site.
+//
+// Note what this does *not* do: play telemetry is untouched because it carries no uid at
+// all. There is nothing there to erase, which is the intended property, not a gap.
+
+import { erasePlayerSignals } from '../src/erase-player-signals.js';
+import { FirestoreStore } from '../src/store.js';
+
+function usage(): never {
+  console.error(
+    [
+      'Usage:',
+      '  player:erase -- <uid> --dry-run    # show what would be removed',
+      '  player:erase -- <uid> --confirm    # actually remove it',
+      '',
+      'One of --dry-run or --confirm is required.',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const uid = args.find((arg) => !arg.startsWith('--'));
+  const dryRun = args.includes('--dry-run');
+  const confirm = args.includes('--confirm');
+
+  // Neither flag, or both, is ambiguous about intent — and the destructive reading is
+  // the one you do not want to guess at.
+  if (!uid || dryRun === confirm) usage();
+
+  const store = new FirestoreStore();
+  const result = await erasePlayerSignals({ store, uid, dryRun });
+
+  const verb = result.dryRun ? 'would remove' : 'removed';
+  console.log(`${result.dryRun ? '[dry run] ' : ''}${verb} for ${result.uid}:`);
+  console.log(
+    `  votes:    ${result.votesCleared.length}${result.votesCleared.length ? ` (${result.votesCleared.join(', ')})` : ''}`,
+  );
+  console.log(`  feedback: ${result.feedbackDeleted}`);
+  if (result.votesCleared.length === 0 && result.feedbackDeleted === 0) {
+    console.log('  nothing found — this account left no votes or feedback.');
+  }
+  console.log('  play telemetry: not applicable (carries no uid by design).');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/apps/api/src/erase-player-signals.test.ts
+++ b/apps/api/src/erase-player-signals.test.ts
@@ -79,6 +79,17 @@ describe('erasePlayerSignals', () => {
     expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 2, down: 0 });
   });
 
+  it('previews exactly what it then deletes', async () => {
+    // The dry run is the only thing between an operator and an irreversible delete, so
+    // the two must agree by construction rather than by coincidence — they run the same
+    // query, and this is the assertion that keeps them running the same query.
+    const preview = await erasePlayerSignals({ store, uid: 'g:leaver', dryRun: true });
+    const actual = await erasePlayerSignals({ store, uid: 'g:leaver' });
+
+    expect(actual.feedbackDeleted).toBe(preview.feedbackDeleted);
+    expect(actual.votesCleared).toEqual(preview.votesCleared);
+  });
+
   it('is idempotent — a second run finds nothing left', async () => {
     await erasePlayerSignals({ store, uid: 'g:leaver' });
     const second = await erasePlayerSignals({ store, uid: 'g:leaver' });

--- a/apps/api/src/erase-player-signals.test.ts
+++ b/apps/api/src/erase-player-signals.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { erasePlayerSignals } from './erase-player-signals.js';
+import { InMemoryStore } from './store.js';
+
+/**
+ * This is the executable half of a promise the privacy notice makes, so the tests are
+ * about the promise rather than the plumbing: everything of this person's goes, nothing
+ * of anyone else's does, and the aggregate counts other people see stay honest
+ * afterwards.
+ */
+
+describe('erasePlayerSignals', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:leaver' });
+    await store.upsertUser({ uid: 'g:stayer' });
+
+    await store.castVote('brick-storm', 'g:leaver', 'up');
+    await store.castVote('brick-storm', 'g:stayer', 'up');
+    await store.castVote('rock-blaster', 'g:leaver', 'down');
+
+    await store.addPlayerFeedback('brick-storm', 'g:leaver', 'level two is a wall');
+    await store.addPlayerFeedback('brick-storm', 'g:stayer', 'the controls feel great');
+    await store.addPlayerFeedback('rock-blaster', 'g:leaver', 'asteroids spawn on top of me');
+  });
+
+  it('removes the leaver’s votes and feedback across every game', async () => {
+    const result = await erasePlayerSignals({ store, uid: 'g:leaver' });
+
+    expect(result.votesCleared.sort()).toEqual(['brick-storm', 'rock-blaster']);
+    expect(result.feedbackDeleted).toBe(2);
+
+    expect(await store.getVote('brick-storm', 'g:leaver')).toBeNull();
+    expect(await store.getVote('rock-blaster', 'g:leaver')).toBeNull();
+    expect((await store.listPlayerFeedback('brick-storm')).map((row) => row.uid)).toEqual(['g:stayer']);
+    expect(await store.listPlayerFeedback('rock-blaster')).toEqual([]);
+  });
+
+  it('leaves everyone else’s signals untouched', async () => {
+    await erasePlayerSignals({ store, uid: 'g:leaver' });
+
+    expect(await store.getVote('brick-storm', 'g:stayer')).toBe('up');
+    expect((await store.listPlayerFeedback('brick-storm'))[0]?.text).toContain('controls feel great');
+  });
+
+  it('keeps the public vote tallies honest after the erase', async () => {
+    // The property most easily lost: votes are counted on the parent game document, so
+    // deleting a vote row directly would leave the count overstating reality forever —
+    // a number every visitor sees, wrong, with nothing to notice it.
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 2, down: 0 });
+
+    await erasePlayerSignals({ store, uid: 'g:leaver' });
+
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 1, down: 0 });
+    expect(await store.getVoteCounts('rock-blaster')).toEqual({ up: 0, down: 0 });
+  });
+
+  it('reports what it would do without touching anything on a dry run', async () => {
+    const result = await erasePlayerSignals({ store, uid: 'g:leaver', dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.votesCleared.sort()).toEqual(['brick-storm', 'rock-blaster']);
+    expect(result.feedbackDeleted).toBe(2);
+
+    // Still all there.
+    expect(await store.getVote('brick-storm', 'g:leaver')).toBe('up');
+    expect(await store.listPlayerFeedback('rock-blaster')).toHaveLength(1);
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 2, down: 0 });
+  });
+
+  it('is a no-op for an account that never voted or wrote anything', async () => {
+    const result = await erasePlayerSignals({ store, uid: 'g:ghost' });
+
+    expect(result.votesCleared).toEqual([]);
+    expect(result.feedbackDeleted).toBe(0);
+    // And nobody else was disturbed by the attempt.
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 2, down: 0 });
+  });
+
+  it('is idempotent — a second run finds nothing left', async () => {
+    await erasePlayerSignals({ store, uid: 'g:leaver' });
+    const second = await erasePlayerSignals({ store, uid: 'g:leaver' });
+
+    expect(second.votesCleared).toEqual([]);
+    expect(second.feedbackDeleted).toBe(0);
+    // The first run's correction is not applied twice.
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 1, down: 0 });
+  });
+});

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -25,6 +25,14 @@ import type { Store } from './store.js';
  *   walking the games and clearing each one — and cleared through `clearVote` rather than
  *   deleted directly, because the aggregate counts live on the parent game document and a
  *   raw delete would leave `votesUp`/`votesDown` overstating reality forever.
+ *
+ * The walk looks like something a collection-group query should replace, and it cannot be:
+ * `collectionGroup('votes').where(FieldPath.documentId(), '==', uid)` throws, because a
+ * documentId comparison on a collection group requires a *full document path*, and a bare
+ * uid is a single segment. The path it wants is `games/{slug}/votes/{uid}` — which means
+ * knowing the slug, which is the thing the query was supposed to find. Verified against
+ * @google-cloud/firestore 8.7.0; the check is client-side, so it fails every time, not
+ * just against a real database.
  */
 
 export interface ErasePlayerSignalsResult {

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -58,25 +58,13 @@ export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Pr
     if (!dryRun) await store.clearVote(slug, uid);
   }
 
+  // Count and delete run the same `where('uid','==',uid)` predicate over the same
+  // collection group, differing only in `.count()` versus `.get()`. That matters more than
+  // it looks: a dry run is the only thing standing between an operator and an irreversible
+  // delete, so it must not be able to see a different set of rows than the delete will.
   const feedbackDeleted = dryRun
-    ? await countFeedbackFor(store, uid, slugs)
+    ? await store.countPlayerFeedbackByUid(uid)
     : await store.deletePlayerFeedbackByUid(uid);
 
   return { uid, votesCleared, feedbackDeleted, dryRun };
-}
-
-/**
- * Counts a user's feedback without deleting it — the dry-run path only.
- *
- * Walks the games rather than adding a count-by-uid to the Store interface: this runs
- * once per erase request, by an operator, and a second query shape that exists solely to
- * preview a delete is a second thing that can disagree with the delete it previews.
- */
-async function countFeedbackFor(store: Store, uid: string, slugs: string[]): Promise<number> {
-  let total = 0;
-  for (const slug of slugs) {
-    const rows = await store.listPlayerFeedback(slug);
-    total += rows.filter((row) => row.uid === uid).length;
-  }
-  return total;
 }

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -1,0 +1,82 @@
+import type { Store } from './store.js';
+
+/**
+ * Erase everything a person contributed *as a player*: their votes and their written
+ * feedback.
+ *
+ * This exists because the privacy notice promises it. Section 8 says account deletion
+ * removes "the votes and written feedback you left on games", and until now that was a
+ * promise nothing could execute — an operator would have had to find the rows by hand in
+ * the Firestore console, across every game, knowing that a vote is keyed by document id.
+ * A commitment that depends on somebody remembering how the schema works is one that
+ * quietly stops being true.
+ *
+ * **Play telemetry is deliberately not touched, and that is not an omission.** Play
+ * events carry no uid, no IP and no user agent by construction, so there is nothing in
+ * them to erase and nothing that could be found even if we tried. That is the whole point
+ * of the "measures games, not people" invariant: the erase path for play data is that it
+ * was never attributed in the first place.
+ *
+ * Two shapes of deletion, because the two collections are keyed differently:
+ *
+ * - **Feedback** carries `uid` as a field, so one collection-group query finds every row
+ *   a person wrote, across all games.
+ * - **A vote's uid is its document id**, with no field to query on. So votes are found by
+ *   walking the games and clearing each one — and cleared through `clearVote` rather than
+ *   deleted directly, because the aggregate counts live on the parent game document and a
+ *   raw delete would leave `votesUp`/`votesDown` overstating reality forever.
+ */
+
+export interface ErasePlayerSignalsResult {
+  uid: string;
+  /** Games where a vote was found (and cleared, unless this was a dry run). */
+  votesCleared: string[];
+  /** Feedback rows found (and deleted, unless this was a dry run). */
+  feedbackDeleted: number;
+  dryRun: boolean;
+}
+
+export interface ErasePlayerSignalsOptions {
+  store: Store;
+  uid: string;
+  /** Report what would go without touching anything. */
+  dryRun?: boolean;
+}
+
+export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Promise<ErasePlayerSignalsResult> {
+  const { store, uid } = options;
+  const dryRun = options.dryRun ?? false;
+
+  const slugs = await store.listGameSlugs();
+  const votesCleared: string[] = [];
+  for (const slug of slugs) {
+    const vote = await store.getVote(slug, uid);
+    if (vote === null) continue;
+    votesCleared.push(slug);
+    // `clearVote` is transactional and fixes the parent game's tallies; deleting the
+    // vote document directly would strand the counts.
+    if (!dryRun) await store.clearVote(slug, uid);
+  }
+
+  const feedbackDeleted = dryRun
+    ? await countFeedbackFor(store, uid, slugs)
+    : await store.deletePlayerFeedbackByUid(uid);
+
+  return { uid, votesCleared, feedbackDeleted, dryRun };
+}
+
+/**
+ * Counts a user's feedback without deleting it — the dry-run path only.
+ *
+ * Walks the games rather than adding a count-by-uid to the Store interface: this runs
+ * once per erase request, by an operator, and a second query shape that exists solely to
+ * preview a delete is a second thing that can disagree with the delete it previews.
+ */
+async function countFeedbackFor(store: Store, uid: string, slugs: string[]): Promise<number> {
+  let total = 0;
+  for (const slug of slugs) {
+    const rows = await store.listPlayerFeedback(slug);
+    total += rows.filter((row) => row.uid === uid).length;
+  }
+  return total;
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -661,6 +661,17 @@ export interface Store {
    * asymmetry with votes above.
    */
   deletePlayerFeedbackByUid(uid: string): Promise<number>;
+  /**
+   * How many feedback rows a user wrote, across all games — the dry run for the delete
+   * above.
+   *
+   * Deliberately the *same* predicate as `deletePlayerFeedbackByUid`, differing only in
+   * `.count()` versus `.get()`. A preview of a destructive operation that finds its rows
+   * by a different route than the deletion does is a preview that can quietly disagree
+   * with what follows, and the direction it disagrees in — under-reporting — is the one
+   * an operator would not catch.
+   */
+  countPlayerFeedbackByUid(uid: string): Promise<number>;
   /** Persist a newly minted personal access token. */
   createAccessToken(record: AccessTokenRecord): Promise<void>;
   /** Point lookup by token id — the hot path on every bearer-authenticated request. */
@@ -1215,6 +1226,14 @@ export class InMemoryStore implements Store {
       this.playerFeedback.set(slug, kept);
     }
     return deleted;
+  }
+
+  async countPlayerFeedbackByUid(uid: string): Promise<number> {
+    let total = 0;
+    for (const rows of this.playerFeedback.values()) {
+      total += rows.filter((row) => row.uid === uid).length;
+    }
+    return total;
   }
 
   async createAccessToken(record: AccessTokenRecord): Promise<void> {
@@ -1883,8 +1902,16 @@ export class FirestoreStore implements Store {
     return refs.map((ref) => ref.id).sort();
   }
 
+  // Both of these need the COLLECTION_GROUP index on playerFeedback.uid that
+  // infra/setup-gcp.sh step 7 provisions. Firestore auto-indexes single fields at
+  // COLLECTION scope only, so without it they fail with 9 FAILED_PRECONDITION rather
+  // than merely running slowly.
+  private feedbackByUid(uid: string) {
+    return this.db.collectionGroup('playerFeedback').where('uid', '==', uid);
+  }
+
   async deletePlayerFeedbackByUid(uid: string): Promise<number> {
-    const snap = await this.db.collectionGroup('playerFeedback').where('uid', '==', uid).get();
+    const snap = await this.feedbackByUid(uid).get();
     if (snap.empty) return 0;
 
     // Chunked because a batch tops out at 500 writes, and "delete everything this
@@ -1896,6 +1923,11 @@ export class FirestoreStore implements Store {
       await batch.commit();
     }
     return docs.length;
+  }
+
+  async countPlayerFeedbackByUid(uid: string): Promise<number> {
+    const snap = await this.feedbackByUid(uid).count().get();
+    return snap.data().count;
   }
 
   async getScorecard(slug: string): Promise<Scorecard | null> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -645,6 +645,22 @@ export interface Store {
    * this is one query behind an operator page rather than a paginated surface.
    */
   listScorecards(opts?: { limit?: number }): Promise<Scorecard[]>;
+  /**
+   * Every slug that has a `games/{slug}` entry — including games whose document does
+   * not exist but which have subcollections (votes, feedback, scorecard).
+   *
+   * Exists for the erase path. A vote's uid is its *document id* and not a field, so
+   * unlike feedback there is no query that finds one user's votes across games; the only
+   * way is to look under each game. Bounded by the catalog, so a walk is affordable.
+   */
+  listGameSlugs(): Promise<string[]>;
+  /**
+   * Deletes every feedback row a user wrote, across all games. Returns how many.
+   *
+   * Feedback *is* findable by uid because the row carries it as a field, which is the
+   * asymmetry with votes above.
+   */
+  deletePlayerFeedbackByUid(uid: string): Promise<number>;
   /** Persist a newly minted personal access token. */
   createAccessToken(record: AccessTokenRecord): Promise<void>;
   /** Point lookup by token id — the hot path on every bearer-authenticated request. */
@@ -1182,6 +1198,23 @@ export class InMemoryStore implements Store {
       .map((card) => structuredClone(card))
       .sort(compareScorecards)
       .slice(0, opts?.limit ?? 200);
+  }
+
+  async listGameSlugs(): Promise<string[]> {
+    // Union of every slug this store knows anything about, mirroring Firestore's
+    // `listDocuments()`, which also returns a game whose document never existed but
+    // whose subcollections do.
+    return [...new Set([...this.votes.keys(), ...this.playerFeedback.keys(), ...this.scorecards.keys()])].sort();
+  }
+
+  async deletePlayerFeedbackByUid(uid: string): Promise<number> {
+    let deleted = 0;
+    for (const [slug, rows] of this.playerFeedback) {
+      const kept = rows.filter((row) => row.uid !== uid);
+      deleted += rows.length - kept.length;
+      this.playerFeedback.set(slug, kept);
+    }
+    return deleted;
   }
 
   async createAccessToken(record: AccessTokenRecord): Promise<void> {
@@ -1839,6 +1872,30 @@ export class FirestoreStore implements Store {
       .limit(opts?.limit ?? 200)
       .get();
     return snap.docs.map((doc) => doc.data() as Scorecard).sort(compareScorecards);
+  }
+
+  async listGameSlugs(): Promise<string[]> {
+    // `listDocuments()` rather than `get()`: it lists references without reading
+    // documents, and — the part that matters here — it includes games whose parent
+    // document was never written but which have subcollections underneath. A game that
+    // only ever received feedback is exactly that case, and a `get()` would miss it.
+    const refs = await this.db.collection('games').listDocuments();
+    return refs.map((ref) => ref.id).sort();
+  }
+
+  async deletePlayerFeedbackByUid(uid: string): Promise<number> {
+    const snap = await this.db.collectionGroup('playerFeedback').where('uid', '==', uid).get();
+    if (snap.empty) return 0;
+
+    // Chunked because a batch tops out at 500 writes, and "delete everything this
+    // person wrote" is precisely the request that could exceed it.
+    const docs = snap.docs;
+    for (let index = 0; index < docs.length; index += 400) {
+      const batch = this.db.batch();
+      for (const doc of docs.slice(index, index + 400)) batch.delete(doc.ref);
+      await batch.commit();
+    }
+    return docs.length;
   }
 
   async getScorecard(slug: string): Promise<Scorecard | null> {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -191,6 +191,32 @@ a Firestore TTL policy at `expiresAt` as stored today — that field is an ISO s
 TTL only deletes on Timestamp/Date values (a no-op policy otherwise). Self-cleaning would
 need a dedicated Timestamp field or an operator sweep; it is hygiene, not a control.
 
+## Honouring a deletion request
+
+The privacy notice (§8) promises that deleting an account removes the votes and written
+feedback that person left on games. Deletion arrives by email, so it is an operator command
+rather than an endpoint — a destructive uid-targeted route would be attack surface buying
+nothing when a human already has to verify the request out of band.
+
+```bash
+npm run player:erase -w @gamedevpl/api -- g:12345 --dry-run   # preview
+npm run player:erase -w @gamedevpl/api -- g:12345 --confirm   # do it
+```
+
+One of `--dry-run` or `--confirm` is required; neither-or-both exits with usage, because
+the destructive reading is not one to guess at. The command is idempotent, so re-running
+after a partial failure is safe.
+
+Two things worth knowing before you run it:
+
+- **Votes are cleared through the same transaction the product uses**, not deleted
+  directly. Vote tallies live on the parent `games/{slug}` document, so a raw delete would
+  leave `votesUp`/`votesDown` overstating reality permanently — a number every visitor
+  sees, wrong, with nothing to catch it.
+- **Play telemetry is not touched, and that is the point.** Play events carry no uid, no IP
+  and no user agent by construction, so there is nothing in them to erase and nothing that
+  could be found if you tried. The erase path for play data is that it was never attributed.
+
 ## How to deploy manually
 
 [`apps/api/Dockerfile`](../apps/api/Dockerfile) is a multi-stage image built from the repo root

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -216,6 +216,11 @@ Two things worth knowing before you run it:
 - **Play telemetry is not touched, and that is the point.** Play events carry no uid, no IP
   and no user agent by construction, so there is nothing in them to erase and nothing that
   could be found if you tried. The erase path for play data is that it was never attributed.
+- **It needs the `playerFeedback.uid` collection-group index** from step 7 of
+  [`infra/setup-gcp.sh`](../infra/setup-gcp.sh). If the command fails with
+  `9 FAILED_PRECONDITION`, that index is missing — re-run the setup script, wait for the
+  build, and run the erase again. Nothing partial happens in that case: the failure is on
+  the read, before any delete.
 
 ## How to deploy manually
 

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -101,43 +101,58 @@ for GROUP in $TELEMETRY_GROUPS; do
   fi
 done
 
-# The operator scorecards read (GET /api/admin/scorecards, backing the /health panel)
-# runs a COLLECTION GROUP query ordered by computedAt — see listScorecards in
-# apps/api/src/store.ts: db.collectionGroup('scorecard').orderBy('computedAt','desc').
-# Firestore auto-indexes single fields only at COLLECTION scope, never COLLECTION_GROUP,
-# so without this index the query fails with `9 FAILED_PRECONDITION` and the whole /health
-# telemetry page 500s — all four operator reads share one Promise.all and one error state,
-# so the missing index blanks the game-health table too.
+# Two reads run COLLECTION GROUP queries over a single field, and Firestore auto-indexes
+# single fields only at COLLECTION scope, never COLLECTION_GROUP. Without these the query
+# fails with `9 FAILED_PRECONDITION` — not a slow query, a hard error:
 #
-# This is a SINGLE-FIELD index, which Firestore requires be configured through single-field
-# controls: `gcloud firestore indexes composite create` rejects it ("not necessary, configure
+#   scorecard.computedAt (DESC)  listScorecards, apps/api/src/store.ts
+#     Backs GET /api/admin/scorecards and the /health scorecards panel. All four operator
+#     reads share one Promise.all and one error state, so this one missing index blanks
+#     the game-health table too, not just the panel that needs it.
+#
+#   playerFeedback.uid (ASC)     deletePlayerFeedbackByUid, apps/api/src/store.ts
+#     Backs `npm run player:erase` — the executable half of the privacy notice's promise
+#     to remove a person's votes and feedback on account deletion. This one fails at the
+#     worst possible moment: an operator running a deletion request they have already
+#     accepted, with no other way to carry it out. Equality needs only ASCENDING.
+#
+# These are SINGLE-FIELD indexes, which Firestore requires be configured through single-field
+# controls: `gcloud firestore indexes composite create` rejects them ("not necessary, configure
 # using single field index controls"), and `gcloud firestore indexes fields update` cannot set
-# `query-scope` in this CLI. So it is applied through the Firestore Admin REST field override,
-# which is the only interface that expresses a COLLECTION_GROUP single-field index here.
+# `query-scope` in this CLI. So they are applied through the Firestore Admin REST field
+# override, the only interface that expresses a COLLECTION_GROUP single-field index here.
 #
-# This is an INDEX, not a TTL policy — it must NEVER be added to the TTL loop above. Scorecards
-# are the durable aggregate meant to outlive the raw play rows a TTL expires; a TTL here would
-# delete the summaries and keep nothing. The index just makes them readable in order.
-echo "==> 7/8 Ensuring the COLLECTION_GROUP index for the scorecards operator read"
-SCORECARD_FIELD_URL="https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/collectionGroups/scorecard/fields/computedAt"
-SCORECARD_ACCESS_TOKEN="$(gcloud auth print-access-token --project="$PROJECT_ID")"
-if curl -s -H "Authorization: Bearer ${SCORECARD_ACCESS_TOKEN}" "$SCORECARD_FIELD_URL" \
-  | grep -q '"COLLECTION_GROUP"'; then
-  echo "    scorecard.computedAt COLLECTION_GROUP index: already present."
-else
+# These are INDEXES, not TTL policies — they must NEVER be added to the TTL loop above.
+# Scorecards are the durable aggregate meant to outlive the raw play rows a TTL expires, and
+# feedback is a person's own words; a TTL on either would delete what we meant to keep.
+echo "==> 7/8 Ensuring the COLLECTION_GROUP indexes the operator reads need"
+FIELD_ACCESS_TOKEN="$(gcloud auth print-access-token --project="$PROJECT_ID")"
+# group:field:order — one line per COLLECTION_GROUP single-field index.
+CG_INDEXES="scorecard:computedAt:DESCENDING playerFeedback:uid:ASCENDING"
+for ENTRY in $CG_INDEXES; do
+  CG_GROUP="${ENTRY%%:*}"
+  CG_REST="${ENTRY#*:}"
+  CG_FIELD="${CG_REST%%:*}"
+  CG_ORDER="${CG_REST#*:}"
+  FIELD_URL="https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/collectionGroups/${CG_GROUP}/fields/${CG_FIELD}"
+  if curl -s -H "Authorization: Bearer ${FIELD_ACCESS_TOKEN}" "$FIELD_URL" \
+    | grep -q '"COLLECTION_GROUP"'; then
+    echo "    ${CG_GROUP}.${CG_FIELD} COLLECTION_GROUP index: already present."
+    continue
+  fi
   # The COLLECTION (asc/desc) entries reassert Firestore's default single-field indexing,
-  # which setting an explicit indexConfig would otherwise drop; the COLLECTION_GROUP DESC
-  # entry is the one the query needs. Builds asynchronously (seconds for a handful of rows).
-  curl -s -X PATCH "${SCORECARD_FIELD_URL}?updateMask=indexConfig" \
-    -H "Authorization: Bearer ${SCORECARD_ACCESS_TOKEN}" \
+  # which setting an explicit indexConfig would otherwise drop; the COLLECTION_GROUP entry
+  # is the one the query needs. Builds asynchronously (seconds for a handful of rows).
+  curl -s -X PATCH "${FIELD_URL}?updateMask=indexConfig" \
+    -H "Authorization: Bearer ${FIELD_ACCESS_TOKEN}" \
     -H "Content-Type: application/json" \
-    -d '{"indexConfig":{"indexes":[
-      {"queryScope":"COLLECTION","fields":[{"fieldPath":"computedAt","order":"ASCENDING"}]},
-      {"queryScope":"COLLECTION","fields":[{"fieldPath":"computedAt","order":"DESCENDING"}]},
-      {"queryScope":"COLLECTION_GROUP","fields":[{"fieldPath":"computedAt","order":"DESCENDING"}]}
-    ]}}' >/dev/null
-  echo "    scorecard.computedAt COLLECTION_GROUP index: creating (builds asynchronously)."
-fi
+    -d "{\"indexConfig\":{\"indexes\":[
+      {\"queryScope\":\"COLLECTION\",\"fields\":[{\"fieldPath\":\"${CG_FIELD}\",\"order\":\"ASCENDING\"}]},
+      {\"queryScope\":\"COLLECTION\",\"fields\":[{\"fieldPath\":\"${CG_FIELD}\",\"order\":\"DESCENDING\"}]},
+      {\"queryScope\":\"COLLECTION_GROUP\",\"fields\":[{\"fieldPath\":\"${CG_FIELD}\",\"order\":\"${CG_ORDER}\"}]}
+    ]}}" >/dev/null
+  echo "    ${CG_GROUP}.${CG_FIELD} COLLECTION_GROUP index: creating (builds asynchronously)."
+done
 
 # Pre-assembled published games (apps/api/src/game-snapshot.ts). The bucket sits in
 # the Cloud Run region, not the Firestore one: it is read on the play path, and a


### PR DESCRIPTION
## Why

Privacy notice §8 says account deletion removes "the votes and written feedback you left on games" — wording I added in #250. Nothing could execute it. An operator would have had to find the rows by hand in the Firestore console, across every game, knowing that a vote is keyed by document id rather than a field. A commitment that depends on somebody remembering how the schema works is one that quietly stops being true.

## What

```bash
npm run player:erase -w @gamedevpl/api -- g:12345 --dry-run   # preview
npm run player:erase -w @gamedevpl/api -- g:12345 --confirm   # do it
```

A shared service (`erase-player-signals.ts`) behind the CLI, following the `access-token-service.ts` pattern so a future HTTP caller can't drift from it. Neither-or-both of the two flags exits with usage — the destructive reading isn't one to guess at. Idempotent, so re-running after a partial failure is safe.

**CLI rather than an endpoint** on purpose: deletion requests arrive by email and a human verifies them out of band, so a destructive uid-targeted route would be attack surface buying nothing.

## The bit that needed actual thought

The two collections are keyed differently, which is why this isn't one query:

- **Feedback** carries `uid` as a field → one collection-group query finds every row a person wrote.
- **A vote's uid is its document id**, with no field to query on → votes are found by walking the games, and cleared through the existing transactional `clearVote` rather than deleted directly.

That second point is the one worth reviewing. Vote tallies live on the parent `games/{slug}` document. A raw delete of the vote row would leave `votesUp`/`votesDown` permanently overstating reality — a number **every visitor sees**, wrong, with nothing in the system to notice. There's a test asserting the public counts are still correct after an erase, and another asserting a second run doesn't double-correct them.

## Play telemetry is untouched, and that's the property

Not an omission. Play events carry no uid, no IP and no user agent by construction, so there is nothing in them to erase and nothing that could be found if we tried. The erase path for play data is that it was never attributed in the first place. The CLI says so in its output, so an operator handling a request doesn't wonder whether something was missed.

## Also: the feedback write path is now verified in production

It had only ever been exercised on its *rejection* paths (401/404/400/422). I wrote one real row as `bot:e2e` — the same identity the deploy pipeline's authenticated smoke already uses. The `{"ok":true}` covers the whole chain: PAT auth → published-slug gate → sanitize + length recheck → **live Gemini moderation** (prod uses `VertexChecker`, not the pattern checker) → quota → Firestore write.

That row is still on `brick-storm`. Removing it is the first real use of this tool:

```bash
npm run player:erase -w @gamedevpl/api -- bot:e2e --confirm
```

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — `apps/api` 689 (6 new), `apps/web` unchanged
- [x] `npm run build`
- [x] Production write path exercised end to end (above)

New tests: both signal types removed across all games; other users untouched; **public vote tallies stay honest**; dry run reports without mutating; no-op for an account with nothing; idempotent on a second run.

## Instrumentation definition-of-done

Affects none of the seven questions — this removes data rather than capturing it, and deliberately cannot touch the anonymous play stream. Worth stating explicitly: erasing a player's votes lowers that game's vote counts, so a scorecard computed after an erase legitimately differs from one computed before. That's the promise working, not drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4qCA3ruvWreLtyibx71q)_