### PR TITLE
docs(skill): note SVG span-rect banding from mascot #270

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -111,6 +111,15 @@ Two concrete instances of that (observed 2026-07-23):
   _fully assembled app_ (`buildApp`/equivalent), not just the plugin that defines the
   route — and grep for the wall's exemption list explicitly to confirm the new path
   matches it.
+- **Hundreds of adjacent 1px SVG `<rect>`s look solid in `crispEdges` and band under
+  `auto`.** Observed (mascot follow-up, 2026-07-27): a pixel silhouette drawn as ~200
+  horizontal span-rects was fine for the idle nav mark (`shape-rendering: crispEdges`)
+  but every emotion placement used `auto` AA — each rect got soft top/bottom edges, and
+  neighbouring partial coverage did not sum to opaque, so the body showed horizontal
+  banding / speckles on phones. Flatten spans into one `<path>` (interior edges cancel
+  in a single coverage pass). Also: a "solid" fill derived separately from the punched
+  silhouette can leave pinholes inside the mouth/eyes; derive solid from idle + enclosed
+  holes, and test that solid covers every idle pixel and leaves only intentional holes.
 
 ## Read the diff against the spec
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Small addition to the verify-agent-work skill from reviewing Claude Code’s merged mascot follow-up (#270): adjacent 1px SVG rects band under auto AA, and a separately derived “solid” silhouette can leave pinholes. Recorded so the next review catches it earlier.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa478-55b6-7a84-9d2c-f21149a547ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa478-55b6-7a84-9d2c-f21149a547ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

