### PR TITLE
Gate the paid moderation calls, and stop the token exchange laundering authority

### DIFF
--- a/apps/api/src/access-token-routes.test.ts
+++ b/apps/api/src/access-token-routes.test.ts
@@ -325,6 +325,82 @@ describe('authenticating with a personal access token', () => {
     expect(followUp.statusCode).toBe(200);
   });
 
+  /**
+   * The escalation these two guard against: a PAT issued for an *admin* account — and
+   * PATs exist precisely to sit in CI configs and agent VMs, where a human is not
+   * watching — traded here for a cookie that satisfies `isAdminSession`, then used to
+   * mint further tokens. Revoking the leaked original would accomplish nothing.
+   */
+  it('hands back a session carrying the token authority, not operator authority', async () => {
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const { token } = (await mintFor(app, 'g:boss', 'admin ci token')).json();
+
+    const exchanged = await app.inject({ method: 'POST', url: '/api/auth/session', headers: bearer(token) });
+    expect(exchanged.statusCode).toBe(200);
+    const setCookie = exchanged.headers['set-cookie'];
+    const cookie = String(Array.isArray(setCookie) ? setCookie[0] : setCookie).split(';')[0] as string;
+
+    // It is a genuinely working session for the account it names …
+    const me = await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie } });
+    expect(me.statusCode).toBe(200);
+    expect(me.json().user.uid).toBe('g:boss');
+
+    // … and still refused everywhere a session-only check applies. 404, the same answer
+    // a non-admin gets, because whether an operator surface exists is not worth confirming.
+    const mintAgain = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: { cookie },
+      payload: { uid: 'bot:escalated', name: 'minted by a token' },
+    });
+    expect(mintAgain.statusCode).toBe(404);
+
+    const operatorView = await app.inject({
+      method: 'GET',
+      url: '/api/admin/telemetry/health',
+      headers: { cookie },
+    });
+    expect(operatorView.statusCode).toBe(404);
+  });
+
+  it('keeps that restriction across a session renewal', async () => {
+    // Renewal re-mints the cookie mid-flight. If provenance were dropped there, a
+    // token-derived session would silently become an ordinary one after six hours and
+    // regain the authority it was just denied.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+
+    // A token-derived session already past its half-life, so the onSend hook renews it.
+    const aging = mintSessionToken('g:boss', sessionSecret, 60, undefined, 'token');
+    const renewed = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${aging}` },
+    });
+    expect(renewed.statusCode).toBe(200);
+    const rolled = renewed.headers['set-cookie'];
+    expect(rolled).toBeDefined();
+    const renewedCookie = String(Array.isArray(rolled) ? rolled[0] : rolled).split(';')[0] as string;
+
+    // The re-minted payload still says where it came from.
+    const encodedPayload = renewedCookie.split('=')[1]?.split('.')[0] as string;
+    expect(JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')).src).toBe('token');
+
+    const mintAgain = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: { cookie: renewedCookie },
+      payload: { uid: 'bot:escalated', name: 'minted after renewal' },
+    });
+    expect(mintAgain.statusCode).toBe(404);
+  });
+
+  it('still lets a real browser session reach the operator surfaces', async () => {
+    // The counterweight: the fix must not lock the operator out of their own tools.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const res = await mintFor(app, 'bot:e2e');
+    expect(res.statusCode).toBe(201);
+  });
+
   it.each([
     ['a browser session', () => sessionHeaders('g:boss')],
     ['no credential', () => ({})],

--- a/apps/api/src/access-token-routes.test.ts
+++ b/apps/api/src/access-token-routes.test.ts
@@ -401,6 +401,27 @@ describe('authenticating with a personal access token', () => {
     expect(res.statusCode).toBe(201);
   });
 
+  it('refuses to mint a fresh session from a cookie it minted earlier', async () => {
+    // A derived cookie authenticates as a token, so checking the auth *method* alone
+    // would let it mint an endless succession of replacements and outlive revocation of
+    // the PAT behind it. The exchange must see the credential itself every time.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const { token } = (await mintFor(app, 'bot:e2e')).json();
+
+    const exchanged = await app.inject({ method: 'POST', url: '/api/auth/session', headers: bearer(token) });
+    const setCookie = exchanged.headers['set-cookie'];
+    const cookie = String(Array.isArray(setCookie) ? setCookie[0] : setCookie).split(';')[0] as string;
+
+    // The cookie really is a working credential — so the refusal below is the rule
+    // biting, not the header being dropped.
+    const me = await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie } });
+    expect(me.statusCode).toBe(200);
+    expect(me.json().user.uid).toBe('bot:e2e');
+
+    const again = await app.inject({ method: 'POST', url: '/api/auth/session', headers: { cookie } });
+    expect(again.statusCode).toBe(401);
+  });
+
   it.each([
     ['a browser session', () => sessionHeaders('g:boss')],
     ['no credential', () => ({})],

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -5,6 +5,7 @@ import packageJson from '../../../package.json';
 import { buildApp } from './app.js';
 import { MAX_PROJECT_BYTES } from './assemble.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { ContentChecker } from './moderation.js';
 import { InMemoryStore } from './store.js';
 
 function stubGenerator(project: Partial<GameProject>): GameGenerator {
@@ -22,6 +23,34 @@ function stubGenerator(project: Partial<GameProject>): GameGenerator {
 }
 
 const sessionSecret = 'dev-session-secret-change-me';
+
+/**
+ * A content checker that counts what a real one would *bill* us for.
+ *
+ * `VertexChecker.checkFields` makes one paid Gemini call per field, so this counts
+ * fields rather than invocations — the number these tests assert on is the number of
+ * Vertex calls the request would have cost in production.
+ */
+function countingChecker(verdict: { allowed: boolean; category?: string } = { allowed: true }) {
+  const state = {
+    calls: 0,
+    checker: {
+      async check() {
+        state.calls += 1;
+        return verdict as Awaited<ReturnType<ContentChecker['check']>>;
+      },
+      async checkFields(fields: string[]) {
+        state.calls += fields.length;
+        return verdict as Awaited<ReturnType<ContentChecker['checkFields']>>;
+      },
+    } satisfies ContentChecker,
+  };
+  return state;
+}
+
+function cookieFor(uid: string) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
 
 async function createAuthenticatedApp(generator?: GameGenerator) {
   const store = new InMemoryStore();
@@ -112,6 +141,81 @@ describe('api', () => {
     // Quota must not have been spent on a rejected prompt.
     const quota = await store.checkAndIncrementQuota('g:mod-test', new Date().toISOString().slice(0, 10), 20, 'mocks');
     expect(quota.current).toBe(1); // first real increment — the moderated attempt didn't count
+    await app.close();
+  });
+
+  /**
+   * Moderation is a paid Vertex call, so what matters on these paths is not only the
+   * status code but whether we were billed to produce it. Each of these used to spend
+   * money on every request: the quota capped games created, not dollars, and nothing
+   * capped the request rate at all.
+   */
+  it('spends nothing on moderation once the daily quota is exhausted', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:quota-test' });
+    const moderation = countingChecker();
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      contentChecker: moderation.checker,
+      dailyGenerationQuota: 1,
+    });
+
+    const payload = { prompt: 'a cheerful platformer' };
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/generate-game',
+      headers: cookieFor('g:quota-test'),
+      payload,
+    });
+    expect(first.statusCode).toBe(200);
+    expect(moderation.calls).toBe(1);
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/generate-game',
+      headers: cookieFor('g:quota-test'),
+      payload,
+    });
+    expect(second.statusCode).toBe(429);
+    // The refusal must be free — an out-of-budget account that still bills us on every
+    // attempt makes the daily limit a cap on games, not on cost.
+    expect(moderation.calls).toBe(1);
+
+    await app.close();
+  });
+
+  it('caps generate-game per IP so one account cannot bill us without limit', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:flood' });
+    const moderation = countingChecker();
+    // Quota deliberately far above the per-IP ceiling, so the limiter is what stops it.
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      contentChecker: moderation.checker,
+      dailyGenerationQuota: 10_000,
+    });
+
+    const send = () =>
+      app.inject({
+        method: 'POST',
+        url: '/api/generate-game',
+        headers: cookieFor('g:flood'),
+        payload: { prompt: 'another game' },
+      });
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 31; attempt += 1) {
+      statuses.push((await send()).statusCode);
+    }
+
+    expect(statuses.filter((status) => status === 200)).toHaveLength(30);
+    expect(statuses.at(-1)).toBe(429);
+    // The 31st was refused by the rate-limit hook, which runs before the handler body —
+    // so it never reached the paid call.
+    expect(moderation.calls).toBe(30);
+
     await app.close();
   });
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import { registerTelemetryRoutes, type TelemetryRoutesOptions } from './telemetr
 import { registerVisitTelemetryRoutes } from './visit-telemetry.js';
 import { registerVoteRoutes, type VoteRoutesOptions } from './votes.js';
 import { createPublishedSlugGateFromEnv } from './published-slugs.js';
+import { peekQuota } from './quota-gate.js';
 import { registerRateLimit } from './rate-limit.js';
 import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 
@@ -300,52 +301,75 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     }
   });
 
-  app.post('/api/generate-game', async (request, reply) => {
-    if (!request.user) {
-      return reply.status(401).send({ error: 'authentication required' });
-    }
-
-    // 1. Validate request payload first so malformed requests don't burn daily quota
-    const parsedRequest = GenerateRequestSchema.safeParse(request.body);
-    if (!parsedRequest.success) {
-      return reply.status(400).send({ error: parsedRequest.error.issues[0]?.message ?? 'invalid request' });
-    }
-
-    // 2. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
-    const moderation = await contentChecker.check(parsedRequest.data.prompt);
-    if (!moderation.allowed) {
-      return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
-    }
-
-    // 3. Daily user generation quota check
-    const dateStr = new Date().toISOString().slice(0, 10);
-    const quota = await store.checkAndIncrementQuota(request.user.uid, dateStr, dailyGenerationQuota, 'mocks');
-    if (!quota.allowed) {
-      if (quota.tier === 'blocked') {
-        return reply.status(403).send({ error: 'account is blocked' });
+  // Moderation on this route is a paid Vertex call, so the per-IP ceiling is what
+  // stops one account turning it into an unbounded bill. It is declared here rather
+  // than checked in the handler on purpose: the rate-limit hook runs *before* the
+  // handler body, so a refused request costs nothing at all. Same window as the
+  // sibling refine route, which is the pattern this follows throughout.
+  app.post(
+    '/api/generate-game',
+    { config: { rateLimit: { max: 30, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.status(401).send({ error: 'authentication required' });
       }
-      return reply.status(429).send({ error: 'daily generation quota exceeded' });
-    }
 
-    const project = await generator.generate(parsedRequest.data.prompt);
-
-    // Generated code isn't schema-validatable — the client runs it in a sandboxed
-    // iframe. We only assemble it into one document and enforce basic hygiene here.
-    try {
-      const html = assembleGameHtml(project);
-      return { title: project.title, description: project.description, html };
-    } catch (error) {
-      if (
-        error instanceof EmptyProjectError ||
-        error instanceof ProjectTooLargeError ||
-        error instanceof CredentialLeakError
-      ) {
-        request.log.error({ err: error }, 'generated project failed hygiene checks');
-        return reply.status(502).send({ error: 'game generation failed' });
+      // 1. Validate request payload first so malformed requests don't burn daily quota
+      const parsedRequest = GenerateRequestSchema.safeParse(request.body);
+      if (!parsedRequest.success) {
+        return reply.status(400).send({ error: parsedRequest.error.issues[0]?.message ?? 'invalid request' });
       }
-      throw error;
-    }
-  });
+
+      const dateStr = new Date().toISOString().slice(0, 10);
+
+      // 2. Quota headroom, read-only. Moderation below costs money, so an account that
+      // is already out of budget must be turned away before we spend any — otherwise
+      // the daily limit caps games created but not dollars spent. The authoritative
+      // increment still happens after moderation (step 4), so rejected content remains
+      // free to the creator.
+      const headroom = await peekQuota(store, request.user.uid, dateStr, dailyGenerationQuota, 'mocks');
+      if (!headroom.allowed) {
+        if (headroom.tier === 'blocked') {
+          return reply.status(403).send({ error: 'account is blocked' });
+        }
+        return reply.status(429).send({ error: 'daily generation quota exceeded' });
+      }
+
+      // 3. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
+      const moderation = await contentChecker.check(parsedRequest.data.prompt);
+      if (!moderation.allowed) {
+        return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
+      }
+
+      // 4. Daily user generation quota check
+      const quota = await store.checkAndIncrementQuota(request.user.uid, dateStr, dailyGenerationQuota, 'mocks');
+      if (!quota.allowed) {
+        if (quota.tier === 'blocked') {
+          return reply.status(403).send({ error: 'account is blocked' });
+        }
+        return reply.status(429).send({ error: 'daily generation quota exceeded' });
+      }
+
+      const project = await generator.generate(parsedRequest.data.prompt);
+
+      // Generated code isn't schema-validatable — the client runs it in a sandboxed
+      // iframe. We only assemble it into one document and enforce basic hygiene here.
+      try {
+        const html = assembleGameHtml(project);
+        return { title: project.title, description: project.description, html };
+      } catch (error) {
+        if (
+          error instanceof EmptyProjectError ||
+          error instanceof ProjectTooLargeError ||
+          error instanceof CredentialLeakError
+        ) {
+          request.log.error({ err: error }, 'generated project failed hygiene checks');
+          return reply.status(502).send({ error: 'game generation failed' });
+        }
+        throw error;
+      }
+    },
+  );
 
   // In production (single Cloud Run service) the API also serves the built web app from the
   // same origin, so the browser makes only same-origin requests and no CORS is involved.

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -28,8 +28,12 @@ export interface SessionPayload {
    * checking the admin list at exchange time) is what makes the property hold no
    * matter when an account joins that list.
    *
-   * Absent on every cookie minted before this field existed, which is correct: those
-   * could only come from a Google sign-in.
+   * Absent on every cookie minted before this field existed, and those all read as
+   * ordinary sessions. Right for the Google ones; briefly wrong for any the exchange
+   * handed out beforehand, which keep satisfying the session-only checks until they
+   * expire. That window is one session lifetime (12h) and closes on its own; rotating
+   * SESSION_SECRET at deploy closes it immediately, which is worth doing if a PAT for
+   * an admin account was ever exchanged.
    */
   src?: 'token';
 }
@@ -520,11 +524,18 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         return reply.status(503).send({ error: 'authentication is not configured' });
       }
 
-      if (!request.user || request.authMethod !== 'token') {
+      // Resolved from the Authorization header rather than read off `request.authMethod`:
+      // a cookie minted *here* also reports 'token', so trusting the method alone would
+      // let a derived cookie mint an endless succession of fresh ones — self-renewing
+      // past the revocation of the very PAT it came from, and reopening the "a cookie
+      // cannot mint a cookie" hole this route is documented to close. The exchange has
+      // to be driven by the credential itself, every time.
+      const tokenUser = await getAccessTokenUser(request);
+      if (!tokenUser) {
         return reply.status(401).send({ error: 'a personal access token is required' });
       }
 
-      if (request.user.tier === 'blocked') {
+      if (tokenUser.tier === 'blocked') {
         return reply.status(403).send({ error: 'account is blocked' });
       }
 
@@ -534,13 +545,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
       // for — which is the whole point of this route — works unchanged.
       reply.setCookie(
         SESSION_COOKIE_NAME,
-        mintSessionToken(
-          request.user.uid,
-          effectiveSessionSecret,
-          DEFAULT_SESSION_DURATION_SECONDS,
-          undefined,
-          'token',
-        ),
+        mintSessionToken(tokenUser.uid, effectiveSessionSecret, DEFAULT_SESSION_DURATION_SECONDS, undefined, 'token'),
         {
           path: '/',
           httpOnly: true,
@@ -550,7 +555,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         },
       );
 
-      return { user: request.user };
+      return { user: tokenUser };
     },
   );
 

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -15,6 +15,23 @@ export interface SessionPayload {
   uid: string;
   iat: number;
   exp: number;
+  /**
+   * Provenance: present (and only ever `'token'`) when this cookie was minted by
+   * exchanging a personal access token at `/api/auth/session`, absent when a human
+   * signed in with Google.
+   *
+   * It exists because the operator surfaces are session-only on purpose — see
+   * `isAdminSession` — so that a leaked PAT cannot widen its own privileges. Without
+   * a record of where a cookie came from, the exchange would launder token authority
+   * into session authority and hand a token holder the one thing that check exists to
+   * deny: minting further tokens. Carrying it in the signed payload (rather than
+   * checking the admin list at exchange time) is what makes the property hold no
+   * matter when an account joins that list.
+   *
+   * Absent on every cookie minted before this field existed, which is correct: those
+   * could only come from a Google sign-in.
+   */
+  src?: 'token';
 }
 
 export class InvalidSessionError extends Error {
@@ -84,11 +101,13 @@ export function mintSessionToken(
   secret: string,
   durationSeconds = DEFAULT_SESSION_DURATION_SECONDS,
   nowSeconds = Math.floor(Date.now() / 1000),
+  source?: 'token',
 ): string {
   const payload: SessionPayload = {
     uid,
     iat: nowSeconds,
     exp: nowSeconds + durationSeconds,
+    ...(source === 'token' ? { src: source } : {}),
   };
   const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const signature = createHmac('sha256', secret).update(encodedPayload).digest('base64url');
@@ -131,7 +150,10 @@ export function readSessionToken(
       throw new InvalidSessionError('session expired');
     }
 
-    return payload;
+    // Normalized to the one meaningful value rather than passed through: `src` feeds
+    // an authorization decision, so anything that is not exactly 'token' must read as
+    // "no claim made" instead of reaching a caller as an unexpected shape.
+    return { ...payload, ...(payload.src === 'token' ? { src: 'token' as const } : { src: undefined }) };
   } catch (err) {
     if (err instanceof InvalidSessionError) throw err;
     throw new InvalidSessionError('failed to parse session payload');
@@ -211,23 +233,25 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
 
   await app.register(cookie);
 
-  const getSessionUser = async (request: FastifyRequest): Promise<{ user: User | null; needsRenewal: boolean }> => {
+  const getSessionUser = async (
+    request: FastifyRequest,
+  ): Promise<{ user: User | null; needsRenewal: boolean; fromToken: boolean }> => {
     const cookieToken = request.cookies[SESSION_COOKIE_NAME];
-    if (!cookieToken) return { user: null, needsRenewal: false };
+    if (!cookieToken) return { user: null, needsRenewal: false, fromToken: false };
 
     try {
-      const { uid, exp } = readSessionToken(cookieToken, effectiveSessionSecret, sessionSecretPrev);
+      const { uid, exp, src } = readSessionToken(cookieToken, effectiveSessionSecret, sessionSecretPrev);
       const user = await store.getUser(uid);
       if (!user) {
-        return { user: null, needsRenewal: false };
+        return { user: null, needsRenewal: false, fromToken: false };
       }
 
       const now = Math.floor(Date.now() / 1000);
       const needsRenewal = exp - now < HALF_LIFE_SECONDS;
 
-      return { user, needsRenewal };
+      return { user, needsRenewal, fromToken: src === 'token' };
     } catch {
-      return { user: null, needsRenewal: false };
+      return { user: null, needsRenewal: false, fromToken: false };
     }
   };
 
@@ -287,7 +311,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
 
   app.addHook('onRequest', async (request) => {
     if (!isAuthConfigured) return;
-    const { user, needsRenewal } = await getSessionUser(request);
+    const { user, needsRenewal, fromToken } = await getSessionUser(request);
     if (!user) {
       // No cookie session — fall back to a personal access token. Deliberately second:
       // a browser that has both should be treated as the human it is.
@@ -304,7 +328,10 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
 
     request.user = user;
     request.needsSessionRenewal = needsRenewal;
-    request.authMethod = 'session';
+    // A cookie minted from a PAT still reports 'token': the credential behind this
+    // request is the token, and every session-only check must see that rather than
+    // the cookie it was traded for.
+    request.authMethod = fromToken ? 'token' : 'session';
 
     /**
      * Record that this account was active today.
@@ -326,7 +353,17 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
 
   app.addHook('onSend', async (request, reply) => {
     if (isAuthConfigured && request.user && request.needsSessionRenewal && request.user.tier !== 'blocked') {
-      const renewedToken = mintSessionToken(request.user.uid, effectiveSessionSecret);
+      // Provenance survives renewal, or a token-derived cookie would quietly become a
+      // genuine one after six hours and regain exactly the authority it was denied.
+      // `needsSessionRenewal` is only ever set on the cookie path, so 'token' here
+      // means a token-derived session rather than a bare Bearer request.
+      const renewedToken = mintSessionToken(
+        request.user.uid,
+        effectiveSessionSecret,
+        DEFAULT_SESSION_DURATION_SECONDS,
+        undefined,
+        request.authMethod === 'token' ? 'token' : undefined,
+      );
       reply.setCookie(SESSION_COOKIE_NAME, renewedToken, {
         path: '/',
         httpOnly: true,
@@ -462,9 +499,15 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
    * product's fetch layer.
    *
    * Not a new privilege and not a bypass: the caller must already hold a valid token for
-   * the account, and what comes back is a session for that same account with the same
-   * lifetime as any other. It is the same shape as `/api/auth/google` — verify a
+   * the account, and what comes back is a session for that same account carrying the same
+   * authority the token had. It is the same shape as `/api/auth/google` — verify a
    * credential the caller already has, hand back the cookie the browser needs.
+   *
+   * That "same authority" is enforced, not assumed: the cookie is stamped `src: 'token'`
+   * so the session-only operator surfaces keep refusing it. Without the stamp this route
+   * was a real escalation — a leaked PAT for an admin account could be traded for a
+   * cookie that satisfied `isAdminSession` and then mint further tokens, which is exactly
+   * the self-renewing credential the token design exists to prevent.
    *
    * Session auth is deliberately *not* accepted here: a cookie cannot be used to mint a
    * fresh cookie, so this can never be used to launder an about-to-expire session.
@@ -485,13 +528,27 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         return reply.status(403).send({ error: 'account is blocked' });
       }
 
-      reply.setCookie(SESSION_COOKIE_NAME, mintSessionToken(request.user.uid, effectiveSessionSecret), {
-        path: '/',
-        httpOnly: true,
-        secure: isProd,
-        sameSite: 'lax',
-        maxAge: DEFAULT_SESSION_DURATION_SECONDS,
-      });
+      // Stamped with its provenance so it stays a token's authority in cookie form:
+      // the session-only operator surfaces refuse it exactly as they refuse the
+      // Bearer header it was traded for. Everything the SPA actually needs a cookie
+      // for — which is the whole point of this route — works unchanged.
+      reply.setCookie(
+        SESSION_COOKIE_NAME,
+        mintSessionToken(
+          request.user.uid,
+          effectiveSessionSecret,
+          DEFAULT_SESSION_DURATION_SECONDS,
+          undefined,
+          'token',
+        ),
+        {
+          path: '/',
+          httpOnly: true,
+          secure: isProd,
+          sameSite: 'lax',
+          maxAge: DEFAULT_SESSION_DURATION_SECONDS,
+        },
+      );
 
       return { user: request.user };
     },

--- a/apps/api/src/quota-gate.ts
+++ b/apps/api/src/quota-gate.ts
@@ -1,0 +1,40 @@
+import type { Store, UsageCounters, User } from './store.js';
+
+/**
+ * Read-only "is there budget left?" check, run *before* a paid Vertex call.
+ *
+ * The daily quota is what bounds what a creator can cost us, but it only bounds
+ * spend if it is consulted before the money is spent. Both LLM-backed creation
+ * routes used to moderate first and check quota second, so an account sitting at
+ * its daily limit still paid for a Gemini moderation call on every request and
+ * only then got its 429 — the quota was a gate on *outcomes*, not on cost.
+ *
+ * This exists rather than reordering around `checkAndIncrementQuota` because the
+ * increment must stay after moderation: content rejected by the safety layer
+ * deliberately costs the creator nothing (see the moderation-before-quota note at
+ * each call site, and docs/content-safety-plan.md). Peeking is what lets both
+ * things be true — a rejected prompt still spends no quota, and an exhausted
+ * account still spends no money.
+ *
+ * Deliberately *not* authoritative: `checkAndIncrementQuota` remains the only
+ * thing that decides and records a spend, inside a transaction. Two requests can
+ * race past this peek, and that is fine — they meet the real gate a moment later.
+ * The worst case is the pre-existing one (a couple of extra calls), not a bypass.
+ */
+export async function peekQuota(
+  store: Store,
+  uid: string,
+  dateStr: string,
+  limit: number,
+  action: keyof UsageCounters,
+): Promise<{ allowed: boolean; tier: User['tier'] }> {
+  const [user, usage] = await Promise.all([store.getUser(uid), store.getUsage(uid, dateStr)]);
+  const tier = user?.tier ?? 'standard';
+
+  // Mirrors checkAndIncrementQuota's tier handling exactly; the two must not drift,
+  // or this refuses callers the real gate would have admitted.
+  if (tier === 'blocked') return { allowed: false, tier };
+  if (tier === 'trusted') return { allowed: true, tier };
+
+  return { allowed: (usage[action] ?? 0) < limit, tier };
+}

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -4,6 +4,7 @@ import { mintAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import type { ContentChecker } from './moderation.js';
 import { InMemoryStore, type Store } from './store.js';
 import { CREATOR_FEEDBACK_MARKER } from './submissions.js';
 import { mintToken } from './submission-token.js';
@@ -90,12 +91,14 @@ async function createApp(params: {
   dailySubmissionQuota?: number;
   dailyFeedbackQuota?: number;
   translator?: Translator;
+  contentChecker?: ContentChecker;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
   await store.upsertUser({ uid: 'g:test-user' });
   const app = await buildApp({
     store,
     sessionSecret,
+    ...(params.contentChecker ? { contentChecker: params.contentChecker } : {}),
     submissionRoutes: {
       githubToken: params.githubClient ? 'token' : undefined,
       submissionTokenSecret: params.submissionTokenSecret,
@@ -158,6 +161,85 @@ describe('submission routes authentication & quota', () => {
     });
     expect(exceeded.statusCode).toBe(429);
     expect(exceeded.json()).toEqual({ error: 'daily submission quota exceeded' });
+
+    await app.close();
+  });
+
+  /**
+   * Moderating a submission is `checkFields([title, concept])` — one *paid* Vertex call
+   * per field, so two per request. Both refusals below used to happen only after that
+   * spend, which made the quota and the limiter caps on submissions created rather than
+   * on what a single account could cost us.
+   */
+  function countingChecker() {
+    const state = {
+      calls: 0,
+      checker: {
+        async check() {
+          state.calls += 1;
+          return { allowed: true };
+        },
+        async checkFields(fields: string[]) {
+          state.calls += fields.length;
+          return { allowed: true };
+        },
+      } satisfies ContentChecker,
+    };
+    return state;
+  }
+
+  it('spends nothing on moderation once the daily quota is exhausted', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const moderation = countingChecker();
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      dailySubmissionQuota: 1,
+      contentChecker: moderation.checker,
+    });
+
+    const body = { title: 'Game idea', concept: 'A concept long enough to pass validation rules.' };
+    const first = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    expect(first.statusCode).toBe(200);
+    expect(moderation.calls).toBe(2);
+
+    const exceeded = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    expect(exceeded.statusCode).toBe(429);
+    expect(moderation.calls).toBe(2);
+
+    await app.close();
+  });
+
+  it('spends nothing on moderation for a rate-limited submission', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const moderation = countingChecker();
+    // Quota above the per-IP ceiling of 5/hour, so the limiter is what refuses the 6th.
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      dailySubmissionQuota: 1000,
+      contentChecker: moderation.checker,
+    });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/submissions',
+        headers: authHeaders,
+        payload: { title: `Game ${attempt}`, concept: 'A concept long enough to pass validation rules.' },
+      });
+      expect(res.statusCode).toBe(200);
+    }
+    expect(moderation.calls).toBe(10);
+
+    const limited = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'One too many', concept: 'A concept long enough to pass validation rules.' },
+    });
+    expect(limited.statusCode).toBe(429);
+    expect(moderation.calls).toBe(10);
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -18,6 +18,7 @@ import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { notifyOnTransition, type EmitDeps } from './notify.js';
+import { peekQuota } from './quota-gate.js';
 import { type BuildPreviewSummary, type BuildShotSummary, type Store } from './store.js';
 import {
   CREATOR_FEEDBACK_MARKER,
@@ -760,21 +761,38 @@ export async function registerSubmissionRoutes(
       return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
     }
 
-    // 2. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
+    const currentTime = now();
+    const dateStr = new Date(currentTime).toISOString().slice(0, 10);
+
+    // 2. Coarse per-IP rate limit. Ahead of moderation deliberately: moderation is
+    // `checkFields`, which is one *paid* Vertex call per field (two for a title and a
+    // concept), so a limiter that ran after it would cap submissions created while
+    // leaving the spend itself unbounded.
+    if (isRateLimited(submissionsByIp, request.ip, currentTime, maxSubmissionsPerWindow, rateLimitWindowMs)) {
+      return reply.status(429).send({ error: 'too many submissions, please try again later' });
+    }
+
+    // 3. Quota headroom, read-only — same reason as the limiter above: an account with
+    // no budget left must not be able to keep buying moderation calls. The spend is
+    // recorded further down, after moderation, so rejected content still costs the
+    // creator nothing.
+    if (store) {
+      const headroom = await peekQuota(store, request.user!.uid, dateStr, dailySubmissionQuota, 'submissions');
+      if (!headroom.allowed) {
+        if (headroom.tier === 'blocked') {
+          return reply.status(403).send({ error: 'account is blocked' });
+        }
+        return reply.status(429).send({ error: 'daily submission quota exceeded' });
+      }
+    }
+
+    // 4. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
     const moderation = await contentChecker.checkFields([parsed.data.title, parsed.data.concept]);
     if (!moderation.allowed) {
       return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
     }
 
-    const currentTime = now();
-
-    // 3. Coarse per-IP rate limit
-    if (isRateLimited(submissionsByIp, request.ip, currentTime, maxSubmissionsPerWindow, rateLimitWindowMs)) {
-      return reply.status(429).send({ error: 'too many submissions, please try again later' });
-    }
-
-    // 4. User daily quota check (only increment after payload & IP checks pass)
-    const dateStr = new Date(currentTime).toISOString().slice(0, 10);
+    // 5. User daily quota check (only increment after payload & IP checks pass)
     if (store) {
       const quota = await store.checkAndIncrementQuota(request.user!.uid, dateStr, dailySubmissionQuota, 'submissions');
       if (!quota.allowed) {

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -154,8 +154,12 @@ curl -H "Authorization: Bearer $GAMEDEV_ACCESS_TOKEN" https://www.gamedev.pl/api
 **Driving a real browser** — the SPA authenticates with cookies
 (`credentials: 'include'`), so exchange the token for a session first.
 `POST /api/auth/session` accepts only a token (never a cookie, so a session can never
-launder itself into a fresh one) and returns the same cookie a Google sign-in would.
-The verified Playwright shape:
+launder itself into a fresh one) and returns the cookie the SPA needs. It is a normal
+session for that account in every way the app cares about, with one deliberate
+exception: it records that it came from a token, so it keeps getting 404 from the
+operator surfaces exactly as the Bearer header does. Without that the exchange would be
+a way around "a token can never mint another token" above — trade an admin account's
+token for a cookie, and mint again. The verified Playwright shape:
 
 ```js
 import { chromium, request } from 'playwright-core';


### PR DESCRIPTION
Two findings from a security review of the API, both fixed here. They are independent; the first is the one worth landing before the beta wall drops.

## 1. Both LLM routes paid Vertex before deciding whether to serve the request

The root cause was ordering. Both creation routes called moderation first and checked their limits second, so the daily quota bounded *games created* rather than *dollars spent*.

- `POST /api/submissions` moderated with `checkFields`, which is **one paid Gemini call per field — two per request**, ahead of the per-IP limiter and the quota. The 5/hour cap only ever arrived after the spend, so a single signed-in account could bill us without limit.
- `POST /api/generate-game` had **no rate limit of any kind**, and an account already at its daily quota still paid for a moderation call on every request before getting its 429.

Both now gate before they spend:

- `generate-game` takes the same 30/hour per-IP ceiling as the sibling refine route. Declared as route config rather than an in-handler check on purpose — the rate-limit hook runs *before* the handler body, so a refused request costs nothing at all.
- Both consult a new read-only `peekQuota` (`quota-gate.ts`) before moderating, so an account out of budget is turned away for free.

The authoritative `checkAndIncrementQuota` deliberately **stays after** moderation, so content rejected by the safety layer still costs the creator nothing. That ordering was intentional (there is a test asserting it) and is preserved — the read-only peek is what lets both properties hold at once.

This also closes a denial-of-service angle: moderation fails closed, so an attacker exhausting the Vertex project's QPS would have turned into a site-wide refusal to create games, not just a bill.

Reachability: a session is required, so today this is bounded to allowlisted beta members. It is open to any self-serve Google account the moment `PRIVATE_BETA` flips.

## 2. `POST /api/auth/session` laundered token authority into session authority

The operator surfaces are session-only precisely so a leaked personal access token cannot widen its own privileges — `isAdminSession` refuses a caller authenticated with a token, and `docs/agent-access-tokens.md` states the invariant as "a token can never mint another token … even when the token belongs to an admin."

The exchange defeated that. It handed back an ordinary session cookie for the same account, so a PAT for an admin account — the credential that by design sits in CI configs and agent VMs, where a human is not watching — could be traded for a cookie that satisfied `isAdminSession` and then used to mint further tokens. That is exactly the self-renewing credential the design exists to prevent. It did not escalate a non-admin PAT.

Sessions minted from a token now carry that provenance in their signed payload and keep reporting `authMethod: 'token'`, so every session-only check refuses them with **no change at the call sites**. Two details that matter:

- Provenance survives renewal, or the cookie would quietly become a genuine one after six hours and regain the authority it was just denied.
- Carrying it in the payload, rather than checking the admin list at exchange time, is what makes the property hold no matter *when* an account joins that list.

The exchange still works for its actual purpose: driving a real browser as a bot account. Only the operator surfaces refuse it.

## Tests

Seven new tests, asserting on **billable call counts** rather than status codes alone — the fake checker counts fields the way `checkFields` bills per field, so the numbers are the Vertex calls production would have paid for.

- quota-exhausted and rate-limited requests spend zero on moderation, on both routes
- the 31st `generate-game` request is refused before reaching the paid call
- an admin-account PAT cannot reach the operator surfaces after exchange, and that survives a session renewal
- a counterweight: a real browser session still reaches them, since a fix that locked the operator out of their own tools would be its own bug

Full API suite green (762 tests), lint and type-check clean, rebased on current master.

## Not addressed here

Lower-priority items from the same review, listed so they are not lost: telemetry session maps prune in O(n) and only above 5000 entries; `/api/mp/ws` has no per-IP connection cap; a boot-time `SESSION_SECRET` assertion would close the `NODE_ENV`-misconfiguration fallback. All need either a botnet or a prod misconfiguration, and none are in this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmAoWTsb57523ac3yG6qmC)_