### PR TITLE
Sync assemble budget with games-repo hostPause (250062)

### DIFF
--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(248_638);
+    expect(MAX_PROJECT_BYTES).toBe(250_062);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(248_638);
+    expect(MAX_PROJECT_BYTES).toBe(250_062);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -72,6 +72,7 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_POINTER_POLL_BYTES = 7_083;
       const GAMEKIT_DRAW_SURFACE_BYTES = 9_459;
       const GAMEKIT_POINTER_RELEASE_BYTES = 430;
+      const GAMEKIT_HOST_PAUSE_BYTES = 1_424;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -82,7 +83,8 @@ describe('games-repo source extractors', () => {
         GAMEKIT_UNIVERSAL_INPUT_BYTES +
         GAMEKIT_POINTER_POLL_BYTES +
         GAMEKIT_DRAW_SURFACE_BYTES +
-        GAMEKIT_POINTER_RELEASE_BYTES;
+        GAMEKIT_POINTER_RELEASE_BYTES +
+        GAMEKIT_HOST_PAUSE_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -31,23 +31,21 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
 
 /**
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
- * music, touch hint, progress, universal input, pointer poll, draw surface, …).
- * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
- * `MAX_BUNDLE_BYTES` (248_638, matching games-repo `shared/assemble-contract.json`
- * `maxProjectBytes`). Not a round KiB: the platform side is an explicit sum of named
- * allowances, not a padded `42 * 1024` block.
+ * music, touch hint, progress, universal input, pointer poll, draw surface,
+ * pointer release, host pause, …). Together with {@link GAME_BUDGET_BYTES} this
+ * must equal games-repo `MAX_BUNDLE_BYTES` (250_062, matching games-repo
+ * `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB: the
+ * platform side is an explicit sum of named allowances, not a padded
+ * `42 * 1024` block.
  *
- * Last moved by games-repo PR #103: the `touch` allowance went 12_795 → 13_061 (+266)
- * when `createInput` began requiring an explicit steer decision, which costs the
- * tightest published title a few author bytes for the mandatory `steer:` declaration.
- * Before that, games-repo PR #95 took it 7_501 → 12_795 (+5_294) for the on-screen
- * pad's discoverability chrome — contrast, direction glyphs, the bilingual coach hint,
- * the attention pulse — plus playfield touch steering and `setSteerAnchor` for
- * character-relative walking. Every game is served that layer whether it asked for it
- * or not, so it is charged to the platform side; charging it to authors would silently
- * shrink what they may write.
+ * Last moved by games-repo host-pause: +1_424 (`hostPause`) so Creator Studio /
+ * theater can dispatch `gdpl-pause` / `gdpl-resume` without the shell patching
+ * rAF. Before that, games-repo PR #103 raised `touch` 12_795 → 13_061 (+266)
+ * when `createInput` began requiring an explicit steer decision. Every game is
+ * served that layer whether it asked for it or not, so it is charged to the
+ * platform side; charging it to authors would silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 43_838;
+export const GAMEKIT_PLATFORM_BYTES = 45_262;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Games-repo already raised Check 4 / `MAX_BUNDLE_BYTES` to **250062** (+1424 `hostPause` for `gdpl-pause` / `gdpl-resume`). The website still enforced **248638**, so the snapshot bake rejected games that clear games-repo validation:

- `rooftop-dash` (249519)
- `settlers-of-the-north` (249042)
- `tower-defence` (249912)

## Change

Sync the website half of the lockstep:

- `GAMEKIT_PLATFORM_BYTES`: 43838 → **45262**
- `MAX_PROJECT_BYTES`: 248638 → **250062**

No games-repo change needed — it already has the higher cap.

## After merge

Deploy picks this up; then a green **Publish games snapshot** (auto on next games-repo merge, or manual workflow_dispatch) will advance `current.json` with those three games baked.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3889bb0e-c4d3-44c2-b799-1342e77859a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3889bb0e-c4d3-44c2-b799-1342e77859a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

