### PR TITLE
Fix the mobile suggestion chips falling out of the card, and track the games-repo budget raise

### DIFF
--- a/apps/web/src/styles.chipStrip.test.ts
+++ b/apps/web/src/styles.chipStrip.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+/**
+ * Returns the declarations of the LAST `.chip-container { ... }` block, which is the
+ * phone one — the desktop rule above it wraps instead of scrolling and is unaffected.
+ */
+function mobileChipContainerRule(): string {
+  const marker = '.chip-container {';
+  const start = css.lastIndexOf(marker);
+  expect(start, 'no .chip-container rule in styles.css').toBeGreaterThan(-1);
+  const end = css.indexOf('}', start);
+  expect(end, '.chip-container rule is never closed').toBeGreaterThan(start);
+  return css.slice(start + marker.length, end);
+}
+
+describe('mobile suggestion chip strip', () => {
+  const rule = mobileChipContainerRule();
+
+  it('is a bleeding horizontal scroller, not a wrapped stack', () => {
+    // Three wrapped chips cost ~148px of an iPhone SE. The strip trades that for
+    // one 44px row that bleeds to the card edge so a cut-off chip advertises the swipe.
+    expect(rule).toMatch(/flex-wrap:\s*nowrap/);
+    expect(rule).toMatch(/overflow-x:\s*auto/);
+    expect(rule).toMatch(/margin:\s*0 -14px/);
+    expect(rule).toMatch(/padding:\s*0 14px/);
+  });
+
+  /**
+   * Regression: chips appeared to fall out of the card on a phone.
+   *
+   * The bleed puts the scrollport edge exactly on the card's border, and
+   * `.chip-btn` carries `scroll-snap-align: start`. Snapping aligns a chip to the
+   * snapport start, so the browser scrolled the 14px padding away to satisfy it
+   * (scrollLeft settled at 14, not 0) and the first chip came to rest sliced by the
+   * glowing border. Any padding here has to be mirrored in scroll-padding or
+   * snapping simply undoes it.
+   */
+  it('keeps its inset under scroll snapping', () => {
+    if (/scroll-snap-type/.test(rule)) {
+      expect(rule, 'scroll-snap-type without scroll-padding scrolls the padding away').toMatch(
+        /scroll-padding:\s*0 14px/,
+      );
+    }
+  });
+
+  /**
+   * The chip that runs past the card was cut dead on the border, which reads as
+   * broken layout rather than as more-to-swipe. Both ends of the strip are empty at
+   * their scroll extremes, so a 14px fade at each end only bites while there is
+   * actually something further to reach.
+   */
+  it('fades the bleed at both ends instead of guillotining a chip', () => {
+    expect(rule).toMatch(/-webkit-mask-image:\s*linear-gradient\(to right/);
+    expect(rule).toMatch(/[^-]mask-image:\s*linear-gradient\(to right/);
+    expect(rule).toMatch(/transparent,\s*#000 14px,\s*#000 calc\(100% - 14px\),\s*transparent/);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2667,8 +2667,20 @@ body.player-open {
     margin: 0 -14px;
     padding: 0 14px;
     scroll-snap-type: x proximity;
+    /* Snapping aligns a chip to the scrollport edge — and the scrollport edge is
+       the card border, because of the bleed above. Without this the browser
+       scrolls the 14px padding away to satisfy the snap, and the first chip comes
+       to rest sliced by the border. scroll-padding moves the snap edge inwards so
+       the inset the padding exists to create actually survives. */
+    scroll-padding: 0 14px;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
+    /* Soften the bleed. A chip running past the card was cut dead on the glowing
+       border, which reads as broken layout rather than as more-to-swipe. Both
+       ends of the strip are empty at their scroll extremes, so each fade only
+       bites while there is something under it left to reach. */
+    -webkit-mask-image: linear-gradient(to right, transparent, #000 14px, #000 calc(100% - 14px), transparent);
+    mask-image: linear-gradient(to right, transparent, #000 14px, #000 calc(100% - 14px), transparent);
   }
 
   .chip-container::-webkit-scrollbar {


### PR DESCRIPTION
Two unrelated changes, kept in one branch because they were reported together.

## 1. Suggestion chips no longer read as fallen out of the card

On a phone the chips are a bleeding scroll strip: `margin: 0 -14px` puts the scrollport edge on the card border, and `padding: 0 14px` was meant to hold the first chip clear of it.

**Snapping undid that.** `.chip-btn` carries `scroll-snap-align: start`, so the browser scrolled the padding away to align the first chip with the snapport — `scrollLeft` settled at **14, not 0** — and the chip came to rest sliced by the glowing border, with the next one guillotined dead on it at the other end. Two chips looked like they had fallen out of the card rather than like there was more to swipe to.

The fix is two declarations:

- `scroll-padding: 0 14px` moves the snap edge inwards so the inset the padding exists to create actually survives.
- A 14px `mask-image` fade at each end softens the bleed. Both ends are empty at their scroll extremes, so each fade only bites while something is genuinely left to reach — the affordance appears and disappears on its own, with no JS.

Verified in headless Chromium at 320px and 390px: the first chip now rests 14px inside the border, the last clears it by 14px at full scroll, and the page still has no horizontal overflow at either width.

`styles.chipStrip.test.ts` pins the invariant — including that `scroll-snap-type` here always comes with `scroll-padding`, since that pairing is the whole bug and is easy to undo by accident. I confirmed the guard fails when the declaration is removed.

## 2. Tracking the games-repo budget raise

gamedevpl/www.gamedev.pl-games#102 adds `draw.mascot` to the draw surface. That lives in `gfx.ts`, a module every game loads, so Check 4's ceiling moves by the measured 679 bytes it costs — to **243,757**. Mirrored here because this side re-derives the same number and CI diffs the two.

### Merge order

**gamedevpl/www.gamedev.pl-games#102 must merge first.** `contract:games-repo` compares these constants against the live games repo, so this PR is red until that one is on `main`. Nothing to fix on this side when it goes red before then — just merge order.

## Verification

Both suites green: 45 web test files / 287 tests, 47 api test files / 692 tests. Contract alignment checked directly with CI's own extractors against the games branch — modules, `MAX_BUNDLE_BYTES`, the contract JSON, and the allowance sum all agree at 243,757.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_