### PR TITLE
docs(games-repo): mark published-bundle hosting as the GCS snapshot

### DIFF
--- a/docs/games-repo.md
+++ b/docs/games-repo.md
@@ -134,12 +134,14 @@ validation gate so it guards published bundles.
 
 ## Open questions
 
-- **Where are published bundles hosted?** Today the app reads the private games
-  repo through its authenticated API. `GET /api/catalog` exposes catalog
-  metadata, `GET /api/games/:slug` serves assembled sandbox content, and
-  `GET /api/games/:slug/media/:filename` proxies only metadata-listed gallery
-  images/videos. A separate bucket/CDN remains an optimization if the catalog
-  outgrows this delivery shape.
+- ~~**Where are published bundles hosted?**~~ **Resolved: a Cloud Storage snapshot,
+  with GitHub as fallback.** Merges to the games repo bake catalog, assembled HTML,
+  and media into `gs://…-games-snapshots`; the API prefers that snapshot on
+  `GET /api/catalog`, `GET /api/games/:slug`, and media routes, and falls back to
+  live GitHub reads (plus on-demand assemble) when the bucket is unset, a game
+  failed to bake, or Storage is down. PR / draft previews still read GitHub live.
+  The API remains the games origin — the bucket is not public. Details:
+  [`games-snapshot.md`](./games-snapshot.md).
 - **Repository ownership and merge authority.** Agent PRs need a human gate initially,
   especially because review is also the moderation point.
 - **Submission identity, attribution, rights, and abuse controls.** These must be decided before


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the stale open question in `docs/games-repo.md`: published bundles are no longer “maybe a bucket someday.”

#260 shipped the Cloud Storage snapshot path. The question is marked resolved and points at [`docs/games-snapshot.md`](docs/games-snapshot.md) — bake on merge, API prefers snapshot with GitHub fallback, previews still live from GitHub, bucket stays private.

## Test plan

- [x] Docs-only change; link to `games-snapshot.md` resolves in-tree
- [ ] Skim rendered open-questions section for accuracy vs live bake workflow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa297-4414-7495-898a-44039244d244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa297-4414-7495-898a-44039244d244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

