### PR TITLE
fix(e2e): allowlist GSI FedCM NetworkError so deploys can promote

### DIFF
--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -194,8 +194,9 @@ const EXPECTED_NOISE: { pattern: RegExp; why: string }[] = [
   {
     // The closed-beta splash renders Google's sign-in button, and GSI initialises
     // FedCM as soon as it loads. A CI browser has no Google session, so the provider
-    // answers with an empty account list and GSI logs it as an error. It is a
-    // statement about the browser profile, not about the button.
+    // either answers with an empty account list or rejects the token get with a
+    // NetworkError — GSI logs both as console.error. Those are statements about
+    // the browser profile, not about the button.
     //
     // Narrow on purpose: a client id or origin that is actually wrong fails
     // differently and loudly ("The given origin is not allowed for the given client
@@ -203,8 +204,8 @@ const EXPECTED_NOISE: { pattern: RegExp; why: string }[] = [
     // That pair is what wedged every deploy between 18:41 and 23:0x UTC on
     // 2026-07-27, when the candidate revision's host was missing from the OAuth
     // client's authorised JavaScript origins.
-    pattern: /Provider's accounts list is empty/,
-    why: 'a fresh CI browser has no Google session, so FedCM reports no accounts',
+    pattern: /\[GSI_LOGGER\]: FedCM (?:get\(\) rejects with NetworkError|.*Provider's accounts list is empty)/,
+    why: 'a fresh CI browser has no Google session, so FedCM cannot mint a token',
   },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy to Cloud Run has been failing the browser gate on `anonymous-and-mobile.test.ts` with:

`[GSI_LOGGER]: FedCM get() rejects with NetworkError: Error retrieving a token`

This is the same class of noise as the existing “Provider's accounts list is empty” allowlist: the closed-beta splash loads Google Sign-In, CI has no Google session, GSI logs a FedCM failure. It is **not** an OAuth origin/client misconfig (those still fail loudly with “origin is not allowed” / 403).

Seen blocking promotion for #293 (pause rollout), #299, and earlier master deploys today.

## Test plan

- [x] Pattern matches the failing console line; does not match OAuth origin errors
- [ ] Deploy browser gate passes on this PR / subsequent master deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

