### PR TITLE
Studio: give the Build tab's live pill its elapsed timer back

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -427,6 +427,11 @@ export function CreatorStudioView({
                     <SubmissionStatusView
                       token={selectedGame.token}
                       embedded
+                      // Feeds the live pill's elapsed timer. With the numeric ETA gone, "Live · 12m"
+                      // is the only thing on this tab saying the build is still moving — a bare
+                      // "Live" next to the header's status pill reads like a second, contradictory
+                      // status instead of a heartbeat.
+                      submittedAt={Date.parse(selectedGame.createdAt)}
                       onRetry={
                         onRetryConcept
                           ? (concept) => {


### PR DESCRIPTION
Walking the Build tab in a browser, a queued game showed two turquoise pills
within 50px of each other: the header status pill ("Checking…") and the
embedded status panel's live indicator, reading a bare "Live". Side by side
they read as two contradictory statuses rather than status + heartbeat.

The live pill is meant to carry an elapsed timer; it only renders one when
given `submittedAt`, which Studio never passed. Pass the game's createdAt, so
it reads "Live · In progress for 12m". With the numeric ETA gone this is the
only thing on the tab telling a creator the build is still moving — which is
what the removed ETA was there to do, without promising a time it can't keep.