### PR TITLE
Point the weekly digest at the studio

### DIFF
--- a/apps/api/src/digest.test.ts
+++ b/apps/api/src/digest.test.ts
@@ -131,6 +131,9 @@ describe('runDigestSweep', () => {
     expect(notification.type).toBe('creator.digest');
     expect(notification.id).toBe(digestId('2026-W31'));
     expect(notification.params).toMatchObject({ games: '1', sessions: '12', feedback: '3' });
+    // The studio is where the numbers behind the digest live, per game, with the themes
+    // the digest itself does not carry. Anywhere else makes the reader go looking.
+    expect(notification.link).toBe('/studio');
   });
 
   it('sends nothing to a creator whose games nobody played', async () => {

--- a/apps/api/src/digest.ts
+++ b/apps/api/src/digest.ts
@@ -58,11 +58,13 @@ const NOTIFICATION_SCAN_LIMIT = 200;
 /**
  * Where a digest sends the creator.
  *
- * A digest spans every game they own, so it cannot deep-link to one. Today that means the
- * home page, which carries the "my games" rail; when the creator studio lands this becomes
- * `/studio`, and this constant is the only line that changes.
+ * A digest spans every game they own, so it cannot deep-link to one — it links to the
+ * shelf. `/studio` is where the numbers behind the digest actually live: the same
+ * scorecards, per game, with the feedback themes the digest deliberately does not carry.
+ * Sending someone to the home page instead would make them hunt for what the message was
+ * about.
  */
-const DIGEST_LINK = '/';
+const DIGEST_LINK = '/studio';
 
 export interface DigestTotals {
   /** Games with a scorecard — i.e. games with evidence, not games owned. */


### PR DESCRIPTION
## Why

A one-constant follow-up flagged in #287, now that #236 has shipped `/studio`.

The digest links to the shelf rather than to one game, because it spans every game a creator owns. It pointed at `/` only because the studio didn't exist when it was written.

`/studio` is where the numbers behind the digest actually live — the same scorecards, per game, alongside the feedback themes the digest deliberately *doesn't* carry. Landing on the home page made someone hunt for what the message was about.

## What

`DIGEST_LINK = '/studio'`, plus a test asserting the emitted notification's link, so this cannot silently drift back. The plan doc's "should become `/studio`" note is now a statement of fact rather than a TODO.

This changes the in-app bell target, the email CTA, and the push URL together — all three read `notification.link`.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` (exit 0)
- [x] `npm run build`

## Note

Worth merging before the scheduler job is created, so the first digest anyone receives already points at the right place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4qCA3ruvWreLtyibx71q)_