### PR TITLE
Bake a snapshot from one tarball instead of 2,246 GitHub reads

### DIFF
--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -25,7 +25,8 @@
 
 import { publishSnapshot } from '../src/game-snapshot-publish.js';
 import { createGcsSnapshotStore, type GameSnapshotWriter, type SnapshotPointer } from '../src/game-snapshot.js';
-import { createGitHubClient } from '../src/github-client.js';
+import { fetchGamesRepoArchive } from '../src/games-repo-archive.js';
+import { createGitHubClient, type RepoFileSource } from '../src/github-client.js';
 
 function readFlag(name: string): string | null {
   const index = process.argv.indexOf(`--${name}`);
@@ -65,7 +66,27 @@ async function main(): Promise<void> {
     fail('GAMES_SNAPSHOT_BUCKET is required (or pass --dry-run)');
   }
 
-  const client = createGitHubClient({ token, repo });
+  // One tarball instead of a read per file. A bake touches nearly every file in
+  // the games repo, and the per-file version cost ~1,000 requests against a token
+  // shared with CI — enough, at a bake per push, to exhaust its hourly budget and
+  // 403 everything else holding it. If the download fails the bake still runs the
+  // old way: slower and expensive, but a stale snapshot is worse.
+  let files: RepoFileSource | undefined;
+  try {
+    const archive = await fetchGamesRepoArchive({ repo, ref, token });
+    files = archive;
+    console.log(
+      `snapshot publish: archive ${repo}@${ref} — ${archive.fileCount} files, ` +
+        `${(archive.byteCount / 1024 / 1024).toFixed(1)} MiB, 1 request`,
+    );
+  } catch (error: unknown) {
+    console.warn(
+      `snapshot publish: archive download failed (${error instanceof Error ? error.message : String(error)}) — ` +
+        'falling back to per-file contents reads',
+    );
+  }
+
+  const client = createGitHubClient({ token, repo, files });
   const writer = dryRun ? createDryRunWriter() : createGcsSnapshotStore({ bucket });
 
   console.log(`snapshot publish: ${repo}@${ref} → ${dryRun ? '(dry run, nothing written)' : `gs://${bucket}`}`);

--- a/apps/api/src/games-repo-archive.test.ts
+++ b/apps/api/src/games-repo-archive.test.ts
@@ -1,0 +1,92 @@
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it, vi } from 'vitest';
+import { fetchGamesRepoArchive } from './games-repo-archive.js';
+
+const BLOCK = 512;
+const ROOT = 'gamedevpl-www.gamedev.pl-games-3f8a1c9';
+
+/** One tar entry, the way `git archive` writes it. */
+function entryBlocks(name: string, body: Buffer | string, type = '0'): Buffer {
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, 100, 'utf8');
+  header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+  header.write(type, 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  const padding = Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK);
+  return Buffer.concat([header, payload, padding]);
+}
+
+function tarball(files: Record<string, Buffer | string>): Buffer {
+  const entries = Object.entries(files).map(([name, body]) => entryBlocks(`${ROOT}/${name}`, body));
+  return gzipSync(Buffer.concat([...entries, Buffer.alloc(BLOCK * 2)]));
+}
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff]);
+
+const REPO_FILES = {
+  'catalog.json': '[{"slug":"pong"}]',
+  'games/pong/game.ts': 'export const speed = 3;',
+  'games/pong/media/opening.png': PNG_BYTES,
+  'shared/modules/core.ts': 'export const core = 1;',
+  'tools/validate.ts': 'const MAX_BUNDLE_BYTES = 1;',
+  'docs/notes.md': '# notes',
+};
+
+const BASE = { repo: 'gamedevpl/www.gamedev.pl-games', ref: 'main', token: 't' };
+
+function createFetch(body: Buffer, init: ResponseInit = {}): typeof fetch {
+  return (async () => new Response(body, init)) as unknown as typeof fetch;
+}
+
+describe('fetchGamesRepoArchive', () => {
+  it('downloads the whole repo in a single request', async () => {
+    const fetchImpl = vi.fn(async () => new Response(tarball(REPO_FILES)));
+
+    await fetchGamesRepoArchive({ ...BASE, fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0][0])).toBe(
+      'https://api.github.com/repos/gamedevpl/www.gamedev.pl-games/tarball/main',
+    );
+  });
+
+  it('reads text and bytes at repo-relative paths, with the archive root stripped', async () => {
+    const archive = await fetchGamesRepoArchive({ ...BASE, fetchImpl: createFetch(tarball(REPO_FILES)) });
+
+    await expect(archive.readText('games/pong/game.ts', 'main')).resolves.toBe('export const speed = 3;');
+    await expect(archive.readText('catalog.json', 'main')).resolves.toBe('[{"slug":"pong"}]');
+    expect(Buffer.from((await archive.readBytes('games/pong/media/opening.png', 'main')) ?? [])).toEqual(PNG_BYTES);
+  });
+
+  it('answers null for a file the ref does not have — the same as a 404 read', async () => {
+    const archive = await fetchGamesRepoArchive({ ...BASE, fetchImpl: createFetch(tarball(REPO_FILES)) });
+
+    await expect(archive.readText('games/absent/game.ts', 'main')).resolves.toBeNull();
+    await expect(archive.readBytes('games/absent/media/opening.png', 'main')).resolves.toBeNull();
+  });
+
+  it('keeps only what serving needs', async () => {
+    const archive = await fetchGamesRepoArchive({ ...BASE, fetchImpl: createFetch(tarball(REPO_FILES)) });
+
+    // tools/ and docs/ are most of the repo by file count and none of it by use.
+    expect(archive.fileCount).toBe(4);
+    await expect(archive.readText('tools/validate.ts', 'main')).resolves.toBeNull();
+  });
+
+  it('refuses to answer for a ref it does not hold', async () => {
+    const archive = await fetchGamesRepoArchive({ ...BASE, fetchImpl: createFetch(tarball(REPO_FILES)) });
+
+    // Otherwise a PR preview would be quietly served files baked from main.
+    await expect(archive.readText('games/pong/game.ts', 'some-pr-branch')).rejects.toThrow(/holds main, not/);
+  });
+
+  it('throws when the archive cannot be downloaded, so the caller can fall back', async () => {
+    const fetchImpl = createFetch(Buffer.from('{"message":"API rate limit exceeded"}'), {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+
+    await expect(fetchGamesRepoArchive({ ...BASE, fetchImpl })).rejects.toThrow(/cannot download .* \(403 Forbidden\)/);
+  });
+});

--- a/apps/api/src/games-repo-archive.ts
+++ b/apps/api/src/games-repo-archive.ts
@@ -1,0 +1,118 @@
+/**
+ * The games repo as one download instead of a thousand reads.
+ *
+ * The snapshot bake needs nearly every file in the games repo — sources and media
+ * for all ~84 published games — and used to ask GitHub for them one at a time
+ * through the contents API. At roughly a thousand requests per bake, and a bake per
+ * push to the games repo, that is what drained `GAMES_REPO_TOKEN`'s hourly budget
+ * and 403'd everything else holding the same token, CI included.
+ *
+ * `GET /repos/<repo>/tarball/<ref>` answers the same question in **one** request.
+ * What comes back is a file source with the same shape the contents API path
+ * exposes, so `createGitHubClient` can be handed either one and every line of
+ * assembly logic downstream stays identical (`RepoFileSource` in
+ * `github-client.ts`).
+ */
+
+import { createGunzip } from 'node:zlib';
+import { Readable } from 'node:stream';
+import type { RepoFileSource } from './github-client.js';
+import { readTarEntries } from './tar.js';
+
+export interface FetchGamesRepoArchiveOptions {
+  repo: string;
+  ref: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+  /**
+   * Which archive paths to keep, relative to the repo root. Defaults to what
+   * serving a game needs — everything else in the repo (tools, docs, templates)
+   * would only be memory.
+   */
+  include?: (path: string) => boolean;
+  maxTotalBytes?: number;
+}
+
+export interface GamesRepoArchive extends RepoFileSource {
+  /** Files retained from the archive. */
+  fileCount: number;
+  /** Their total size, for the bake's log line. */
+  byteCount: number;
+}
+
+/** Sources, media, and the committed catalog — everything the bake reads. */
+function defaultInclude(path: string): boolean {
+  return path === 'catalog.json' || path.startsWith('games/') || path.startsWith('shared/');
+}
+
+/**
+ * GitHub archives are rooted at `<owner>-<repo>-<sha>/`. Strip that so paths match
+ * what the contents API would have been asked for.
+ */
+function stripRoot(path: string): string | null {
+  const slash = path.indexOf('/');
+  return slash === -1 ? null : path.slice(slash + 1);
+}
+
+export async function fetchGamesRepoArchive(options: FetchGamesRepoArchiveOptions): Promise<GamesRepoArchive> {
+  const { repo, ref, token } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const include = options.include ?? defaultInclude;
+
+  const url = `https://api.github.com/repos/${repo}/tarball/${encodeURIComponent(ref)}`;
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'gamedevpl-games-snapshot-bake',
+    },
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`cannot download ${repo}@${ref} archive (${response.status} ${response.statusText})`);
+  }
+
+  const files = new Map<string, Uint8Array>();
+  let byteCount = 0;
+
+  // The archive is gzipped; gunzip it as it arrives rather than buffering the
+  // compressed copy and the decompressed one at once.
+  const gunzipped = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]).pipe(createGunzip());
+
+  for await (const entry of readTarEntries(gunzipped, {
+    include: (path) => {
+      const relative = stripRoot(path);
+      return relative !== null && include(relative);
+    },
+    maxTotalBytes: options.maxTotalBytes,
+  })) {
+    const relative = stripRoot(entry.path);
+    if (relative === null) {
+      continue;
+    }
+    files.set(relative, entry.bytes);
+    byteCount += entry.bytes.byteLength;
+  }
+
+  function assertRef(requested: string): void {
+    // The archive is one commit. Serving a different ref from it would quietly
+    // answer the wrong question — a PR preview baked from main, say.
+    if (requested !== ref) {
+      throw new Error(`games-repo archive holds ${ref}, not ${requested}`);
+    }
+  }
+
+  return {
+    fileCount: files.size,
+    byteCount,
+    async readText(path: string, requestedRef: string): Promise<string | null> {
+      assertRef(requestedRef);
+      const bytes = files.get(path);
+      return bytes ? Buffer.from(bytes).toString('utf8') : null;
+    },
+    async readBytes(path: string, requestedRef: string): Promise<Uint8Array | null> {
+      assertRef(requestedRef);
+      return files.get(path) ?? null;
+    },
+  };
+}

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -1,4 +1,6 @@
+import { gzipSync } from 'node:zlib';
 import { describe, expect, it, vi } from 'vitest';
+import { fetchGamesRepoArchive } from './games-repo-archive.js';
 import { createGitHubClient, resolveGameTypeScriptPath } from './github-client.js';
 
 describe('resolveGameTypeScriptPath', () => {
@@ -540,7 +542,9 @@ describe('getGameSources', () => {
     expect(sources?.gameJs).toContain('"coin":"data:audio/wav;base64,AwQ="');
     // Games-repo contract: selected name as a string, plus a one-entry tracks map.
     expect(sources?.gameJs).toContain('window.__GAME_AUDIO_MUSIC__ = "menu-theme";');
-    expect(sources?.gameJs).toContain('window.__GAME_MUSIC_TRACKS__ = Object.freeze({"menu-theme":{"loop":true,"data":"data:audio/mpeg;base64,AAA="}});');
+    expect(sources?.gameJs).toContain(
+      'window.__GAME_MUSIC_TRACKS__ = Object.freeze({"menu-theme":{"loop":true,"data":"data:audio/mpeg;base64,AAA="}});',
+    );
     expect(sources?.gameJs).not.toContain('other-theme');
     expect(sources?.gameJs.indexOf('window.GameKit =')).toBeLessThan(
       sources?.gameJs.indexOf('GameKit.createInput') ?? 0,
@@ -596,7 +600,9 @@ describe('getGameSources', () => {
     expect(sources?.gameJs).toContain('GameKit.gfx = true');
     expect(sources?.gameJs).toContain('GameKit.actors = true');
     expect(sources?.gameJs).toContain('GameKit.world = true');
-    expect(sources?.gameJs.indexOf('GameKit.world = true')).toBeLessThan(sources?.gameJs.indexOf('GameKit.gfx = true') ?? 0);
+    expect(sources?.gameJs.indexOf('GameKit.world = true')).toBeLessThan(
+      sources?.gameJs.indexOf('GameKit.gfx = true') ?? 0,
+    );
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
@@ -633,18 +639,21 @@ describe('getGameSources', () => {
     {
       label: '.ts suffix',
       entry: "import { startGame } from './game/runtime.ts'; startGame();",
-      runtimeImport: "import type { Score } from './model.ts'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+      runtimeImport:
+        "import type { Score } from './model.ts'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
     },
     {
       // TypeScript's Node ESM convention — import path says .js, source file is .ts.
       label: '.js suffix',
       entry: "import { startGame } from './game/runtime.js'; startGame();",
-      runtimeImport: "import type { Score } from './model.js'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+      runtimeImport:
+        "import type { Score } from './model.js'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
     },
     {
       label: 'extensionless',
       entry: "import { startGame } from './game/runtime'; startGame();",
-      runtimeImport: "import type { Score } from './model'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
+      runtimeImport:
+        "import type { Score } from './model'; export function startGame(): void { const score: Score = { value: 3 }; GameKit.mount({ score }); }",
     },
   ])('bundles a game-local TypeScript module graph from GitHub ($label)', async ({ entry, runtimeImport }) => {
     const files = new Map<string, string | Uint8Array>([
@@ -810,5 +819,98 @@ describe('findLinkedPR', () => {
     const client = createGitHubClient({ token: 'test-token', repo, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     await expect(client.findLinkedPR(7)).rejects.toThrow('Bad credentials');
+  });
+});
+
+describe('archive-backed file source', () => {
+  const BLOCK = 512;
+  const ROOT = 'gamedevpl-www.gamedev.pl-games-3f8a1c9';
+
+  const gameFiles = new Map<string, string | Uint8Array>([
+    ['games/coin-catcher/index.html', '<canvas id="game"></canvas>'],
+    ['games/coin-catcher/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+    ['games/coin-catcher/style.css', '.game { color: gold; }'],
+    ['games/coin-catcher/SPEC.md', specMd({ title: 'Coin Catcher' })],
+    ['games/coin-catcher/GAME.json', JSON.stringify({ engine: { modules: ['input'] } })],
+    ['games/coin-catcher/media/opening.png', new Uint8Array([0x89, 0x50, 0x4e, 0x47])],
+    ['shared/game-shell.css', '.shell { display: grid; }'],
+    ['shared/modules/core.ts', 'const version: number = 1; window.GameKit = { mount() {} };'],
+    ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+  ]);
+
+  function tarball(): Buffer {
+    const blocks = [...gameFiles].map(([name, body]) => {
+      const payload = Buffer.from(body as Uint8Array | string);
+      const header = Buffer.alloc(BLOCK);
+      header.write(`${ROOT}/${name}`, 0, 100, 'utf8');
+      header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+      header.write('0', 156, 1, 'utf8');
+      header.write('ustar\0', 257, 6, 'utf8');
+      return Buffer.concat([header, payload, Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK)]);
+    });
+    return gzipSync(Buffer.concat([...blocks, Buffer.alloc(BLOCK * 2)]));
+  }
+
+  /** The contents API: one request per file. */
+  function createContentsFetch() {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = gameFiles.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    });
+  }
+
+  it('assembles a game identically to the contents API, and stops asking GitHub for files', async () => {
+    const contentsFetch = createContentsFetch();
+    const viaApi = await createGitHubClient({
+      token: 'test-token',
+      repo,
+      fetchImpl: contentsFetch as unknown as typeof fetch,
+    }).getGameSources('main', 'coin-catcher');
+    // The old path: index.html, game.ts, style.css, SPEC.md, GAME.json, shell css, core, input.
+    expect(contentsFetch.mock.calls.length).toBeGreaterThan(5);
+
+    const archiveFetch = vi.fn(async () => new Response(tarball()));
+    const files = await fetchGamesRepoArchive({
+      repo,
+      ref: 'main',
+      token: 'test-token',
+      fetchImpl: archiveFetch as unknown as typeof fetch,
+    });
+    const forbiddenFetch = (async () => {
+      throw new Error('the archive path must not read files over the API');
+    }) as unknown as typeof fetch;
+    const viaArchive = await createGitHubClient({
+      token: 'test-token',
+      repo,
+      fetchImpl: forbiddenFetch,
+      files,
+    }).getGameSources('main', 'coin-catcher');
+
+    expect(viaArchive).toEqual(viaApi);
+    expect(archiveFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves media bytes from the archive too', async () => {
+    const files = await fetchGamesRepoArchive({
+      repo,
+      ref: 'main',
+      token: 'test-token',
+      fetchImpl: (async () => new Response(tarball())) as unknown as typeof fetch,
+    });
+    const client = createGitHubClient({
+      token: 'test-token',
+      repo,
+      fetchImpl: (() => {
+        throw new Error('must not fetch');
+      }) as unknown as typeof fetch,
+      files,
+    });
+
+    const bytes = await client.getGameMedia('main', 'coin-catcher', 'opening.png');
+    expect(Buffer.from(bytes ?? [])).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    await expect(client.getGameMedia('main', 'coin-catcher', 'absent.png')).resolves.toBeNull();
   });
 });

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -455,7 +455,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     }
   }
 
-  /** Reads a file's raw bytes from the contents API; null when it doesn't exist on `ref`. */
+  /** Reads a file as text from the contents API; null when it doesn't exist on `ref`. */
   async function readRawFileFromApi(path: string, ref: string): Promise<string | null> {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
     const response = await githubFetch(url, {

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -351,10 +351,23 @@ export interface GitHubClient {
   getCatalog(ref: string): Promise<CatalogGameEntry[]>;
 }
 
+/**
+ * Where this client reads repo files from. The default is GitHub's contents API,
+ * one request per file; the snapshot bake supplies an archive downloaded once
+ * (`fetchGamesRepoArchive`) instead, which is the same files at 1/1000th the
+ * request count. Reads that are not plain file reads — GraphQL, issues, PRs —
+ * always go to the API.
+ */
+export interface RepoFileSource {
+  readText(path: string, ref: string): Promise<string | null>;
+  readBytes(path: string, ref: string): Promise<Uint8Array | null>;
+}
+
 export interface GitHubClientOptions {
   token: string;
   repo: string;
   fetchImpl?: typeof fetch;
+  files?: RepoFileSource;
 }
 
 interface GraphQLResponse<T> {
@@ -443,7 +456,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
   }
 
   /** Reads a file's raw bytes from the contents API; null when it doesn't exist on `ref`. */
-  async function readRawFile(path: string, ref: string): Promise<string | null> {
+  async function readRawFileFromApi(path: string, ref: string): Promise<string | null> {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
     const response = await githubFetch(url, {
       headers: {
@@ -461,7 +474,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     return response.text();
   }
 
-  async function readRawBytes(path: string, ref: string): Promise<Uint8Array | null> {
+  async function readRawBytesFromApi(path: string, ref: string): Promise<Uint8Array | null> {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
     const response = await githubFetch(url, {
       headers: {
@@ -477,6 +490,12 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     }
     return new Uint8Array(await response.arrayBuffer());
   }
+
+  // One seam for every file read in this client. The bake swaps in an archive
+  // (`games-repo-archive.ts`) so a whole snapshot costs one download instead of a
+  // read per file, and every line of assembly below stays the same either way.
+  const readRawFile = options.files ? options.files.readText : readRawFileFromApi;
+  const readRawBytes = options.files ? options.files.readBytes : readRawBytesFromApi;
 
   async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
     const response = await githubFetch(url, {

--- a/apps/api/src/tar.test.ts
+++ b/apps/api/src/tar.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { readTarEntries, type TarEntry } from './tar.js';
+
+const BLOCK = 512;
+
+interface FixtureEntry {
+  name: string;
+  body?: string;
+  type?: string;
+  prefix?: string;
+  ustar?: boolean;
+}
+
+/** Builds a tar header + padded body, the way `git archive` would. */
+function entryBlocks({ name, body = '', type = '0', prefix = '', ustar = true }: FixtureEntry): Buffer {
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, 100, 'utf8');
+  header.write('000644 \0', 100, 8, 'utf8');
+  header.write(`${Buffer.byteLength(body).toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+  header.write(type, 156, 1, 'utf8');
+  if (ustar) {
+    header.write('ustar\0', 257, 6, 'utf8');
+    header.write('00', 263, 2, 'utf8');
+    header.write(prefix, 345, 155, 'utf8');
+  }
+
+  const payload = Buffer.from(body, 'utf8');
+  const padding = Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK);
+  return Buffer.concat([header, payload, padding]);
+}
+
+function archive(...entries: FixtureEntry[]): Buffer {
+  return Buffer.concat([...entries.map(entryBlocks), Buffer.alloc(BLOCK * 2)]);
+}
+
+/** Feeds the parser one chunk, or several of a fixed size. */
+async function* stream(buffer: Buffer, chunkSize = buffer.length): AsyncGenerator<Uint8Array> {
+  for (let offset = 0; offset < buffer.length; offset += chunkSize) {
+    yield buffer.subarray(offset, offset + chunkSize);
+  }
+}
+
+async function collect(source: AsyncIterable<Uint8Array>, options?: Parameters<typeof readTarEntries>[1]) {
+  const entries: TarEntry[] = [];
+  for await (const entry of readTarEntries(source, options)) {
+    entries.push(entry);
+  }
+  return entries;
+}
+
+function text(entry: TarEntry): string {
+  return Buffer.from(entry.bytes).toString('utf8');
+}
+
+describe('readTarEntries', () => {
+  it('reads files and their bytes', async () => {
+    const entries = await collect(
+      stream(
+        archive(
+          { name: 'repo-abc123/catalog.json', body: '{"games":[]}' },
+          { name: 'repo-abc123/games/pong/game.ts', body: 'export const x = 1;' },
+        ),
+      ),
+    );
+
+    expect(entries.map((entry) => entry.path)).toEqual(['repo-abc123/catalog.json', 'repo-abc123/games/pong/game.ts']);
+    expect(text(entries[0])).toBe('{"games":[]}');
+    expect(text(entries[1])).toBe('export const x = 1;');
+  });
+
+  it('rejoins a long path split across the ustar prefix field', async () => {
+    const prefix = 'www.gamedev.pl-games-3f8a1c9d2b7e4506a1b2c3d4e5f60718293a4b5c/games/space-treasure-hunter/media';
+    const entries = await collect(stream(archive({ name: 'screenshot-opening.png', prefix, body: 'PNG' })));
+
+    expect(entries[0].path).toBe(`${prefix}/screenshot-opening.png`);
+  });
+
+  it('honours a pax path record over the header name', async () => {
+    const longPath = `repo-abc123/games/${'x'.repeat(120)}/game.ts`;
+    const record = `${`path=${longPath}\n`.length + 4} path=${longPath}\n`;
+    const entries = await collect(
+      stream(
+        archive(
+          { name: 'repo-abc123/PaxHeader/game.ts', body: record, type: 'x' },
+          { name: 'repo-abc123/games/truncated/game.ts', body: 'const a = 1;' },
+        ),
+      ),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe(longPath);
+    expect(text(entries[0])).toBe('const a = 1;');
+  });
+
+  it('honours a GNU long name over the header name', async () => {
+    const longPath = `repo-abc123/games/${'y'.repeat(130)}/style.css`;
+    const entries = await collect(
+      stream(
+        archive(
+          { name: '././@LongLink', body: `${longPath}\0`, type: 'L' },
+          { name: 'repo-abc123/games/truncated/style.css', body: 'body{}' },
+        ),
+      ),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe(longPath);
+  });
+
+  it('skips directories, symlinks and global pax headers', async () => {
+    const entries = await collect(
+      stream(
+        archive(
+          { name: 'repo-abc123/games/', type: '5' },
+          { name: 'repo-abc123/link', type: '2' },
+          { name: 'pax_global_header', body: 'comment=abc\n', type: 'g' },
+          { name: 'repo-abc123/games/pong/style.css', body: 'body{}' },
+        ),
+      ),
+    );
+
+    expect(entries.map((entry) => entry.path)).toEqual(['repo-abc123/games/pong/style.css']);
+  });
+
+  it('keeps only what include asks for', async () => {
+    const entries = await collect(
+      stream(
+        archive(
+          { name: 'repo-abc123/tools/validate.ts', body: 'huge' },
+          { name: 'repo-abc123/games/pong/game.ts', body: 'kept' },
+        ),
+      ),
+      { include: (path) => path.includes('/games/') },
+    );
+
+    expect(entries.map((entry) => entry.path)).toEqual(['repo-abc123/games/pong/game.ts']);
+  });
+
+  it('reassembles entries split across chunk boundaries', async () => {
+    const body = 'a'.repeat(1500);
+    const buffer = archive(
+      { name: 'repo-abc123/games/pong/game.ts', body },
+      { name: 'repo-abc123/games/pong/style.css', body: 'body{}' },
+    );
+
+    // 37 is deliberately hostile: no chunk aligns to a 512-byte block.
+    const entries = await collect(stream(buffer, 37));
+    expect(entries.map((entry) => entry.path)).toEqual([
+      'repo-abc123/games/pong/game.ts',
+      'repo-abc123/games/pong/style.css',
+    ]);
+    expect(text(entries[0])).toBe(body);
+  });
+
+  it('stops at the end-of-archive marker and ignores what follows', async () => {
+    const buffer = Buffer.concat([
+      archive({ name: 'repo-abc123/games/pong/game.ts', body: 'kept' }),
+      entryBlocks({ name: 'repo-abc123/games/after-the-end/game.ts', body: 'ignored' }),
+    ]);
+
+    const entries = await collect(stream(buffer));
+    expect(entries.map((entry) => entry.path)).toEqual(['repo-abc123/games/pong/game.ts']);
+  });
+
+  it('refuses to retain more than maxTotalBytes', async () => {
+    const buffer = archive({ name: 'repo-abc123/games/pong/media/gameplay.mp4', body: 'z'.repeat(4096) });
+
+    await expect(collect(stream(buffer), { maxTotalBytes: 1024 })).rejects.toThrow(/exceeds 1024 retained bytes/);
+  });
+});

--- a/apps/api/src/tar.ts
+++ b/apps/api/src/tar.ts
@@ -1,0 +1,220 @@
+/**
+ * Just enough tar to read a GitHub source archive.
+ *
+ * `GET /repos/<repo>/tarball/<ref>` answers the whole games repo in one request,
+ * which is the difference between a bake that costs ~1,000 GitHub reads and one
+ * that costs 1 (see `games-repo-archive.ts`). Reading it needs a tar parser, and
+ * this is that parser rather than a dependency: the format is a fixed 512-byte
+ * header we only read four fields of, and `git archive` emits a narrow, well-known
+ * subset of it.
+ *
+ * Handled, because GitHub's archives contain all of them:
+ *   - ustar `prefix` — paths over 100 chars split across two header fields
+ *   - pax extended headers (`x`) — a `path=` record overriding the next entry
+ *   - GNU long names (`L`) — the older long-path convention
+ *
+ * Not handled, because a source archive never contains them: sparse files, device
+ * nodes, hard links. They are skipped rather than guessed at.
+ */
+
+const BLOCK_SIZE = 512;
+
+/** Header field offsets, per the ustar layout. */
+const NAME_OFFSET = 0;
+const NAME_LENGTH = 100;
+const SIZE_OFFSET = 124;
+const SIZE_LENGTH = 12;
+const TYPE_OFFSET = 156;
+const MAGIC_OFFSET = 257;
+const PREFIX_OFFSET = 345;
+const PREFIX_LENGTH = 155;
+
+/** Type flags we act on; everything else (dirs, links, devices) is skipped. */
+const TYPE_FILE = '0';
+const TYPE_FILE_ALT = '\0';
+const TYPE_GNU_LONGNAME = 'L';
+const TYPE_PAX_NEXT = 'x';
+const TYPE_PAX_GLOBAL = 'g';
+
+export interface TarEntry {
+  path: string;
+  bytes: Uint8Array;
+}
+
+export interface ReadTarOptions {
+  /**
+   * Decides which entries are worth keeping in memory. Everything else is
+   * skipped without ever being retained — the whole point when the archive is
+   * larger than the part of it anyone wants.
+   */
+  include?: (path: string) => boolean;
+  /** Ceiling on retained bytes. Exceeding it throws rather than exhausting the heap. */
+  maxTotalBytes?: number;
+}
+
+const DEFAULT_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+
+function readString(block: Uint8Array, offset: number, length: number): string {
+  const slice = block.subarray(offset, offset + length);
+  const end = slice.indexOf(0);
+  return Buffer.from(end === -1 ? slice : slice.subarray(0, end)).toString('utf8');
+}
+
+/** Sizes are octal ASCII. GNU's base-256 form appears only for entries >8GB. */
+function readSize(block: Uint8Array): number {
+  const raw = readString(block, SIZE_OFFSET, SIZE_LENGTH).trim();
+  if (raw === '') {
+    return 0;
+  }
+  const size = Number.parseInt(raw, 8);
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(`tar: unreadable entry size "${raw}"`);
+  }
+  return size;
+}
+
+/** A pax header is a stream of `<len> <key>=<value>\n` records; we want `path`. */
+function readPaxPath(payload: Uint8Array): string | null {
+  const text = Buffer.from(payload).toString('utf8');
+  let cursor = 0;
+  while (cursor < text.length) {
+    const space = text.indexOf(' ', cursor);
+    if (space === -1) {
+      break;
+    }
+    const length = Number.parseInt(text.slice(cursor, space), 10);
+    if (!Number.isFinite(length) || length <= 0) {
+      break;
+    }
+    const record = text.slice(space + 1, cursor + length).replace(/\n$/, '');
+    const equals = record.indexOf('=');
+    if (equals !== -1 && record.slice(0, equals) === 'path') {
+      return record.slice(equals + 1);
+    }
+    cursor += length;
+  }
+  return null;
+}
+
+function isZeroBlock(block: Uint8Array): boolean {
+  return block.every((byte) => byte === 0);
+}
+
+/**
+ * Yields the regular files in a (already decompressed) tar stream.
+ *
+ * Buffers only the entry being read plus whatever `include` keeps, so a 100MB
+ * archive does not become 100MB of retained chunks.
+ */
+export async function* readTarEntries(
+  source: AsyncIterable<Uint8Array>,
+  options: ReadTarOptions = {},
+): AsyncGenerator<TarEntry> {
+  const include = options.include ?? (() => true);
+  const maxTotalBytes = options.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES;
+
+  // A queue of arrived chunks rather than one growing Buffer: concatenating on
+  // every chunk would copy the whole archive again per chunk.
+  const queue: Buffer[] = [];
+  let queued = 0;
+
+  /** Removes and returns the first `n` bytes; callers check `queued` first. */
+  function consume(n: number): Buffer {
+    const parts: Buffer[] = [];
+    let taken = 0;
+    while (taken < n) {
+      const head = queue[0];
+      const want = n - taken;
+      if (head.length <= want) {
+        parts.push(queue.shift() as Buffer);
+        taken += head.length;
+      } else {
+        parts.push(head.subarray(0, want));
+        queue[0] = head.subarray(want);
+        taken = n;
+      }
+    }
+    queued -= n;
+    return parts.length === 1 ? parts[0] : Buffer.concat(parts, n);
+  }
+
+  let retained = 0;
+  /** Set by a pax `x` or GNU `L` header — overrides the next entry's own name. */
+  let overrideName: string | null = null;
+  let sawEmptyBlock = false;
+  /** The header of an entry whose body has not fully arrived yet. */
+  let heldHeader: Buffer | null = null;
+
+  for await (const chunk of source) {
+    const buffer = Buffer.from(chunk);
+    if (buffer.length === 0) {
+      continue;
+    }
+    queue.push(buffer);
+    queued += buffer.length;
+
+    for (;;) {
+      if (!heldHeader) {
+        if (queued < BLOCK_SIZE) {
+          break;
+        }
+        heldHeader = consume(BLOCK_SIZE);
+      }
+      const header = heldHeader;
+
+      if (isZeroBlock(header)) {
+        // Two consecutive zero blocks end the archive; one alone is padding.
+        heldHeader = null;
+        if (sawEmptyBlock) {
+          return;
+        }
+        sawEmptyBlock = true;
+        continue;
+      }
+      sawEmptyBlock = false;
+
+      const size = readSize(header);
+      const padded = Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+      if (queued < padded) {
+        break; // Entry body has not fully arrived yet; the header stays held.
+      }
+      heldHeader = null;
+
+      const block = consume(padded);
+      const body = block.subarray(0, size);
+
+      const type = String.fromCharCode(header[TYPE_OFFSET]);
+
+      if (type === TYPE_GNU_LONGNAME) {
+        overrideName = Buffer.from(body).toString('utf8').replace(/\0+$/, '');
+        continue;
+      }
+      if (type === TYPE_PAX_NEXT) {
+        overrideName = readPaxPath(body) ?? overrideName;
+        continue;
+      }
+      if (type === TYPE_PAX_GLOBAL) {
+        continue; // Global defaults carry nothing we read.
+      }
+
+      const name = readString(header, NAME_OFFSET, NAME_LENGTH);
+      const isUstar = readString(header, MAGIC_OFFSET, 5) === 'ustar';
+      const prefix = isUstar ? readString(header, PREFIX_OFFSET, PREFIX_LENGTH) : '';
+      const path = overrideName ?? (prefix ? `${prefix}/${name}` : name);
+      overrideName = null;
+
+      if (type !== TYPE_FILE && type !== TYPE_FILE_ALT) {
+        continue; // Directories, symlinks, everything else.
+      }
+      if (!include(path)) {
+        continue;
+      }
+
+      retained += size;
+      if (retained > maxTotalBytes) {
+        throw new Error(`tar: archive exceeds ${maxTotalBytes} retained bytes`);
+      }
+      yield { path, bytes: new Uint8Array(body.buffer, body.byteOffset, body.byteLength) };
+    }
+  }
+}

--- a/apps/api/src/tar.ts
+++ b/apps/api/src/tar.ts
@@ -214,7 +214,11 @@ export async function* readTarEntries(
       if (retained > maxTotalBytes) {
         throw new Error(`tar: archive exceeds ${maxTotalBytes} retained bytes`);
       }
-      yield { path, bytes: new Uint8Array(body.buffer, body.byteOffset, body.byteLength) };
+      // Copy rather than view: `body` sits inside a padded block that is itself a
+      // slice of an arriving chunk, so a view would pin that whole chunk for as
+      // long as the caller holds one small file — and `retained` would be
+      // counting something other than what is actually held.
+      yield { path, bytes: Uint8Array.from(body) };
     }
   }
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,10 +94,16 @@ without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta a
 instead. Delete the secret when you are sure nothing references it.
 
 **`GAMES_REPO_TOKEN` is one hourly REST budget shared by two very different consumers.**
-The CI lockstep check spends 2 requests per run; the snapshot bake spends roughly a
-thousand — one per source and media file across every published game — and runs on every
-`games-published` dispatch. When bakes come in bursts, the PAT's ~5,000 requests/hour is
-reachable, and everything else holding that token starts seeing `403`. The contract check
+The CI lockstep check spends 2 requests per run. The snapshot bake used to spend roughly a
+thousand — one per source and media file across every published game — on every
+`games-published` dispatch, and on 2026-07-28 that emptied the PAT's ~5,000 requests/hour
+and 403'd everything else holding it, CI included. The bake now downloads the games repo
+as **one tarball** (`fetchGamesRepoArchive`), so a full bake costs 1 request instead of
+~1,000; see [`games-snapshot.md`](./games-snapshot.md). If that download fails it falls
+back to per-file reads, which is slower and expensive but still bakes.
+
+A shared budget can still run out — the site's own serving reads go through the separate
+`github-token`, but nothing stops a burst of manual re-bakes. The contract check
 therefore treats an unreadable games repo as _no evidence about drift_: it annotates the
 job with GitHub's own quota headers and passes, rather than reddening every PR in this
 repo over a shared budget. Real drift still fails. Set

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -117,6 +117,27 @@ GAMES_REPO_TOKEN=... npm run snapshot:publish -- --dry-run
 GAMES_REPO_TOKEN=... GAMES_SNAPSHOT_BUCKET=... npm run snapshot:publish
 ```
 
+### How the bake reads the games repo
+
+**One tarball, not a read per file.** A bake touches nearly everything in the games
+repo — sources, media, catalog — and reading that through the contents API cost about a
+thousand requests per run. `GAMES_REPO_TOKEN` is shared with CI's `contract:games-repo`
+check, so at a bake per push to the games repo those bursts emptied the PAT's hourly
+budget and 403'd both jobs (2026-07-28).
+
+`fetchGamesRepoArchive` ([`games-repo-archive.ts`](../apps/api/src/games-repo-archive.ts))
+downloads `GET /repos/<repo>/tarball/<ref>` once and hands `createGitHubClient` a
+`RepoFileSource` backed by it. Assembly logic is untouched — the same
+`getGameSources` / `getGameMedia` / `getCatalog` run against archive bytes instead of
+API responses, so there is no second implementation of "what a served game is" to drift.
+Only `games/`, `shared/` and `catalog.json` are retained in memory; `tools/` and `docs/`
+are dropped as they stream past.
+
+The archive is pinned to the ref it was downloaded for and refuses reads for any other —
+otherwise a PR preview could be quietly served files baked from `main`. If the download
+fails, the bake logs it and falls back to per-file contents reads: slower and expensive,
+but a stale snapshot is worse than an expensive one.
+
 ### A game that fails to bake
 
 It stays in the snapshot catalog and simply gets no game object, so its play route


### PR DESCRIPTION
Follow-up to #285, which made CI survive the shared-token outage. This removes what caused it.

## The number is worse than "roughly a thousand"

Measured, not estimated — a full bake of the live games repo at `main`:

| | GitHub requests | wall clock |
| --- | --- | --- |
| per-file contents reads (before) | **2,246** | — |
| one tarball (after) | **1** | 1.6s |

Both runs bake the same thing: 84 games, 356 media files, 0 failures. 2,246 is nearly half a PAT's 5,000/hour budget **per bake**, on a token shared with CI's `contract:games-repo`. Two bakes in an hour empty it — and since games-repo #104 a bake fires on every push to the games repo. Six ran between 22:52 and 00:17 on 2026-07-28, which is why every PR and master went red.

`GET /repos/<repo>/tarball/<ref>` answers the same question in one request.

## A narrow seam, not a second implementation

`createGitHubClient` gained an optional `files: RepoFileSource`. Every file read in that client already funnelled through one pair of functions; the archive is just a different implementation of them. Everything downstream — module selection, the esbuild bundle, audio inlining, the CSP and provenance meta — is untouched and shared, so there is no second definition of "what a served game is" to drift out of sync.

The test that matters bakes the same fixture both ways and asserts the results are **equal**, with the archive path's `fetchImpl` wired to throw if anything reaches for the network.

## The tar parser

Reading a tarball needs one, and this is ~150 lines rather than a dependency: a fixed 512-byte header of which we read four fields. It handles the three long-path conventions GitHub archives actually contain — ustar `prefix`, pax `path=`, GNU `L` — and skips what a source archive never has.

It streams: gunzip as bytes arrive, keep only `games/`, `shared/` and `catalog.json` (25 MiB, not the whole repo), and cap retained bytes so a hostile archive cannot exhaust the heap. Chunk boundaries are exercised at a deliberately hostile 37 bytes, so no chunk aligns to a block.

Fixtures alone would only prove the parser agrees with itself, so I also ran it against **GNU tar's** output including a 190-character path, and against a `git archive` of the real games repo — the 84-game bake above.

## Two safety properties

- **The archive is pinned to its ref** and throws for any other. Otherwise a PR preview could be quietly served files baked from `main`.
- **Download failure falls back** to per-file contents reads, logged. Slower and expensive, but a stale snapshot is worse than an expensive one.

## Verification

Full gate green: lint, type-check, build, 772 API tests / 302 web tests (up 17). Docs updated in `games-snapshot.md` (how the bake reads the repo) and `deployment.md` (the shared-budget note from #285, now that the bake is no longer the thing spending it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB4mJKo6bamZG33SMijayy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB4mJKo6bamZG33SMijayy)_