### PR TITLE
Add mascot to GAME_KIT_MODULES lockstep

### DIFF
--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -32,6 +32,7 @@ describe('games-repo-contract (website half)', () => {
       'effects',
       'audio',
       'party',
+      'mascot',
     ]);
   });
 
@@ -47,7 +48,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'effects', 'audio', 'party',
+        'drawing', 'actors', 'gfx', 'effects', 'audio', 'party', 'mascot',
       ] as const;
     `;
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -20,6 +20,7 @@ export const GAME_KIT_MODULES = [
   'effects',
   'audio',
   'party',
+  'mascot',
 ] as const;
 
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the red **Games-repo contract** check again: live games-repo `GAME_KIT_MODULES` now ends with `mascot` after `party`. Sync the website lockstep list.

Separate from contact-form (#267) on purpose (same pattern as #272).

## Test plan

- [x] `games-repo-contract` unit tests
- [ ] CI **Games-repo contract** green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2acd77-ecc3-47c8-b6df-381d72e10b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2acd77-ecc3-47c8-b6df-381d72e10b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

