### PR TITLE
Count the header badge from the server, and leave one way out of Build

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,6 +39,7 @@ function readLocationRoute(): AppRoute {
   return parsePathRoute(window.location.pathname, window.location.hash);
 }
 import { submitSpec, refineSpec, type SubmissionApiError } from './submissionApi.js';
+import { useActiveBuildCount } from './activeBuilds.js';
 import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs.js';
 import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa.js';
 import { useAuth } from './AuthContext.js';
@@ -82,6 +83,10 @@ export function App() {
 
   // Stage content
   const [stageContent, setStageContent] = useState<StageContent | null>(null);
+  // Builds actually in flight, from the server — the header badge's source of truth.
+  // Paused while a game is on screen: the player covers the header, and a direct
+  // /play/<slug> link is meant to cost the game and nothing else.
+  const activeBuildCount = useActiveBuildCount(myGamesRefreshKey, !stageContent);
 
   // Greenfield submission state
   // 'refining' is the spec-refiner call that precedes a submission — a few seconds
@@ -516,7 +521,7 @@ export function App() {
     return (
       <div className="app app--legal">
         <NavHeader
-          activeSpecsCount={savedSpecs.length}
+          activeBuildCount={activeBuildCount}
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
@@ -534,7 +539,7 @@ export function App() {
     return (
       <div className="app app--contact">
         <NavHeader
-          activeSpecsCount={savedSpecs.length}
+          activeBuildCount={activeBuildCount}
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
@@ -553,7 +558,7 @@ export function App() {
     return (
       <div className="app app--not-found">
         <NavHeader
-          activeSpecsCount={savedSpecs.length}
+          activeBuildCount={activeBuildCount}
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
@@ -579,7 +584,7 @@ export function App() {
   return (
     <div className="app">
       <NavHeader
-        activeSpecsCount={savedSpecs.length}
+        activeBuildCount={activeBuildCount}
         onNavigate={handleNavigateSection}
         onHome={() => navigate('/')}
         onStudio={() => navigate(studioPath())}

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -9,7 +9,8 @@ import { PixelIcon } from './PixelIcon.js';
 import githubIcon from './assets/github-mark-white.svg';
 
 type NavHeaderProps = {
-  activeSpecsCount: number;
+  /** Builds currently in flight for the signed-in creator. Server-derived, not a local tally. */
+  activeBuildCount: number;
   onNavigate: (sectionId: string) => void;
   /** In-app home navigation (avoids a full reload / beforeunload while a game is open). */
   onHome: () => void;
@@ -17,7 +18,7 @@ type NavHeaderProps = {
   onStudio: () => void;
 };
 
-export function NavHeader({ activeSpecsCount, onNavigate, onHome, onStudio }: NavHeaderProps) {
+export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio }: NavHeaderProps) {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -110,7 +111,15 @@ export function NavHeader({ activeSpecsCount, onNavigate, onHome, onStudio }: Na
                 }}
               >
                 <PixelIcon name="wrench" size={14} /> {t('header.navStudio')}
-                {activeSpecsCount > 0 && <span className="specs-count-badge">{activeSpecsCount}</span>}
+                {activeBuildCount > 0 && (
+                  // The bare number reads as "Studio 2" to a screen reader; say what it counts.
+                  <span
+                    className="specs-count-badge"
+                    aria-label={t('header.activeBuilds', { count: activeBuildCount })}
+                  >
+                    {activeBuildCount}
+                  </span>
+                )}
               </button>
 
               {/* Controls that live in the header bar on a desktop but cannot fit

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -443,10 +443,16 @@ export function SubmissionStatusView({
 
             {previewError && !preview ? <p className="error">{previewError}</p> : null}
 
-            <div className="status-footer-actions">
-              <a className="inline-link" href="/">
-                {t('statusView.backHome')}
-              </a>
+            {/* Embedded in Creator Studio the panel is a tab, not a page: the header
+                already carries "Back to home", and a second escape hatch a screen
+                below it just reads as two different ways out. Stopping the build has
+                no such duplicate, so it stays either way. */}
+            <div className={`status-footer-actions${embedded ? ' is-embedded' : ''}`}>
+              {!embedded ? (
+                <a className="inline-link" href="/">
+                  {t('statusView.backHome')}
+                </a>
+              ) : null}
               {!TERMINAL_STATUSES.has(status.status) ? <AbandonControl token={token} /> : null}
             </div>
           </>

--- a/apps/web/src/activeBuilds.test.ts
+++ b/apps/web/src/activeBuilds.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActiveBuildCount } from './activeBuilds.js';
+import { listMySubmissions } from './submissionApi.js';
+
+const mockedList = vi.hoisted(() => vi.fn());
+let authUser: { uid: string; name: string } | null = null;
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: authUser, logout: vi.fn() }),
+}));
+
+vi.mock('./submissionApi', async () => {
+  const actual = await vi.importActual<typeof import('./submissionApi.js')>('./submissionApi.js');
+  return { ...actual, listMySubmissions: mockedList };
+});
+
+function submission(token: string, lastKnownStatus: string | null) {
+  return { token, title: token, createdAt: new Date().toISOString(), lastKnownStatus, slug: null };
+}
+
+/** Renders the hook and reports what it returned. */
+async function renderCount() {
+  const seen: number[] = [];
+  function Probe() {
+    seen.push(useActiveBuildCount());
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(Probe));
+  });
+  await act(async () => {
+    // The hook swallows a failed poll; the helper has to as well to observe it.
+    await Promise.resolve(mockedList.mock.results[0]?.value).catch(() => undefined);
+  });
+  return { latest: () => seen[seen.length - 1]!, root };
+}
+
+describe('useActiveBuildCount', () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    authUser = { uid: 'g:creator', name: 'Creator' };
+    mockedList.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+  });
+
+  it('counts only builds still in flight, not everything the creator ever made', async () => {
+    mockedList.mockResolvedValue([
+      submission('a', 'queued'),
+      submission('b', 'building'),
+      submission('c', 'published'),
+      submission('d', 'needs_changes'),
+      // Just submitted: the sweep has not derived a status yet. Still in flight —
+      // dropping it would blank the badge for the first two minutes.
+      submission('e', null),
+    ]);
+
+    const { latest, root } = await renderCount();
+
+    expect(latest()).toBe(3);
+
+    root.unmount();
+  });
+
+  it('asks the server rather than this device, so a signed-out visitor counts nothing', async () => {
+    authUser = null;
+    mockedList.mockResolvedValue([submission('a', 'building')]);
+
+    const { latest, root } = await renderCount();
+
+    expect(latest()).toBe(0);
+    expect(listMySubmissions).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
+
+  it('keeps the last known count when a poll fails — a badge is not worth an error state', async () => {
+    mockedList.mockRejectedValue(new Error('offline'));
+
+    const { latest, root } = await renderCount();
+
+    expect(latest()).toBe(0);
+
+    root.unmount();
+  });
+});

--- a/apps/web/src/activeBuilds.ts
+++ b/apps/web/src/activeBuilds.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from './AuthContext.js';
+import { listMySubmissions, type SubmissionState } from './submissionApi.js';
+import { STUDIO_LIVE_STATUSES } from './studioShelf.js';
+
+/**
+ * How many of this creator's builds are actually in flight right now.
+ *
+ * The header badge used to count locally saved specs, which is a different number:
+ * `mySpecs` is browser storage that nothing prunes when a build finishes, so it grew
+ * into a lifetime tally shown as if it were "in progress" — and read zero on a second
+ * device with builds running. Ownership is server-side, so ask the server.
+ *
+ * One store read per poll (`/api/submissions/mine` returns stored statuses, no GitHub
+ * fan-out), and slower than the home rail: the badge is a glance, not a watch.
+ */
+const REFRESH_MS = 60_000;
+
+/**
+ * A submission with no derived status yet counts as in flight: the list already drops
+ * abandoned builds, and `lastKnownStatus` is filled by the two-minute sweep — so the
+ * only records without one are the builds just submitted. Excluding them would blank
+ * the badge for the first two minutes, which is exactly when a creator looks at it.
+ */
+function isInFlight(status: SubmissionState | null): boolean {
+  return status === null || STUDIO_LIVE_STATUSES.has(status);
+}
+
+/**
+ * @param refreshKey bump to re-read immediately (e.g. right after a new submission).
+ * @param enabled pass false where the badge cannot be seen. A direct `/play/<slug>`
+ *   link costs the game and nothing else — the header sits behind a full-viewport
+ *   player there, and a badge nobody can read is not worth a request.
+ */
+export function useActiveBuildCount(refreshKey = 0, enabled = true): number {
+  const { user } = useAuth();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!user) {
+      setCount(0);
+      return;
+    }
+    // Keep the last count rather than zeroing it: the badge is only hidden, not stale.
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const submissions = await listMySubmissions();
+        if (cancelled) return;
+        setCount(submissions.filter((submission) => isInFlight(submission.lastKnownStatus)).length);
+      } catch {
+        // Signed out mid-poll, or the API is unreachable. A badge is not worth an
+        // error state — leave the last known count and try again on the next tick.
+      }
+    }
+
+    void load();
+    const timer = window.setInterval(() => void load(), REFRESH_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [user, refreshKey, enabled]);
+
+  return count;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -46,7 +46,7 @@
     "navArcade": "Arcade",
     "navStudio": "Studio",
     "navFeed": "Agent Stream",
-    "mySpecs": "My Active Specs ({{count}})"
+    "activeBuilds": "{{count}} in progress"
   },
   "hero": {
     "mainTitle": "Turn any idea into a playable web game",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -46,7 +46,7 @@
     "navArcade": "Arcade",
     "navStudio": "Studio",
     "navFeed": "Strumień Agentów",
-    "mySpecs": "Moje Aktywne Specyfikacje ({{count}})"
+    "activeBuilds": "w trakcie: {{count}}"
   },
   "hero": {
     "mainTitle": "Zamień dowolny pomysł w grywalną grę",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4113,6 +4113,12 @@ body.player-open {
   gap: 12px;
 }
 
+/* Studio's Build tab drops the "back home" half of this row; keep what's left
+   where it was rather than letting it slide across to the empty side. */
+.status-footer-actions.is-embedded {
+  justify-content: flex-end;
+}
+
 .status-abandon {
   /* This cancels a running build, so it stays a quiet text link rather than a
      button — but the tap target measured 14px tall, well under a thumb. Sized


### PR DESCRIPTION
The two follow-ups flagged while reviewing #315, neither of which belonged in that PR.

## The badge counted the wrong thing

`activeSpecsCount` was `getSavedSpecs().length` — browser storage that nothing prunes when a build finishes (`removeSpec` is exported and never called). So the number next to **Studio** was a lifetime tally of every spec ever submitted on that device, displayed as if it were work in progress, and reading zero on a second device with builds actually running. #315 moved that badge onto the creator's primary entry point, which is what made it worth fixing.

It now comes from `/api/submissions/mine` — the same single-store-read list the home rail uses, no GitHub fan-out — polled a minute apart, because a badge is a glance rather than a watch.

A submission with no derived status yet counts as in flight. The list already drops abandoned builds and `lastKnownStatus` is filled by the two-minute sweep, so the only records without one are the builds just submitted — excluding them would blank the badge for the first two minutes, which is exactly when a creator looks at it.

**The poll pauses while a game is on screen.** `App.catalog.test.ts` encodes the invariant that a direct `/play/<slug>` link costs the game and nothing else, and the header sits behind a full-viewport player there. Confirmed in a browser: `/play/<slug>` fires no `/api/submissions/mine`, and the poll resumes on returning home.

The bare number also read as "Studio 2" to a screen reader, so it now carries a label (`header.activeBuilds`, replacing the dead `header.mySpecs` key in both locales).

## Two ways home from the Build tab

Embedded in Creator Studio the status panel is a tab, not a page: the header already offers "Back to home", and the footer's "Back to main page" a screen below it read as a second, different exit. Hidden when embedded, with the remaining row right-aligned so "Stop this build" stays where it was. Stopping the build has no duplicate, so it renders either way.

## Verification

Driven in a real browser against a local dev server (in-memory store, `POST /api/auth/dev`) as well as under test:

- 9 stale local specs seeded alongside 2 real in-flight builds → badge reads **2**
- signed out → no badge at all, with the stale specs still in storage
- `/play/<slug>` → no badge request; home → poll resumes
- Build tab → no "Back to main page", "Stop this build" intact, header's "Back to home" intact

Lint, type-check and build clean; 474 web + 977 API tests pass, including three new ones covering the count (in-flight only, signed-out, failed poll).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dRTrnRDV7hn9VovEKfenq

---
_Generated by [Claude Code](https://claude.ai/code/session_017dRTrnRDV7hn9VovEKfenq)_