### PR TITLE
Stop a shared-quota outage from reading as games-repo contract drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
   # Cross-repo lockstep with gamedevpl/www.gamedev.pl-games (issue #247). The unit
   # tests above already pin this repo's half + a GameKit-shaped fixture; this job
   # fetches the live assemble/validate sources when GAMES_REPO_TOKEN is configured.
+  #
+  # Drift fails this job. A games repo that cannot be read — GAMES_REPO_TOKEN out of
+  # quota (it is shared with the snapshot bake), expired, or GitHub down — annotates
+  # and passes, because it compared nothing and so is no evidence of drift. Set
+  # GAMES_CONTRACT_REQUIRE_REMOTE=1 below to demand the live comparison instead.
   games_repo_contract:
     name: Games-repo contract
     runs-on: ubuntu-latest

--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -1,113 +1,74 @@
 /**
- * Cross-repo lockstep check (issue #247).
+ * Cross-repo lockstep check (issue #247) — CI entry point.
  *
- * Fetches `tools/lib/assemble.ts` and `tools/validate.ts` from the games repo and
- * asserts they still match `games-repo-contract.ts` on this side:
+ * The check itself lives in `../src/games-repo-contract-check.ts`; this file is the
+ * environment, the logging, and the exit code. It asserts the games repo's
+ * `tools/lib/assemble.ts` and `tools/validate.ts` still match
+ * `games-repo-contract.ts` on this side:
  *   - GAME_KIT_MODULES order
  *   - MAX_BUNDLE_BYTES === MAX_PROJECT_BYTES
  *   - music injection contract (tracks + __GAME_AUDIO_MUSIC__ + readMusicCatalog)
  *
- * Requires GAMES_REPO_TOKEN (contents:read on the games repo). In CI, skip with a
- * warning when the secret is unset so forks / fresh clones still go green; set the
- * secret on gamedevpl/www.gamedev.pl so master and same-repo PRs catch drift.
+ * Requires GAMES_REPO_TOKEN (contents:read on the games repo). Drift fails. A games
+ * repo that cannot be read — no token, exhausted quota, GitHub down — warns and
+ * passes, because it is not evidence of drift; set GAMES_CONTRACT_REQUIRE_REMOTE=1
+ * to demand the live comparison instead.
  *
  * Usage: npm run contract:games-repo -w @gamedevpl/api
  */
 
-import {
-  extractGameKitModules,
-  extractMaxBundleBytes,
-  extractMusicContractSignals,
-  GAME_KIT_MODULES,
-  MAX_PROJECT_BYTES,
-} from '../src/games-repo-contract.js';
+import { runGamesRepoContractCheck } from '../src/games-repo-contract-check.js';
 
 const repo = (process.env.GAMES_REPO ?? 'gamedevpl/www.gamedev.pl-games').trim();
 const ref = (process.env.GAMES_PUBLISHED_REF ?? 'main').trim();
 const token = (process.env.GAMES_REPO_TOKEN ?? '').trim();
+const requireRemote = ['1', 'true', 'yes'].includes(
+  (process.env.GAMES_CONTRACT_REQUIRE_REMOTE ?? '').trim().toLowerCase(),
+);
 
-async function readGamesRepoFile(path: string): Promise<string> {
-  const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'application/vnd.github.raw',
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'gamedevpl-games-repo-contract-check',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`failed to read ${repo}@${ref}:${path} (${response.status} ${response.statusText})`);
+/** GitHub Actions renders `::warning::` on the job summary; elsewhere it is a plain line. */
+function annotate(title: string, message: string): void {
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    console.log(`::warning title=${title}::${message.replace(/\n/g, ' ')}`);
   }
-  return response.text();
-}
-
-function fail(message: string): never {
-  console.error(`games-repo contract: ${message}`);
-  process.exit(1);
+  console.warn(`games-repo contract: ${message}`);
 }
 
 async function main(): Promise<void> {
-  if (!token) {
-    console.warn(
-      'games-repo contract: GAMES_REPO_TOKEN unset — skipping live fetch. ' +
-        'Unit tests still guard the website half; set a contents:read PAT on the ' +
-        'games repo as the GAMES_REPO_TOKEN Actions secret to enable the cross-repo check.',
-    );
-    return;
-  }
-
   console.log(`games-repo contract: checking ${repo}@${ref} against apps/api/src/games-repo-contract.ts`);
 
-  const [assembleSource, validateSource] = await Promise.all([
-    readGamesRepoFile('tools/lib/assemble.ts'),
-    readGamesRepoFile('tools/validate.ts'),
-  ]);
+  const outcome = await runGamesRepoContractCheck({
+    repo,
+    ref,
+    token,
+    log: (message) => console.log(message),
+  });
 
-  const remoteModules = extractGameKitModules(assembleSource);
-  const localModules = [...GAME_KIT_MODULES];
-  if (remoteModules.join(',') !== localModules.join(',')) {
-    fail(
-      `GAME_KIT_MODULES mismatch.\n  games-repo: ${remoteModules.join(', ')}\n  website:    ${localModules.join(', ')}`,
-    );
+  switch (outcome.kind) {
+    case 'ok':
+      console.log('games-repo contract: ok');
+      return;
+
+    case 'drift':
+      console.error(`games-repo contract: ${outcome.reason}`);
+      process.exit(1);
+      return;
+
+    case 'skipped':
+    case 'unreachable': {
+      const title =
+        outcome.kind === 'skipped' ? 'games-repo contract check skipped' : 'games-repo contract check could not run';
+      annotate(title, `${outcome.reason}\n  The two halves were NOT compared on this run.`);
+      if (requireRemote) {
+        console.error('games-repo contract: GAMES_CONTRACT_REQUIRE_REMOTE is set — treating this as a failure.');
+        process.exit(1);
+      }
+      return;
+    }
   }
-  console.log(`  ✓ GAME_KIT_MODULES (${remoteModules.length} modules)`);
-
-  const remoteBudget = extractMaxBundleBytes(validateSource);
-  if (remoteBudget !== MAX_PROJECT_BYTES) {
-    const assignLine =
-      validateSource
-        .split('\n')
-        .find((line) => /MAX_BUNDLE_BYTES\s*=/.test(line))
-        ?.trim() ?? '(assignment line not found)';
-    fail(
-      `MAX_BUNDLE_BYTES mismatch: games-repo=${remoteBudget} website MAX_PROJECT_BYTES=${MAX_PROJECT_BYTES}\n` +
-        `  games-repo assignment: ${assignLine}\n` +
-        `  Update GAMEKIT_PLATFORM_BYTES / MAX_PROJECT_BYTES in apps/api/src/games-repo-contract.ts to match.`,
-    );
-  }
-  console.log(`  ✓ MAX_BUNDLE_BYTES / MAX_PROJECT_BYTES (${remoteBudget})`);
-
-  const music = extractMusicContractSignals(assembleSource);
-  if (!music.injectsMusicName || !music.readsTracksKey || !music.readsMusicCatalog) {
-    const musicLines = assembleSource
-      .split('\n')
-      .map((line, index) => ({ line: line.trim(), n: index + 1 }))
-      .filter(({ line }) => /music|__GAME_AUDIO|__GAME_MUSIC|tracks/i.test(line))
-      .slice(0, 40)
-      .map(({ line, n }) => `  L${n}: ${line}`)
-      .join('\n');
-    fail(
-      `music contract mismatch in games-repo assemble.ts: ` +
-        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} readsMusicCatalog=${music.readsMusicCatalog}\n` +
-        `relevant lines:\n${musicLines || '  (none)'}`,
-    );
-  }
-  console.log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + readMusicCatalog)');
-
-  console.log('games-repo contract: ok');
 }
 
 main().catch((error: unknown) => {
-  fail(error instanceof Error ? error.message : String(error));
+  console.error(`games-repo contract: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`);
+  process.exit(1);
 });

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runGamesRepoContractCheck } from './games-repo-contract-check.js';
+import { GAME_KIT_MODULES, MAX_PROJECT_BYTES } from './games-repo-contract.js';
+
+const ASSEMBLE_SOURCE = `
+  const GAME_KIT_MODULES = [${GAME_KIT_MODULES.map((name) => `'${name}'`).join(', ')}];
+  const catalog = readMusicCatalog();
+  const track = catalog.tracks[name];
+  out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
+`;
+
+const VALIDATE_SOURCE = `const MAX_BUNDLE_BYTES = ${MAX_PROJECT_BYTES};`;
+
+function ok(body: string, headers: Record<string, string> = {}): Response {
+  return new Response(body, { status: 200, headers });
+}
+
+function failure(status: number, headers: Record<string, string> = {}, message = 'nope'): Response {
+  return new Response(JSON.stringify({ message }), { status, headers });
+}
+
+/** Serves each requested path from `pages`, in the order given per path. */
+function createFetch(pages: Record<string, Response[]>): { fetchImpl: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: string | URL | Request) => {
+    const href = String(url);
+    calls.push(href);
+    const key = Object.keys(pages).find((path) => href.includes(path));
+    const queue = key ? pages[key] : undefined;
+    if (!queue || queue.length === 0) {
+      throw new Error(`unexpected fetch: ${href}`);
+    }
+    return queue.length === 1 ? queue[0].clone() : (queue.shift() as Response);
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const BASE = { repo: 'gamedevpl/www.gamedev.pl-games', ref: 'main', token: 't', sleep: async () => {} };
+
+describe('runGamesRepoContractCheck', () => {
+  it('passes when both halves agree', async () => {
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
+    });
+
+    await expect(runGamesRepoContractCheck({ ...BASE, fetchImpl })).resolves.toEqual({ kind: 'ok' });
+  });
+
+  it('reports drift when the games-repo budget moved', async () => {
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [ok(`const MAX_BUNDLE_BYTES = ${MAX_PROJECT_BYTES + 679};`)],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('drift');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('MAX_BUNDLE_BYTES mismatch');
+  });
+
+  it('reports drift when the module order diverges', async () => {
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE.replace("'input'", "'sensing', 'input'"))],
+      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('drift');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('GAME_KIT_MODULES mismatch');
+  });
+
+  it('skips without a token so forks and fresh clones stay green', async () => {
+    const outcome = await runGamesRepoContractCheck({
+      ...BASE,
+      token: '',
+      fetchImpl: (() => {
+        throw new Error('must not fetch');
+      }) as unknown as typeof fetch,
+    });
+    expect(outcome.kind).toBe('skipped');
+  });
+
+  it('retries a rate-limited read and succeeds on the retry', async () => {
+    const { fetchImpl, calls } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [
+        failure(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000' }, 'API rate limit exceeded'),
+        ok(VALIDATE_SOURCE),
+      ],
+    });
+
+    await expect(runGamesRepoContractCheck({ ...BASE, fetchImpl })).resolves.toEqual({ kind: 'ok' });
+    expect(calls.filter((url) => url.includes('tools/validate.ts'))).toHaveLength(2);
+  });
+
+  it('waits the Retry-After a secondary limit asks for', async () => {
+    const sleep = vi.fn(async () => {});
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [failure(403, { 'retry-after': '7' }, 'secondary rate limit'), ok(VALIDATE_SOURCE)],
+    });
+
+    await runGamesRepoContractCheck({ ...BASE, fetchImpl, sleep });
+    expect(sleep).toHaveBeenCalledWith(7000);
+  });
+
+  it('does not fail the build when the quota is exhausted — that is not drift', async () => {
+    const reset = Math.floor(Date.UTC(2026, 6, 28, 1, 0, 0) / 1000);
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [
+        failure(
+          403,
+          { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(reset) },
+          'API rate limit exceeded for installation',
+        ),
+      ],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('unreachable');
+    // The operator has to be able to tell "out of quota" from "token cannot read this".
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain('API rate limit exceeded');
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain('rate limit 0/5000 remaining');
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain('2026-07-28T01:00:00.000Z');
+  });
+
+  it('does not retry a bare 403 — that is a permission problem, not a limit', async () => {
+    const { fetchImpl, calls } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [failure(403, {}, 'Resource not accessible by personal access token')],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('unreachable');
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain('Resource not accessible');
+    expect(calls.filter((url) => url.includes('tools/validate.ts'))).toHaveLength(1);
+  });
+
+  it('gives up after bounded retries on a 5xx', async () => {
+    const { fetchImpl, calls } = createFetch({
+      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      'tools/validate.ts': [
+        failure(502, {}, 'Bad gateway'),
+        failure(502, {}, 'Bad gateway'),
+        failure(502, {}, 'Bad gateway'),
+      ],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('unreachable');
+    expect(calls.filter((url) => url.includes('tools/validate.ts'))).toHaveLength(3);
+  });
+
+  it('treats a network fault as unreachable rather than drift', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('getaddrinfo ENOTFOUND api.github.com');
+    }) as unknown as typeof fetch;
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('unreachable');
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain('ENOTFOUND');
+  });
+});

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -1,0 +1,250 @@
+/**
+ * The cross-repo lockstep check itself (issue #247), separated from the CI script
+ * so its failure modes are unit-testable.
+ *
+ * Reads `tools/lib/assemble.ts` and `tools/validate.ts` from the games repo and
+ * asserts they still match `games-repo-contract.ts` on this side. Two outcomes are
+ * emphatically not the same thing, and the difference is why this lives here:
+ *
+ *   - **drift** — the two halves disagree. That is the bug this check exists to
+ *     catch, and it fails CI.
+ *   - **unreachable** — the games repo could not be read at all (the shared PAT is
+ *     out of quota, expired, or GitHub is down). That is no evidence about drift in
+ *     either direction, so it must not read as one. `GAMES_REPO_TOKEN` is a single
+ *     token shared with the snapshot bake, which spends thousands of contents reads
+ *     per run; when it hits the hourly limit, every PR in this repo and master would
+ *     otherwise go red on a check that never actually compared anything.
+ *
+ * The remaining defence against an unreachable remote silently disabling the check
+ * is that it says so loudly — as a CI annotation, with GitHub's own rate-limit
+ * headers — and that `GAMES_CONTRACT_REQUIRE_REMOTE=1` turns it back into a failure
+ * for anyone who wants the strict posture.
+ */
+
+import {
+  extractGameKitModules,
+  extractMaxBundleBytes,
+  extractMusicContractSignals,
+  GAME_KIT_MODULES,
+  MAX_PROJECT_BYTES,
+} from './games-repo-contract.js';
+import { isRateLimitResponse } from './github-rate-limit.js';
+
+export type ContractCheckOutcome =
+  /** No token configured — forks and fresh clones still go green. */
+  | { kind: 'skipped'; reason: string }
+  /** The games repo could not be read. Says nothing about drift. */
+  | { kind: 'unreachable'; reason: string }
+  /** Both halves agree. */
+  | { kind: 'ok' }
+  /** The halves disagree — the failure this check is for. */
+  | { kind: 'drift'; reason: string };
+
+export interface ContractCheckOptions {
+  repo: string;
+  ref: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+  /** Progress lines (stdout in CI). */
+  log?: (message: string) => void;
+  /** Test seam — replaced so retry backoff does not slow the suite. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Attempts per file, including the first. Bounded so a dead remote fails fast. */
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 1_000;
+/** Never wait longer than this for one retry — a CI job may not sit on a quota reset. */
+const MAX_RETRY_DELAY_MS = 10_000;
+/** Enough of GitHub's error body to name the cause without pasting a page of JSON. */
+const MAX_BODY_CHARS = 300;
+
+class UnreachableGamesRepoError extends Error {}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** 5xx and network faults are worth another go; 4xx other than a rate limit is not. */
+function isTransientResponse(response: Response): boolean {
+  return isRateLimitResponse(response) || response.status >= 500;
+}
+
+/**
+ * GitHub's own account of the request: status, its `message` field, and the quota
+ * headers. Without these a 403 is indistinguishable between "out of quota" and
+ * "this token may not read that repo", which are opposite operator actions.
+ */
+async function describeFailure(response: Response): Promise<string> {
+  const parts = [`${response.status} ${response.statusText}`];
+
+  const body = await response.text().catch(() => '');
+  if (body) {
+    let message = body;
+    try {
+      const parsed = JSON.parse(body) as { message?: unknown };
+      if (typeof parsed.message === 'string') {
+        message = parsed.message;
+      }
+    } catch {
+      // Not JSON — fall back to the raw body.
+    }
+    parts.push(message.slice(0, MAX_BODY_CHARS).trim());
+  }
+
+  const quota = describeQuota(response);
+  if (quota) {
+    parts.push(quota);
+  }
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) {
+    parts.push(`retry-after=${retryAfter}s`);
+  }
+  return parts.filter(Boolean).join(' — ');
+}
+
+/** `used/limit` plus the reset time, when GitHub sent the headers. */
+export function describeQuota(response: Response): string | null {
+  const remaining = response.headers.get('x-ratelimit-remaining');
+  const limit = response.headers.get('x-ratelimit-limit');
+  if (remaining === null && limit === null) {
+    return null;
+  }
+  const reset = Number(response.headers.get('x-ratelimit-reset'));
+  const resetAt = Number.isFinite(reset) && reset > 0 ? new Date(reset * 1000).toISOString() : null;
+  return `rate limit ${remaining ?? '?'}/${limit ?? '?'} remaining${resetAt ? `, resets ${resetAt}` : ''}`;
+}
+
+export async function runGamesRepoContractCheck(options: ContractCheckOptions): Promise<ContractCheckOutcome> {
+  const { repo, ref, token } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const log = options.log ?? (() => {});
+  const sleep = options.sleep ?? defaultSleep;
+
+  if (!token) {
+    return {
+      kind: 'skipped',
+      reason:
+        'GAMES_REPO_TOKEN unset — skipping live fetch. Unit tests still guard the website half; ' +
+        'set a contents:read PAT on the games repo as the GAMES_REPO_TOKEN Actions secret to ' +
+        'enable the cross-repo check.',
+    };
+  }
+
+  async function readGamesRepoFile(path: string): Promise<string> {
+    const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+    let lastFailure = 'no attempt was made';
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+      let response: Response;
+      try {
+        response = await fetchImpl(url, {
+          headers: {
+            Accept: 'application/vnd.github.raw',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'gamedevpl-games-repo-contract-check',
+          },
+        });
+      } catch (error: unknown) {
+        // A network fault is transient by definition — retry it like a 5xx.
+        lastFailure = error instanceof Error ? error.message : String(error);
+        if (attempt + 1 < MAX_ATTEMPTS) {
+          await sleep(RETRY_BASE_DELAY_MS * 2 ** attempt);
+          continue;
+        }
+        break;
+      }
+
+      if (response.ok) {
+        const quota = describeQuota(response);
+        if (quota) {
+          log(`  · ${path}: ${quota}`);
+        }
+        return response.text();
+      }
+
+      lastFailure = await describeFailure(response);
+      if (!isTransientResponse(response) || attempt + 1 >= MAX_ATTEMPTS) {
+        break;
+      }
+
+      const retryAfterSeconds = Number(response.headers.get('retry-after'));
+      const delayMs =
+        Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+          ? retryAfterSeconds * 1000
+          : RETRY_BASE_DELAY_MS * 2 ** attempt;
+      if (delayMs > MAX_RETRY_DELAY_MS) {
+        break;
+      }
+      log(`  · ${path}: ${lastFailure} — retrying in ${Math.round(delayMs / 1000)}s`);
+      await sleep(delayMs);
+    }
+
+    throw new UnreachableGamesRepoError(`cannot read ${repo}@${ref}:${path} (${lastFailure})`);
+  }
+
+  let assembleSource: string;
+  let validateSource: string;
+  try {
+    [assembleSource, validateSource] = await Promise.all([
+      readGamesRepoFile('tools/lib/assemble.ts'),
+      readGamesRepoFile('tools/validate.ts'),
+    ]);
+  } catch (error: unknown) {
+    if (error instanceof UnreachableGamesRepoError) {
+      return { kind: 'unreachable', reason: error.message };
+    }
+    throw error;
+  }
+
+  const remoteModules = extractGameKitModules(assembleSource);
+  const localModules = [...GAME_KIT_MODULES];
+  if (remoteModules.join(',') !== localModules.join(',')) {
+    return {
+      kind: 'drift',
+      reason:
+        `GAME_KIT_MODULES mismatch.\n  games-repo: ${remoteModules.join(', ')}\n` +
+        `  website:    ${localModules.join(', ')}`,
+    };
+  }
+  log(`  ✓ GAME_KIT_MODULES (${remoteModules.length} modules)`);
+
+  const remoteBudget = extractMaxBundleBytes(validateSource);
+  if (remoteBudget !== MAX_PROJECT_BYTES) {
+    const assignLine =
+      validateSource
+        .split('\n')
+        .find((line) => /MAX_BUNDLE_BYTES\s*=/.test(line))
+        ?.trim() ?? '(assignment line not found)';
+    return {
+      kind: 'drift',
+      reason:
+        `MAX_BUNDLE_BYTES mismatch: games-repo=${remoteBudget} website MAX_PROJECT_BYTES=${MAX_PROJECT_BYTES}\n` +
+        `  games-repo assignment: ${assignLine}\n` +
+        `  Update GAMEKIT_PLATFORM_BYTES / MAX_PROJECT_BYTES in apps/api/src/games-repo-contract.ts to match.`,
+    };
+  }
+  log(`  ✓ MAX_BUNDLE_BYTES / MAX_PROJECT_BYTES (${remoteBudget})`);
+
+  const music = extractMusicContractSignals(assembleSource);
+  if (!music.injectsMusicName || !music.readsTracksKey || !music.readsMusicCatalog) {
+    const musicLines = assembleSource
+      .split('\n')
+      .map((line, index) => ({ line: line.trim(), n: index + 1 }))
+      .filter(({ line }) => /music|__GAME_AUDIO|__GAME_MUSIC|tracks/i.test(line))
+      .slice(0, 40)
+      .map(({ line, n }) => `  L${n}: ${line}`)
+      .join('\n');
+    return {
+      kind: 'drift',
+      reason:
+        `music contract mismatch in games-repo assemble.ts: ` +
+        `injectsMusicName=${music.injectsMusicName} readsTracksKey=${music.readsTracksKey} ` +
+        `readsMusicCatalog=${music.readsMusicCatalog}\nrelevant lines:\n${musicLines || '  (none)'}`,
+    };
+  }
+  log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + readMusicCatalog)');
+
+  return { kind: 'ok' };
+}

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
 import { GAME_KIT_MODULES } from './games-repo-contract.js';
+import { isRateLimitResponse } from './github-rate-limit.js';
 
 interface CreateIssueInput {
   title: string;
@@ -408,18 +409,6 @@ function createRequestGate(limit: number) {
       waiters.shift()?.();
     },
   };
-}
-
-/**
- * True for responses that indicate GitHub's rate limiting rather than a real,
- * permanent failure — a primary-limit 403 carries `x-ratelimit-remaining: 0`, a
- * secondary-limit 403 carries `Retry-After`, and 429 is always a limit. A bare 403
- * with neither header is a genuine permission problem and must not be retried.
- */
-function isRateLimitResponse(response: Response): boolean {
-  if (response.status === 429) return true;
-  if (response.status !== 403) return false;
-  return response.headers.get('retry-after') !== null || response.headers.get('x-ratelimit-remaining') === '0';
 }
 
 export function createGitHubClient(options: GitHubClientOptions): GitHubClient {

--- a/apps/api/src/github-rate-limit.ts
+++ b/apps/api/src/github-rate-limit.ts
@@ -1,0 +1,19 @@
+/**
+ * How a GitHub response announces that it was throttled.
+ *
+ * Its own module so the CI contract check can share it with the serving client
+ * without pulling that client's bundler graph into a script that only reads two
+ * files.
+ */
+
+/**
+ * True for responses that indicate GitHub's rate limiting rather than a real,
+ * permanent failure — a primary-limit 403 carries `x-ratelimit-remaining: 0`, a
+ * secondary-limit 403 carries `Retry-After`, and 429 is always a limit. A bare 403
+ * with neither header is a genuine permission problem and must not be retried.
+ */
+export function isRateLimitResponse(response: Response): boolean {
+  if (response.status === 429) return true;
+  if (response.status !== 403) return false;
+  return response.headers.get('retry-after') !== null || response.headers.get('x-ratelimit-remaining') === '0';
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,6 +93,18 @@ a single `--set-secrets` list.
 without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta allowlist
 instead. Delete the secret when you are sure nothing references it.
 
+**`GAMES_REPO_TOKEN` is one hourly REST budget shared by two very different consumers.**
+The CI lockstep check spends 2 requests per run; the snapshot bake spends roughly a
+thousand — one per source and media file across every published game — and runs on every
+`games-published` dispatch. When bakes come in bursts, the PAT's ~5,000 requests/hour is
+reachable, and everything else holding that token starts seeing `403`. The contract check
+therefore treats an unreadable games repo as _no evidence about drift_: it annotates the
+job with GitHub's own quota headers and passes, rather than reddening every PR in this
+repo over a shared budget. Real drift still fails. Set
+`GAMES_CONTRACT_REQUIRE_REMOTE=1` on the job to demand the live comparison and fail when
+it cannot be made. A bake that 403s **does** stay red — that one is a real outage, since
+it means the snapshot did not refresh.
+
 **Opening the site to everyone** is a config change, not a code change: set `PRIVATE_BETA=false`
 on the service (and clear the allowlists if you want). Nothing needs redeploying from source.
 


### PR DESCRIPTION
`Games-repo contract` went red on every PR **and on master** — not on drift, but on this:

```
games-repo contract: failed to read gamedevpl/www.gamedev.pl-games@main:tools/validate.ts (403 Forbidden)
```

At the same time the snapshot bake was 403-ing on **all 84 games** ([publish-games run 30316849102](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30316849102)). One credential sits behind both: `GAMES_REPO_TOKEN`. The contract check spends 2 requests per run; the bake spends roughly a thousand — one per source and media file across every published game — and it now fires on every games-repo push (six bakes between 22:52 and 00:17). That is what a PAT's ~5,000 requests/hour looks like when it runs out.

Nothing had drifted. The two halves were never compared.

## The check could not say which failure it had hit

It reported `403 Forbidden` and nothing else — no response body, no `x-ratelimit-*`. That leaves "out of quota" indistinguishable from "this token may not read that repo", which are opposite operator actions: wait or re-scope the PAT. So failures now print GitHub's own account of the request — the API's `message`, `x-ratelimit-limit/remaining/reset`, any `Retry-After` — and a successful read logs the remaining quota, which makes this job a budget canary rather than a mystery.

## Drift fails. Unreachable does not.

These were one outcome and are now two:

- **drift** — the halves disagree. That is the bug this check exists to catch, and it still fails CI.
- **unreachable** — the games repo could not be read at all (quota, expired credential, 5xx, network). It compared nothing, so it is no evidence about drift in either direction. It now annotates the job (`::warning::`, *"the two halves were NOT compared on this run"*) and passes — the same posture the check already took for an unset token, which exists so forks stay green.

The defence against that silently disabling the check is that it says so loudly, with the quota headers attached, and that `GAMES_CONTRACT_REQUIRE_REMOTE=1` restores the strict posture for anyone who wants it.

Rate-limited and 5xx reads retry with bounded backoff first (honouring `Retry-After`, capped at 10s so a CI job never sits on a quota reset). A **bare** 403 — no `retry-after`, no `x-ratelimit-remaining: 0` — is a permission problem, and is not retried.

## Shape

The check moved into `apps/api/src/games-repo-contract-check.ts` so its failure modes are unit-testable, leaving `scripts/check-games-repo-contract.ts` as environment and exit code. `isRateLimitResponse` moved to its own `github-rate-limit.ts` so the CI script shares the serving client's definition of "throttled" instead of copying it — and without pulling esbuild in behind it for a script that reads two files.

## What this does not touch

**A bake that 403s stays red, and should.** That one is a real outage — the snapshot did not refresh — and it is the signal that the token's budget needs attention. The bake's per-file fan-out is the root cause of the exhaustion; reading a tarball or the git-trees API once per run instead is the fix for it, and is bigger than this change.

Unrelated but worth flagging while looking at this check: #278 pins `MAX_PROJECT_BYTES` at 243,757, and games-repo `main` has since moved to 248,638.

## Verification

Full gate green: lint, type-check, 755 API tests / 302 web tests, build. Ten new tests cover drift (budget and module order), quota exhaustion, a bare 403 (asserting it is *not* retried), bounded 5xx retries, a network fault, and that `Retry-After` is honoured. Ran the script for real both ways — token unset skips; a bogus token reports `401 Unauthorized — Bad credentials` and exits 0 with the annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB4mJKo6bamZG33SMijayy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB4mJKo6bamZG33SMijayy)_