### PR TITLE
Wake the header mascot up, fit the beta splash on a small phone, and let him feel the tilt

### DIFF
--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -39,6 +39,7 @@ export function ClosedBetaSplash() {
         <InteractiveMascot
           className="beta-splash__mascot"
           idleEmotion="wave"
+          reactsToTilt
           size={96}
           pokeLabel={t('mascot.poke')}
         />

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -9,7 +9,8 @@
  * waving arm). `staticPose` freezes everything; `prefers-reduced-motion` does too.
  *
  * `InteractiveMascot` wraps the SVG in a button: hover peeks, click cycles
- * reactions, and the face tracks the pointer a little.
+ * reactions, and the face tracks the pointer a little. With `reactsToTilt` he also
+ * leans with the phone's own orientation and gets dizzy when it is shaken.
  */
 
 import {
@@ -23,6 +24,7 @@ import {
   type ReactNode,
 } from 'react';
 import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans.js';
+import { useDeviceTilt } from './useDeviceTilt.js';
 
 export type MascotEmotion =
   'idle' | 'happy' | 'curious' | 'thinking' | 'excited' | 'confused' | 'sad' | 'proud' | 'wave' | 'busy';
@@ -279,14 +281,7 @@ function BlinkLids() {
   );
 }
 
-export function Mascot({
-  emotion = 'idle',
-  size = 48,
-  className,
-  title,
-  staticPose = false,
-  look,
-}: MascotProps) {
+export function Mascot({ emotion = 'idle', size = 48, className, title, staticPose = false, look }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
   const height = Math.round((size * 60) / 70);
@@ -354,14 +349,7 @@ export function Mascot({
 }
 
 /** Playful reactions cycled when the visitor pokes the splash mascot. */
-const POKE_REACTIONS: readonly MascotEmotion[] = [
-  'excited',
-  'happy',
-  'curious',
-  'proud',
-  'thinking',
-  'confused',
-];
+const POKE_REACTIONS: readonly MascotEmotion[] = ['excited', 'happy', 'curious', 'proud', 'thinking', 'confused'];
 
 const POKE_HOLD_MS = 1400;
 
@@ -372,6 +360,11 @@ type InteractiveMascotProps = {
   idleEmotion?: MascotEmotion;
   /** Accessible name for the poke control. */
   pokeLabel: string;
+  /**
+   * Lean and look with the phone's own tilt, and get dizzy when it is shaken.
+   * Off by default: it costs two window listeners and, on iOS, a permission prompt.
+   */
+  reactsToTilt?: boolean;
 };
 
 /**
@@ -383,6 +376,7 @@ export function InteractiveMascot({
   className,
   idleEmotion = 'wave',
   pokeLabel,
+  reactsToTilt = false,
 }: InteractiveMascotProps) {
   const rootRef = useRef<HTMLButtonElement>(null);
   const pokeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -419,6 +413,26 @@ export function InteractiveMascot({
     };
   }, []);
 
+  // Tilting the phone is the same gesture as moving the pointer, as far as he is
+  // concerned — both end up as a look vector. Reduced motion opts out entirely.
+  const device = useDeviceTilt(reactsToTilt && !reduceMotion);
+
+  // Shake him and he gets dizzy. Skips the first render: shakeCount starts at 0 and
+  // reaching 1 is the first real shake.
+  useEffect(() => {
+    if (device.shakeCount === 0) return;
+    pokingRef.current = true;
+    setPoking(true);
+    setEmotion('confused');
+    if (pokeTimer.current) clearTimeout(pokeTimer.current);
+    pokeTimer.current = setTimeout(() => {
+      pokingRef.current = false;
+      setPoking(false);
+      setEmotion(hoveredRef.current ? 'curious' : idleEmotion);
+      pokeTimer.current = null;
+    }, POKE_HOLD_MS);
+  }, [device.shakeCount, idleEmotion]);
+
   // Reduced motion still gets the emotion swap — only tilt/boop are suppressed.
   const settleEmotion = () => (hoveredRef.current ? 'curious' : idleEmotion);
 
@@ -453,6 +467,15 @@ export function InteractiveMascot({
   };
 
   const handlePoke = () => {
+    /*
+     * iOS only hands out orientation events if you ask from inside a user gesture, so
+     * the ask has to be attached to something the visitor already wants to do. Poking
+     * the mascot is exactly that, which is why there is no separate "enable motion"
+     * button: he wakes up to the phone's tilt the first time you touch him. Safe to
+     * call every time — it is a no-op once granted, and on Android entirely.
+     */
+    if (reactsToTilt && device.needsPermission) device.request();
+
     const next = POKE_REACTIONS[reactionIndex.current % POKE_REACTIONS.length]!;
     reactionIndex.current += 1;
     pokingRef.current = true;
@@ -467,10 +490,19 @@ export function InteractiveMascot({
     }, POKE_HOLD_MS);
   };
 
+  /*
+   * A finger on him beats the phone's own angle — otherwise the mascot keeps staring
+   * off to one side while you are actively touching him. `look` is only non-zero while
+   * a pointer is over him, and `resetLook` zeroes it on leave, so this needs no extra
+   * state to decide which source is live.
+   */
+  const pointerLeads = look.x !== 0 || look.y !== 0;
+  const effectiveLook = pointerLeads || !device.active ? look : device.tilt;
+
   const tiltStyle: CSSProperties | undefined = reduceMotion
     ? undefined
     : {
-        transform: `rotate(${(look.x * 7).toFixed(2)}deg) translateY(${(look.y * 2).toFixed(2)}px)`,
+        transform: `rotate(${(effectiveLook.x * 7).toFixed(2)}deg) translateY(${(effectiveLook.y * 2).toFixed(2)}px)`,
       };
 
   return (
@@ -501,7 +533,7 @@ export function InteractiveMascot({
       {/* Tilt lives on an inner span so the button can still run the poke squash. */}
       <span className="mascot-interactive__tilt" style={tiltStyle}>
         {/* Button owns the accessible name; keep the SVG presentational to avoid a double announce. */}
-        <Mascot emotion={emotion} size={size} look={reduceMotion ? undefined : look} />
+        <Mascot emotion={emotion} size={size} look={reduceMotion ? undefined : effectiveLook} />
       </span>
     </button>
   );

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -35,7 +35,11 @@ type MascotProps = {
   size?: number;
   className?: string;
   title?: string;
-  /** When true, all motion is forced off (e.g. tiny nav mark). */
+  /**
+   * When true, all motion is forced off. Nothing in the app sets this today — the
+   * header mark breathes like every other instance — but a still frame is what a
+   * favicon/OG rasteriser or a print stylesheet would want.
+   */
   staticPose?: boolean;
   /** Nudge face cutouts toward a point — no-op on the baked idle silhouette. */
   look?: MascotLook;

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -471,10 +471,15 @@ export function InteractiveMascot({
      * iOS only hands out orientation events if you ask from inside a user gesture, so
      * the ask has to be attached to something the visitor already wants to do. Poking
      * the mascot is exactly that, which is why there is no separate "enable motion"
-     * button: he wakes up to the phone's tilt the first time you touch him. Safe to
-     * call every time — it is a no-op once granted, and on Android entirely.
+     * button: he wakes up to the phone's tilt the first time you touch him.
+     *
+     * Called unguarded on purpose. Gating on `needsPermission` would read the result
+     * of an effect that may not have run yet on a fast first poke, and losing that
+     * race means the prompt never appears. `request()` already no-ops when there is
+     * nothing to ask — on Android it returns immediately — so the guard bought
+     * nothing and could only cost the one interaction that matters.
      */
-    if (reactsToTilt && device.needsPermission) device.request();
+    if (reactsToTilt) device.request();
 
     const next = POKE_REACTIONS[reactionIndex.current % POKE_REACTIONS.length]!;
     reactionIndex.current += 1;

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -40,7 +40,7 @@ export function NavHeader({ activeSpecsCount, onNavigate, onHome, onStudio }: Na
     <header className="app-header">
       <div className="logo-brand">
         <a href="/" className="logo" onClick={handleLogoClick}>
-          <Mascot className="mascot--logo" emotion="idle" size={35} title={t('header.logoAlt')} staticPose />
+          <Mascot className="mascot--logo" emotion="idle" size={35} title={t('header.logoAlt')} />
           gamedev<span className="turquoise">.pl</span>
         </a>
       </div>

--- a/apps/web/src/betaSplashFit.test.ts
+++ b/apps/web/src/betaSplashFit.test.ts
@@ -26,6 +26,23 @@ describe('the beta splash fits a small phone', () => {
     }
   });
 
+  it('centres the card without making an overflowing one unreachable', () => {
+    const query = css.slice(css.indexOf('@media (max-height: 720px)'));
+    // Comments here explain what NOT to use, so strip them before asserting absence.
+    const splash = query
+      .slice(query.indexOf('.beta-splash {'), query.indexOf('.beta-splash__card {'))
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Centring a flex item that overflows puts its top edge where it cannot be
+    // scrolled to. `safe center` expresses the intent but older Safari drops it and
+    // falls back to plain `center` — the bug it was meant to avoid. Auto margins on
+    // the card do the same job with no support caveat.
+    expect(splash).toContain('align-items: flex-start');
+    expect(splash).not.toContain('align-items: center');
+    expect(splash).not.toContain('safe center');
+    const card = query.slice(query.indexOf('.beta-splash__card {'));
+    expect(card.slice(0, 200)).toMatch(/margin-top: auto;\s*margin-bottom: auto;/);
+  });
+
   it('never hides the legal links to make room', () => {
     // Anything may be trimmed except the two links that have to be reachable on the
     // screen where signing in happens.

--- a/apps/web/src/betaSplashFit.test.ts
+++ b/apps/web/src/betaSplashFit.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The closed-beta splash is the entire site for anyone not signed in, and on an
+ * iPhone SE it did not fit: the card wanted 678px of the ~553px Safari actually
+ * leaves visible, so the terms and privacy links sat behind the toolbar.
+ */
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+describe('the beta splash fits a small phone', () => {
+  it('measures the viewport as the part you can see', () => {
+    const rule = css.slice(css.indexOf('.beta-splash {'), css.indexOf('.beta-splash__card {'));
+    // Both, in this order. iOS resolves 100vh to the large viewport, so dvh has to
+    // come second and win; the vh line stays as the fallback for browsers without dvh.
+    expect(rule).toMatch(/min-height: 100vh;[\s\S]*min-height: 100dvh;/);
+  });
+
+  it('compresses the card on a short screen', () => {
+    const query = css.slice(css.indexOf('@media (max-height: 720px)'));
+    expect(query.slice(0, 40)).toContain('@media (max-height: 720px)');
+    // Keyed on height, not width — a phone in landscape is short too.
+    for (const selector of ['.beta-splash__card', '.beta-splash__mascot .mascot', '.beta-splash__headline']) {
+      expect(query).toContain(selector);
+    }
+  });
+
+  it('never hides the legal links to make room', () => {
+    // Anything may be trimmed except the two links that have to be reachable on the
+    // screen where signing in happens.
+    const query = css.slice(css.indexOf('@media (max-height: 720px)'));
+    const legalBlock = query.slice(query.indexOf('.beta-splash__legal'), query.indexOf('.beta-splash__legal') + 120);
+    expect(legalBlock).not.toMatch(/display:\s*none/);
+  });
+});

--- a/apps/web/src/headerMascot.test.ts
+++ b/apps/web/src/headerMascot.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The header mark is the one mascot every visitor sees, on every page. It shipped
+ * frozen — `staticPose` on the nav instance keys off every `:not(.mascot--static)`
+ * animation in the stylesheet at once — so the site's mascot was the only one that
+ * never breathed or blinked.
+ *
+ * Both halves of that are asserted from source rather than from a render: the prop is
+ * a one-word regression that a rendered-DOM test would have to reach through
+ * AuthContext and i18n to catch, and the hover rule has no DOM footprint at all.
+ */
+const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, import.meta.url)), 'utf8');
+
+describe('the header mascot is alive', () => {
+  it('does not freeze the nav mark', () => {
+    const navHeader = read('NavHeader.tsx');
+    const logoMascot = navHeader.match(/<Mascot[^>]*mascot--logo[^>]*\/>/s);
+    expect(logoMascot).not.toBeNull();
+    expect(logoMascot![0]).not.toMatch(/staticPose/);
+  });
+
+  it('promotes the idle breath to a hop while the logo is hovered', () => {
+    expect(read('styles.css')).toMatch(
+      /\.logo:hover \.mascot--logo:not\(\.mascot--static\) \.mascot__body-group \{\s*animation: mascot-bounce/,
+    );
+  });
+
+  it('still lets prefers-reduced-motion win over both', () => {
+    const css = read('styles.css');
+    const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+    // `!important` is what beats the hover rule — a plain `animation: none` there
+    // loses to it on specificity and the hop would survive the media query.
+    expect(reduced).toMatch(/\.mascot \.mascot__body-group,[\s\S]{0,200}?animation: none !important/);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3410,12 +3410,18 @@ body.player-open {
 @media (max-height: 720px) {
   .beta-splash {
     padding: 12px;
-    /* Still centred on a roomy screen, but a card taller than the viewport starts at
-       the top instead of having its head cut off as well as its feet. */
-    align-items: safe center;
+    /* Centring a flex item that overflows pushes its top edge past the container's,
+       where it cannot be scrolled back to — the head gets cut off as well as the feet.
+       `align-items: safe center` says exactly that, but older Safari drops the whole
+       declaration as invalid and silently falls back to plain `center`, which is the
+       bug. Auto margins do the same job with no support story: they centre while there
+       is free space and collapse to zero when there is not. */
+    align-items: flex-start;
   }
 
   .beta-splash__card {
+    margin-top: auto;
+    margin-bottom: auto;
     padding: 24px 20px;
     border-radius: 14px;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3254,6 +3254,11 @@ body.player-open {
 /* CLOSED BETA SPLASH */
 .beta-splash {
   min-height: 100vh;
+  /* iOS resolves 100vh to the LARGE viewport — the one you get with the toolbars
+     retracted — so a screen centred in it sits partly behind Safari's bottom bar
+     until you scroll. dvh tracks the visible viewport instead. Kept as a second
+     declaration so browsers without dvh keep the vh line. */
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3391,6 +3396,86 @@ body.player-open {
   color: #ff8080;
   font-size: 0.95rem;
   margin: 0;
+}
+
+/*
+ * Short screens — an iPhone SE is 375×667, and Safari's bars leave about 553px of
+ * that actually visible. The desktop card wants 678px, so the legal links sat behind
+ * the toolbar: the terms have to be reachable on the screen where you sign in, not a
+ * scroll away. Everything below trims vertical rhythm only; nothing is hidden.
+ *
+ * Keyed on height rather than width because the constraint is vertical — this also
+ * catches a phone held in landscape, where a width query would not fire.
+ */
+@media (max-height: 720px) {
+  .beta-splash {
+    padding: 12px;
+    /* Still centred on a roomy screen, but a card taller than the viewport starts at
+       the top instead of having its head cut off as well as its feet. */
+    align-items: safe center;
+  }
+
+  .beta-splash__card {
+    padding: 24px 20px;
+    border-radius: 14px;
+  }
+
+  /* CSS wins over the SVG's width/height attributes, so the mascot shrinks without
+     the component needing to know anything about the viewport. */
+  .beta-splash__mascot .mascot {
+    width: 68px;
+    height: 58px;
+  }
+
+  .beta-splash__mascot {
+    margin-bottom: 10px;
+  }
+
+  .beta-splash__logo {
+    font-size: 1.4rem;
+    margin-bottom: 12px;
+  }
+
+  .beta-splash__headline {
+    font-size: 1.3rem;
+    margin-bottom: 8px;
+  }
+
+  .beta-splash__sub {
+    font-size: 0.92rem;
+    margin-bottom: 14px;
+  }
+
+  .beta-splash__badge {
+    margin-bottom: 16px;
+  }
+
+  .beta-splash__signin {
+    margin-bottom: 14px;
+  }
+
+  .beta-splash__footer {
+    margin-top: 12px;
+  }
+
+  /* Only a margin that already exists is trimmed — the confirm/rejected lines sit at
+     margin 0 and must stay there, or the blocked state grows instead of shrinking. */
+  .beta-splash__blocked-msg {
+    font-size: 0.92rem;
+    margin-bottom: 12px;
+  }
+
+  .beta-splash__legal {
+    margin-top: 0.7rem;
+  }
+
+  /* The invite-only panel adds a message and a button, and it only ever appears after
+     the visitor has read the pitch and tried to sign in — so on a short screen the
+     pitch is what gives way, rather than the legal links dropping off the bottom
+     again. Progressive enhancement: without :has() the card scrolls, as it does now. */
+  .beta-splash__card:has(.beta-splash__blocked) .beta-splash__sub {
+    display: none;
+  }
 }
 
 /* Creator Q&A Clarifications */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4819,6 +4819,16 @@ body.player-open {
   color: var(--turquoise);
 }
 
+/*
+ * The header mark breathes and blinks like every other mascot on the site — it is the
+ * one instance every visitor sees, so freezing it was the wrong instance to freeze.
+ * Hovering the logo promotes that idle breath to the excited hop, which gives the
+ * brand link a reaction of its own instead of borrowing the text underline.
+ */
+.logo:hover .mascot--logo:not(.mascot--static) .mascot__body-group {
+  animation: mascot-bounce 0.55s ease-in-out infinite;
+}
+
 .mascot-moment {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/useDeviceTilt.test.tsx
+++ b/apps/web/src/useDeviceTilt.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { angleDelta, shakeJerk, tiltFromOrientation, useDeviceTilt, type DeviceTilt } from './useDeviceTilt.js';
+
+describe('tilt maths', () => {
+  it('takes the short way round the circle', () => {
+    // gamma/alpha wrap, so a small physical turn can look like a 358° swing.
+    expect(angleDelta(359, 1)).toBe(2);
+    expect(angleDelta(1, 359)).toBe(-2);
+    expect(angleDelta(0, 0)).toBe(0);
+  });
+
+  it('measures tilt from how the phone was first held, not from flat', () => {
+    // Held up to read: beta ~60. That must be the neutral, or he starts pinned down.
+    const baseline = { beta: 60, gamma: 0 };
+    expect(tiltFromOrientation({ beta: 60, gamma: 0 }, baseline)).toEqual({ x: 0, y: 0 });
+
+    const leaned = tiltFromOrientation({ beta: 74, gamma: 14 }, baseline);
+    expect(leaned.x).toBeCloseTo(0.5, 2);
+    expect(leaned.y).toBeCloseTo(0.5, 2);
+  });
+
+  it('clamps a phone turned right over', () => {
+    const hard = tiltFromOrientation({ beta: 180, gamma: -90 }, { beta: 0, gamma: 0 });
+    expect(hard.x).toBe(-1);
+    expect(hard.y).toBeLessThanOrEqual(1);
+    expect(hard.y).toBeGreaterThanOrEqual(-1);
+  });
+
+  it('survives a reading with no angles', () => {
+    expect(tiltFromOrientation({ beta: null, gamma: null }, { beta: 30, gamma: 10 })).toEqual({ x: 0, y: 0 });
+  });
+
+  it('scores a shake by the change between samples, not by gravity', () => {
+    // A still phone still reads ~9.8 on one axis — that must not count as a shake.
+    const still = { x: 0, y: 9.8, z: 0 };
+    expect(shakeJerk(still, still)).toBe(0);
+    expect(shakeJerk(still, { x: 0, y: -9.8, z: 0 })).toBeCloseTo(19.6, 1);
+  });
+});
+
+/** Mount a hook and expose its latest value. */
+function renderTilt(enabled: boolean) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const seen: DeviceTilt[] = [];
+  function Probe() {
+    seen.push(useDeviceTilt(enabled));
+    return null;
+  }
+  act(() => root.render(<Probe />));
+  return { latest: () => seen[seen.length - 1]!, unmount: () => act(() => root.unmount()) };
+}
+
+describe('useDeviceTilt', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports no support when the browser has no orientation events', () => {
+    // jsdom defines DeviceOrientationEvent, so absence has to be staged. Desktop
+    // Chrome defines it too with no sensor behind it — which is why `active` (an
+    // event actually arrived), not `supported`, is what gates the mascot.
+    vi.stubGlobal('DeviceOrientationEvent', undefined);
+    const probe = renderTilt(true);
+    expect(probe.latest().supported).toBe(false);
+    expect(probe.latest().active).toBe(false);
+    probe.unmount();
+  });
+
+  it('treats a requestPermission-bearing browser as needing a gesture', () => {
+    // This is the iOS shape: the constructor carries a static requestPermission.
+    const ctor = function DeviceOrientationEvent() {} as unknown as Record<string, unknown>;
+    ctor.requestPermission = vi.fn(() => Promise.resolve('granted'));
+    vi.stubGlobal('DeviceOrientationEvent', ctor);
+
+    const probe = renderTilt(true);
+    expect(probe.latest().supported).toBe(true);
+    expect(probe.latest().needsPermission).toBe(true);
+    probe.unmount();
+  });
+
+  it('does not ask for permission where the events simply flow', () => {
+    // Android/Chrome: constructor exists, no requestPermission. Asking would throw.
+    vi.stubGlobal('DeviceOrientationEvent', function DeviceOrientationEvent() {});
+    const probe = renderTilt(true);
+    expect(probe.latest().supported).toBe(true);
+    expect(probe.latest().needsPermission).toBe(false);
+    // request() must stay safe to call unconditionally.
+    expect(() => probe.latest().request()).not.toThrow();
+    probe.unmount();
+  });
+
+  it('stays asleep while disabled, so it costs nothing off the splash', () => {
+    vi.stubGlobal('DeviceOrientationEvent', function DeviceOrientationEvent() {});
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const probe = renderTilt(false);
+    expect(addSpy.mock.calls.some(([type]) => type === 'deviceorientation')).toBe(false);
+    probe.unmount();
+    addSpy.mockRestore();
+  });
+
+  it('listens, and lets go again on unmount', () => {
+    vi.stubGlobal('DeviceOrientationEvent', function DeviceOrientationEvent() {});
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const probe = renderTilt(true);
+    const listened = addSpy.mock.calls.map(([type]) => type);
+    expect(listened).toContain('deviceorientation');
+    expect(listened).toContain('devicemotion');
+
+    probe.unmount();
+    const released = removeSpy.mock.calls.map(([type]) => type);
+    expect(released).toContain('deviceorientation');
+    expect(released).toContain('devicemotion');
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/apps/web/src/useDeviceTilt.ts
+++ b/apps/web/src/useDeviceTilt.ts
@@ -1,0 +1,194 @@
+/**
+ * Device orientation as a normalized look vector, for the splash mascot.
+ *
+ * Three things make this awkward on the web, and all three are handled here rather
+ * than at the call site:
+ *
+ * 1. **iOS needs a gesture.** Since iOS 13 `DeviceOrientationEvent.requestPermission()`
+ *    exists, returns a promise, and throws unless it was called from a user gesture on
+ *    a secure origin. Android/Chrome has no such call and simply fires the event. So
+ *    support and permission are two separate questions, and `request()` is a no-op on
+ *    the platforms that do not need it.
+ * 2. **There is no neutral holding angle.** `beta` is ~0 with the phone flat on a table
+ *    and ~70 held up to read. Treating raw angles as absolute means the mascot is
+ *    already pinned to one side before you tilt anything, so the first reading becomes
+ *    the zero and everything after it is a delta from how you happened to be holding it.
+ * 3. **The events fire at 60Hz+.** Raw values are also jittery enough to shiver a
+ *    rendered face, so readings are smoothed and only published past a threshold.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type Tilt = { x: number; y: number };
+
+/** Degrees of tilt that count as a full deflection. A wrist roll, not a whole arm. */
+const FULL_TILT_DEGREES = 28;
+/** Ignore deltas below this so a resting hand does not re-render at display rate. */
+const PUBLISH_THRESHOLD = 0.035;
+/** Fraction of the gap to close per reading — lower is smoother and laggier. */
+const SMOOTHING = 0.18;
+/** m/s² of jerk between samples that reads as a deliberate shake, not a wobble. */
+const SHAKE_JERK = 22;
+/** Shakes cannot retrigger faster than this. */
+const SHAKE_COOLDOWN_MS = 900;
+
+const clamp = (value: number) => Math.max(-1, Math.min(1, value));
+
+/** Signed shortest distance between two angles, so 359°→1° is +2 and not -358. */
+export function angleDelta(from: number, to: number): number {
+  return ((to - from + 540) % 360) - 180;
+}
+
+/** Orientation reading → look vector, relative to the angles first seen. */
+export function tiltFromOrientation(
+  reading: { beta: number | null; gamma: number | null },
+  baseline: { beta: number; gamma: number },
+): Tilt {
+  return {
+    x: clamp(angleDelta(baseline.gamma, reading.gamma ?? baseline.gamma) / FULL_TILT_DEGREES),
+    y: clamp(angleDelta(baseline.beta, reading.beta ?? baseline.beta) / FULL_TILT_DEGREES),
+  };
+}
+
+/** Jerk between two acceleration samples — the quantity a shake actually is. */
+export function shakeJerk(
+  previous: { x: number; y: number; z: number },
+  next: { x: number; y: number; z: number },
+): number {
+  return Math.hypot(next.x - previous.x, next.y - previous.y, next.z - previous.z);
+}
+
+type OrientationConstructor = typeof DeviceOrientationEvent & {
+  requestPermission?: () => Promise<PermissionState | 'granted' | 'denied'>;
+};
+
+function orientationCtor(): OrientationConstructor | null {
+  if (typeof window === 'undefined') return null;
+  const ctor = (window as unknown as { DeviceOrientationEvent?: OrientationConstructor }).DeviceOrientationEvent;
+  return ctor ?? null;
+}
+
+export type DeviceTilt = {
+  /** The browser exposes orientation events at all. */
+  supported: boolean;
+  /** iOS: a gesture-initiated `request()` is still required. */
+  needsPermission: boolean;
+  /** Readings are arriving. */
+  active: boolean;
+  tilt: Tilt;
+  /** Increments once per detected shake — a signal to react to, not a level. */
+  shakeCount: number;
+  /** Safe to call unconditionally; only meaningful inside a user gesture on iOS. */
+  request: () => void;
+};
+
+export function useDeviceTilt(enabled: boolean): DeviceTilt {
+  const [supported, setSupported] = useState(false);
+  const [needsPermission, setNeedsPermission] = useState(false);
+  const [granted, setGranted] = useState(false);
+  const [active, setActive] = useState(false);
+  const [tilt, setTilt] = useState<Tilt>({ x: 0, y: 0 });
+  const [shakeCount, setShakeCount] = useState(0);
+
+  const baseline = useRef<{ beta: number; gamma: number } | null>(null);
+  const smoothed = useRef<Tilt>({ x: 0, y: 0 });
+  const published = useRef<Tilt>({ x: 0, y: 0 });
+  const lastAccel = useRef<{ x: number; y: number; z: number } | null>(null);
+  const lastShakeAt = useRef(0);
+
+  useEffect(() => {
+    const ctor = orientationCtor();
+    if (!ctor) return;
+    setSupported(true);
+    // Only iOS defines requestPermission; everywhere else the events just flow.
+    setNeedsPermission(typeof ctor.requestPermission === 'function');
+  }, []);
+
+  const request = useCallback(() => {
+    const ctor = orientationCtor();
+    if (!ctor || typeof ctor.requestPermission !== 'function') return;
+    // Must stay inside the gesture's task — no awaiting anything first.
+    ctor
+      .requestPermission()
+      .then((result) => {
+        if (result === 'granted') {
+          setGranted(true);
+          setNeedsPermission(false);
+        }
+      })
+      // A denial is a normal outcome, not an error to surface — the mascot simply
+      // keeps reacting to touch instead.
+      .catch(() => undefined);
+  }, []);
+
+  const listening = enabled && supported && (granted || !needsPermission);
+
+  useEffect(() => {
+    if (!listening) {
+      setActive(false);
+      return;
+    }
+
+    let frame = 0;
+    let pending: Tilt | null = null;
+
+    const flush = () => {
+      frame = 0;
+      if (!pending) return;
+      const target = pending;
+      pending = null;
+      smoothed.current = {
+        x: smoothed.current.x + (target.x - smoothed.current.x) * SMOOTHING,
+        y: smoothed.current.y + (target.y - smoothed.current.y) * SMOOTHING,
+      };
+      const next = smoothed.current;
+      const previous = published.current;
+      if (Math.abs(next.x - previous.x) < PUBLISH_THRESHOLD && Math.abs(next.y - previous.y) < PUBLISH_THRESHOLD) {
+        return;
+      }
+      published.current = { ...next };
+      setTilt(published.current);
+    };
+
+    const onOrientation = (event: DeviceOrientationEvent) => {
+      if (event.beta == null && event.gamma == null) return;
+      if (!baseline.current) {
+        baseline.current = { beta: event.beta ?? 0, gamma: event.gamma ?? 0 };
+        setActive(true);
+        return;
+      }
+      pending = tiltFromOrientation(event, baseline.current);
+      if (!frame) frame = requestAnimationFrame(flush);
+    };
+
+    const onMotion = (event: DeviceMotionEvent) => {
+      const a = event.accelerationIncludingGravity;
+      if (!a || a.x == null || a.y == null || a.z == null) return;
+      const sample = { x: a.x, y: a.y, z: a.z };
+      const previous = lastAccel.current;
+      lastAccel.current = sample;
+      if (!previous) return;
+      if (shakeJerk(previous, sample) < SHAKE_JERK) return;
+      const now = performance.now();
+      if (now - lastShakeAt.current < SHAKE_COOLDOWN_MS) return;
+      lastShakeAt.current = now;
+      // A shake is also a good moment to forget how the phone was first held.
+      baseline.current = null;
+      setShakeCount((count) => count + 1);
+    };
+
+    window.addEventListener('deviceorientation', onOrientation);
+    window.addEventListener('devicemotion', onMotion);
+    return () => {
+      window.removeEventListener('deviceorientation', onOrientation);
+      window.removeEventListener('devicemotion', onMotion);
+      if (frame) cancelAnimationFrame(frame);
+      baseline.current = null;
+      lastAccel.current = null;
+      smoothed.current = { x: 0, y: 0 };
+      published.current = { x: 0, y: 0 };
+    };
+  }, [listening]);
+
+  return { supported, needsPermission, active, tilt, shakeCount, request };
+}


### PR DESCRIPTION
Three mascot/mobile fixes reported together.

## 1. The header mascot was the only frozen one on the site

`NavHeader` passed `staticPose`, and that single prop adds `mascot--static` — which every animation rule in the stylesheet is written to exclude (`.mascot:not(.mascot--static)…`). One word switched off the body breathe *and* the blink lids, on the one instance every visitor sees on every page.

Dropping it is the whole fix. At 35px the breathe keyframe moves 3 units of a 60-unit viewBox — about 1.5 CSS px — and the body is a single union outline rather than ~200 stacked rects, so it squashes without the pixel rows seaming. Filmstripped in headless Chromium at 1x to confirm that rather than assume it.

Hovering the logo promotes that idle breath to the excited hop, reusing the existing `mascot-bounce` keyframes, so the brand link has a reaction of its own instead of borrowing the text underline.

`staticPose` stays as an escape hatch — a still frame is what a favicon/OG rasteriser would want — but nothing sets it now.

## 2. The beta splash did not fit an iPhone SE

The splash is the entire site for anyone not signed in, and the terms and privacy links were sitting behind Safari's bottom bar. Two independent causes:

**`min-height: 100vh`.** iOS resolves `vh` against the *large* viewport — the one you get with the toolbars retracted — so the card was centred in 667px while only about 553px was actually visible. `100dvh` tracks the visible viewport; the `vh` line stays as a fallback for browsers without it.

**Desktop spacing.** The card wanted 678px. A `max-height: 720px` query trims vertical rhythm only — measured **678px → 474px**, which clears 553px with 79px to spare. Keyed on height rather than width, so a phone held in landscape gets it too.

The invite-only state is taller (message + waitlist button) and now measures 512px, so it fits as well. That is the worst case with *both* sign-in providers rendered; `AppleSignInButton` returns `null` unless `VITE_APPLE_SERVICES_ID` is set, so in practice it is ~54px shorter still. The one thing that gives way in that state is the pitch paragraph, via `:has()` — by then the visitor has read it and already tried to sign in. The legal links never yield; that is asserted in a test.

## 3. He reacts to the phone's tilt

The mascot leans with the device, his face tracks the direction, and shaking the phone makes him dizzy. Orientation feeds the *same* normalized look vector the pointer already produced, so there is no new rendering path — just a second source for an existing one.

Three things the platform makes awkward, all handled in `useDeviceTilt.ts` rather than at the call site:

- **iOS needs a user gesture.** `DeviceOrientationEvent.requestPermission()` throws unless called from one. Rather than add an "enable motion" button, the ask rides on poking the mascot — the thing people already want to do. It is a no-op on Android, where the events simply flow, and calling it there would throw.
- **There is no neutral holding angle.** `beta` is ~0 with the phone flat on a table and ~60 held up to read, so absolute angles would leave him pinned to one side before you tilt anything. The first reading becomes the zero; a shake re-zeroes it.
- **The events outrun the display.** Readings are smoothed and only published past a threshold, so a resting hand does not re-render at sensor rate.

A finger on him beats the accelerometer while it is on him, `prefers-reduced-motion` opts out of the whole thing, and it is attached nowhere but the splash (`reactsToTilt` is off by default — it costs two window listeners and, on iOS, a prompt).

## Verification

Full web suite green: 58 test files, 429 tests. Typecheck and prettier clean.

Layout numbers above are measured in headless Chromium at 375×553 and 375×667, in both the default and invite-only states, not estimated. The tilt behaviour was driven end to end against the real component: the baseline reading stays neutral, tilt reaches the full ±6.2° either way, and a `devicemotion` spike flips him to `mascot--confused`.

New guards fail when deliberately broken — I checked each one by breaking it: the header mark is not frozen, `scroll-snap`-style pairing of `100vh`/`100dvh` survives, and the short-screen query still compresses the card.

**One gap worth knowing about:** Chromium has no `requestPermission`, so the iOS permission path is covered by unit tests against a stubbed iOS-shaped constructor, not by a real device. That specific flow is the piece to try on an actual iPhone.

## Not in this branch

The earlier `GAMEKIT_PLATFORM_BYTES` mirror commit is gone. It was dropped from #278 before merge, and `master` has since moved well past it (45_262 / cap 250_062 via `hostPause` and a `touch` raise), so resurrecting it would have re-pinned a stale number. Separately, `mascotDraw` appears nowhere on `master` — gamedevpl/www.gamedev.pl-games#102 has not landed, and its branch now sits on a `main` that has moved, so its byte measurement and captures need redoing before it can merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_