### PR TITLE
Stop build previews losing their order after a prune

### DIFF
--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { InMemoryStore, TELEMETRY_COLLECTION, TELEMETRY_RETENTION_DAYS, telemetryExpiresAt } from './store.js';
 
 describe('InMemoryStore', () => {
@@ -153,5 +153,38 @@ describe('telemetry retention', () => {
     // A TTL policy is scoped to a collection group. Sharing `events` with
     // `submissions/{n}/events` would put one retention rule over both.
     expect(TELEMETRY_COLLECTION).not.toBe('events');
+  });
+});
+
+describe('InMemoryStore build previews', () => {
+  const ISSUE = 4242;
+
+  async function push(store: InMemoryStore, label: string) {
+    await store.appendBuildPreview(ISSUE, { slug: 'sky-dodge', label, data: '<html></html>' } as never);
+    // Same keep count the agent channel uses, so the interaction under test is the real one.
+    await store.pruneBuildPreviews(ISSUE, 4);
+  }
+
+  it('keeps append order across a prune, even within a single millisecond', async () => {
+    // `pruneBuildPreviews` writes the array back sorted newest-first, so after the first
+    // prune the last element is the *oldest*. `appendBuildPreview` used to read that
+    // element to decide whether to bump the timestamp, which meant the bump stopped
+    // firing exactly when previews were arriving fast enough to need it — two appends in
+    // one millisecond then tied on `createdAt` and were ordered by a random UUID.
+    //
+    // The clock is frozen so every append genuinely lands on the same tick: the ordering
+    // then depends on nothing but the bump, and the test fails every run instead of one
+    // in eight.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T09:00:00.000Z'));
+    try {
+      const store = new InMemoryStore();
+      for (let index = 0; index < 7; index += 1) await push(store, `build ${index}`);
+
+      const newest = await store.listBuildPreviews(ISSUE);
+      expect(newest.map((preview) => preview.label)).toEqual(['build 6', 'build 5', 'build 4', 'build 3']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1037,10 +1037,19 @@ export class InMemoryStore implements Store {
     // tests (and occasionally in prod) land on the same tick; bump so "newest"
     // matches append order instead of UUID tie-breaks.
     const nowIso = new Date().toISOString();
-    const lastCreatedAt = existing[existing.length - 1]?.createdAt;
+    // The newest by value, not by position. `pruneBuildPreviews` writes the array back
+    // sorted newest-first, so after the first prune the last element is the *oldest* — and
+    // reading it here silently disabled this bump, letting two appends in the same
+    // millisecond tie on `createdAt` and be ordered by a random UUID instead.
+    const newestCreatedAt = existing.reduce<string | undefined>(
+      (newest, entry) => (newest === undefined || entry.createdAt > newest ? entry.createdAt : newest),
+      undefined,
+    );
     const createdAt =
       preview.createdAt ??
-      (lastCreatedAt && lastCreatedAt >= nowIso ? new Date(Date.parse(lastCreatedAt) + 1).toISOString() : nowIso);
+      (newestCreatedAt && newestCreatedAt >= nowIso
+        ? new Date(Date.parse(newestCreatedAt) + 1).toISOString()
+        : nowIso);
     const record: BuildPreview = {
       ...preview,
       id: randomUUID(),


### PR DESCRIPTION
## Why

`agent-channel.test.ts` fails about **one run in eight**:

```
FAIL src/agent-channel.test.ts > keeps only the newest previews, because each one obsoletes the last
AssertionError: expected 'build 5' to be 'build 6'
```

It has been failing CI on unrelated pull requests — it's what took down #289's `Lint, Test & Build`, and it's a coin flip whether any given PR sees it.

## The bug

`appendBuildPreview` bumps a preview's timestamp when it would collide with the previous one — ISO timestamps carry only milliseconds, and the agent pushes previews faster than that. Its own comment says so.

It found "the previous one" by position:

```ts
const lastCreatedAt = existing[existing.length - 1]?.createdAt;
```

But `pruneBuildPreviews` writes the array back **sorted newest-first**:

```ts
const kept = [...existing].sort(byNewestFirst).slice(0, keep);
this.buildPreviews.set(issueNumber, kept);
```

So from the first prune onward, the last element is the **oldest**. `nowIso` is comfortably greater than it, the bump never fires, and two appends in one millisecond tie on `createdAt`. The tie-break is `b.id.localeCompare(a.id)` on a **random UUID** — so which preview counts as "newest" is decided by chance.

The guard stopped working precisely when previews arrived fast enough to need it.

## The fix

Take the newest `createdAt` **by value, not by position**, so the guard doesn't depend on how any other method chooses to order the array. That's the property worth having here — the previous coupling was invisible from either side.

## Verification

The regression test freezes the clock, so every append genuinely lands on the same tick and ordering depends on nothing but the bump:

| | old code | new code |
| --- | --- | --- |
| new store test | **5 / 5 fail** | 5 / 5 pass |
| `agent-channel.test.ts` | ~1 in 8 fail | 10 / 10 pass |

A 1-in-8 flake made deterministic, then fixed.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` (exit 0)
- [x] Reverted the fix and confirmed the new test fails every run

## Note

This is not from either open PR — `appendBuildPreview` and `pruneBuildPreviews` both landed with #236. It's split out so #287 and #289 don't carry an unrelated fix, and so this can merge first and unblock both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4qCA3ruvWreLtyibx71q)_