### PR TITLE
Fix Creator Studio deep links, nav, layout, and discouraging ETA

### DIFF
--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -144,12 +144,11 @@ roughly in order of how often they turn up real issues:
   `/play/<slug>` (see `apps/web/src/router.ts`).
 - **Multiplayer lobby** — click "Play together" on a catalog entry with `multiplayer` set;
   check the QR/join-link screen renders and the join URL matches `/join/<CODE>#<token>`.
-- **Header menu** (hamburger, top right) — items are `<button class="nav-link">`, not links;
-  they call `scrollIntoView` on a same-page section id (`#hero-prompt`, `#arcade`,
-  `#my-games`), not client-side routes. Don't be fooled by a URL that doesn't change — wait
-  for the smooth-scroll to actually land before screenshotting. `#my-games` only exists in the
-  DOM once `MyGamesRail` has at least one non-abandoned submission to show — for a fresh
-  bot identity with zero submissions, clicking "My Games" is a legitimate no-op.
+- **Header menu** (hamburger, top right) — items are `<button class="nav-link">`, not
+  always links. Create Game / Arcade still `scrollIntoView` on home sections
+  (`#hero-prompt`, `#arcade`). **Studio** navigates to `/studio` (the creator home);
+  the home page only keeps a short My Games gist. Don't expect a URL change for the
+  scroll items — wait for the smooth-scroll to land before screenshotting.
 - **Language toggle** (EN/PL) — check strings actually swap, not just the button state.
 - **Static/legal routes** — `/privacy`, `/terms`.
 - **Error paths** — an unknown path (→ `notFound` view, real 404), an unknown game slug at

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -55,6 +55,7 @@ describe('isKnownSpaShellPath', () => {
     '/draft/..%2Fadmin',
     '/health/brick-storm',
     '/studio/tok-abc/nope',
+    '/studio/tok-abc/feedback',
     '/studio/tok-abc/build/extra',
     '/join/lower1',
     '/join/TOOLONG9',

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -36,6 +36,10 @@ describe('isKnownSpaShellPath', () => {
     '/ai/sky-dodge',
     '/draft/space-runner',
     '/status/tok-abc',
+    '/studio',
+    '/studio/tok-abc',
+    '/studio/tok-abc/build',
+    '/studio/tok-abc/playtest',
     '/join/K7M3QP',
   ])('treats %s as a known shell path (HTTP 200)', (path) => {
     expect(isKnownSpaShellPath(path)).toBe(true);
@@ -50,6 +54,8 @@ describe('isKnownSpaShellPath', () => {
     '/draft/',
     '/draft/..%2Fadmin',
     '/health/brick-storm',
+    '/studio/tok-abc/nope',
+    '/studio/tok-abc/build/extra',
     '/join/lower1',
     '/join/TOOLONG9',
     '/join/K7M3QP/extra',

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -15,7 +15,7 @@ const DRAFT_PATTERN = /^\/draft\/([^/]+)$/;
 const STATUS_PATTERN = /^\/status\/([^/]+)$/;
 const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
 /** `/studio`, `/studio/:token`, `/studio/:token/:tab` — keep aligned with router.ts. */
-const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats|improve|feedback))?)?$/;
+const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats|improve))?)?$/;
 /** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
 const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
 

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -14,6 +14,8 @@ const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
 const DRAFT_PATTERN = /^\/draft\/([^/]+)$/;
 const STATUS_PATTERN = /^\/status\/([^/]+)$/;
 const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
+/** `/studio`, `/studio/:token`, `/studio/:token/:tab` — keep aligned with router.ts. */
+const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats|improve|feedback))?)?$/;
 /** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
 const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
 
@@ -47,6 +49,8 @@ export function isKnownSpaShellPath(urlOrPath: string): boolean {
   if (pathname === '/privacy' || pathname === '/terms' || pathname === '/health' || pathname === '/contact') {
     return true;
   }
+
+  if (STUDIO_PATTERN.test(pathname)) return true;
 
   const statusMatch = pathname.match(STATUS_PATTERN);
   if (statusMatch?.[1]) return true;

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1702,45 +1702,6 @@ describe('GET /api/drafts/:slug (shareable, read-only)', () => {
   });
 });
 
-describe('GET /api/submissions/stats (build-time expectation)', () => {
-  it('reports the median build time of recently published games', async () => {
-    const { githubClient } = createGithubClientStub({});
-    const store = new InMemoryStore();
-    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
-
-    // 20, 30 and 40 minute builds → median 30.
-    const minutes = [20, 30, 40];
-    for (const [index, mins] of minutes.entries()) {
-      const issueNumber = 100 + index;
-      await store.createSubmission(issueNumber, 'g:test-user', `Game ${index}`);
-      const record = (await store.getSubmission(issueNumber))!;
-      await store.setSubmissionPublishedAt(
-        issueNumber,
-        new Date(Date.parse(record.createdAt) + mins * 60_000).toISOString(),
-      );
-    }
-    // An abandoned-then-resumed build must not poison the median.
-    await store.createSubmission(200, 'g:test-user', 'Stale');
-    await store.setSubmissionPublishedAt(200, new Date(Date.now() + 40 * 3600_000).toISOString());
-
-    const res = await app.inject({ method: 'GET', url: '/api/submissions/stats', headers: authHeaders });
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ medianMinutes: 30, sampleSize: 3 });
-
-    await app.close();
-  });
-
-  it('reports no median before any game has published', async () => {
-    const { githubClient } = createGithubClientStub({});
-    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret });
-
-    const res = await app.inject({ method: 'GET', url: '/api/submissions/stats', headers: authHeaders });
-    expect(res.json()).toEqual({ medianMinutes: null, sampleSize: 0 });
-
-    await app.close();
-  });
-});
-
 describe('agent progress note', () => {
   it('surfaces the agent’s own "what I am doing" line from its branch journal', async () => {
     const { githubClient, getProgressNotes } = createGithubClientStub({

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1001,50 +1001,6 @@ export async function registerSubmissionRoutes(
     };
   }
 
-  // The creator's own submissions, newest first. Ownership lives in Firestore (never
-  // in GitHub), so this is the only way to answer "what was I building?" — and it's
-  // what frees a creator from having to save the tracking link. Tokens are re-minted
-  // from the issue number, so a fresh device recovers full access to its own games.
-  // Deliberately GitHub-free: it must stay fast enough to render on the home page.
-  // How long a build actually takes, measured from the last few published games.
-  // "In the queue" with no expectation is where creators give up, and a real median
-  // beats invented copy. Cached in memory — it moves on the scale of hours.
-  const buildStatsTtlMs = 10 * 60_000;
-  const buildStatsSampleSize = 25;
-  // A build that "took" more than this was almost certainly abandoned and resumed;
-  // including it would poison the median.
-  const maxPlausibleBuildMs = 12 * 3600_000;
-  let buildStatsCache: { expiresAt: number; value: { medianMinutes: number | null; sampleSize: number } } | null = null;
-
-  app.get('/api/submissions/stats', async (request, reply) => {
-    if (!checkUserAccess(request, reply)) {
-      return;
-    }
-
-    const currentTime = now();
-    if (buildStatsCache && buildStatsCache.expiresAt > currentTime) {
-      return reply.send(buildStatsCache.value);
-    }
-
-    if (!store) {
-      return reply.send({ medianMinutes: null, sampleSize: 0 });
-    }
-
-    const published = await store.listRecentlyPublished(buildStatsSampleSize);
-    const durations = published
-      .map((record) => Date.parse(record.publishedAt ?? '') - Date.parse(record.createdAt))
-      .filter((ms) => Number.isFinite(ms) && ms > 0 && ms < maxPlausibleBuildMs)
-      .sort((a, b) => a - b);
-
-    const median = durations.length === 0 ? null : durations[Math.floor(durations.length / 2)]!;
-    const value = {
-      medianMinutes: median === null ? null : Math.max(1, Math.round(median / 60_000)),
-      sampleSize: durations.length,
-    };
-    buildStatsCache = { value, expiresAt: currentTime + buildStatsTtlMs };
-    return reply.send(value);
-  });
-
   // What's left of today's allowance. Read-only (never increments), so the hero can
   // show it before a creator spends their last submission on a surprise 429.
   app.get('/api/me/quota', async (request, reply) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -462,16 +462,20 @@ export function App() {
     [pendingSpec, qaQuestions],
   );
 
-  function navigate(path: string) {
+  const navigate = useCallback((path: string, options?: { replace?: boolean }) => {
     // Update the URL (the source of truth) and the route synchronously so
     // navigation is immediate (and testable) without waiting for popstate.
-    window.history.pushState(null, '', path);
-    // pushState is silent, so announce the navigation for anything living outside
-    // this component (see NAVIGATE_EVENT). Dispatched before the state update so a
-    // listener reading window.location sees the URL we just pushed.
+    if (options?.replace) {
+      window.history.replaceState(null, '', path);
+    } else {
+      window.history.pushState(null, '', path);
+    }
+    // pushState/replaceState are silent, so announce the navigation for anything
+    // living outside this component (see NAVIGATE_EVENT). Dispatched before the
+    // state update so a listener reading window.location sees the URL we just set.
     window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT, { detail: { path } }));
     setRoute(readLocationRoute());
-  }
+  }, []);
 
   function handlePlayGame(game: CatalogEntry) {
     // Published games are permalinked: drive play through the URL so a refresh or
@@ -586,6 +590,7 @@ export function App() {
         ) : route.view === 'studio' ? (
           <CreatorStudioView
             selectedToken={route.token}
+            selectedTab={route.tab}
             onNavigate={navigate}
             onPlay={(slug) => navigate(playPath(slug))}
             onRetryConcept={(concept) => {

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -194,6 +194,32 @@ describe('CreatorStudioView', () => {
 
     root.unmount();
   });
+
+  it('keeps a capability token out of the URL on bare /studio until a game is picked', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    window.history.replaceState(null, '', '/studio');
+
+    const { container, root, onNavigate } = await renderStudio();
+
+    // First game is selected in the UI for convenience…
+    expect(container.querySelector('.studio-shelf-item.is-active')?.textContent).toContain('Game 1');
+    // …but the address bar stays token-free until an explicit pick.
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    const second = Array.from(container.querySelectorAll('.studio-shelf-item')).find((item) =>
+      item.textContent?.includes('Game 2'),
+    );
+    expect(second).toBeTruthy();
+    await act(async () => {
+      second!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-1/overview');
+
+    root.unmount();
+  });
 });
 
 describe('CreatorStudioView — what players think', () => {

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -173,6 +173,27 @@ describe('CreatorStudioView', () => {
 
     root.unmount();
   });
+
+  it('falls back to the default tab when the deep-linked one does not exist for the game', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    // token-0 is still building, so Stats has nothing to show for it.
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    window.history.replaceState(null, '', '/studio/token-0/stats');
+
+    const { container, root, onNavigate } = await renderStudio({ selectedToken: 'token-0', selectedTab: 'stats' });
+
+    // Landed on Build, and the URL was corrected in place rather than pushed.
+    const activeTab = container.querySelector('[role="tab"][aria-selected="true"]');
+    expect(activeTab?.textContent).toContain('Build');
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/build', { replace: true });
+    // No tab may exist in the URL that has no button to leave it by.
+    const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((button) => button.textContent);
+    expect(tabLabels.some((label) => label?.includes('Player feedback'))).toBe(false);
+
+    root.unmount();
+  });
 });
 
 describe('CreatorStudioView — what players think', () => {

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -39,19 +39,26 @@ function manyGames(count: number): StudioGame[] {
   }));
 }
 
-async function renderStudio() {
+async function renderStudio(props: Partial<Parameters<typeof CreatorStudioView>[0]> = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
+  const onNavigate = props.onNavigate ?? vi.fn();
   await act(async () => {
-    root.render(createElement(CreatorStudioView, { onNavigate: vi.fn(), onPlay: vi.fn() }));
+    root.render(
+      createElement(CreatorStudioView, {
+        onNavigate,
+        onPlay: vi.fn(),
+        ...props,
+      }),
+    );
   });
   await act(async () => {
     await fetchStudioGames.mock.results[0]?.value;
     await fetchStudioHealth.mock.results[0]?.value;
     await fetchStudioScorecards.mock.results[0]?.value;
   });
-  return { container, root };
+  return { container, root, onNavigate };
 }
 
 describe('CreatorStudioView', () => {
@@ -140,6 +147,29 @@ describe('CreatorStudioView', () => {
 
     expect(container.querySelector('.studio-layout')?.classList.contains('is-focus')).toBe(true);
     expect(container.querySelector('.studio-game-switcher')?.textContent).toMatch(/10 games/i);
+
+    root.unmount();
+  });
+
+  it('persists the selected tab in the URL', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    window.history.replaceState(null, '', '/studio/token-0');
+
+    const { container, root, onNavigate } = await renderStudio({ selectedToken: 'token-0' });
+
+    const improveTab = Array.from(container.querySelectorAll('[role="tab"]')).find((button) =>
+      button.textContent?.includes('Improve'),
+    );
+    expect(improveTab).toBeTruthy();
+
+    await act(async () => {
+      improveTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/improve');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -225,18 +225,23 @@ export function CreatorStudioView({
   );
   const liveCount = useMemo(() => games.filter((game) => isStudioGamePublished(game)).length, [games]);
 
-  // Keep the visible tab + URL aligned with the selected game and any deep-link tab.
+  // Keep the visible tab aligned with the selected game. Only write the
+  // capability token into the URL when the route already carried one (a deep
+  // link, or an earlier explicit pick via selectGame/openTab). Bare `/studio`
+  // keeps shelf selection local so a screenshot or history entry doesn't mint a
+  // token the creator never asked for.
   useEffect(() => {
     if (!selected) return;
     const game = games.find((entry) => entry.token === selected);
     if (!game) return;
     const next = resolveTab(game, selectedTab);
     setTab(next);
+    if (!selectedToken) return;
     const canonical = studioPath(game.token, next);
     if (window.location.pathname !== canonical) {
       onNavigate(canonical, { replace: true });
     }
-  }, [selected, selectedTab, games, onNavigate]);
+  }, [selected, selectedTab, selectedToken, games, onNavigate]);
 
   useEffect(() => {
     if (!pickerOpen) return;

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -31,7 +31,7 @@ import {
  *
  * One place for the whole creator loop: shelf of owned games, the draft Build
  * (former status / "dev studio" page), playtest-with-pause prompting, play
- * health, and post-publish improve. Player-feedback analysis is stubbed.
+ * health, and post-publish improve.
  *
  * Shelf scales past a handful of games: compact rows, search/filter once the
  * list grows, and on narrow viewports a game switcher (picker sheet) so the
@@ -53,6 +53,16 @@ const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
 
 const WINDOWS = [1, 7, 30];
 
+/** Tab strip order, and the label each tab carries. */
+const TAB_ORDER: readonly StudioTab[] = ['overview', 'build', 'playtest', 'stats', 'improve'];
+const TAB_LABELS: Record<StudioTab, string> = {
+  overview: 'studioPanel.tabs.overview',
+  build: 'studioPanel.tabs.build',
+  playtest: 'studioPanel.tabs.playtest',
+  stats: 'studioPanel.tabs.stats',
+  improve: 'studioPanel.tabs.improve',
+};
+
 type NavigateOptions = { replace?: boolean };
 
 type CreatorStudioViewProps = {
@@ -71,10 +81,14 @@ function defaultTabFor(game: StudioGame | null): StudioTab {
   return isStudioGamePublished(game) ? 'overview' : 'build';
 }
 
+/**
+ * Which surfaces exist for this game. Must stay in step with the rendered tab list
+ * below: a tab that resolves but has no button and no panel is a blank work surface.
+ */
 function tabAvailable(game: StudioGame, tab: StudioTab): boolean {
   const published = isStudioGamePublished(game);
   if (tab === 'build') return !published;
-  if (tab === 'stats' || tab === 'feedback') return published;
+  if (tab === 'stats') return published;
   return true;
 }
 
@@ -283,13 +297,9 @@ export function CreatorStudioView({
     />
   );
 
-  const tabItems = [
-    ['overview', 'studioPanel.tabs.overview'],
-    ...(!selectedGame || isStudioGamePublished(selectedGame) ? [] : ([['build', 'studioPanel.tabs.build']] as const)),
-    ['playtest', 'studioPanel.tabs.playtest'],
-    ...(selectedGame && isStudioGamePublished(selectedGame) ? ([['stats', 'studioPanel.tabs.stats']] as const) : []),
-    ['improve', 'studioPanel.tabs.improve'],
-  ] as const;
+  // Derived from the same predicate the router uses, so a deep-linked tab can never
+  // resolve to a surface with no button to leave it by.
+  const tabItems = selectedGame ? TAB_ORDER.filter((id) => tabAvailable(selectedGame, id)) : [];
 
   return (
     <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}`}>
@@ -377,7 +387,7 @@ export function CreatorStudioView({
               </div>
 
               <div className="studio-tabs" role="tablist" aria-label={t('studioPanel.title')}>
-                {tabItems.map(([id, labelKey]) => (
+                {tabItems.map((id) => (
                   <button
                     key={id}
                     type="button"
@@ -386,7 +396,7 @@ export function CreatorStudioView({
                     className={`studio-tab${tab === id ? ' is-active' : ''}`}
                     onClick={() => openTab(id)}
                   >
-                    {t(labelKey)}
+                    {t(TAB_LABELS[id])}
                   </button>
                 ))}
               </div>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -5,7 +5,7 @@ import { AuthModal } from './AuthModal.js';
 import type { GameHealth } from './healthApi.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
-import { studioPath } from './router.js';
+import { studioPath, type StudioTab } from './router.js';
 import { abandonSubmission, submitFeedback, type SubmissionApiError, type SubmissionState } from './submissionApi.js';
 import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import {
@@ -36,6 +36,9 @@ import {
  * Shelf scales past a handful of games: compact rows, search/filter once the
  * list grows, and on narrow viewports a game switcher (picker sheet) so the
  * work surface is not buried under ten cards.
+ *
+ * Selection + active tab live in the URL (`/studio/:token/:tab`) so a refresh
+ * or shared link reopens the same work surface.
  */
 
 const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
@@ -50,12 +53,14 @@ const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
 
 const WINDOWS = [1, 7, 30];
 
-type StudioTab = 'overview' | 'build' | 'playtest' | 'stats' | 'improve' | 'feedback';
+type NavigateOptions = { replace?: boolean };
 
 type CreatorStudioViewProps = {
   /** Deep-link into a specific game when present. */
   selectedToken?: string;
-  onNavigate: (path: string) => void;
+  /** Deep-link into a work-surface tab when present. */
+  selectedTab?: StudioTab;
+  onNavigate: (path: string, options?: NavigateOptions) => void;
   onPlay: (slug: string) => void;
   /** Loads a failed/abandoned concept back into the home hero prompt. */
   onRetryConcept?: (concept: string) => void;
@@ -64,6 +69,18 @@ type CreatorStudioViewProps = {
 function defaultTabFor(game: StudioGame | null): StudioTab {
   if (!game) return 'overview';
   return isStudioGamePublished(game) ? 'overview' : 'build';
+}
+
+function tabAvailable(game: StudioGame, tab: StudioTab): boolean {
+  const published = isStudioGamePublished(game);
+  if (tab === 'build') return !published;
+  if (tab === 'stats' || tab === 'feedback') return published;
+  return true;
+}
+
+function resolveTab(game: StudioGame, requested?: StudioTab): StudioTab {
+  if (requested && tabAvailable(game, requested)) return requested;
+  return defaultTabFor(game);
 }
 
 function formatSeconds(seconds: number): string {
@@ -82,7 +99,13 @@ function healthFor(game: StudioGame, rows: GameHealth[]): GameHealth | null {
   return rows.find((row) => row.slug === game.slug) ?? null;
 }
 
-export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryConcept }: CreatorStudioViewProps) {
+export function CreatorStudioView({
+  selectedToken,
+  selectedTab,
+  onNavigate,
+  onPlay,
+  onRetryConcept,
+}: CreatorStudioViewProps) {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
   const [authOpen, setAuthOpen] = useState(false);
@@ -95,7 +118,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(selectedToken ?? null);
-  const [tab, setTab] = useState<StudioTab>('overview');
+  const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'overview');
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -188,17 +211,18 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
   );
   const liveCount = useMemo(() => games.filter((game) => isStudioGamePublished(game)).length, [games]);
 
+  // Keep the visible tab + URL aligned with the selected game and any deep-link tab.
   useEffect(() => {
-    if (selectedGame) {
-      setTab((current) => {
-        // Keep the user on a tab that still exists for this game.
-        if (current === 'build' && isStudioGamePublished(selectedGame)) return 'overview';
-        if (current === 'stats' && !isStudioGamePublished(selectedGame)) return 'build';
-        if (current === 'feedback' && !isStudioGamePublished(selectedGame)) return 'improve';
-        return current;
-      });
+    if (!selected) return;
+    const game = games.find((entry) => entry.token === selected);
+    if (!game) return;
+    const next = resolveTab(game, selectedTab);
+    setTab(next);
+    const canonical = studioPath(game.token, next);
+    if (window.location.pathname !== canonical) {
+      onNavigate(canonical, { replace: true });
     }
-  }, [selectedGame]);
+  }, [selected, selectedTab, games, onNavigate]);
 
   useEffect(() => {
     if (!pickerOpen) return;
@@ -218,10 +242,17 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
 
   function selectGame(token: string) {
     const next = games.find((game) => game.token === token) ?? null;
+    const nextTab = defaultTabFor(next);
     setSelected(token);
-    setTab(defaultTabFor(next));
+    setTab(nextTab);
     setPickerOpen(false);
-    onNavigate(studioPath(token));
+    onNavigate(studioPath(token, nextTab));
+  }
+
+  function openTab(next: StudioTab) {
+    if (!selectedGame || !tabAvailable(selectedGame, next)) return;
+    setTab(next);
+    onNavigate(studioPath(selectedGame.token, next));
   }
 
   if (!user) {
@@ -229,6 +260,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
       <section className="studio-panel">
         <header className="studio-panel-header">
           <div>
+            <p className="studio-kicker">{t('studioPanel.kicker')}</p>
             <h1 className="section-title">{t('studioPanel.title')}</h1>
             <p className="panel-copy">{t('studioPanel.signInHint')}</p>
           </div>
@@ -251,15 +283,24 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
     />
   );
 
+  const tabItems = [
+    ['overview', 'studioPanel.tabs.overview'],
+    ...(!selectedGame || isStudioGamePublished(selectedGame) ? [] : ([['build', 'studioPanel.tabs.build']] as const)),
+    ['playtest', 'studioPanel.tabs.playtest'],
+    ...(selectedGame && isStudioGamePublished(selectedGame) ? ([['stats', 'studioPanel.tabs.stats']] as const) : []),
+    ['improve', 'studioPanel.tabs.improve'],
+  ] as const;
+
   return (
     <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}`}>
       <header className="studio-panel-header">
         <div>
+          <p className="studio-kicker">{t('studioPanel.kicker')}</p>
           <h1 className="section-title">{t('studioPanel.title')}</h1>
           <p className="panel-copy">{t('studioPanel.subtitle')}</p>
         </div>
-        <button type="button" className="secondary-btn" onClick={() => onNavigate('/')}>
-          {t('studioPanel.backHome')}
+        <button type="button" className="studio-home-link" onClick={() => onNavigate('/')}>
+          <PixelIcon name="undo" size={12} /> {t('studioPanel.backHome')}
         </button>
       </header>
 
@@ -327,31 +368,23 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                   <PixelIcon name="expand" size={12} />
                 </button>
                 <div className="studio-detail-title-row">
-                  <h2>{selectedGame.title}</h2>
-                  {selectedGame.slug ? <code className="studio-slug">{selectedGame.slug}</code> : null}
+                  <div className="studio-detail-title-block">
+                    <h2>{selectedGame.title}</h2>
+                    {selectedGame.slug ? <code className="studio-slug">{selectedGame.slug}</code> : null}
+                  </div>
+                  <StudioStatusPill game={selectedGame} />
                 </div>
               </div>
 
               <div className="studio-tabs" role="tablist" aria-label={t('studioPanel.title')}>
-                {(
-                  [
-                    ['overview', 'studioPanel.tabs.overview'],
-                    ...(!isStudioGamePublished(selectedGame) ? ([['build', 'studioPanel.tabs.build']] as const) : []),
-                    ['playtest', 'studioPanel.tabs.playtest'],
-                    ...(isStudioGamePublished(selectedGame) ? ([['stats', 'studioPanel.tabs.stats']] as const) : []),
-                    ['improve', 'studioPanel.tabs.improve'],
-                    ...(isStudioGamePublished(selectedGame)
-                      ? ([['feedback', 'studioPanel.tabs.feedback']] as const)
-                      : []),
-                  ] as const
-                ).map(([id, labelKey]) => (
+                {tabItems.map(([id, labelKey]) => (
                   <button
                     key={id}
                     type="button"
                     role="tab"
                     aria-selected={tab === id}
                     className={`studio-tab${tab === id ? ' is-active' : ''}`}
-                    onClick={() => setTab(id)}
+                    onClick={() => openTab(id)}
                   >
                     {t(labelKey)}
                   </button>
@@ -363,8 +396,8 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                   <OverviewTab
                     game={selectedGame}
                     health={selectedHealth}
-                    onOpenBuild={() => setTab('build')}
-                    onOpenPlaytest={() => setTab('playtest')}
+                    onOpenBuild={() => openTab('build')}
+                    onOpenPlaytest={() => openTab('playtest')}
                     onPlay={() => selectedGame.slug && onPlay(selectedGame.slug)}
                     onRemoved={(token) => {
                       setGames((prev) => prev.filter((game) => game.token !== token));
@@ -395,7 +428,7 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                   <StudioPlaytestPanel
                     game={selectedGame}
                     published={isStudioGamePublished(selectedGame)}
-                    onExit={() => setTab('overview')}
+                    onExit={() => openTab('overview')}
                   />
                 ) : null}
 
@@ -412,16 +445,6 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
                 ) : null}
 
                 {tab === 'improve' ? <ImproveTab game={selectedGame} /> : null}
-
-                {tab === 'feedback' ? (
-                  <div className="studio-coming-soon">
-                    <PixelIcon name="eye" size={18} />
-                    <div>
-                      <h3>{t('studioPanel.feedback.title')}</h3>
-                      <p>{t('studioPanel.feedback.body')}</p>
-                    </div>
-                  </div>
-                ) : null}
               </div>
             </div>
           ) : null}
@@ -473,6 +496,22 @@ export function CreatorStudioView({ selectedToken, onNavigate, onPlay, onRetryCo
         </div>
       ) : null}
     </section>
+  );
+}
+
+function StudioStatusPill({ game }: { game: StudioGame }) {
+  const { t } = useTranslation();
+  const published = isStudioGamePublished(game);
+  const statusLabel = game.lastKnownStatus
+    ? t(`statusView.states.${game.lastKnownStatus}.label`)
+    : t('myGames.checking');
+  const live = game.lastKnownStatus ? STUDIO_LIVE_STATUSES.has(game.lastKnownStatus) : false;
+
+  return (
+    <span className={`status-play-badge studio-status-pill${published || live ? ' is-live' : ''}`}>
+      {(published || live) && <span className="live-dot" aria-hidden="true" />}
+      {statusLabel}
+    </span>
   );
 }
 
@@ -629,20 +668,8 @@ function OverviewTab({
     }
   }
 
-  const statusLabel = game.lastKnownStatus
-    ? t(`statusView.states.${game.lastKnownStatus}.label`)
-    : t('myGames.checking');
-  const live = game.lastKnownStatus ? STUDIO_LIVE_STATUSES.has(game.lastKnownStatus) : false;
-
   return (
     <div className="studio-overview">
-      <div className="studio-overview-status">
-        <span className={`status-play-badge${published || live ? ' is-live' : ''}`}>
-          {(published || live) && <span className="live-dot" aria-hidden="true" />}
-          {statusLabel}
-        </span>
-      </div>
-
       <ul className="funnel-stats studio-facts">
         <li>
           <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.createdAt), i18n.language)}</span>

--- a/apps/web/src/MyGamesRail.tsx
+++ b/apps/web/src/MyGamesRail.tsx
@@ -32,8 +32,8 @@ const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
 };
 
 const LIVE_STATUSES = new Set<SubmissionState>(['queued', 'building', 'in_review', 'publishing']);
-/** How many games the rail shows. One list request covers all of them. */
-const MAX_TRACKED = 6;
+/** How many games the home-page gist shows. Full shelf lives in Creator Studio. */
+const MAX_TRACKED = 4;
 /** Refresh cadence for the rail. Slower than the status page: this is a glance, not a watch. */
 const REFRESH_MS = 30_000;
 

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -98,21 +98,20 @@ export function NavHeader({ activeSpecsCount, onNavigate, onHome, onStudio }: Na
               <button className="nav-link" onClick={() => handleNavClick('arcade')}>
                 <PixelIcon name="gamepad" size={14} /> {t('header.navArcade')}
               </button>
-              <button className="nav-link" onClick={() => handleNavClick('my-games')}>
-                <PixelIcon name="folder" size={14} /> {t('header.navMyGames')}
+              {/* Studio is the creator home. The home page only keeps a short
+                  "your games" gist; the full shelf + build/playtest/improve loop
+                  lives here. Always offered — unsigned visitors get the sign-in
+                  prompt inside Studio rather than a dead "My Games" scroll target. */}
+              <button
+                className="nav-link"
+                onClick={() => {
+                  setIsMenuOpen(false);
+                  onStudio();
+                }}
+              >
+                <PixelIcon name="wrench" size={14} /> {t('header.navStudio')}
                 {activeSpecsCount > 0 && <span className="specs-count-badge">{activeSpecsCount}</span>}
               </button>
-              {user ? (
-                <button
-                  className="nav-link"
-                  onClick={() => {
-                    setIsMenuOpen(false);
-                    onStudio();
-                  }}
-                >
-                  <PixelIcon name="wrench" size={14} /> {t('header.navStudio')}
-                </button>
-              ) : null}
 
               {/* Controls that live in the header bar on a desktop but cannot fit
                   beside it on a phone. Hidden above the mobile breakpoint, where

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -2,16 +2,10 @@
 
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView.js';
-import {
-  abandonSubmission,
-  getBuildStats,
-  getSubmissionPreview,
-  getSubmissionStatus,
-  submitFeedback,
-} from './submissionApi.js';
+import { abandonSubmission, getSubmissionPreview, getSubmissionStatus, submitFeedback } from './submissionApi.js';
 
 vi.mock('./submissionApi', async () => {
   const actual = await vi.importActual<typeof import('./submissionApi')>('./submissionApi');
@@ -20,7 +14,6 @@ vi.mock('./submissionApi', async () => {
     getSubmissionStatus: vi.fn(),
     getSubmissionPreview: vi.fn(),
     submitFeedback: vi.fn(),
-    getBuildStats: vi.fn(),
     abandonSubmission: vi.fn(),
   };
 });
@@ -28,7 +21,6 @@ vi.mock('./submissionApi', async () => {
 const mockedGetSubmissionStatus = vi.mocked(getSubmissionStatus);
 const mockedGetSubmissionPreview = vi.mocked(getSubmissionPreview);
 const mockedSubmitFeedback = vi.mocked(submitFeedback);
-const mockedGetBuildStats = vi.mocked(getBuildStats);
 const mockedAbandonSubmission = vi.mocked(abandonSubmission);
 
 async function flushEffects() {
@@ -37,11 +29,6 @@ async function flushEffects() {
 }
 
 describe('SubmissionStatusView', () => {
-  beforeEach(() => {
-    // Default: no build-time sample yet, so the fallback copy shows.
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: null, sampleSize: 0 });
-  });
-
   afterEach(() => {
     document.body.innerHTML = '';
     localStorage.clear();
@@ -636,40 +623,9 @@ describe('SubmissionStatusView expectations & failures', () => {
     vi.clearAllMocks();
   });
 
-  it('sets a build-time expectation from real medians, and flags an overrun', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-    mockedGetSubmissionStatus.mockResolvedValue({ status: 'queued' });
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: 30, sampleSize: 8 });
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(createElement(SubmissionStatusView, { token: 'eta-token', submittedAt: Date.now() - 5 * 60_000 }));
-      await flushEffects();
-      await flushEffects();
-    });
-    expect(container.textContent).toContain('usually take about 30 min');
-
-    // Past the median, the copy stops pretending it's on schedule.
-    await act(async () => {
-      root.render(createElement(SubmissionStatusView, { token: 'eta-token', submittedAt: Date.now() - 90 * 60_000 }));
-      await flushEffects();
-      await flushEffects();
-    });
-    expect(container.textContent).toContain('taking longer than the usual 30 min');
-
-    await act(async () => {
-      root.unmount();
-    });
-  });
-
   it('shows the agent’s own progress line above anything it infers', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: null, sampleSize: 0 });
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
       progress: {
@@ -703,7 +659,6 @@ describe('SubmissionStatusView expectations & failures', () => {
   it('says so when CI is failing on the build', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: null, sampleSize: 0 });
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
       progress: { headSha: 'sha-1', commits: [], checklist: [], checks: 'FAILURE' },
@@ -737,7 +692,6 @@ describe('SubmissionStatusView stop & retry', () => {
   it('requires a second click before stopping a build', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: null, sampleSize: 0 });
     mockedGetSubmissionStatus.mockResolvedValue({ status: 'building' });
     mockedAbandonSubmission.mockResolvedValue(undefined);
 
@@ -779,7 +733,6 @@ describe('SubmissionStatusView stop & retry', () => {
   it('offers no stop control once the build is finished, and hands a stopped idea back for retry', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
-    mockedGetBuildStats.mockResolvedValue({ medianMinutes: null, sampleSize: 0 });
     mockedGetSubmissionStatus.mockResolvedValue({ status: 'abandoned' });
     const onRetry = vi.fn();
 

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -5,7 +5,6 @@ import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
   abandonSubmission,
-  getBuildStats,
   getSubmissionPreview,
   getSubmissionStatus,
   submitFeedback,
@@ -369,8 +368,6 @@ export function SubmissionStatusView({
               {t(`statusView.states.${status.status}.description`)}
             </p>
 
-            {!TERMINAL_STATUSES.has(status.status) ? <BuildEta submittedAt={submittedAt} /> : null}
-
             {status.progress?.checks === 'FAILURE' ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t('statusView.checksFailed')}
@@ -474,46 +471,6 @@ export function SubmissionStatusView({
         />
       ) : null}
     </>
-  );
-}
-
-/**
- * "Most games are ready in about N minutes" — measured from recently published
- * games, not invented. Once the build is past that estimate it switches to a
- * gentler line rather than silently going stale, which is the moment creators
- * otherwise assume something broke.
- */
-function BuildEta({ submittedAt }: { submittedAt?: number }) {
-  const { t } = useTranslation();
-  const [stats, setStats] = useState<{ medianMinutes: number | null; sampleSize: number } | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    getBuildStats()
-      .then((result) => {
-        if (!cancelled) setStats(result);
-      })
-      .catch(() => {
-        // No stats is not an error — the fallback copy covers it.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Three builds is the point where a median says more than it misleads.
-  const median = stats && stats.sampleSize >= 3 ? stats.medianMinutes : null;
-  if (median === null) {
-    return <p className="status-eta">{t('statusView.eta.unknown')}</p>;
-  }
-
-  const elapsedMinutes = submittedAt ? (Date.now() - submittedAt) / 60_000 : 0;
-  return (
-    <p className="status-eta">
-      {elapsedMinutes > median
-        ? t('statusView.eta.overrun', { minutes: median })
-        : t('statusView.eta.typical', { minutes: median })}
-    </p>
   );
 }
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -164,9 +164,10 @@
   },
   "studioPanel": {
     "title": "Creator Studio",
-    "subtitle": "Manage your games, check how they play, and ask for improvements.",
+    "kicker": "For creators",
+    "subtitle": "Your games, builds, playtests, and improvements — in one place.",
     "signInHint": "Sign in to see the games you commissioned and their play stats.",
-    "backHome": "Back home",
+    "backHome": "Back to home",
     "loading": "Loading your games…",
     "loadError": "Could not load your studio right now. Try again in a moment.",
     "empty": "You have not commissioned a game yet.",
@@ -414,11 +415,6 @@
     "shareCopied": "Copied!",
     "checksFailed": "Automatic checks are failing on this build. The agent usually notices and fixes it — no action needed from you.",
     "tryAgain": "Try this idea again",
-    "eta": {
-      "unknown": "Most games are ready within an hour.",
-      "typical": "Games like this usually take about {{minutes}} min.",
-      "overrun": "This one is taking longer than the usual {{minutes}} min. Bigger ideas do — you can close this page, we will notify you."
-    },
     "abandon": {
       "start": "Stop this build",
       "confirm": "Stop building this game?",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -45,7 +45,6 @@
     "navPrompt": "Create Game",
     "navArcade": "Arcade",
     "navStudio": "Studio",
-    "navMyGames": "My Games",
     "navFeed": "Agent Stream",
     "mySpecs": "My Active Specs ({{count}})"
   },
@@ -194,8 +193,7 @@
       "build": "Build",
       "playtest": "Playtest",
       "stats": "Stats",
-      "improve": "Improve",
-      "feedback": "Player feedback"
+      "improve": "Improve"
     },
     "overview": {
       "status": "Status",
@@ -258,10 +256,6 @@
       "rateLimit": "Too many requests just now. Please wait a moment and try again.",
       "rejected": "That request could not be accepted. Please rephrase and try again.",
       "error": "Could not send the request right now. Please try again."
-    },
-    "feedback": {
-      "title": "Player feedback — coming soon",
-      "body": "Written player comments and vote themes will land here once capture ships. Your play stats above already show how sessions go."
     }
   },
   "submit": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -164,7 +164,8 @@
   },
   "studioPanel": {
     "title": "Studio Twórcy",
-    "subtitle": "Zarządzaj grami, sprawdzaj jak się grają i proś o ulepszenia.",
+    "kicker": "Dla twórców",
+    "subtitle": "Twoje gry, buildy, playtesty i ulepszenia — w jednym miejscu.",
     "signInHint": "Zaloguj się, aby zobaczyć zlecone gry i ich statystyki.",
     "backHome": "Wróć na start",
     "loading": "Ładujemy Twoje gry…",
@@ -414,11 +415,6 @@
     "shareCopied": "Skopiowano!",
     "checksFailed": "Automatyczne testy tej wersji nie przechodzą. Agent zwykle to zauważa i poprawia — nie musisz nic robić.",
     "tryAgain": "Spróbuj z tym pomysłem jeszcze raz",
-    "eta": {
-      "unknown": "Większość gier jest gotowa w niecałą godzinę.",
-      "typical": "Takie gry powstają zwykle około {{minutes}} min.",
-      "overrun": "Ta powstaje dłużej niż typowe {{minutes}} min. Większe pomysły tak mają — możesz zamknąć tę stronę, damy Ci znać."
-    },
     "abandon": {
       "start": "Zatrzymaj tę grę",
       "confirm": "Zatrzymać tworzenie tej gry?",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -45,7 +45,6 @@
     "navPrompt": "Stwórz Grę",
     "navArcade": "Arcade",
     "navStudio": "Studio",
-    "navMyGames": "Moje Gry",
     "navFeed": "Strumień Agentów",
     "mySpecs": "Moje Aktywne Specyfikacje ({{count}})"
   },
@@ -194,8 +193,7 @@
       "build": "Build",
       "playtest": "Playtest",
       "stats": "Statystyki",
-      "improve": "Ulepsz",
-      "feedback": "Opinie graczy"
+      "improve": "Ulepsz"
     },
     "overview": {
       "status": "Status",
@@ -258,10 +256,6 @@
       "rateLimit": "Zbyt wiele próśb naraz. Poczekaj chwilę i spróbuj ponownie.",
       "rejected": "Tej prośby nie udało się przyjąć. Przeformułuj i spróbuj ponownie.",
       "error": "Nie udało się teraz wysłać prośby. Spróbuj ponownie."
-    },
-    "feedback": {
-      "title": "Opinie graczy — wkrótce",
-      "body": "Komentarze graczy i tematy głosów pojawią się tu, gdy capture będzie gotowy. Statystyki powyżej już pokazują, jak przebiegają sesje."
     }
   },
   "submit": {

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -77,6 +77,13 @@ describe('parsePathRoute', () => {
   it('parses the creator studio route', () => {
     expect(parsePathRoute('/studio')).toEqual({ view: 'studio' });
     expect(parsePathRoute('/studio/abc%2Ftoken')).toEqual({ view: 'studio', token: 'abc/token' });
+    expect(parsePathRoute('/studio/abc%2Ftoken/build')).toEqual({
+      view: 'studio',
+      token: 'abc/token',
+      tab: 'build',
+    });
+    expect(parsePathRoute('/studio/tok/playtest')).toEqual({ view: 'studio', token: 'tok', tab: 'playtest' });
+    expect(parsePathRoute('/studio/tok/nope')).toEqual({ view: 'notFound' });
     // Trailing slash is not a studio deep-link.
     expect(parsePathRoute('/studio/')).toEqual({ view: 'notFound' });
   });
@@ -138,7 +145,13 @@ describe('path builders', () => {
   it('builds a studio path that round-trips', () => {
     expect(studioPath()).toBe('/studio');
     expect(studioPath('tok')).toBe('/studio/tok');
+    expect(studioPath('a b', 'stats')).toBe('/studio/a%20b/stats');
     expect(parsePathRoute(studioPath('a b'))).toEqual({ view: 'studio', token: 'a b' });
+    expect(parsePathRoute(studioPath('tok', 'improve'))).toEqual({
+      view: 'studio',
+      token: 'tok',
+      tab: 'improve',
+    });
   });
 
   it('builds a hybrid join path that round-trips', () => {

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -84,6 +84,9 @@ describe('parsePathRoute', () => {
     });
     expect(parsePathRoute('/studio/tok/playtest')).toEqual({ view: 'studio', token: 'tok', tab: 'playtest' });
     expect(parsePathRoute('/studio/tok/nope')).toEqual({ view: 'notFound' });
+    // The stubbed feedback surface is gone from the UI, so its path is gone too —
+    // otherwise a deep link resolves to a tab with nothing to render.
+    expect(parsePathRoute('/studio/tok/feedback')).toEqual({ view: 'notFound' });
     // Trailing slash is not a studio deep-link.
     expect(parsePathRoute('/studio/')).toEqual({ view: 'notFound' });
   });

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -2,9 +2,9 @@ import type { LegalDocId } from './legal/types.js';
 
 /** Creator Studio work surface. Persisted in the URL so a refresh or shared link
  * reopens the same tab on the same game. */
-export type StudioTab = 'overview' | 'build' | 'playtest' | 'stats' | 'improve' | 'feedback';
+export type StudioTab = 'overview' | 'build' | 'playtest' | 'stats' | 'improve';
 
-const STUDIO_TABS = new Set<StudioTab>(['overview', 'build', 'playtest', 'stats', 'improve', 'feedback']);
+const STUDIO_TABS = new Set<StudioTab>(['overview', 'build', 'playtest', 'stats', 'improve']);
 
 export function isStudioTab(value: string): value is StudioTab {
   return STUDIO_TABS.has(value as StudioTab);
@@ -106,8 +106,9 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     return { view: 'studio' };
   }
 
-  // `/studio/:token` or `/studio/:token/:tab`. A bare second segment that is not a
-  // known tab stays a token-only deep link (tokens are opaque capability strings).
+  // `/studio/:token` or `/studio/:token/:tab`. A third segment that is not a known
+  // tab is a 404 rather than a silent fallback to the token-only view: it keeps the
+  // client in step with the API's shell allowlist, which serves those paths a real 404.
   const studioMatch = normalizedPath.match(/^\/studio\/([^/]+)(?:\/([^/]+))?$/);
   if (studioMatch?.[1]) {
     const token = decodeURIComponent(studioMatch[1]);

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,5 +1,15 @@
 import type { LegalDocId } from './legal/types.js';
 
+/** Creator Studio work surface. Persisted in the URL so a refresh or shared link
+ * reopens the same tab on the same game. */
+export type StudioTab = 'overview' | 'build' | 'playtest' | 'stats' | 'improve' | 'feedback';
+
+const STUDIO_TABS = new Set<StudioTab>(['overview', 'build', 'playtest', 'stats', 'improve', 'feedback']);
+
+export function isStudioTab(value: string): value is StudioTab {
+  return STUDIO_TABS.has(value as StudioTab);
+}
+
 export type AppRoute =
   | { view: 'home' }
   // A published game being played. The slug is a stable permalink, so refreshing
@@ -21,7 +31,8 @@ export type AppRoute =
   | { view: 'health' }
   // Creator control panel: own games, draft build (ex-status), playtest, improve.
   // `/status/:token` is accepted as an alias and resolves here too.
-  | { view: 'studio'; token?: string }
+  // Optional `tab` deep-links into a work surface (`/studio/:token/build`).
+  | { view: 'studio'; token?: string; tab?: StudioTab }
   // Privacy policy and terms. Reachable without a session — someone deciding whether
   // to sign in has to be able to read what signing in would mean first.
   | { view: 'legal'; doc: LegalDocId }
@@ -95,9 +106,19 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     return { view: 'studio' };
   }
 
-  const studioMatch = normalizedPath.match(/^\/studio\/([^/]+)$/);
+  // `/studio/:token` or `/studio/:token/:tab`. A bare second segment that is not a
+  // known tab stays a token-only deep link (tokens are opaque capability strings).
+  const studioMatch = normalizedPath.match(/^\/studio\/([^/]+)(?:\/([^/]+))?$/);
   if (studioMatch?.[1]) {
-    return { view: 'studio', token: decodeURIComponent(studioMatch[1]) };
+    const token = decodeURIComponent(studioMatch[1]);
+    const tabSegment = studioMatch[2] ? decodeURIComponent(studioMatch[2]) : undefined;
+    if (!tabSegment) {
+      return { view: 'studio', token };
+    }
+    if (!isStudioTab(tabSegment)) {
+      return { view: 'notFound' };
+    }
+    return { view: 'studio', token, tab: tabSegment };
   }
 
   // Hybrid join: /join/<code>#<token> — credential stays out of the request line.
@@ -134,9 +155,14 @@ export function draftPath(slug: string): string {
   return `/draft/${encodeURIComponent(slug)}`;
 }
 
-/** Creator control panel. Optional token deep-links into one game on the shelf. */
-export function studioPath(token?: string): string {
-  return token ? `/studio/${encodeURIComponent(token)}` : '/studio';
+/**
+ * Creator control panel. Optional token deep-links into one game on the shelf;
+ * optional tab deep-links into a work surface on that game.
+ */
+export function studioPath(token?: string, tab?: StudioTab): string {
+  if (!token) return '/studio';
+  const base = `/studio/${encodeURIComponent(token)}`;
+  return tab ? `${base}/${tab}` : base;
 }
 
 /** QR / share URL path+fragment for a multiplayer lobby guest. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2957,13 +2957,6 @@ body.player-open {
   color: var(--turquoise);
 }
 
-/* Build-time expectation, right under the phase description. */
-.status-eta {
-  margin: -6px 0 12px;
-  font-size: 0.85rem;
-  color: var(--muted);
-}
-
 /* CI is red on this build — stated plainly, without alarm. */
 .status-warning {
   display: flex;
@@ -5898,10 +5891,6 @@ body.player-open {
   color: var(--error);
 }
 
-.studio-overview-status {
-  margin-bottom: 16px;
-}
-
 .studio-overview {
   display: flex;
   flex-direction: column;
@@ -5974,30 +5963,6 @@ body.player-open {
 
 .studio-improve {
   margin: 0;
-}
-
-.studio-coming-soon {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  color: var(--muted);
-  padding: 20px 18px;
-  border-radius: 12px;
-  border: 1px dashed var(--panel-border);
-  background: rgba(13, 17, 21, 0.4);
-}
-
-.studio-coming-soon h3 {
-  margin: 0 0 4px;
-  color: var(--text);
-  font-size: 1.05rem;
-}
-
-.studio-coming-soon p {
-  margin: 0;
-  max-width: 36rem;
-  line-height: 1.45;
-  font-size: 0.95rem;
 }
 
 .studio-build .status-panel.is-embedded {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5375,13 +5375,12 @@ body.player-open {
 }
 
 /* CREATOR CONTROL PANEL (/studio)
-   Reuses home/status tokens: section-title, panel, my-game-card, chip/health-window
-   tabs, funnel-stats, status-feedback, status-play-badge. Keep Studio from inventing
-   a parallel visual language. */
+   One product surface: shared card chrome for shelf + detail, underline tabs,
+   quiet home escape. Reuses status/funnel tokens where they already fit. */
 .studio-panel {
-  max-width: 1100px;
+  max-width: 1180px;
   margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  padding: 1.25rem 1rem 3rem;
 }
 
 .studio-panel-header {
@@ -5389,7 +5388,16 @@ body.player-open {
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.studio-kicker {
+  margin: 0 0 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--turquoise);
 }
 
 .studio-panel-header .section-title {
@@ -5397,24 +5405,52 @@ body.player-open {
 }
 
 .studio-panel-header .panel-copy {
-  max-width: 36rem;
+  max-width: 38rem;
+  margin: 0;
+  color: var(--muted);
+}
+
+.studio-home-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.studio-home-link:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .studio-layout {
   display: grid;
-  grid-template-columns: minmax(200px, 260px) 1fr;
-  gap: 16px;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 18px;
   align-items: start;
 }
 
 .studio-shelf {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   position: sticky;
   top: 1rem;
   max-height: calc(100vh - 2rem);
   min-height: 0;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--panel-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 40%), var(--panel);
 }
 
 .studio-shelf-head {
@@ -5605,32 +5641,46 @@ body.player-open {
 .studio-detail {
   background: var(--panel);
   border: 1px solid var(--panel-border);
-  border-radius: 12px;
-  padding: 24px;
+  border-radius: 14px;
+  padding: 22px 24px 26px;
   min-width: 0;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
 }
 
 .studio-detail-head {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 10px;
-  margin-bottom: 14px;
+  gap: 12px;
+  margin-bottom: 8px;
 }
 
 .studio-detail-title-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.studio-detail-title-block {
+  display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   gap: 10px;
+  min-width: 0;
 }
 
 .studio-detail-head h2 {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.45rem;
   font-weight: 700;
-  letter-spacing: -0.3px;
+  letter-spacing: -0.35px;
   overflow-wrap: anywhere;
+}
+
+.studio-status-pill {
+  flex-shrink: 0;
 }
 
 .studio-game-switcher {
@@ -5783,45 +5833,48 @@ body.player-open {
   padding: 2px 10px;
 }
 
-/* Chip-style tabs — same grammar as .chip-btn / .health-window. */
+/* Underline tabs — clearer hierarchy than chip pills for a primary work surface. */
 .studio-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin: 0 0 18px;
-  padding: 0 0 14px;
+  gap: 2px;
+  margin: 0 0 20px;
+  padding: 0;
   border-bottom: 1px solid var(--panel-border);
 }
 
 .studio-tab {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--panel-border);
+  position: relative;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
   color: var(--muted);
-  border-radius: 999px;
-  padding: 6px 14px;
+  border-radius: 0;
+  padding: 10px 14px;
+  margin-bottom: -1px;
   font-size: 13px;
   font-weight: 600;
   white-space: nowrap;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .studio-tab:hover {
   color: #fff;
-  border-color: var(--turquoise);
-  background: rgba(0, 228, 172, 0.08);
 }
 
 .studio-tab.is-active {
-  color: #08241d;
-  background: var(--turquoise);
-  border-color: var(--turquoise);
-  box-shadow: 0 0 12px var(--turquoise-glow);
+  color: var(--turquoise);
+  background: transparent;
+  border-bottom-color: var(--turquoise);
+  box-shadow: none;
 }
 
 .studio-tab.is-active:hover {
-  color: #08241d;
-  filter: brightness(1.05);
+  color: var(--turquoise);
+  filter: none;
 }
 
 .studio-tab-panel {
@@ -5849,8 +5902,14 @@ body.player-open {
   margin-bottom: 16px;
 }
 
+.studio-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .studio-facts {
-  margin: 0 0 1.25rem;
+  margin: 0;
 }
 
 .studio-fact-suffix {

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -206,21 +206,6 @@ export async function getSubmissionPreview(token: string): Promise<SubmissionPre
 }
 
 /**
- * How long recent builds actually took. Used to turn "your game is in the queue"
- * into an expectation the creator can plan around. Null median = not enough data
- * yet; the UI falls back to a range.
- */
-export async function getBuildStats(): Promise<{ medianMinutes: number | null; sampleSize: number }> {
-  const response = await fetch(`${API_BASE}/api/submissions/stats`, { credentials: 'include' });
-
-  if (!response.ok) {
-    await throwResponseError(response);
-  }
-
-  return (await response.json()) as { medianMinutes: number | null; sampleSize: number };
-}
-
-/**
  * The read-only, shareable form of a draft: addressed by slug like a published game,
  * with no status token involved — so a shared link can't send change requests.
  */

--- a/docs/creator-experience-review.md
+++ b/docs/creator-experience-review.md
@@ -19,8 +19,10 @@ at the flow from more than one angle. This is the review; the first batch of fix
 
 ### The 11-year-old on a phone (the actual target user)
 
-- No expectation is ever set for **how long** this takes. "In the queue" for 20 minutes with no ETA
-  is where a kid leaves. Show a typical range ("most games take 20–60 min") from real data.
+- No expectation is ever set for **how long** this takes. A silent wait is still hard,
+  but a multi-hour median ("usually take about 337 min") is worse than silence — it reads
+  as "give up". Prefer progress + notifications over numeric ETAs when the distribution
+  is this wide.
 - The rail and status page assume a desktop-ish width; the play/draft flow on a phone is untested.
 - Nothing tells them the build **failed**. `needs_changes` is a dead end with no "try again" button.
 - Quota is invisible until it's spent — 5 submissions/day, discovered as an error.

--- a/docs/path-routing-plan.md
+++ b/docs/path-routing-plan.md
@@ -60,18 +60,19 @@ Section anchors like `#studio` in `SplitHero.tsx` are **not** app routes; leave 
 
 Same path shapes, without the `#`:
 
-| Path              | `AppRoute`                                   |
-| ----------------- | -------------------------------------------- |
-| `/`               | `{ view: 'home' }`                           |
-| `/play/<slug>`    | `{ view: 'play', slug }` (canonical)         |
-| `/ay/<slug>`      | same play view — rewritten to `/play/<slug>` |
-| `/ai/<slug>`      | same play view — rewritten to `/play/<slug>` |
-| `/draft/<slug>`   | `{ view: 'draft', slug }`                    |
-| `/status/<token>` | `{ view: 'status', token }`                  |
-| `/health`         | `{ view: 'health' }`                         |
-| `/studio`         | `{ view: 'studio' }`                         |
-| `/studio/<token>` | `{ view: 'studio', token }` — deep-link      |
-| `/join/<code>/…`  | `{ view: 'join', code, token }` — see § Join |
+| Path                    | `AppRoute`                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `/`                     | `{ view: 'home' }`                                                                                     |
+| `/play/<slug>`          | `{ view: 'play', slug }` (canonical)                                                                   |
+| `/ay/<slug>`            | same play view — rewritten to `/play/<slug>`                                                           |
+| `/ai/<slug>`            | same play view — rewritten to `/play/<slug>`                                                           |
+| `/draft/<slug>`         | `{ view: 'draft', slug }`                                                                              |
+| `/status/<token>`       | `{ view: 'status', token }`                                                                            |
+| `/health`               | `{ view: 'health' }`                                                                                   |
+| `/studio`               | `{ view: 'studio' }`                                                                                   |
+| `/studio/<token>`       | `{ view: 'studio', token }` — deep-link                                                                |
+| `/studio/<token>/<tab>` | `{ view: 'studio', token, tab }` — `tab` is `overview`/`build`/`playtest`/`stats`/`improve`/`feedback` |
+| `/join/<code>/…`        | `{ view: 'join', code, token }` — see § Join                                                           |
 
 No `/game/` segment — everything playable is a game; `/play` (and the `/ay` /
 `/ai` aliases) is enough. Emitters always write `/play/<slug>`.
@@ -83,7 +84,7 @@ Slug validation stays as today: lowercase kebab-case only
 **HTTP status (proper 404, not soft):** the document request for an unknown path
 answers **404** while still serving `index.html`, so crawlers and `curl -I` see a
 real miss and the SPA can still render `NotFoundPage`. Known deep links
-(`/play/<slug>`, `/status/<token>`, `/join/<code>`, …) stay **200**. Missing
+(`/play/<slug>`, `/studio`, `/studio/<token>`, `/status/<token>`, `/join/<code>`, …) stay **200**. Missing
 extension-bearing files (`/assets/…`, `/sw.js`) stay hard 404s without the HTML
 shell. See `apps/api/src/spa-paths.ts` (also wired into Vite for local dev).
 

--- a/docs/path-routing-plan.md
+++ b/docs/path-routing-plan.md
@@ -60,19 +60,19 @@ Section anchors like `#studio` in `SplitHero.tsx` are **not** app routes; leave 
 
 Same path shapes, without the `#`:
 
-| Path                    | `AppRoute`                                                                                             |
-| ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| `/`                     | `{ view: 'home' }`                                                                                     |
-| `/play/<slug>`          | `{ view: 'play', slug }` (canonical)                                                                   |
-| `/ay/<slug>`            | same play view — rewritten to `/play/<slug>`                                                           |
-| `/ai/<slug>`            | same play view — rewritten to `/play/<slug>`                                                           |
-| `/draft/<slug>`         | `{ view: 'draft', slug }`                                                                              |
-| `/status/<token>`       | `{ view: 'status', token }`                                                                            |
-| `/health`               | `{ view: 'health' }`                                                                                   |
-| `/studio`               | `{ view: 'studio' }`                                                                                   |
-| `/studio/<token>`       | `{ view: 'studio', token }` — deep-link                                                                |
-| `/studio/<token>/<tab>` | `{ view: 'studio', token, tab }` — `tab` is `overview`/`build`/`playtest`/`stats`/`improve`/`feedback` |
-| `/join/<code>/…`        | `{ view: 'join', code, token }` — see § Join                                                           |
+| Path                    | `AppRoute`                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `/`                     | `{ view: 'home' }`                                                                          |
+| `/play/<slug>`          | `{ view: 'play', slug }` (canonical)                                                        |
+| `/ay/<slug>`            | same play view — rewritten to `/play/<slug>`                                                |
+| `/ai/<slug>`            | same play view — rewritten to `/play/<slug>`                                                |
+| `/draft/<slug>`         | `{ view: 'draft', slug }`                                                                   |
+| `/status/<token>`       | `{ view: 'studio', token }` — legacy alias, canonicalised to `/studio/<token>/<tab>`        |
+| `/health`               | `{ view: 'health' }`                                                                        |
+| `/studio`               | `{ view: 'studio' }`                                                                        |
+| `/studio/<token>`       | `{ view: 'studio', token }` — deep-link                                                     |
+| `/studio/<token>/<tab>` | `{ view: 'studio', token, tab }` — `tab` is `overview`/`build`/`playtest`/`stats`/`improve` |
+| `/join/<code>/…`        | `{ view: 'join', code, token }` — see § Join                                                |
 
 No `/game/` segment — everything playable is a game; `/play` (and the `/ay` /
 `/ai` aliases) is enough. Emitters always write `/play/<slug>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Persist Creator Studio selection + tab in the URL (`/studio/:token/:tab`) and treat `/studio` paths as known SPA shells so refresh/share/back work
- Make **Studio** the hamburger destination for creators; keep only a short My Games gist on the home page
- Polish Studio layout (clearer hierarchy, underline tabs, card shelf, quieter chrome) and remove the empty Feedback tab entirely (route 404s instead of a blank panel)
- Remove the discouraging “Games like this usually take about N min” build ETA — and the now-unused `GET /api/submissions/stats` endpoint behind it
- Bare `/studio` keeps shelf selection local until the creator picks a game, so a capability token is not written into the address bar / history / screenshots by default

## Test plan
- [ ] Open `/studio` signed in → first game selected in UI, URL stays `/studio` (no token); clicking a game writes `/studio/<token>/<tab>`
- [ ] Open `/studio/<token>` or `/status/<token>` → canonicalises to `/studio/<token>/<default-tab>`; refresh keeps the same game/tab
- [ ] Switch tabs and games → URL updates; back/forward restores prior state
- [ ] Hard-refresh `/studio/<token>/build` returns HTTP 200 (not 404) with Studio on Build; `/studio/<token>/feedback` is a 404
- [ ] Hamburger menu shows Studio (with badge), not My Games; tap opens `/studio`
- [ ] Home still shows a short My Games rail with Open Studio
- [ ] Building status view no longer shows the numeric ETA; `GET /api/submissions/stats` is gone
- [ ] Studio layout looks coherent on desktop + ~390px phone width
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310cc849-e1ea-4c8b-8f2e-fdf8fdd571f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310cc849-e1ea-4c8b-8f2e-fdf8fdd571f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

