### PR TITLE
fix(studio): mobile playtest layout; pause via GameKit events

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -251,7 +251,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
   );
 
   return (
-    <section className="studio-panel">
+    <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}`}>
       <header className="studio-panel-header">
         <div>
           <h1 className="section-title">{t('studioPanel.title')}</h1>

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -47,6 +47,21 @@ type StudioPlaytestPanelProps = {
   published: boolean;
 };
 
+/** Studio playtest assumes landscape games — nudge when the phone is upright. */
+function useNeedsLandscape(): boolean {
+  const [needs, setNeeds] = useState(() =>
+    typeof window !== 'undefined' ? !window.matchMedia('(orientation: landscape)').matches : false,
+  );
+  useEffect(() => {
+    const query = window.matchMedia('(orientation: landscape)');
+    const sync = () => setNeeds(!query.matches);
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+  return needs;
+}
+
 function toContext(
   pngBase64: string | null | undefined,
   instrumentation: PlaytestInstrumentation,
@@ -78,6 +93,7 @@ export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProp
   const [text, setText] = useState('');
   const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent'>('idle');
   const [sendError, setSendError] = useState<string | null>(null);
+  const needsLandscape = useNeedsLandscape();
 
   const active = Boolean(html);
   const { paused, snapshot, instrumentation, pause, resume, clearSnapshot } = useCreatorPlaytest(frameRef, active);
@@ -161,7 +177,15 @@ export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProp
 
       {html ? (
         <div className={`studio-playtest-stage${paused ? ' is-paused' : ''}`}>
-          <GameFrame frameRef={frameRef} title={game.title} html={html} embed />
+          <div className="studio-playtest-viewport">
+            <GameFrame frameRef={frameRef} title={game.title} html={html} embed />
+            {needsLandscape ? (
+              <div className="studio-playtest-rotate" role="status">
+                <PixelIcon name="gamepad" size={14} />
+                <span>{t('player.rotateLandscape')}</span>
+              </div>
+            ) : null}
+          </div>
           <div className="studio-playtest-controls">
             {paused ? (
               <button type="button" className="secondary-btn" onClick={resume}>

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -47,18 +47,30 @@ type StudioPlaytestPanelProps = {
   published: boolean;
 };
 
-/** Studio playtest assumes landscape games — nudge when the phone is upright. */
+/**
+ * Studio playtest assumes landscape games — nudge when a handheld is upright.
+ * Desktop windows can be any shape (owner resizes; don't tell them to rotate).
+ * Mirrors GameTheater's coarse-pointer gate + Mascot's Safari MediaQueryList shim.
+ */
 function useNeedsLandscape(): boolean {
-  const [needs, setNeeds] = useState(() =>
-    typeof window !== 'undefined' ? !window.matchMedia('(orientation: landscape)').matches : false,
-  );
+  const [needs, setNeeds] = useState(false);
+
   useEffect(() => {
-    const query = window.matchMedia('(orientation: landscape)');
+    if (typeof matchMedia !== 'function' || !matchMedia('(pointer: coarse)').matches) {
+      setNeeds(false);
+      return;
+    }
+    const query = matchMedia('(orientation: landscape)');
     const sync = () => setNeeds(!query.matches);
     sync();
-    query.addEventListener('change', sync);
-    return () => query.removeEventListener('change', sync);
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', sync);
+      return () => query.removeEventListener('change', sync);
+    }
+    query.addListener(sync);
+    return () => query.removeListener(sync);
   }, []);
+
   return needs;
 }
 

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -150,4 +150,36 @@ describe('the injected bridge reports health', () => {
     expect(bridge.frameWindow.document.getElementById('gdpl-pause-overlay')).toBeNull();
     bridge.stop();
   });
+
+  it('holds requestAnimationFrame callbacks while paused so the sim actually stops', async () => {
+    const bridge = runBridge('<canvas id="game" width="8" height="8"></canvas>');
+    let ticks = 0;
+    const frameWindow = bridge.frameWindow as Window & typeof globalThis;
+
+    bridge.frameWindow.dispatchEvent(
+      new bridge.frameWindow.MessageEvent('message', {
+        data: { source: 'gdpl-host', type: 'pause' },
+      }),
+    );
+    await delivered();
+
+    const heldId = frameWindow.requestAnimationFrame(() => {
+      ticks += 1;
+    });
+    // Give any eager rAF polyfill a turn — held callbacks must not run while paused.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(ticks).toBe(0);
+
+    // Cancelling a held id must drop it so resume does not flush a stale frame.
+    frameWindow.cancelAnimationFrame(heldId);
+    bridge.frameWindow.dispatchEvent(
+      new bridge.frameWindow.MessageEvent('message', {
+        data: { source: 'gdpl-host', type: 'resume' },
+      }),
+    );
+    await delivered();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(ticks).toBe(0);
+    bridge.stop();
+  });
 });

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -125,6 +125,10 @@ describe('the injected bridge reports health', () => {
     // jsdom's cross-realm postMessage into an iframe is unreliable; dispatch the
     // host envelope the same way the real parent would deliver it.
     const bridge = runBridge('<canvas id="game" width="40" height="20"></canvas>');
+    const pauseEvents: Event[] = [];
+    const resumeEvents: Event[] = [];
+    bridge.frameWindow.document.addEventListener('gdpl-pause', (event) => pauseEvents.push(event));
+    bridge.frameWindow.document.addEventListener('gdpl-resume', (event) => resumeEvents.push(event));
 
     bridge.frameWindow.dispatchEvent(
       new bridge.frameWindow.MessageEvent('message', {
@@ -139,6 +143,7 @@ describe('the injected bridge reports health', () => {
     expect(snap?.paused).toBe(true);
     expect(snap?.reason).toBe('pause');
     expect(bridge.frameWindow.document.getElementById('gdpl-pause-overlay')).not.toBeNull();
+    expect(pauseEvents).toHaveLength(1);
 
     bridge.frameWindow.dispatchEvent(
       new bridge.frameWindow.MessageEvent('message', {
@@ -148,38 +153,7 @@ describe('the injected bridge reports health', () => {
     await delivered();
     expect(bridge.received.some((message) => message.type === 'resumed')).toBe(true);
     expect(bridge.frameWindow.document.getElementById('gdpl-pause-overlay')).toBeNull();
-    bridge.stop();
-  });
-
-  it('holds requestAnimationFrame callbacks while paused so the sim actually stops', async () => {
-    const bridge = runBridge('<canvas id="game" width="8" height="8"></canvas>');
-    let ticks = 0;
-    const frameWindow = bridge.frameWindow as Window & typeof globalThis;
-
-    bridge.frameWindow.dispatchEvent(
-      new bridge.frameWindow.MessageEvent('message', {
-        data: { source: 'gdpl-host', type: 'pause' },
-      }),
-    );
-    await delivered();
-
-    const heldId = frameWindow.requestAnimationFrame(() => {
-      ticks += 1;
-    });
-    // Give any eager rAF polyfill a turn — held callbacks must not run while paused.
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(ticks).toBe(0);
-
-    // Cancelling a held id must drop it so resume does not flush a stale frame.
-    frameWindow.cancelAnimationFrame(heldId);
-    bridge.frameWindow.dispatchEvent(
-      new bridge.frameWindow.MessageEvent('message', {
-        data: { source: 'gdpl-host', type: 'resume' },
-      }),
-    );
-    await delivered();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(ticks).toBe(0);
+    expect(resumeEvents).toHaveLength(1);
     bridge.stop();
   });
 });

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -2,16 +2,17 @@ import { describe, it, expect } from 'vitest';
 import { embedGameHtml, withGameLocale } from './gamePlayer.js';
 
 describe('embedGameHtml', () => {
-  it('injects the hide-chrome style and bridge script before </body>', () => {
+  it('injects the hide-chrome style and bridge script in <head> before game body work', () => {
     const html = '<html><head></head><body><canvas id="game"></canvas></body></html>';
     const out = embedGameHtml(html);
 
-    // Style + script land inside the document, before the closing body tag.
+    // Style + script land inside the document early so pause patches precede game loops.
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('#game-title,#game-desc,.game-controls,.hint{display:none!important}');
     expect(out).toContain('gdpl-player');
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</body>'));
-    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</body>'));
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeGreaterThan(out.indexOf('<head'));
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</head>'));
+    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('<body'));
     // Original game content is preserved.
     expect(out).toContain('<canvas id="game">');
   });
@@ -24,11 +25,24 @@ describe('embedGameHtml', () => {
     expect(out).toContain("type:'key'");
   });
 
+  it('falls back to <body> when there is no <head>', () => {
+    const out = embedGameHtml('<html><body><canvas id="game"></canvas></body></html>');
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeGreaterThan(out.indexOf('<body'));
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('<canvas'));
+  });
+
   it('appends the injection when there is no </body>', () => {
     const out = embedGameHtml('<canvas id="game"></canvas>');
     expect(out.startsWith('<canvas id="game"></canvas>')).toBe(true);
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('<script>');
+  });
+
+  it('freezes requestAnimationFrame while the host asks for pause', () => {
+    const out = embedGameHtml('<html><head></head><body></body></html>');
+    expect(out).toContain('heldRaf');
+    expect(out).toContain('flushHeldRaf');
+    expect(out).toContain('suspendAudio');
   });
 });
 

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -2,17 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { embedGameHtml, withGameLocale } from './gamePlayer.js';
 
 describe('embedGameHtml', () => {
-  it('injects the hide-chrome style and bridge script in <head> before game body work', () => {
+  it('injects the hide-chrome style and bridge script before </body>', () => {
     const html = '<html><head></head><body><canvas id="game"></canvas></body></html>';
     const out = embedGameHtml(html);
 
-    // Style + script land inside the document early so pause patches precede game loops.
+    // Style + script land inside the document, before the closing body tag.
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('#game-title,#game-desc,.game-controls,.hint{display:none!important}');
     expect(out).toContain('gdpl-player');
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeGreaterThan(out.indexOf('<head'));
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</head>'));
-    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('<body'));
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</body>'));
+    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</body>'));
     // Original game content is preserved.
     expect(out).toContain('<canvas id="game">');
   });
@@ -25,12 +24,6 @@ describe('embedGameHtml', () => {
     expect(out).toContain("type:'key'");
   });
 
-  it('falls back to <body> when there is no <head>', () => {
-    const out = embedGameHtml('<html><body><canvas id="game"></canvas></body></html>');
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeGreaterThan(out.indexOf('<body'));
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('<canvas'));
-  });
-
   it('appends the injection when there is no </body>', () => {
     const out = embedGameHtml('<canvas id="game"></canvas>');
     expect(out.startsWith('<canvas id="game"></canvas>')).toBe(true);
@@ -38,11 +31,14 @@ describe('embedGameHtml', () => {
     expect(out).toContain('<script>');
   });
 
-  it('freezes requestAnimationFrame while the host asks for pause', () => {
+  it('dispatches gdpl-pause / gdpl-resume so GameKit can freeze the sim', () => {
     const out = embedGameHtml('<html><head></head><body></body></html>');
-    expect(out).toContain('heldRaf');
-    expect(out).toContain('flushHeldRaf');
-    expect(out).toContain('suspendAudio');
+    expect(out).toContain("CustomEvent('gdpl-pause')");
+    expect(out).toContain("CustomEvent('gdpl-resume')");
+    // Freeze is GameKit's job — the bridge must not patch globals.
+    expect(out).not.toContain('heldRaf');
+    expect(out).not.toContain('flushHeldRaf');
+    expect(out).not.toContain('suspendAudio');
   });
 });
 

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -45,56 +45,11 @@ const BRIDGE = `(function(){
     var r=e&&e.reason;post({type:'error',message:String((r&&r.message)||r||'unhandled rejection').slice(0,200)});
   });
   var frames=0,paused=false,overlay=null,lastAlive=0;
-  // Freeze game loops without games-repo cooperation. Overlay alone only veiled the
-  // canvas while rAF/timers kept ticking (Creator Studio pause felt broken). Patch
-  // globals early so games that look up requestAnimationFrame each frame are held;
-  // already-scheduled native callbacks may run once more, then re-enter the patch.
-  var _raf=window.requestAnimationFrame&&window.requestAnimationFrame.bind(window);
-  var _caf=window.cancelAnimationFrame&&window.cancelAnimationFrame.bind(window);
-  var _si=window.setInterval.bind(window);
-  var heldRaf=[],rafSeq=0,heldRafIds={},audioCtxs=[];
-  if(_raf){
-    window.requestAnimationFrame=function(cb){
-      if(!paused)return _raf(cb);
-      var id=++rafSeq;
-      heldRaf.push({id:id,cb:cb});
-      heldRafIds[id]=1;
-      return id;
-    };
-    window.cancelAnimationFrame=function(id){
-      if(heldRafIds[id]){
-        heldRaf=heldRaf.filter(function(h){return h.id!==id;});
-        delete heldRafIds[id];
-        return;
-      }
-      if(_caf)_caf(id);
-    };
-  }
-  var OrigAC=window.AudioContext||window.webkitAudioContext;
-  if(OrigAC){
-    var WrapAC=function(){
-      var ctx=new OrigAC();
-      try{audioCtxs.push(ctx);}catch(err){}
-      if(paused&&ctx.suspend)try{ctx.suspend();}catch(err){}
-      return ctx;
-    };
-    WrapAC.prototype=OrigAC.prototype;
-    window.AudioContext=WrapAC;
-    if('webkitAudioContext'in window)window.webkitAudioContext=WrapAC;
-  }
-  function suspendAudio(yes){
-    for(var i=0;i<audioCtxs.length;i++){
-      var c=audioCtxs[i];
-      try{if(yes){if(c.suspend)c.suspend();}else if(c.resume)c.resume();}catch(err){}
-    }
-  }
-  function flushHeldRaf(){
-    var q=heldRaf;heldRaf=[];heldRafIds={};
-    if(!_raf)return;
-    for(var i=0;i<q.length;i++){(function(cb){_raf(function(t){try{cb(t);}catch(err){}});}(q[i].cb));}
-  }
-  if(_raf){(function tick(){frames++;requestAnimationFrame(tick);})();}
-  _si(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
+  // Freeze is owned by GameKit (gdpl-pause / gdpl-resume on document). The bridge
+  // only dispatches those events, shows the veil, and snapshots — it does not patch
+  // requestAnimationFrame or AudioContext.
+  if('requestAnimationFrame'in window){(function tick(){frames++;requestAnimationFrame(tick);})();}
+  setInterval(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
   function largestCanvas(){
     var best=null,area=0,list=document.querySelectorAll('canvas');
     for(var i=0;i<list.length;i++){
@@ -194,12 +149,9 @@ const BRIDGE = `(function(){
       var png=capturePng();
       document.dispatchEvent(new CustomEvent('gdpl-pause'));
       showOverlay();
-      suspendAudio(true);
       sendSnapshot('pause',png);
     }else{
       hideOverlay();
-      suspendAudio(false);
-      flushHeldRaf();
       document.dispatchEvent(new CustomEvent('gdpl-resume'));
       post({type:'resumed'});
     }
@@ -231,24 +183,12 @@ const HIDE_CHROME = `#game-title,#game-desc,.game-controls,.hint{display:none!im
 
 /**
  * Injects the player bridge + hide-chrome style into an assembled game document
- * so it can run headless-of-its-own-chrome inside the app's player.
- *
- * Prefers `<head>` (then `<body>`, then `</body>`, then append) so rAF / AudioContext
- * patches land before game scripts schedule their loops — pause in Creator Studio
- * depends on that ordering.
+ * so it can run headless-of-its-own-chrome inside the app's player. Falls back to
+ * appending if there's no </body> (assembled games always have one, but be safe).
  */
 export function embedGameHtml(html: string): string {
   const inject = `<style id="gdpl-embed">${HIDE_CHROME}</style><script>${BRIDGE}</script>`;
-  if (/<head\b[^>]*>/i.test(html)) {
-    return html.replace(/<head\b[^>]*>/i, (open) => `${open}${inject}`);
-  }
-  if (/<body\b[^>]*>/i.test(html)) {
-    return html.replace(/<body\b[^>]*>/i, (open) => `${open}${inject}`);
-  }
-  if (html.includes('</body>')) {
-    return html.replace('</body>', `${inject}</body>`);
-  }
-  return html + inject;
+  return html.includes('</body>') ? html.replace('</body>', `${inject}</body>`) : html + inject;
 }
 
 /** en/pl are the only locales games ship strings for; anything else maps to en. */

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -45,8 +45,56 @@ const BRIDGE = `(function(){
     var r=e&&e.reason;post({type:'error',message:String((r&&r.message)||r||'unhandled rejection').slice(0,200)});
   });
   var frames=0,paused=false,overlay=null,lastAlive=0;
-  if('requestAnimationFrame'in window){(function tick(){frames++;requestAnimationFrame(tick);})();}
-  setInterval(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
+  // Freeze game loops without games-repo cooperation. Overlay alone only veiled the
+  // canvas while rAF/timers kept ticking (Creator Studio pause felt broken). Patch
+  // globals early so games that look up requestAnimationFrame each frame are held;
+  // already-scheduled native callbacks may run once more, then re-enter the patch.
+  var _raf=window.requestAnimationFrame&&window.requestAnimationFrame.bind(window);
+  var _caf=window.cancelAnimationFrame&&window.cancelAnimationFrame.bind(window);
+  var _si=window.setInterval.bind(window);
+  var heldRaf=[],rafSeq=0,heldRafIds={},audioCtxs=[];
+  if(_raf){
+    window.requestAnimationFrame=function(cb){
+      if(!paused)return _raf(cb);
+      var id=++rafSeq;
+      heldRaf.push({id:id,cb:cb});
+      heldRafIds[id]=1;
+      return id;
+    };
+    window.cancelAnimationFrame=function(id){
+      if(heldRafIds[id]){
+        heldRaf=heldRaf.filter(function(h){return h.id!==id;});
+        delete heldRafIds[id];
+        return;
+      }
+      if(_caf)_caf(id);
+    };
+  }
+  var OrigAC=window.AudioContext||window.webkitAudioContext;
+  if(OrigAC){
+    var WrapAC=function(){
+      var ctx=new OrigAC();
+      try{audioCtxs.push(ctx);}catch(err){}
+      if(paused&&ctx.suspend)try{ctx.suspend();}catch(err){}
+      return ctx;
+    };
+    WrapAC.prototype=OrigAC.prototype;
+    window.AudioContext=WrapAC;
+    if('webkitAudioContext'in window)window.webkitAudioContext=WrapAC;
+  }
+  function suspendAudio(yes){
+    for(var i=0;i<audioCtxs.length;i++){
+      var c=audioCtxs[i];
+      try{if(yes){if(c.suspend)c.suspend();}else if(c.resume)c.resume();}catch(err){}
+    }
+  }
+  function flushHeldRaf(){
+    var q=heldRaf;heldRaf=[];heldRafIds={};
+    if(!_raf)return;
+    for(var i=0;i<q.length;i++){(function(cb){_raf(function(t){try{cb(t);}catch(err){}});}(q[i].cb));}
+  }
+  if(_raf){(function tick(){frames++;requestAnimationFrame(tick);})();}
+  _si(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
   function largestCanvas(){
     var best=null,area=0,list=document.querySelectorAll('canvas');
     for(var i=0;i<list.length;i++){
@@ -146,9 +194,12 @@ const BRIDGE = `(function(){
       var png=capturePng();
       document.dispatchEvent(new CustomEvent('gdpl-pause'));
       showOverlay();
+      suspendAudio(true);
       sendSnapshot('pause',png);
     }else{
       hideOverlay();
+      suspendAudio(false);
+      flushHeldRaf();
       document.dispatchEvent(new CustomEvent('gdpl-resume'));
       post({type:'resumed'});
     }
@@ -180,12 +231,24 @@ const HIDE_CHROME = `#game-title,#game-desc,.game-controls,.hint{display:none!im
 
 /**
  * Injects the player bridge + hide-chrome style into an assembled game document
- * so it can run headless-of-its-own-chrome inside the app's player. Falls back to
- * appending if there's no </body> (assembled games always have one, but be safe).
+ * so it can run headless-of-its-own-chrome inside the app's player.
+ *
+ * Prefers `<head>` (then `<body>`, then `</body>`, then append) so rAF / AudioContext
+ * patches land before game scripts schedule their loops — pause in Creator Studio
+ * depends on that ordering.
  */
 export function embedGameHtml(html: string): string {
   const inject = `<style id="gdpl-embed">${HIDE_CHROME}</style><script>${BRIDGE}</script>`;
-  return html.includes('</body>') ? html.replace('</body>', `${inject}</body>`) : html + inject;
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/<head\b[^>]*>/i, (open) => `${open}${inject}`);
+  }
+  if (/<body\b[^>]*>/i.test(html)) {
+    return html.replace(/<body\b[^>]*>/i, (open) => `${open}${inject}`);
+  }
+  if (html.includes('</body>')) {
+    return html.replace('</body>', `${inject}</body>`);
+  }
+  return html + inject;
 }
 
 /** en/pl are the only locales games ship strings for; anything else maps to en. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5731,8 +5731,8 @@ body.player-open {
   border: 1px solid var(--panel-border);
   border-radius: 14px;
   overflow: hidden;
-  background: radial-gradient(circle at 50% 20%, rgba(56, 189, 248, 0.1), transparent 55%), #0a0e12;
-  min-height: 280px;
+  background: #05080c;
+  min-height: 0;
 }
 
 .studio-playtest-stage.is-paused {
@@ -5740,16 +5740,50 @@ body.player-open {
   box-shadow: 0 0 24px rgba(0, 228, 172, 0.08);
 }
 
-.studio-playtest-stage .game-frame {
+.studio-playtest-viewport {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
-  aspect-ratio: 16 / 10;
-  min-height: 240px;
+  background: #000;
+  /* Games are landscape — give the stage the width budget, not side padding. */
+  min-height: 0;
+}
+
+.studio-playtest-stage .game-frame {
+  width: min(100%, calc(70vh * 16 / 9));
+  aspect-ratio: 16 / 9;
+  max-height: 70vh;
+  min-height: 180px;
   height: auto;
   border: 0;
   border-radius: 0;
   box-shadow: none;
   display: block;
-  background: transparent;
+  background: #000;
+}
+
+.studio-playtest-rotate {
+  position: absolute;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  left: 12px;
+  right: 12px;
+  margin-inline: auto;
+  width: max-content;
+  max-width: calc(100% - 24px);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(12, 18, 24, 0.88);
+  border: 1px solid rgba(0, 228, 172, 0.32);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .studio-playtest-controls {
@@ -5872,6 +5906,50 @@ body.player-open {
     padding: 18px 16px;
   }
 
+  /* Playtest needs every horizontal pixel — bleed the stage edge-to-edge and keep
+     chrome padding only on the text/controls around it. */
+  .studio-panel.is-playtesting {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .studio-panel.is-playtesting .studio-panel-header,
+  .studio-panel.is-playtesting .studio-empty,
+  .studio-panel.is-playtesting .studio-empty-state,
+  .studio-panel.is-playtesting .studio-game-switcher,
+  .studio-panel.is-playtesting .studio-tabs,
+  .studio-panel.is-playtesting .studio-playtest-hint,
+  .studio-panel.is-playtesting .studio-playtest-prompt,
+  .studio-panel.is-playtesting .studio-muted,
+  .studio-panel.is-playtesting .error {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .studio-panel.is-playtesting .studio-detail {
+    padding: 12px 0 18px;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .studio-panel.is-playtesting .studio-playtest-stage {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .studio-panel.is-playtesting .studio-playtest-stage .game-frame {
+    width: 100%;
+    max-height: min(56vw, 48vh);
+    min-height: 160px;
+  }
+
+  .studio-panel.is-playtesting .studio-playtest-controls {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
   .studio-tabs {
     flex-wrap: nowrap;
     overflow-x: auto;
@@ -5886,6 +5964,13 @@ body.player-open {
 
   .studio-picker {
     width: 100%;
+  }
+}
+
+@media (max-width: 800px) and (orientation: landscape) {
+  .studio-panel.is-playtesting .studio-playtest-stage .game-frame {
+    width: min(100%, calc(78vh * 16 / 9));
+    max-height: 78vh;
   }
 }
 

--- a/docs/improvement-loop-plan.md
+++ b/docs/improvement-loop-plan.md
@@ -446,20 +446,13 @@ considerably:
 - 📋 **Pause-and-prompt enrichment** — first cut ships: bridge `pause` / `resume` /
   `capture`, host accumulates error/alive/progress during the playtest, feedback
   and improve accept optional `context.screenshotPng` + `instrumentation` (fenced
-<<<<<<< HEAD
-  as data; PNG stored as a creator playtest shot). True game-loop pause still
-  needs games-repo cooperation (`gdpl-pause` CustomEvent); today the overlay +
-  frame capture freeze the _moment_ for the prompt even when the sim keeps
-  ticking under the veil.
-=======
-  as data; PNG stored as a creator playtest shot). The bridge now freezes
-  `requestAnimationFrame` (and suspends `AudioContext`s it constructed) on pause
-  so the sim stops under the veil for typical canvas loops; games that closed over
-  a private rAF handle or drive logic only via raw timers may still tick — those
-  can opt into `gdpl-pause` / `gdpl-resume` CustomEvents. Studio playtest assumes
-  landscape and goes edge-to-edge on narrow screens with a rotate nudge when the
-  phone is upright.
->>>>>>> a1f95285 (fix(studio): real playtest pause, landscape stage, fewer margins)
+  as data; PNG stored as a creator playtest shot). The bridge dispatches
+  `gdpl-pause` / `gdpl-resume` CustomEvents (plus overlay + snapshot); GameKit
+  freezes the sim and suspends audio when those fire
+  ([www.gamedev.pl-games#110](https://github.com/gamedevpl/www.gamedev.pl-games/pull/110)).
+  The shell does not patch `requestAnimationFrame` / `AudioContext`. Studio
+  playtest assumes landscape and goes edge-to-edge on narrow screens with a
+  rotate nudge when the phone is upright.
 - 📋 **Suggestion inbox** — cards with insight → evidence → proposed change →
   [Approve → files issue] / [Dismiss with reason]. Dismissal reasons feed router
   tuning. Approval reuses the feedback-comment path that already works.

--- a/docs/improvement-loop-plan.md
+++ b/docs/improvement-loop-plan.md
@@ -446,10 +446,20 @@ considerably:
 - 📋 **Pause-and-prompt enrichment** — first cut ships: bridge `pause` / `resume` /
   `capture`, host accumulates error/alive/progress during the playtest, feedback
   and improve accept optional `context.screenshotPng` + `instrumentation` (fenced
+<<<<<<< HEAD
   as data; PNG stored as a creator playtest shot). True game-loop pause still
   needs games-repo cooperation (`gdpl-pause` CustomEvent); today the overlay +
   frame capture freeze the _moment_ for the prompt even when the sim keeps
   ticking under the veil.
+=======
+  as data; PNG stored as a creator playtest shot). The bridge now freezes
+  `requestAnimationFrame` (and suspends `AudioContext`s it constructed) on pause
+  so the sim stops under the veil for typical canvas loops; games that closed over
+  a private rAF handle or drive logic only via raw timers may still tick — those
+  can opt into `gdpl-pause` / `gdpl-resume` CustomEvents. Studio playtest assumes
+  landscape and goes edge-to-edge on narrow screens with a rotate nudge when the
+  phone is upright.
+>>>>>>> a1f95285 (fix(studio): real playtest pause, landscape stage, fewer margins)
 - 📋 **Suggestion inbox** — cards with insight → evidence → proposed change →
   [Approve → files issue] / [Dismiss with reason]. Dismissal reasons feed router
   tuning. Approval reuses the feedback-comment path that already works.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Studio playtest on mobile was hard to use: the stage was narrow with side padding, and portrait phones got a tiny landscape canvas. Pause behavior is owned by GameKit — not by patching globals in the player bridge.

### Keep (shell / UI)

- Playtest stage is **16:9**, sized to use available width
- On narrow screens, playtest goes **edge-to-edge** (`is-playtesting`)
- **Rotate-to-landscape** nudge when a **coarse-pointer** device is upright (same copy as the main player; desktop tall windows are not nudged)
- Pause overlay + snapshot-before-veil
- Bridge still dispatches `gdpl-pause` / `gdpl-resume` (unchanged contract)

### Removed (the hack)

- No more `heldRaf` / `flushHeldRaf` / `requestAnimationFrame` hold
- No more `AudioContext` wrapping / `suspendAudio`
- Inject restored to before `</body>` (early `<head>` inject was only for the rAF race)

### Freeze ownership

Depends on [www.gamedev.pl-games#110](https://github.com/gamedevpl/www.gamedev.pl-games/pull/110) (**merged**) — GameKit listens for `gdpl-pause` / `gdpl-resume`. Serve contract lockstep: `GAMEKIT_PLATFORM_BYTES` **45,262** (`hostPause` +1,424 → `MAX_PROJECT_BYTES` **250,062**).

### Merge order

1. ~~Merge games **#110** first~~ **done**
2. Merge **this** PR (contract check should now pass against games `main`)

## Test plan

- [x] Green gate (`type-check`, `lint`, `test`, `build`)
- [x] Bridge tests: overlay + snapshot + `gdpl-pause` / `gdpl-resume` dispatched; no rAF patch asserts
- [x] Copilot review: coarse-pointer gate + Safari `MediaQueryList` shim for rotate nudge
- [ ] CI Games-repo contract green after #110 on main
- [ ] Manual: Playtest → Pause freezes motion + audio; rotate → wider playable stage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-329e62f8-dd48-45b6-a663-99c556690e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-329e62f8-dd48-45b6-a663-99c556690e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

