### PR TITLE
Make the header mascot's idle actually visible

### DIFF
--- a/apps/web/src/headerMascot.test.ts
+++ b/apps/web/src/headerMascot.test.ts
@@ -28,6 +28,30 @@ describe('the header mascot is alive', () => {
     );
   });
 
+  it('gives the mark its own idle, because the shared one is invisible at 35px', () => {
+    // 35px wide against a 70-unit viewBox is a 0.5 scale, so the shared keyframes
+    // came out as ~1.5px of travel over 2.8s — running, but not visible. It was
+    // reported as "not animated" twice while animating the whole time.
+    const css = read('styles.css');
+    expect(css).toMatch(
+      /\.mascot\.mascot--logo:not\(\.mascot--static\)\.mascot--idle \.mascot__body-group \{\s*animation: mascot-logo-idle/,
+    );
+    const frames = css.slice(css.indexOf('@keyframes mascot-logo-idle'));
+    // The hop is what makes it legible: an event the eye catches, not a drift.
+    expect(frames).toMatch(/translateY\(-9px\)/);
+  });
+
+  it('keeps the hover hop winning over that idle', () => {
+    // Both selectors carry the same weight once `:hover` is counted, so the only
+    // thing deciding it is source order. Move the hover rule above the idle rule and
+    // hovering the logo silently stops doing anything.
+    const css = read('styles.css');
+    const idleAt = css.indexOf('.mascot.mascot--logo:not(.mascot--static).mascot--idle .mascot__body-group');
+    const hoverAt = css.indexOf('.logo:hover .mascot--logo:not(.mascot--static) .mascot__body-group');
+    expect(idleAt).toBeGreaterThan(-1);
+    expect(hoverAt).toBeGreaterThan(idleAt);
+  });
+
   it('still lets prefers-reduced-motion win over both', () => {
     const css = read('styles.css');
     const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4911,6 +4911,74 @@ body.player-open {
 }
 
 /*
+ * The header mark needs its own idle, because the shared one is invisible at its size.
+ *
+ * Every other mascot on the site renders at 64–96px, where `mascot-breathe` reads
+ * nicely. The mark is 35px wide against a 70-unit viewBox — a 0.5 scale — so the same
+ * keyframes come out as 1.5px of travel spread over 2.8 seconds. That is genuinely
+ * animating and genuinely imperceptible, which is the worst of both: it was reported
+ * twice as "not animated" while the animation was running the whole time.
+ *
+ * So: roughly double the breath, and end each cycle with a hop. The hop is what makes
+ * it legible — a periodic event the eye catches, rather than a drift it never will.
+ * transform-origin is already his feet, so he compresses into the jump and lands on
+ * them. Five classes to outrank the shared `.mascot--idle` rule above.
+ */
+.mascot.mascot--logo:not(.mascot--static).mascot--idle .mascot__body-group {
+  animation: mascot-logo-idle 5.6s ease-in-out infinite;
+}
+
+@keyframes mascot-logo-idle {
+  0%,
+  48%,
+  88%,
+  100% {
+    transform: translateY(0) scale(1, 1);
+  }
+  /* Two slow breaths… */
+  12%,
+  36% {
+    transform: translateY(-3px) scale(1.03, 0.97);
+  }
+  24% {
+    transform: translateY(0) scale(1, 1);
+  }
+  /* …then he hops. */
+  64% {
+    transform: translateY(-9px) scale(0.94, 1.08);
+  }
+  74% {
+    transform: translateY(0) scale(1.1, 0.9);
+  }
+  80% {
+    transform: translateY(-2px) scale(0.98, 1.02);
+  }
+}
+
+/*
+ * The blink needs the same treatment for the same reason: the lids are 5 units square,
+ * which is 2.5px here, and the shared keyframe shows them for about 138ms. Holding a
+ * little longer is the difference between a blink and a dropped frame.
+ */
+.mascot--logo:not(.mascot--static) .mascot__lid {
+  animation-name: mascot-logo-blink;
+  animation-duration: 5.6s;
+}
+
+@keyframes mascot-logo-blink {
+  0%,
+  30%,
+  38%,
+  100% {
+    opacity: 0;
+  }
+  32%,
+  36% {
+    opacity: 1;
+  }
+}
+
+/*
  * The header mark breathes and blinks like every other mascot on the site — it is the
  * one instance every visitor sees, so freezing it was the wrong instance to freeze.
  * Hovering the logo promotes that idle breath to the excited hop, which gives the


### PR DESCRIPTION
Reported twice as "not animated". **It was animating both times** — and that turned out to be the interesting part.

## What I found

I checked the deployed site rather than the source, signed in so the header actually renders (an anonymous visitor gets the splash, and its `mascot--wave` is easy to mistake for the header mark):

- `mascot-breathe` and `mascot-lid-blink` both running on `.app-header .logo .mascot`
- `prefers-reduced-motion` off
- the group's transform changing across six distinct samples in 1.3s

So nothing was frozen, and #306's fix was working. The problem is **amplitude**.

Every other mascot on the site renders at 64–96px, which is what the shared keyframes were tuned for. The mark is 35px wide against a 70-unit viewBox — a 0.5 scale — so the same keyframes come out as:

| | at 35px |
| --- | --- |
| breathe travel | **1.5px**, spread over 2.8s |
| breathe squash | 0.53px of width |
| blink | 2.5px lids shown for **138ms** every 4.6s |

Genuinely animating and genuinely imperceptible. That's the worst of both: nothing looks broken, so the only report anyone can give is "it doesn't move" — which sends you looking for a frozen animation that isn't there. Twice, in this case.

## The change

The mark gets its own idle: two slow breaths, then a hop. The hop is what makes it legible — a periodic *event* the eye catches, rather than a drift it never will. `transform-origin` is already his feet, so he compresses into the jump and lands on them.

Measured in Chromium over a full cycle: travel **1.5px → 4.47px**, peak squash 3% → 10%. The blink gets a longer hold for the same reason — the difference between a blink and a dropped frame.

## One trap worth naming

The new idle rule and the hover-hop rule from #306 carry **the same specificity** once `:hover` is counted. Hover only still wins because it appears later in the file.

I nearly shipped this having miscounted (I forgot `:hover` contributes), so I checked it in a browser instead of by reasoning — `getComputedStyle(...).animationName` reads `mascot-bounce` on hover, `mascot-logo-idle` at rest. There's now a test pinning the source order, and I confirmed it fails when the two rules are swapped: moving the hover rule up silently stops hovering doing anything, with no error anywhere.

## Verification

449 tests green, lint clean (`--max-warnings 0`), typecheck and prettier clean. Amplitude numbers above are measured from computed transforms in a real browser, not derived from the keyframes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137XvZYxU41ynTtGMezR88g)_