### PR TITLE
Fail the build when a collection-group query has no index

### DIFF
--- a/apps/api/src/firestore-indexes.test.ts
+++ b/apps/api/src/firestore-indexes.test.ts
@@ -46,20 +46,34 @@ function apiSources(): string[] {
     .map((name) => readFileSync(join(here, name), 'utf8'));
 }
 
-interface QuerySite {
+type IndexOrder = 'ASCENDING' | 'DESCENDING';
+
+interface Constraint {
   group: string;
-  fields: string[];
+  field: string;
+  order: IndexOrder;
+}
+
+/** `scorecard.computedAt:DESCENDING` — the identity an index either has or does not. */
+function key(constraint: Pick<Constraint, 'group' | 'field' | 'order'>): string {
+  return `${constraint.group}.${constraint.field}:${constraint.order}`;
 }
 
 /**
- * Finds `collectionGroup('x')` and the fields constrained on the same statement.
+ * Finds `collectionGroup('x')` and the constraints on the same statement.
  *
  * "Same statement" is everything up to the next `;`, which is what makes chained calls
  * across several lines work. Both `where` and `orderBy` count: each needs the field
  * indexed at COLLECTION_GROUP scope.
+ *
+ * **Direction is part of the requirement, not decoration.** The field override written by
+ * step 7 creates exactly one COLLECTION_GROUP entry, in one direction, so an index
+ * provisioned ASCENDING does not satisfy an `orderBy(field, 'desc')` — that is the same
+ * hard 9 FAILED_PRECONDITION as having no index at all. An equality `where` is served by
+ * ASCENDING, and `orderBy` defaults to ascending when the direction is left off.
  */
-function findCollectionGroupQueries(source: string): QuerySite[] {
-  const sites: QuerySite[] = [];
+function findCollectionGroupQueries(source: string): Constraint[] {
+  const constraints: Constraint[] = [];
   const groupPattern = /\.collectionGroup\(\s*'([^']+)'\s*\)/g;
 
   for (const match of source.matchAll(groupPattern)) {
@@ -67,11 +81,16 @@ function findCollectionGroupQueries(source: string): QuerySite[] {
     const end = source.indexOf(';', start);
     const statement = source.slice(start, end === -1 ? source.length : end);
 
-    const fields = [...statement.matchAll(/\.(?:where|orderBy)\(\s*'([^']+)'/g)].map((field) => field[1]);
-    sites.push({ group: match[1], fields });
+    // Second capture is the operator for `where` ('==') and the direction for `orderBy`
+    // ('desc'), which is why the direction is read per-kind rather than positionally.
+    const constraintPattern = /\.(where|orderBy)\(\s*'([^']+)'\s*(?:,\s*'([^']*)')?/g;
+    for (const [, kind, field, second] of statement.matchAll(constraintPattern)) {
+      const order: IndexOrder = kind === 'orderBy' && second === 'desc' ? 'DESCENDING' : 'ASCENDING';
+      constraints.push({ group: match[1], field, order });
+    }
   }
 
-  return sites;
+  return constraints;
 }
 
 /** Parses the `CG_INDEXES="group:field:ORDER ..."` list that step 7 iterates over. */
@@ -81,44 +100,52 @@ function provisionedIndexes(script: string): Set<string> {
 
   const provisioned = new Set<string>();
   for (const entry of declaration[1].split(/\s+/).filter(Boolean)) {
-    const [group, field] = entry.split(':');
-    provisioned.add(`${group}.${field}`);
+    const [group, field, order] = entry.split(':');
+    // A malformed entry would otherwise become an index nobody notices is absent — the
+    // shell loop would PATCH a nonsense order and this check would compare against
+    // `undefined`, so both halves would agree the query is covered when it is not.
+    if (!group || !field || (order !== 'ASCENDING' && order !== 'DESCENDING')) {
+      throw new Error(`Malformed CG_INDEXES entry "${entry}" — expected group:field:ASCENDING|DESCENDING.`);
+    }
+    provisioned.add(key({ group, field, order }));
   }
   return provisioned;
 }
 
 describe('COLLECTION_GROUP indexes', () => {
-  const sites = apiSources().flatMap((source) => findCollectionGroupQueries(source));
+  const constraints = apiSources().flatMap((source) => findCollectionGroupQueries(source));
 
   it('finds the collection-group queries it is meant to be guarding', () => {
     // If a refactor moves these queries or changes how they are written, this fails
-    // rather than quietly guarding an empty list.
-    const found = sites.map((site) => site.group).sort();
+    // rather than quietly guarding an empty list. Deduplicated: this asserts *which*
+    // groups are queried, so a second query against a group already covered is not a
+    // change worth failing over.
+    const found = [...new Set(constraints.map((constraint) => constraint.group))].sort();
 
     expect(
       found,
-      'The set of collection groups queried by store.ts changed. If you added a query, add the ' +
-        'group here and its field to CG_INDEXES in infra/setup-gcp.sh. If this went empty or ' +
+      'The set of collection groups queried by apps/api/src changed. If you added a query, add ' +
+        'the group here and its field to CG_INDEXES in infra/setup-gcp.sh. If this went empty or ' +
         'lost an entry, the regex above stopped matching the code it guards — fix the regex, ' +
         'because a guard that matches nothing still passes and reads as coverage.',
     ).toEqual(['playerFeedback', 'scorecard']);
   });
 
-  it('provisions an index for every field a collection-group query constrains', () => {
+  it('provisions an index, in the right direction, for every constrained field', () => {
     const provisioned = provisionedIndexes(setupScript);
 
-    const missing = sites.flatMap((site) =>
-      site.fields.filter((field) => !provisioned.has(`${site.group}.${field}`)).map((field) => `${site.group}.${field}`),
-    );
+    const missing = [...new Set(constraints.filter((constraint) => !provisioned.has(key(constraint))).map(key))];
 
     expect(
       missing,
       missing.length
         ? `No COLLECTION_GROUP index for ${missing.join(', ')}. Firestore indexes single fields at ` +
             'COLLECTION scope only, so this query will fail in production with 9 FAILED_PRECONDITION ' +
-            '— not run slowly, fail. Add it to CG_INDEXES in infra/setup-gcp.sh (step 7) as ' +
-            '`group:field:ASCENDING` (equality) or `group:field:DESCENDING` (descending orderBy), ' +
-            'then re-run the script against the live project.'
+            '— not run slowly, fail. Add each to CG_INDEXES in infra/setup-gcp.sh (step 7) in exactly ' +
+            'the `group:field:ORDER` form listed above, then re-run the script against the live ' +
+            'project. If an entry for that field already exists, the direction is wrong rather than ' +
+            'the index missing: step 7 writes one COLLECTION_GROUP entry per field, and the opposite ' +
+            'direction does not satisfy the query.'
         : undefined,
     ).toEqual([]);
   });

--- a/apps/api/src/firestore-indexes.test.ts
+++ b/apps/api/src/firestore-indexes.test.ts
@@ -1,0 +1,125 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every COLLECTION GROUP query must have a matching index provisioned in setup-gcp.sh.
+ *
+ * This test exists because the same mistake shipped twice in two days, both times through
+ * a full review:
+ *
+ * - `listScorecards` ordered a collection group by `computedAt` with no index, so
+ *   GET /api/admin/scorecards returned 9 FAILED_PRECONDITION — and because the four
+ *   operator reads share one Promise.all, that blanked the whole /health page.
+ * - `deletePlayerFeedbackByUid` filtered a collection group by `uid` with no index, which
+ *   would have failed an operator mid-way through a deletion request they had already
+ *   accepted.
+ *
+ * Firestore auto-indexes single fields at COLLECTION scope only, never COLLECTION_GROUP,
+ * and the failure is a hard error rather than a slow query. Nothing catches it before
+ * production: `InMemoryStore` has no concept of an index, so every test passes either way,
+ * and the query reads exactly like the collection-scoped ones that do work.
+ *
+ * So the check has to be on the source itself. It is a lint over text, not a type — which
+ * means it can be defeated by writing the query in a shape the regex does not match. That
+ * is why it also asserts it found the call sites it expects: a guard that silently matches
+ * nothing is worse than no guard, because it reads as coverage.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+
+const setupScript = readFileSync(resolve(repoRoot, 'infra/setup-gcp.sh'), 'utf8');
+
+/**
+ * Every non-test source file, not just store.ts.
+ *
+ * Firestore access is *conventionally* confined to the store, but nothing enforces that,
+ * and a guard that assumes the convention holds is one that stops working the first time
+ * somebody breaks it — silently, which is the failure mode this whole file exists to
+ * prevent.
+ */
+function apiSources(): string[] {
+  return readdirSync(here)
+    .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+    .map((name) => readFileSync(join(here, name), 'utf8'));
+}
+
+interface QuerySite {
+  group: string;
+  fields: string[];
+}
+
+/**
+ * Finds `collectionGroup('x')` and the fields constrained on the same statement.
+ *
+ * "Same statement" is everything up to the next `;`, which is what makes chained calls
+ * across several lines work. Both `where` and `orderBy` count: each needs the field
+ * indexed at COLLECTION_GROUP scope.
+ */
+function findCollectionGroupQueries(source: string): QuerySite[] {
+  const sites: QuerySite[] = [];
+  const groupPattern = /\.collectionGroup\(\s*'([^']+)'\s*\)/g;
+
+  for (const match of source.matchAll(groupPattern)) {
+    const start = match.index + match[0].length;
+    const end = source.indexOf(';', start);
+    const statement = source.slice(start, end === -1 ? source.length : end);
+
+    const fields = [...statement.matchAll(/\.(?:where|orderBy)\(\s*'([^']+)'/g)].map((field) => field[1]);
+    sites.push({ group: match[1], fields });
+  }
+
+  return sites;
+}
+
+/** Parses the `CG_INDEXES="group:field:ORDER ..."` list that step 7 iterates over. */
+function provisionedIndexes(script: string): Set<string> {
+  const declaration = /CG_INDEXES="([^"]*)"/.exec(script);
+  if (!declaration) throw new Error('CG_INDEXES not found in infra/setup-gcp.sh — did step 7 get renamed?');
+
+  const provisioned = new Set<string>();
+  for (const entry of declaration[1].split(/\s+/).filter(Boolean)) {
+    const [group, field] = entry.split(':');
+    provisioned.add(`${group}.${field}`);
+  }
+  return provisioned;
+}
+
+describe('COLLECTION_GROUP indexes', () => {
+  const sites = apiSources().flatMap((source) => findCollectionGroupQueries(source));
+
+  it('finds the collection-group queries it is meant to be guarding', () => {
+    // If a refactor moves these queries or changes how they are written, this fails
+    // rather than quietly guarding an empty list.
+    const found = sites.map((site) => site.group).sort();
+
+    expect(
+      found,
+      'The set of collection groups queried by store.ts changed. If you added a query, add the ' +
+        'group here and its field to CG_INDEXES in infra/setup-gcp.sh. If this went empty or ' +
+        'lost an entry, the regex above stopped matching the code it guards — fix the regex, ' +
+        'because a guard that matches nothing still passes and reads as coverage.',
+    ).toEqual(['playerFeedback', 'scorecard']);
+  });
+
+  it('provisions an index for every field a collection-group query constrains', () => {
+    const provisioned = provisionedIndexes(setupScript);
+
+    const missing = sites.flatMap((site) =>
+      site.fields.filter((field) => !provisioned.has(`${site.group}.${field}`)).map((field) => `${site.group}.${field}`),
+    );
+
+    expect(
+      missing,
+      missing.length
+        ? `No COLLECTION_GROUP index for ${missing.join(', ')}. Firestore indexes single fields at ` +
+            'COLLECTION scope only, so this query will fail in production with 9 FAILED_PRECONDITION ' +
+            '— not run slowly, fail. Add it to CG_INDEXES in infra/setup-gcp.sh (step 7) as ' +
+            '`group:field:ASCENDING` (equality) or `group:field:DESCENDING` (descending orderBy), ' +
+            'then re-run the script against the live project.'
+        : undefined,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The same mistake shipped **twice in two days**, both times through a full review:

| Query | Consequence |
| --- | --- |
| `listScorecards` — `collectionGroup('scorecard').orderBy('computedAt')` (#262) | `GET /api/admin/scorecards` 500s. The four operator reads share one `Promise.all`, so it blanked the **entire** `/health` page, game-health table included. Fixed in 196bec2. |
| `deletePlayerFeedbackByUid` — `collectionGroup('playerFeedback').where('uid', ...)` (#268) | `player:erase` would have failed on **first real use** — an operator mid-way through a deletion request they had already accepted, with no other way to carry it out. Caught in review. |

Twice is a pattern, not bad luck.

## Why nothing caught it

Three things line up badly:

- Firestore auto-indexes single fields at `COLLECTION` scope only, **never** `COLLECTION_GROUP`.
- The failure is a hard `9 FAILED_PRECONDITION` — not a slow query, an error.
- `InMemoryStore` has no concept of an index, so **every test passes either way**, and the query reads exactly like the collection-scoped ones that work fine.

There is no type, no runtime check, and no local signal. The first evidence is production.

## What

A test that reads the source: find every `collectionGroup()` call in `apps/api/src` with the fields it constrains (`where` / `orderBy`, across chained multi-line calls) **and the direction each needs**, then require a matching entry in the `CG_INDEXES` list that `setup-gcp.sh` step 7 iterates.

Direction is part of the requirement, not decoration: step 7's field override writes exactly **one** `COLLECTION_GROUP` entry per field, in one direction, so an index provisioned `ASCENDING` does not satisfy `orderBy(field, 'desc')` — same hard failure as no index at all. Equality and bare `orderBy` imply `ASCENDING`; `orderBy(..., 'desc')` implies `DESCENDING`.

Failure names the fix:

```
No COLLECTION_GROUP index for playerFeedback.uid:ASCENDING. Firestore indexes single fields
at COLLECTION scope only, so this query will fail in production with 9 FAILED_PRECONDITION
— not run slowly, fail. Add each to CG_INDEXES in infra/setup-gcp.sh (step 7) in exactly the
`group:field:ORDER` form listed above, then re-run the script against the live project. If an
entry for that field already exists, the direction is wrong rather than the index missing.
```

## Decisions worth reviewing

**It scans the whole workspace, not just `store.ts`.** Firestore access is only *conventionally* confined to the store. A guard resting on that convention stops working the moment somebody breaks it — silently, which is the exact failure mode this file exists to prevent.

**It asserts the set of groups it found.** This is a lint over text, so it can be defeated by writing a query in a shape the regex misses — and a guard that matches zero call sites still *passes*, reading as coverage. So an inventory assertion fails loudly if the regex stops matching the code it guards. Deduplicated, so a second query against an already-covered group isn't a failure.

**Malformed `CG_INDEXES` entries throw.** A missing order segment would compare against `undefined` — the shell loop would PATCH a nonsense order *and* the test would agree the query was covered. Both halves wrong, agreeing.

Matching a `.collectionGroup('x')` inside a comment would be a false positive. That direction is fine — it fails loudly and is cheap to resolve.

## Verification

Not "the test passes" — each failure was reintroduced and observed:

| Reintroduced | Guard reports |
| --- | --- |
| `playerFeedback.uid` index removed | `playerFeedback.uid:ASCENDING` |
| `scorecard.computedAt` index removed | `scorecard.computedAt:DESCENDING` |
| New `collectionGroup('votes').orderBy('castAt','desc')` | `votes.castAt:DESCENDING` (direction inferred) + inventory assertion |
| `scorecard:computedAt` provisioned **ASCENDING** | `scorecard.computedAt:DESCENDING`, message flagging wrong direction |
| `CG_INDEXES` entry missing its order segment | `Malformed CG_INDEXES entry` |

Restored → green.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check` (`@gamedevpl/api`; `apps/e2e` has 15 pre-existing errors on clean `master` from `playwright-core` not installed locally)
- [x] `npm test` — api 711 (2 new), web/e2e/games unchanged
- [x] `npm run build`

## Instrumentation definition-of-done

Affects none of the seven questions — this captures no data. It protects the reads that *answer* them: the scorecards query behind `/health` is one of the two call sites it guards.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4qCA3ruvWreLtyibx71q)_