### PR TITLE
Run both indexed reads before the first write in player:erase

### DIFF
--- a/apps/api/scripts/erase-player-signals.ts
+++ b/apps/api/scripts/erase-player-signals.ts
@@ -78,9 +78,10 @@ main().catch((error) => {
   console.error(message);
 
   const hint = indexHint(message);
-  // Safe to state as fact: the feedback query is the only step needing an index and it
-  // runs before any vote is cleared, so an index failure happens before the first write.
-  // `erasePlayerSignals` has a test pinning that order for exactly this claim.
+  // Safe to state as fact: both steps needing an index — the world listing and the
+  // feedback query — run before anything is written, so an index failure happens before
+  // the first write. `erasePlayerSignals` has a test per index pinning that order for
+  // exactly this claim.
   if (hint) console.error(`\n${hint}\nNothing was erased — this failed before the first write.`);
 
   process.exit(1);

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(326_027);
+    expect(MAX_PROJECT_BYTES).toBe(358_027);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/erase-player-signals.test.ts
+++ b/apps/api/src/erase-player-signals.test.ts
@@ -37,14 +37,34 @@ describe('indexHint', () => {
   });
 
   it('does not claim an index error belonging to some other query', () => {
-    // This command depends on exactly one index. An index failure naming a different
-    // collection is a real failure the operator must read, and answering it with
-    // "provision playerFeedback.uid" sends them to fix something already fine.
+    // This command depends on two indexes. An index failure naming a different collection
+    // is a real failure the operator must read, and answering it with "provision
+    // playerFeedback.uid" sends them to fix something already fine.
     expect(
       indexHint(
         '9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_DESC index for collection scorecard and field computedAt.',
       ),
     ).toBeNull();
+  });
+
+  it('names the world index when that is the one that failed', () => {
+    // Sending an operator to check playerFeedback when worldEntries is what is missing
+    // costs them the whole debugging session, so the hint has to say which.
+    const hint = indexHint(
+      '9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_ASC index for collection ' +
+        'worldEntries and field ownerUid. That index is not ready yet.',
+    );
+    expect(hint).toContain('worldEntries.ownerUid');
+    expect(hint).not.toContain('playerFeedback');
+    expect(hint).toContain('still building');
+  });
+
+  it('tells an operator to run setup when the world index was never created', () => {
+    const hint = indexHint(
+      '9 FAILED_PRECONDITION: no matching index found for collection worldEntries and field ownerUid.',
+    );
+    expect(hint).toContain('worldEntries.ownerUid');
+    expect(hint).toContain('infra/setup-gcp.sh');
   });
 });
 
@@ -156,11 +176,31 @@ describe('erasePlayerSignals', () => {
     expect(actual.savesDeleted).toEqual(preview.savesDeleted);
   });
 
+  it('writes nothing when the world query fails', async () => {
+    // The companion to the feedback case below, and the one that was missing: P2 added
+    // `listWorldsForUser` — a second query needing a collection-group index — and put it
+    // *after* the writes. A missing worldEntries index would have deleted this person's
+    // feedback, votes and saves, and only then thrown. It is hoisted above the writes now,
+    // and this is what holds it there.
+    const boom = new Error(
+      '9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_ASC index for collection ' +
+        'worldEntries and field ownerUid. That index is not ready yet.',
+    );
+    store.listWorldsForUser = () => Promise.reject(boom);
+
+    await expect(erasePlayerSignals({ store, uid: 'g:leaver' })).rejects.toThrow('FAILED_PRECONDITION');
+
+    expect(await store.getVote('brick-storm', 'g:leaver')).toBe('up');
+    expect(await store.getVoteCounts('brick-storm')).toEqual({ up: 2, down: 0 });
+    expect(await store.countPlayerFeedbackByUid('g:leaver')).toBeGreaterThan(0);
+    expect((await store.listGameSaves('g:leaver')).length).toBeGreaterThan(0);
+  });
+
   it('writes nothing when the feedback query fails', async () => {
     // The CLI tells an operator "nothing was erased" when it hits the index error, and
-    // that has to be true, not hopeful. Feedback is the only step needing an index, so it
-    // runs before any vote is cleared. If someone reorders it, this fails: the erase would
-    // wipe every vote and then report that nothing happened.
+    // that has to be true, not hopeful. Every indexed read runs before any vote is
+    // cleared. If someone reorders it, this fails: the erase would wipe every vote and
+    // then report that nothing happened.
     const boom = new Error(
       '9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_ASC index for collection ' +
         'playerFeedback and field uid. That index is not ready yet.',

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -58,12 +58,22 @@ import type { Store } from './store.js';
  */
 export function indexHint(message: string): string | null {
   const isIndexFailure = message.includes('FAILED_PRECONDITION') && message.includes('index');
-  const namesOurIndex = message.includes('playerFeedback') && message.includes('uid');
-  if (!isIndexFailure || !namesOurIndex) return null;
+  if (!isIndexFailure) return null;
+  // Two collection-group indexes carry this command now — feedback since it was written,
+  // and world entries since P2. Naming the one that actually failed matters: sending an
+  // operator to check `playerFeedback` when `worldEntries` is the missing one costs them
+  // the whole debugging session.
+  const failed =
+    message.includes('playerFeedback') && message.includes('uid')
+      ? 'playerFeedback.uid'
+      : message.includes('worldEntries') && message.includes('ownerUid')
+        ? 'worldEntries.ownerUid'
+        : null;
+  if (!failed) return null;
   return message.includes('not ready yet')
-    ? 'The index exists and is still building. Wait a minute and run this again — re-running\n' +
-        'infra/setup-gcp.sh will not help; it will report the index as already present.'
-    : 'The playerFeedback.uid collection-group index is missing. Run infra/setup-gcp.sh\n' +
+    ? `The ${failed} index exists and is still building. Wait a minute and run this again —\n` +
+        're-running infra/setup-gcp.sh will not help; it will report the index as already present.'
+    : `The ${failed} collection-group index is missing. Run infra/setup-gcp.sh\n` +
         '(step 7), wait for the build to finish, then run this again.';
 }
 
@@ -98,20 +108,35 @@ export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Pr
   const { store, uid } = options;
   const dryRun = options.dryRun ?? false;
 
-  // Feedback goes first, and the order is load-bearing rather than incidental.
+  // Every step that needs a Firestore index runs before every step that writes, and that
+  // order is load-bearing rather than incidental.
   //
-  // It is the only step that needs a Firestore index, so it is the only step that can fail
-  // for a reason unrelated to the data — a missing or still-building index throws
-  // 9 FAILED_PRECONDITION. The vote walk needs no index at all: `listDocuments`, document
-  // reads, and single-document transactions. Running feedback first therefore means an
-  // index failure happens before anything has been written, so the CLI can tell an operator
-  // "nothing was erased" and have that be true. With the walk first, a failure here would
-  // have cleared every vote and then reported that nothing happened.
+  // An index-backed query is the only kind of step here that can fail for a reason
+  // unrelated to the data — a missing or still-building index throws 9 FAILED_PRECONDITION.
+  // The vote walk needs no index at all: `listDocuments`, document reads, and
+  // single-document transactions. Doing the indexed reads first therefore means such a
+  // failure happens before anything has been written, so the CLI can tell an operator
+  // "nothing was erased" and have that be true.
+  //
+  // There are two of them now. Feedback has needed one since this was written; listing a
+  // person's worlds has needed a second since P2 added `worldEntries.ownerUid`, and that
+  // one was originally left down beside its delete — which quietly broke this guarantee,
+  // because a missing world index would have wiped feedback, votes and saves first and
+  // then thrown. Both are pinned by tests; if someone moves either below a write, they
+  // fail.
   //
   // Count and delete run the same `where('uid','==',uid)` predicate over the same
   // collection group, differing only in `.count()` versus `.get()`. That matters more than
   // it looks: a dry run is the only thing standing between an operator and an irreversible
   // delete, so it must not be able to see a different set of rows than the delete will.
+  // Listing worlds goes first because it is the one indexed step that is a *pure* read.
+  // Feedback cannot take that position: on a real run its query and its delete are the
+  // same call, so whichever indexed step runs first, feedback is already gone by the time
+  // a later one could fail. Listing is also what lets the report name the worlds rather
+  // than count them — "your plantings in these two games are gone" is the sentence an
+  // operator has to be able to say back to the person who asked.
+  const worldsErased = await store.listWorldsForUser(uid);
+
   const feedbackDeleted = dryRun
     ? await store.countPlayerFeedbackByUid(uid)
     : await store.deletePlayerFeedbackByUid(uid);
@@ -133,9 +158,6 @@ export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Pr
   const savesDeleted = (await store.listGameSaves(uid)).map((save) => save.slug).sort();
   if (!dryRun && savesDeleted.length > 0) await store.deleteGameSaves(uid);
 
-  // Same list-then-delete shape and for the same reason: the report has to name the
-  // worlds, not count them.
-  const worldsErased = await store.listWorldsForUser(uid);
   if (!dryRun && worldsErased.length > 0) await store.deleteWorldEntriesForUser(uid);
 
   return { uid, votesCleared, feedbackDeleted, savesDeleted, worldsErased, dryRun };

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -50,11 +50,16 @@ import type { Store } from './store.js';
  * still-building index reports it as already present, which reads as "the fix did not
  * work" and invites the operator to conclude the tool is broken.
  *
+ * Two indexes carry this command — `playerFeedback.uid` and, since P2 added the world
+ * listing, `worldEntries.ownerUid` — so the hint has to name which of them failed. Sending
+ * an operator to check the wrong collection costs them the debugging session.
+ *
  * Returns null for anything else — an unrecognised failure should be shown as-is, not
- * dressed up as an index problem. That includes an index error naming some *other* query:
- * this command depends on exactly one index, so a hint is only honest when the message
- * says so. Confidently misidentifying the failure is worse than staying quiet, because a
- * raw error sends an operator to read it while a wrong hint sends them somewhere useless.
+ * dressed up as an index problem. That includes an index error naming a collection this
+ * command never queries: it belongs to some other caller, and answering it with "provision
+ * playerFeedback.uid" points at something already fine. Confidently misidentifying the
+ * failure is worse than staying quiet, because a raw error sends an operator to read it
+ * while a wrong hint sends them somewhere useless.
  */
 export function indexHint(message: string): string | null {
   const isIndexFailure = message.includes('FAILED_PRECONDITION') && message.includes('index');

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(326_027);
+    expect(MAX_PROJECT_BYTES).toBe(358_027);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -29,6 +29,7 @@ describe('games-repo-contract (website half)', () => {
       'drawing',
       'actors',
       'gfx',
+      'gfx3d',
       'effects',
       'audio',
       'party',
@@ -50,7 +51,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'effects', 'audio', 'party', 'save', 'commons', 'mascot',
+        'drawing', 'actors', 'gfx', 'gfx3d', 'effects', 'audio', 'party', 'save', 'commons', 'mascot',
       ] as const;
     `;
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);
@@ -76,6 +77,7 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_HOST_PAUSE_BYTES = 1_473;
       const GAMEKIT_MASCOT_DRAW_BYTES = 679;
       const GAMEKIT_HEADROOM_BYTES = 75_237;
+      const GAMEKIT_GFX3D_BYTES = 32_000;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -89,7 +91,8 @@ describe('games-repo source extractors', () => {
         GAMEKIT_POINTER_RELEASE_BYTES +
         GAMEKIT_HOST_PAUSE_BYTES +
         GAMEKIT_MASCOT_DRAW_BYTES +
-        GAMEKIT_HEADROOM_BYTES;
+        GAMEKIT_HEADROOM_BYTES +
+        GAMEKIT_GFX3D_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -17,6 +17,7 @@ export const GAME_KIT_MODULES = [
   'drawing',
   'actors',
   'gfx',
+  'gfx3d',
   'effects',
   'audio',
   'party',
@@ -35,12 +36,20 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * music, touch hint, progress, universal input, pointer poll, draw surface,
  * pointer release, host pause, mascot draw, …) plus a deliberate headroom band.
  * Together with {@link GAME_BUDGET_BYTES} this must equal games-repo
- * `MAX_BUNDLE_BYTES` (326_027, matching games-repo
+ * `MAX_BUNDLE_BYTES` (358_027, matching games-repo
  * `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB: the
  * platform side is an explicit sum of named allowances, not a padded
  * `42 * 1024` block.
  *
- * Last moved by games-repo #102, which did two things: +679 (`mascotDraw`) for
+ * Last moved by games-repo #111 (the `gfx3d` kit): +32_000 (`gfx3d`) for an
+ * opt-in Lambert-mesh scene module measured at ~31.5 KiB transpiled. It is only
+ * inlined when a `GAME.json` asks for it, so unlike the allowances below it is
+ * not bytes every game pays — but the cap is a single number, and a gfx3d game
+ * that clears Check 4 over there has to assemble here to be playable at all.
+ * That is the same shape as the touch-layer drift that put block-cascade and
+ * rooftop-dash live answering 422.
+ *
+ * Before that, games-repo #102 did two things: +679 (`mascotDraw`) for
  * `draw.mascot` on the createRenderer surface, and +75_237 (`headroom`) — 30% of
  * the 250_790 ceiling that resulted — to stop the cap being a hair trigger. It had
  * been pinned to the exact assembled size of the tightest published title, so a
@@ -56,7 +65,7 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * it or not, so it is charged to the platform side; charging it to authors would
  * silently shrink what they may write.
  */
-export const GAMEKIT_PLATFORM_BYTES = 121_227;
+export const GAMEKIT_PLATFORM_BYTES = 153_227;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
Verifying the `worldEntries.ownerUid` index against prod turned up a real ordering bug that P2 (#298) introduced in the erase path itself.

## The invariant that broke

`erasePlayerSignals` is built around one rule: **every step that needs a Firestore index runs before every step that writes.** That is what lets the CLI say &#34;nothing was erased&#34; after an index failure and have it be *true* rather than hopeful. A missing or still-building index throws `9 FAILED_PRECONDITION`; with a write ahead of it, the command would clear data and then report that nothing happened.

P2 added a second indexed query — `listWorldsForUser`, backed by the `worldEntries.ownerUid` collection group — and placed it at the bottom beside its delete:

```ts
const savesDeleted = ...;
if (!dryRun && savesDeleted.length > 0) await store.deleteGameSaves(uid);

const worldsErased = await store.listWorldsForUser(uid);   // <- indexed, after three writes
```

So on a real run with that index missing, `player:erase --confirm` would have deleted the person's feedback, cleared their votes, deleted their saves, and *then* thrown — a half-finished erase reported as a failure, on the privacy path.

The existing guard (`writes nothing when the feedback query fails`) missed it because it only ever mocked the feedback query.

## The fix

The world listing now runs **first**. It has to be first rather than merely early: on a real run the feedback query and the feedback delete are the same call (`deletePlayerFeedbackByUid`), so any indexed step placed after it is already downstream of a write. Listing worlds is the only indexed step here that is a pure read, so it is the only one that can hold the position.

I found that the hard way — my first attempt hoisted it above the vote walk but below feedback, and the new test caught it.

## The test that was missing

`writes nothing when the world query fails` asserts votes, feedback **and** saves all survive when `listWorldsForUser` rejects. Verified it actually bites by restoring the previous ordering — it fails, and passes again on the fix.

## `indexHint` knew about only one index

It matched on `playerFeedback` + `uid`, so a `worldEntries` failure fell through to `null` and the operator got a raw gRPC error with no guidance. Now it names whichever index actually failed — sending someone to check `playerFeedback` when `worldEntries` is the missing one costs them the whole debugging session. Two tests cover the new branch, and the existing &#34;don't claim an index error belonging to some other query&#34; test still holds for unrelated collections.

## Verification

Prod dry run against a synthetic uid (exercises the collection-group query without touching real data, since `listWorldsForUser` runs regardless of the dry-run flag):

```
$ npm run player:erase -w @gamedevpl/api -- g:verify-cg-index-000 --dry-run
[dry run] would remove for g:verify-cg-index-000:
  votes:    0
  feedback: 0
  saves:    0
  worlds:   0
  nothing found — this account left no votes, feedback, saved progress, or world entries.
```

Reaching `worlds: 0` without throwing is the result: the collection-group query executes against prod. Index state had been reported READY, but that is not the same as usable — this closes that gap.

980 API tests pass, `tsc` clean.

**Known limit, stated rather than buried:** an empty result cannot distinguish &#34;the query works and found nothing&#34; from &#34;the query would never match&#34;. Proving the erase path handles real rows needs a uid that actually owns world entries — plant something in `wanderers-green` from a test account and re-run. That part remains unexercised against prod.

## Also here: the gfx3d serve contract (15201ba)

Unrelated to the erase path, and included because it was what made CI red. The **Games-repo contract** job has been failing since games-repo [#111](https://github.com/gamedevpl/www.gamedev.pl-games/pull/111) landed the `gfx3d` kit on `main`; that check reads the live games repo rather than the diff, so it fails on `master` too.

Not cosmetic — both halves of the drift are load-bearing at serve time. `github-client.ts` rejects any `GAME.json` naming a module outside `GAME_KIT_MODULES`, and `assemble.ts` caps a project at `MAX_PROJECT_BYTES`. The first published gfx3d game would clear Check 4 over there, ship, and answer 422 here: the failure #247 exists to catch, and the one that put block-cascade and rooftop-dash live and unplayable when the touch layer moved.

```
GAMEKIT_PLATFORM_BYTES  121_227 -> 153_227   (+32_000, the gfx3d reserve)
MAX_PROJECT_BYTES       326_027 -> 358_027   (= games-repo MAX_BUNDLE_BYTES)
```

Author budget untouched at 200 KiB; `gfx3d` is opt-in and only inlined when a manifest asks for it, so no other game gains room. Verified against the games-repo `main` tip rather than against the CI error text — the three extractors in `games-repo-contract.ts` were run over that revision's `assemble.ts` and `validate.ts`, and module order, byte total and music injection signals all agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo5HHMs3TbKXsiCJQoXKmF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo5HHMs3TbKXsiCJQoXKmF)_