### PR TITLE
fix(studio): Playtest is full-viewport theater mode

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -174,8 +174,9 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
 
   const selectedGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
   const selectedHealth = selectedGame ? healthFor(selectedGame, healthRows) : null;
-  const selectedScorecard =
-    selectedGame?.slug ? (scorecards.find((card) => card.slug === selectedGame.slug) ?? null) : null;
+  const selectedScorecard = selectedGame?.slug
+    ? (scorecards.find((card) => card.slug === selectedGame.slug) ?? null)
+    : null;
   const visibleGames = useMemo(
     () => filterStudioGames(games, { filter: shelfFilter, query: shelfQuery }),
     [games, shelfFilter, shelfQuery],
@@ -391,7 +392,11 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                 ) : null}
 
                 {tab === 'playtest' ? (
-                  <StudioPlaytestPanel game={selectedGame} published={isStudioGamePublished(selectedGame)} />
+                  <StudioPlaytestPanel
+                    game={selectedGame}
+                    published={isStudioGamePublished(selectedGame)}
+                    onExit={() => setTab('overview')}
+                  />
                 ) : null}
 
                 {tab === 'stats' ? (

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
+import type { StudioGame } from './studioApi.js';
+
+vi.mock('./catalog.js', () => ({
+  fetchPublishedGame: vi.fn(async () => ({
+    slug: 'sky-dodge',
+    title: 'Sky Dodge',
+    html: '<!doctype html><html><body><canvas id="game"></canvas></body></html>',
+  })),
+}));
+
+vi.mock('./submissionApi.js', () => ({
+  getSubmissionPreview: vi.fn(async () => ({
+    html: '<!doctype html><html><body><canvas id="game"></canvas></body></html>',
+  })),
+  submitFeedback: vi.fn(),
+}));
+
+vi.mock('./studioApi.js', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi.js')>('./studioApi.js');
+  return {
+    ...actual,
+    submitImprovement: vi.fn(),
+  };
+});
+
+const game: StudioGame = {
+  token: 'tok-1',
+  title: 'Sky Dodge',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  lastKnownStatus: 'published',
+  slug: 'sky-dodge',
+  publishedAt: '2026-07-02T00:00:00.000Z',
+};
+
+describe('StudioPlaytestPanel theater', () => {
+  beforeEach(() => {
+    document.body.className = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+  });
+
+  it('opens a full-viewport theater with overlay controls once the build loads', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const onExit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioPlaytestPanel, { game, published: true, onExit }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const theater = container.querySelector('.studio-playtest-theater');
+    expect(theater).not.toBeNull();
+    expect(theater?.getAttribute('role')).toBe('dialog');
+    expect(container.querySelector('.studio-playtest-bar')).not.toBeNull();
+    expect(container.querySelector('.studio-playtest-viewport .game-frame')).not.toBeNull();
+    expect(container.querySelector('.studio-playtest-stage')).toBeNull();
+    expect(document.body.classList.contains('player-open')).toBe(true);
+
+    const exit = container.querySelector('.exit-btn') as HTMLButtonElement;
+    await act(async () => {
+      exit.click();
+    });
+    expect(onExit).toHaveBeenCalledTimes(1);
+
+    root.unmount();
+    expect(document.body.classList.contains('player-open')).toBe(false);
+  });
+});

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -75,10 +75,17 @@ describe('StudioPlaytestPanel theater', () => {
     expect(document.body.classList.contains('player-open')).toBe(true);
 
     const exit = container.querySelector('.exit-btn') as HTMLButtonElement;
+    expect(exit).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onExit).toHaveBeenCalledTimes(1);
+
     await act(async () => {
       exit.click();
     });
-    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledTimes(2);
 
     root.unmount();
     expect(document.body.classList.contains('player-open')).toBe(false);

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -17,6 +17,10 @@ import { submitImprovement, type StudioGame } from './studioApi.js';
  * talking about, and send a change request with the paused frame + a small
  * instrumentation digest attached. The parent cannot screenshot the sandboxed
  * canvas (no allow-same-origin) — capture runs inside the player bridge.
+ *
+ * Always mounts as a full-viewport theater (same idea as GameTheater): the game
+ * owns the screen; pause/resume + the note sheet are layers on top. An inset
+ * 16:9 card inside Studio chrome is unplayable on a phone (iPhone SE especially).
  */
 
 /** Tiny canvas toy used only when DEV_SEED_STUDIO left no real preview HTML. */
@@ -45,6 +49,8 @@ const DEV_PLAYTEST_HTML = `<!doctype html><html><head><meta charset="utf-8"><tit
 type StudioPlaytestPanelProps = {
   game: StudioGame;
   published: boolean;
+  /** Leave theater — typically returns to Overview so Studio chrome is usable again. */
+  onExit: () => void;
 };
 
 /**
@@ -96,9 +102,10 @@ function toContext(
   };
 }
 
-export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProps) {
+export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestPanelProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const exitRef = useRef<HTMLButtonElement | null>(null);
   const [html, setHtml] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -146,8 +153,21 @@ export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProp
     };
   }, [game.token, game.slug, published, t, clearSnapshot]);
 
+  // Same scroll lock as GameTheater — fixed overlay must own the viewport.
+  useEffect(() => {
+    if (!html) return;
+    document.body.classList.add('player-open');
+    return () => document.body.classList.remove('player-open');
+  }, [html]);
+
+  useEffect(() => {
+    if (!html) return;
+    exitRef.current?.focus();
+  }, [html]);
+
   const attachedPng = snapshot?.pngBase64 ?? null;
   const trimmed = text.trim();
+  const promptOpen = Boolean(paused || snapshot);
 
   const send = async () => {
     if (trimmed.length < 10) return;
@@ -182,13 +202,55 @@ export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProp
 
   return (
     <div className="studio-playtest">
-      <p className="panel-copy studio-playtest-hint">{t('studioPanel.playtest.hint')}</p>
+      {!html ? (
+        <>
+          <p className="panel-copy studio-playtest-hint">{t('studioPanel.playtest.hint')}</p>
+          {loading ? <p className="studio-muted">{t('studioPanel.playtest.loading')}</p> : null}
+          {loadError ? <p className="error">{loadError}</p> : null}
+        </>
+      ) : (
+        <div
+          className={`studio-playtest-theater${paused ? ' is-paused' : ''}${promptOpen ? ' is-prompting' : ''}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('studioPanel.playtest.theaterAria', { title: game.title })}
+        >
+          <div className="studio-playtest-bar">
+            <div className="studio-playtest-bar-meta">
+              <span className="studio-playtest-badge">{t('studioPanel.tabs.playtest')}</span>
+              <h2 className="studio-playtest-title">{game.title}</h2>
+              <span className="studio-playtest-meta">
+                {t('studioPanel.playtest.played', { seconds: instrumentation.playSeconds })}
+                {instrumentation.errors.length > 0
+                  ? ` · ${t('studioPanel.playtest.errorCount', { count: instrumentation.errors.length })}`
+                  : null}
+              </span>
+            </div>
+            <div className="studio-playtest-bar-actions">
+              {paused ? (
+                <button type="button" className="secondary-btn" onClick={resume}>
+                  <PixelIcon name="play" size={12} />
+                  <span className="btn-label">{t('studioPanel.playtest.resume')}</span>
+                </button>
+              ) : (
+                <button type="button" className="primary-btn" onClick={pause}>
+                  <PixelIcon name="pause" size={12} />
+                  <span className="btn-label">{t('studioPanel.playtest.pause')}</span>
+                </button>
+              )}
+              <button
+                type="button"
+                className="secondary-btn exit-btn"
+                onClick={onExit}
+                ref={exitRef}
+                aria-label={t('catalog.exitPlayer', { defaultValue: 'Close' })}
+                title={t('catalog.exitPlayer', { defaultValue: 'Close' })}
+              >
+                <PixelIcon name="close" size={14} />
+              </button>
+            </div>
+          </div>
 
-      {loading ? <p className="studio-muted">{t('studioPanel.playtest.loading')}</p> : null}
-      {loadError ? <p className="error">{loadError}</p> : null}
-
-      {html ? (
-        <div className={`studio-playtest-stage${paused ? ' is-paused' : ''}`}>
           <div className="studio-playtest-viewport">
             <GameFrame frameRef={frameRef} title={game.title} html={html} embed />
             {needsLandscape ? (
@@ -198,77 +260,60 @@ export function StudioPlaytestPanel({ game, published }: StudioPlaytestPanelProp
               </div>
             ) : null}
           </div>
-          <div className="studio-playtest-controls">
-            {paused ? (
-              <button type="button" className="secondary-btn" onClick={resume}>
-                <PixelIcon name="play" size={12} /> {t('studioPanel.playtest.resume')}
-              </button>
-            ) : (
-              <button type="button" className="primary-btn" onClick={pause}>
-                <PixelIcon name="pause" size={12} /> {t('studioPanel.playtest.pause')}
-              </button>
-            )}
-            <span className="studio-playtest-meta">
-              {t('studioPanel.playtest.played', { seconds: instrumentation.playSeconds })}
-              {instrumentation.errors.length > 0
-                ? ` · ${t('studioPanel.playtest.errorCount', { count: instrumentation.errors.length })}`
-                : null}
-            </span>
-          </div>
-        </div>
-      ) : null}
 
-      {(paused || snapshot) && (
-        <div className="status-feedback studio-playtest-prompt">
-          <h3 className="status-feedback-title">{t('studioPanel.playtest.promptTitle')}</h3>
-          <p className="status-feedback-hint">{t('studioPanel.playtest.promptHint')}</p>
+          {promptOpen ? (
+            <div className="studio-playtest-sheet status-feedback">
+              <h3 className="status-feedback-title">{t('studioPanel.playtest.promptTitle')}</h3>
+              <p className="status-feedback-hint">{t('studioPanel.playtest.promptHint')}</p>
 
-          {attachedPng ? (
-            <figure className="studio-playtest-shot">
-              <img src={`data:image/png;base64,${attachedPng}`} alt="" />
-              <figcaption>{t('studioPanel.playtest.shotCaption')}</figcaption>
-            </figure>
-          ) : (
-            <p className="studio-muted">{t('studioPanel.playtest.noShot')}</p>
-          )}
+              {attachedPng ? (
+                <figure className="studio-playtest-shot">
+                  <img src={`data:image/png;base64,${attachedPng}`} alt="" />
+                  <figcaption>{t('studioPanel.playtest.shotCaption')}</figcaption>
+                </figure>
+              ) : (
+                <p className="studio-muted">{t('studioPanel.playtest.noShot')}</p>
+              )}
 
-          {(snapshot?.instrumentation ?? instrumentation).errors.length > 0 ? (
-            <ul className="studio-playtest-errors">
-              {(snapshot?.instrumentation ?? instrumentation).errors.slice(-3).map((error) => (
-                <li key={error}>
-                  <code>{error}</code>
-                </li>
-              ))}
-            </ul>
+              {(snapshot?.instrumentation ?? instrumentation).errors.length > 0 ? (
+                <ul className="studio-playtest-errors">
+                  {(snapshot?.instrumentation ?? instrumentation).errors.slice(-3).map((error) => (
+                    <li key={error}>
+                      <code>{error}</code>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+
+              <textarea
+                className="status-feedback-input"
+                value={text}
+                onChange={(event) => {
+                  setText(event.target.value);
+                  if (sendState === 'sent') setSendState('idle');
+                }}
+                placeholder={t('studioPanel.playtest.placeholder')}
+                rows={3}
+                maxLength={2000}
+              />
+              <div className="status-feedback-actions">
+                <button
+                  type="button"
+                  className="primary-btn"
+                  onClick={() => void send()}
+                  disabled={sendState === 'sending' || trimmed.length < 10}
+                >
+                  {sendState === 'sending' ? t('studioPanel.improve.sending') : t('studioPanel.playtest.submit')}
+                </button>
+                {sendState === 'sent' ? (
+                  <span className="status-feedback-sent">
+                    <PixelIcon name="check" size={13} /> {t('studioPanel.improve.sent')}
+                  </span>
+                ) : null}
+              </div>
+              {sendError ? <p className="error">{sendError}</p> : null}
+            </div>
           ) : null}
-
-          <textarea
-            className="status-feedback-input"
-            value={text}
-            onChange={(event) => {
-              setText(event.target.value);
-              if (sendState === 'sent') setSendState('idle');
-            }}
-            placeholder={t('studioPanel.playtest.placeholder')}
-            rows={3}
-            maxLength={2000}
-          />
-          <div className="status-feedback-actions">
-            <button
-              type="button"
-              className="primary-btn"
-              onClick={() => void send()}
-              disabled={sendState === 'sending' || trimmed.length < 10}
-            >
-              {sendState === 'sending' ? t('studioPanel.improve.sending') : t('studioPanel.playtest.submit')}
-            </button>
-            {sendState === 'sent' ? (
-              <span className="status-feedback-sent">
-                <PixelIcon name="check" size={13} /> {t('studioPanel.improve.sent')}
-              </span>
-            ) : null}
-          </div>
-          {sendError ? <p className="error">{sendError}</p> : null}
         </div>
       )}
     </div>

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -105,7 +105,6 @@ function toContext(
 export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestPanelProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
-  const exitRef = useRef<HTMLButtonElement | null>(null);
   const [html, setHtml] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -237,7 +236,6 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
                 type="button"
                 className="secondary-btn exit-btn"
                 onClick={onExit}
-                ref={exitRef}
                 aria-label={t('catalog.exitPlayer', { defaultValue: 'Close' })}
                 title={t('catalog.exitPlayer', { defaultValue: 'Close' })}
               >

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchPublishedGame } from './catalog.js';
 import { GameFrame } from './GameFrame.js';
-import { useCreatorPlaytest, type PlaytestInstrumentation } from './gamePlayer.js';
+import { useCreatorPlaytest, useGamePlayer, type PlaytestInstrumentation } from './gamePlayer.js';
 import { PixelIcon } from './PixelIcon.js';
 import {
   getSubmissionPreview,
@@ -105,6 +105,7 @@ function toContext(
 export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestPanelProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const exitRef = useRef<HTMLButtonElement | null>(null);
   const [html, setHtml] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -115,6 +116,15 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
 
   const active = Boolean(html);
   const { paused, snapshot, instrumentation, pause, resume, clearSnapshot } = useCreatorPlaytest(frameRef, active);
+
+  // Stable exit for Escape (window + iframe bridge) — same pattern as GameTheater.
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
+  const requestExit = useCallback(() => {
+    onExitRef.current();
+  }, []);
+  // Escape inside the sandboxed game never reaches the parent — the bridge relays it.
+  useGamePlayer(frameRef, active, requestExit);
 
   useEffect(() => {
     let cancelled = false;
@@ -152,12 +162,24 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
     };
   }, [game.token, game.slug, published, t, clearSnapshot]);
 
-  // Same scroll lock as GameTheater — fixed overlay must own the viewport.
+  // Scroll lock + Escape + focus handoff while the theater owns the viewport.
   useEffect(() => {
     if (!html) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     document.body.classList.add('player-open');
-    return () => document.body.classList.remove('player-open');
-  }, [html]);
+    exitRef.current?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') requestExit();
+    };
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.body.classList.remove('player-open');
+      previouslyFocused?.focus?.();
+    };
+  }, [html, requestExit]);
 
   const attachedPng = snapshot?.pngBase64 ?? null;
   const trimmed = text.trim();
@@ -236,6 +258,7 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
                 type="button"
                 className="secondary-btn exit-btn"
                 onClick={onExit}
+                ref={exitRef}
                 aria-label={t('catalog.exitPlayer', { defaultValue: 'Close' })}
                 title={t('catalog.exitPlayer', { defaultValue: 'Close' })}
               >

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -160,11 +160,6 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
     return () => document.body.classList.remove('player-open');
   }, [html]);
 
-  useEffect(() => {
-    if (!html) return;
-    exitRef.current?.focus();
-  }, [html]);
-
   const attachedPng = snapshot?.pngBase64 ?? null;
   const trimmed = text.trim();
   const promptOpen = Boolean(paused || snapshot);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -211,6 +211,7 @@
       "hint": "Play the game, pause on a moment worth changing, and send a request with that viewport and live instrumentation attached.",
       "loading": "Loading the playable build…",
       "loadError": "No playable build is ready yet. Check the Build tab and try again once a preview exists.",
+      "theaterAria": "Playtest · {{title}}",
       "pause": "Pause & note",
       "resume": "Resume",
       "played": "{{seconds}}s played",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -211,6 +211,7 @@
       "hint": "Zagraj, wstrzymaj w momencie wartym zmiany i wyślij prośbę z tym widokiem oraz sygnałami z sesji.",
       "loading": "Ładujemy grywalny build…",
       "loadError": "Nie ma jeszcze grywalnego buildu. Sprawdź zakładkę Build i spróbuj, gdy pojawi się podgląd.",
+      "theaterAria": "Playtest · {{title}}",
       "pause": "Wstrzymaj i zanotuj",
       "resume": "Wznów",
       "played": "{{seconds}}s gry",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5825,93 +5825,182 @@ body.player-open {
   margin: 0 0 0.75rem;
 }
 
-.studio-playtest-stage {
-  position: relative;
+/* Full-viewport playtest theater — same contract as `.stage.is-playing-full-viewport`.
+   An inset card inside Studio chrome leaves a postage-stamp iframe on phones
+   (iPhone SE especially); the game must own the screen, with controls as layers. */
+.studio-playtest-theater {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: #06090c;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--panel-border);
-  border-radius: 14px;
-  overflow: hidden;
-  background: #05080c;
-  min-height: 0;
+  box-shadow: none;
+  animation: fadeIn 0.2s ease-out;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.studio-playtest-stage.is-paused {
-  border-color: rgba(0, 228, 172, 0.35);
-  box-shadow: 0 0 24px rgba(0, 228, 172, 0.08);
+.studio-playtest-theater.is-paused .studio-playtest-bar {
+  border-bottom-color: rgba(0, 228, 172, 0.35);
+}
+
+.studio-playtest-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 16px;
+  padding-top: max(10px, env(safe-area-inset-top));
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
+  background: rgba(18, 24, 30, 0.95);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--panel-border);
+  width: 100%;
+  flex: none;
+  z-index: 2;
+}
+
+.studio-playtest-bar-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.studio-playtest-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--turquoise);
+}
+
+.studio-playtest-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.studio-playtest-meta {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.studio-playtest-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+
+.studio-playtest-bar-actions .primary-btn,
+.studio-playtest-bar-actions .secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.studio-playtest-bar-actions .exit-btn {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  justify-content: center;
 }
 
 .studio-playtest-viewport {
+  flex: 1;
+  width: 100%;
   position: relative;
+  min-height: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
   background: #000;
-  /* Games are landscape — give the stage the width budget, not side padding. */
-  min-height: 0;
+  overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
-.studio-playtest-stage .game-frame {
-  width: min(100%, calc(70vh * 16 / 9));
-  aspect-ratio: 16 / 9;
-  max-height: 70vh;
-  min-height: 180px;
-  height: auto;
+.studio-playtest-theater .game-frame {
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  min-height: 0;
+  aspect-ratio: auto;
   border: 0;
   border-radius: 0;
   box-shadow: none;
   display: block;
   background: #000;
+  touch-action: none;
 }
 
 .studio-playtest-rotate {
   position: absolute;
-  bottom: max(12px, env(safe-area-inset-bottom));
-  left: 12px;
-  right: 12px;
+  bottom: max(18px, env(safe-area-inset-bottom));
+  left: 16px;
+  right: 16px;
   margin-inline: auto;
   width: max-content;
-  max-width: calc(100% - 24px);
+  max-width: calc(100% - 32px);
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
+  gap: 10px;
+  padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(12, 18, 24, 0.88);
+  background: rgba(12, 18, 24, 0.86);
   border: 1px solid rgba(0, 228, 172, 0.32);
   color: var(--text);
-  font-size: 0.85rem;
+  font-size: 0.88rem;
   font-weight: 600;
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
   pointer-events: none;
   z-index: 2;
+  animation: fadeIn 0.25s ease-out;
 }
 
-.studio-playtest-controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
-  border-top: 1px solid var(--panel-border);
-  background: rgba(22, 28, 34, 0.92);
-}
-
-.studio-playtest-controls .primary-btn,
-.studio-playtest-controls .secondary-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.studio-playtest-meta {
-  color: var(--muted);
-  font-size: 0.85rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.studio-playtest-prompt {
-  margin-top: 16px;
+/* Pause note sheet — floats over the game, does not push the iframe into a stamp. */
+.studio-playtest-sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 3;
+  max-height: min(72vh, 34rem);
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0;
+  padding: 14px 16px calc(14px + env(safe-area-inset-bottom));
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
+  border-radius: 16px 16px 0 0;
+  border: 1px solid var(--panel-border);
+  border-bottom: none;
+  background: rgba(18, 24, 30, 0.96);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
+  touch-action: manipulation;
+  -webkit-user-select: text;
+  user-select: text;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .studio-playtest-shot {
@@ -5953,6 +6042,56 @@ body.player-open {
   font-size: 0.8rem;
   overflow-wrap: anywhere;
   color: var(--error);
+}
+
+@media (max-width: 768px) {
+  .studio-playtest-bar {
+    padding: 8px 12px;
+    padding-top: max(8px, env(safe-area-inset-top));
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+
+  .studio-playtest-title {
+    font-size: 0.92rem;
+  }
+
+  /* Short landscape phone: every pixel the bar takes is a pixel the game doesn't. */
+  .studio-playtest-badge,
+  .studio-playtest-meta {
+    display: none;
+  }
+
+  .studio-playtest-bar-actions .btn-label {
+    display: none;
+  }
+
+  .studio-playtest-bar-actions .primary-btn,
+  .studio-playtest-bar-actions .secondary-btn:not(.exit-btn) {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .studio-playtest-sheet {
+    max-height: min(78vh, 28rem);
+  }
+
+  .studio-playtest-shot {
+    max-width: 100%;
+  }
+}
+
+@media (max-height: 420px) {
+  .studio-playtest-bar {
+    padding-top: max(4px, env(safe-area-inset-top));
+    padding-bottom: 4px;
+  }
+
+  .studio-playtest-title {
+    font-size: 0.85rem;
+  }
 }
 
 .my-games-header-actions {
@@ -6007,50 +6146,6 @@ body.player-open {
     padding: 18px 16px;
   }
 
-  /* Playtest needs every horizontal pixel — bleed the stage edge-to-edge and keep
-     chrome padding only on the text/controls around it. */
-  .studio-panel.is-playtesting {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .studio-panel.is-playtesting .studio-panel-header,
-  .studio-panel.is-playtesting .studio-empty,
-  .studio-panel.is-playtesting .studio-empty-state,
-  .studio-panel.is-playtesting .studio-game-switcher,
-  .studio-panel.is-playtesting .studio-tabs,
-  .studio-panel.is-playtesting .studio-playtest-hint,
-  .studio-panel.is-playtesting .studio-playtest-prompt,
-  .studio-panel.is-playtesting .studio-muted,
-  .studio-panel.is-playtesting .error {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
-  .studio-panel.is-playtesting .studio-detail {
-    padding: 12px 0 18px;
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-  }
-
-  .studio-panel.is-playtesting .studio-playtest-stage {
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-  }
-
-  .studio-panel.is-playtesting .studio-playtest-stage .game-frame {
-    width: 100%;
-    max-height: min(56vw, 48vh);
-    min-height: 160px;
-  }
-
-  .studio-panel.is-playtesting .studio-playtest-controls {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
   .studio-tabs {
     flex-wrap: nowrap;
     overflow-x: auto;
@@ -6065,13 +6160,6 @@ body.player-open {
 
   .studio-picker {
     width: 100%;
-  }
-}
-
-@media (max-width: 800px) and (orientation: landscape) {
-  .studio-panel.is-playtesting .studio-playtest-stage .game-frame {
-    width: min(100%, calc(78vh * 16 / 9));
-    max-height: 78vh;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5841,7 +5841,8 @@ body.player-open {
   flex-direction: column;
   box-shadow: none;
   animation: fadeIn 0.2s ease-out;
-  touch-action: none;
+  /* Do not set touch-action:none on the theater root — the pause note sheet scrolls
+     and touch-action intersects with ancestors. Hold gestures on the game surface. */
   -webkit-user-select: none;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
@@ -5935,6 +5936,8 @@ body.player-open {
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+  /* Game surface only — keep this off the note sheet ancestors. */
+  touch-action: none;
 }
 
 .studio-playtest-theater .game-frame {
@@ -5997,7 +6000,8 @@ body.player-open {
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
   box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
-  touch-action: manipulation;
+  /* Explicit pan so a long note sheet scrolls on phones (theater no longer sets none). */
+  touch-action: pan-y;
   -webkit-user-select: text;
   user-select: text;
   animation: fadeIn 0.2s ease-out;

--- a/docs/improvement-loop-plan.md
+++ b/docs/improvement-loop-plan.md
@@ -451,8 +451,9 @@ considerably:
   patches land before game loops), shows overlay + snapshot, and also dispatches
   `gdpl-pause` / `gdpl-resume` for GameKit
   ([www.gamedev.pl-games#110](https://github.com/gamedevpl/www.gamedev.pl-games/pull/110)).
-  Studio playtest assumes landscape and goes edge-to-edge on narrow screens with a
-  rotate nudge when the phone is upright.
+  Studio playtest assumes landscape and opens as a full-viewport theater (same
+  idea as GameTheater) with pause/resume on the bar and the note sheet layered
+  over the game — not an inset iframe inside Studio chrome.
 - 📋 **Suggestion inbox** — cards with insight → evidence → proposed change →
   [Approve → files issue] / [Dismiss with reason]. Dismissal reasons feed router
   tuning. Approval reuses the feedback-comment path that already works.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Studio Playtest on iPhone SE (and other small phones) left a tiny inset 16:9 iframe under Studio chrome — unplayable. Playtest must be theater mode.

## Change

- Playtest opens as a **full-viewport theater** (same idea as GameTheater): game fills the screen
- **Bar overlay**: title, play time, Pause & note / Resume, Exit (→ Overview)
- **Note sheet** layers over the bottom of the game when paused (does not shrink the iframe)
- Rotate nudge stays as an overlay; `body.player-open` locks scroll
- Dropped the old inset card / `max-height: 56vw` mobile rules

## Test plan

- [ ] iPhone SE portrait: Playtest fills the screen; game is usable
- [ ] Landscape: bar stays thin; game gets the rest
- [ ] Pause opens the note sheet over the game; Resume continues
- [ ] Exit returns to Overview and unlocks page scroll

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d370a5c-a5e8-4ead-9404-85b0f547c142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

