### PR TITLE
Bound the intake bookkeeping and cap concurrent multiplayer sockets

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,8 +38,10 @@
   "devDependencies": {
     "@types/node": "^20.14.15",
     "@types/web-push": "^3.6.4",
+    "@types/ws": "^8.18.1",
     "tsx": "^4.16.5",
     "typescript": "^5.5.4",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "ws": "^8.18.0"
   }
 }

--- a/apps/api/src/bounded-map.test.ts
+++ b/apps/api/src/bounded-map.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { rememberBounded } from './bounded-map.js';
+
+describe('rememberBounded', () => {
+  it('never grows past the cap, however many distinct keys arrive', () => {
+    const map = new Map<string, number>();
+    for (let index = 0; index < 10_000; index += 1) {
+      rememberBounded(map, `key-${index}`, index, 100);
+    }
+    expect(map.size).toBe(100);
+  });
+
+  it('evicts the least recently used key, not the oldest insertion', () => {
+    // The distinction the delete-then-set exists for: `first` is the oldest *insertion*
+    // but the most recent *use*, so it must outlive a key that has sat untouched.
+    const map = new Map<string, number>();
+    rememberBounded(map, 'first', 1, 3);
+    rememberBounded(map, 'second', 2, 3);
+    rememberBounded(map, 'third', 3, 3);
+
+    rememberBounded(map, 'first', 10, 3); // touched — moves to the back
+    rememberBounded(map, 'fourth', 4, 3); // pushes one out
+
+    expect(map.has('first')).toBe(true);
+    expect(map.has('second')).toBe(false); // untouched the longest
+    expect([...map.keys()]).toEqual(['third', 'first', 'fourth']);
+  });
+
+  it('updates in place without growing', () => {
+    const map = new Map<string, number>();
+    rememberBounded(map, 'same', 1, 10);
+    rememberBounded(map, 'same', 2, 10);
+
+    expect(map.size).toBe(1);
+    expect(map.get('same')).toBe(2);
+  });
+
+  it('handles a cap of one', () => {
+    const map = new Map<string, number>();
+    rememberBounded(map, 'a', 1, 1);
+    rememberBounded(map, 'b', 2, 1);
+
+    expect([...map.entries()]).toEqual([['b', 2]]);
+  });
+});

--- a/apps/api/src/bounded-map.ts
+++ b/apps/api/src/bounded-map.ts
@@ -1,0 +1,35 @@
+/**
+ * Insertion-ordered maps with a hard entry cap, for the per-caller bookkeeping the
+ * unauthenticated intake endpoints keep in memory.
+ *
+ * The pattern this replaces looked bounded but was not: a lazy sweep that ran only
+ * above N entries and deleted only entries idle for hours. Under a stream of
+ * never-before-seen keys — which is exactly what a client-supplied `visitId` or
+ * `sessionId` is — nothing was ever old enough to delete, so every request past the
+ * threshold paid for a full scan that freed nothing while the map kept growing. The
+ * work per request rose with the size of the map, which is the wrong direction for a
+ * surface anyone on the internet can reach.
+ *
+ * A cap plus LRU eviction fixes both halves: memory stops at a known ceiling, and the
+ * cost per request is constant.
+ */
+
+/**
+ * Records `key` → `value`, evicting least-recently-used entries past `maxEntries`.
+ *
+ * The delete-then-set is load-bearing. `Map.set` on an existing key keeps its original
+ * insertion position, so without it the *busiest* keys drift to the front and get
+ * evicted first — the opposite of what a cache wants.
+ */
+export function rememberBounded<K, V>(map: Map<K, V>, key: K, value: V, maxEntries: number): void {
+  map.delete(key);
+  map.set(key, value);
+
+  while (map.size > maxEntries) {
+    // `.done` rather than `value === undefined`: undefined is a legal key, and an
+    // empty map must end the loop rather than delete nothing forever.
+    const oldest = map.keys().next();
+    if (oldest.done) break;
+    map.delete(oldest.value);
+  }
+}

--- a/apps/api/src/mp.test.ts
+++ b/apps/api/src/mp.test.ts
@@ -405,7 +405,7 @@ describe('websocket relay', () => {
     // costs the opener nothing while holding memory and a descriptor on a service
     // documented as running a single instance.
     const app = await createApp({ maxSocketsPerIp: 2 });
-    await app.listen({ port: 0 });
+    await app.listen({ port: 0, host: '127.0.0.1' });
     const url = wsUrl(app);
 
     const first = await openSocket(url);
@@ -428,7 +428,7 @@ describe('websocket relay', () => {
     // A flood never sends `hello`, so those sockets hold no room — releasing only
     // joined ones would leak the ceiling to exactly the connections it bounds.
     const app = await createApp({ maxSocketsPerIp: 1 });
-    await app.listen({ port: 0 });
+    await app.listen({ port: 0, host: '127.0.0.1' });
     const url = wsUrl(app);
 
     const first = await openSocket(url);

--- a/apps/api/src/mp.test.ts
+++ b/apps/api/src/mp.test.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { describe, expect, it } from 'vitest';
+import WebSocket from 'ws';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import {
@@ -39,10 +40,25 @@ function lastFrame(socket: { sent: Array<Record<string, unknown>> }, type: strin
   return [...socket.sent].reverse().find((frame) => frame.t === type);
 }
 
-async function createApp(): Promise<FastifyInstance> {
+function wsUrl(app: FastifyInstance): string {
+  const address = app.server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return `ws://127.0.0.1:${port}/api/mp/ws`;
+}
+
+/** Resolves once the connection is actually established, so the cap has counted it. */
+function openSocket(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    socket.on('open', () => resolve(socket));
+    socket.on('error', reject);
+  });
+}
+
+async function createApp(multiplayerRoutes?: { maxSocketsPerIp?: number }): Promise<FastifyInstance> {
   const store = new InMemoryStore();
   await store.upsertUser({ uid: 'g:test-user' });
-  return buildApp({ store, sessionSecret });
+  return buildApp({ store, sessionSecret, ...(multiplayerRoutes ? { multiplayerRoutes } : {}) });
 }
 
 describe('room tokens', () => {
@@ -375,6 +391,63 @@ describe('websocket relay', () => {
 
     hostSocket.close();
     guestSocket.close();
+    await app.close();
+  });
+
+  /**
+   * These two connect over real TCP rather than `injectWS`, because the cap keys on
+   * `request.ip` and an injected upgrade has no underlying socket for that getter to
+   * read — the connection is deliberately left uncapped in that case, so an injected
+   * socket cannot exercise the limit at all.
+   */
+  it('refuses more concurrent sockets than one address may hold', async () => {
+    // The websocket is the one door an anonymous guest reaches, and an idle socket
+    // costs the opener nothing while holding memory and a descriptor on a service
+    // documented as running a single instance.
+    const app = await createApp({ maxSocketsPerIp: 2 });
+    await app.listen({ port: 0 });
+    const url = wsUrl(app);
+
+    const first = await openSocket(url);
+    const second = await openSocket(url);
+
+    const third = new WebSocket(url);
+    const frames: Array<Record<string, unknown>> = [];
+    third.on('message', (data: Buffer) => frames.push(JSON.parse(data.toString()) as Record<string, unknown>));
+
+    await waitFor(() => frames.some((frame) => frame.t === 'closed'));
+    expect(frames.find((frame) => frame.t === 'closed')).toMatchObject({ reason: 'too_many_connections' });
+
+    first.close();
+    second.close();
+    third.close();
+    await app.close();
+  });
+
+  it('frees the allowance when a socket closes, even one that never joined', async () => {
+    // A flood never sends `hello`, so those sockets hold no room — releasing only
+    // joined ones would leak the ceiling to exactly the connections it bounds.
+    const app = await createApp({ maxSocketsPerIp: 1 });
+    await app.listen({ port: 0 });
+    const url = wsUrl(app);
+
+    const first = await openSocket(url);
+    await new Promise<void>((resolve) => {
+      first.on('close', () => resolve());
+      first.close();
+    });
+
+    // The replacement is admitted rather than refused: it reaches normal frame
+    // handling, which a connection over the cap never would.
+    const second = await openSocket(url);
+    const frames: Array<Record<string, unknown>> = [];
+    second.on('message', (data: Buffer) => frames.push(JSON.parse(data.toString()) as Record<string, unknown>));
+    second.send('not json');
+
+    await waitFor(() => frames.some((frame) => frame.t === 'closed'));
+    expect(frames.find((frame) => frame.t === 'closed')).toMatchObject({ reason: 'bad_frame' });
+
+    second.close();
     await app.close();
   });
 

--- a/apps/api/src/mp.ts
+++ b/apps/api/src/mp.ts
@@ -485,6 +485,37 @@ export interface MultiplayerRoutesOptions {
   registry?: RoomRegistry;
   /** Max rooms one IP may open per hour. */
   maxRoomsPerWindow?: number;
+  /** Max controller/host sockets one IP may hold open at once. */
+  maxSocketsPerIp?: number;
+}
+
+/**
+ * A shared screen plus a full lobby of phones is `MAX_SLOTS + 1` sockets, and they
+ * are normally on one household's wifi — so the default clears two simultaneous
+ * parties from a single address, leaving room for reconnect overlap.
+ */
+export const DEFAULT_MAX_SOCKETS_PER_IP = 24;
+
+/**
+ * The address to bucket a connection under, or null when it cannot be determined.
+ *
+ * `request.ip` is the value we want — `trustProxy` resolves the real client rather
+ * than Cloud Run's proxy, which is the whole reason app.ts sets it — but the getter
+ * reads `raw.socket.remoteAddress`, and an upgrade request with no underlying socket
+ * makes it throw rather than return undefined.
+ *
+ * Null (rather than a shared "unknown" bucket) is the deliberate choice: connections
+ * we cannot classify simply are not capped. Collapsing them together would let one
+ * unclassifiable transport exhaust a single bucket and lock everyone out of
+ * multiplayer — a cap that takes down the feature it protects is worse than no cap,
+ * and the fail-open case degrades to exactly the behaviour that shipped before this.
+ */
+function connectionAddress(request: FastifyRequest): string | null {
+  try {
+    return request.ip || null;
+  } catch {
+    return null;
+  }
 }
 
 const CreateSessionSchema = z.object({
@@ -519,6 +550,9 @@ export async function registerMultiplayerRoutes(
   const registry = options.registry ?? new RoomRegistry();
   const maxRoomsPerWindow = options.maxRoomsPerWindow ?? 30;
   const roomsByIp = new Map<string, number[]>();
+  const maxSocketsPerIp = options.maxSocketsPerIp ?? DEFAULT_MAX_SOCKETS_PER_IP;
+  /** Live socket count per address. Entries are deleted at zero, so this cannot grow. */
+  const socketsByIp = new Map<string, number>();
 
   // Hosting a room is an authenticated, rate-limited action. Guests never touch
   // this route — they arrive over the websocket with a room token instead.
@@ -545,7 +579,7 @@ export async function registerMultiplayerRoutes(
   // One websocket endpoint for both roles. The first frame decides which: a host
   // token attaches the shared screen, a guest token claims a controller slot.
   // Deliberately NO credential in the URL — query strings land in access logs.
-  app.get('/api/mp/ws', { websocket: true }, (socket) => {
+  app.get('/api/mp/ws', { websocket: true }, (socket, request) => {
     const limiter = new FrameLimiter();
     let role: 'none' | 'host' | 'guest' = 'none';
     let roomCode: string | null = null;
@@ -558,6 +592,36 @@ export async function registerMultiplayerRoutes(
         // socket already gone
       }
       socket.close(1000, reason);
+    };
+
+    // This is the one door an anonymous guest may reach, and until now nothing
+    // limited how many they could hold open. Everything *inside* a connection is
+    // bounded (4KB payloads, 2KB frames, 40 fps) but an idle socket costs memory and
+    // a file descriptor while costing the opener nothing — and multiplayer is
+    // documented as running on a single instance (see the note at the top of this
+    // file), so there is no second container to absorb a flood.
+    //
+    // The ceiling has to clear a real party comfortably: the phones and the shared
+    // screen are usually on the same wifi, so one household is legitimately
+    // MAX_SLOTS + 1 sockets at once, plus reconnect overlap.
+    const ip = connectionAddress(request);
+    if (ip !== null) {
+      const openForIp = socketsByIp.get(ip) ?? 0;
+      if (openForIp >= maxSocketsPerIp) {
+        closeWith('too_many_connections');
+        return;
+      }
+      socketsByIp.set(ip, openForIp + 1);
+    }
+
+    // Exactly once, whichever of close/error fires (both can, and both call onClose).
+    let released = false;
+    const releaseSocket = () => {
+      if (released || ip === null) return;
+      released = true;
+      const remaining = (socketsByIp.get(ip) ?? 1) - 1;
+      if (remaining > 0) socketsByIp.set(ip, remaining);
+      else socketsByIp.delete(ip);
     };
 
     const onMessage = (raw: unknown) => {
@@ -658,6 +722,10 @@ export async function registerMultiplayerRoutes(
     };
 
     const onClose = () => {
+      // Before the early return below: a socket that never sent `hello` has no room,
+      // and that is precisely the shape a flood takes — releasing only joined sockets
+      // would leak the ceiling to the connections it exists to bound.
+      releaseSocket();
       if (!roomCode) return;
       if (role === 'host') {
         // The shared screen going away ends the party — controllers are useless

--- a/apps/api/src/telemetry.ts
+++ b/apps/api/src/telemetry.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { rememberBounded } from './bounded-map.js';
 import type { PublishedSlugGate } from './published-slugs.js';
 import type { Store, TelemetryEvent } from './store.js';
 
@@ -34,6 +35,14 @@ const MAX_EVENTS_PER_SESSION = 400;
 /** Flushes one IP may send per minute, across all its tabs. */
 const MAX_REQUESTS_PER_WINDOW = 120;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+/**
+ * Hard ceilings on the in-memory bookkeeping. `sessionId` is client-supplied, so the
+ * cap on sessions is what stops a stream of fresh ids from growing the map without
+ * bound; the IP ceiling is far higher because evicting a limiter bucket hands that
+ * caller a fresh window, and real client addresses are not cheap to vary.
+ */
+const MAX_TRACKED_SESSIONS = 5000;
+const MAX_TRACKED_IPS = 20_000;
 const MAX_MESSAGE_LENGTH = 200;
 const MAX_LABEL_LENGTH = 40;
 /** Log every Nth unknown-slug drop: enough to notice a systemic problem, not a flood. */
@@ -113,11 +122,11 @@ export interface TelemetryRoutesOptions {
 function isRateLimited(buckets: Map<string, number[]>, key: string, currentTime: number): boolean {
   const hits = (buckets.get(key) ?? []).filter((timestamp) => currentTime - timestamp < RATE_LIMIT_WINDOW_MS);
   if (hits.length >= MAX_REQUESTS_PER_WINDOW) {
-    buckets.set(key, hits);
+    rememberBounded(buckets, key, hits, MAX_TRACKED_IPS);
     return true;
   }
   hits.push(currentTime);
-  buckets.set(key, hits);
+  rememberBounded(buckets, key, hits, MAX_TRACKED_IPS);
   return false;
 }
 
@@ -128,15 +137,8 @@ export async function registerTelemetryRoutes(app: FastifyInstance, options: Tel
   const requestsByIp = new Map<string, number[]>();
   /** Flushes discarded for an unrecognised slug; logged sparsely, never per request. */
   let droppedUnknownSlug = 0;
-  /** sessionId -> { count, lastSeen }, pruned lazily so an idle process does not grow. */
+  /** sessionId -> { count, lastSeen }. Capped and LRU-evicted — see bounded-map.ts. */
   const sessionCounts = new Map<string, { count: number; lastSeen: number }>();
-
-  function pruneSessions(currentTime: number): void {
-    if (sessionCounts.size < 5000) return;
-    for (const [sessionId, entry] of sessionCounts) {
-      if (currentTime - entry.lastSeen > 6 * 60 * 60 * 1000) sessionCounts.delete(sessionId);
-    }
-  }
 
   app.post('/api/telemetry', async (request, reply) => {
     const currentTime = now();
@@ -168,11 +170,15 @@ export async function registerTelemetryRoutes(app: FastifyInstance, options: Tel
       return reply.status(202).send({ accepted: 0 });
     }
 
-    pruneSessions(currentTime);
     const session = sessionCounts.get(parsed.data.sessionId) ?? { count: 0, lastSeen: currentTime };
     const room = MAX_EVENTS_PER_SESSION - session.count;
     if (room <= 0) {
-      sessionCounts.set(parsed.data.sessionId, { count: session.count, lastSeen: currentTime });
+      rememberBounded(
+        sessionCounts,
+        parsed.data.sessionId,
+        { count: session.count, lastSeen: currentTime },
+        MAX_TRACKED_SESSIONS,
+      );
       return reply.status(202).send({ accepted: 0 });
     }
 
@@ -221,7 +227,12 @@ export async function registerTelemetryRoutes(app: FastifyInstance, options: Tel
       }
     });
 
-    sessionCounts.set(parsed.data.sessionId, { count: session.count + events.length, lastSeen: currentTime });
+    rememberBounded(
+      sessionCounts,
+      parsed.data.sessionId,
+      { count: session.count + events.length, lastSeen: currentTime },
+      MAX_TRACKED_SESSIONS,
+    );
 
     // Back-dating means one flush can straddle midnight, so events go to the partition
     // their own timestamp names rather than all following the last one's.

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { rememberBounded } from './bounded-map.js';
 import type { Store, VisitEvent } from './store.js';
 
 /**
@@ -29,6 +30,14 @@ const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const MAX_VISIT_MS = 24 * 60 * 60 * 1000;
 /** How far back an event may be dated from its flush — bounds client-supplied offsets. */
 const MAX_BACKDATE_MS = 6 * 60 * 60 * 1000;
+/**
+ * Hard ceilings on the in-memory bookkeeping. `visitId` is client-supplied, so the
+ * cap on visits is what stops a stream of fresh ids from growing the map without
+ * bound; the IP ceiling is far higher because evicting a limiter bucket hands that
+ * caller a fresh window, and real client addresses are not cheap to vary.
+ */
+const MAX_TRACKED_VISITS = 5000;
+const MAX_TRACKED_IPS = 20_000;
 
 const RouteKindSchema = z.enum(['home', 'play', 'draft', 'status', 'join', 'legal', 'health', 'studio', 'notFound']);
 /**
@@ -90,11 +99,11 @@ export interface VisitTelemetryRoutesOptions {
 function isRateLimited(buckets: Map<string, number[]>, key: string, currentTime: number): boolean {
   const hits = (buckets.get(key) ?? []).filter((timestamp) => currentTime - timestamp < RATE_LIMIT_WINDOW_MS);
   if (hits.length >= MAX_REQUESTS_PER_WINDOW) {
-    buckets.set(key, hits);
+    rememberBounded(buckets, key, hits, MAX_TRACKED_IPS);
     return true;
   }
   hits.push(currentTime);
-  buckets.set(key, hits);
+  rememberBounded(buckets, key, hits, MAX_TRACKED_IPS);
   return false;
 }
 
@@ -106,15 +115,8 @@ export async function registerVisitTelemetryRoutes(
   const now = options.now ?? Date.now;
 
   const requestsByIp = new Map<string, number[]>();
-  /** visitId -> { count, lastSeen }, pruned lazily so an idle process does not grow. */
+  /** visitId -> { count, lastSeen }. Capped and LRU-evicted — see bounded-map.ts. */
   const visitCounts = new Map<string, { count: number; lastSeen: number }>();
-
-  function pruneVisits(currentTime: number): void {
-    if (visitCounts.size < 5000) return;
-    for (const [visitId, entry] of visitCounts) {
-      if (currentTime - entry.lastSeen > 6 * 60 * 60 * 1000) visitCounts.delete(visitId);
-    }
-  }
 
   app.post('/api/telemetry/visit', async (request, reply) => {
     const currentTime = now();
@@ -128,11 +130,15 @@ export async function registerVisitTelemetryRoutes(
       return reply.status(429).send({ error: 'too many telemetry requests' });
     }
 
-    pruneVisits(currentTime);
     const visit = visitCounts.get(parsed.data.visitId) ?? { count: 0, lastSeen: currentTime };
     const room = MAX_EVENTS_PER_VISIT - visit.count;
     if (room <= 0) {
-      visitCounts.set(parsed.data.visitId, { count: visit.count, lastSeen: currentTime });
+      rememberBounded(
+        visitCounts,
+        parsed.data.visitId,
+        { count: visit.count, lastSeen: currentTime },
+        MAX_TRACKED_VISITS,
+      );
       return reply.status(202).send({ accepted: 0 });
     }
 
@@ -173,7 +179,12 @@ export async function registerVisitTelemetryRoutes(
       }
     });
 
-    visitCounts.set(parsed.data.visitId, { count: visit.count + events.length, lastSeen: currentTime });
+    rememberBounded(
+      visitCounts,
+      parsed.data.visitId,
+      { count: visit.count + events.length, lastSeen: currentTime },
+      MAX_TRACKED_VISITS,
+    );
 
     // Back-dating means one flush can straddle midnight, so events go to the partition
     // their own timestamp names rather than all following the last one's.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,11 @@
       "devDependencies": {
         "@types/node": "^20.14.15",
         "@types/web-push": "^3.6.4",
+        "@types/ws": "^8.18.1",
         "tsx": "^4.16.5",
         "typescript": "^5.5.4",
-        "vitest": "^3.2.7"
+        "vitest": "^3.2.7",
+        "ws": "^8.18.0"
       }
     },
     "apps/api/node_modules/genaicode": {
@@ -2374,6 +2376,16 @@
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
       "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Follow-up hardening from the security review in #286. Both items are resource-exhaustion rather than access-control, which is why they weren't in that PR. Neither is urgent — both need many addresses to exploit — but both are cheap to close.

The third item that PR listed turned out not to be a real issue; see the last section.

## 1. The telemetry maps could not be prevented from growing

Both intake endpoints kept a per-caller map swept by a pass that ran only above 5,000 entries and deleted only entries idle for six hours. The keys are a **client-supplied** `visitId` / `sessionId`, so under a stream of fresh ids nothing was ever old enough to delete: every request past the threshold paid for a full scan that freed nothing, while the map kept growing. Work per request rose with the size of the map — the wrong direction for an endpoint reachable without a session (`/api/telemetry/visit` is exempt from the beta wall by design).

Replaced with a hard cap plus LRU eviction (`bounded-map.ts`): memory stops at a known ceiling and the per-request cost is constant.

The delete-then-set in that helper is load-bearing — `Map.set` on an existing key keeps its original insertion position, so without it the *busiest* keys drift to the front and get evicted first, which is backwards. There's a unit test for exactly that distinction.

Also applied to the per-IP limiter buckets in the same two files, whose keys were never removed either. Those get a much higher ceiling than the visit/session maps: evicting a limiter bucket hands that caller a fresh window, and real client addresses aren't cheap to vary.

## 2. Multiplayer sockets had no per-address ceiling

Everything *inside* a connection was already bounded (4KB payloads, 2KB frames, 40fps), but nothing limited how many an anonymous caller could hold open — against a relay documented as running on a single instance, so there's no second container to absorb a flood. An idle socket costs the opener nothing and costs us memory and a descriptor.

Now capped per address, defaulting to 24. That has to clear a real party: the phones and the shared screen are usually on one household's wifi, so `MAX_SLOTS + 1` sockets from a single address is legitimate, plus reconnect overlap.

Released on close **before** the room-cleanup early return. A flood never sends `hello`, so those sockets hold no room — releasing only joined ones would have leaked the ceiling to exactly the connections it's meant to bound.

**One design note worth a reviewer's eye.** The cap keys on `request.ip`, whose getter reads `raw.socket.remoteAddress` and *throws* when an upgrade request has no underlying socket. Connections that can't be classified are left **uncapped** rather than pooled under a shared `"unknown"` key: pooling would let one unclassifiable transport exhaust a single bucket and lock everyone out of multiplayer. A cap that takes down the feature it protects is worse than no cap, and failing open degrades to exactly the behaviour that shipped before this.

That choice is why those two tests connect over real TCP with a `ws` client instead of `injectWS` — an injected socket has no `raw.socket`, so it can't exercise the limit at all.

## Dropped: the boot-time `SESSION_SECRET` assertion

#286 listed this as the third follow-up. On inspection it isn't a real vulnerability, so there's no change here.

The production path is already fail-closed: without the secret, `isAuthConfigured` is false, the request hook never resolves a session, and a cookie forged with the published dev literal gets a 401. I verified that empirically before dropping the item rather than reasoning about it. The dev-secret fallback is only reachable when `NODE_ENV` isn't `production`, and the Dockerfile bakes `ENV NODE_ENV=production` into the image.

Adding the assertion would have broken the intentional "503 when authentication is unconfigured" behaviour (there's a test asserting it) to fix nothing. Flagging it because my earlier summary presented it as actionable — that was overstated.

## Tests

813 passing, lint and type-check clean, branch cut fresh from current master.

- `bounded-map.test.ts` — the cap holds across 10,000 distinct keys; LRU beats insertion order; in-place update doesn't grow; cap of one
- two multiplayer tests over real sockets — the connection past the cap is refused, and closing one frees the allowance even when it never joined

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmAoWTsb57523ac3yG6qmC)_