### PR TITLE
fix(player): restore rAF hold so Studio pause actually freezes

### DIFF
--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -130,6 +130,19 @@ describe('the injected bridge reports health', () => {
     bridge.frameWindow.document.addEventListener('gdpl-pause', (event) => pauseEvents.push(event));
     bridge.frameWindow.document.addEventListener('gdpl-resume', (event) => resumeEvents.push(event));
 
+    // A game-style loop that looks up requestAnimationFrame each frame — the
+    // bridge must hold it or Studio pause is only a veil.
+    let ticks = 0;
+    const frameWindow = bridge.frameWindow;
+    function gameTick() {
+      ticks += 1;
+      frameWindow.requestAnimationFrame(gameTick);
+    }
+    frameWindow.requestAnimationFrame(gameTick);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const beforePause = ticks;
+    expect(beforePause).toBeGreaterThan(0);
+
     bridge.frameWindow.dispatchEvent(
       new bridge.frameWindow.MessageEvent('message', {
         data: { source: 'gdpl-host', type: 'pause' },
@@ -145,6 +158,12 @@ describe('the injected bridge reports health', () => {
     expect(bridge.frameWindow.document.getElementById('gdpl-pause-overlay')).not.toBeNull();
     expect(pauseEvents).toHaveLength(1);
 
+    // One already-scheduled native rAF may still fire; after that the hold must stick.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const afterScheduled = ticks;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(ticks).toBe(afterScheduled);
+
     bridge.frameWindow.dispatchEvent(
       new bridge.frameWindow.MessageEvent('message', {
         data: { source: 'gdpl-host', type: 'resume' },
@@ -154,6 +173,9 @@ describe('the injected bridge reports health', () => {
     expect(bridge.received.some((message) => message.type === 'resumed')).toBe(true);
     expect(bridge.frameWindow.document.getElementById('gdpl-pause-overlay')).toBeNull();
     expect(resumeEvents).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(ticks).toBeGreaterThan(afterScheduled);
     bridge.stop();
   });
 });

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { embedGameHtml, withGameLocale } from './gamePlayer.js';
 
 describe('embedGameHtml', () => {
-  it('injects the hide-chrome style and bridge script before </body>', () => {
+  it('injects the hide-chrome style and bridge script in <head> before game code', () => {
     const html = '<html><head></head><body><canvas id="game"></canvas></body></html>';
     const out = embedGameHtml(html);
 
-    // Style + script land inside the document, before the closing body tag.
+    // Style + script land inside <head> so rAF patches precede game scripts.
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('#game-title,#game-desc,.game-controls,.hint{display:none!important}');
     expect(out).toContain('gdpl-player');
-    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</body>'));
-    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</body>'));
+    expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</head>'));
+    expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</head>'));
     // Original game content is preserved.
     expect(out).toContain('<canvas id="game">');
   });
@@ -31,14 +31,15 @@ describe('embedGameHtml', () => {
     expect(out).toContain('<script>');
   });
 
-  it('dispatches gdpl-pause / gdpl-resume so GameKit can freeze the sim', () => {
+  it('holds rAF on pause and still dispatches gdpl-pause for GameKit', () => {
     const out = embedGameHtml('<html><head></head><body></body></html>');
     expect(out).toContain("CustomEvent('gdpl-pause')");
     expect(out).toContain("CustomEvent('gdpl-resume')");
-    // Freeze is GameKit's job — the bridge must not patch globals.
-    expect(out).not.toContain('heldRaf');
-    expect(out).not.toContain('flushHeldRaf');
-    expect(out).not.toContain('suspendAudio');
+    // Bridge freeze is required — GameKit alone keeps draw() running, and older
+    // assembled docs never listen for gdpl-pause.
+    expect(out).toContain('heldRaf');
+    expect(out).toContain('flushHeldRaf');
+    expect(out).toContain('suspendAudio');
   });
 });
 

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -45,11 +45,57 @@ const BRIDGE = `(function(){
     var r=e&&e.reason;post({type:'error',message:String((r&&r.message)||r||'unhandled rejection').slice(0,200)});
   });
   var frames=0,paused=false,overlay=null,lastAlive=0;
-  // Freeze is owned by GameKit (gdpl-pause / gdpl-resume on document). The bridge
-  // only dispatches those events, shows the veil, and snapshots — it does not patch
-  // requestAnimationFrame or AudioContext.
-  if('requestAnimationFrame'in window){(function tick(){frames++;requestAnimationFrame(tick);})();}
-  setInterval(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
+  // Hold rAF / AudioContext here — GameKit's gdpl-pause only skips update() and
+  // still calls draw(), and many playtest docs were assembled before those listeners
+  // existed. Overlay alone left motion visible through the veil (Studio felt broken).
+  // Patch early (inject in <head>) so games that look up requestAnimationFrame each
+  // frame are held; already-scheduled native callbacks may run once more, then re-enter.
+  var _raf=window.requestAnimationFrame&&window.requestAnimationFrame.bind(window);
+  var _caf=window.cancelAnimationFrame&&window.cancelAnimationFrame.bind(window);
+  var _si=window.setInterval.bind(window);
+  var heldRaf=[],rafSeq=0,heldRafIds={},audioCtxs=[];
+  if(_raf){
+    window.requestAnimationFrame=function(cb){
+      if(!paused)return _raf(cb);
+      var id=++rafSeq;
+      heldRaf.push({id:id,cb:cb});
+      heldRafIds[id]=1;
+      return id;
+    };
+    window.cancelAnimationFrame=function(id){
+      if(heldRafIds[id]){
+        heldRaf=heldRaf.filter(function(h){return h.id!==id;});
+        delete heldRafIds[id];
+        return;
+      }
+      if(_caf)_caf(id);
+    };
+  }
+  var OrigAC=window.AudioContext||window.webkitAudioContext;
+  if(OrigAC){
+    var WrapAC=function(){
+      var ctx=new OrigAC();
+      try{audioCtxs.push(ctx);}catch(err){}
+      if(paused&&ctx.suspend)try{ctx.suspend();}catch(err){}
+      return ctx;
+    };
+    WrapAC.prototype=OrigAC.prototype;
+    window.AudioContext=WrapAC;
+    if('webkitAudioContext'in window)window.webkitAudioContext=WrapAC;
+  }
+  function suspendAudio(yes){
+    for(var i=0;i<audioCtxs.length;i++){
+      var c=audioCtxs[i];
+      try{if(yes){if(c.suspend)c.suspend();}else if(c.resume)c.resume();}catch(err){}
+    }
+  }
+  function flushHeldRaf(){
+    var q=heldRaf;heldRaf=[];heldRafIds={};
+    if(!_raf)return;
+    for(var i=0;i<q.length;i++){(function(cb){_raf(function(t){try{cb(t);}catch(err){}});}(q[i].cb));}
+  }
+  if(_raf){(function tick(){frames++;requestAnimationFrame(tick);})();}
+  _si(function(){lastAlive=frames;post({type:'alive',frames:frames});frames=0;},5000);
   function largestCanvas(){
     var best=null,area=0,list=document.querySelectorAll('canvas');
     for(var i=0;i<list.length;i++){
@@ -149,9 +195,12 @@ const BRIDGE = `(function(){
       var png=capturePng();
       document.dispatchEvent(new CustomEvent('gdpl-pause'));
       showOverlay();
+      suspendAudio(true);
       sendSnapshot('pause',png);
     }else{
       hideOverlay();
+      suspendAudio(false);
+      flushHeldRaf();
       document.dispatchEvent(new CustomEvent('gdpl-resume'));
       post({type:'resumed'});
     }
@@ -183,12 +232,23 @@ const HIDE_CHROME = `#game-title,#game-desc,.game-controls,.hint{display:none!im
 
 /**
  * Injects the player bridge + hide-chrome style into an assembled game document
- * so it can run headless-of-its-own-chrome inside the app's player. Falls back to
- * appending if there's no </body> (assembled games always have one, but be safe).
+ * so it can run headless-of-its-own-chrome inside the app's player.
+ *
+ * Prefers `<head>` (then `<body>`, then `</body>`, then append) so rAF / AudioContext
+ * patches land before game scripts schedule their loops — Studio pause depends on that.
  */
 export function embedGameHtml(html: string): string {
   const inject = `<style id="gdpl-embed">${HIDE_CHROME}</style><script>${BRIDGE}</script>`;
-  return html.includes('</body>') ? html.replace('</body>', `${inject}</body>`) : html + inject;
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/<head\b[^>]*>/i, (open) => `${open}${inject}`);
+  }
+  if (/<body\b[^>]*>/i.test(html)) {
+    return html.replace(/<body\b[^>]*>/i, (open) => `${open}${inject}`);
+  }
+  if (html.includes('</body>')) {
+    return html.replace('</body>', `${inject}</body>`);
+  }
+  return html + inject;
 }
 
 /** en/pl are the only locales games ship strings for; anything else maps to en. */

--- a/docs/improvement-loop-plan.md
+++ b/docs/improvement-loop-plan.md
@@ -446,12 +446,12 @@ considerably:
 - 📋 **Pause-and-prompt enrichment** — first cut ships: bridge `pause` / `resume` /
   `capture`, host accumulates error/alive/progress during the playtest, feedback
   and improve accept optional `context.screenshotPng` + `instrumentation` (fenced
-  as data; PNG stored as a creator playtest shot). The bridge dispatches
-  `gdpl-pause` / `gdpl-resume` CustomEvents (plus overlay + snapshot); GameKit
-  freezes the sim and suspends audio when those fire
+  as data; PNG stored as a creator playtest shot). The bridge holds
+  `requestAnimationFrame` / suspends `AudioContext`s (injects in `<head>` so
+  patches land before game loops), shows overlay + snapshot, and also dispatches
+  `gdpl-pause` / `gdpl-resume` for GameKit
   ([www.gamedev.pl-games#110](https://github.com/gamedevpl/www.gamedev.pl-games/pull/110)).
-  The shell does not patch `requestAnimationFrame` / `AudioContext`. Studio
-  playtest assumes landscape and goes edge-to-edge on narrow screens with a
+  Studio playtest assumes landscape and goes edge-to-edge on narrow screens with a
   rotate nudge when the phone is upright.
 - 📋 **Suggestion inbox** — cards with insight → evidence → proposed change →
   [Approve → files issue] / [Dismiss with reason]. Dismissal reasons feed router
@@ -674,6 +674,7 @@ at all and feeds the only autonomous-eligible class.
     failed all produce `[]`, and the panel renders no block at all rather than an empty
     heading. Cost is bounded by a per-sweep call budget, and when that budget binds the
     result says so — otherwise "no themes" would silently mean "we stopped looking".
+
 - ✅ **Creator Studio** (`/studio`, #236): the creator's own shelf, build status, playtest
   and stats surface, with per-game play health from `/api/me/studio/health`.
 - ✅ **Weekly creator digest** (2026-07-28): [digest.ts](../apps/api/src/digest.ts) —
@@ -685,7 +686,7 @@ at all and feeds the only autonomous-eligible class.
   aggregation, so a digest is a few document reads per creator, and the digest and the
   studio cannot disagree about a number because both read the same document.
 
-  It also *enumerates* from scorecards rather than from recently-published submissions.
+  It also _enumerates_ from scorecards rather than from recently-published submissions.
   Publication date must not decide who hears from us: the creator of an older game that is
   still being played is exactly who a "your games are still being played" message is for,
   and listing recent publications would have silently dropped them.
@@ -696,7 +697,7 @@ at all and feeds the only autonomous-eligible class.
     than a message full of zeros — manufactured evidence of exactly the kind the rest of
     this system avoids, and a weekly "0 sessions" is a reason to stop opening them.
   - **Nothing changed, no digest.** A rolling 28-day window barely moves week to week, so
-    identical numbers are suppressed. The comparison is the *previous digest's own params*
+    identical numbers are suppressed. The comparison is the _previous digest's own params_
     — the notification already is the record of what the creator was last told, and a
     second copy of that fact is a second thing that can drift from it.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Studio Pause was only a veil. After #293 we dropped the bridge `requestAnimationFrame` / `AudioContext` hold and relied on GameKit `gdpl-pause` alone. That is not enough:

- GameKit host pause skips `update()` but **keeps calling `draw()`**, so time-based animation still runs under the semi-transparent overlay.
- Many playtest / published docs were assembled **before** games #110, so nothing listens for `gdpl-pause`.

## Fix

Restore the proven bridge freeze:

- Hold `requestAnimationFrame` while paused; flush on resume
- Wrap / suspend `AudioContext`s
- Inject bridge in `<head>` so patches land before game loops
- Still dispatch `gdpl-pause` / `gdpl-resume` for GameKit when present

Bridge test now drives a real rAF loop and asserts it stops after pause.

## Test plan

- [ ] Studio → Playtest → Pause: motion and audio freeze (not just dark veil)
- [ ] Resume continues cleanly
- [ ] Snapshot / change-request prompt still appears

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

