### PR TITLE
Track the games-repo cap raise to 326,027

### DIFF
--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(250_111);
+    expect(MAX_PROJECT_BYTES).toBe(326_027);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(250_111);
+    expect(MAX_PROJECT_BYTES).toBe(326_027);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -73,6 +73,8 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_DRAW_SURFACE_BYTES = 9_459;
       const GAMEKIT_POINTER_RELEASE_BYTES = 430;
       const GAMEKIT_HOST_PAUSE_BYTES = 1_473;
+      const GAMEKIT_MASCOT_DRAW_BYTES = 679;
+      const GAMEKIT_HEADROOM_BYTES = 75_237;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -84,7 +86,9 @@ describe('games-repo source extractors', () => {
         GAMEKIT_POINTER_POLL_BYTES +
         GAMEKIT_DRAW_SURFACE_BYTES +
         GAMEKIT_POINTER_RELEASE_BYTES +
-        GAMEKIT_HOST_PAUSE_BYTES;
+        GAMEKIT_HOST_PAUSE_BYTES +
+        GAMEKIT_MASCOT_DRAW_BYTES +
+        GAMEKIT_HEADROOM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -32,21 +32,30 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
 /**
  * Sum of GameKit platform allowances outside the author budget (touch, restart,
  * music, touch hint, progress, universal input, pointer poll, draw surface,
- * pointer release, host pause, …). Together with {@link GAME_BUDGET_BYTES} this
- * must equal games-repo `MAX_BUNDLE_BYTES` (250_111, matching games-repo
+ * pointer release, host pause, mascot draw, …) plus a deliberate headroom band.
+ * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
+ * `MAX_BUNDLE_BYTES` (326_027, matching games-repo
  * `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB: the
  * platform side is an explicit sum of named allowances, not a padded
  * `42 * 1024` block.
  *
- * Last moved by games-repo host-pause: +1_473 (`hostPause`, includes
- * `suspend().catch`) so Creator Studio / theater can dispatch `gdpl-pause` /
- * `gdpl-resume` without the shell patching rAF. Before that, games-repo PR #103
+ * Last moved by games-repo #102, which did two things: +679 (`mascotDraw`) for
+ * `draw.mascot` on the createRenderer surface, and +75_237 (`headroom`) — 30% of
+ * the 250_790 ceiling that resulted — to stop the cap being a hair trigger. It had
+ * been pinned to the exact assembled size of the tightest published title, so a
+ * 679-byte platform change needed a measured constant and a paired PR on this
+ * side; `tower-defence` had 90 bytes of room. The band is deliberate slack, not a
+ * measurement, and the author budget above is untouched by it.
+ *
+ * Before that, host-pause: +1_473 (`hostPause`, includes `suspend().catch`) so
+ * Creator Studio / theater can dispatch `gdpl-pause` / `gdpl-resume` without the
+ * shell patching rAF. Before that, games-repo PR #103
  * raised `touch` 12_795 → 13_061 (+266) when `createInput` began requiring an
  * explicit steer decision. Every game is served that layer whether it asked for
  * it or not, so it is charged to the platform side; charging it to authors would
  * silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 45_311;
+export const GAMEKIT_PLATFORM_BYTES = 121_227;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
The website half of gamedevpl/www.gamedev.pl-games#102, which is now on `main` (`e90151e`). **`master` is red on `contract:games-repo` until this lands.**

## What moved, and why it is two numbers

#102 changed `MAX_BUNDLE_BYTES` twice:

- **+679 (`mascotDraw`)** — `draw.mascot(...)` on the `createRenderer` surface. It lives in `gfx.ts`, which every game loads, so every bundle pays it. Measured, identical across `tower-defence`, `rooftop-dash` and `block-cascade`.
- **+75_237 (`headroom`)** — 30% of the 250_790 ceiling that resulted. The cap had always been pinned to the exact assembled size of the tightest published title, which made it a hair trigger: `tower-defence` had **90 bytes** of room, so a 679-byte platform change needed a newly measured constant *and* a paired PR on this side. There are eleven such constants. The band is deliberate slack, not a measurement.

`GAMEKIT_PLATFORM_BYTES` 45_311 → **121_227**, cap **326_027**. `GAME_BUDGET_BYTES` is untouched at 200 KiB — games do not get bigger, the platform gets room to move.

## Why this is not just bookkeeping

`MAX_PROJECT_BYTES` gates serving on this side. A game that clears Check 4 in the games repo but exceeds the cap here answers 422 while catalog and media still look perfectly fine — which is issue #247, and how `block-cascade` and `rooftop-dash` once went live and unplayable.

## Verification

Checked with CI's own extractors against the merged games-repo `main` on disk, rather than by re-doing the arithmetic:

| Source | Value |
| --- | --- |
| games `tools/validate.ts` `MAX_BUNDLE_BYTES` | 326,027 |
| games `shared/assemble-contract.json` `maxProjectBytes` | 326,027 |
| website `MAX_PROJECT_BYTES` | 326,027 |
| `authorBudgetBytes` + allowance sum | 326,027 |

`GAME_KIT_MODULES` also matches, including the `save` module that landed here separately.

15 contract tests pass (`games-repo-contract.test.ts`, `assemble.test.ts`); prettier clean. `npm run contract:games-repo` skips its live fetch locally without `GAMES_REPO_TOKEN` — CI runs the real comparison.

The extractor fixture gains `GAMEKIT_MASCOT_DRAW_BYTES` and `GAMEKIT_HEADROOM_BYTES` rather than just moving the expected total: its purpose is proving the parser handles the real shape of the games-repo source, so it has to contain the constants that source now has.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_