### PR TITLE
Let a build push a playable game before it commits anything

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -436,6 +436,10 @@ describe('agent build channel', () => {
     // A game bundle is offline by construction, so nothing legitimate needs the network.
     expect(csp).toContain("connect-src 'none'");
     expect(csp).toContain("form-action 'none'");
+    // Deliberately absent: the web app may live on a different origin than the API
+    // (VITE_API_BASE_URL), and frame-ancestors would block the status page from
+    // framing its own preview in exactly those deployments.
+    expect(csp).not.toContain('frame-ancestors');
     expect(page.headers['x-content-type-options']).toBe('nosniff');
     expect(page.headers['cache-control']).toContain('private');
   });

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -371,4 +371,149 @@ describe('agent build channel', () => {
     });
     expect(stolen.statusCode).toBe(404);
   });
+
+  const GAME_HTML = Buffer.from('<!doctype html><html><body><canvas id="game"></canvas></body></html>').toString(
+    'base64',
+  );
+
+  it('stores a pushed playable build, lists it on the status response, and serves it', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    const pushed = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/preview',
+      headers: agentHeaders(),
+      payload: { html: GAME_HTML, slug: 'puppy-stroll', label: 'You can walk the puppy now.' },
+    });
+
+    expect(pushed.statusCode).toBe(200);
+    expect(pushed.json().accepted).toBe(true);
+    const previewId = pushed.json().preview.id as string;
+
+    const token = mintToken(ISSUE, secret);
+    const status = await app.inject({ method: 'GET', url: `/api/submissions/${token}` });
+    expect(status.json().playable).toEqual([
+      expect.objectContaining({ ref: previewId, slug: 'puppy-stroll', label: 'You can walk the puppy now.' }),
+    ]);
+
+    const page = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}/preview/${previewId}`,
+      headers: creatorHeaders(),
+    });
+    expect(page.statusCode).toBe(200);
+    expect(page.headers['content-type']).toContain('text/html');
+    expect(page.body).toContain('<canvas id="game">');
+  });
+
+  it('serves a preview sandboxed, uncacheable by shared caches, and unable to call home', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    const pushed = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/preview',
+      headers: agentHeaders(),
+      payload: { html: GAME_HTML },
+    });
+    const token = mintToken(ISSUE, secret);
+    const page = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}/preview/${pushed.json().preview.id}`,
+      headers: creatorHeaders(),
+    });
+
+    // This document is unreviewed agent output executed in the creator's browser. Each
+    // of these is load-bearing, so each is asserted rather than assumed.
+    const csp = page.headers['content-security-policy'] as string;
+    expect(csp).toContain('sandbox allow-scripts');
+    // Never granted: with it, the sandbox would share the site's origin and the
+    // document could reach the creator's session.
+    expect(csp).not.toContain('allow-same-origin');
+    // A game bundle is offline by construction, so nothing legitimate needs the network.
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("form-action 'none'");
+    expect(page.headers['x-content-type-options']).toBe('nosniff');
+    expect(page.headers['cache-control']).toContain('private');
+  });
+
+  it('refuses a payload that is not an HTML document', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/preview',
+      headers: agentHeaders(),
+      payload: { html: Buffer.from('GIF89a<script>alert(1)</script>').toString('base64') },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toBe('not an HTML document');
+    expect(await store.countBuildPreviews(ISSUE)).toBe(0);
+  });
+
+  it('keeps only the newest previews, because each one obsoletes the last', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    for (let index = 0; index < 7; index++) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/preview',
+        headers: agentHeaders(),
+        payload: { html: GAME_HTML, label: `build ${index}` },
+      });
+      expect(response.json().accepted).toBe(true);
+    }
+
+    // A watcher pushing every time the game recompiles would otherwise accumulate
+    // hundreds of megabytes over one build.
+    expect(await store.countBuildPreviews(ISSUE)).toBe(4);
+    const newest = await store.listBuildPreviews(ISSUE);
+    expect(newest[0]?.label).toBe('build 6');
+  });
+
+  it('will not serve one build’s playable preview to another build’s token', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await seedSubmission(store, 99);
+    app = await createApp(store);
+
+    const pushed = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/preview',
+      headers: agentHeaders(),
+      payload: { html: GAME_HTML },
+    });
+
+    const stolen = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(99, secret)}/preview/${pushed.json().preview.id}`,
+      headers: creatorHeaders(),
+    });
+    expect(stolen.statusCode).toBe(404);
+  });
+
+  it('stops accepting previews once the creator has stopped the build', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionAbandoned(ISSUE, new Date().toISOString());
+    app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/preview',
+      headers: agentHeaders(),
+      payload: { html: GAME_HTML },
+    });
+
+    expect(response.json()).toMatchObject({ accepted: false, rejected: 'stopped' });
+    expect(await store.countBuildPreviews(ISSUE)).toBe(0);
+  });
 });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -88,6 +88,45 @@ const BuildShotInputSchema = z.object({
     .optional(),
 });
 
+const MAX_PREVIEW_LABEL = 120;
+/**
+ * 320 KB decoded. The games repo caps an assembled bundle at a little over 200 KB
+ * (validate.ts Check 4) and the largest game in the catalog measures 243 KB, so this
+ * clears the real ceiling with slack while staying well inside a Firestore document.
+ */
+const maxPreviewBytes = 320 * 1024;
+
+const BuildPreviewInputSchema = z.object({
+  html: z
+    .string()
+    .trim()
+    .min(1, 'html is required')
+    .max(Math.ceil((maxPreviewBytes * 4) / 3) + 1024, 'preview is too large')
+    .regex(/^[A-Za-z0-9+/\s]*={0,2}$/, 'html must be base64'),
+  slug: z
+    .string()
+    .trim()
+    .max(64)
+    .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'invalid slug')
+    .optional(),
+  label: z
+    .string()
+    .trim()
+    .max(MAX_PREVIEW_LABEL * 4)
+    .optional(),
+  labelLocalized: z
+    .string()
+    .trim()
+    .max(MAX_PREVIEW_LABEL * 4)
+    .optional(),
+  locale: z
+    .string()
+    .trim()
+    .max(10)
+    .regex(/^[a-z]{2}(-[A-Za-z0-9]{2,8})?$/, 'invalid locale')
+    .optional(),
+});
+
 export interface AgentChannelOptions {
   store?: Store;
   /** Signing key for build tokens; the same secret that mints submission tokens. */
@@ -106,6 +145,10 @@ export interface AgentChannelOptions {
   maxShotsPerBuild?: number;
   /** Screenshots one build may push per hour. */
   maxShotsPerWindow?: number;
+  /** How many playable previews are kept; older ones are pruned on write. */
+  keepPreviews?: number;
+  /** Playable previews one build may push per hour. */
+  maxPreviewsPerWindow?: number;
 }
 
 type RejectionReason = 'stopped' | 'rate_limited' | 'too_many_events' | 'too_many_shots';
@@ -136,9 +179,16 @@ export async function registerAgentChannelRoutes(
   // Screenshots are far heavier than sentences, so they get their own, tighter caps.
   const maxShotsPerBuild = options.maxShotsPerBuild ?? 24;
   const maxShotsPerWindow = options.maxShotsPerWindow ?? 40;
+  // A watcher pushes whatever currently builds, so previews arrive on a cadence rather
+  // than on the agent's judgement. Only the newest few are worth keeping — each one
+  // obsoletes the last — but the hourly allowance is generous, because a build that
+  // recompiles every thirty seconds for half an hour is working exactly as intended.
+  const keepPreviews = options.keepPreviews ?? 4;
+  const maxPreviewsPerWindow = options.maxPreviewsPerWindow ?? 90;
   const eventsByBuild = new Map<number, number[]>();
   const inboxChecksByBuild = new Map<number, number[]>();
   const shotsByBuild = new Map<number, number[]>();
+  const previewsByBuild = new Map<number, number[]>();
 
   /**
    * Resolves the build a request is about. The token is the whole credential: it
@@ -327,6 +377,82 @@ export async function registerAgentChannelRoutes(
       ...(await channelState(issueNumber, record)),
     });
   });
+
+  /**
+   * A playable build of the game, pushed before any commit.
+   *
+   * The measured problem: `npm run create` leaves a playable starter on disk about a
+   * minute into a build, and the agent does not attempt its first build until minute
+   * eight or eleven. For those ten minutes something runnable exists and nobody looks at
+   * it, while the creator watches a status page. This is the route that closes that gap,
+   * and it is meant to be driven by a watcher rather than by the agent's judgement —
+   * whatever currently compiles, as often as it changes.
+   *
+   * What arrives is a self-contained offline HTML document, the same shape the site
+   * already serves for a published game. Two things are checked rather than trusted: the
+   * decoded size, and that the bytes actually open as an HTML document. Everything else
+   * about it is unreviewed agent output, so the route that serves it back sandboxes it.
+   */
+  app.post(
+    '/api/agent/build/preview',
+    { config: { rateLimit: { max: 200, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      const parsed = BuildPreviewInputSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      const reject = async (reason: RejectionReason) =>
+        reply.send({ accepted: false, rejected: reason, ...(await channelState(issueNumber, record)) });
+
+      if (stopReason(record)) {
+        return reject('stopped');
+      }
+      if (isRateLimited(previewsByBuild, issueNumber, now(), maxPreviewsPerWindow)) {
+        return reject('rate_limited');
+      }
+
+      const bytes = Buffer.from(parsed.data.html, 'base64');
+      if (bytes.length > maxPreviewBytes) {
+        return reply.status(413).send({ error: 'preview is too large' });
+      }
+      // The equivalent of the PNG signature check on shots. It proves nothing about what
+      // the document does — only that serving it as text/html is not a category error.
+      const head = bytes.subarray(0, 512).toString('utf8').trimStart().toLowerCase();
+      if (!head.startsWith('<!doctype html') && !head.startsWith('<html')) {
+        return reply.status(400).send({ error: 'not an HTML document' });
+      }
+
+      const label = parsed.data.label
+        ? sanitizeCreatorText(parsed.data.label, { singleLine: true }).slice(0, MAX_PREVIEW_LABEL)
+        : '';
+      const labelLocalized = parsed.data.labelLocalized
+        ? sanitizeCreatorText(parsed.data.labelLocalized, { singleLine: true }).slice(0, MAX_PREVIEW_LABEL)
+        : '';
+      const hasLocalized = Boolean(labelLocalized && parsed.data.locale);
+
+      const stored = await store!.appendBuildPreview(issueNumber, {
+        data: bytes.toString('base64'),
+        ...(parsed.data.slug ? { slug: parsed.data.slug } : {}),
+        ...(label ? { label } : {}),
+        ...(hasLocalized ? { labelLocalized, locale: parsed.data.locale } : {}),
+      });
+      // Pruning after the write, not before: a push that succeeds and then fails to tidy up
+      // has still delivered the thing the creator is waiting for.
+      await store!.pruneBuildPreviews(issueNumber, keepPreviews).catch(() => 0);
+      options.onEvent?.(issueNumber);
+
+      return reply.send({
+        accepted: true,
+        preview: { id: stored.id, createdAt: stored.createdAt, ...(stored.slug ? { slug: stored.slug } : {}) },
+        ...(await channelState(issueNumber, record)),
+      });
+    },
+  );
 
   // Collect without reporting. Deliberately does NOT mark messages delivered — an
   // agent that reads a request and then crashes must not lose it. Acking is explicit.

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(248_372);
+    expect(MAX_PROJECT_BYTES).toBe(248_638);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(248_372);
+    expect(MAX_PROJECT_BYTES).toBe(248_638);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -62,7 +62,7 @@ describe('games-repo source extractors', () => {
     // opaque number — so the extractor has to evaluate those, not just read literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_TOUCH_BYTES = 7_501 + 5_294;
+      const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
       const GAMEKIT_RESTART_BYTES = 2_477;
       const GAMEKIT_MUSIC_BYTES = 7_091 + 650;
       const GAMEKIT_TOUCH_HINT_BYTES = 89;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -32,18 +32,21 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
  * music, touch hint, progress, universal input, pointer poll, draw surface, …).
  * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
- * `MAX_BUNDLE_BYTES` (248_372, matching games-repo `shared/assemble-contract.json`
+ * `MAX_BUNDLE_BYTES` (248_638, matching games-repo `shared/assemble-contract.json`
  * `maxProjectBytes`). Not a round KiB: the platform side is an explicit sum of named
  * allowances, not a padded `42 * 1024` block.
  *
- * Last moved by games-repo PR #95: the `touch` allowance went 7_501 → 12_795 (+5_294)
- * when the on-screen pad gained the discoverability chrome kids need to notice it —
- * contrast, direction glyphs, the bilingual coach hint, the attention pulse — plus
- * playfield touch steering and `setSteerAnchor` for character-relative walking. Every
- * game is served that layer whether it asked for it or not, so it is charged to the
- * platform side; charging it to authors would silently shrink what they may write.
+ * Last moved by games-repo PR #103: the `touch` allowance went 12_795 → 13_061 (+266)
+ * when `createInput` began requiring an explicit steer decision, which costs the
+ * tightest published title a few author bytes for the mandatory `steer:` declaration.
+ * Before that, games-repo PR #95 took it 7_501 → 12_795 (+5_294) for the on-screen
+ * pad's discoverability chrome — contrast, direction glyphs, the bilingual coach hint,
+ * the attention pulse — plus playfield touch steering and `setSteerAnchor` for
+ * character-relative walking. Every game is served that layer whether it asked for it
+ * or not, so it is charged to the platform side; charging it to authors would silently
+ * shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 43_572;
+export const GAMEKIT_PLATFORM_BYTES = 43_838;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1584,9 +1584,17 @@ export class FirestoreStore implements Store {
     const snap = await this.previewsCollection(issueNumber).select('createdAt').orderBy('createdAt', 'desc').get();
     const stale = snap.docs.slice(keep);
     if (!stale.length) return 0;
-    const batch = this.db.batch();
-    for (const doc of stale) batch.delete(doc.ref);
-    await batch.commit();
+    // Chunked, because a Firestore batch takes at most 500 operations. Steady state is
+    // one deletion per push, so this never matters — until pruning falls behind (a spell
+    // of write errors while the watcher keeps pushing), at which point a single batch
+    // would start failing permanently and previews would grow without bound. The cheap
+    // loop is what stops a transient fault from becoming a permanent one.
+    const BATCH_LIMIT = 500;
+    for (let start = 0; start < stale.length; start += BATCH_LIMIT) {
+      const batch = this.db.batch();
+      for (const doc of stale.slice(start, start + BATCH_LIMIT)) batch.delete(doc.ref);
+      await batch.commit();
+    }
     return stale.length;
   }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -148,6 +148,38 @@ export interface BuildShot {
 /** A shot without its bytes — what a listing needs. */
 export type BuildShotSummary = Omit<BuildShot, 'data'>;
 
+/**
+ * A playable build of the game as it stood at some moment, pushed before any commit.
+ *
+ * A screenshot answers "what does it look like"; this answers "does it play", which is
+ * the only question a creator can really judge a game by. It is the same self-contained
+ * offline HTML the site serves for a published game — one file, no assets, capped by the
+ * games repo's own bundle budget — so whatever plays a published game plays this.
+ *
+ * Bytes live here as base64 for the same reason shots do: an assembled bundle is a couple
+ * of hundred kilobytes, which sits inside a Firestore document with room to spare, and a
+ * preview that is obsolete within minutes is not worth a bucket and a retention job.
+ *
+ * This is unreviewed agent output. It has passed a build and a smoke run and nothing
+ * else — no gate, no review, no merge. Whatever serves it must treat it as hostile.
+ */
+export interface BuildPreview {
+  id: string;
+  /** base64-encoded self-contained HTML document. */
+  data: string;
+  /** The game's slug, for a title the creator recognizes. */
+  slug?: string;
+  /** Agent-authored caption in English, already sanitized. */
+  label?: string;
+  /** The same caption in `locale`, authored rather than machine translated. */
+  labelLocalized?: string;
+  locale?: string;
+  createdAt: string;
+}
+
+/** A preview without its bytes — what a listing needs. */
+export type BuildPreviewSummary = Omit<BuildPreview, 'data'>;
+
 export interface UsageCounters {
   submissions: number;
   previews: number;
@@ -540,6 +572,20 @@ export interface Store {
   getBuildShot(issueNumber: number, id: string): Promise<BuildShot | null>;
   /** How many screenshots a build has pushed — the cap that bounds a runaway agent. */
   countBuildShots(issueNumber: number): Promise<number>;
+
+  appendBuildPreview(
+    issueNumber: number,
+    preview: Omit<BuildPreview, 'id' | 'createdAt'> & { createdAt?: string },
+  ): Promise<BuildPreview>;
+
+  listBuildPreviews(issueNumber: number, opts?: { limit?: number }): Promise<BuildPreviewSummary[]>;
+
+  getBuildPreview(issueNumber: number, id: string): Promise<BuildPreview | null>;
+
+  countBuildPreviews(issueNumber: number): Promise<number>;
+
+  /** Drops all but the newest `keep` previews, returning how many were removed. */
+  pruneBuildPreviews(issueNumber: number, keep: number): Promise<number>;
   /** Queues a creator change request for the agent to collect. */
   appendCreatorMessage(issueNumber: number, text: string): Promise<CreatorMessage>;
   /** Undelivered creator messages, oldest first — the agent's inbox. */
@@ -746,6 +792,7 @@ export class InMemoryStore implements Store {
   private submissions = new Map<number, SubmissionRecord>();
   private buildEvents = new Map<number, BuildEvent[]>();
   private buildShots = new Map<number, BuildShot[]>();
+  private buildPreviews = new Map<number, BuildPreview[]>();
   private creatorMessages = new Map<number, CreatorMessage[]>();
   private usage = new Map<string, UsageCounters>();
   private waitlist = new Map<string, WaitlistEntry>();
@@ -903,6 +950,45 @@ export class InMemoryStore implements Store {
 
   async countBuildShots(issueNumber: number): Promise<number> {
     return this.buildShots.get(issueNumber)?.length ?? 0;
+  }
+
+  async appendBuildPreview(
+    issueNumber: number,
+    preview: Omit<BuildPreview, 'id' | 'createdAt'> & { createdAt?: string },
+  ): Promise<BuildPreview> {
+    const record: BuildPreview = {
+      ...preview,
+      id: randomUUID(),
+      createdAt: preview.createdAt ?? new Date().toISOString(),
+    };
+    const existing = this.buildPreviews.get(issueNumber) ?? [];
+    existing.push(record);
+    this.buildPreviews.set(issueNumber, existing);
+    return { ...record };
+  }
+
+  async listBuildPreviews(issueNumber: number, opts?: { limit?: number }): Promise<BuildPreviewSummary[]> {
+    return [...(this.buildPreviews.get(issueNumber) ?? [])]
+      .sort(byNewestFirst)
+      .slice(0, opts?.limit ?? 4)
+      .map(({ data: _data, ...summary }) => ({ ...summary }));
+  }
+
+  async getBuildPreview(issueNumber: number, id: string): Promise<BuildPreview | null> {
+    const found = this.buildPreviews.get(issueNumber)?.find((preview) => preview.id === id);
+    return found ? { ...found } : null;
+  }
+
+  async countBuildPreviews(issueNumber: number): Promise<number> {
+    return this.buildPreviews.get(issueNumber)?.length ?? 0;
+  }
+
+  async pruneBuildPreviews(issueNumber: number, keep: number): Promise<number> {
+    const existing = this.buildPreviews.get(issueNumber) ?? [];
+    if (existing.length <= keep) return 0;
+    const kept = [...existing].sort(byNewestFirst).slice(0, keep);
+    this.buildPreviews.set(issueNumber, kept);
+    return existing.length - kept.length;
   }
 
   async appendCreatorMessage(issueNumber: number, text: string): Promise<CreatorMessage> {
@@ -1395,6 +1481,10 @@ export class FirestoreStore implements Store {
     return this.db.collection('submissions').doc(String(issueNumber)).collection('shots');
   }
 
+  private previewsCollection(issueNumber: number) {
+    return this.db.collection('submissions').doc(String(issueNumber)).collection('previews');
+  }
+
   async appendBuildEvent(
     issueNumber: number,
     event: Omit<BuildEvent, 'id' | 'createdAt'> & { createdAt?: string },
@@ -1449,6 +1539,55 @@ export class FirestoreStore implements Store {
   async countBuildShots(issueNumber: number): Promise<number> {
     const snap = await this.shotsCollection(issueNumber).count().get();
     return snap.data().count;
+  }
+
+  async appendBuildPreview(
+    issueNumber: number,
+    preview: Omit<BuildPreview, 'id' | 'createdAt'> & { createdAt?: string },
+  ): Promise<BuildPreview> {
+    const record: BuildPreview = {
+      ...preview,
+      id: randomUUID(),
+      createdAt: preview.createdAt ?? new Date().toISOString(),
+    };
+    const document = Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+    await this.previewsCollection(issueNumber).doc(record.id).set(document);
+    return record;
+  }
+
+  async listBuildPreviews(issueNumber: number, opts?: { limit?: number }): Promise<BuildPreviewSummary[]> {
+    // `select()` matters far more here than it does for shots: a preview document is a
+    // couple of hundred kilobytes, and this listing rides a status response the creator's
+    // browser polls every few seconds. The bytes are fetched once, by the iframe.
+    const snap = await this.previewsCollection(issueNumber)
+      .select('id', 'slug', 'label', 'labelLocalized', 'locale', 'createdAt')
+      .orderBy('createdAt', 'desc')
+      .limit(opts?.limit ?? 4)
+      .get();
+    return snap.docs.map((doc) => doc.data() as BuildPreviewSummary).sort(byNewestFirst);
+  }
+
+  async getBuildPreview(issueNumber: number, id: string): Promise<BuildPreview | null> {
+    const doc = await this.previewsCollection(issueNumber).doc(id).get();
+    return doc.exists ? (doc.data() as BuildPreview) : null;
+  }
+
+  async countBuildPreviews(issueNumber: number): Promise<number> {
+    const snap = await this.previewsCollection(issueNumber).count().get();
+    return snap.data().count;
+  }
+
+  async pruneBuildPreviews(issueNumber: number, keep: number): Promise<number> {
+    // Previews are heavy and each one obsoletes the last, so the collection is trimmed on
+    // write rather than left to a retention job. Ids only — pulling the documents to
+    // decide which to drop would fetch the very bytes this is trying not to keep.
+    const snap = await this.previewsCollection(issueNumber).select('createdAt').orderBy('createdAt', 'desc').get();
+    const stale = snap.docs.slice(keep);
+    if (!stale.length) return 0;
+    const batch = this.db.batch();
+    for (const doc of stale) batch.delete(doc.ref);
+    await batch.commit();
+    return stale.length;
   }
 
   async appendCreatorMessage(issueNumber: number, text: string): Promise<CreatorMessage> {

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -153,6 +153,26 @@ export interface SubmissionStatusResponseBase {
    * with no pull request yet can still show something.
    */
   media?: BuildMediaItem[];
+  /**
+   * Playable builds pushed over the channel, newest first. A picture tells the creator
+   * what the game looks like; these are the first thing that lets them find out whether
+   * it is any fun, which is the only question they can really answer.
+   */
+  playable?: BuildPlayableItem[];
+}
+
+/**
+ * One playable build in progress. Unlike `BuildMediaItem` there is no `branch` variant:
+ * a committed game is reachable through the draft link already, and this exists for the
+ * window before any commit — from about a minute in, when the scaffold first compiles.
+ */
+export interface BuildPlayableItem {
+  /** Stored preview id — the client builds the URL. */
+  ref: string;
+  slug?: string;
+  /** Agent-authored caption, in the reader's language when one was supplied. */
+  label?: string;
+  createdAt?: string;
 }
 
 /**

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1610,10 +1610,6 @@ export async function registerSubmissionRoutes(
    * This serves unreviewed agent output as executable HTML, which is the most dangerous
    * thing in this file, so the defences are layered and none of them is decorative:
    *
-   *  - The document is served from a *different origin* than the site whenever
-   *    PREVIEW_ORIGIN is configured, and the browser is told to sandbox it besides. A
-   *    game bundle is self-contained and offline by construction, so it needs no access
-   *    to the site's origin, cookies, or storage to run correctly.
    *  - `Content-Security-Policy: sandbox` is the header form of the iframe attribute, so
    *    the restriction holds even if the document is opened directly rather than framed.
    *    `allow-scripts` is granted because a game is nothing without it; `allow-same-origin`
@@ -1624,6 +1620,12 @@ export async function registerSubmissionRoutes(
    *    fails, so an injected exfiltration payload has nowhere to send anything.
    *  - `X-Content-Type-Options: nosniff` and `Content-Disposition: inline` keep the
    *    response from being reinterpreted as anything other than what it is.
+   *
+   * No `frame-ancestors`: the web app may be served from a different origin than this API
+   * (`VITE_API_BASE_URL`), and restricting it would block the status page from framing the
+   * preview in exactly those deployments. It would also buy nothing — the URL is reachable
+   * only with the creator's submission token, and a document already confined to an opaque
+   * origin has nothing worth clickjacking.
    *
    * Caching is short and private. A preview is superseded within minutes and belongs to
    * one creator's build; it must not sit in a shared cache the way published media can.
@@ -1670,7 +1672,7 @@ export async function registerSubmissionRoutes(
             'Content-Security-Policy',
             "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; " +
               "style-src 'unsafe-inline'; img-src data: blob:; media-src data: blob:; font-src data:; " +
-              "connect-src 'none'; form-action 'none'; frame-ancestors 'self'; base-uri 'none'",
+              "connect-src 'none'; form-action 'none'; base-uri 'none'",
           )
           .header('X-Content-Type-Options', 'nosniff')
           .header('Content-Disposition', 'inline')

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -18,7 +18,7 @@ import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { notifyOnTransition, type EmitDeps } from './notify.js';
-import { type BuildShotSummary, type Store } from './store.js';
+import { type BuildPreviewSummary, type BuildShotSummary, type Store } from './store.js';
 import {
   CREATOR_FEEDBACK_MARKER,
   countCreatorClarifications,
@@ -28,6 +28,7 @@ import {
   sanitizeCreatorText,
   type BuildEvent,
   type BuildMediaItem,
+  type BuildPlayableItem,
   type SubmissionStatusResponse,
 } from './submission-status.js';
 import { InvalidTokenError, mintToken, verifyToken } from './submission-token.js';
@@ -353,6 +354,23 @@ export async function registerSubmissionRoutes(
     return value;
   }
 
+  // Only the newest few previews are kept at all (the channel prunes on write), and the
+  // creator only ever wants the latest playable thing plus a little history.
+  const maxPreviewsShown = 4;
+  const previewsCache = new Map<number, { expiresAt: number; value: BuildPreviewSummary[] }>();
+
+  async function loadBuildPreviews(issueNumber: number): Promise<BuildPreviewSummary[]> {
+    if (!store) return [];
+    const currentTime = now();
+    const cached = previewsCache.get(issueNumber);
+    if (cached && cached.expiresAt > currentTime) {
+      return cached.value;
+    }
+    const value = await store.listBuildPreviews(issueNumber, { limit: maxPreviewsShown });
+    previewsCache.set(issueNumber, { value, expiresAt: currentTime + eventsCacheTtlMs });
+    return value;
+  }
+
   const maxShotsShown = 12;
   const shotsCache = new Map<number, { expiresAt: number; value: BuildShotSummary[] }>();
 
@@ -429,6 +447,19 @@ export async function registerSubmissionRoutes(
     ];
   }
 
+  /** Playable builds pushed over the channel, newest first. */
+  async function buildPlayables(issueNumber: number, locale: string): Promise<BuildPlayableItem[]> {
+    return (await loadBuildPreviews(issueNumber)).map((preview): BuildPlayableItem => {
+      const caption = preview.locale === locale && preview.labelLocalized ? preview.labelLocalized : preview.label;
+      return {
+        ref: preview.id,
+        ...(preview.slug ? { slug: preview.slug } : {}),
+        ...(caption ? { label: caption } : {}),
+        createdAt: preview.createdAt,
+      };
+    });
+  }
+
   /**
    * Resolves each event to one sentence in the reader's language. An agent that wrote
    * the sentence in the creator's language already (the common case — we tell it which
@@ -472,11 +503,16 @@ export async function registerSubmissionRoutes(
     issueNumber: number,
     locale: string,
   ): Promise<SubmissionStatusResponse> {
-    const [events, media] = await Promise.all([loadBuildEvents(issueNumber), buildMedia(status, issueNumber, locale)]);
+    const [events, media, playable] = await Promise.all([
+      loadBuildEvents(issueNumber),
+      buildMedia(status, issueNumber, locale),
+      buildPlayables(issueNumber, locale),
+    ]);
     return {
       ...status,
       ...(events.length > 0 ? { events: await localizeEvents(events, locale) } : {}),
       ...(media.length > 0 ? { media } : {}),
+      ...(playable.length > 0 ? { playable } : {}),
     };
   }
 
@@ -1564,6 +1600,86 @@ export async function registerSubmissionRoutes(
       } catch (error) {
         request.log.error({ err: error }, 'failed to serve build screenshot');
         return reply.status(502).send({ error: 'failed to load game media' });
+      }
+    },
+  );
+
+  /**
+   * A playable build the agent pushed over the channel, before it committed anything.
+   *
+   * This serves unreviewed agent output as executable HTML, which is the most dangerous
+   * thing in this file, so the defences are layered and none of them is decorative:
+   *
+   *  - The document is served from a *different origin* than the site whenever
+   *    PREVIEW_ORIGIN is configured, and the browser is told to sandbox it besides. A
+   *    game bundle is self-contained and offline by construction, so it needs no access
+   *    to the site's origin, cookies, or storage to run correctly.
+   *  - `Content-Security-Policy: sandbox` is the header form of the iframe attribute, so
+   *    the restriction holds even if the document is opened directly rather than framed.
+   *    `allow-scripts` is granted because a game is nothing without it; `allow-same-origin`
+   *    deliberately is not, which leaves the document in an opaque origin with no access
+   *    to storage or cookies anywhere.
+   *  - `default-src 'none'` with inline script and style allowed matches what an assembled
+   *    bundle actually is — everything embedded, nothing fetched. Any attempt to call home
+   *    fails, so an injected exfiltration payload has nowhere to send anything.
+   *  - `X-Content-Type-Options: nosniff` and `Content-Disposition: inline` keep the
+   *    response from being reinterpreted as anything other than what it is.
+   *
+   * Caching is short and private. A preview is superseded within minutes and belongs to
+   * one creator's build; it must not sit in a shared cache the way published media can.
+   */
+  app.get(
+    '/api/submissions/:token/preview/:id',
+    { config: { rateLimit: { max: maxMediaPerWindow, timeWindow: gamesRateLimitWindowMs } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret || !store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) {
+        return;
+      }
+
+      const parsedParams = z.object({ token: z.string(), id: z.string().max(64) }).safeParse(request.params);
+      if (!parsedParams.success) {
+        return reply.status(404).send({ error: 'preview not found' });
+      }
+
+      const currentTime = now();
+      if (isRateLimited(mediaByIp, request.ip, currentTime, maxMediaPerWindow, gamesRateLimitWindowMs)) {
+        return reply.status(429).send({ error: 'too many game requests, please try again later' });
+      }
+
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(parsedParams.data.token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      try {
+        const preview = await store.getBuildPreview(issueNumber, parsedParams.data.id);
+        if (!preview) {
+          return reply.status(404).send({ error: 'preview not found' });
+        }
+
+        return reply
+          .header(
+            'Content-Security-Policy',
+            "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; " +
+              "style-src 'unsafe-inline'; img-src data: blob:; media-src data: blob:; font-src data:; " +
+              "connect-src 'none'; form-action 'none'; frame-ancestors 'self'; base-uri 'none'",
+          )
+          .header('X-Content-Type-Options', 'nosniff')
+          .header('Content-Disposition', 'inline')
+          .header('Cache-Control', 'private, max-age=60')
+          .type('text/html; charset=utf-8')
+          .send(Buffer.from(preview.data, 'base64'));
+      } catch (error) {
+        request.log.error({ err: error }, 'failed to serve build preview');
+        return reply.status(502).send({ error: 'failed to load preview' });
       }
     },
   );

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -71,6 +71,48 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('offers the latest playable build in a sandboxed frame, before any commit exists', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    // Still queued: no pull request, no commit, no committed capture. This is the
+    // ten-minute stretch a watcher fills, and the whole reason the route exists.
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'queued',
+      playable: [
+        {
+          ref: 'newest',
+          slug: 'puppy-stroll',
+          label: 'You can walk the puppy now.',
+          createdAt: new Date().toISOString(),
+        },
+        { ref: 'older', slug: 'puppy-stroll', createdAt: new Date(Date.now() - 120_000).toISOString() },
+      ],
+    });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/playable-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'playable-token' }));
+      await flushEffects();
+    });
+
+    const frame = container.querySelector('iframe.game-frame') as HTMLIFrameElement | null;
+    expect(frame).not.toBeNull();
+    // Newest wins: an older build is history, not the thing to play.
+    expect(frame?.getAttribute('src')).toContain('/preview/newest');
+    // The document is unreviewed agent output, so the frame must isolate it. Without
+    // allow-same-origin it lands in an opaque origin with no reach into this app.
+    expect(frame?.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(container.textContent).toContain('You can walk the puppy now.');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('shows agent channel updates while the build is still queued, with translated step labels', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // No PR yet — so no `progress` at all. This is exactly the stretch where the

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { GameFrame } from './GameFrame.js';
 import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
@@ -9,8 +10,10 @@ import {
   getSubmissionStatus,
   submitFeedback,
   buildMediaUrl,
+  buildPlayableUrl,
   type BuildEvent,
   type BuildMediaItem,
+  type BuildPlayableItem,
   type BuildEventKind,
   type BuildProgress,
   type BuildStep,
@@ -402,6 +405,10 @@ export function SubmissionStatusView({
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
               />
             ) : null}
+
+            {/* Above the feed on purpose: a playable build outranks any description of
+                one, and it is available minutes before the first commit. */}
+            <PlayableBuildPanel token={token} playable={status.playable ?? []} />
 
             <BuildProgressPanel
               token={token}
@@ -835,6 +842,38 @@ function buildActivityFeed(
 
   // Newest first — that's what makes the build feel live.
   return entries.filter((entry) => Number.isFinite(entry.at)).sort((a, b) => b.at - a.at);
+}
+
+/**
+ * The game as it stands right now, playable, before anything has been committed.
+ *
+ * This is the earliest honest answer to the only question the creator can really
+ * judge: is it any fun. `npm run create` leaves a playable starter on disk about a
+ * minute into a build, and a watcher pushes whatever compiles from then on — so this
+ * panel typically appears long before the first screenshot and many minutes before the
+ * first commit. It is deliberately loaded by URL into a sandboxed frame rather than
+ * fetched and inlined: the document is unreviewed agent output.
+ */
+function PlayableBuildPanel({ token, playable }: { token: string; playable: BuildPlayableItem[] }) {
+  const { t, i18n } = useTranslation();
+  const latest = playable[0];
+  if (!latest) return null;
+
+  return (
+    <section className="status-playable" aria-live="polite">
+      <h3>{t('statusView.playableTitle')}</h3>
+      {/* The agent's own caption when it wrote one — untrusted text, rendered as text. */}
+      <p className="status-playable-hint">{latest.label ?? t('statusView.playableHint')}</p>
+      <div className="status-playable-frame">
+        <GameFrame title={latest.slug ?? t('statusView.playableTitle')} src={buildPlayableUrl(token, latest)} />
+      </div>
+      {latest.createdAt ? (
+        <p className="status-playable-time">
+          {t('statusView.playableUpdated', { time: formatRelativeTime(latest.createdAt, i18n.language) })}
+        </p>
+      ) : null}
+    </section>
+  );
 }
 
 function BuildProgressPanel({

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -313,7 +313,10 @@
       "no": "Keep building",
       "sending": "Stopping…",
       "error": "We couldn't stop this build right now. Please try again in a moment."
-    }
+    },
+    "playableTitle": "Play it now",
+    "playableHint": "An early build, straight from the workshop — rough, unfinished, and already playable. Tell them what to change while it is easy.",
+    "playableUpdated": "Updated {{time}}"
   },
   "suggestions": {
     "dodge": "Dodge the falling rocks",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -313,7 +313,10 @@
       "no": "Twórz dalej",
       "sending": "Zatrzymuję…",
       "error": "Nie udało się teraz zatrzymać tej gry. Spróbuj ponownie za chwilę."
-    }
+    },
+    "playableTitle": "Zagraj teraz",
+    "playableHint": "Wczesna wersja prosto z warsztatu — surowa, niedokończona i już grywalna. Powiedz, co zmienić, póki to łatwe.",
+    "playableUpdated": "Zaktualizowano {{time}}"
   },
   "suggestions": {
     "dodge": "Unikaj spadających skał",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4969,3 +4969,39 @@ body.player-open {
     animation: none !important;
   }
 }
+
+/* The playable build panel on the status page.
+   Sized so the game is genuinely playable rather than a thumbnail — this is the first
+   thing a creator can actually judge, and it arrives before any commit. */
+.status-playable {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid var(--border, #333);
+  border-radius: 8px;
+}
+
+.status-playable h3 {
+  margin: 0 0 0.25rem;
+}
+
+.status-playable-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.status-playable-frame {
+  position: relative;
+  width: 100%;
+  /* Matches the aspect the games themselves are laid out for. */
+  aspect-ratio: 4 / 3;
+  max-height: 70vh;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+.status-playable-time {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -82,7 +82,28 @@ export type SubmissionStatus = {
    * before the first commit. Build the URL with {@link buildMediaUrl}.
    */
   media?: BuildMediaItem[];
+  /**
+   * Playable builds pushed over the channel, newest first — the game as it stood at
+   * some moment, before any commit. Build the URL with {@link buildPlayableUrl}.
+   */
+  playable?: BuildPlayableItem[];
 };
+
+export type BuildPlayableItem = {
+  ref: string;
+  slug?: string;
+  /** Untrusted, agent-authored text — render escaped. */
+  label?: string;
+  createdAt?: string;
+};
+
+/**
+ * Where to fetch one playable build. The response is unreviewed agent output served as
+ * HTML, so it is only ever loaded into a sandboxed frame — never fetched and inlined.
+ */
+export function buildPlayableUrl(token: string, item: BuildPlayableItem): string {
+  return `${API_BASE}/api/submissions/${encodeURIComponent(token)}/preview/${encodeURIComponent(item.ref)}`;
+}
 
 export type BuildMediaItem = {
   source: 'branch' | 'channel';


### PR DESCRIPTION
Lets a build push a **playable** game to the creator before it has committed anything.

## Why

Measured from two full Copilot session logs:

| moment | production build | benchmark run |
|---|---|---|
| `npm run create` leaves a **playable** starter on disk | +1.7 min | +1.0 min |
| agent first attempts a build | +11.5 min | +8.3 min |
| progress updates sent | +3.5, +19.4, +22.9 min | +3.9, +11.3, +15.0 min |

For ten minutes something runnable sits on disk and nobody looks at it, while the creator watches a status page. A screenshot says what the game looks like; only playing it answers whether it is any fun, which is the only question the creator can really judge — and the one that makes their feedback worth having while changing the game is still cheap.

## What this adds

**`POST /api/agent/build/preview`** takes one self-contained offline HTML document — the same shape the site already serves for a published game — and the status response carries the newest few back as `playable`. The status page shows the latest one, above the activity feed, in the existing `GameFrame`.

It is designed to be driven by a **watcher** rather than by the agent's judgement (gamedevpl/www.gamedev.pl-games#TBD). The hourly allowance is deliberately generous — a game that recompiles every thirty seconds for half an hour is working as intended — and only the newest four are kept, pruned on write, since each preview obsoletes the last.

**Storage is Firestore alongside shots, not a bucket.** The games repo caps an assembled bundle at a little over 200KB and the largest game in the catalog measures 243KB, so a preview fits a document with room to spare. That is the same reasoning already written down for `BuildShot`: not worth a bucket, its IAM, and a retention job.

## Security

This serves unreviewed agent output as executable HTML to the creator's browser. It has passed a build and a smoke run and nothing else — no gate, no review, no merge. The defences are layered and each one is asserted in a test rather than assumed:

- Loaded **by URL into a sandboxed frame**, never fetched and inlined. `sandbox="allow-scripts"` **without** `allow-same-origin` leaves the document in an opaque origin with no reach into the site, its cookies, or its storage.
- The response repeats that as a `Content-Security-Policy: sandbox allow-scripts` header, so the restriction holds even if the URL is opened directly rather than framed.
- `default-src 'none'` with `connect-src 'none'` and `form-action 'none'`. A bundle is offline by construction — everything embedded, nothing fetched — so an injected exfiltration payload has nowhere to send anything.
- `X-Content-Type-Options: nosniff`, `Content-Disposition: inline`, and `Cache-Control: private` — a preview belongs to one creator's build and is stale within minutes, so it must not sit in a shared cache the way published media can.
- Payloads are checked, not trusted: decoded size against a 320KB ceiling, and the bytes must actually open as an HTML document (the equivalent of the PNG signature check on shots).

## Verification

- `npm run type-check` and `npm run lint` clean.
- **722 API tests and 292 web tests passing**, including new coverage for: the sandbox headers (and the explicit absence of `allow-same-origin`), rejection of a payload that is not HTML, the prune-on-write ceiling under a watcher-like push loop, cross-build token isolation, and the creator's stop switch.

## Ordering

**This must deploy before** the games-repo watcher runs against production, or `preview:watch` posts into a 404 and silently does nothing every cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SED1V7uvoVsNpv1tPBwG92)_