### PR TITLE
Fix red CI contract check, and stop the mascot banding when it rotates

### DIFF
--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -32,6 +32,7 @@ describe('games-repo-contract (website half)', () => {
       'effects',
       'audio',
       'party',
+      'mascot',
     ]);
   });
 
@@ -47,7 +48,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'effects', 'audio', 'party',
+        'drawing', 'actors', 'gfx', 'effects', 'audio', 'party', 'mascot',
       ] as const;
     `;
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -20,6 +20,7 @@ export const GAME_KIT_MODULES = [
   'effects',
   'audio',
   'party',
+  'mascot',
 ] as const;
 
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
+import { createHash } from 'node:crypto';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Mascot, MascotMoment, type MascotEmotion } from './Mascot';
 import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans';
@@ -104,6 +105,23 @@ describe('mascot spans', () => {
   it('idle spans keep the face open so the logo reads as the logo', () => {
     // eyes, mouth and both ear rings
     expect(enclosedHoles(toGrid(MASCOT_IDLE_SPANS))).toHaveLength(5);
+  });
+
+  /**
+   * The games repo carries the same artwork (`shared/modules/mascot.ts` over there) so
+   * a game can draw the mascot as a canvas cameo without depending on this app. The
+   * two renderers are deliberately independent, but they must agree on the geometry,
+   * or the mascot in a game slowly stops being the mascot in this header.
+   *
+   * Both repos hash the span tables the same way and pin this digest, so editing the
+   * pixels here fails the build until the games repo is updated too. Changing the
+   * mascot on purpose means updating the digest in BOTH places.
+   */
+  it('matches the artwork the games-repo cameo draws', () => {
+    const canonical = [...MASCOT_IDLE_SPANS.flat(), '|', ...MASCOT_SOLID_SPANS.flat()].join(',');
+    expect(createHash('sha256').update(canonical).digest('hex')).toBe(
+      '453c7a011d7a7bfbe316cb55b0632aaaf82316d8410d87c150cd24f83f975c23',
+    );
   });
 });
 
@@ -210,6 +228,35 @@ describe('Mascot', () => {
       // A handful of rects is fine (blink lids, the masked fill); hundreds is the bug.
       expect(container.querySelectorAll('rect').length, emotion).toBeLessThan(10);
     }
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  // The body must be the union OUTLINE of the pixels, not one subpath per span.
+  // Coincident interior edges only cancel while the shape is axis-aligned, so a
+  // per-span path seams the moment an emotion rotates — and five of them do.
+  // A correct trace has one loop per connected boundary and no more:
+  //   idle  — silhouette + mouth + 2 eyes + 2 ear rings + 2 ear centres = 8
+  //   solid — silhouette + 2 ear rings + 2 ear centres = 5
+  it('traces the body as boundary loops, not one subpath per span', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const subpaths = (d: string | null | undefined) => (d ?? '').match(/M/g)?.length ?? 0;
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'idle', size: 88 }));
+    });
+    expect(subpaths(container.querySelector('.mascot__pixels path')?.getAttribute('d'))).toBe(8);
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'confused', size: 88 }));
+    });
+    expect(subpaths(container.querySelector('mask path')?.getAttribute('d'))).toBe(5);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -24,21 +24,88 @@ type MascotProps = {
   staticPose?: boolean;
 };
 
+type Span = readonly [number, number, number];
+
 /**
- * Flatten the pixel spans into ONE path rather than one `<rect>` per span.
+ * Trace the outline of a pixel-span set, so the body is one path with no edges
+ * running through its middle.
  *
- * Separate rects are composited separately, so an antialiasing renderer gives each
- * 1px-tall rect a soft top and bottom edge. Two neighbours each contributing partial
- * coverage at their shared boundary does not add up to full coverage, so a seam shows
- * on every row — as horizontal banding on the body, and as speckle once the browser
- * downscales it. Inside a single path those interior edges cancel during the one
- * coverage pass, and the shape fills solid.
+ * The body used to be one `<rect>` per span — around 200 of them, each 1px tall.
+ * Separate shapes are antialiased separately, and two neighbours each contributing
+ * partial coverage at their shared boundary do not add up to full coverage, so a
+ * seam showed on every row: horizontal banding, and speckle once downscaled.
  *
- * This matters most in the emotion mask, where the banding became holes in the mask
- * itself. Each span is emitted as its own closed subpath.
+ * Merging the spans into one path is not enough on its own. Coincident interior
+ * edges only cancel exactly while the shape is axis-aligned; the moment it is
+ * rotated — and `peek`, `ponder`, `hustle`, `sigh` and `wobble` all rotate up to
+ * 6deg — the seams come back. So we emit the true union outline instead: the
+ * boundary between filled and empty pixels, and nothing else. There are no interior
+ * edges left to seam, at any angle.
+ *
+ * Edges are wound so that outer loops and hole loops run opposite ways, which is
+ * what the default nonzero fill needs to punch the ear rings out.
  */
-function spansToPath(spans: ReadonlyArray<readonly [number, number, number]>): string {
-  return spans.map(([x, y, width]) => `M${x} ${y}h${width}v1h${-width}Z`).join('');
+function spansToOutlinePath(spans: ReadonlyArray<Span>): string {
+  const filled = Array.from({ length: 60 }, () => Array<boolean>(70).fill(false));
+  for (const [x, y, width] of spans) {
+    for (let i = 0; i < width; i++) filled[y][x + i] = true;
+  }
+  const isFilled = (x: number, y: number) => x >= 0 && x < 70 && y >= 0 && y < 60 && filled[y][x];
+
+  const key = (x: number, y: number) => x * 100 + y;
+  const steps = new Map<number, Array<[number, number]>>();
+  const addEdge = (fx: number, fy: number, tx: number, ty: number) => {
+    const from = key(fx, fy);
+    const list = steps.get(from);
+    if (list) list.push([tx, ty]);
+    else steps.set(from, [[tx, ty]]);
+  };
+  for (let y = 0; y < 60; y++) {
+    for (let x = 0; x < 70; x++) {
+      if (!filled[y][x]) continue;
+      if (!isFilled(x, y - 1)) addEdge(x, y, x + 1, y);
+      if (!isFilled(x + 1, y)) addEdge(x + 1, y, x + 1, y + 1);
+      if (!isFilled(x, y + 1)) addEdge(x + 1, y + 1, x, y + 1);
+      if (!isFilled(x - 1, y)) addEdge(x, y + 1, x, y);
+    }
+  }
+
+  const parts: string[] = [];
+  while (steps.size) {
+    const startKey = steps.keys().next().value as number;
+    const start: [number, number] = [Math.floor(startKey / 100), startKey % 100];
+    const loop: Array<[number, number]> = [start];
+    let cursor = start;
+    for (;;) {
+      const list = steps.get(key(cursor[0], cursor[1]));
+      if (!list || list.length === 0) break;
+      const step = list.pop()!;
+      if (list.length === 0) steps.delete(key(cursor[0], cursor[1]));
+      loop.push(step);
+      cursor = step;
+      if (cursor[0] === start[0] && cursor[1] === start[1]) break;
+    }
+
+    // Drop the repeated closing point, then collapse runs of collinear corners.
+    const points = loop.slice(0, -1);
+    const corners = points.filter((point, i) => {
+      const before = points[(i - 1 + points.length) % points.length];
+      const after = points[(i + 1) % points.length];
+      return (point[0] - before[0]) * (after[1] - point[1]) !== (point[1] - before[1]) * (after[0] - point[0]);
+    });
+    if (corners.length < 3) continue;
+
+    let [cx, cy] = corners[0];
+    const d = [`M${cx} ${cy}`];
+    for (const [px, py] of corners.slice(1)) {
+      d.push(px === cx ? `v${py - cy}` : `h${px - cx}`);
+      cx = px;
+      cy = py;
+    }
+    d.push('Z');
+    parts.push(d.join(''));
+  }
+  return parts.join('');
 }
 
 function eyeSlits(
@@ -102,9 +169,9 @@ const MOUTH_CURIOUS =
 const MOUTH_BUSY =
   'M20 13 L25 20 L30 12 L35 21 L40 11 L45 21 L50 13 L50 32 L45 26 L40 34 L35 25 L30 33 L25 26 L20 31 Z';
 
-// Built once at module load — the spans never change.
-const IDLE_PATH = spansToPath(MASCOT_IDLE_SPANS);
-const SOLID_PATH = spansToPath(MASCOT_SOLID_SPANS);
+// Traced once at module load — the spans never change.
+const IDLE_PATH = spansToOutlinePath(MASCOT_IDLE_SPANS);
+const SOLID_PATH = spansToOutlinePath(MASCOT_SOLID_SPANS);
 
 function cutoutsFor(emotion: MascotEmotion): ReactElement | null {
   switch (emotion) {


### PR DESCRIPTION
Two loose ends from #270 and gamedevpl/www.gamedev.pl-games#99. The first is breaking CI on master right now.

## `contract:games-repo` is failing on master

The games repo shipped `mascot` in `GAME_KIT_MODULES` with #99, but this side never got its half. The CI job fetches `tools/lib/assemble.ts` from games-repo `main` and compares the module list — twelve entries there against eleven here.

**This is my mistake.** The website half rode on the branch I reset when the other mascot implementation landed, and it went with the reset, while the games-repo half stayed on its own branch and merged.

Nothing 502s today because no game declares `mascot` yet; this restores the lockstep before one does. The fixture games-repo needs no copy of the module for the same reason — modules are fetched per game, and no fixture game asks for it.

Verified by running the check's own `extractGameKitModules` against the live games-repo `main`: the two lists now match exactly.

## The banding fix in #270 was incomplete

#270 merged with only its first commit; the follow-up never landed, so master still flattens the pixel spans into one subpath per span.

That fixes the static case and **not** the rotated one. Coincident interior edges only cancel exactly while the shape is axis-aligned — and `peek`, `ponder`, `hustle`, `sigh` and `wobble` all rotate the body up to 6deg, so the seams return mid-animation on five of the ten emotions. My check on #270 missed it because it screenshotted with animations disabled.

The body is now the **true union outline** of the filled pixels: the boundary between filled and empty, and nothing else. No interior edges remain to seam, at any angle. It also comes out smaller than the per-span path — 8 boundary loops rather than ~200 subpaths — and the nav logo is unchanged.

Confirmed by holding the 404 mascot at `rotate(6deg)`: master stripes, this build is solid.

## Also

Pins a digest of the span tables matching the guard now on games-repo `main`, so the canvas cameo and this renderer cannot drift apart. A test asserts the body is traced as boundary loops (8 idle / 5 solid) rather than one subpath per span.

Green: type-check, lint, 988 tests, build.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_