### PR TITLE
Make the closed-beta splash mascot interactable

### DIFF
--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -62,6 +62,9 @@ describe('ClosedBetaSplash', () => {
 
     expect(container.querySelector('.google-sign-in-container')).not.toBeNull();
     expect(container.querySelector('#btn-join-waitlist')).toBeNull();
+    const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
+    expect(mascot).not.toBeNull();
+    expect(mascot?.getAttribute('aria-label')).toMatch(/poke|szturchnij/i);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { GoogleSignInButton } from './GoogleSignInButton.js';
-import { Mascot } from './Mascot.js';
+import { InteractiveMascot } from './Mascot.js';
 
 type WaitlistState = 'idle' | 'joining' | 'joined' | 'error';
 
@@ -31,7 +31,12 @@ export function ClosedBetaSplash() {
   return (
     <div className="beta-splash">
       <div className="beta-splash__card">
-        <Mascot className="beta-splash__mascot" emotion="wave" size={96} title={t('mascot.waveAlt')} />
+        <InteractiveMascot
+          className="beta-splash__mascot"
+          idleEmotion="wave"
+          size={96}
+          pokeLabel={t('mascot.poke')}
+        />
         <div className="beta-splash__logo">
           <span className="beta-splash__logo-main">gamedev</span>
           <span className="beta-splash__logo-tld">.pl</span>

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -367,22 +367,19 @@ describe('InteractiveMascot', () => {
       value: () => ({ left: 0, top: 0, width: 80, height: 80, right: 80, bottom: 80, x: 0, y: 0, toJSON: () => ({}) }),
     });
 
+    // React wires onPointerEnter/Leave to pointerover/out (enter/leave don't bubble).
     await act(async () => {
-      button.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+      button.dispatchEvent(new PointerEvent('pointerover', { bubbles: true }));
     });
     expect(container.querySelector('.mascot--curious')).not.toBeNull();
 
     await act(async () => {
-      button.dispatchEvent(
-        new PointerEvent('pointermove', { bubbles: true, clientX: 80, clientY: 0 }),
-      );
+      button.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 80, clientY: 0 }));
     });
-    expect(container.querySelector('.mascot__face-features')?.getAttribute('transform')).toBe(
-      'translate(2.40 -1.80)',
-    );
+    expect(container.querySelector('.mascot__face-features')?.getAttribute('transform')).toBe('translate(2.40 -1.80)');
 
     await act(async () => {
-      button.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+      button.dispatchEvent(new PointerEvent('pointerout', { bubbles: true }));
     });
     expect(container.querySelector('.mascot--wave')).not.toBeNull();
 

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -387,4 +387,41 @@ describe('InteractiveMascot', () => {
       root.unmount();
     });
   });
+
+  it('still peeks on hover when prefers-reduced-motion is set', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(InteractiveMascot, { pokeLabel: 'Poke', idleEmotion: 'wave', size: 64 }));
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive')!;
+    await act(async () => {
+      button.dispatchEvent(new PointerEvent('pointerover', { bubbles: true }));
+    });
+    expect(container.querySelector('.mascot--curious')).not.toBeNull();
+    // Tilt/look stay off under reduced motion.
+    expect(container.querySelector('.mascot__face-features')?.getAttribute('transform')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    window.matchMedia = originalMatchMedia;
+  });
 });

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -4,7 +4,7 @@ import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createHash } from 'node:crypto';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Mascot, MascotMoment, type MascotEmotion } from './Mascot.js';
+import { InteractiveMascot, Mascot, MascotMoment, type MascotEmotion } from './Mascot.js';
 import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans.js';
 
 const EMOTIONS: MascotEmotion[] = [
@@ -276,6 +276,115 @@ describe('Mascot', () => {
     expect(container.querySelector('.mascot-moment')).not.toBeNull();
     expect(container.querySelector('.mascot--confused')).not.toBeNull();
     expect(container.textContent).toContain('Lost the plot');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('nudges face cutouts when given a look direction', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'wave', look: { x: 1, y: -0.5 } }));
+    });
+
+    const features = container.querySelector('.mascot__face-features');
+    expect(features?.getAttribute('transform')).toBe('translate(2.40 -0.90)');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+describe('InteractiveMascot', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('pokes through a reaction cycle on click', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(InteractiveMascot, {
+          pokeLabel: 'Poke the monster',
+          idleEmotion: 'wave',
+          size: 64,
+        }),
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive');
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute('aria-label')).toBe('Poke the monster');
+    expect(container.querySelector('.mascot--wave')).not.toBeNull();
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.mascot--excited')).not.toBeNull();
+    expect(button?.classList.contains('mascot-interactive--poking')).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1400);
+    });
+    expect(container.querySelector('.mascot--wave')).not.toBeNull();
+    expect(button?.classList.contains('mascot-interactive--poking')).toBe(false);
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.mascot--happy')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('peeks on hover and follows the pointer a little', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(InteractiveMascot, { pokeLabel: 'Poke', idleEmotion: 'wave', size: 80 }));
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive')!;
+    Object.defineProperty(button, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 80, height: 80, right: 80, bottom: 80, x: 0, y: 0, toJSON: () => ({}) }),
+    });
+
+    await act(async () => {
+      button.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    });
+    expect(container.querySelector('.mascot--curious')).not.toBeNull();
+
+    await act(async () => {
+      button.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 80, clientY: 0 }),
+      );
+    });
+    expect(container.querySelector('.mascot__face-features')?.getAttribute('transform')).toBe(
+      'translate(2.40 -1.80)',
+    );
+
+    await act(async () => {
+      button.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    });
+    expect(container.querySelector('.mascot--wave')).not.toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -7,13 +7,28 @@
  *
  * Animation lives in layered SVG groups + CSS (bob, bounce, sway, blink lids,
  * waving arm). `staticPose` freezes everything; `prefers-reduced-motion` does too.
+ *
+ * `InteractiveMascot` wraps the SVG in a button: hover peeks, click cycles
+ * reactions, and the face tracks the pointer a little.
  */
 
-import { useId, type ReactElement, type ReactNode } from 'react';
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans.js';
 
 export type MascotEmotion =
   'idle' | 'happy' | 'curious' | 'thinking' | 'excited' | 'confused' | 'sad' | 'proud' | 'wave' | 'busy';
+
+/** Normalized look direction in roughly [-1, 1] for each axis. */
+export type MascotLook = { x: number; y: number };
 
 type MascotProps = {
   emotion?: MascotEmotion;
@@ -22,6 +37,8 @@ type MascotProps = {
   title?: string;
   /** When true, all motion is forced off (e.g. tiny nav mark). */
   staticPose?: boolean;
+  /** Nudge face cutouts toward a point — no-op on the baked idle silhouette. */
+  look?: MascotLook;
 };
 
 type Span = readonly [number, number, number];
@@ -258,7 +275,14 @@ function BlinkLids() {
   );
 }
 
-export function Mascot({ emotion = 'idle', size = 48, className, title, staticPose = false }: MascotProps) {
+export function Mascot({
+  emotion = 'idle',
+  size = 48,
+  className,
+  title,
+  staticPose = false,
+  look,
+}: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
   const height = Math.round((size * 60) / 70);
@@ -268,6 +292,9 @@ export function Mascot({ emotion = 'idle', size = 48, className, title, staticPo
   const cutouts = cutoutsFor(emotion);
   const isIdle = emotion === 'idle' || cutouts == null;
   const showWaveArm = emotion === 'wave' || emotion === 'excited';
+  // Keep the nudge small — past ~3px the mouth starts to clip the silhouette.
+  const lookTransform =
+    look && !isIdle ? `translate(${(look.x * 2.4).toFixed(2)} ${(look.y * 1.8).toFixed(2)})` : undefined;
 
   return (
     <svg
@@ -293,7 +320,9 @@ export function Mascot({ emotion = 'idle', size = 48, className, title, staticPo
             <defs>
               <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
                 <path fill="#fff" d={SOLID_PATH} />
-                <g fill="#000">{cutouts}</g>
+                <g fill="#000" className="mascot__face-features" transform={lookTransform}>
+                  {cutouts}
+                </g>
               </mask>
             </defs>
             <rect
@@ -317,6 +346,145 @@ export function Mascot({ emotion = 'idle', size = 48, className, title, staticPo
         ) : null}
       </g>
     </svg>
+  );
+}
+
+/** Playful reactions cycled when the visitor pokes the splash mascot. */
+const POKE_REACTIONS: readonly MascotEmotion[] = [
+  'excited',
+  'happy',
+  'curious',
+  'proud',
+  'thinking',
+  'confused',
+];
+
+const POKE_HOLD_MS = 1400;
+
+type InteractiveMascotProps = {
+  size?: number;
+  className?: string;
+  /** Resting emotion between pokes (default: wave). */
+  idleEmotion?: MascotEmotion;
+  /** Accessible name for the poke control. */
+  pokeLabel: string;
+};
+
+/**
+ * Clickable mascot for branded empty states (splash, etc.).
+ * Hover peeks, click cycles a reaction, pointer position nudges the face.
+ */
+export function InteractiveMascot({
+  size = 96,
+  className,
+  idleEmotion = 'wave',
+  pokeLabel,
+}: InteractiveMascotProps) {
+  const rootRef = useRef<HTMLButtonElement>(null);
+  const pokeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reactionIndex = useRef(0);
+  const hoveredRef = useRef(false);
+  const pokingRef = useRef(false);
+  const [emotion, setEmotion] = useState<MascotEmotion>(idleEmotion);
+  const [look, setLook] = useState<MascotLook>({ x: 0, y: 0 });
+  const [poking, setPoking] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const reduceMotionRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof matchMedia !== 'function') return;
+    const media = matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => {
+      reduceMotionRef.current = media.matches;
+      setReduceMotion(media.matches);
+    };
+    sync();
+    media.addEventListener('change', sync);
+    return () => media.removeEventListener('change', sync);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (pokeTimer.current) clearTimeout(pokeTimer.current);
+    };
+  }, []);
+
+  const settleEmotion = () =>
+    hoveredRef.current && !reduceMotionRef.current ? 'curious' : idleEmotion;
+
+  const clearPokeTimer = () => {
+    if (pokeTimer.current) {
+      clearTimeout(pokeTimer.current);
+      pokeTimer.current = null;
+    }
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (reduceMotionRef.current) return;
+    const node = rootRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = ((event.clientY - rect.top) / rect.height) * 2 - 1;
+    const clamp = (value: number) => Math.max(-1, Math.min(1, value));
+    setLook({ x: clamp(x), y: clamp(y) });
+  };
+
+  const resetLook = () => setLook({ x: 0, y: 0 });
+
+  const handlePoke = () => {
+    const next = POKE_REACTIONS[reactionIndex.current % POKE_REACTIONS.length]!;
+    reactionIndex.current += 1;
+    pokingRef.current = true;
+    setPoking(true);
+    setEmotion(next);
+    clearPokeTimer();
+    pokeTimer.current = setTimeout(() => {
+      pokingRef.current = false;
+      setPoking(false);
+      setEmotion(settleEmotion());
+      pokeTimer.current = null;
+    }, POKE_HOLD_MS);
+  };
+
+  const tiltStyle: CSSProperties | undefined = reduceMotion
+    ? undefined
+    : {
+        transform: `rotate(${(look.x * 7).toFixed(2)}deg) translateY(${(look.y * 2).toFixed(2)}px)`,
+      };
+
+  return (
+    <button
+      ref={rootRef}
+      type="button"
+      className={['mascot-interactive', poking ? 'mascot-interactive--poking' : null, className]
+        .filter(Boolean)
+        .join(' ')}
+      aria-label={pokeLabel}
+      onClick={handlePoke}
+      onPointerEnter={() => {
+        hoveredRef.current = true;
+        if (!pokingRef.current && !reduceMotionRef.current) setEmotion('curious');
+      }}
+      onPointerLeave={() => {
+        hoveredRef.current = false;
+        resetLook();
+        if (!pokingRef.current) setEmotion(idleEmotion);
+      }}
+      onPointerMove={handlePointerMove}
+      onBlur={() => {
+        hoveredRef.current = false;
+        resetLook();
+        if (!pokingRef.current) setEmotion(idleEmotion);
+      }}
+    >
+      {/* Tilt lives on an inner span so the button can still run the poke squash. */}
+      <span className="mascot-interactive__tilt" style={tiltStyle}>
+        {/* Button owns the accessible name; keep the SVG presentational to avoid a double announce. */}
+        <Mascot emotion={emotion} size={size} look={reduceMotion ? undefined : look} />
+      </span>
+    </button>
   );
 }
 

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -385,6 +385,7 @@ export function InteractiveMascot({
   const reactionIndex = useRef(0);
   const hoveredRef = useRef(false);
   const pokingRef = useRef(false);
+  const lookRef = useRef<MascotLook>({ x: 0, y: 0 });
   const [emotion, setEmotion] = useState<MascotEmotion>(idleEmotion);
   const [look, setLook] = useState<MascotLook>({ x: 0, y: 0 });
   const [poking, setPoking] = useState(false);
@@ -399,8 +400,13 @@ export function InteractiveMascot({
       setReduceMotion(media.matches);
     };
     sync();
-    media.addEventListener('change', sync);
-    return () => media.removeEventListener('change', sync);
+    // MediaQueryList used addListener/removeListener before addEventListener landed in Safari.
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', sync);
+      return () => media.removeEventListener('change', sync);
+    }
+    media.addListener(sync);
+    return () => media.removeListener(sync);
   }, []);
 
   useEffect(() => {
@@ -409,8 +415,8 @@ export function InteractiveMascot({
     };
   }, []);
 
-  const settleEmotion = () =>
-    hoveredRef.current && !reduceMotionRef.current ? 'curious' : idleEmotion;
+  // Reduced motion still gets the emotion swap — only tilt/boop are suppressed.
+  const settleEmotion = () => (hoveredRef.current ? 'curious' : idleEmotion);
 
   const clearPokeTimer = () => {
     if (pokeTimer.current) {
@@ -425,13 +431,22 @@ export function InteractiveMascot({
     if (!node) return;
     const rect = node.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return;
-    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-    const y = ((event.clientY - rect.top) / rect.height) * 2 - 1;
     const clamp = (value: number) => Math.max(-1, Math.min(1, value));
-    setLook({ x: clamp(x), y: clamp(y) });
+    const next = {
+      x: clamp(((event.clientX - rect.left) / rect.width) * 2 - 1),
+      y: clamp(((event.clientY - rect.top) / rect.height) * 2 - 1),
+    };
+    // Skip sub-pixel wiggles so pointermove does not re-render at 60–120Hz.
+    const prev = lookRef.current;
+    if (Math.abs(next.x - prev.x) < 0.04 && Math.abs(next.y - prev.y) < 0.04) return;
+    lookRef.current = next;
+    setLook(next);
   };
 
-  const resetLook = () => setLook({ x: 0, y: 0 });
+  const resetLook = () => {
+    lookRef.current = { x: 0, y: 0 };
+    setLook({ x: 0, y: 0 });
+  };
 
   const handlePoke = () => {
     const next = POKE_REACTIONS[reactionIndex.current % POKE_REACTIONS.length]!;
@@ -465,7 +480,7 @@ export function InteractiveMascot({
       onClick={handlePoke}
       onPointerEnter={() => {
         hoveredRef.current = true;
-        if (!pokingRef.current && !reduceMotionRef.current) setEmotion('curious');
+        if (!pokingRef.current) setEmotion('curious');
       }}
       onPointerLeave={() => {
         hoveredRef.current = false;

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -375,7 +375,8 @@
     "confusedAlt": "The gamedev.pl monster looking confused",
     "sadAlt": "The gamedev.pl monster looking sad",
     "curiousAlt": "The gamedev.pl monster looking curious",
-    "busyAlt": "The gamedev.pl monster hard at work"
+    "busyAlt": "The gamedev.pl monster hard at work",
+    "poke": "Poke the gamedev.pl monster"
   },
   "footer": {
     "legalNav": "Legal information",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -375,7 +375,8 @@
     "confusedAlt": "Potwór gamedev.pl zdezorientowany",
     "sadAlt": "Potwór gamedev.pl smutny",
     "curiousAlt": "Potwór gamedev.pl zaciekawiony",
-    "busyAlt": "Potwór gamedev.pl w pełni pracy"
+    "busyAlt": "Potwór gamedev.pl w pełni pracy",
+    "poke": "Szturchnij potwora gamedev.pl"
   },
   "footer": {
     "legalNav": "Informacje prawne",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4834,6 +4834,75 @@ body.player-open {
   margin: 0 auto 20px;
 }
 
+/* Interactive poke target — used on the closed-beta splash. */
+.mascot-interactive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 12px;
+  transform-origin: 50% 85%;
+  transition: transform 0.12s ease-out;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mascot-interactive__tilt {
+  display: inline-flex;
+  transform-origin: 50% 85%;
+  transition: transform 0.08s linear;
+  will-change: transform;
+}
+
+.mascot-interactive:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 4px;
+}
+
+.mascot-interactive:hover .mascot {
+  filter: brightness(1.08);
+}
+
+.mascot-interactive:active {
+  transform: scale(0.94, 0.9);
+}
+
+.mascot-interactive--poking {
+  animation: mascot-interactive-boop 0.45s ease-out;
+}
+
+@keyframes mascot-interactive-boop {
+  0% {
+    transform: scale(1, 1);
+  }
+  35% {
+    transform: scale(1.08, 0.92);
+  }
+  70% {
+    transform: scale(0.96, 1.06);
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mascot-interactive,
+  .mascot-interactive__tilt,
+  .mascot-interactive--poking {
+    transition: none;
+    animation: none;
+  }
+
+  .mascot-interactive:active {
+    transform: none;
+  }
+}
+
 .auth-modal-mascot {
   margin: 0 auto 12px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The splash mascot was a static wave. It is now pokeable:

- **Hover** → peeks (`curious`)
- **Click / tap** → cycles reactions (`excited` → `happy` → `curious` → `proud` → `thinking` → `confused`), with a short squash
- **Pointer move** → face and body tilt slightly toward the cursor
- Respects `prefers-reduced-motion` (emotion still changes on poke/hover; no tilt/boop)
- Accessible control with en/pl poke label

## Review follow-ups
Addressed Copilot feedback:
- Safari `MediaQueryList` `addListener` fallback
- Hover/settle emotion still works under reduced motion
- Pointer-look deadband to avoid high-frequency re-renders

## Try it
Standalone HTML artifact (same interactions as the splash):

[`interactive-mascot.html`](/opt/cursor/artifacts/interactive-mascot.html)

[Interactive mascot preview](https://cursor.com/agents/bc-ab241e87-f03f-4841-bb88-b38cf895aa54/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finteractive-mascot-preview.png)

## Test plan
- [x] Open closed-beta splash signed out; hover and click the mascot through a few reactions
- [x] Confirm face tracks the pointer and returns to waving when the pointer leaves
- [x] Reduced-motion: emotion still changes; no tilt/boop
- [x] `npm run type-check && npm run lint && npm run test && npm run build`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab241e87-f03f-4841-bb88-b38cf895aa54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab241e87-f03f-4841-bb88-b38cf895aa54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

