### PR TITLE
Accept optional gfxBackend on play telemetry (Scene3D B18)

### DIFF
--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -261,6 +261,11 @@ export interface TelemetryEvent {
   value?: number;
   /** `end`: how the session finished. */
   outcome?: 'won' | 'lost' | 'quit';
+  /**
+   * `progress` / `end`: optional render backend from the game snapshot (B18).
+   * Fixed vocabulary only — never free text.
+   */
+  gfxBackend?: 'canvas2d' | 'webgl' | 'webgl3d';
 }
 
 /**
@@ -1159,9 +1164,7 @@ export class InMemoryStore implements Store {
     );
     const createdAt =
       preview.createdAt ??
-      (newestCreatedAt && newestCreatedAt >= nowIso
-        ? new Date(Date.parse(newestCreatedAt) + 1).toISOString()
-        : nowIso);
+      (newestCreatedAt && newestCreatedAt >= nowIso ? new Date(Date.parse(newestCreatedAt) + 1).toISOString() : nowIso);
     const record: BuildPreview = {
       ...preview,
       id: randomUUID(),

--- a/apps/api/src/telemetry-health.ts
+++ b/apps/api/src/telemetry-health.ts
@@ -128,6 +128,11 @@ export interface GameHealth {
    * never safe to interpolate into an agent's instructions.
    */
   progressLabels: Array<{ label: string; sessions: number }>;
+  /**
+   * Sessions that reported a render backend on `end` / `progress` (B18).
+   * Soft capture vs live WebGL — fixed vocabulary only.
+   */
+  gfxBackends: { canvas2d: number; webgl: number; webgl3d: number };
 }
 
 interface SessionState {
@@ -142,6 +147,8 @@ interface SessionState {
   bestScore: number | null;
   /** Landmarks this session reached, deduplicated — a replay is not extra reach. */
   labels: Set<string>;
+  /** Last reported render backend on progress/end (B18). */
+  gfxBackend: 'canvas2d' | 'webgl' | 'webgl3d' | null;
 }
 
 /**
@@ -219,6 +226,7 @@ export function summarizeGameHealth(events: TelemetryEvent[]): GameHealth[] {
         reachedEnd: false,
         bestScore: null,
         labels: new Set(),
+        gfxBackend: null,
       };
       sessions.set(sessionId, state);
 
@@ -263,6 +271,9 @@ export function summarizeGameHealth(events: TelemetryEvent[]): GameHealth[] {
             if (outcome !== 'won' && outcome !== 'lost' && outcome !== 'quit') break;
             outcomes[outcome] += 1;
             state.reachedEnd = true;
+            if (event.gfxBackend === 'canvas2d' || event.gfxBackend === 'webgl' || event.gfxBackend === 'webgl3d') {
+              state.gfxBackend = event.gfxBackend;
+            }
             break;
           }
           case 'score': {
@@ -276,6 +287,9 @@ export function summarizeGameHealth(events: TelemetryEvent[]): GameHealth[] {
             if (typeof label !== 'string' || label.length === 0) break;
             if (state.labels.size < MAX_TRACKED_LABELS_PER_SESSION || state.labels.has(label)) {
               state.labels.add(label);
+            }
+            if (event.gfxBackend === 'canvas2d' || event.gfxBackend === 'webgl' || event.gfxBackend === 'webgl3d') {
+              state.gfxBackend = event.gfxBackend;
             }
             break;
           }
@@ -298,6 +312,10 @@ export function summarizeGameHealth(events: TelemetryEvent[]): GameHealth[] {
     const bestScores = sessionStates.map((state) => state.bestScore).filter((score): score is number => score !== null);
     const sessionsWithEnding = sessionStates.filter((state) => state.reachedEnd).length;
     const decided = outcomes.won + outcomes.lost;
+    const gfxBackends = { canvas2d: 0, webgl: 0, webgl3d: 0 };
+    for (const state of sessionStates) {
+      if (state.gfxBackend) gfxBackends[state.gfxBackend] += 1;
+    }
 
     rows.push({
       slug,
@@ -325,6 +343,7 @@ export function summarizeGameHealth(events: TelemetryEvent[]): GameHealth[] {
         .map(([label, sessionCount]) => ({ label, sessions: sessionCount }))
         .sort((a, b) => b.sessions - a.sessions || a.label.localeCompare(b.label))
         .slice(0, MAX_PROGRESS_LABELS),
+      gfxBackends,
     });
   }
 

--- a/apps/api/src/telemetry.ts
+++ b/apps/api/src/telemetry.ts
@@ -62,6 +62,10 @@ const MAX_BACKDATE_MS = 6 * 60 * 60 * 1000;
  * simply fall back to receipt time, which is what every event used to get.
  */
 const offsetField = { msSinceOpen: z.number().int().min(0).max(MAX_SESSION_MS).optional() };
+/** Scene3D / gfx soft vs WebGL — optional on progress/end (games snapshot). */
+const gfxBackendField = {
+  gfxBackend: z.enum(['canvas2d', 'webgl', 'webgl3d']).optional(),
+};
 
 const EventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('game_opened'), slots: z.number().int().min(1).max(8).optional(), ...offsetField }),
@@ -84,10 +88,16 @@ const EventSchema = z.discriminatedUnion('type', [
       .trim()
       .min(1)
       .max(MAX_LABEL_LENGTH * 4),
+    ...gfxBackendField,
     ...offsetField,
   }),
   z.object({ type: z.literal('score'), value: z.number().finite(), ...offsetField }),
-  z.object({ type: z.literal('end'), outcome: z.enum(['won', 'lost', 'quit']), ...offsetField }),
+  z.object({
+    type: z.literal('end'),
+    outcome: z.enum(['won', 'lost', 'quit']),
+    ...gfxBackendField,
+    ...offsetField,
+  }),
 ]);
 
 const RequestSchema = z.object({
@@ -217,11 +227,21 @@ export async function registerTelemetryRoutes(app: FastifyInstance, options: Tel
         case 'alive':
           return { ...base, type: event.type, frames: event.frames };
         case 'progress':
-          return { ...base, type: event.type, label: event.label.slice(0, MAX_LABEL_LENGTH) };
+          return {
+            ...base,
+            type: event.type,
+            label: event.label.slice(0, MAX_LABEL_LENGTH),
+            ...(event.gfxBackend === undefined ? {} : { gfxBackend: event.gfxBackend }),
+          };
         case 'score':
           return { ...base, type: event.type, value: event.value };
         case 'end':
-          return { ...base, type: event.type, outcome: event.outcome };
+          return {
+            ...base,
+            type: event.type,
+            outcome: event.outcome,
+            ...(event.gfxBackend === undefined ? {} : { gfxBackend: event.gfxBackend }),
+          };
         default:
           return { ...base, type: event.type };
       }

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -41,6 +41,7 @@ function game(partial: Partial<GameHealth> & { slug: string }): GameHealth {
     winRate: null,
     medianBestScore: null,
     progressLabels: [],
+    gfxBackends: { canvas2d: 0, webgl: 0, webgl3d: 0 },
     ...partial,
   };
 }

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -320,6 +320,7 @@ export function useGameTelemetry(slug: string, enabled: boolean, slots?: number)
         label?: string;
         value?: number;
         outcome?: 'won' | 'lost' | 'quit';
+        gfxBackend?: 'canvas2d' | 'webgl' | 'webgl3d';
       };
       if (!data || data.source !== PLAYER) return;
       switch (data.type) {
@@ -332,13 +333,27 @@ export function useGameTelemetry(slug: string, enabled: boolean, slots?: number)
           if (isPlayTimeAccruing(document)) session.record({ type: 'alive', frames: Number(data.frames ?? 0) });
           break;
         case 'progress':
-          session.record({ type: 'progress', label: String(data.label ?? '') });
+          session.record({
+            type: 'progress',
+            label: String(data.label ?? ''),
+            ...(data.gfxBackend === 'canvas2d' || data.gfxBackend === 'webgl' || data.gfxBackend === 'webgl3d'
+              ? { gfxBackend: data.gfxBackend }
+              : {}),
+          });
           break;
         case 'score':
           session.record({ type: 'score', value: Number(data.value) });
           break;
         case 'end':
-          if (data.outcome) session.record({ type: 'end', outcome: data.outcome });
+          if (data.outcome) {
+            session.record({
+              type: 'end',
+              outcome: data.outcome,
+              ...(data.gfxBackend === 'canvas2d' || data.gfxBackend === 'webgl' || data.gfxBackend === 'webgl3d'
+                ? { gfxBackend: data.gfxBackend }
+                : {}),
+            });
+          }
           break;
       }
     }

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -29,6 +29,8 @@ export interface GameHealth {
   medianBestScore: number | null;
   /** Landmarks reached, most-reached first. Game-authored text — render, never interpolate. */
   progressLabels: Array<{ label: string; sessions: number }>;
+  /** Sessions that reported a render backend on progress/end (B18). */
+  gfxBackends: { canvas2d: number; webgl: number; webgl3d: number };
 }
 
 export interface HealthResponse {

--- a/apps/web/src/telemetry.test.ts
+++ b/apps/web/src/telemetry.test.ts
@@ -169,6 +169,27 @@ describe('TelemetrySession timing', () => {
     expect(batches[0].events[0].msSinceOpen).toBe(0);
     expect(batches[0].flushMsSinceOpen).toBe(0);
   });
+
+  it('forwards gfxBackend on progress and end (B18)', () => {
+    const { batches, send } = collector();
+    const session = newSession(send);
+
+    expect(session.record({ type: 'progress', label: 'exit', gfxBackend: 'webgl3d' })).toBe(true);
+    expect(session.record({ type: 'end', outcome: 'won', gfxBackend: 'webgl3d' })).toBe(true);
+    // Unknown backends are stripped, not rejected — older shells stay compatible.
+    expect(session.record({ type: 'end', outcome: 'lost', gfxBackend: 'opengl' as 'webgl' })).toBe(true);
+    session.flush();
+
+    expect(batches[0].events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'progress', label: 'exit', gfxBackend: 'webgl3d' }),
+        expect.objectContaining({ type: 'end', outcome: 'won', gfxBackend: 'webgl3d' }),
+        expect.objectContaining({ type: 'end', outcome: 'lost' }),
+      ]),
+    );
+    const lost = batches[0].events.find((e) => e.type === 'end' && e.outcome === 'lost');
+    expect(lost && 'gfxBackend' in lost ? lost.gfxBackend : undefined).toBeUndefined();
+  });
 });
 
 describe('isPlayTimeAccruing', () => {

--- a/apps/web/src/telemetry.ts
+++ b/apps/web/src/telemetry.ts
@@ -19,9 +19,9 @@ export type TelemetryEvent =
   | { type: 'game_closed' }
   | { type: 'error'; message: string }
   | { type: 'alive'; frames: number }
-  | { type: 'progress'; label: string }
+  | { type: 'progress'; label: string; gfxBackend?: 'canvas2d' | 'webgl' | 'webgl3d' }
   | { type: 'score'; value: number }
-  | { type: 'end'; outcome: 'won' | 'lost' | 'quit' };
+  | { type: 'end'; outcome: 'won' | 'lost' | 'quit'; gfxBackend?: 'canvas2d' | 'webgl' | 'webgl3d' };
 
 /** Flush when this many events are queued, so a busy session does not sit on data. */
 const FLUSH_AT = 10;
@@ -178,14 +178,18 @@ export class TelemetrySession {
         // label stay welcome, since that is what a drop-off curve is made of.
         if (!this.labels.has(label) && this.labels.size >= MAX_DISTINCT_LABELS) return null;
         this.labels.add(label);
-        return { type: 'progress', label };
+        const gfxBackend = normalizeGfxBackend(event.gfxBackend);
+        return gfxBackend ? { type: 'progress', label, gfxBackend } : { type: 'progress', label };
       }
       case 'score':
         return Number.isFinite(event.value) ? { type: 'score', value: event.value } : null;
-      case 'end':
-        return event.outcome === 'won' || event.outcome === 'lost' || event.outcome === 'quit'
-          ? { type: 'end', outcome: event.outcome }
-          : null;
+      case 'end': {
+        if (event.outcome !== 'won' && event.outcome !== 'lost' && event.outcome !== 'quit') return null;
+        const gfxBackend = normalizeGfxBackend(event.gfxBackend);
+        return gfxBackend
+          ? { type: 'end', outcome: event.outcome, gfxBackend }
+          : { type: 'end', outcome: event.outcome };
+      }
       default:
         return null;
     }
@@ -195,6 +199,10 @@ export class TelemetrySession {
 function clampInt(value: unknown, min: number, max: number): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) return null;
   return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function normalizeGfxBackend(value: unknown): 'canvas2d' | 'webgl' | 'webgl3d' | null {
+  return value === 'canvas2d' || value === 'webgl' || value === 'webgl3d' ? value : null;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Website half of **Scene3D B18** — accept optional `gfxBackend` on play telemetry.

### Changes

- API schema: `progress` / `end` may include `gfxBackend: canvas2d|webgl|webgl3d`
- Store field + intake mapping
- Shell (`telemetry.ts` / `gamePlayer.ts`): normalize and forward
- Health: `gfxBackends` session counts per game

### Descoped

**Frame-health / FPS histogram buckets** are not in B18. Backend identity only; latency/FPS quality remains a future pass. (Paired games docs: `render-backend-future.md` §B18.)

### Paired games

https://github.com/gamedevpl/www.gamedev.pl-games/pull/143

No assemble-contract change. Can merge independently of the games stack (optional field).

### Checks

- [x] CI Lint/Test/Build (+ CodeQL, contract) — GitHub Actions green after `GameHealth` test fixture fix for required `gfxBackends`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4aa8cb4-338d-4ec4-a484-8c0627a35976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4aa8cb4-338d-4ec4-a484-8c0627a35976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

