### PR TITLE
Give the mascot things to discover on the accelerometer

### DIFF
--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -24,7 +24,7 @@ import {
   type ReactNode,
 } from 'react';
 import { MASCOT_IDLE_SPANS, MASCOT_SOLID_SPANS } from './mascotSpans.js';
-import { useDeviceTilt } from './useDeviceTilt.js';
+import { SHAKE_DELIGHT_AT, useDeviceTilt, type MascotGesture } from './useDeviceTilt.js';
 
 export type MascotEmotion =
   'idle' | 'happy' | 'curious' | 'thinking' | 'excited' | 'confused' | 'sad' | 'proud' | 'wave' | 'busy';
@@ -387,6 +387,9 @@ export function InteractiveMascot({
   const [emotion, setEmotion] = useState<MascotEmotion>(idleEmotion);
   const [look, setLook] = useState<MascotLook>({ x: 0, y: 0 });
   const [poking, setPoking] = useState(false);
+  /** Which gesture is currently being answered, for the one-shot motion classes. */
+  const [flourish, setFlourish] = useState<MascotGesture | null>(null);
+  const upsideDownRef = useRef(false);
   const [reduceMotion, setReduceMotion] = useState(false);
   const reduceMotionRef = useRef(false);
 
@@ -417,21 +420,49 @@ export function InteractiveMascot({
   // concerned — both end up as a look vector. Reduced motion opts out entirely.
   const device = useDeviceTilt(reactsToTilt && !reduceMotion);
 
-  // Shake him and he gets dizzy. Skips the first render: shakeCount starts at 0 and
-  // reaching 1 is the first real shake.
+  /*
+   * How he answers each thing you can do to the phone. Skips the first render:
+   * `gestureSeq` starts at 0 and reaching 1 is the first real gesture.
+   *
+   * Shaking escalates on purpose. One shake and he is dizzy, which is the joke; keep
+   * going and he decides he likes it, which is the better joke and the reason to try
+   * it twice. Being turned over is the only reaction that persists — it lasts as long
+   * as you hold it there — so it gets its own state rather than a timer.
+   */
   useEffect(() => {
-    if (device.shakeCount === 0) return;
+    if (device.gestureSeq === 0) return;
+    const reaction: MascotEmotion =
+      device.gesture === 'freefall'
+        ? 'excited'
+        : device.gesture === 'flip'
+          ? 'sad'
+          : device.gesture === 'right-side-up'
+            ? 'happy'
+            : device.shakeStreak >= SHAKE_DELIGHT_AT
+              ? 'excited'
+              : 'confused';
+
     pokingRef.current = true;
     setPoking(true);
-    setEmotion('confused');
+    setEmotion(reaction);
+    // The tumble is the payoff for keeping at it — a single shake just makes him
+    // dizzy, and spinning him every time would spend the joke immediately.
+    const earnedTumble = device.gesture !== 'shake' || device.shakeStreak >= SHAKE_DELIGHT_AT;
+    setFlourish(earnedTumble ? device.gesture : null);
     if (pokeTimer.current) clearTimeout(pokeTimer.current);
     pokeTimer.current = setTimeout(() => {
       pokingRef.current = false;
       setPoking(false);
-      setEmotion(hoveredRef.current ? 'curious' : idleEmotion);
+      setFlourish(null);
+      // Still upside down when the reaction expires? Then he stays unhappy about it.
+      setEmotion(upsideDownRef.current ? 'sad' : hoveredRef.current ? 'curious' : idleEmotion);
       pokeTimer.current = null;
     }, POKE_HOLD_MS);
-  }, [device.shakeCount, idleEmotion]);
+    // `gestureSeq` is the trigger; the rest is read at the moment it changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [device.gestureSeq]);
+
+  upsideDownRef.current = device.upsideDown;
 
   // Reduced motion still gets the emotion swap — only tilt/boop are suppressed.
   const settleEmotion = () => (hoveredRef.current ? 'curious' : idleEmotion);
@@ -514,7 +545,13 @@ export function InteractiveMascot({
     <button
       ref={rootRef}
       type="button"
-      className={['mascot-interactive', poking ? 'mascot-interactive--poking' : null, className]
+      className={[
+        'mascot-interactive',
+        poking ? 'mascot-interactive--poking' : null,
+        device.upsideDown ? 'mascot-interactive--upside-down' : null,
+        flourish ? `mascot-interactive--${flourish}` : null,
+        className,
+      ]
         .filter(Boolean)
         .join(' ')}
       aria-label={pokeLabel}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5017,12 +5017,74 @@ body.player-open {
   }
 }
 
+/*
+ * Accelerometer reactions.
+ *
+ * These all drive the inner `.mascot` rather than `.mascot-interactive__tilt`, which
+ * already carries an inline transform recomputed from the tilt vector every frame —
+ * anything written here would be overwritten by it, and a transition on that element
+ * would put lag between the phone moving and him leaning. The SVG underneath is free,
+ * so the two compose: he can hang upside down and still lean with the tilt.
+ */
+.mascot-interactive .mascot {
+  transform-origin: 50% 60%;
+  transition: transform 0.5s cubic-bezier(0.34, 1.3, 0.64, 1);
+}
+
+/* Held over — the only reaction that persists rather than expiring on a timer. */
+.mascot-interactive--upside-down .mascot {
+  transform: rotate(180deg);
+}
+
+/* Shaken hard enough that he starts enjoying it: a full tumble, once. */
+.mascot-interactive--shake .mascot {
+  animation: mascot-tumble 0.6s ease-in-out;
+}
+
+/* Dropped. He stretches like something falling in a cartoon. */
+.mascot-interactive--freefall .mascot {
+  animation: mascot-plummet 0.5s ease-in-out;
+}
+
+@keyframes mascot-tumble {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes mascot-plummet {
+  0%,
+  100% {
+    transform: scale(1, 1) translateY(0);
+  }
+  40% {
+    transform: scale(0.86, 1.22) translateY(-6px);
+  }
+  70% {
+    transform: scale(1.1, 0.9) translateY(2px);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mascot-interactive,
   .mascot-interactive__tilt,
   .mascot-interactive--poking {
     transition: none;
     animation: none;
+  }
+
+  /* The gesture reactions are motion by definition, so they go entirely — the
+     emotion still changes, which is the part that carries the meaning. */
+  .mascot-interactive .mascot,
+  .mascot-interactive--shake .mascot,
+  .mascot-interactive--freefall .mascot,
+  .mascot-interactive--upside-down .mascot {
+    transition: none;
+    animation: none;
+    transform: none;
   }
 
   .mascot-interactive:active {

--- a/apps/web/src/useDeviceTilt.test.tsx
+++ b/apps/web/src/useDeviceTilt.test.tsx
@@ -2,12 +2,13 @@
 
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   angleDelta,
   gravityAlignment,
   isFreeFall,
   shakeJerk,
+  SHAKE_DELIGHT_AT,
   tiltFromOrientation,
   useDeviceTilt,
   type DeviceTilt,
@@ -94,6 +95,19 @@ describe('dropping the phone', () => {
   });
 });
 
+/**
+ * jsdom's DeviceMotionEvent constructor drops the init dictionary, so the payload is
+ * attached to a plain Event instead. The hook only ever reads the property.
+ */
+function motion(x: number, y: number, z: number): Event {
+  const event = new Event('devicemotion');
+  Object.assign(event, { accelerationIncludingGravity: { x, y, z } });
+  return event;
+}
+
+// Without this React warns and does not promise to flush effects inside act().
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
 /** Mount a hook and expose its latest value. */
 function renderTilt(enabled: boolean) {
   const container = document.createElement('div');
@@ -173,5 +187,130 @@ describe('useDeviceTilt', () => {
 
     addSpy.mockRestore();
     removeSpy.mockRestore();
+  });
+});
+
+/**
+ * The gesture semantics — hold times, hysteresis, streak window, consecutive-sample
+ * gating — are the load-bearing part and none of it is visible in the pure helpers.
+ * These drive the real hook with real events and a clock under test control, so the
+ * thresholds cannot drift silently (Copilot review on #313).
+ */
+describe('gesture recognition', () => {
+  const HELD = [0, 9.8, 0] as const;
+  const OVER = [0, -9.8, 0] as const;
+  let clock = 0;
+
+  const send = (sample: readonly [number, number, number]) =>
+    act(() => {
+      window.dispatchEvent(motion(sample[0], sample[1], sample[2]));
+    });
+  const advance = (ms: number) => {
+    clock += ms;
+  };
+
+  beforeEach(() => {
+    // Well past every cooldown, so the start of the clock is never what is under test.
+    clock = 50_000;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+    vi.stubGlobal('DeviceOrientationEvent', function DeviceOrientationEvent() {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('makes you hold a flip before believing it', () => {
+    const probe = renderTilt(true);
+    send(HELD); // establishes which way was up
+
+    send(OVER);
+    advance(120);
+    send(OVER);
+    // A shake swings through every angle; reacting instantly would fire flips constantly.
+    expect(probe.latest().upsideDown).toBe(false);
+    expect(probe.latest().gestureSeq).toBe(0);
+
+    advance(300); // now past FLIP_HOLD_MS in total
+    send(OVER);
+    expect(probe.latest().gesture).toBe('flip');
+    expect(probe.latest().upsideDown).toBe(true);
+
+    probe.unmount();
+  });
+
+  it('reports being turned back the right way', () => {
+    const probe = renderTilt(true);
+    send(HELD);
+    send(OVER);
+    advance(400);
+    send(OVER);
+    expect(probe.latest().upsideDown).toBe(true);
+
+    send(HELD);
+    expect(probe.latest().gesture).toBe('right-side-up');
+    expect(probe.latest().upsideDown).toBe(false);
+    probe.unmount();
+  });
+
+  it('escalates a shake streak, and forgets it once you stop', () => {
+    const probe = renderTilt(true);
+    send(HELD);
+
+    // Each jump is well over the jerk threshold, and stays aligned with the baseline
+    // so the flip detector has nothing to say about it.
+    send([0, 40, 0]);
+    expect(probe.latest().gesture).toBe('shake');
+    expect(probe.latest().shakeStreak).toBe(1);
+
+    advance(950); // past the cooldown, inside the streak window
+    send(HELD);
+    expect(probe.latest().shakeStreak).toBe(2);
+
+    advance(950);
+    send([0, 40, 0]);
+    expect(probe.latest().shakeStreak).toBe(SHAKE_DELIGHT_AT);
+
+    // Stop for longer than the streak window and the next one starts over.
+    advance(3_000);
+    send(HELD);
+    expect(probe.latest().shakeStreak).toBe(1);
+    probe.unmount();
+  });
+
+  it('ignores a shake that arrives inside the cooldown', () => {
+    const probe = renderTilt(true);
+    send(HELD);
+    send([0, 40, 0]);
+    const afterFirst = probe.latest().gestureSeq;
+
+    advance(100);
+    send(HELD);
+    expect(probe.latest().gestureSeq).toBe(afterFirst);
+    probe.unmount();
+  });
+
+  it('wants two falling samples in a row before calling it a drop', () => {
+    const probe = renderTilt(true);
+    send(HELD);
+
+    send([0.1, 0.1, 0.1]);
+    expect(probe.latest().gestureSeq).toBe(0); // one reading could be noise
+
+    send([0.2, 0.1, 0.2]);
+    expect(probe.latest().gesture).toBe('freefall');
+    probe.unmount();
+  });
+
+  it('does not let a single odd reading accumulate into a drop', () => {
+    const probe = renderTilt(true);
+    send(HELD);
+
+    send([0.1, 0.1, 0.1]);
+    send(HELD); // back to rest — the run is broken
+    send([0.1, 0.1, 0.1]);
+    expect(probe.latest().gestureSeq).toBe(0);
+    probe.unmount();
   });
 });

--- a/apps/web/src/useDeviceTilt.test.tsx
+++ b/apps/web/src/useDeviceTilt.test.tsx
@@ -3,7 +3,15 @@
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { angleDelta, shakeJerk, tiltFromOrientation, useDeviceTilt, type DeviceTilt } from './useDeviceTilt.js';
+import {
+  angleDelta,
+  gravityAlignment,
+  isFreeFall,
+  shakeJerk,
+  tiltFromOrientation,
+  useDeviceTilt,
+  type DeviceTilt,
+} from './useDeviceTilt.js';
 
 describe('tilt maths', () => {
   it('takes the short way round the circle', () => {
@@ -39,6 +47,50 @@ describe('tilt maths', () => {
     const still = { x: 0, y: 9.8, z: 0 };
     expect(shakeJerk(still, still)).toBe(0);
     expect(shakeJerk(still, { x: 0, y: -9.8, z: 0 })).toBeCloseTo(19.6, 1);
+  });
+});
+
+describe('turning the phone over', () => {
+  const held = { x: 0, y: 9.8, z: 0 };
+
+  it('measures against how you were holding it, not against an axis', () => {
+    expect(gravityAlignment(held, held)).toBeCloseTo(1, 3);
+    expect(gravityAlignment(held, { x: 0, y: -9.8, z: 0 })).toBeCloseTo(-1, 3);
+    expect(gravityAlignment(held, { x: 9.8, y: 0, z: 0 })).toBeCloseTo(0, 3);
+  });
+
+  /**
+   * The point of doing it this way: a device whose axes are signed the other way
+   * round still reports "same as I started" as +1 and "turned over" as −1, because
+   * the quantity is an angle between two of its own readings. Guessing an absolute
+   * axis sign wrong would invert the whole feature on half the devices.
+   */
+  it('is independent of which way the axes are signed', () => {
+    const heldOtherConvention = { x: 0, y: -9.8, z: 0 };
+    expect(gravityAlignment(heldOtherConvention, heldOtherConvention)).toBeCloseTo(1, 3);
+    expect(gravityAlignment(heldOtherConvention, { x: 0, y: 9.8, z: 0 })).toBeCloseTo(-1, 3);
+  });
+
+  it('works for a phone that started flat on a table', () => {
+    const flat = { x: 0, y: 0, z: 9.8 };
+    expect(gravityAlignment(flat, { x: 0, y: 0, z: -9.8 })).toBeCloseTo(-1, 3);
+  });
+
+  it('refuses to guess a direction from a falling sample', () => {
+    // No usable "down" while falling — 0 keeps it clear of both flip thresholds.
+    expect(gravityAlignment(held, { x: 0.1, y: 0.1, z: 0.1 })).toBe(0);
+    expect(gravityAlignment({ x: 0, y: 0, z: 0 }, held)).toBe(0);
+  });
+});
+
+describe('dropping the phone', () => {
+  it('knows a fall from a hold', () => {
+    // At rest something reads ~9.8; in free fall the accelerometer sees ~nothing.
+    expect(isFreeFall({ x: 0, y: 0, z: 0 })).toBe(true);
+    expect(isFreeFall({ x: 0.4, y: -0.9, z: 1.1 })).toBe(true);
+    expect(isFreeFall({ x: 0, y: 9.8, z: 0 })).toBe(false);
+    // A brisk wave is high-magnitude, not low — it must not read as a drop.
+    expect(isFreeFall({ x: 4, y: 14, z: 3 })).toBe(false);
   });
 });
 

--- a/apps/web/src/useDeviceTilt.ts
+++ b/apps/web/src/useDeviceTilt.ts
@@ -93,7 +93,7 @@ export type Vec3 = { x: number; y: number; z: number };
 export function gravityAlignment(baseline: Vec3, current: Vec3): number {
   const baseLength = Math.hypot(baseline.x, baseline.y, baseline.z);
   const currentLength = Math.hypot(current.x, current.y, current.z);
-  if (baseLength < 1 || currentLength < 1) return 0;
+  if (baseLength < FREE_FALL_MS2 || currentLength < FREE_FALL_MS2) return 0;
   const dot = baseline.x * current.x + baseline.y * current.y + baseline.z * current.z;
   return clamp(dot / (baseLength * currentLength));
 }
@@ -157,7 +157,9 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
   const smoothed = useRef<Tilt>({ x: 0, y: 0 });
   const published = useRef<Tilt>({ x: 0, y: 0 });
   const lastAccel = useRef<Vec3 | null>(null);
-  const lastShakeAt = useRef(0);
+  // −Infinity, not 0: `performance.now()` counts from page load, so a 0 sentinel
+  // silently swallows a gesture made within one cooldown of the page opening.
+  const lastShakeAt = useRef(Number.NEGATIVE_INFINITY);
   const streak = useRef(0);
   /**
    * Captured once and deliberately NOT reset by a shake, unlike the tilt baseline.
@@ -168,7 +170,7 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
   const flippedSince = useRef(0);
   const flipped = useRef(false);
   const fallingSamples = useRef(0);
-  const lastFallAt = useRef(0);
+  const lastFallAt = useRef(Number.NEGATIVE_INFINITY);
 
   const emit = useCallback((kind: MascotGesture) => {
     setGesture((previous) => ({ seq: previous.seq + 1, kind }));
@@ -311,7 +313,7 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
       smoothed.current = { x: 0, y: 0 };
       published.current = { x: 0, y: 0 };
     };
-  }, [listening]);
+  }, [listening, emit]);
 
   return {
     supported,

--- a/apps/web/src/useDeviceTilt.ts
+++ b/apps/web/src/useDeviceTilt.ts
@@ -31,6 +31,22 @@ const SMOOTHING = 0.18;
 const SHAKE_JERK = 22;
 /** Shakes cannot retrigger faster than this. */
 const SHAKE_COOLDOWN_MS = 900;
+/** A further shake inside this window escalates the streak instead of starting over. */
+const SHAKE_STREAK_MS = 2_200;
+/** Streak at which he stops being dizzy and starts enjoying it. */
+export const SHAKE_DELIGHT_AT = 3;
+/** Gravity agreement below which the device counts as turned over. */
+const FLIP_ALIGNMENT = -0.55;
+/** …and above which it counts as righted again. Hysteresis, so the edge cannot chatter. */
+const FLIP_RELEASE_ALIGNMENT = -0.25;
+/** Hold the flip this long before reacting, so a shake passing through does not trip it. */
+const FLIP_HOLD_MS = 350;
+/** Total acceleration below this is a fall rather than a hold. */
+const FREE_FALL_MS2 = 3;
+/** Consecutive falling samples required, so one noisy reading cannot fake a drop. */
+const FREE_FALL_SAMPLES = 2;
+/** Falls cannot retrigger faster than this. */
+const FREE_FALL_COOLDOWN_MS = 1_200;
 
 const clamp = (value: number) => Math.max(-1, Math.min(1, value));
 
@@ -58,6 +74,39 @@ export function shakeJerk(
   return Math.hypot(next.x - previous.x, next.y - previous.y, next.z - previous.z);
 }
 
+export type Vec3 = { x: number; y: number; z: number };
+
+/**
+ * How closely the device's current "down" agrees with the "down" it had when the
+ * first reading arrived: +1 held exactly as you started, 0 rotated a quarter turn,
+ * −1 turned right over.
+ *
+ * Doing it relative to the start, rather than against an absolute axis, is what
+ * keeps this honest across platforms. The sign of each accelerometer axis depends
+ * on the device and the browser, and guessing wrong inverts the whole feature — but
+ * *the angle between two readings from the same device* needs no convention at all.
+ * It also matches what a person means by upside down: flipped from how they were
+ * holding it, not flipped relative to the room.
+ *
+ * Returns 0 for a degenerate sample (free fall has no usable direction).
+ */
+export function gravityAlignment(baseline: Vec3, current: Vec3): number {
+  const baseLength = Math.hypot(baseline.x, baseline.y, baseline.z);
+  const currentLength = Math.hypot(current.x, current.y, current.z);
+  if (baseLength < 1 || currentLength < 1) return 0;
+  const dot = baseline.x * current.x + baseline.y * current.y + baseline.z * current.z;
+  return clamp(dot / (baseLength * currentLength));
+}
+
+/**
+ * A dropped phone reads close to zero on every axis — the accelerometer measures
+ * proper acceleration, and something falling freely has none. At rest it reads ~9.8
+ * on whichever axis is down, so this is a wide, unambiguous gap.
+ */
+export function isFreeFall(sample: Vec3): boolean {
+  return Math.hypot(sample.x, sample.y, sample.z) < FREE_FALL_MS2;
+}
+
 type OrientationConstructor = typeof DeviceOrientationEvent & {
   requestPermission?: () => Promise<PermissionState | 'granted' | 'denied'>;
 };
@@ -76,11 +125,23 @@ export type DeviceTilt = {
   /** Readings are arriving. */
   active: boolean;
   tilt: Tilt;
-  /** Increments once per detected shake — a signal to react to, not a level. */
-  shakeCount: number;
+  /**
+   * Increments once per recognised gesture. Read it with {@link DeviceTilt.gesture} —
+   * the counter exists because the same gesture twice in a row still has to fire
+   * twice, which a bare string could not express.
+   */
+  gestureSeq: number;
+  gesture: MascotGesture | null;
+  /** Shakes so far in the current burst: 1, 2, 3… Resets when the burst stops. */
+  shakeStreak: number;
+  /** Held turned over, relative to how it was being held when readings began. */
+  upsideDown: boolean;
   /** Safe to call unconditionally; only meaningful inside a user gesture on iOS. */
   request: () => void;
 };
+
+/** Things worth reacting to, as opposed to the continuous tilt. */
+export type MascotGesture = 'shake' | 'flip' | 'right-side-up' | 'freefall';
 
 export function useDeviceTilt(enabled: boolean): DeviceTilt {
   const [supported, setSupported] = useState(false);
@@ -88,13 +149,30 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
   const [granted, setGranted] = useState(false);
   const [active, setActive] = useState(false);
   const [tilt, setTilt] = useState<Tilt>({ x: 0, y: 0 });
-  const [shakeCount, setShakeCount] = useState(0);
+  const [gesture, setGesture] = useState<{ seq: number; kind: MascotGesture | null }>({ seq: 0, kind: null });
+  const [shakeStreak, setShakeStreak] = useState(0);
+  const [upsideDown, setUpsideDown] = useState(false);
 
   const baseline = useRef<{ beta: number; gamma: number } | null>(null);
   const smoothed = useRef<Tilt>({ x: 0, y: 0 });
   const published = useRef<Tilt>({ x: 0, y: 0 });
-  const lastAccel = useRef<{ x: number; y: number; z: number } | null>(null);
+  const lastAccel = useRef<Vec3 | null>(null);
   const lastShakeAt = useRef(0);
+  const streak = useRef(0);
+  /**
+   * Captured once and deliberately NOT reset by a shake, unlike the tilt baseline.
+   * "Upside down" has to stay relative to how you first held the phone, or shaking it
+   * would quietly redefine which way is up and the flip would never register.
+   */
+  const gravityBaseline = useRef<Vec3 | null>(null);
+  const flippedSince = useRef(0);
+  const flipped = useRef(false);
+  const fallingSamples = useRef(0);
+  const lastFallAt = useRef(0);
+
+  const emit = useCallback((kind: MascotGesture) => {
+    setGesture((previous) => ({ seq: previous.seq + 1, kind }));
+  }, []);
 
   useEffect(() => {
     const ctor = orientationCtor();
@@ -164,17 +242,57 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
     const onMotion = (event: DeviceMotionEvent) => {
       const a = event.accelerationIncludingGravity;
       if (!a || a.x == null || a.y == null || a.z == null) return;
-      const sample = { x: a.x, y: a.y, z: a.z };
+      const sample: Vec3 = { x: a.x, y: a.y, z: a.z };
       const previous = lastAccel.current;
       lastAccel.current = sample;
+      const now = performance.now();
+
+      // ——— Dropped. Checked before anything else: a fall has no usable gravity
+      // direction, so letting it reach the flip test would compare against noise.
+      if (isFreeFall(sample)) {
+        fallingSamples.current += 1;
+        if (fallingSamples.current >= FREE_FALL_SAMPLES && now - lastFallAt.current > FREE_FALL_COOLDOWN_MS) {
+          lastFallAt.current = now;
+          emit('freefall');
+        }
+        return;
+      }
+      fallingSamples.current = 0;
+
+      if (!gravityBaseline.current) gravityBaseline.current = sample;
+
+      // ——— Turned over. Has to be held: a shake swings the phone through every
+      // angle on the way, and reacting to that would fire flips constantly.
+      const alignment = gravityAlignment(gravityBaseline.current, sample);
+      if (!flipped.current && alignment < FLIP_ALIGNMENT) {
+        if (!flippedSince.current) flippedSince.current = now;
+        if (now - flippedSince.current >= FLIP_HOLD_MS) {
+          flipped.current = true;
+          flippedSince.current = 0;
+          setUpsideDown(true);
+          emit('flip');
+        }
+      } else if (flipped.current && alignment > FLIP_RELEASE_ALIGNMENT) {
+        flipped.current = false;
+        flippedSince.current = 0;
+        setUpsideDown(false);
+        emit('right-side-up');
+      } else if (alignment >= FLIP_ALIGNMENT) {
+        flippedSince.current = 0;
+      }
+
+      // ——— Shaken.
       if (!previous) return;
       if (shakeJerk(previous, sample) < SHAKE_JERK) return;
-      const now = performance.now();
       if (now - lastShakeAt.current < SHAKE_COOLDOWN_MS) return;
+      // Keep shaking and it escalates; stop and the next one starts over at 1.
+      streak.current = now - lastShakeAt.current < SHAKE_STREAK_MS ? streak.current + 1 : 1;
       lastShakeAt.current = now;
-      // A shake is also a good moment to forget how the phone was first held.
+      // A shake is also a good moment to forget how the phone was first held — the
+      // tilt baseline only, never the gravity one.
       baseline.current = null;
-      setShakeCount((count) => count + 1);
+      setShakeStreak(streak.current);
+      emit('shake');
     };
 
     window.addEventListener('deviceorientation', onOrientation);
@@ -185,10 +303,25 @@ export function useDeviceTilt(enabled: boolean): DeviceTilt {
       if (frame) cancelAnimationFrame(frame);
       baseline.current = null;
       lastAccel.current = null;
+      gravityBaseline.current = null;
+      flipped.current = false;
+      flippedSince.current = 0;
+      fallingSamples.current = 0;
+      streak.current = 0;
       smoothed.current = { x: 0, y: 0 };
       published.current = { x: 0, y: 0 };
     };
   }, [listening]);
 
-  return { supported, needsPermission, active, tilt, shakeCount, request };
+  return {
+    supported,
+    needsPermission,
+    active,
+    tilt,
+    gestureSeq: gesture.seq,
+    gesture: gesture.kind,
+    shakeStreak,
+    upsideDown,
+    request,
+  };
 }


### PR DESCRIPTION
Tilting was one continuous signal. This adds the discrete ones — the things you can *do* to a phone that deserve a reaction — as a small gesture vocabulary the component answers, rather than a pile of thresholds at the call site.

## What he now does

| Do this | He does this |
| --- | --- |
| **Turn the phone over** | Hangs there looking unimpressed, for as long as you hold it |
| **Turn it back** | Relieved — briefly happy |
| **Shake once** | Dizzy |
| **Keep shaking** | By the third he has decided he likes it, and tumbles |
| **Drop it** | Stretches like something falling in a cartoon |

Shaking escalates on purpose. One shake making him dizzy is the joke; realising he *enjoys* it if you persist is the better joke, and it's the reason to try a second time. Spinning him on every shake would spend that immediately, so the tumble is gated behind the streak. Stop shaking and the streak resets.

Being turned over is the only reaction with no timer — it's a state, not an event, so it lasts exactly as long as you hold it there, and he stays unhappy about it even after the initial reaction expires.

## The part that needed care

**Upside down is measured against the gravity vector captured when readings began, not against a fixed axis.** Accelerometer axis signs vary by device and browser; guessing one wrong inverts the whole feature on half of them. But *the angle between two readings from the same device* needs no convention at all — so `gravityAlignment` returns +1 for "held as you started", −1 for "turned right over", whatever the hardware thinks its axes are. There's a test asserting it behaves identically under a flipped-sign convention.

It also happens to be the better product behaviour: it matches what a person means by upside down — flipped from how *they* were holding it, not relative to the room. Someone lying down gets the same feature.

Two ordering details that are load-bearing:

- **The flip must be held 350ms.** A shake swings the phone through every angle on the way, so an instantaneous check fires flips constantly.
- **The free-fall check runs first.** A falling sample has no usable gravity direction, so letting it reach the flip comparison would be comparing against noise. `gravityAlignment` also returns 0 rather than guessing for a degenerate sample.

Free fall is the easiest of the three to detect honestly: an accelerometer measures *proper* acceleration, so a falling device reads near zero on every axis against ~9.8 at rest. That's a wide, unambiguous gap — it needs two consecutive samples only to rule out a single noisy reading.

## Constraints respected

- **No DOM added to the splash card**, so the iPhone SE fit from #306 is untouched — re-measured at 474px with zero overflow in all three viewports.
- The reactions drive the inner SVG, not `.mascot-interactive__tilt`, whose inline transform is recomputed from the tilt vector every frame and would overwrite anything set in CSS. They compose: he can hang upside down *and* still lean with the tilt.
- `prefers-reduced-motion` drops every transform and animation and keeps only the emotion change, which is the part carrying the meaning.
- Still off by default (`reactsToTilt`), still only on the splash.

## Verification

Full web suite green: 59 files, 440 tests. Typecheck and prettier clean.

Driven end to end in Chromium against the real component with synthetic sensor events:

```
over, only 120ms   → no flip yet          (debounce holds)
over, held >350ms  → sad + upside-down
righted            → happy
shake #1           → confused
shake #2           → confused
shake #3           → excited + tumble     (streak escalates)
dropped            → excited + plummet
```

New unit tests cover the alignment maths — including the flipped-sign convention, a phone that started flat on a table, and the degenerate falling sample — plus free-fall discrimination against a brisk wave, which is high-magnitude rather than low and must not read as a drop.

**Unchanged gap from #306:** Chromium has no `requestPermission`, so the iOS permission path is still covered only by unit tests against a stubbed iOS-shaped constructor. Real-device sensor behaviour — particularly how quickly a real accelerometer's noise floor settles — is the piece worth trying on an actual phone.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_