### PR TITLE
fix(contract): sync hostPause +49 budget with games-repo

### DIFF
--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(250_062);
+    expect(MAX_PROJECT_BYTES).toBe(250_111);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(250_062);
+    expect(MAX_PROJECT_BYTES).toBe(250_111);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -72,7 +72,7 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_POINTER_POLL_BYTES = 7_083;
       const GAMEKIT_DRAW_SURFACE_BYTES = 9_459;
       const GAMEKIT_POINTER_RELEASE_BYTES = 430;
-      const GAMEKIT_HOST_PAUSE_BYTES = 1_424;
+      const GAMEKIT_HOST_PAUSE_BYTES = 1_473;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -33,19 +33,20 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
  * music, touch hint, progress, universal input, pointer poll, draw surface,
  * pointer release, host pause, …). Together with {@link GAME_BUDGET_BYTES} this
- * must equal games-repo `MAX_BUNDLE_BYTES` (250_062, matching games-repo
+ * must equal games-repo `MAX_BUNDLE_BYTES` (250_111, matching games-repo
  * `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB: the
  * platform side is an explicit sum of named allowances, not a padded
  * `42 * 1024` block.
  *
- * Last moved by games-repo host-pause: +1_424 (`hostPause`) so Creator Studio /
- * theater can dispatch `gdpl-pause` / `gdpl-resume` without the shell patching
- * rAF. Before that, games-repo PR #103 raised `touch` 12_795 → 13_061 (+266)
- * when `createInput` began requiring an explicit steer decision. Every game is
- * served that layer whether it asked for it or not, so it is charged to the
- * platform side; charging it to authors would silently shrink what they may write.
+ * Last moved by games-repo host-pause: +1_473 (`hostPause`, includes
+ * `suspend().catch`) so Creator Studio / theater can dispatch `gdpl-pause` /
+ * `gdpl-resume` without the shell patching rAF. Before that, games-repo PR #103
+ * raised `touch` 12_795 → 13_061 (+266) when `createInput` began requiring an
+ * explicit steer decision. Every game is served that layer whether it asked for
+ * it or not, so it is charged to the platform side; charging it to authors would
+ * silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 45_262;
+export const GAMEKIT_PLATFORM_BYTES = 45_311;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sync serve budget with games-repo `suspend().catch` (+49 → `MAX_PROJECT_BYTES` **250111** / `GAMEKIT_PLATFORM_BYTES` **45311**).

FedCM empty-accounts allowlist already landed on master (`9e1260fb`); this PR is the budget lockstep only (rebased).

### Merge order
1. Merge [games #119](https://github.com/gamedevpl/www.gamedev.pl-games/pull/119) first
2. Then this PR (contract check expects the new games-repo budget)
3. Deploy should then promote #293 pause rollout

## Test plan
- [x] API contract/assemble unit tests
- [ ] Games-repo contract green after #119 on main
- [ ] Deploy browser gate green after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

