### PR TITLE
Remove GitHub fallback for published snapshot serving

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,8 @@ jobs:
       REPO: 'gamedev'
       GAMES_REPO: 'gamedevpl/www.gamedev.pl-games'
       # Pre-assembled published games (apps/api/src/game-snapshot.ts), written by
-      # publish-games.yml. Unset would simply mean every play rebuilds from GitHub
-      # again — serving treats the snapshot as a fast path, never a requirement.
+      # publish-games.yml. When set, published catalog / play / media are served
+      # only from the snapshot; unset is the local/dev opt-out (GitHub / fixtures).
       GAMES_SNAPSHOT_BUCKET: 'gamedevpl-games-snapshots'
       WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
       WIF_SERVICE_ACCOUNT: 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com'

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -17,10 +17,10 @@ name: Publish games snapshot
 # authority follows the snapshot catalog, so if the dispatch stops arriving —
 # an expired or under-permissioned SITE_DISPATCH_TOKEN, a games-repo workflow
 # failing before it reaches that step — nothing else retires the current snapshot
-# and the site serves a frozen catalog indefinitely. That failure is silent on this
-# side: serving falls back to GitHub only for games *missing* from the snapshot,
-# never for stale ones. The schedule bounds that staleness at a day, and re-bakes a
-# takedown that a failed publish left serving.
+# and the site serves a frozen catalog indefinitely. A partial bake no longer
+# advances the pointer (no published-serve GitHub fallback), so a failed publish
+# also leaves the previous good snapshot live. The schedule bounds that staleness
+# at a day, and re-bakes a takedown that a failed publish left serving.
 
 on:
   repository_dispatch:

--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -4,12 +4,18 @@
  * This moves game assembly off the request path: instead of every cache-cold play
  * rebuilding a game from a fan-out of GitHub reads plus an esbuild bundle, a merge
  * to the games repo's default branch bakes every published game once and the site
- * serves the result. GitHub stays in the picture only for unmerged PR previews and
- * as the fallback when a game is missing from the snapshot.
+ * serves the result. GitHub stays the source of truth for content and for
+ * unmerged PR / draft previews; it is not a published-serve fallback when the
+ * snapshot bucket is configured.
+ *
+ * A non-empty failures list leaves `current.json` on the previous good snapshot
+ * (immutable objects under the new id may still be written for debugging) and
+ * exits non-zero — without a serve-time GitHub fallback, advancing the pointer
+ * on a partial bake would half-publish failed games.
  *
  * Run by .github/workflows/publish-games.yml on a repository_dispatch from the
- * games repo (and manually via workflow_dispatch). Safe to re-run: each run writes
- * a fresh immutable snapshot prefix and only then moves `current.json`.
+ * games repo (and manually via workflow_dispatch). Safe to re-run: each successful
+ * run writes a fresh immutable snapshot prefix and only then moves `current.json`.
  *
  * Environment:
  *   GAMES_SNAPSHOT_BUCKET  target GCS bucket (required unless --dry-run)
@@ -106,12 +112,11 @@ async function main(): Promise<void> {
   console.log(`  failures    : ${result.failures.length}`);
 
   if (result.failures.length > 0) {
-    // The pointer has already moved — a game that fails to bake falls back to the
-    // GitHub path and keeps working, so a partial snapshot is better than none.
-    // But a failure means a published game is no longer being served the cheap
-    // way, and the games repo's own gate should have caught it, so end red.
+    // The pointer was left unchanged — without a serve-time GitHub fallback,
+    // advancing it on a partial bake would half-publish failed games. The site
+    // keeps serving the previous good snapshot until a clean bake succeeds.
     console.error('');
-    console.error('games that could not be baked (serving falls back to GitHub for these):');
+    console.error('games that could not be baked (pointer not advanced; previous snapshot still live):');
     for (const failure of result.failures) {
       console.error(`  - ${failure.slug}: ${failure.reason}`);
     }

--- a/apps/api/src/game-snapshot-publish.test.ts
+++ b/apps/api/src/game-snapshot-publish.test.ts
@@ -193,7 +193,7 @@ describe('publishSnapshot', () => {
 });
 
 describe('publishSnapshot failure handling', () => {
-  it('reports a game it could not bake without failing the whole publish', async () => {
+  it('bakes what it can but does not advance the pointer when anything fails', async () => {
     const { client } = createClientStub({
       catalog: [catalogEntry('good'), catalogEntry('broken')],
       sourcesBySlug: { good: gameSources(), broken: null },
@@ -204,10 +204,14 @@ describe('publishSnapshot failure handling', () => {
 
     expect(result.published).toBe(1);
     expect(result.failures).toEqual([{ slug: 'broken', reason: 'game sources not found on ref' }]);
-    expect(spy.pointer).not.toBeNull();
+    expect(spy.games.has('good')).toBe(true);
+    // Without a serve-time GitHub fallback, flipping the pointer on a partial
+    // bake would half-publish failed games. Leave current.json where it is.
+    expect(spy.pointer).toBeNull();
+    expect(spy.order).not.toContain('pointer');
   });
 
-  it('keeps an unbakeable game in the snapshot catalog so it is not silently unpublished', async () => {
+  it('still writes the full catalog under the new id for debugging, without publishing it', async () => {
     const { client } = createClientStub({
       catalog: [catalogEntry('good'), catalogEntry('broken')],
       sourcesBySlug: { good: gameSources(), broken: null },
@@ -216,14 +220,15 @@ describe('publishSnapshot failure handling', () => {
 
     await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
 
-    // Catalog membership is the games repo's decision, not this job's. The game
-    // stays listed and its play route falls back to GitHub — exactly what it did
-    // before the snapshot existed.
+    // Catalog membership is the games repo's decision, not this job's. The
+    // objects are written for debugging, but the pointer stays put so failed
+    // games are not half-published and successful ones are not silently dropped.
     expect(spy.catalog?.map((entry) => entry.slug)).toEqual(['good', 'broken']);
     expect(spy.games.has('broken')).toBe(false);
+    expect(spy.pointer).toBeNull();
   });
 
-  it('treats a game that fails the hygiene gate as a failure, not a bad snapshot', async () => {
+  it('treats a game that fails the hygiene gate as a failure, not a published snapshot', async () => {
     const { client } = createClientStub({
       catalog: [catalogEntry('empty')],
       sourcesBySlug: { empty: gameSources({ gameJs: '   ' }) },
@@ -234,7 +239,7 @@ describe('publishSnapshot failure handling', () => {
 
     expect(result.published).toBe(0);
     expect(result.failures[0]?.slug).toBe('empty');
-    expect(spy.pointer?.gameCount).toBe(0);
+    expect(spy.pointer).toBeNull();
   });
 
   it('carries on when one game is missing a declared media file', async () => {
@@ -251,6 +256,7 @@ describe('publishSnapshot failure handling', () => {
     expect(result.published).toBe(1);
     expect(result.mediaFiles).toBe(0);
     expect(result.failures).toEqual([]);
+    expect(spy.pointer).not.toBeNull();
   });
 
   it('bakes an empty catalog without writing a broken pointer', async () => {

--- a/apps/api/src/game-snapshot-publish.ts
+++ b/apps/api/src/game-snapshot-publish.ts
@@ -44,9 +44,14 @@ export interface PublishSnapshotResult {
   snapshotId: string;
   /** Games written to the snapshot. */
   published: number;
-  /** Games in the catalog that could not be baked; these fall back to GitHub. */
+  /**
+   * Games in the catalog that could not be baked. A non-empty list means the
+   * pointer was left on the previous good snapshot — immutable objects may still
+   * have been written under `snapshotId` for debugging.
+   */
   failures: PublishSnapshotFailure[];
   mediaFiles: number;
+  /** The pointer that was written, or that would have been written on failure. */
   pointer: SnapshotPointer;
 }
 
@@ -82,11 +87,12 @@ export async function publishSnapshot(options: PublishSnapshotOptions): Promise<
     }
   });
 
-  // The catalog is written whole, including games that failed to bake. Catalog
-  // membership is the games repo's decision, not this job's: dropping a game
-  // here would silently unpublish it because one bake failed. A game with no
-  // snapshot object simply falls back to the GitHub path at serve time, which is
-  // exactly what it did before this job existed.
+  // The catalog is written whole, including games that failed to bake — useful
+  // under the new snapshotId for debugging. Catalog membership is the games
+  // repo's decision, not this job's: dropping a failed game from a catalog that
+  // then becomes current would silently unpublish it. Instead, when anything
+  // failed, we leave `current.json` on the previous good snapshot so the site
+  // keeps serving a complete bake.
   await writer.putCatalog(snapshotId, published);
 
   const pointer: SnapshotPointer = {
@@ -96,10 +102,18 @@ export async function publishSnapshot(options: PublishSnapshotOptions): Promise<
     gameCount: publishedCount,
   };
 
+  if (failures.length > 0) {
+    log(
+      `snapshot ${snapshotId} not published: ${publishedCount} games baked, ${mediaFiles} media, ` +
+        `${failures.length} failed — pointer left unchanged`,
+    );
+    return { snapshotId, published: publishedCount, failures, mediaFiles, pointer };
+  }
+
   // Last, and only after every object is durable: until the pointer moves, the
   // half-written snapshot is invisible and the site keeps serving the previous one.
   await writer.putPointer(pointer);
-  log(`published snapshot ${snapshotId}: ${publishedCount} games, ${mediaFiles} media, ${failures.length} failed`);
+  log(`published snapshot ${snapshotId}: ${publishedCount} games, ${mediaFiles} media`);
 
   return { snapshotId, published: publishedCount, failures, mediaFiles, pointer };
 }
@@ -141,7 +155,8 @@ async function bakeGame(args: {
     const bytes = await client.getGameMedia(ref, entry.slug, filename);
     if (!bytes) {
       // Catalog metadata is generated from what is committed, so a gap here is
-      // odd but not fatal — the media route falls back to GitHub for this file.
+      // odd but not fatal to the game bake — the media route will 404 for this
+      // filename until a later bake catches up.
       continue;
     }
     await writer.putMedia(snapshotId, entry.slug, filename, {

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -7,8 +7,9 @@ import { InMemoryStore } from './store.js';
 import { NoopTranslator } from './translate.js';
 
 /**
- * The serve half of the snapshot: published games are read from the bucket, and
- * every way that can fail falls back to the GitHub path the site used before.
+ * The serve half of the snapshot: when configured, published games are read
+ * only from the bucket. Misses and Storage errors fail the request — they do
+ * not assemble from GitHub. Unset snapshotReader keeps the GitHub / local path.
  */
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -120,40 +121,39 @@ describe('playing a published game', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ slug: 'bubble-pop', title: 'Bubble Pop', html: '<!doctype html><p>baked</p>' });
-    // The point of the whole change: no source fan-out, no esbuild bundle.
     expect(getGameSources).not.toHaveBeenCalled();
     await app.close();
   });
 
-  it('falls back to GitHub for a game that is not in the snapshot', async () => {
+  it('returns 502 when the slug is published but the game object is missing', async () => {
     const { githubClient, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
     const snapshot = createSnapshotStub({ catalog: [catalogEntry('bubble-pop')], games: {} });
     const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
 
     const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.json().html).toContain('from github');
-    expect(getGameSources).toHaveBeenCalledWith('main', 'bubble-pop');
+    expect(response.statusCode).toBe(502);
+    expect(response.json().error).toBe('game snapshot incomplete');
+    expect(getGameSources).not.toHaveBeenCalled();
     await app.close();
   });
 
-  it('falls back to GitHub when the snapshot bucket is unreachable', async () => {
-    const { githubClient, getGameSources } = createGithubStub([catalogEntry('bubble-pop')]);
+  it('returns 503 when the snapshot bucket is unreachable', async () => {
+    const { githubClient, getGameSources, getCatalog } = createGithubStub([catalogEntry('bubble-pop')]);
     const snapshot = createSnapshotStub({ failWith: new Error('storage 503') });
     const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
 
     const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop' });
 
-    // A Storage outage must degrade to the old behaviour, not to a broken site.
-    expect(response.statusCode).toBe(200);
-    expect(response.json().html).toContain('from github');
-    expect(getGameSources).toHaveBeenCalled();
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error).toBe('game snapshot unavailable');
+    expect(getCatalog).not.toHaveBeenCalled();
+    expect(getGameSources).not.toHaveBeenCalled();
     await app.close();
   });
 
   it('still refuses a slug the catalog does not publish', async () => {
-    const { githubClient } = createGithubStub([]);
+    const { githubClient, getGameSources } = createGithubStub([]);
     const snapshot = createSnapshotStub({
       catalog: [],
       games: { sneaky: { slug: 'sneaky', title: 'Sneaky', html: '<!doctype html>' } },
@@ -165,6 +165,7 @@ describe('playing a published game', () => {
     // Publication is decided by the catalog, not by what happens to sit in the
     // bucket — a stale object must never resurrect an unpublished game.
     expect(response.statusCode).toBe(404);
+    expect(getGameSources).not.toHaveBeenCalled();
     await app.close();
   });
 
@@ -197,27 +198,28 @@ describe('the catalog', () => {
     await app.close();
   });
 
-  it('falls back to GitHub before any snapshot has been published', async () => {
+  it('returns 503 when no snapshot has been published yet', async () => {
     const { githubClient, getCatalog } = createGithubStub([catalogEntry('from-github')]);
     const snapshot = createSnapshotStub({ catalog: null });
     const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
 
     const response = await app.inject({ method: 'GET', url: '/api/catalog' });
 
-    expect(response.json().map((entry: CatalogGameEntry) => entry.slug)).toEqual(['from-github']);
-    expect(getCatalog).toHaveBeenCalled();
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error).toBe('catalog snapshot unavailable');
+    expect(getCatalog).not.toHaveBeenCalled();
     await app.close();
   });
 
-  it('falls back to GitHub when the snapshot read fails', async () => {
+  it('returns 503 when the snapshot read fails', async () => {
     const { githubClient, getCatalog } = createGithubStub([catalogEntry('from-github')]);
     const snapshot = createSnapshotStub({ failWith: new Error('storage 503') });
     const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
 
     const response = await app.inject({ method: 'GET', url: '/api/catalog' });
 
-    expect(response.statusCode).toBe(200);
-    expect(getCatalog).toHaveBeenCalled();
+    expect(response.statusCode).toBe(503);
+    expect(getCatalog).not.toHaveBeenCalled();
     await app.close();
   });
 
@@ -256,20 +258,42 @@ describe('gallery media', () => {
     await app.close();
   });
 
-  it('falls back to GitHub when the file is not in the snapshot', async () => {
+  it('returns 404 when the file is allowlisted but missing from the snapshot', async () => {
     const { githubClient, getGameMedia } = createGithubStub([withMedia]);
     const snapshot = createSnapshotStub({ catalog: [withMedia], media: {} });
     const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
 
     const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
 
-    expect(response.statusCode).toBe(200);
-    expect(getGameMedia).toHaveBeenCalledWith('main', 'bubble-pop', 'opening.png');
+    expect(response.statusCode).toBe(404);
+    expect(getGameMedia).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('returns 503 when the snapshot media read fails', async () => {
+    const { githubClient, getGameMedia } = createGithubStub([withMedia]);
+    // Catalog succeeds so the allowlist can run; only the media object read fails.
+    const getCatalog = vi.fn(async () => [withMedia]);
+    const getMedia = vi.fn(async () => {
+      throw new Error('storage 503');
+    });
+    const reader: GameSnapshotReader = {
+      getPointer: vi.fn(async () => null),
+      getCatalog,
+      getGame: vi.fn(async () => null),
+      getMedia,
+    };
+    const app = await createApp({ githubClient, snapshotReader: reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
+
+    expect(response.statusCode).toBe(503);
+    expect(getGameMedia).not.toHaveBeenCalled();
     await app.close();
   });
 
   it('still rejects a filename the catalog does not vouch for', async () => {
-    const { githubClient } = createGithubStub([withMedia]);
+    const { githubClient, getGameMedia } = createGithubStub([withMedia]);
     const snapshot = createSnapshotStub({
       catalog: [withMedia],
       media: { 'bubble-pop/secret.png': Buffer.from('should-not-be-served') },
@@ -281,6 +305,7 @@ describe('gallery media', () => {
     // The catalog allowlist runs before the snapshot is consulted, so a stray
     // object in the bucket cannot widen what the API will serve.
     expect(response.statusCode).toBe(404);
+    expect(getGameMedia).not.toHaveBeenCalled();
     await app.close();
   });
 });

--- a/apps/api/src/game-snapshot.test.ts
+++ b/apps/api/src/game-snapshot.test.ts
@@ -150,7 +150,7 @@ describe('snapshot reads', () => {
     fake.raw.mockResolvedValueOnce(new Response('nope', { status: 500 }));
 
     // A 500 must not look like "not published" — serving tells the two apart to
-    // decide between falling back to GitHub and answering 404.
+    // decide between 503 (snapshot unreachable) and 404 / 502 (miss / incomplete).
     await expect(createStore(fake).getPointer()).rejects.toThrow(/500/);
   });
 

--- a/apps/api/src/game-snapshot.ts
+++ b/apps/api/src/game-snapshot.ts
@@ -53,9 +53,35 @@ export interface SnapshotMedia {
 }
 
 /**
+ * The snapshot is configured but cannot answer the request: no `current.json`,
+ * an empty pointer, or a Storage / transport failure. Published serve routes map
+ * this to 503 and must not assemble from GitHub.
+ */
+export class SnapshotUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SnapshotUnavailableError';
+  }
+}
+
+/**
+ * The snapshot catalog says the game (or media) is published, but the baked
+ * object is missing — a bake inconsistency. Published serve routes map this to
+ * 502 and must not assemble from GitHub.
+ */
+export class SnapshotIncompleteError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SnapshotIncompleteError';
+  }
+}
+
+/**
  * The read side, used by the serve routes. Every method throws on transport
  * failure and resolves to null on a genuine miss, so callers can tell "snapshot
- * is unreachable, fall back to GitHub" apart from "this game isn't published".
+ * is unreachable" apart from "this object is not in the current snapshot".
+ * When a reader is configured, published routes treat either outcome as a hard
+ * failure — they do not fall back to GitHub.
  */
 export interface GameSnapshotReader {
   getPointer(): Promise<SnapshotPointer | null>;
@@ -315,10 +341,10 @@ async function safeBodyText(response: Response): Promise<string> {
 /**
  * Builds the reader the serve routes use, or null when no bucket is configured.
  *
- * Absent configuration is a supported state, not an error: local development and
- * tests run without a bucket, and production keeps working from GitHub if the
- * snapshot is switched off. Serving is written so the snapshot is a fast path,
- * never a requirement.
+ * Absent configuration is a supported opt-out, not a fallback from a configured
+ * bucket: local development, fixtures, and `local-games-repo` leave
+ * `GAMES_SNAPSHOT_BUCKET` unset and serve from GitHub / the local tree. When the
+ * env var is set, published catalog / play / media routes require the snapshot.
  */
 export function createSnapshotReaderFromEnv(env: NodeJS.ProcessEnv = process.env): GameSnapshotReader | null {
   const bucket = env.GAMES_SNAPSHOT_BUCKET?.trim();

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -12,7 +12,12 @@ import {
   type GitHubClient,
   type LinkedPullRequest,
 } from './github-client.js';
-import { createSnapshotReaderFromEnv, type GameSnapshotReader } from './game-snapshot.js';
+import {
+  createSnapshotReaderFromEnv,
+  SnapshotIncompleteError,
+  SnapshotUnavailableError,
+  type GameSnapshotReader,
+} from './game-snapshot.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
@@ -390,7 +395,7 @@ export async function registerSubmissionRoutes(
   // that assert the GitHub-backed behaviour pass null).
   const snapshotReader = options.snapshotReader === undefined ? createSnapshotReaderFromEnv() : options.snapshotReader;
   if (snapshotReader) {
-    app.log.info('serving published games from the snapshot bucket, with GitHub as fallback');
+    app.log.info('serving published games from the snapshot bucket only (no GitHub fallback)');
   }
 
   const githubClient =
@@ -666,10 +671,15 @@ export async function registerSubmissionRoutes(
   /**
    * Where a catalog read actually comes from.
    *
-   * `forceFresh` deliberately skips the snapshot. It is only set by
-   * isSlugPublished for the publishing→published transition, and that is exactly
-   * the window where the snapshot is the stale source (it is baked a minute or
-   * two after the merge) and GitHub is the fresh one.
+   * When the snapshot is configured, published routes require it: a missing
+   * pointer or Storage error fails the request (503). `forceFresh` deliberately
+   * skips the snapshot — it is only set by isSlugPublished for the
+   * publishing→published transition, which is exactly the window where the
+   * snapshot is the stale source (baked a minute or two after the merge) and
+   * GitHub is the fresh one.
+   *
+   * Unset `GAMES_SNAPSHOT_BUCKET` (null snapshotReader) keeps the GitHub /
+   * local-dev path — that is an opt-out, not a fallback from a configured bucket.
    */
   async function loadCatalog(client: GitHubClient, forceFresh: boolean): Promise<CatalogGameEntry[]> {
     if (!forceFresh && snapshotReader) {
@@ -679,25 +689,29 @@ export async function registerSubmissionRoutes(
           return entries;
         }
       } catch (error) {
-        app.log.warn({ err: error }, 'snapshot catalog unavailable; falling back to GitHub');
+        if (error instanceof SnapshotUnavailableError) throw error;
+        app.log.warn({ err: error }, 'snapshot catalog unavailable');
+        throw new SnapshotUnavailableError('snapshot catalog unavailable', { cause: error });
       }
+      throw new SnapshotUnavailableError('snapshot catalog is not published');
     }
     return client.getCatalog(publishedRef);
   }
 
   /**
-   * Snapshot lookups never fail a request. A miss (game not in this snapshot) and
-   * a transport error both fall back to the GitHub path, so switching the bucket
-   * off, an unbaked game, and a Storage outage all degrade to exactly the
-   * behaviour the site had before the snapshot existed.
+   * Snapshot lookups for published routes. Transport errors throw
+   * SnapshotUnavailableError (503); a genuine miss returns null so the caller
+   * can decide between bake-inconsistency (502) and not-found (404). There is
+   * no GitHub escape hatch when snapshotReader is present.
    */
   async function readSnapshotGame(slug: string): Promise<{ slug: string; title: string; html: string } | null> {
     if (!snapshotReader) return null;
     try {
       return await snapshotReader.getGame(slug);
     } catch (error) {
-      app.log.warn({ err: error, slug }, 'snapshot game unavailable; falling back to GitHub');
-      return null;
+      if (error instanceof SnapshotUnavailableError) throw error;
+      app.log.warn({ err: error, slug }, 'snapshot game unavailable');
+      throw new SnapshotUnavailableError('snapshot game unavailable', { cause: error });
     }
   }
 
@@ -709,8 +723,9 @@ export async function registerSubmissionRoutes(
     try {
       return await snapshotReader.getMedia(slug, filename);
     } catch (error) {
-      app.log.warn({ err: error, slug, filename }, 'snapshot media unavailable; falling back to GitHub');
-      return null;
+      if (error instanceof SnapshotUnavailableError) throw error;
+      app.log.warn({ err: error, slug, filename }, 'snapshot media unavailable');
+      throw new SnapshotUnavailableError('snapshot media unavailable', { cause: error });
     }
   }
 
@@ -1998,6 +2013,10 @@ export async function registerSubmissionRoutes(
       const entries = await getCatalogEntries(githubClient);
       return reply.send(entries.filter((entry) => entry.status === 'published'));
     } catch (error) {
+      if (error instanceof SnapshotUnavailableError) {
+        request.log.error({ err: error }, 'snapshot catalog unavailable');
+        return reply.status(503).send({ error: 'catalog snapshot unavailable' });
+      }
       request.log.error({ err: error }, 'failed to load catalog');
       return reply.status(502).send({ error: 'failed to load catalog' });
     }
@@ -2046,9 +2065,12 @@ export async function registerSubmissionRoutes(
 
       // The catalog allowlist above still gates every read, so the snapshot can
       // only ever answer for a filename the validated metadata already vouches for.
-      const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
       let body: Buffer;
-      if (snapshotMedia) {
+      if (snapshotReader) {
+        const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
+        if (!snapshotMedia) {
+          return reply.status(404).send({ error: 'media not found' });
+        }
         body = snapshotMedia.body;
       } else {
         const media = await githubClient.getGameMedia(publishedRef, parsedParams.data.slug, parsedParams.data.filename);
@@ -2074,12 +2096,17 @@ export async function registerSubmissionRoutes(
 
       return sendMedia(request, reply, cacheEntry);
     } catch (error) {
+      if (error instanceof SnapshotUnavailableError) {
+        request.log.error({ err: error }, 'snapshot media unavailable');
+        return reply.status(503).send({ error: 'media snapshot unavailable' });
+      }
       request.log.error({ err: error }, 'failed to serve game media');
       return reply.status(502).send({ error: 'failed to load game media' });
     }
   });
 
-  // Play a published game: sources are fetched from the games repo's default
+  // Play a published game. When the snapshot is configured, the baked document
+  // is required; otherwise sources are fetched from the games repo's default
   // branch and assembled into one document for the sandboxed, opaque-origin
   // iframe — the same trust model as the preview endpoint. Only slugs present
   // in the catalog as published are served.
@@ -2104,11 +2131,13 @@ export async function registerSubmissionRoutes(
         return reply.status(404).send({ error: 'game not found' });
       }
 
-      // Baked at merge time by the same assembler this route would use, with the
-      // same CSP, provenance meta and credential scan already applied — so a hit
-      // skips the GitHub fan-out and the esbuild bundle entirely.
-      const snapshotGame = await readSnapshotGame(slug);
-      if (snapshotGame) {
+      if (snapshotReader) {
+        // Baked at merge time by the same assembler the GitHub path would use,
+        // with the same CSP, provenance meta and credential scan already applied.
+        const snapshotGame = await readSnapshotGame(slug);
+        if (!snapshotGame) {
+          throw new SnapshotIncompleteError(`published game "${slug}" is missing from the snapshot`);
+        }
         gameCache.set(slug, { value: snapshotGame, expiresAt: currentTime + gameTtlMs });
         return reply.send(snapshotGame);
       }
@@ -2133,6 +2162,17 @@ export async function registerSubmissionRoutes(
       gameCache.set(slug, { value, expiresAt: currentTime + gameTtlMs });
       return reply.send(value);
     } catch (error) {
+      if (error instanceof SnapshotUnavailableError) {
+        request.log.error({ err: error, slug }, 'snapshot game unavailable');
+        return reply.status(503).send({ error: 'game snapshot unavailable' });
+      }
+      if (error instanceof SnapshotIncompleteError) {
+        request.log.error({ err: error, slug }, 'snapshot game incomplete');
+        return reply.status(502).send({
+          error: 'game snapshot incomplete',
+          detail: error.message.replace(/\s+/g, ' ').trim().slice(0, 240),
+        });
+      }
       if (
         error instanceof EmptyProjectError ||
         error instanceof ProjectTooLargeError ||

--- a/docs/games-repo.md
+++ b/docs/games-repo.md
@@ -134,14 +134,15 @@ validation gate so it guards published bundles.
 
 ## Open questions
 
-- ~~**Where are published bundles hosted?**~~ **Resolved: a Cloud Storage snapshot,
-  with GitHub as fallback.** Merges to the games repo bake catalog, assembled HTML,
-  and media into `gs://…-games-snapshots`; the API prefers that snapshot on
-  `GET /api/catalog`, `GET /api/games/:slug`, and media routes, and falls back to
-  live GitHub reads (plus on-demand assemble) when the bucket is unset, a game
-  failed to bake, or Storage is down. PR / draft previews still read GitHub live.
-  The API remains the games origin — the bucket is not public. Details:
-  [`games-snapshot.md`](./games-snapshot.md).
+- ~~**Where are published bundles hosted?**~~ **Resolved: a Cloud Storage snapshot.**
+  Merges to the games repo bake catalog, assembled HTML, and media into
+  `gs://…-games-snapshots`. When `GAMES_SNAPSHOT_BUCKET` is set, the API serves
+  published `GET /api/catalog`, `GET /api/games/:slug`, and media routes **only**
+  from that snapshot — misses and Storage errors fail the request (503 / 502 /
+  404 as appropriate); they do not assemble from GitHub. Unset the env var for
+  local/dev. GitHub remains the source of truth for content (the bake reads it)
+  and for PR / draft previews. The API remains the games origin — the bucket is
+  not public. Details: [`games-snapshot.md`](./games-snapshot.md).
 - **Repository ownership and merge authority.** Agent PRs need a human gate initially,
   especially because review is also the moderation point.
 - **Submission identity, attribution, rights, and abuse controls.** These must be decided before

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -1,7 +1,9 @@
 # Published-game snapshots
 
-**Status: ✅ built.** Serving reads the snapshot with a GitHub fallback; the bake runs
-on every merge to the games repo's `main`.
+**Status: ✅ built.** When `GAMES_SNAPSHOT_BUCKET` is set, published catalog / play /
+media are served **only** from the Cloud Storage snapshot. The bake runs on every
+merge to the games repo's `main`. Unset the env var for local/dev / fixtures /
+`local-games-repo` — that is an opt-out, not a fallback from a configured bucket.
 
 ## The problem
 
@@ -52,7 +54,7 @@ properties fall out of that:
 ## Who bakes, and why it is this side
 
 `scripts/publish-snapshot.ts` runs in _this_ repo and reuses `assembleGameHtml` — the
-same function the play route calls.
+same function the play route calls when the snapshot is not configured.
 
 The games repo has its own `tools/build.ts` that emits standalone HTML, and uploading
 that instead would have removed GitHub from the loop entirely. It was the wrong trade:
@@ -67,18 +69,26 @@ of truth for _what a served game is_, and the bake is where the two meet.
 
 ## Serving
 
-`apps/api/src/submissions.ts` consults the snapshot first on three routes:
+`apps/api/src/submissions.ts` reads the snapshot on three published routes when
+`GAMES_SNAPSHOT_BUCKET` is set:
 
-| Route                              | Snapshot hit                  | Snapshot miss or error     |
-| ---------------------------------- | ----------------------------- | -------------------------- |
-| `GET /api/catalog`                 | `snapshots/<id>/catalog.json` | `client.getCatalog(ref)`   |
-| `GET /api/games/:slug`             | pre-assembled document        | GitHub sources + esbuild   |
-| `GET /api/games/:slug/media/:file` | snapshot bytes                | `client.getGameMedia(...)` |
+| Route                              | Snapshot hit                  | Miss / error (bucket configured)                                           |
+| ---------------------------------- | ----------------------------- | -------------------------------------------------------------------------- |
+| `GET /api/catalog`                 | `snapshots/<id>/catalog.json` | No pointer / Storage error → **503** (no `client.getCatalog`)              |
+| `GET /api/games/:slug`             | pre-assembled document        | Storage error → **503**; published in catalog but object missing → **502** |
+| `GET /api/games/:slug/media/:file` | snapshot bytes                | Storage error → **503**; allowlisted but object missing → **404**          |
 
-**The snapshot is a fast path, never a requirement.** An unset `GAMES_SNAPSHOT_BUCKET`,
-a game that failed to bake, an unbaked media file and a Cloud Storage outage all
-degrade to exactly the behaviour the site had before this existed. That is deliberate:
-the fallback is the reason this change is safe to ship in one step.
+Slug not in the catalog → **404** (unchanged). Publication authority is the snapshot
+catalog, not “object exists in the bucket” — a stray object cannot resurrect a game.
+
+**When the bucket is configured, there is no GitHub assemble on the published serve
+path.** GitHub remains the source of truth for content (the bake reads it) and for
+draft / PR preview routes (unmerged heads have no snapshot). Unset
+`GAMES_SNAPSHOT_BUCKET` is the local/dev opt-out and restores the GitHub / fixtures /
+`local-games-repo` path.
+
+In-process caches (catalog TTL, game TTL, last-known catalog on refresh failure) still
+apply; they cache snapshot results, not a GitHub escape hatch.
 
 Two invariants survive unchanged, and are tested:
 
@@ -87,10 +97,11 @@ Two invariants survive unchanged, and are tested:
 - **Media is still gated by the catalog allowlist** before the snapshot is consulted, so
   a stray object cannot widen what the API will serve.
 
-One deliberate exception: `isSlugPublished` skips the snapshot when it forces a
-refresh. That only happens during the publishing→published transition, which is
-precisely the window where the snapshot is the stale source and GitHub is the fresh
-one.
+One deliberate exception: `isSlugPublished(..., { refreshOnMiss: true })` skips the
+snapshot when it forces a refresh (`forceFresh`). That only happens during the
+publishing→published transition, which is precisely the window where the snapshot is
+the stale source and GitHub is the fresh one — status correctness while the bake is
+still in flight.
 
 ## The publish path
 
@@ -100,7 +111,7 @@ merge to games-repo main
   → validate.yml: regenerate + commit catalog.json
   → validate.yml: repository_dispatch → this repo
   → publish-games.yml: npm run snapshot:publish
-  → objects written, then current.json moves
+  → objects written, then current.json moves (only if every game baked cleanly)
   → running instances pick it up within the pointer TTL (~1 min)
 ```
 
@@ -140,10 +151,14 @@ but a stale snapshot is worse than an expensive one.
 
 ### A game that fails to bake
 
-It stays in the snapshot catalog and simply gets no game object, so its play route
-falls back to GitHub — exactly what it did before. Dropping it from the catalog would
-silently unpublish a game because of a transient build failure, and catalog membership
-is the games repo's decision, not the bake job's.
+A non-empty `failures` list does **not** advance `current.json`. Immutable objects under
+the new snapshot id may still be written (including a full catalog listing) for
+debugging, but the site keeps serving the previous good snapshot. Failed games are not
+half-published, and successful peers are not silently dropped from a newly published
+catalog.
+
+Do **not** flip the pointer while omitting failed games from the new catalog — that
+would unpublish them. Prefer “pointer stays put”.
 
 The job still exits non-zero, because the games repo's own gate should have caught it.
 
@@ -189,8 +204,8 @@ runtime cannot rewrite what it serves. `infra/setup-gcp.sh` step 7 provisions al
 including a 90-day lifecycle rule on `snapshots/`.
 
 If the games repo ever goes 90 days without a merge, the live snapshot ages out and
-serving falls back to GitHub — degraded, not broken, which is the right way for a cost
-control to fail.
+published serving returns **503** until a fresh bake restores `current.json` — the
+lifecycle rule is a cost control, not a soft degrade to GitHub.
 
 ## What this does not solve
 
@@ -201,5 +216,8 @@ control to fail.
   object layout is already CDN-shaped for when that trade becomes worth making.
 - **Preview and draft routes still read GitHub live**, and should — an unmerged PR head
   has no snapshot, and that immediacy is the point of the creator's build channel.
+- **GitHub remains SoT for content and for the bake.** Removing the published-serve
+  fallback does not mean GitHub left the system; it means visitors no longer pay for
+  assembly when the snapshot is the configured source.
 - **`--max-instances 1`** remains the scaling ceiling (see `docs/roadmap.md`). This
   removes work from each request; it does not add instances.

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -190,8 +190,8 @@ gcloud storage buckets add-iam-policy-binding "gs://${SNAPSHOT_BUCKET}" \
 # Old snapshots are dead weight once the pointer moves past them, but they are
 # also the rollback path, so they are kept for a quarter rather than a day. If the
 # games repo ever goes 90 days without a merge the live snapshot ages out and
-# serving falls back to GitHub — degraded, not broken, which is the right way for
-# a cost control to fail.
+# published serving returns 503 until a fresh bake restores current.json — the
+# lifecycle rule is a cost control, not a soft degrade to GitHub.
 LIFECYCLE_FILE="$(mktemp)"
 cat > "$LIFECYCLE_FILE" <<'EOF'
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `GAMES_SNAPSHOT_BUCKET` is set, published catalog / play / media are served **only** from the Cloud Storage snapshot. GitHub is no longer consulted on that request path for misses or Storage errors.

Unset `GAMES_SNAPSHOT_BUCKET` remains the local/dev / fixtures / `local-games-repo` opt-out — not a fallback from a configured bucket.

GitHub is still used for the bake job, draft/PR previews, `forceFresh` / `refreshOnMiss` catalog reads during the publishing→published transition, submissions, issues, and contract checks.

## New published-serve failure modes (bucket configured)

| Situation | Response |
|---|---|
| Snapshot hit | Unchanged |
| No `current.json` / empty pointer | **503** — no `getCatalog` / `getGameSources` / `getGameMedia` |
| Storage / transport error | **503** — no GitHub fallback |
| Slug published in snapshot catalog but game object missing | **502** (bake inconsistency) |
| Media allowlisted but object missing | **404** |
| Slug not in catalog | **404** (unchanged; catalog still decides publication) |

In-process caches (catalog TTL, game TTL, last-known catalog on refresh failure) still cache snapshot results only.

## Bake: no pointer on partial failure

`publishSnapshot` no longer calls `putPointer` when `failures.length > 0`. Immutable objects under the new snapshot id may still be written for debugging, but `current.json` stays on the previous good snapshot. The job still exits non-zero.

Do **not** drop failed games from a newly published catalog while flipping the pointer — that would unpublish them. Prefer “pointer stays put”.

## Docs

Updated `docs/games-snapshot.md` and the open-question resolution in `docs/games-repo.md`: GitHub remains SoT for content and previews; it is no longer the published-serve fallback.

## CI note

Rebased onto `master` after #291 (`save` GameKit module). The earlier Games-repo contract failure was lockstep drift against games-repo `main`, unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3889bb0e-c4d3-44c2-b799-1342e77859a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3889bb0e-c4d3-44c2-b799-1342e77859a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

