### PR TITLE
Show creators what players think of their games

### DIFF
--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -236,12 +236,29 @@ describe('GET /api/me/studio/scorecards', () => {
     // The health route recomputes over a window the creator picks; a scorecard is a fixed
     // roll. Two numbers labelled "sessions" disagreeing on one screen is the bug this
     // response shape exists to prevent.
-    await store.putScorecard('sky-dodge', card('sky-dodge'));
+    //
+    // Asserted as an exact key set rather than by searching the serialized body: themes are
+    // player-written text, so a player who writes "too many sessions" would otherwise fail
+    // this test against a route that is behaving perfectly.
+    await store.putScorecard('sky-dodge', card('sky-dodge', {
+      untrusted: {
+        errorSamples: [],
+        progressLabels: [],
+        feedbackThemes: [{ theme: 'too many sessions before the finishRate improves', count: 3 }],
+      },
+    }));
 
     const body = (await get()).json() as CreatorScorecardsResponse;
 
-    expect(JSON.stringify(body)).not.toContain('sessions');
-    expect(JSON.stringify(body)).not.toContain('finishRate');
+    expect(Object.keys(body.scorecards[0]).sort()).toEqual([
+      'computedAt',
+      'feedbackCount',
+      'slug',
+      'truncated',
+      'untrustedThemes',
+      'votes',
+      'windowDays',
+    ]);
   });
 
   it('omits a game with no scorecard rather than reporting zeros', async () => {

--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
-import type { CreatorHealthResponse, CreatorStudioGame } from './creator-studio.js';
-import { InMemoryStore, type TelemetryEvent } from './store.js';
+import type { CreatorHealthResponse, CreatorScorecardsResponse, CreatorStudioGame } from './creator-studio.js';
+import { InMemoryStore, type Scorecard, type TelemetryEvent } from './store.js';
 import { mintToken } from './submission-token.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -168,6 +168,127 @@ describe('GET /api/me/studio/health', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ days: [], truncated: false, games: [] });
+    await app.close();
+  });
+});
+
+describe('GET /api/me/studio/scorecards', () => {
+  let store: InMemoryStore;
+
+  /** A scorecard carrying only the fields this route reads. */
+  function card(slug: string, partial: Partial<Scorecard> = {}): Scorecard {
+    return {
+      slug,
+      computedAt: `${today}T03:00:00.000Z`,
+      window: { days: [today, '2026-07-26'], truncated: false },
+      sessions: { count: 9, bounces: 1, closes: 5, medianPlaySeconds: 30, totalPlaySeconds: 300 },
+      health: { errors: 0, aliveTicks: 0, stalledTicks: 0, stallRate: 0, medianFps: 60, resumeTicksIgnored: 0 },
+      depth: {
+        outcomes: { won: 1, lost: 2, quit: 0 },
+        sessionsWithEnding: 3,
+        finishRate: 0.3,
+        winRate: 0.33,
+        medianBestScore: 40,
+      },
+      votes: { up: 4, down: 1 },
+      feedback: { count: 3 },
+      untrusted: { errorSamples: [], progressLabels: [], feedbackThemes: [{ theme: 'level 2 is a wall', count: 3 }] },
+      ...partial,
+    } as Scorecard;
+  }
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.createSubmission(20, 'g:creator', 'Sky Dodge');
+    await store.setSubmissionSlug(20, 'sky-dodge');
+    await store.setSubmissionPublishedAt(20, `${today}T12:00:00.000Z`);
+  });
+
+  async function get(uid = 'g:creator') {
+    const app = await buildApp({ store, sessionSecret, submissionRoutes: { submissionTokenSecret } });
+    const res = await app.inject({ method: 'GET', url: '/api/me/studio/scorecards', headers: authHeaders(uid) });
+    await app.close();
+    return res;
+  }
+
+  it('returns votes, note count and themes for the creator’s own game', async () => {
+    await store.putScorecard('sky-dodge', card('sky-dodge'));
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CreatorScorecardsResponse;
+    expect(body.scorecards).toEqual([
+      {
+        slug: 'sky-dodge',
+        computedAt: `${today}T03:00:00.000Z`,
+        windowDays: 2,
+        truncated: false,
+        votes: { up: 4, down: 1 },
+        feedbackCount: 3,
+        untrustedThemes: [{ theme: 'level 2 is a wall', count: 3 }],
+      },
+    ]);
+  });
+
+  it('does not return session counts that would contradict the health route', async () => {
+    // The health route recomputes over a window the creator picks; a scorecard is a fixed
+    // roll. Two numbers labelled "sessions" disagreeing on one screen is the bug this
+    // response shape exists to prevent.
+    await store.putScorecard('sky-dodge', card('sky-dodge'));
+
+    const body = (await get()).json() as CreatorScorecardsResponse;
+
+    expect(JSON.stringify(body)).not.toContain('sessions');
+    expect(JSON.stringify(body)).not.toContain('finishRate');
+  });
+
+  it('omits a game with no scorecard rather than reporting zeros', async () => {
+    const body = (await get()).json() as CreatorScorecardsResponse;
+
+    // Not measured is not the same as measured and found empty.
+    expect(body.scorecards).toEqual([]);
+  });
+
+  it('never returns another creator’s game', async () => {
+    await store.upsertUser({ uid: 'g:other' });
+    await store.createSubmission(21, 'g:other', 'Not Mine');
+    await store.setSubmissionSlug(21, 'not-mine');
+    await store.setSubmissionPublishedAt(21, `${today}T12:00:00.000Z`);
+    await store.putScorecard('not-mine', card('not-mine'));
+    await store.putScorecard('sky-dodge', card('sky-dodge'));
+
+    const body = (await get()).json() as CreatorScorecardsResponse;
+
+    expect(body.scorecards.map((entry) => entry.slug)).toEqual(['sky-dodge']);
+  });
+
+  it('leaves out an unpublished game even when a scorecard somehow exists', async () => {
+    await store.createSubmission(22, 'g:creator', 'Draft');
+    await store.setSubmissionSlug(22, 'draft-game');
+    await store.putScorecard('draft-game', card('draft-game'));
+    await store.putScorecard('sky-dodge', card('sky-dodge'));
+
+    const body = (await get()).json() as CreatorScorecardsResponse;
+
+    expect(body.scorecards.map((entry) => entry.slug)).toEqual(['sky-dodge']);
+  });
+
+  it('carries themes under a name that says they are untrusted', async () => {
+    // The field name is part of the defence: a caller reaching for `untrustedThemes` has
+    // been told what it is holding, the same way `card.untrusted` does server-side.
+    await store.putScorecard('sky-dodge', card('sky-dodge'));
+
+    const body = (await get()).json() as CreatorScorecardsResponse;
+
+    expect(Object.keys(body.scorecards[0])).toContain('untrustedThemes');
+  });
+
+  it('requires a signed-in creator', async () => {
+    const app = await buildApp({ store, sessionSecret, submissionRoutes: { submissionTokenSecret } });
+    const res = await app.inject({ method: 'GET', url: '/api/me/studio/scorecards' });
+    expect(res.statusCode).toBe(401);
     await app.close();
   });
 });

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -49,6 +49,37 @@ export interface CreatorHealthResponse {
 }
 
 /**
+ * The parts of a game's scorecard the health route cannot produce.
+ *
+ * Deliberately **not** the whole scorecard. Health recomputes over a window the creator
+ * picks (7/14/30d); a scorecard is a fixed 28-day roll. Returning its session counts too
+ * would put two numbers labelled "sessions" on one screen, disagreeing, with nothing
+ * saying why — so this carries only what recomputation genuinely cannot supply, and the
+ * window it was measured over travels with it.
+ */
+export interface CreatorScorecardSummary {
+  slug: string;
+  computedAt: string;
+  /** Days the sweep actually read — the window these numbers describe. */
+  windowDays: number;
+  truncated: boolean;
+  votes: { up: number; down: number };
+  feedbackCount: number;
+  /**
+   * Recurring themes distilled from written feedback.
+   *
+   * Player-written text, summarized by a model that read player-written text: safe to
+   * render to the creator as text, never safe to hand an agent as instruction. It reaches
+   * the client under a name that says so.
+   */
+  untrustedThemes: Array<{ theme: string; count: number }>;
+}
+
+export interface CreatorScorecardsResponse {
+  scorecards: CreatorScorecardSummary[];
+}
+
+/**
  * Reads play events for a fixed set of slugs under one shared document budget.
  *
  * Per-slug queries (not a full-partition scan) so a quiet creator's niche game is not
@@ -178,6 +209,48 @@ export async function registerCreatorStudioRoutes(
     const games = summarizeGameHealth(events).filter((game) => owned.has(game.slug));
 
     const body: CreatorHealthResponse = { days: scanned, truncated, games };
+    return reply.send(body);
+  });
+
+  /**
+   * Votes and feedback themes for the creator's own published games.
+   *
+   * The third of IL-2's exit questions — "what do they say" — which the health route above
+   * cannot answer at any window size, because votes, feedback and themes are not derived
+   * from play events at all. Reads the scorecards the nightly sweep already wrote: cheap
+   * (one document per game), and it means the studio and the weekly digest cannot report
+   * different numbers, since both read the same document.
+   *
+   * A game with no scorecard is simply absent from the list rather than present with
+   * zeros — it has not been measured, which is not the same as having been measured as
+   * nothing.
+   */
+  app.get('/api/me/studio/scorecards', async (request, reply) => {
+    if (!requireUser(request, reply)) return;
+
+    const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: MAX_STUDIO_GAMES });
+    const slugs = [
+      ...new Set(
+        records
+          .filter((record) => !record.abandonedAt && record.slug && record.publishedAt)
+          .map((record) => record.slug as string),
+      ),
+    ];
+
+    const cards = await Promise.all(slugs.map((slug) => store.getScorecard(slug)));
+    const scorecards: CreatorScorecardSummary[] = cards
+      .filter((card): card is NonNullable<typeof card> => card !== null)
+      .map((card) => ({
+        slug: card.slug,
+        computedAt: card.computedAt,
+        windowDays: card.window.days.length,
+        truncated: card.window.truncated,
+        votes: card.votes,
+        feedbackCount: card.feedback.count,
+        untrustedThemes: card.untrusted.feedbackThemes ?? [],
+      }));
+
+    const body: CreatorScorecardsResponse = { scorecards };
     return reply.send(body);
   });
 }

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -246,6 +246,31 @@ describe('CreatorStudioView — what players think', () => {
     root.unmount();
   });
 
+  it('does not re-read scorecards when the creator switches the health window', async () => {
+    // A scorecard is the nightly roll-up's fixed window; it cannot change when the
+    // creator toggles 7/14/30d. Re-fetching would re-read every one of their games for a
+    // response guaranteed to be identical.
+    fetchStudioScorecards.mockResolvedValue([scorecard()]);
+
+    const { container, root } = await openStats();
+    expect(fetchStudioScorecards).toHaveBeenCalledTimes(1);
+    const healthCallsBefore = fetchStudioHealth.mock.calls.length;
+
+    const otherWindow = Array.from(container.querySelectorAll('.health-window')).find(
+      (button) => !button.className.includes('is-active'),
+    );
+    expect(otherWindow).toBeTruthy();
+    await act(async () => {
+      otherWindow!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Health follows the window; scorecards do not.
+    expect(fetchStudioHealth.mock.calls.length).toBeGreaterThan(healthCallsBefore);
+    expect(fetchStudioScorecards).toHaveBeenCalledTimes(1);
+
+    root.unmount();
+  });
+
   it('shows nothing at all for a game that has not been rolled up yet', async () => {
     // Absent, not zero: no scorecard means unmeasured, which is not the same as measured
     // and found empty.

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -5,10 +5,11 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatorStudioView } from './CreatorStudioView.js';
 import i18n from './i18n/index.js';
-import type { StudioGame } from './studioApi.js';
+import type { StudioGame, StudioScorecard } from './studioApi.js';
 
 const fetchStudioGames = vi.fn();
 const fetchStudioHealth = vi.fn();
+const fetchStudioScorecards = vi.fn();
 let authUser: { uid: string; name: string } | null = null;
 
 vi.mock('./AuthContext', () => ({
@@ -21,6 +22,7 @@ vi.mock('./studioApi', async () => {
     ...actual,
     fetchStudioGames: (...args: unknown[]) => fetchStudioGames(...args),
     fetchStudioHealth: (...args: unknown[]) => fetchStudioHealth(...args),
+    fetchStudioScorecards: (...args: unknown[]) => fetchStudioScorecards(...args),
     submitImprovement: vi.fn(),
   };
 });
@@ -47,6 +49,7 @@ async function renderStudio() {
   await act(async () => {
     await fetchStudioGames.mock.results[0]?.value;
     await fetchStudioHealth.mock.results[0]?.value;
+    await fetchStudioScorecards.mock.results[0]?.value;
   });
   return { container, root };
 }
@@ -57,6 +60,8 @@ describe('CreatorStudioView', () => {
     fetchStudioGames.mockReset();
     fetchStudioHealth.mockReset();
     fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset();
+    fetchStudioScorecards.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -135,6 +140,131 @@ describe('CreatorStudioView', () => {
 
     expect(container.querySelector('.studio-layout')?.classList.contains('is-focus')).toBe(true);
     expect(container.querySelector('.studio-game-switcher')?.textContent).toMatch(/10 games/i);
+
+    root.unmount();
+  });
+});
+
+describe('CreatorStudioView — what players think', () => {
+  const published: StudioGame[] = [
+    {
+      token: 'token-live',
+      title: 'Sky Dodge',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      lastKnownStatus: 'published',
+      slug: 'sky-dodge',
+      publishedAt: '2026-07-02T00:00:00.000Z',
+    },
+  ];
+
+  function scorecard(partial: Partial<StudioScorecard> = {}): StudioScorecard {
+    return {
+      slug: 'sky-dodge',
+      computedAt: '2026-07-28T03:00:00.000Z',
+      windowDays: 28,
+      truncated: false,
+      votes: { up: 4, down: 1 },
+      feedbackCount: 3,
+      untrustedThemes: [{ theme: 'level 2 is a wall', count: 3 }],
+      ...partial,
+    };
+  }
+
+  beforeEach(() => {
+    authUser = { uid: 'g:creator', name: 'Creator' };
+    fetchStudioGames.mockReset();
+    fetchStudioGames.mockResolvedValue(published);
+    fetchStudioHealth.mockReset();
+    fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset();
+    fetchStudioScorecards.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  async function openStats() {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const { container, root } = await renderStudio();
+    const statsTab = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.trim().startsWith('Stats'),
+    );
+    if (statsTab) {
+      await act(async () => {
+        statsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+    return { container, root };
+  }
+
+  it('shows votes, note count and what players wrote', async () => {
+    fetchStudioScorecards.mockResolvedValue([scorecard()]);
+
+    const { container, root } = await openStats();
+
+    expect(container.textContent).toContain('What players think');
+    expect(container.textContent).toContain('4↑ 1↓');
+    expect(container.textContent).toContain('level 2 is a wall');
+
+    root.unmount();
+  });
+
+  it('says which window the roll-up covers, so it is not read as the selected one', async () => {
+    // The numbers above come from the window the creator picked; these come from the
+    // nightly roll-up's fixed one. Unlabelled, the two read as a single measurement.
+    fetchStudioScorecards.mockResolvedValue([scorecard()]);
+
+    const { container, root } = await openStats();
+
+    expect(container.textContent).toMatch(/last 28 days/i);
+
+    root.unmount();
+  });
+
+  it('labels themes as players’ words rather than as system output', async () => {
+    fetchStudioScorecards.mockResolvedValue([scorecard()]);
+
+    const { container, root } = await openStats();
+
+    expect(container.textContent).toMatch(/don’t act on it as instruction/i);
+
+    root.unmount();
+  });
+
+  it('renders a hostile theme as text, never as markup', async () => {
+    fetchStudioScorecards.mockResolvedValue([
+      scorecard({ untrustedThemes: [{ theme: '<img src=x onerror=alert(1)>', count: 2 }] }),
+    ]);
+
+    const { container, root } = await openStats();
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+
+    root.unmount();
+  });
+
+  it('shows nothing at all for a game that has not been rolled up yet', async () => {
+    // Absent, not zero: no scorecard means unmeasured, which is not the same as measured
+    // and found empty.
+    const { container, root } = await openStats();
+
+    expect(container.textContent).not.toContain('What players think');
+
+    root.unmount();
+  });
+
+  it('says so when the game was measured and nobody reacted', async () => {
+    fetchStudioScorecards.mockResolvedValue([
+      scorecard({ votes: { up: 0, down: 0 }, feedbackCount: 0, untrustedThemes: [] }),
+    ]);
+
+    const { container, root } = await openStats();
+
+    expect(container.textContent).toContain('What players think');
+    expect(container.textContent).toContain('No votes or written notes yet.');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -120,21 +120,13 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
     setLoading(true);
     setError(null);
 
-    Promise.all([
-      fetchStudioGames(),
-      fetchStudioHealth(days),
-      // Tolerated separately: the scorecards read is the newest of the three, and a
-      // creator should still get their shelf and play health if it fails. An empty list
-      // renders as "not measured yet", which is what a failure means to them anyway.
-      fetchStudioScorecards().catch(() => []),
-    ])
-      .then(([shelf, health, cards]) => {
+    Promise.all([fetchStudioGames(), fetchStudioHealth(days)])
+      .then(([shelf, health]) => {
         if (cancelled) return;
         setGames(shelf);
         setHealthRows(health.games);
         setHealthDays(health.days);
         setTruncated(health.truncated);
-        setScorecards(cards);
         setLoading(false);
         setSelected((current) => {
           if (current && shelf.some((game) => game.token === current)) return current;
@@ -152,6 +144,33 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
       cancelled = true;
     };
   }, [user, days, t]);
+
+  // Keyed on `user` alone, deliberately: a scorecard is the nightly roll-up's fixed window
+  // and does not move when the creator switches 7/14/30d. Fetching it in the effect above
+  // re-read every one of their games on each toggle, for a response that could not change.
+  //
+  // Tolerated separately too — a creator should still get their shelf and play health if
+  // this fails, and an empty list renders as "not measured yet", which is what a failure
+  // means to them anyway.
+  useEffect(() => {
+    if (!user) {
+      setScorecards([]);
+      return;
+    }
+
+    let cancelled = false;
+    fetchStudioScorecards()
+      .then((cards) => {
+        if (!cancelled) setScorecards(cards);
+      })
+      .catch(() => {
+        if (!cancelled) setScorecards([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   const selectedGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
   const selectedHealth = selectedGame ? healthFor(selectedGame, healthRows) : null;

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -19,9 +19,11 @@ import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
   fetchStudioGames,
   fetchStudioHealth,
+  fetchStudioScorecards,
   submitImprovement,
   type StudioApiError,
   type StudioGame,
+  type StudioScorecard,
 } from './studioApi.js';
 
 /**
@@ -86,6 +88,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
   const [authOpen, setAuthOpen] = useState(false);
   const [games, setGames] = useState<StudioGame[]>([]);
   const [healthRows, setHealthRows] = useState<GameHealth[]>([]);
+  const [scorecards, setScorecards] = useState<StudioScorecard[]>([]);
   const [healthDays, setHealthDays] = useState<string[]>([]);
   const [truncated, setTruncated] = useState(false);
   const [days, setDays] = useState(7);
@@ -108,6 +111,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
     if (!user) {
       setGames([]);
       setHealthRows([]);
+      setScorecards([]);
       setLoading(false);
       return;
     }
@@ -116,13 +120,21 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
     setLoading(true);
     setError(null);
 
-    Promise.all([fetchStudioGames(), fetchStudioHealth(days)])
-      .then(([shelf, health]) => {
+    Promise.all([
+      fetchStudioGames(),
+      fetchStudioHealth(days),
+      // Tolerated separately: the scorecards read is the newest of the three, and a
+      // creator should still get their shelf and play health if it fails. An empty list
+      // renders as "not measured yet", which is what a failure means to them anyway.
+      fetchStudioScorecards().catch(() => []),
+    ])
+      .then(([shelf, health, cards]) => {
         if (cancelled) return;
         setGames(shelf);
         setHealthRows(health.games);
         setHealthDays(health.days);
         setTruncated(health.truncated);
+        setScorecards(cards);
         setLoading(false);
         setSelected((current) => {
           if (current && shelf.some((game) => game.token === current)) return current;
@@ -143,6 +155,8 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
 
   const selectedGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
   const selectedHealth = selectedGame ? healthFor(selectedGame, healthRows) : null;
+  const selectedScorecard =
+    selectedGame?.slug ? (scorecards.find((card) => card.slug === selectedGame.slug) ?? null) : null;
   const visibleGames = useMemo(
     () => filterStudioGames(games, { filter: shelfFilter, query: shelfQuery }),
     [games, shelfFilter, shelfQuery],
@@ -368,6 +382,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                     days={days}
                     healthDays={healthDays}
                     truncated={truncated}
+                    scorecard={selectedScorecard}
                     onDaysChange={setDays}
                   />
                 ) : null}
@@ -662,6 +677,7 @@ function StatsTab({
   days,
   healthDays,
   truncated,
+  scorecard,
   onDaysChange,
 }: {
   game: StudioGame;
@@ -669,6 +685,7 @@ function StatsTab({
   days: number;
   healthDays: string[];
   truncated: boolean;
+  scorecard: StudioScorecard | null;
   onDaysChange: (days: number) => void;
 }) {
   const { t } = useTranslation();
@@ -736,6 +753,8 @@ function StatsTab({
         </ul>
       )}
 
+      <PlayerReactions scorecard={scorecard} />
+
       {health && health.errorSamples.length > 0 ? (
         <div className="studio-error-samples">
           <h3 className="health-section-title">{t('studioPanel.stats.errorSamples')}</h3>
@@ -744,6 +763,67 @@ function StatsTab({
               <li key={sample.message}>
                 <code>{sample.message}</code>
                 <span className="health-error-count">×{sample.count}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Votes and what players wrote — the third question the stats tab has to answer.
+ *
+ * Separated visually from the numbers above because it is measured over a different
+ * window: the health block recomputes over the window the creator picked, while these come
+ * from the nightly scorecard's fixed roll. Two windows on one screen is fine; two windows
+ * that look like one is not, so the period is stated.
+ *
+ * Themes are player-written text summarized by a model. React escapes them, which is what
+ * makes showing them safe; the label is what stops them being mistaken for something the
+ * system is asserting.
+ */
+function PlayerReactions({ scorecard }: { scorecard: StudioScorecard | null }) {
+  const { t } = useTranslation();
+
+  // Absent, not zero: no scorecard means this game has not been rolled up yet, which is
+  // not the same as a game measured and found to have no reactions.
+  if (!scorecard) return null;
+
+  const themes = scorecard.untrustedThemes;
+  const nothingYet = scorecard.votes.up === 0 && scorecard.votes.down === 0 && scorecard.feedbackCount === 0;
+
+  return (
+    <div className="studio-reactions">
+      <h3 className="health-section-title">{t('studioPanel.stats.reactions')}</h3>
+      <p className="studio-stats-range">{t('studioPanel.stats.reactionsWindow', { days: scorecard.windowDays })}</p>
+
+      {nothingYet ? (
+        <p className="studio-empty">{t('studioPanel.stats.reactionsEmpty')}</p>
+      ) : (
+        <ul className="funnel-stats">
+          <li>
+            <span className="funnel-stat-value">
+              {scorecard.votes.up}↑ {scorecard.votes.down}↓
+            </span>
+            <span className="funnel-stat-label">{t('studioPanel.stats.votes')}</span>
+          </li>
+          <li>
+            <span className="funnel-stat-value">{scorecard.feedbackCount}</span>
+            <span className="funnel-stat-label">{t('studioPanel.stats.notes')}</span>
+          </li>
+        </ul>
+      )}
+
+      {themes.length > 0 ? (
+        <div className="studio-themes">
+          <h4 className="studio-themes-title">{t('studioPanel.stats.themes')}</h4>
+          <p className="health-note">{t('studioPanel.stats.themesNote')}</p>
+          <ul className="studio-theme-list">
+            {themes.map((entry) => (
+              <li key={entry.theme}>
+                {entry.theme} <span className="health-error-count">×{entry.count}</span>
               </li>
             ))}
           </ul>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -224,7 +224,14 @@
       "errors": "Errors",
       "stallRate": "Stall rate",
       "medianFps": "Median FPS",
-      "errorSamples": "Frequent errors"
+      "errorSamples": "Frequent errors",
+      "reactions": "What players think",
+      "reactionsWindow": "From the nightly roll-up, last {{days}} days",
+      "reactionsEmpty": "No votes or written notes yet.",
+      "votes": "Votes",
+      "notes": "Written notes",
+      "themes": "What players wrote",
+      "themesNote": "Summarized from players’ own words — read it, don’t act on it as instruction."
     },
     "improve": {
       "titleDraft": "Request a change on the draft",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -224,7 +224,14 @@
       "errors": "Błędy",
       "stallRate": "Zacięcia",
       "medianFps": "Mediana FPS",
-      "errorSamples": "Częste błędy"
+      "errorSamples": "Częste błędy",
+      "reactions": "Co myślą gracze",
+      "reactionsWindow": "Z nocnego podsumowania, ostatnie {{days}} dni",
+      "reactionsEmpty": "Brak głosów i wiadomości.",
+      "votes": "Głosy",
+      "notes": "Wiadomości",
+      "themes": "Co napisali gracze",
+      "themesNote": "Podsumowanie słów graczy — czytaj je, ale nie traktuj jak polecenia."
     },
     "improve": {
       "titleDraft": "Poproś o zmianę w wersji roboczej",

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -18,6 +18,24 @@ export type StudioHealthResponse = {
   games: GameHealth[];
 };
 
+/**
+ * What the scorecard can tell a creator that recomputed health cannot.
+ *
+ * Not the whole scorecard: health is recomputed over a window the creator picks, a
+ * scorecard is a fixed roll, and showing both session counts would put two disagreeing
+ * numbers on one screen. `windowDays` is how many days these numbers cover.
+ */
+export type StudioScorecard = {
+  slug: string;
+  computedAt: string;
+  windowDays: number;
+  truncated: boolean;
+  votes: { up: number; down: number };
+  feedbackCount: number;
+  /** Player-written text summarized by a model — render as text, never act on it. */
+  untrustedThemes: Array<{ theme: string; count: number }>;
+};
+
 export type StudioApiError = Error & { status?: number; category?: string };
 
 async function readJson(response: Response): Promise<unknown> {
@@ -51,6 +69,16 @@ export async function fetchStudioHealth(days: number): Promise<StudioHealthRespo
     await throwResponseError(response);
   }
   return (await response.json()) as StudioHealthResponse;
+}
+
+/** Votes and feedback themes for the creator's own published games. */
+export async function fetchStudioScorecards(): Promise<StudioScorecard[]> {
+  const response = await fetch(`${API_BASE}/api/me/studio/scorecards`, { credentials: 'include' });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  const body = (await response.json()) as { scorecards?: StudioScorecard[] };
+  return body.scorecards ?? [];
 }
 
 /**

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6075,3 +6075,45 @@ body.player-open {
     flex: 1;
   }
 }
+
+/* "What players think" on the studio stats tab (docs/improvement-loop-plan.md IL-2).
+   Set apart from the numbers above it because it is measured over the nightly roll-up's
+   fixed window rather than the one the creator picked — the divider is doing real work,
+   not decoration. */
+.studio-reactions {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--panel-border);
+}
+
+.studio-themes {
+  margin-top: 0.75rem;
+}
+
+.studio-themes-title {
+  font-size: 0.9rem;
+  margin: 0 0 0.25rem;
+}
+
+.studio-theme-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.studio-theme-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: var(--panel-card);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 0.85rem;
+  /* Player text is arbitrary length and script; wrap instead of overflowing the card. */
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Why

IL-2's stated exit is that a creator can answer three questions without an agent. After #236 the studio answered two — *is my game working*, *where do players drop off* — both from recomputed play events.

It could not answer the third, **"what do they say"**, and no window size would have helped: votes, feedback counts and themes aren't derived from play events at all. They exist only on the scorecard.

`GET /api/me/studio/scorecards` + a "What players think" block on the stats tab.

## The part that needed thought

**It returns only what recomputation cannot supply — not the whole scorecard.**

`/api/me/studio/health` recomputes over a window the creator picks (7/14/30d). A scorecard is a fixed nightly roll. Returning its session counts *as well* would put two numbers labelled "sessions" on one screen, disagreeing, with nothing on the page to explain why — a bug that looks exactly like a data bug and would be debugged as one.

So the response carries votes, feedback count, themes, `computedAt` and `windowDays`; the window travels with the numbers, the UI states it ("last 28 days"), and there's a test asserting the response has no `sessions` field at all.

## `untrustedThemes`

Themes cross the wire under that name deliberately. They're player-written text summarized by a model that read player-written text, so they inherit that taint completely — and a field name is read by everyone who touches it in a way a comment isn't. It's the same reasoning as `card.untrusted` server-side.

The UI labels them as players' words to read rather than act on. A test drives ``'&lt;img src=x onerror=alert(1)&gt;'`` through to the DOM and asserts it arrives as text with no element created from it.

## Absence stays absence

A game with no scorecard is **omitted** from the list, not returned with zeros — unmeasured isn't the same as measured and found empty, and the panel renders nothing at all for it. A game that *was* rolled up and genuinely has no reactions says so instead.

The scorecards fetch is also tolerated independently of the other two: if it fails, the creator still gets their shelf and play health.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check` (api + web)
- [x] `npm test` — api 777 (+7), web 320 (+6)
- [x] `npm run build`

API tests: the response shape; no `sessions`/`finishRate` leakage; a game with no scorecard omitted; another creator's game never returned; an unpublished game excluded even if a scorecard exists; 401 unauthenticated.

View tests: votes/notes/themes render; the window is stated; the untrusted label is present; a hostile theme renders as text; no block when unmeasured; an explicit "nothing yet" when measured and empty.

## Note

Stacked on top of #236 (merged). It does not depend on #287 (weekly digest) — but both read the same scorecard documents, which is the point: the studio and the digest cannot report different numbers.

## Instrumentation definition-of-done

No new capture. This is a read of aggregates IL-2 already produces, scoped to the one person entitled to see them for their own games.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4qCA3ruvWreLtyibx71q)_