### PR TITLE
Build tab: Play the draft only — drop the inline iframe

### DIFF
--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -13,14 +13,8 @@ import { useGameSaveBridge } from './gameSave.js';
 import { useWorldBridge } from './world.js';
 import { useScreenWakeLock } from './useScreenWakeLock.js';
 
-/**
- * A game to run in the theater.
- * - `html`: assembled document (draft / generated) loaded via srcdoc.
- * - `slug`: published catalog game fetched by the player.
- * - `src`: URL of an unreviewed channel build — loaded by the iframe itself, never
- *   fetched into the parent (same boundary as GameFrame's `src` mode).
- */
-export type GameTheaterSource = { html: string } | { slug: string } | { src: string };
+/** A game to run, sourced either from raw assembled HTML or a published slug. */
+export type GameTheaterSource = { html: string } | { slug: string };
 
 type GameTheaterProps = {
   title: string;
@@ -330,11 +324,6 @@ export function GameTheater({
       <div className="game-viewport-container">
         {'slug' in source ? (
           <PublishedGameFrame key={source.slug} slug={source.slug} title={title} frameRef={frameRef} embed />
-        ) : 'src' in source ? (
-          // Channel builds stay on `src` — the document is unreviewed agent output and
-          // must not be fetched into the parent. No embed bridge: we can't rewrite a
-          // cross-origin URL document the way we rewrite srcdoc HTML.
-          <GameFrame title={title} src={source.src} frameRef={frameRef} />
         ) : (
           <GameFrame title={title} html={source.html} frameRef={frameRef} embed />
         )}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -13,8 +13,14 @@ import { useGameSaveBridge } from './gameSave.js';
 import { useWorldBridge } from './world.js';
 import { useScreenWakeLock } from './useScreenWakeLock.js';
 
-/** A game to run, sourced either from raw assembled HTML or a published slug. */
-export type GameTheaterSource = { html: string } | { slug: string };
+/**
+ * A game to run in the theater.
+ * - `html`: assembled document (draft / generated) loaded via srcdoc.
+ * - `slug`: published catalog game fetched by the player.
+ * - `src`: URL of an unreviewed channel build — loaded by the iframe itself, never
+ *   fetched into the parent (same boundary as GameFrame's `src` mode).
+ */
+export type GameTheaterSource = { html: string } | { slug: string } | { src: string };
 
 type GameTheaterProps = {
   title: string;
@@ -324,6 +330,11 @@ export function GameTheater({
       <div className="game-viewport-container">
         {'slug' in source ? (
           <PublishedGameFrame key={source.slug} slug={source.slug} title={title} frameRef={frameRef} embed />
+        ) : 'src' in source ? (
+          // Channel builds stay on `src` — the document is unreviewed agent output and
+          // must not be fetched into the parent. No embed bridge: we can't rewrite a
+          // cross-origin URL document the way we rewrite srcdoc HTML.
+          <GameFrame title={title} src={source.src} frameRef={frameRef} />
         ) : (
           <GameFrame title={title} html={source.html} frameRef={frameRef} embed />
         )}

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -58,7 +58,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('offers the latest playable build in a sandboxed frame, before any commit exists', async () => {
+  it('offers the latest channel build via Play the draft → theater, before any commit exists', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // Still queued: no pull request, no commit, no committed capture. This is the
     // ten-minute stretch a watcher fills, and the whole reason the route exists.
@@ -86,6 +86,17 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
+    // Same surface as the PR draft: a PlayCard, nothing embedded inline.
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent).toContain('You can walk the puppy now.');
+    const playDraft = container.querySelector<HTMLButtonElement>('.status-play-cta');
+    expect(playDraft?.textContent).toContain('Play the draft');
+
+    await act(async () => {
+      playDraft?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
     const frame = container.querySelector('iframe.game-frame') as HTMLIFrameElement | null;
     expect(frame).not.toBeNull();
     // Newest wins: an older build is history, not the thing to play.
@@ -93,7 +104,6 @@ describe('SubmissionStatusView', () => {
     // The document is unreviewed agent output, so the frame must isolate it. Without
     // allow-same-origin it lands in an opaque origin with no reach into this app.
     expect(frame?.getAttribute('sandbox')).toBe('allow-scripts');
-    expect(container.textContent).toContain('You can walk the puppy now.');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -5,7 +5,13 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView.js';
-import { abandonSubmission, getSubmissionPreview, getSubmissionStatus, submitFeedback } from './submissionApi.js';
+import {
+  abandonSubmission,
+  getChannelPlayable,
+  getSubmissionPreview,
+  getSubmissionStatus,
+  submitFeedback,
+} from './submissionApi.js';
 
 vi.mock('./submissionApi', async () => {
   const actual = await vi.importActual<typeof import('./submissionApi')>('./submissionApi');
@@ -13,6 +19,7 @@ vi.mock('./submissionApi', async () => {
     ...actual,
     getSubmissionStatus: vi.fn(),
     getSubmissionPreview: vi.fn(),
+    getChannelPlayable: vi.fn(),
     submitFeedback: vi.fn(),
     abandonSubmission: vi.fn(),
   };
@@ -20,6 +27,7 @@ vi.mock('./submissionApi', async () => {
 
 const mockedGetSubmissionStatus = vi.mocked(getSubmissionStatus);
 const mockedGetSubmissionPreview = vi.mocked(getSubmissionPreview);
+const mockedGetChannelPlayable = vi.mocked(getChannelPlayable);
 const mockedSubmitFeedback = vi.mocked(submitFeedback);
 const mockedAbandonSubmission = vi.mocked(abandonSubmission);
 
@@ -74,6 +82,8 @@ describe('SubmissionStatusView', () => {
         { ref: 'older', slug: 'puppy-stroll', createdAt: new Date(Date.now() - 120_000).toISOString() },
       ],
     });
+    // Fetched as text so the theater can inject the player bridge (Escape / sound).
+    mockedGetChannelPlayable.mockResolvedValue('<!doctype html><canvas></canvas>');
     await i18n.changeLanguage('en');
     window.history.pushState(null, '', '/status/playable-token');
 
@@ -84,11 +94,14 @@ describe('SubmissionStatusView', () => {
     await act(async () => {
       root.render(createElement(SubmissionStatusView, { token: 'playable-token' }));
       await flushEffects();
+      await flushEffects();
     });
 
     // Same surface as the PR draft: a PlayCard, nothing embedded inline.
     expect(container.querySelector('iframe')).toBeNull();
     expect(container.textContent).toContain('You can walk the puppy now.');
+    // Newest wins: an older build is history, not the thing to play.
+    expect(mockedGetChannelPlayable).toHaveBeenCalledWith('playable-token', expect.objectContaining({ ref: 'newest' }));
     const playDraft = container.querySelector<HTMLButtonElement>('.status-play-cta');
     expect(playDraft?.textContent).toContain('Play the draft');
 
@@ -97,12 +110,10 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    const frame = container.querySelector('iframe.game-frame') as HTMLIFrameElement | null;
+    const frame = container.querySelector('iframe[title="puppy-stroll"]') as HTMLIFrameElement | null;
     expect(frame).not.toBeNull();
-    // Newest wins: an older build is history, not the thing to play.
-    expect(frame?.getAttribute('src')).toContain('/preview/newest');
-    // The document is unreviewed agent output, so the frame must isolate it. Without
-    // allow-same-origin it lands in an opaque origin with no reach into this app.
+    // srcdoc + bridge — same path as a PR draft, so theater chrome actually works.
+    expect(frame?.getAttribute('srcdoc') ?? '').toContain('gdpl-player');
     expect(frame?.getAttribute('sandbox')).toBe('allow-scripts');
 
     await act(async () => {

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -4,14 +4,13 @@ import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
   abandonSubmission,
+  getChannelPlayable,
   getSubmissionPreview,
   getSubmissionStatus,
   submitFeedback,
   buildMediaUrl,
-  buildPlayableUrl,
   type BuildEvent,
   type BuildMediaItem,
-  type BuildPlayableItem,
   type BuildEventKind,
   type BuildProgress,
   type BuildStep,
@@ -144,21 +143,25 @@ export function SubmissionStatusView({
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewRefreshing, setPreviewRefreshing] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  // Early channel build HTML (pre-commit). Loaded as text so GameTheater can inject
+  // the player bridge — same sandbox as framing by URL, with working Escape/sound.
+  const [channelHtml, setChannelHtml] = useState<string | null>(null);
+  const [channelLoading, setChannelLoading] = useState(false);
 
-  // Which game (if any) is open in the full-viewport theater. The draft's HTML is
-  // snapshotted at launch (`launchedHtml`) so a background refresh doesn't reload
-  // the game out from under the player mid-session — reopening picks up the latest.
-  // Channel builds use `launchedSrc` instead: unreviewed agent output stays on the
-  // iframe's `src`, never fetched into the parent.
-  const [playing, setPlaying] = useState<'draft' | 'channel' | 'published' | null>(null);
+  // Which game (if any) is open in the full-viewport theater. HTML is snapshotted at
+  // launch (`launchedHtml`) so a background refresh doesn't reload the game out from
+  // under the player mid-session — reopening picks up the latest. Channel builds use
+  // the same path as PR drafts: fetched as text, then srcdoc + player bridge.
+  const [playing, setPlaying] = useState<'draft' | 'published' | null>(null);
   const [launchedHtml, setLaunchedHtml] = useState<string | null>(null);
-  const [launchedSrc, setLaunchedSrc] = useState<string | null>(null);
 
   // Tracks the PR head SHA the currently-displayed preview was built from, so we
   // only re-fetch (and reload the iframe) when the agent has actually pushed new
   // work — not on every status poll.
   const loadedPreviewShaRef = useRef<string | null>(null);
   const previewInFlightRef = useRef(false);
+  const loadedChannelRef = useRef<string | null>(null);
+  const channelInFlightRef = useRef(false);
 
   const currentTrackingUrl = useMemo(
     () => trackingUrl ?? new URL(embedded ? studioPath(token) : statusPath(token), window.location.href).toString(),
@@ -176,13 +179,16 @@ export function SubmissionStatusView({
     setIsInvalidToken(false);
     setPlaying(null);
     setLaunchedHtml(null);
-    setLaunchedSrc(null);
     setPreview(null);
     setPreviewLoading(false);
     setPreviewRefreshing(false);
     setPreviewError(null);
+    setChannelHtml(null);
+    setChannelLoading(false);
     loadedPreviewShaRef.current = null;
     previewInFlightRef.current = false;
+    loadedChannelRef.current = null;
+    channelInFlightRef.current = false;
 
     const stopPolling = () => {
       if (timeoutId !== undefined) {
@@ -287,6 +293,40 @@ export function SubmissionStatusView({
       });
   }, [status?.preview?.slug, status?.progress?.headSha, t, token]);
 
+  // Prefetch the latest channel build when there is no PR preview yet — same PlayCard
+  // → theater path, so Escape / sound / chrome-hide need the player bridge, which
+  // means the HTML has to arrive as text (srcdoc), not as an iframe `src`.
+  useEffect(() => {
+    const latest = status?.playable?.[0];
+    if (preview || !latest) {
+      if (!latest) {
+        setChannelHtml(null);
+        loadedChannelRef.current = null;
+      }
+      return;
+    }
+    if (latest.ref === loadedChannelRef.current || channelInFlightRef.current) return;
+
+    channelInFlightRef.current = true;
+    setChannelLoading(true);
+    setPreviewError(null);
+
+    getChannelPlayable(token, latest)
+      .then((html) => {
+        setChannelHtml(html);
+        loadedChannelRef.current = latest.ref;
+      })
+      .catch((err: unknown) => {
+        const apiError = err as SubmissionApiError;
+        setChannelHtml(null);
+        setPreviewError(apiError.message || t('statusView.previewError'));
+      })
+      .finally(() => {
+        channelInFlightRef.current = false;
+        setChannelLoading(false);
+      });
+  }, [preview, status?.playable, t, token]);
+
   const previewTitle = preview?.title ?? submittedTitle ?? status?.preview?.slug ?? t('statusView.previewGameTitle');
 
   // Lock page scroll while the theater overlay is open (matches the home player).
@@ -299,18 +339,16 @@ export function SubmissionStatusView({
   const openDraft = () => {
     if (!preview) return;
     setLaunchedHtml(preview.html);
-    setLaunchedSrc(null);
     setPlaying('draft');
   };
-  const openChannelBuild = (item: BuildPlayableItem) => {
-    setLaunchedSrc(buildPlayableUrl(token, item));
-    setLaunchedHtml(null);
-    setPlaying('channel');
+  const openChannel = () => {
+    if (!channelHtml) return;
+    setLaunchedHtml(channelHtml);
+    setPlaying('draft');
   };
   const closeTheater = () => {
     setPlaying(null);
     setLaunchedHtml(null);
-    setLaunchedSrc(null);
   };
 
   const latestChannelBuild = status?.playable?.[0] ?? null;
@@ -422,7 +460,7 @@ export function SubmissionStatusView({
                 cta={t('statusView.playDraft')}
                 onPlay={openDraft}
               />
-            ) : latestChannelBuild ? (
+            ) : channelHtml && latestChannelBuild ? (
               <PlayCard
                 badge={
                   <>
@@ -432,9 +470,9 @@ export function SubmissionStatusView({
                 title={submittedTitle ?? latestChannelBuild.slug ?? t('statusView.previewGameTitle')}
                 subtitle={latestChannelBuild.label ?? t('statusView.playableHint')}
                 cta={t('statusView.playDraft')}
-                onPlay={() => openChannelBuild(latestChannelBuild)}
+                onPlay={openChannel}
               />
-            ) : previewLoading ? (
+            ) : previewLoading || channelLoading ? (
               <p className="status-preview-pending">
                 <span className="status-preview-spinner" aria-hidden="true" /> {t('statusView.previewLoading')}
               </p>
@@ -452,7 +490,7 @@ export function SubmissionStatusView({
             {status.status !== 'published' && status.status !== 'abandoned' ? (
               <FeedbackPanel
                 token={token}
-                building={!preview && !latestChannelBuild}
+                building={!preview && !channelHtml}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
               />
             ) : null}
@@ -494,18 +532,11 @@ export function SubmissionStatusView({
 
       {playing === 'draft' && launchedHtml != null ? (
         <GameTheater
-          title={previewTitle}
+          title={
+            preview ? previewTitle : (submittedTitle ?? latestChannelBuild?.slug ?? t('statusView.previewGameTitle'))
+          }
           badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
           source={{ html: launchedHtml }}
-          onExit={closeTheater}
-        />
-      ) : null}
-
-      {playing === 'channel' && launchedSrc != null ? (
-        <GameTheater
-          title={submittedTitle ?? latestChannelBuild?.slug ?? t('statusView.previewGameTitle')}
-          badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
-          source={{ src: launchedSrc }}
           onExit={closeTheater}
         />
       ) : null}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GameFrame } from './GameFrame.js';
 import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
@@ -149,8 +148,11 @@ export function SubmissionStatusView({
   // Which game (if any) is open in the full-viewport theater. The draft's HTML is
   // snapshotted at launch (`launchedHtml`) so a background refresh doesn't reload
   // the game out from under the player mid-session — reopening picks up the latest.
-  const [playing, setPlaying] = useState<'draft' | 'published' | null>(null);
+  // Channel builds use `launchedSrc` instead: unreviewed agent output stays on the
+  // iframe's `src`, never fetched into the parent.
+  const [playing, setPlaying] = useState<'draft' | 'channel' | 'published' | null>(null);
   const [launchedHtml, setLaunchedHtml] = useState<string | null>(null);
+  const [launchedSrc, setLaunchedSrc] = useState<string | null>(null);
 
   // Tracks the PR head SHA the currently-displayed preview was built from, so we
   // only re-fetch (and reload the iframe) when the agent has actually pushed new
@@ -174,6 +176,7 @@ export function SubmissionStatusView({
     setIsInvalidToken(false);
     setPlaying(null);
     setLaunchedHtml(null);
+    setLaunchedSrc(null);
     setPreview(null);
     setPreviewLoading(false);
     setPreviewRefreshing(false);
@@ -296,12 +299,25 @@ export function SubmissionStatusView({
   const openDraft = () => {
     if (!preview) return;
     setLaunchedHtml(preview.html);
+    setLaunchedSrc(null);
     setPlaying('draft');
+  };
+  const openChannelBuild = (item: BuildPlayableItem) => {
+    setLaunchedSrc(buildPlayableUrl(token, item));
+    setLaunchedHtml(null);
+    setPlaying('channel');
   };
   const closeTheater = () => {
     setPlaying(null);
     setLaunchedHtml(null);
+    setLaunchedSrc(null);
   };
+
+  const latestChannelBuild = status?.playable?.[0] ?? null;
+  // PR preview wins when both exist — same PlayCard, theater on click. An inline
+  // iframe for the channel build used to sit under that card and doubled the "play"
+  // surface; Studio's own playtest already learned inset frames are unplayable on
+  // phones, so everything playable here opens the theater.
 
   return (
     <>
@@ -406,6 +422,18 @@ export function SubmissionStatusView({
                 cta={t('statusView.playDraft')}
                 onPlay={openDraft}
               />
+            ) : latestChannelBuild ? (
+              <PlayCard
+                badge={
+                  <>
+                    <span className="live-dot" aria-hidden="true" /> {t('statusView.previewBadge')}
+                  </>
+                }
+                title={submittedTitle ?? latestChannelBuild.slug ?? t('statusView.previewGameTitle')}
+                subtitle={latestChannelBuild.label ?? t('statusView.playableHint')}
+                cta={t('statusView.playDraft')}
+                onPlay={() => openChannelBuild(latestChannelBuild)}
+              />
             ) : previewLoading ? (
               <p className="status-preview-pending">
                 <span className="status-preview-spinner" aria-hidden="true" /> {t('statusView.previewLoading')}
@@ -424,14 +452,10 @@ export function SubmissionStatusView({
             {status.status !== 'published' && status.status !== 'abandoned' ? (
               <FeedbackPanel
                 token={token}
-                building={!preview}
+                building={!preview && !latestChannelBuild}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
               />
             ) : null}
-
-            {/* Above the feed on purpose: a playable build outranks any description of
-                one, and it is available minutes before the first commit. */}
-            <PlayableBuildPanel token={token} playable={status.playable ?? []} />
 
             <BuildProgressPanel
               token={token}
@@ -473,6 +497,15 @@ export function SubmissionStatusView({
           title={previewTitle}
           badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
           source={{ html: launchedHtml }}
+          onExit={closeTheater}
+        />
+      ) : null}
+
+      {playing === 'channel' && launchedSrc != null ? (
+        <GameTheater
+          title={submittedTitle ?? latestChannelBuild?.slug ?? t('statusView.previewGameTitle')}
+          badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
+          source={{ src: launchedSrc }}
           onExit={closeTheater}
         />
       ) : null}
@@ -831,38 +864,6 @@ function buildActivityFeed(
 
   // Newest first — that's what makes the build feel live.
   return entries.filter((entry) => Number.isFinite(entry.at)).sort((a, b) => b.at - a.at);
-}
-
-/**
- * The game as it stands right now, playable, before anything has been committed.
- *
- * This is the earliest honest answer to the only question the creator can really
- * judge: is it any fun. `npm run create` leaves a playable starter on disk about a
- * minute into a build, and a watcher pushes whatever compiles from then on — so this
- * panel typically appears long before the first screenshot and many minutes before the
- * first commit. It is deliberately loaded by URL into a sandboxed frame rather than
- * fetched and inlined: the document is unreviewed agent output.
- */
-function PlayableBuildPanel({ token, playable }: { token: string; playable: BuildPlayableItem[] }) {
-  const { t, i18n } = useTranslation();
-  const latest = playable[0];
-  if (!latest) return null;
-
-  return (
-    <section className="status-playable" aria-live="polite">
-      <h3>{t('statusView.playableTitle')}</h3>
-      {/* The agent's own caption when it wrote one — untrusted text, rendered as text. */}
-      <p className="status-playable-hint">{latest.label ?? t('statusView.playableHint')}</p>
-      <div className="status-playable-frame">
-        <GameFrame title={latest.slug ?? t('statusView.playableTitle')} src={buildPlayableUrl(token, latest)} />
-      </div>
-      {latest.createdAt ? (
-        <p className="status-playable-time">
-          {t('statusView.playableUpdated', { time: formatRelativeTime(latest.createdAt, i18n.language) })}
-        </p>
-      ) : null}
-    </section>
-  );
 }
 
 function BuildProgressPanel({

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -418,9 +418,7 @@
       "sending": "Stopping…",
       "error": "We couldn't stop this build right now. Please try again in a moment."
     },
-    "playableTitle": "Play it now",
-    "playableHint": "An early build, straight from the workshop — rough, unfinished, and already playable. Tell them what to change while it is easy.",
-    "playableUpdated": "Updated {{time}}"
+    "playableHint": "An early build, straight from the workshop — rough, unfinished, and already playable. Tell them what to change while it is easy."
   },
   "suggestions": {
     "dodge": "Dodge the falling rocks",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -418,9 +418,7 @@
       "sending": "Zatrzymuję…",
       "error": "Nie udało się teraz zatrzymać tej gry. Spróbuj ponownie za chwilę."
     },
-    "playableTitle": "Zagraj teraz",
-    "playableHint": "Wczesna wersja prosto z warsztatu — surowa, niedokończona i już grywalna. Powiedz, co zmienić, póki to łatwe.",
-    "playableUpdated": "Zaktualizowano {{time}}"
+    "playableHint": "Wczesna wersja prosto z warsztatu — surowa, niedokończona i już grywalna. Powiedz, co zmienić, póki to łatwe."
   },
   "suggestions": {
     "dodge": "Unikaj spadających skał",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5321,42 +5321,6 @@ body.player-open {
   }
 }
 
-/* The playable build panel on the status page.
-   Sized so the game is genuinely playable rather than a thumbnail — this is the first
-   thing a creator can actually judge, and it arrives before any commit. */
-.status-playable {
-  margin: 1.5rem 0;
-  padding: 1rem;
-  border: 1px solid var(--border, #333);
-  border-radius: 8px;
-}
-
-.status-playable h3 {
-  margin: 0 0 0.25rem;
-}
-
-.status-playable-hint {
-  margin: 0 0 0.75rem;
-  font-size: 0.9rem;
-  opacity: 0.8;
-}
-
-.status-playable-frame {
-  position: relative;
-  width: 100%;
-  /* Matches the aspect the games themselves are laid out for. */
-  aspect-ratio: 4 / 3;
-  max-height: 70vh;
-  overflow: hidden;
-  border-radius: 6px;
-}
-
-.status-playable-time {
-  margin: 0.5rem 0 0;
-  font-size: 0.8rem;
-  opacity: 0.7;
-}
-
 /* Feedback themes on the scorecard panel (docs/improvement-loop-plan.md IL-2).
    Uses the existing panel-card tone rather than a new colour: these are player-authored
    strings shown for reading, so they should look like content, not like a system status

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -100,8 +100,27 @@ export type BuildPlayableItem = {
 };
 
 /**
- * Where to fetch one playable build. The response is unreviewed agent output served as
- * HTML, so it is only ever loaded into a sandboxed frame — never fetched and inlined.
+ * Fetch one channel-pushed playable build as HTML text.
+ *
+ * The document is unreviewed agent output. Execution stays sandboxed: the app hands
+ * it to GameTheater as srcdoc (`sandbox="allow-scripts"`, no `allow-same-origin`) and
+ * injects the player bridge — the same path as a PR draft. Fetching into the parent
+ * as a string is required for that bridge; it is not the same as inlining the markup
+ * into the app DOM.
+ */
+export async function getChannelPlayable(token: string, item: BuildPlayableItem): Promise<string> {
+  const response = await fetch(buildPlayableUrl(token, item), { credentials: 'include' });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+
+  return response.text();
+}
+
+/**
+ * Where to fetch one playable build. Prefer {@link getChannelPlayable} when the app
+ * will open it in the theater (needs the HTML string to inject the player bridge).
  */
 export function buildPlayableUrl(token: string, item: BuildPlayableItem): string {
   return `${API_BASE}/api/submissions/${encodeURIComponent(token)}/preview/${encodeURIComponent(item.ref)}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Build tab (and the shared status view) had two play surfaces:

1. **Play the draft** — PlayCard → full-viewport theater (the intentional path)
2. **Play it now** — an inset sandboxed iframe under that card

We do not need both. PlayCard’s own comment already says the status page should never embed a live iframe, and Studio’s playtest panel already learned that an inset frame is unplayable on phones.

## What changed

- Removed the inline `PlayableBuildPanel` iframe from the Build / status view
- Early channel builds (pre-commit) use the same **Play the draft** → theater path
- Channel HTML is prefetched and opened as srcdoc (with the player bridge), so Escape / sound / pointer relays work — same as PR drafts. Sandbox isolation is unchanged.
- When a PR preview exists, it wins; we never show two play CTAs

## Copilot feedback

Addressed: loading by iframe `src` left theater chrome as a no-op because `gdpl-player` only injects into srcdoc. Channel builds now fetch HTML into the theater like drafts.

## Test plan

- [x] `SubmissionStatusView` + `GameTheater` unit tests
- [x] `npm run type-check` && `npm run lint`
- [x] Rebased onto latest `master`
- [ ] Manual: Build tab with only a channel playable → Play the draft opens theater with working Escape/sound
- [ ] Manual: Build tab with PR preview → one Play the draft card, theater on click
- [ ] Manual: phone-width → theater fills the viewport as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-603b6675-135b-4f57-8626-f3c7f619786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-603b6675-135b-4f57-8626-f3c7f619786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

