### PR TITLE
Raise the serve cap for the games-repo touch discoverability layer

### DIFF
--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(247_904);
+    expect(MAX_PROJECT_BYTES).toBe(248_372);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(243_078);
+    expect(MAX_PROJECT_BYTES).toBe(247_904);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(247_904);
+    expect(MAX_PROJECT_BYTES).toBe(248_372);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -62,7 +62,7 @@ describe('games-repo source extractors', () => {
     // opaque number — so the extractor has to evaluate those, not just read literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_TOUCH_BYTES = 7_501 + 4_826;
+      const GAMEKIT_TOUCH_BYTES = 7_501 + 5_294;
       const GAMEKIT_RESTART_BYTES = 2_477;
       const GAMEKIT_MUSIC_BYTES = 7_091 + 650;
       const GAMEKIT_TOUCH_HINT_BYTES = 89;
@@ -87,7 +87,7 @@ describe('games-repo source extractors', () => {
   });
 
   it('evaluates a numeric MAX_BUNDLE_BYTES literal', () => {
-    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 247_904;')).toBe(247904);
+    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 248_372;')).toBe(248372);
   });
 
   it('detects the music injection contract signals', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(243_078);
+    expect(MAX_PROJECT_BYTES).toBe(247_904);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -55,18 +55,22 @@ describe('games-repo source extractors', () => {
   });
 
   it('evaluates MAX_BUNDLE_BYTES across named platform allowances', () => {
-    // Shape mirrors games-repo validate.ts: author budget + named GameKit
-    // allowances. Totals must match MAX_PROJECT_BYTES on this side.
+    // Values mirror games-repo validate.ts, allowance for allowance, so the total
+    // is the real MAX_PROJECT_BYTES rather than a made-up sum that happens to land
+    // on it. Two of them are `a + b` sums over there — an allowance that was raised
+    // keeps the original and the raise side by side instead of collapsing to one
+    // opaque number — so the extractor has to evaluate those, not just read literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_TOUCH_BYTES = 7_501;
-      const GAMEKIT_RESTART_BYTES = 1_024;
-      const GAMEKIT_MUSIC_BYTES = 4_096;
-      const GAMEKIT_TOUCH_HINT_BYTES = 512;
-      const GAMEKIT_PROGRESS_BYTES = 2_048;
-      const GAMEKIT_UNIVERSAL_INPUT_BYTES = 3_072;
-      const GAMEKIT_POINTER_POLL_BYTES = 1_536;
-      const GAMEKIT_DRAW_SURFACE_BYTES = 18_489;
+      const GAMEKIT_TOUCH_BYTES = 7_501 + 4_826;
+      const GAMEKIT_RESTART_BYTES = 2_477;
+      const GAMEKIT_MUSIC_BYTES = 7_091 + 650;
+      const GAMEKIT_TOUCH_HINT_BYTES = 89;
+      const GAMEKIT_PROGRESS_BYTES = 307;
+      const GAMEKIT_UNIVERSAL_INPUT_BYTES = 3_191;
+      const GAMEKIT_POINTER_POLL_BYTES = 7_083;
+      const GAMEKIT_DRAW_SURFACE_BYTES = 9_459;
+      const GAMEKIT_POINTER_RELEASE_BYTES = 430;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -76,13 +80,14 @@ describe('games-repo source extractors', () => {
         GAMEKIT_PROGRESS_BYTES +
         GAMEKIT_UNIVERSAL_INPUT_BYTES +
         GAMEKIT_POINTER_POLL_BYTES +
-        GAMEKIT_DRAW_SURFACE_BYTES;
+        GAMEKIT_DRAW_SURFACE_BYTES +
+        GAMEKIT_POINTER_RELEASE_BYTES;
     `;
-    expect(extractMaxBundleBytes(source)).toBe(243_078);
+    expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });
 
   it('evaluates a numeric MAX_BUNDLE_BYTES literal', () => {
-    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 243_078;')).toBe(243078);
+    expect(extractMaxBundleBytes('const MAX_BUNDLE_BYTES = 247_904;')).toBe(247904);
   });
 
   it('detects the music injection contract signals', () => {

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -32,11 +32,18 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
  * music, touch hint, progress, universal input, pointer poll, draw surface, …).
  * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
- * `MAX_BUNDLE_BYTES` (243_078 as of the games-repo side that broke CI on
- * 2026-07-27). Not a round KiB: the platform side is an explicit sum of named
+ * `MAX_BUNDLE_BYTES` (247_904, matching games-repo `shared/assemble-contract.json`
+ * `maxProjectBytes`). Not a round KiB: the platform side is an explicit sum of named
  * allowances, not a padded `42 * 1024` block.
+ *
+ * Last moved by games-repo PR #95: the `touch` allowance went 7_501 → 12_327 (+4_826)
+ * when the on-screen pad gained the discoverability chrome kids need to notice it —
+ * contrast, direction glyphs, the bilingual coach hint, the attention pulse — plus
+ * playfield touch steering and `setSteerAnchor` for character-relative walking. Every
+ * game is served that layer whether it asked for it or not, so it is charged to the
+ * platform side; charging it to authors would silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 38_278;
+export const GAMEKIT_PLATFORM_BYTES = 43_104;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -32,18 +32,18 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
  * music, touch hint, progress, universal input, pointer poll, draw surface, …).
  * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
- * `MAX_BUNDLE_BYTES` (247_904, matching games-repo `shared/assemble-contract.json`
+ * `MAX_BUNDLE_BYTES` (248_372, matching games-repo `shared/assemble-contract.json`
  * `maxProjectBytes`). Not a round KiB: the platform side is an explicit sum of named
  * allowances, not a padded `42 * 1024` block.
  *
- * Last moved by games-repo PR #95: the `touch` allowance went 7_501 → 12_327 (+4_826)
+ * Last moved by games-repo PR #95: the `touch` allowance went 7_501 → 12_795 (+5_294)
  * when the on-screen pad gained the discoverability chrome kids need to notice it —
  * contrast, direction glyphs, the bilingual coach hint, the attention pulse — plus
  * playfield touch steering and `setSteerAnchor` for character-relative walking. Every
  * game is served that layer whether it asked for it or not, so it is charged to the
  * platform side; charging it to authors would silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 43_104;
+export const GAMEKIT_PLATFORM_BYTES = 43_572;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/docs/games-repo-validation-spec.md
+++ b/docs/games-repo-validation-spec.md
@@ -19,11 +19,17 @@ This specification defines the quality gates enforced on incoming pull requests 
     _(Note: Field schema is defined in `games-repo-blueprint.md` §2; confirm against a live `SPEC.md` in `gamedevpl/www.gamedev.pl-games` when implementing `validate.yml`.)_
 - Ensure `index.html` entrypoint is present in the game directory.
 
-### 2. Game Bundle Size Cap (`MAX_PROJECT_BYTES = 200 * 1024`)
+### 2. Game Bundle Size Cap
 
 - Calculate total byte size of all files in the individual game directory.
-- Hard failure if total size exceeds 204,800 bytes (200 KB).
-- This aligns with the submission API's `MAX_PROJECT_BYTES` constant in `apps/api/src/assemble.ts`.
+- Hard failure if the author's own bytes exceed 204,800 (200 KiB).
+- On top of that sits the GameKit platform allowance — the touch pad, restart button,
+  music glue and friends that every assembled game carries whether it asked or not.
+  Charging those to the author would silently shrink what they may write, so the served
+  cap is author budget + allowances. The live numbers are `GAME_BUDGET_BYTES` and
+  `GAMEKIT_PLATFORM_BYTES` in `apps/api/src/games-repo-contract.ts`, which
+  `apps/api/src/assemble.ts` re-exports as `MAX_PROJECT_BYTES` — do not restate them
+  here, or this page becomes a third copy to keep in lockstep.
 
 ### 3. Headless Browser Boot Smoke Test
 


### PR DESCRIPTION
Website half of the lockstep for [games-repo #95](https://github.com/gamedevpl/www.gamedev.pl-games/pull/95), which asks for a paired update here.

## What #95 asks of this side

I diffed the PR's commits rather than working from the description. Exactly one thing crosses the repo boundary — the budget:

| | before | after |
|---|---|---|
| `touch` allowance | 7,501 | 12,795 |
| `maxProjectBytes` / `MAX_BUNDLE_BYTES` | 243,078 | 248,372 |

The +5,294 buys the on-screen pad the chrome a kid actually notices — contrast, direction glyphs, a bilingual coach hint, an attention pulse — plus playfield touch steering and `setSteerAnchor` for character-relative walking.

Everything else in #95 (`game-shell.css`, `shared/modules/input.ts`, `game-kit.d.ts`, the crypt-delver / overworld-quest examples) is fetched from the games repo at serve time — `github-client.ts:811-828` — so no copy of it lives here and there is nothing to mirror. I also checked for a website-side GameKit API doc that would need `setSteerAnchor` added; there isn't one.

## The change

`GAMEKIT_PLATFORM_BYTES` 38,278 → 43,572 — the games-repo allowance sum exactly. `MAX_PROJECT_BYTES` derives from it and `assemble.ts` re-exports that, so the single literal stays single. The author budget does not move: authors did not spend those bytes.

Left stale, every published game whose bundle lands in the 5,294-byte gap the raise opens would 502 on the play route while its catalog entry and media kept looking fine — the failure issue #247 exists to prevent.

Two things beyond the number:

- The extractor fixture in `games-repo-contract.test.ts` was a set of invented allowances chosen to total 243,078. Replaced with the real allowance-by-allowance values, which also means it now exercises `a + b` allowance expressions — the shape games-repo uses to keep a raise visible next to the original figure — instead of only bare literals.
- `docs/games-repo-validation-spec.md` claimed the cap was 204,800 "aligning with the submission API's `MAX_PROJECT_BYTES`", stale since the platform allowances landed. It now points at the constants rather than restating a number that would drift again.

## Where 5,294 came from

The figure moved twice during #95's review — 4,826, then 5,272 — and the second one turned Check 4 red on `tower-defence` at 22 bytes over. Assembling the whole catalog on both sides of that branch gives one delta for every game:

```
tower-defence          243,078 → 248,372
rooftop-dash           242,681 → 247,975
settlers-of-the-north  242,164 → 247,458
neon-strike-cell       240,150 → 245,444
block-cascade          238,219 → 243,513
```

5,294 across the board, because the touch layer is a constant blob of CSS and transpiled JS inlined per game — it cannot cost different games different amounts. `tower-defence` is the only game that reports a shortfall because it sat at exactly 243,078 before the branch, dead on the old cap with zero headroom. Fixed on the games side (`gamedevpl/www.gamedev.pl-games@4427e7e`); this PR carries the matching half.

## Verification

- Dry-ran the check's own extractors (`extractMaxBundleBytes`, `extractMusicContractSignals`) against the fixed #95 head: **248,372**, matching this side.
- 709 API tests pass (48 files), `npm run lint` clean, `type-check` clean.
- On the games side, `npm run validate` passes the full catalog and 456 unit tests pass.

## Ordering

`npm run contract:games-repo` fetches games-repo `main`, so it will report the mismatch in the *other* direction until #95 merges. It only runs with `GAMES_REPO_TOKEN` set and the unit tests here are green — but if that check is gating, **merge #95 first**.

Unrelated, noticed while checking: #95's branch carries an `assemble.ts` with 11 GameKit modules (no `mascot`), because it is based on a main that predates #99. `assemble.ts` is not in the PR's file set, so merging will not revert it and the 12-module lockstep here holds. Worth a second look if #95 gets rebased.