### PR TITLE
fix(e2e): unblock Cloud Run deploy after Creator Studio rewrite

### DIFF
--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -83,10 +83,14 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
     expect(describeProblems(watcher.drain())).toBe('');
   });
 
-  it('tells the visitor an expired tracking token is invalid', async () => {
+  it('lands legacy /status links in Creator Studio instead of a dead page', async () => {
+    // `/status/:token` is an alias for `/studio/:token`. An unknown token no longer
+    // renders the old "invalid tracking link" panel — Studio loads the creator's
+    // shelf (empty for this bot identity) and stays usable.
     await visit(page, '/status/deadbeefdeadbeef', 3_000);
 
-    expect(await bodyText()).toMatch(/invalid|expired|nieprawidłow|wygasł/i);
+    expect(new URL(page.url()).pathname).toMatch(/^\/studio(\/|$)/);
+    expect(await bodyText()).toMatch(/creator studio|studio twórcy/i);
     expect(describeProblems(watcher.drain())).toBe('');
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creator Studio (#236) never reached Cloud Run: every deploy since the merge failed the browser gate on `resilience.test.ts`, which still expected the old “invalid/expired tracking token” panel for `/status/:token`.

That path now resolves as Creator Studio (empty shelf for the e2e bot). This updates the assertion so the deploy gate matches the product.

## Test plan

- [x] Assertion matches the live failure body from deploy runs (`Creator Studio` / empty shelf)
- [ ] CI + Deploy to Cloud Run green after merge

## Why you couldn’t find Studio

It isn’t live yet. Once this lands and deploy succeeds:

- Direct URL: `/studio`
- Signed-in hamburger menu → **Studio**
- Home **Your games** rail → **Studio** button

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-329e62f8-dd48-45b6-a663-99c556690e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-329e62f8-dd48-45b6-a663-99c556690e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

