### PR TITLE
Fix iOS long-press magnifier and callout while playing games

### DIFF
--- a/apps/api/fixtures/games-repo/shared/game-shell.css
+++ b/apps/api/fixtures/games-repo/shared/game-shell.css
@@ -16,6 +16,13 @@ body {
   display: flex;
   justify-content: center;
   min-height: 100vh;
+  /* Match the player embed: no iOS long-press loupe / callout on the play surface. */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 .wrap {
@@ -46,6 +53,9 @@ canvas {
   border-radius: 12px;
   background: #05060b;
   touch-action: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .game-controls {

--- a/apps/web/src/GameFrame.sandbox.test.ts
+++ b/apps/web/src/GameFrame.sandbox.test.ts
@@ -28,6 +28,28 @@ describe('Sandbox Invariant Security Guard', () => {
     document.body.removeChild(container);
   });
 
+  it('prevents the context menu on the iframe element (iOS callout backstop)', () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(createElement(GameFrame, { title: 'Test Game', html: '<html><body></body></html>', embed: true }));
+    });
+
+    const iframe = container.querySelector('iframe.game-frame') as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    iframe.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
   it('guarantees no source file in apps/web/src introduces allow-same-origin or dangerous sandbox permissions in code', () => {
     const srcDir = path.resolve(__dirname);
     const files = fs.readdirSync(srcDir, { recursive: true }) as string[];

--- a/apps/web/src/GameFrame.tsx
+++ b/apps/web/src/GameFrame.tsx
@@ -65,6 +65,9 @@ export function GameFrame(props: GameFrameProps) {
       // The load event is the reliable moment to focus: the game's document exists
       // and won't be replaced out from under the focus we just set.
       onLoad={focusGame}
+      // Parent-side backstop for the iOS callout when the long-press hits the iframe
+      // chrome rather than a node inside the opaque-origin document.
+      onContextMenu={(event) => event.preventDefault()}
       tabIndex={0}
       width="100%"
       height="100%"

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -121,6 +121,25 @@ describe('the injected bridge reports health', () => {
     bridge.stop();
   });
 
+  it('cancels contextmenu and selectstart so iOS cannot open the callout over the game', () => {
+    const bridge = runBridge('<canvas id="game"></canvas>');
+
+    const contextMenu = new bridge.frameWindow.MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const selectStart = new bridge.frameWindow.Event('selectstart', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(bridge.frameWindow.dispatchEvent(contextMenu)).toBe(false);
+    expect(contextMenu.defaultPrevented).toBe(true);
+    expect(bridge.frameWindow.dispatchEvent(selectStart)).toBe(false);
+    expect(selectStart.defaultPrevented).toBe(true);
+    bridge.stop();
+  });
+
   it('pauses and resumes on host command, posting a snapshot', async () => {
     // jsdom's cross-realm postMessage into an iframe is unreliable; dispatch the
     // host envelope the same way the real parent would deliver it.

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -41,6 +41,19 @@ describe('embedGameHtml', () => {
     expect(out).toContain('flushHeldRaf');
     expect(out).toContain('suspendAudio');
   });
+
+  it('suppresses the iOS long-press loupe and Copy/Translate callout inside the frame', () => {
+    const out = embedGameHtml('<html><head></head><body><canvas id="game"></canvas></body></html>');
+
+    // CSS must land in the opaque-origin document — parent styles cannot reach it.
+    expect(out).toContain('-webkit-touch-callout:none');
+    expect(out).toContain('-webkit-user-select:none');
+    expect(out).toContain('user-select:none');
+    expect(out).toContain('touch-action:none');
+    // Event backstops for Safari versions that still open the callout under CSS alone.
+    expect(out).toContain("addEventListener('contextmenu'");
+    expect(out).toContain("addEventListener('selectstart'");
+  });
 });
 
 describe('withGameLocale', () => {

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -219,6 +219,11 @@ const BRIDGE = `(function(){
     if(e.key==='Escape'){post({type:'key',key:'Escape'});}
   });
   addEventListener('pointerdown',function(){post({type:'pointer'});},{passive:true});
+  // iOS Safari: long-press on the canvas opens the callout (Copy / Translate / Look Up)
+  // and the text-selection loupe ("mini zoom"). CSS covers most of it; these kill the
+  // remaining native handlers. Games have no selectable document chrome in the player.
+  addEventListener('contextmenu',function(e){e.preventDefault();});
+  addEventListener('selectstart',function(e){e.preventDefault();});
   function init(){
     sendMeta();
     var s=el('sound-toggle');
@@ -228,7 +233,20 @@ const BRIDGE = `(function(){
   if(document.readyState==='loading')addEventListener('DOMContentLoaded',init);else init();
 })();`;
 
-const HIDE_CHROME = `#game-title,#game-desc,.game-controls,.hint{display:none!important}`;
+// Hide the game's own chrome (the app theater shows title/desc/sound instead), and
+  // strip iOS long-press chrome inside the opaque-origin frame — parent CSS cannot
+  // reach in here. Without this, a hold on iPhone SE pops the selection loupe and
+  // the Copy / Translate / Look Up callout over the playfield.
+const HIDE_CHROME =
+  `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
+  `html,body,canvas,img,video{` +
+  `-webkit-touch-callout:none;` +
+  `-webkit-user-select:none;` +
+  `user-select:none;` +
+  `-webkit-tap-highlight-color:transparent;` +
+  `touch-action:none;` +
+  `overscroll-behavior:none` +
+  `}`;
 
 /**
  * Injects the player bridge + hide-chrome style into an assembled game document

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -234,9 +234,9 @@ const BRIDGE = `(function(){
 })();`;
 
 // Hide the game's own chrome (the app theater shows title/desc/sound instead), and
-  // strip iOS long-press chrome inside the opaque-origin frame — parent CSS cannot
-  // reach in here. Without this, a hold on iPhone SE pops the selection loupe and
-  // the Copy / Translate / Look Up callout over the playfield.
+// strip iOS long-press chrome inside the opaque-origin frame — parent CSS cannot
+// reach in here. Without this, a hold on iPhone SE pops the selection loupe and
+// the Copy / Translate / Look Up callout over the playfield.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
   `html,body,canvas,img,video{` +

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1368,6 +1368,12 @@ button:disabled {
     0 0 1px var(--turquoise-glow);
   overflow: hidden;
   transition: box-shadow 0.3s ease;
+  /* Parent-side only — the document inside is opaque-origin. Still suppresses the
+     iOS callout when the long-press lands on the iframe element itself. */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* While the full-viewport player is open, lock page scroll so the fixed overlay is
@@ -1400,6 +1406,8 @@ body.player-open {
   touch-action: none;
   -webkit-user-select: none;
   user-select: none;
+  /* iOS long-press loupe + Copy/Translate callout on the theater chrome. */
+  -webkit-touch-callout: none;
   /* Stop iOS from flashing a grey tap highlight over the game on every touch. */
   -webkit-tap-highlight-color: transparent;
 }
@@ -1773,6 +1781,7 @@ body.player-open {
   border-radius: 0;
   box-shadow: none;
   touch-action: none;
+  -webkit-touch-callout: none;
 }
 
 /* The rotate nudge. Deliberately not a blocking overlay: the game keeps running
@@ -3918,6 +3927,8 @@ body.player-open {
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
   overscroll-behavior: none;
 }
 
@@ -6014,6 +6025,7 @@ body.player-open {
      and touch-action intersects with ancestors. Hold gestures on the game surface. */
   -webkit-user-select: none;
   user-select: none;
+  -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -6121,6 +6133,7 @@ body.player-open {
   display: block;
   background: #000;
   touch-action: none;
+  -webkit-touch-callout: none;
 }
 
 .studio-playtest-rotate {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On iPhone SE (Safari), a long-press while playing sometimes opened the text-selection loupe (“mini zoom”) and the Copy / Translate / Look Up context menu over the game.

Games run in a sandboxed iframe with **no `allow-same-origin`**, so parent theater CSS cannot style the playfield document. The player embed now injects the iOS touch protections into that document, with parent-side backstops on the iframe and theater chrome.

## Changes

- Embed stylesheet: `-webkit-touch-callout`, `user-select`, `touch-action`, tap-highlight on `html`/`body`/`canvas`/`img`/`video`
- Embed bridge: `preventDefault` on `contextmenu` and `selectstart`
- `GameFrame`: `onContextMenu` preventDefault on the iframe element
- Theater / studio / party-controller CSS: matching `-webkit-touch-callout: none`
- Fixture game shell aligned with the same contract
- Unit + bridge tests covering the inject and event cancellation

## Test plan

- [x] Green gate (`type-check`, `lint`, `test`, `build`) — passed
- [ ] On a real iPhone SE: open a catalog game, long-press the playfield — no loupe, no Copy/Translate menu
- [ ] Confirm taps / drag gameplay still work
- [ ] Confirm theater header controls (More menu, exit) still work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa9ea-017e-75e6-ac78-be18ec36dde0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa9ea-017e-75e6-ac78-be18ec36dde0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

