### PR TITLE
Sync serve budget with games-repo MAX_BUNDLE_BYTES (243078)

### DIFF
--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -5,7 +5,7 @@
  * asserts they still match `games-repo-contract.ts` on this side:
  *   - GAME_KIT_MODULES order
  *   - MAX_BUNDLE_BYTES === MAX_PROJECT_BYTES
- *   - music injection contract (tracks + __GAME_AUDIO_MUSIC__)
+ *   - music injection contract (tracks + __GAME_AUDIO_MUSIC__ + readMusicCatalog)
  *
  * Requires GAMES_REPO_TOKEN (contents:read on the games repo). In CI, skip with a
  * warning when the secret is unset so forks / fresh clones still go green; set the
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
   console.log(`  ✓ MAX_BUNDLE_BYTES / MAX_PROJECT_BYTES (${remoteBudget})`);
 
   const music = extractMusicContractSignals(assembleSource);
-  if (!music.injectsMusicName || !music.readsTracksKey || !music.readsMusicJson) {
+  if (!music.injectsMusicName || !music.readsTracksKey || !music.readsMusicCatalog) {
     const musicLines = assembleSource
       .split('\n')
       .map((line, index) => ({ line: line.trim(), n: index + 1 }))
@@ -99,11 +99,11 @@ async function main(): Promise<void> {
       .join('\n');
     fail(
       `music contract mismatch in games-repo assemble.ts: ` +
-        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} readsMusicJson=${music.readsMusicJson}\n` +
+        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} readsMusicCatalog=${music.readsMusicCatalog}\n` +
         `relevant lines:\n${musicLines || '  (none)'}`,
     );
   }
-  console.log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + music.json)');
+  console.log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + readMusicCatalog)');
 
   console.log('games-repo contract: ok');
 }

--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -75,7 +75,16 @@ async function main(): Promise<void> {
 
   const remoteBudget = extractMaxBundleBytes(validateSource);
   if (remoteBudget !== MAX_PROJECT_BYTES) {
-    fail(`MAX_BUNDLE_BYTES mismatch: games-repo=${remoteBudget} website MAX_PROJECT_BYTES=${MAX_PROJECT_BYTES}`);
+    const assignLine =
+      validateSource
+        .split('\n')
+        .find((line) => /MAX_BUNDLE_BYTES\s*=/.test(line))
+        ?.trim() ?? '(assignment line not found)';
+    fail(
+      `MAX_BUNDLE_BYTES mismatch: games-repo=${remoteBudget} website MAX_PROJECT_BYTES=${MAX_PROJECT_BYTES}\n` +
+        `  games-repo assignment: ${assignLine}\n` +
+        `  Update GAMEKIT_PLATFORM_BYTES / MAX_PROJECT_BYTES in apps/api/src/games-repo-contract.ts to match.`,
+    );
   }
   console.log(`  ✓ MAX_BUNDLE_BYTES / MAX_PROJECT_BYTES (${remoteBudget})`);
 

--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -90,9 +90,17 @@ async function main(): Promise<void> {
 
   const music = extractMusicContractSignals(assembleSource);
   if (!music.injectsMusicName || !music.readsTracksKey || !music.readsMusicJson) {
+    const musicLines = assembleSource
+      .split('\n')
+      .map((line, index) => ({ line: line.trim(), n: index + 1 }))
+      .filter(({ line }) => /music|__GAME_AUDIO|__GAME_MUSIC|tracks/i.test(line))
+      .slice(0, 40)
+      .map(({ line, n }) => `  L${n}: ${line}`)
+      .join('\n');
     fail(
       `music contract mismatch in games-repo assemble.ts: ` +
-        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} readsMusicJson=${music.readsMusicJson}`,
+        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} readsMusicJson=${music.readsMusicJson}\n` +
+        `relevant lines:\n${musicLines || '  (none)'}`,
     );
   }
   console.log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + music.json)');

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(242 * 1024);
+    expect(MAX_PROJECT_BYTES).toBe(243_078);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -86,7 +86,8 @@ describe('games-repo source extractors', () => {
 
   it('detects the music injection contract signals', () => {
     const source = `
-      const catalog = JSON.parse(await read('shared/audio/music.json'));
+      import { readMusicCatalog } from '../audio.ts';
+      const catalog = readMusicCatalog();
       const track = catalog.tracks[name];
       out += \`window.__GAME_AUDIO_MUSIC__ = \${JSON.stringify(name)};\`;
       out += \`window.__GAME_MUSIC_TRACKS__ = Object.freeze(\${JSON.stringify({ [name]: track })});\`;
@@ -94,7 +95,20 @@ describe('games-repo source extractors', () => {
     expect(extractMusicContractSignals(source)).toEqual({
       injectsMusicName: true,
       readsTracksKey: true,
-      readsMusicJson: true,
+      readsMusicCatalog: true,
+    });
+  });
+
+  it('still accepts the older inline music.json catalog read', () => {
+    const source = `
+      const catalog = JSON.parse(await read('shared/audio/music.json'));
+      const track = catalog.tracks[name];
+      out += \`window.__GAME_AUDIO_MUSIC__ = \${JSON.stringify(name)};\`;
+    `;
+    expect(extractMusicContractSignals(source)).toMatchObject({
+      injectsMusicName: true,
+      readsTracksKey: true,
+      readsMusicCatalog: true,
     });
   });
 });

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -12,8 +12,8 @@ import {
 import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
-  it('keeps the serve budget at the Check 4 total (242 KiB)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(242 * 1024);
+  it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
+    expect(MAX_PROJECT_BYTES).toBe(243_078);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -54,6 +54,8 @@ describe('games-repo source extractors', () => {
   });
 
   it('evaluates MAX_BUNDLE_BYTES across named platform allowances', () => {
+    // Shape mirrors games-repo validate.ts: author budget + named GameKit
+    // allowances. Totals must match MAX_PROJECT_BYTES on this side.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501;
@@ -63,15 +65,7 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_PROGRESS_BYTES = 2_048;
       const GAMEKIT_UNIVERSAL_INPUT_BYTES = 3_072;
       const GAMEKIT_POINTER_POLL_BYTES = 1_536;
-      const GAMEKIT_DRAW_SURFACE_BYTES =
-        42 * 1024 -
-        GAMEKIT_TOUCH_BYTES -
-        GAMEKIT_RESTART_BYTES -
-        GAMEKIT_MUSIC_BYTES -
-        GAMEKIT_TOUCH_HINT_BYTES -
-        GAMEKIT_PROGRESS_BYTES -
-        GAMEKIT_UNIVERSAL_INPUT_BYTES -
-        GAMEKIT_POINTER_POLL_BYTES;
+      const GAMEKIT_DRAW_SURFACE_BYTES = 18_489;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -83,11 +77,11 @@ describe('games-repo source extractors', () => {
         GAMEKIT_POINTER_POLL_BYTES +
         GAMEKIT_DRAW_SURFACE_BYTES;
     `;
-    expect(extractMaxBundleBytes(source)).toBe(242 * 1024);
+    expect(extractMaxBundleBytes(source)).toBe(243_078);
   });
 
   it('evaluates a numeric MAX_BUNDLE_BYTES literal', () => {
-    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 247_808;')).toBe(247808);
+    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 243_078;')).toBe(243078);
   });
 
   it('detects the music injection contract signals', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -111,4 +111,13 @@ describe('games-repo source extractors', () => {
       readsMusicCatalog: true,
     });
   });
+
+  it('does not treat a bare music.json mention as the historical catalog path', () => {
+    const source = `
+      // TODO: migrate music.json later
+      const track = catalog.tracks[name];
+      out += \`window.__GAME_AUDIO_MUSIC__ = \${JSON.stringify(name)};\`;
+    `;
+    expect(extractMusicContractSignals(source).readsMusicCatalog).toBe(false);
+  });
 });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -29,10 +29,13 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
 
 /**
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
- * music, touch hint, progress, universal input, pointer poll, draw surface).
- * Together with {@link GAME_BUDGET_BYTES} this is the 242 KiB serve cap.
+ * music, touch hint, progress, universal input, pointer poll, draw surface, …).
+ * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
+ * `MAX_BUNDLE_BYTES` (243_078 as of the games-repo side that broke CI on
+ * 2026-07-27). Not a round KiB: the platform side is an explicit sum of named
+ * allowances, not a padded `42 * 1024` block.
  */
-export const GAMEKIT_PLATFORM_BYTES = 42 * 1024;
+export const GAMEKIT_PLATFORM_BYTES = 38_278;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -43,13 +43,17 @@ export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
 /**
  * Music embedding contract (games-repo `tools/lib/assemble.ts`):
  * - `GAME.json` → `audio.music` is a single track-name string
- * - `shared/audio/music.json` → read only the `tracks` map
+ * - catalog is loaded via `readMusicCatalog()` (games-repo `tools/audio.ts`;
+ *   formerly an inline `shared/audio/music.json` read in assemble.ts)
  * - inject `window.__GAME_AUDIO_MUSIC__ = "<name>"` and a one-entry tracks object
  */
 export const MUSIC_CONTRACT = {
   manifestField: 'music',
   manifestFieldType: 'string',
+  /** Historical path; the catalog file may still live here inside `tools/audio.ts`. */
   catalogPath: 'shared/audio/music.json',
+  /** Function assemble.ts calls to load the music catalog (post-refactor lockstep). */
+  catalogReader: 'readMusicCatalog',
   catalogTracksKey: 'tracks',
   windowMusicName: '__GAME_AUDIO_MUSIC__',
   windowTracksName: '__GAME_MUSIC_TRACKS__',
@@ -84,12 +88,16 @@ export function extractMaxBundleBytes(validateSource: string): number {
 export function extractMusicContractSignals(assembleSource: string): {
   injectsMusicName: boolean;
   readsTracksKey: boolean;
-  readsMusicJson: boolean;
+  readsMusicCatalog: boolean;
 } {
   return {
     injectsMusicName: new RegExp(`${MUSIC_CONTRACT.windowMusicName}\\s*=`).test(assembleSource),
     readsTracksKey: new RegExp(`\\b${MUSIC_CONTRACT.catalogTracksKey}\\b`).test(assembleSource),
-    readsMusicJson: /music\.json/.test(assembleSource),
+    // Prefer the post-refactor reader; keep the old inline path as a fallback so an
+    // older games-repo tip still clears the check during a staggered rollout.
+    readsMusicCatalog:
+      new RegExp(`\\b${MUSIC_CONTRACT.catalogReader}\\s*\\(`).test(assembleSource) ||
+      /music\.json/.test(assembleSource),
   };
 }
 

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -90,14 +90,18 @@ export function extractMusicContractSignals(assembleSource: string): {
   readsTracksKey: boolean;
   readsMusicCatalog: boolean;
 } {
+  // Escape so `shared/audio/music.json` is matched literally — a bare `/music\.json/`
+  // would also accept comments or unrelated filenames (Copilot review on #272).
+  const catalogPathPattern = MUSIC_CONTRACT.catalogPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return {
     injectsMusicName: new RegExp(`${MUSIC_CONTRACT.windowMusicName}\\s*=`).test(assembleSource),
     readsTracksKey: new RegExp(`\\b${MUSIC_CONTRACT.catalogTracksKey}\\b`).test(assembleSource),
-    // Prefer the post-refactor reader; keep the old inline path as a fallback so an
-    // older games-repo tip still clears the check during a staggered rollout.
+    // Prefer the post-refactor reader; keep the historical catalog path as a
+    // fallback so an older games-repo tip still clears the check during a
+    // staggered rollout.
     readsMusicCatalog:
       new RegExp(`\\b${MUSIC_CONTRACT.catalogReader}\\s*\\(`).test(assembleSource) ||
-      /music\.json/.test(assembleSource),
+      new RegExp(catalogPathPattern).test(assembleSource),
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the red **Games-repo contract** CI check on `master` (and every open PR).

Two lockstep drifts vs `gamedevpl/www.gamedev.pl-games@main`:

1. **Budget:** live `MAX_BUNDLE_BYTES` is `243078` (was `242 * 1024` / `247808` here). Update `MAX_PROJECT_BYTES` / `GAMEKIT_PLATFORM_BYTES`.
2. **Music:** `assemble.ts` now loads the catalog via `readMusicCatalog()` from `tools/audio.ts` instead of an inline `music.json` read. Retarget the detector (keep the historical `shared/audio/music.json` path as a literal fallback).

Also prints the remote assignment / relevant assemble lines on mismatch so the next drift is easier to chase.

Separate from the contact-form PR (#267) on purpose.

## Copilot follow-up

- Tightened the legacy music-catalog fallback to match `MUSIC_CONTRACT.catalogPath` literally (not any `music.json` substring).

## Test plan

- [x] `games-repo-contract` + `assemble` unit tests
- [x] CI **Games-repo contract** job green on earlier revision
- [x] Copilot comment addressed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2acd77-ecc3-47c8-b6df-381d72e10b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2acd77-ecc3-47c8-b6df-381d72e10b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

