### PR TITLE
fix(e2e): allowlist GSI One Tap noise on anonymous splash

### DIFF
--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -191,6 +191,22 @@ const EXPECTED_NOISE: { pattern: RegExp; why: string }[] = [
     pattern: /401 .*\/api\/auth\/me|\/api\/auth\/me.*401/,
     why: 'anonymous session probe is expected to be unauthenticated',
   },
+  {
+    // ClosedBetaSplash mounts GoogleSignInButton, which calls google.accounts.id.prompt().
+    // In CI / headless Chromium there is no signed-in Google account, so One Tap / FedCM
+    // logs these and nothing else — the splash and the sign-in button still render. Agent
+    // auth uses GAMEDEV_ACCESS_TOKEN (docs/agent-access-tokens.md), not Google, so this
+    // noise is not a product defect the gate should block on.
+    pattern: /Provider's accounts list is empty/,
+    why: 'GSI One Tap with no Google account in the browser (CI / headless)',
+  },
+  {
+    // Same One Tap path: FedCM fails to retrieve a token when there is no account to
+    // offer. Paired with the empty-accounts line above; keep both so either message
+    // alone cannot red the deploy.
+    pattern: /\[GSI_LOGGER\]: FedCM get\(\) rejects with NetworkError/,
+    why: 'GSI FedCM One Tap has no account in headless Chromium',
+  },
 ];
 
 function isExpected(text: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Every deploy since #269 fails the browser gate on `anonymous-and-mobile.test.ts`. The closed-beta splash mounts `GoogleSignInButton`, which calls `google.accounts.id.prompt()`. In headless CI there is no Google account, so GSI logs:

- `Provider's accounts list is empty`
- `[GSI_LOGGER]: FedCM get() rejects with NetworkError`

Those are treated as page problems and block promotion. Agent/CI auth uses `GAMEDEV_ACCESS_TOKEN` (PATs), not Google.

The candidate OAuth JS origin was already added in the console (fixes the earlier `origin is not allowed` / GSI 403). This leftover One Tap noise is what still reds the gate.

## Fix

Allowlist those two messages in `EXPECTED_NOISE` in `apps/e2e/src/browser.ts`, with comments explaining why they are intentional CI noise rather than product defects.

## Verification

- Green gate: `type-check`, `lint`, `test`, `build` all pass
- Patterns match the failing strings from [deploy run 30305063341](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30305063341)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62957b09-5409-46b6-b2c9-27810935edb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62957b09-5409-46b6-b2c9-27810935edb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

