### PR TITLE
P2.5 — presence: someone else is here now (website half)

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -16,6 +16,7 @@
     "party",
     "save",
     "commons",
+    "presence",
     "mascot",
     "zone"
   ],

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import { createDefaultContentChecker, type ContentChecker } from './moderation.j
 import { registerContactRoutes, type ContactRoutesOptions } from './contact.js';
 import { registerEmailRoutes } from './email-routes.js';
 import { registerGameSaveRoutes, type GameSaveRoutesOptions } from './game-saves.js';
+import { registerPresenceRoutes, type PresenceRoutesOptions } from './presence.js';
 import { registerWorldRoutes, type WorldRoutesOptions } from './worlds.js';
 import { createWorldSchemaSourceFromEnv } from './world-source.js';
 import { registerZoneRoutes, type ZoneRoutesOptions } from './zones.js';
@@ -68,6 +69,8 @@ export interface BuildAppOptions {
   gameSaveRoutes?: Omit<GameSaveRoutesOptions, 'store'>;
   /** Seams for shared worlds; defaults to a live games-repo-backed schema source. */
   worldRoutes?: Partial<Omit<WorldRoutesOptions, 'store'>>;
+  /** Seams for ambient presence. Note the absence of a store: it keeps nothing durable. */
+  presenceRoutes?: Partial<PresenceRoutesOptions>;
   zoneRoutes?: Partial<ZoneRoutesOptions>;
   /** Seams for written player feedback; defaults to a live catalog-backed slug gate. */
   playerFeedbackRoutes?: Omit<PlayerFeedbackRoutesOptions, 'store' | 'contentChecker'>;
@@ -241,11 +244,22 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // gating it would show an empty field to exactly the visitor deciding whether to
   // care. Writes need a session, are validated against the game's declared schema, and
   // run every text field past the same moderator written feedback uses.
+  const worldSchemas = await createWorldSchemaSourceFromEnv(envPublishedSlugs);
   await registerWorldRoutes(app, {
     store,
     contentChecker,
-    worlds: await createWorldSchemaSourceFromEnv(envPublishedSlugs),
+    worlds: worldSchemas,
     ...options.worldRoutes,
+  });
+
+  // Ambient co-presence in those worlds (docs/persistent-world-plan.md P2.5). Reads are
+  // public for the same reason the world's are; appearing needs a session. It takes no
+  // `store` on purpose — presence is TTL-only and in memory, so there is nothing durable
+  // to erase and `erase-player-signals.ts` is untouched by it. The schema source is
+  // shared with the world routes: a roster only exists where a world declared one.
+  await registerPresenceRoutes(app, {
+    worlds: worldSchemas,
+    ...options.presenceRoutes,
   });
 
   // Admission to authoritative zones (docs/persistent-world-plan.md P3). This service

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -53,6 +53,7 @@ describe('games-repo-contract (website half)', () => {
       'party',
       'save',
       'commons',
+      'presence',
       'mascot',
       'zone',
     ]);
@@ -70,7 +71,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'gfx3d', 'effects', 'audio', 'party', 'save', 'commons', 'mascot', 'zone',
+        'drawing', 'actors', 'gfx', 'gfx3d', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
       ] as const;
     `;
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -23,6 +23,7 @@ export const GAME_KIT_MODULES = [
   'party',
   'save',
   'commons',
+  'presence',
   'mascot',
   // P3's zone module (docs/persistent-world-plan.md). Opt-in and, at ~9 KiB transpiled,
   // charged to the author budget the way `save` and `commons` are rather than to the
@@ -59,6 +60,10 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Before that, games-repo #113 (the voxel and third-person pilots): `gfx3d`
  * 32_000 → 40_000 (+8_000, 358_027 → 366_027) for the scene3d template and the
  * chase camera those pilots share. Same opt-in shape as the band below.
+ *
+ * `presence` (games-repo P2.5) moves none of this. Like every other module it is only
+ * inlined when a `GAME.json` asks for it, so it comes out of the 200 KiB author budget
+ * rather than the platform allowances here.
  *
  * Before that, games-repo #111 (the `gfx3d` kit): +32_000 (`gfx3d`) for an
  * opt-in Lambert-mesh scene module measured at ~31.5 KiB transpiled. It is only

--- a/apps/api/src/presence.test.ts
+++ b/apps/api/src/presence.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { MAX_PRESENT_PER_WORLD, PRESENCE_TTL_MS, PresenceRegistry } from './presence.js';
+import { InMemoryStore } from './store.js';
+import type { WorldSchema } from './world-schema.js';
+import type { WorldSchemaSource } from './world-source.js';
+
+/**
+ * Presence is the only feature here that reports something about a person *while they
+ * are still there*, so the tests are weighted toward what it must never say rather than
+ * what it says. Three things carry the feature's whole privacy story and each one has a
+ * test that fails loudly if somebody removes it:
+ *
+ *   - no uid reaches another player, in any field, ever;
+ *   - a presence tag is never the same value as a world entry's `ownerTag`, because
+ *     equal tags would tell a player which stranger around them planted which thing;
+ *   - a slot disappears on its own, so there is never anything to erase.
+ *
+ * The rest is about the count being honest: somebody who stopped playing must stop being
+ * counted, and a crowded world must not report a number it trimmed out of the payload.
+ */
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+const green: WorldSchema = {
+  maxPerPlayer: 2,
+  presence: { cols: 15, rows: 9 },
+  fields: { plant: { type: 'enum', values: ['oak', 'fern'] } },
+};
+
+/** A world with entries but no roster — the ordinary P2 world, unchanged by P2.5. */
+const quietWorld: WorldSchema = {
+  maxPerPlayer: 2,
+  presence: null,
+  fields: { plant: { type: 'enum', values: ['oak', 'fern'] } },
+};
+
+function authHeaders(uid: string) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+function worldSource(schemas: Record<string, WorldSchema>): WorldSchemaSource {
+  return { getSchema: async (slug) => schemas[slug] ?? null };
+}
+
+async function appWith(store: InMemoryStore, schemas: Record<string, WorldSchema> = { green, quiet: quietWorld }) {
+  return buildApp({
+    store,
+    sessionSecret,
+    worldRoutes: { worlds: worldSource(schemas) },
+    presenceRoutes: { worlds: worldSource(schemas) },
+  });
+}
+
+describe('presence routes', () => {
+  let store: InMemoryStore;
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:alice' });
+    await store.upsertUser({ uid: 'g:bob' });
+  });
+
+  it('404s for a world that declares no presence', async () => {
+    // A world with entries has not thereby agreed to announce who is standing in it.
+    const app = await appWith(store);
+    const response = await app.inject({ method: 'GET', url: '/api/games/quiet/presence' });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('404s for a game with no world at all', async () => {
+    const app = await appWith(store);
+    const response = await app.inject({ method: 'GET', url: '/api/games/nothing/presence' });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('lets a signed-out visitor read the roster', async () => {
+    // The P2 lesson: a count nobody may look at until they sign in shows an empty world
+    // to exactly the visitor deciding whether an account is worth having.
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 3, row: 4 },
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/green/presence' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.count).toBe(1);
+    expect(body.peers).toHaveLength(1);
+    expect(body.visible).toBe(false);
+  });
+
+  it('refuses a heartbeat from a signed-out visitor', async () => {
+    const app = await appWith(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      payload: { col: 1, row: 1 },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('refuses a heartbeat from a blocked account', async () => {
+    await store.upsertUser({ uid: 'g:mallory', tier: 'blocked' });
+    const app = await appWith(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:mallory'),
+      payload: { col: 1, row: 1 },
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('never reports a uid, in any field, to anyone', async () => {
+    // The single most important assertion in this file. Serialised and searched rather
+    // than field-by-field, so a uid smuggled into a shape nobody thought of still fails.
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 3, row: 4 },
+    });
+
+    const seenByBob = await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:bob'),
+      payload: { col: 1, row: 1 },
+    });
+
+    expect(seenByBob.body).not.toContain('alice');
+    expect(seenByBob.body).not.toContain('g:');
+    expect(await (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).body).not.toContain('alice');
+  });
+
+  it('does not reuse the world ownerTag, so a wanderer cannot be linked to a planting', async () => {
+    // Equal tags would tell a player that the person standing over there is the one who
+    // planted this — where a real person is, right now, tied to what they have built.
+    const app = await appWith(store);
+    await app.inject({
+      method: 'PUT',
+      url: '/api/games/green/world/tile.3.4',
+      headers: authHeaders('g:alice'),
+      payload: { fields: { plant: 'oak' } },
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 3, row: 4 },
+    });
+
+    const world = (await app.inject({ method: 'GET', url: '/api/games/green/world' })).json();
+    const roster = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+
+    expect(world.entries[0].ownerTag).toBeTruthy();
+    expect(roster.peers[0].tag).toBeTruthy();
+    expect(roster.peers[0].tag).not.toBe(world.entries[0].ownerTag);
+  });
+
+  it('counts a player once however many tabs they open', async () => {
+    // A slot is keyed by uid, so there is no anonymous token anybody can mint more of.
+    const app = await appWith(store);
+    for (let tab = 0; tab < 5; tab++) {
+      await app.inject({
+        method: 'POST',
+        url: '/api/games/green/presence',
+        headers: authHeaders('g:alice'),
+        payload: { col: tab, row: 1 },
+      });
+    }
+    const roster = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+    expect(roster.count).toBe(1);
+  });
+
+  it('excludes the asking player from peers but not from the count', async () => {
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:bob'),
+      payload: { col: 9, row: 2 },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 3, row: 4 },
+    });
+
+    const body = response.json();
+    expect(body.count).toBe(2);
+    expect(body.peers).toHaveLength(1);
+    expect(body.peers[0]).toEqual({ tag: expect.any(String), col: 9, row: 2 });
+    expect(body.visible).toBe(true);
+  });
+
+  it('clamps a position into the declared grid rather than refusing the beat', async () => {
+    // Refusing would drop the player out of the world entirely, which is far worse than
+    // drawing them one tile off.
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 9999, row: -40 },
+    });
+
+    const roster = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+    expect(roster.peers[0]).toMatchObject({ col: 14, row: 0 });
+  });
+
+  it('keeps the last reported tile when a beat carries no position', async () => {
+    // The shell beats before the game has said where it is. Snapping to 0,0 for one poll
+    // is a visible teleport with no cause anybody could find in the game's code.
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 7, row: 5 },
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: {},
+    });
+
+    const roster = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+    expect(roster.peers[0]).toMatchObject({ col: 7, row: 5 });
+  });
+
+  it('lets a player withdraw immediately rather than waiting out the TTL', async () => {
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/games/green/presence',
+      headers: authHeaders('g:alice'),
+      payload: { col: 3, row: 4 },
+    });
+    await app.inject({ method: 'DELETE', url: '/api/games/green/presence', headers: authHeaders('g:alice') });
+
+    const roster = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+    expect(roster.count).toBe(0);
+  });
+
+  it('reports the freshness window and cadence, so the two halves cannot drift', async () => {
+    const app = await appWith(store);
+    const body = (await app.inject({ method: 'GET', url: '/api/games/green/presence' })).json();
+    expect(body.ttlMs).toBe(PRESENCE_TTL_MS);
+    expect(body.heartbeatMs).toBeGreaterThan(0);
+    expect(body.heartbeatMs * 2).toBeLessThan(PRESENCE_TTL_MS);
+  });
+});
+
+describe('the presence registry', () => {
+  const grid = { cols: 15, rows: 9 };
+
+  it('forgets a player who stopped beating, with nothing left behind', async () => {
+    // This is the erasure story in one test. There is no delete path to get right
+    // because there is no record: a slot ages out, and the world with it.
+    let now = 1_000_000;
+    const registry = new PresenceRegistry(() => now);
+
+    registry.beat('green', 'g:alice', grid, { col: 3, row: 4 });
+    expect(registry.roster('green').count).toBe(1);
+    expect(registry.worldCount).toBe(1);
+
+    now += PRESENCE_TTL_MS + 1;
+
+    expect(registry.roster('green').count).toBe(0);
+    // Not merely empty — gone. A game nobody is playing costs the process nothing.
+    expect(registry.worldCount).toBe(0);
+  });
+
+  it('keeps a player who is still beating', async () => {
+    let now = 1_000_000;
+    const registry = new PresenceRegistry(() => now);
+
+    registry.beat('green', 'g:alice', grid, { col: 3, row: 4 });
+    now += PRESENCE_TTL_MS - 1_000;
+    registry.beat('green', 'g:alice', grid, { col: 4, row: 4 });
+    now += PRESENCE_TTL_MS - 1_000;
+
+    expect(registry.roster('green').count).toBe(1);
+  });
+
+  it('expires one player without expiring another', async () => {
+    let now = 1_000_000;
+    const registry = new PresenceRegistry(() => now);
+
+    registry.beat('green', 'g:alice', grid, { col: 1, row: 1 });
+    now += PRESENCE_TTL_MS - 1_000;
+    registry.beat('green', 'g:bob', grid, { col: 2, row: 2 });
+    now += 2_000;
+
+    const roster = registry.roster('green');
+    expect(roster.count).toBe(1);
+    expect(roster.peers).toHaveLength(1);
+    expect(roster.peers[0]).toMatchObject({ col: 2, row: 2 });
+  });
+
+  it('caps a world by evicting whoever beat longest ago, not by refusing newcomers', async () => {
+    // Refusing would make a full world permanently full, since everybody in it keeps
+    // renewing and nobody new could ever displace them.
+    let now = 1_000_000;
+    const registry = new PresenceRegistry(() => now);
+
+    for (let index = 0; index < MAX_PRESENT_PER_WORLD + 10; index++) {
+      now += 1;
+      registry.beat('green', `g:player-${index}`, grid, { col: 1, row: 1 });
+    }
+
+    expect(registry.roster('green').count).toBe(MAX_PRESENT_PER_WORLD);
+    // The newest arrival is in, which is the half that a refusing cap gets wrong.
+    const latest = registry.beat('green', `g:player-${MAX_PRESENT_PER_WORLD + 9}`, grid, { col: 2, row: 2 });
+    expect(latest.present).toBe(true);
+  });
+
+  it('reports membership explicitly rather than by comparing count to peers', async () => {
+    // A crowded world trims `peers` below `count`, so inferring "am I here" from the two
+    // numbers would tell a visitor who is merely looking that they are in the roster.
+    const registry = new PresenceRegistry();
+    for (let index = 0; index < 40; index++) {
+      registry.beat('green', `g:player-${index}`, grid, { col: 1, row: 1 });
+    }
+    const looking = registry.roster('green');
+    expect(looking.count).toBe(40);
+    expect(looking.peers.length).toBeLessThan(looking.count);
+    expect(looking.present).toBe(false);
+  });
+
+  it('keeps rosters separate per world, with a different tag in each', async () => {
+    // Same reasoning as the world's per-world ownerTag salt: one game must not be able to
+    // recognise its visitors from another game's roster.
+    const registry = new PresenceRegistry();
+    registry.beat('green', 'g:alice', grid, { col: 1, row: 1 });
+    registry.beat('meadow', 'g:alice', grid, { col: 1, row: 1 });
+
+    const greenTag = registry.roster('green').peers[0].tag;
+    const meadowTag = registry.roster('meadow').peers[0].tag;
+    expect(greenTag).not.toBe(meadowTag);
+  });
+});

--- a/apps/api/src/presence.ts
+++ b/apps/api/src/presence.ts
@@ -1,0 +1,365 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { rememberBounded } from './bounded-map.js';
+import type { PresenceGrid, WorldSchema } from './world-schema.js';
+import type { WorldSchemaSource } from './world-source.js';
+
+/**
+ * Ambient co-presence in a shared world (docs/persistent-world-plan.md, phase P2.5).
+ *
+ * P2 left this out on purpose — "a world is a document set with rules, not a session" —
+ * and named it the natural next thing to want. This is the smallest honest version of it:
+ * how many people are in a world right now, and roughly where, with **no authority of any
+ * kind**. Nothing here validates a position against anything, nothing collides, and two
+ * players cannot affect each other. Authoritative shared simulation is P3's job and this
+ * is deliberately not a down payment on it — the plan's option B says the server enforces
+ * generic constraints and nothing else, and a roster is about as generic as it gets.
+ *
+ * Same bridge as the rest: the game is sandboxed with no network at all, so its GameKit
+ * `presence` module postMessages the trusted shell, and the shell makes these requests on
+ * a heartbeat *it* controls. That last part is not incidental. A liveness feature whose
+ * request rate was set by untrusted code inside an iframe would be a denial-of-service
+ * surface with a friendly name.
+ *
+ * Three decisions carry most of the weight.
+ *
+ * **1. Nothing is stored.** Presence lives in this process's memory with a TTL and is
+ * gone when it expires. That is not a shortcut around the privacy work — it *is* the
+ * privacy work. Every durable collection on this platform has to join the erasure walk in
+ * `erase-player-signals.ts` the day it is created (invariant 4 in the plan's §7), and the
+ * best way to satisfy an erasure obligation is to have nothing to erase. There is no
+ * presence document, no presence index, and consequently no change to the erase path and
+ * no new way for its ordering invariant to be broken. The cost is real and worth naming:
+ * a deploy empties every roster, and rosters do not survive a second instance. Both are
+ * survivable — players reappear within one heartbeat — and the second is the same
+ * constraint `mp.ts` rooms already live under at `--max-instances 1`. When that pin
+ * falls, presence needs the same zone-directory work rooms do (plan §8), not a database.
+ *
+ * **2. No identity crosses the line, and specifically not a linkable one.** A peer is a
+ * tag, a column and a row. The tag is an HMAC-shaped hash over a salt generated fresh in
+ * this process at boot and never written anywhere, so it is stable for as long as a
+ * player keeps playing and meaningless afterwards — nobody, including us later, can
+ * recompute what it was. Critically it uses a **different** salt from `worldOwnerTag`:
+ * if the two matched, a game could tell that the wanderer standing over there is the one
+ * who planted this, which is a fact about a real person's habits — where they are, right
+ * now, tied to what they have built — that no part of this feature is meant to publish.
+ *
+ * **3. Reads are public; appearing needs an account.** Straight from P2's lesson: a
+ * count nobody may look at until they sign in shows an empty world to precisely the
+ * visitor deciding whether an account is worth having. Appearing is the write, and
+ * requiring a session for it also settles inflation for free — a slot is keyed by uid, so
+ * one account is one slot no matter how many tabs it opens, and there is no anonymous
+ * token anybody can mint a thousand of.
+ */
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const ParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(80).regex(SLUG_PATTERN, 'invalid slug'),
+});
+
+/**
+ * A position is advisory, so it is optional and out-of-range values are clamped rather
+ * than refused. A player whose heartbeat is rejected over a coordinate vanishes from the
+ * roster entirely, which is a much worse outcome than being drawn one tile off.
+ */
+const BeatSchema = z
+  .object({
+    col: z.number().finite().optional(),
+    row: z.number().finite().optional(),
+  })
+  .optional();
+
+/**
+ * How long a slot survives its last heartbeat.
+ *
+ * Three missed beats at the shell's cadence. Long enough that a phone switching from
+ * wifi to cellular mid-walk does not blink out of the world; short enough that "someone
+ * else is here now" is not quietly reporting somebody who closed the tab a minute ago.
+ * Reported to the game as `ttlMs` so it can draw a peer as vaguely as the number
+ * deserves rather than as a confident figure.
+ */
+export const PRESENCE_TTL_MS = 40_000;
+/** What the shell aims for. Exported so the two halves cannot drift into three beats. */
+export const PRESENCE_HEARTBEAT_MS = 12_000;
+/**
+ * Slots per world, and worlds held at once.
+ *
+ * The first bounds the response every visitor to a popular game receives; the second
+ * bounds this process. Both are LRU rather than lazily swept, because the keys are
+ * effectively unbounded from the outside and a sweep that only runs above a threshold is
+ * the exact pattern `bounded-map.ts` exists to replace.
+ */
+export const MAX_PRESENT_PER_WORLD = 64;
+const MAX_PRESENT_WORLDS = 512;
+/**
+ * Peers returned in one response. Below the slot cap on purpose: `count` stays honest
+ * for a crowded world while the payload — and the number of figures a game is asked to
+ * draw — stays something a phone can render.
+ */
+const MAX_PEERS_RETURNED = 32;
+
+/**
+ * Two salts, both random per process and never persisted.
+ *
+ * Separate rather than one used twice. `slotKey` is what this map is keyed by and never
+ * leaves the server; `tag` is handed to every other player. Deriving both from one salt
+ * would mean the value we index by is disclosed, which costs nothing today and is the
+ * kind of thing that becomes load-bearing three refactors later.
+ */
+const SLOT_SALT = randomBytes(32).toString('hex');
+const TAG_SALT = randomBytes(32).toString('hex');
+
+function slotKeyFor(worldId: string, uid: string): string {
+  return createHash('sha256').update(`${SLOT_SALT}:${worldId}:${uid}`).digest('hex').slice(0, 32);
+}
+
+/**
+ * The handle other players see. Eight hex characters — enough that two people in one
+ * world colliding is a curiosity rather than a bug, and short enough that nobody mistakes
+ * it for something meaningful.
+ */
+function tagFor(worldId: string, uid: string): string {
+  return createHash('sha256').update(`${TAG_SALT}:${worldId}:${uid}`).digest('hex').slice(0, 8);
+}
+
+interface PresenceSlot {
+  tag: string;
+  col: number;
+  row: number;
+  expiresAt: number;
+}
+
+export interface PresencePeer {
+  tag: string;
+  col: number;
+  row: number;
+}
+
+export interface PresenceRoster {
+  count: number;
+  peers: PresencePeer[];
+  /** Whether the asking player is in this roster. Never inferred from the numbers. */
+  present: boolean;
+}
+
+/**
+ * The whole store: worlds → slots, in memory, with no persistence behind it.
+ *
+ * A class rather than module-level state so tests can hold one, and so the deliberate
+ * absence of a `Store` here is visible in the type rather than only in a comment. If
+ * presence ever grows a durable half, this is the constructor that would have to take
+ * one — and the erase path would have to change in the same commit.
+ */
+export class PresenceRegistry {
+  private readonly worlds = new Map<string, Map<string, PresenceSlot>>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  /** Drops expired slots, and the world itself once nobody is left in it. */
+  private sweep(worldId: string): Map<string, PresenceSlot> | null {
+    const world = this.worlds.get(worldId);
+    if (!world) return null;
+    const at = this.now();
+    for (const [key, slot] of world) {
+      if (slot.expiresAt <= at) world.delete(key);
+    }
+    // An empty world is not kept around waiting to be evicted: a game nobody is playing
+    // should cost this process nothing at all.
+    if (world.size === 0) {
+      this.worlds.delete(worldId);
+      return null;
+    }
+    return world;
+  }
+
+  /** Records this player as present, and returns the world as everyone else sees it. */
+  beat(worldId: string, uid: string, grid: PresenceGrid, position: { col?: number; row?: number }): PresenceRoster {
+    this.sweep(worldId);
+    let world = this.worlds.get(worldId);
+    if (!world) {
+      world = new Map();
+      this.worlds.set(worldId, world);
+    }
+
+    const key = slotKeyFor(worldId, uid);
+    const previous = world.get(key);
+    const slot: PresenceSlot = {
+      tag: tagFor(worldId, uid),
+      // A beat with no position keeps whichever tile was last reported rather than
+      // snapping the player to the origin — the shell sends one before the game has
+      // said where it is, and a wanderer teleporting to 0,0 for one poll is a visible
+      // bug with no cause anybody could find.
+      col: clamp(position.col ?? previous?.col ?? 0, grid.cols),
+      row: clamp(position.row ?? previous?.row ?? 0, grid.rows),
+      expiresAt: this.now() + PRESENCE_TTL_MS,
+    };
+    // LRU by way of `rememberBounded`, so a world at its cap loses whoever beat longest
+    // ago rather than refusing the newcomer. Refusing would make a full world permanently
+    // full, since the people in it keep renewing.
+    rememberBounded(world, key, slot, MAX_PRESENT_PER_WORLD);
+    rememberBounded(this.worlds, worldId, world, MAX_PRESENT_WORLDS);
+
+    return this.roster(worldId, key);
+  }
+
+  /** Withdraws a player — the theater closing, or a game leaving its world behind. */
+  leave(worldId: string, uid: string): void {
+    const world = this.worlds.get(worldId);
+    if (!world) return;
+    world.delete(slotKeyFor(worldId, uid));
+    if (world.size === 0) this.worlds.delete(worldId);
+  }
+
+  /**
+   * Who is here, excluding `selfKey` from `peers` but never from `count`.
+   *
+   * The split matters for what a game can honestly say. `count` is "how many people are
+   * on this green", which includes you; `peers` is "who to draw", which does not.
+   */
+  roster(worldId: string, selfKey?: string): PresenceRoster {
+    const world = this.sweep(worldId);
+    if (!world) return { count: 0, peers: [], present: false };
+
+    const peers: PresencePeer[] = [];
+    for (const [key, slot] of world) {
+      if (key === selfKey) continue;
+      // Capped rather than truncated silently in the caller: `count` stays honest for a
+      // crowded world while `peers` stays something a phone can draw. It also means
+      // `present` cannot be derived from comparing the two — hence the explicit flag,
+      // which a full world would otherwise get wrong in the visitor's favour.
+      if (peers.length >= MAX_PEERS_RETURNED) break;
+      peers.push({ tag: slot.tag, col: slot.col, row: slot.row });
+    }
+    return { count: world.size, peers, present: selfKey !== undefined && world.has(selfKey) };
+  }
+
+  /** Test seam: how many worlds this process is holding. Should return to 0 on its own. */
+  get worldCount(): number {
+    return this.worlds.size;
+  }
+}
+
+/**
+ * Positions are clamped, never refused — see `BeatSchema`. Non-integers are truncated
+ * because the declared space is tiles: a game reporting 3.7 means the fourth column, and
+ * rejecting it would only teach authors to round before every call.
+ */
+function clamp(value: number, size: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.trunc(value), 0), size - 1);
+}
+
+export interface PresenceRoutesOptions {
+  /**
+   * Deliberately no `store`. Presence keeps nothing durable, and the absence of a
+   * Firestore handle here is the enforcement of that — see the note at the top on why
+   * "nothing to erase" is the privacy posture rather than a shortcut around it.
+   */
+  worlds?: WorldSchemaSource | null;
+  registry?: PresenceRegistry;
+}
+
+export async function registerPresenceRoutes(app: FastifyInstance, options: PresenceRoutesOptions): Promise<void> {
+  const { worlds } = options;
+  const registry = options.registry ?? new PresenceRegistry();
+
+  /**
+   * Today a world's roster is keyed by its worldId, which is the slug — the same opaque
+   * identity `worlds.ts` uses, and kept opaque here for the same reason: per-creator or
+   * seasonal worlds should be a new id rather than a migration.
+   */
+  function worldIdFor(slug: string): string {
+    return slug;
+  }
+
+  /**
+   * A world only has a roster if it declared one. Returns the grid, or null for "there
+   * is no presence here", which covers an unpublished game, a game with no world, a
+   * world that declares no presence block, and a declaration that did not parse. A game
+   * cannot act differently on any of those and distinguishing them would leak whether a
+   * slug exists.
+   */
+  async function gridFor(slug: string): Promise<PresenceGrid | null> {
+    const schema: WorldSchema | null = (await worlds?.getSchema(slug)) ?? null;
+    return schema?.presence ?? null;
+  }
+
+  function reply(roster: PresenceRoster, visible: boolean) {
+    return {
+      count: roster.count,
+      peers: roster.peers,
+      // Reported rather than left to the client to infer, so a game can say "sign in to
+      // be seen here" instead of leaving somebody invisible without mentioning it.
+      visible,
+      ttlMs: PRESENCE_TTL_MS,
+      heartbeatMs: PRESENCE_HEARTBEAT_MS,
+    };
+  }
+
+  app.get('/api/games/:slug/presence', async (request, response) => {
+    const params = ParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      return response.status(400).send({ error: params.error.issues[0]?.message ?? 'invalid slug' });
+    }
+    const grid = await gridFor(params.data.slug);
+    if (!grid) return response.status(404).send({ error: 'presence not found' });
+
+    const worldId = worldIdFor(params.data.slug);
+    const uid = request.user?.uid;
+    const selfKey = uid ? slotKeyFor(worldId, uid) : undefined;
+    // A signed-in visitor who has not beaten yet reads as not visible, which is true:
+    // reading the roster does not put you in it.
+    const roster = registry.roster(worldId, selfKey);
+    return response.send(reply(roster, roster.present));
+  });
+
+  app.post(
+    '/api/games/:slug/presence',
+    {
+      config: {
+        // Comfortably above the shell's cadence (one beat per 12s, so five a minute) and
+        // far below anything a runaway loop would produce. The shell owns the timer, so
+        // exceeding this means a modified client rather than a busy player.
+        rateLimit: { max: 30, timeWindow: 60_000 },
+      },
+    },
+    async (request, response) => {
+      if (!request.user) {
+        // The ordinary condition for a signed-out visitor, not an error path: they still
+        // read the roster through GET, they simply are not in it.
+        return response.status(401).send({ error: 'authentication required' });
+      }
+      if (request.user.tier === 'blocked') {
+        return response.status(403).send({ error: 'account is blocked' });
+      }
+      const params = ParamsSchema.safeParse(request.params);
+      if (!params.success) {
+        return response.status(400).send({ error: params.error.issues[0]?.message ?? 'invalid slug' });
+      }
+      const body = BeatSchema.safeParse(request.body);
+      if (!body.success) {
+        return response.status(400).send({ error: 'invalid position' });
+      }
+      const grid = await gridFor(params.data.slug);
+      if (!grid) return response.status(404).send({ error: 'presence not found' });
+
+      const worldId = worldIdFor(params.data.slug);
+      const roster = registry.beat(worldId, request.user.uid, grid, body.data ?? {});
+      return response.send(reply(roster, true));
+    },
+  );
+
+  app.delete('/api/games/:slug/presence', async (request, response) => {
+    if (!request.user) return response.status(401).send({ error: 'authentication required' });
+    const params = ParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      return response.status(400).send({ error: params.error.issues[0]?.message ?? 'invalid slug' });
+    }
+    // No schema gate, matching the world delete: "take me out of the roster" must keep
+    // working even for a game that has left the catalog since the player walked in, or
+    // whose declaration stopped parsing while they were standing in it.
+    registry.leave(worldIdFor(params.data.slug), request.user.uid);
+    return response.send({ ok: true });
+  });
+}

--- a/apps/api/src/verify-erase-signals.ts
+++ b/apps/api/src/verify-erase-signals.ts
@@ -25,6 +25,15 @@ import { MAX_WORLD_ENTRIES } from './world-schema.js';
  * one an operator can run on a Friday without reading the source first, and any design
  * where a mistyped argument erases somebody's account is not that.
  *
+ * ## Why presence is not covered
+ *
+ * Because there is nothing to cover. P2.5 presence is TTL-only and lives in the API
+ * process's memory (`presence.ts`), so it never becomes a row `erasePlayerSignals` could
+ * find or miss. That is the point of the posture rather than a gap in this command: the
+ * signal with no durable form is the one whose erasure cannot silently stop working. If
+ * presence ever grows a stored half, it joins the erase path and this file in the same
+ * commit.
+ *
  * ## Why votes are not covered
  *
  * Three of the four signals can be planted as leaf documents whose parents never have to

--- a/apps/api/src/world-schema.test.ts
+++ b/apps/api/src/world-schema.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_WORLD_TEXT_LENGTH,
   parseWorldSchema,
   validateWorldEntry,
+  MAX_PRESENCE_GRID,
   worldOwnerTag,
   type WorldSchema,
 } from './world-schema.js';
@@ -222,6 +223,42 @@ describe('isValidWorldKey', () => {
     for (const key of ['', '../escape', 'has space', '/leading', '.hidden', 'x'.repeat(65), 42, null, undefined]) {
       expect(isValidWorldKey(key)).toBe(false);
     }
+  });
+});
+
+describe('parseWorldSchema presence block', () => {
+  const base = { maxPerPlayer: 3, fields: { plant: { type: 'enum', values: ['oak'] } } };
+
+  it('leaves presence null when a world declares none', () => {
+    // The ordinary world, unchanged by P2.5. Storing what strangers built is not the
+    // same decision as announcing who is standing in it, so one does not imply the other.
+    expect(parseWorldSchema(base)?.presence).toBeNull();
+  });
+
+  it('reads a declared grid', () => {
+    expect(parseWorldSchema({ ...base, presence: { cols: 15, rows: 9 } })?.presence).toEqual({ cols: 15, rows: 9 });
+  });
+
+  it('takes the whole world down when the presence block does not parse', () => {
+    // Same stance as a bad field spec, for a related reason: failing open would leave a
+    // game reporting positions into a coordinate space nobody agreed to bound.
+    expect(parseWorldSchema({ ...base, presence: {} })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: 15 } })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: 15, rows: 0 } })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: 15, rows: 2.5 } })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: '15', rows: '9' } })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: true })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: [15, 9] })).toBeNull();
+  });
+
+  it('refuses a grid fine enough to be a movement trace', () => {
+    // The cap is what keeps ambient presence ambient: a 4096-wide grid would publish a
+    // real person's position to strangers at roughly pixel resolution.
+    expect(
+      parseWorldSchema({ ...base, presence: { cols: MAX_PRESENCE_GRID, rows: MAX_PRESENCE_GRID } }),
+    ).not.toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: MAX_PRESENCE_GRID + 1, rows: 9 } })).toBeNull();
+    expect(parseWorldSchema({ ...base, presence: { cols: 9, rows: MAX_PRESENCE_GRID + 1 } })).toBeNull();
   });
 });
 

--- a/apps/api/src/world-schema.ts
+++ b/apps/api/src/world-schema.ts
@@ -47,6 +47,17 @@ export const MAX_WORLD_ENTRY_BYTES = 4 * 1024;
  * rather than a bigger number here.
  */
 export const MAX_WORLD_ENTRIES = 2000;
+/**
+ * Ceiling on the tile grid a world may declare for presence (P2.5).
+ *
+ * This is the number that keeps ambient co-presence ambient. A game that could declare a
+ * 4096×4096 grid would be reporting one player's position to every other player at
+ * roughly pixel resolution, which is not "somebody is over there by the north hedge" —
+ * it is a movement trace of a real person, published live to strangers, from a feature
+ * nobody would have described that way. 64×64 is coarse enough that a tile is a place
+ * rather than a location, and generous enough for any board a game can actually draw.
+ */
+export const MAX_PRESENCE_GRID = 64;
 
 /** Keys are game-chosen (`plot.3.4`, `stall-17`) and land in a document path. */
 const KEY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$/;
@@ -62,9 +73,25 @@ export type WorldFieldSpec =
   | { type: 'enum'; values: string[] }
   | { type: 'bool' };
 
+/** The coordinate space presence positions are reported and clamped in. */
+export interface PresenceGrid {
+  cols: number;
+  rows: number;
+}
+
 export interface WorldSchema {
   fields: Record<string, WorldFieldSpec>;
   maxPerPlayer: number;
+  /**
+   * Null for the ordinary world, which has entries but no roster.
+   *
+   * Presence is opt-in per world rather than on for every world, because it is the one
+   * part of this system that reports something about a person *while they are still
+   * there*. A world that stores what strangers built has not thereby agreed to announce
+   * who is standing in it, and the difference should be a decision somebody made in a
+   * reviewed manifest rather than a side effect of having a world at all.
+   */
+  presence: PresenceGrid | null;
 }
 
 export function isValidWorldKey(key: unknown): key is string {
@@ -123,7 +150,28 @@ export function parseWorldSchema(raw: unknown): WorldSchema | null {
     if (!spec) return null;
     fields[name] = spec;
   }
-  return { fields, maxPerPlayer: quota as number };
+
+  // Absent is the ordinary answer and means no roster. Present-but-unparseable takes the
+  // whole world down with it, exactly as a bad field spec does — see the note at the top
+  // on why a partial parse is not an option. Here the stake is a little different and no
+  // smaller: failing open would mean a game reporting positions into a coordinate space
+  // nobody agreed to bound.
+  let presence: PresenceGrid | null = null;
+  if (raw.presence !== undefined) {
+    presence = parsePresence(raw.presence);
+    if (!presence) return null;
+  }
+
+  return { fields, maxPerPlayer: quota as number, presence };
+}
+
+function parsePresence(raw: unknown): PresenceGrid | null {
+  if (!isRecord(raw)) return null;
+  const { cols, rows } = raw;
+  for (const size of [cols, rows]) {
+    if (!Number.isInteger(size) || (size as number) < 1 || (size as number) > MAX_PRESENCE_GRID) return null;
+  }
+  return { cols: cols as number, rows: rows as number };
 }
 
 export type WorldEntryValidation =

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -10,6 +10,7 @@ import { ShareGameButton } from './ShareGameButton.js';
 import { VoteWidget } from './VoteWidget.js';
 import { useGamePlayer } from './gamePlayer.js';
 import { useGameSaveBridge } from './gameSave.js';
+import { usePresenceBridge } from './presence.js';
 import { useWorldBridge } from './world.js';
 import { useZoneBridge } from './zone.js';
 import { useScreenWakeLock } from './useScreenWakeLock.js';
@@ -131,6 +132,12 @@ export function GameTheater({
   // against a shape it is about to change would be visible to every other player as
   // something the game can no longer render.
   useWorldBridge(frameRef, reportSlug);
+
+  // And who is walking that world right now (P2.5). Mounted beside the world bridge
+  // rather than inside it because the two answer different questions on different
+  // clocks: a world changes when somebody acts, a roster changes when somebody arrives
+  // or stops looking. A game that never asks for a roster costs this nothing.
+  usePresenceBridge(frameRef, reportSlug);
 
   // Authoritative real-time zones (P3). Published slug again, and here the reason is
   // sharpest of the three: the host runs the *same* sim.ts the client predicts with, and

--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -95,6 +95,15 @@ export const privacyEn: LegalDocument = {
               'Until you delete your account, or remove it from within the game',
             ],
             [
+              'While you are playing a game with a shared world, that you are in it and roughly where — a coarse ' +
+                'tile position, not a precise location. Held only in memory for about 40 seconds after your last ' +
+                'move and never written to any database. Other players see a short code and a tile: never your ' +
+                'name, your account, or the code attached to anything you have built there',
+              'Letting players see that others are in the same world at the same time',
+              'Art. 6(1)(b) — performance of a contract',
+              'About 40 seconds after you stop playing. There is nothing kept to delete later',
+            ],
+            [
               'The moderation outcome for your description (whether it was rejected and why)',
               'Preventing unlawful or harmful content from being created',
               'Art. 6(1)(c) — legal obligation (Digital Services Act), and 6(1)(f) — our legitimate interest in a ' +

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -100,6 +100,15 @@ export const privacyPl: LegalDocument = {
               'Do usunięcia konta lub do usunięcia tego z poziomu samej gry',
             ],
             [
+              'W trakcie gry we wspólnym świecie — to, że w nim jesteś i mniej więcej gdzie: przybliżona pozycja ' +
+                'na siatce kafelków, a nie dokładna lokalizacja. Przechowywane wyłącznie w pamięci przez około ' +
+                '40 sekund od Twojego ostatniego ruchu i nigdy niezapisywane w żadnej bazie danych. Inni gracze ' +
+                'widzą krótki kod i kafelek: nigdy Twoje imię, konto ani kod powiązany z tym, co tam zbudowałeś',
+              'Umożliwienie graczom zobaczenia, że inni są w tym samym świecie w tym samym czasie',
+              'art. 6 ust. 1 lit. b — wykonanie umowy',
+              'Około 40 sekund po zakończeniu gry. Nie pozostaje nic, co można by później usunąć',
+            ],
+            [
               'Wynik moderacji Twojego opisu (czy i dlaczego został odrzucony)',
               'Niedopuszczenie do powstania treści bezprawnych lub szkodliwych',
               'art. 6 ust. 1 lit. c — obowiązek prawny (akt o usługach cyfrowych) oraz lit. f — nasz prawnie ' +

--- a/apps/web/src/presence.test.tsx
+++ b/apps/web/src/presence.test.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
+import { parsePresenceMessage, usePresenceBridge } from './presence.js';
+
+/**
+ * The presence bridge is the first place on the platform where the *shell* owns a clock
+ * on the game's behalf, and that is what most of this file is about.
+ *
+ * Everywhere else, a request happens because a player did something: they saved, they
+ * planted. Here requests happen because time passed, and if the game could set that
+ * interval then a hostile or merely careless generated game would have a periodic
+ * request primitive pointed at our API. So: the game says *where it is*, this side
+ * decides *how often anybody hears about it*, and a game calling `here()` sixty times a
+ * second must produce exactly the same request rate as one calling it twice.
+ */
+
+function frame(payload: Record<string, unknown>) {
+  return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload };
+}
+
+describe('parsePresenceMessage', () => {
+  it('accepts the three requests a game may make', () => {
+    expect(parsePresenceMessage(frame({ t: 'presence:hello' }))).toEqual({ t: 'presence:hello' });
+    expect(parsePresenceMessage(frame({ t: 'presence:away' }))).toEqual({ t: 'presence:away' });
+    expect(parsePresenceMessage(frame({ t: 'presence:here', col: 3, row: 4 }))).toEqual({
+      t: 'presence:here',
+      col: 3,
+      row: 4,
+    });
+  });
+
+  it('drops anything outside the namespace or protocol version', () => {
+    expect(parsePresenceMessage({ t: 'presence:hello' })).toBeNull();
+    expect(parsePresenceMessage({ ns: 'other', v: PROTOCOL_VERSION, t: 'presence:hello' })).toBeNull();
+    expect(parsePresenceMessage({ ns: BRIDGE_NAMESPACE, v: 99, t: 'presence:hello' })).toBeNull();
+    expect(parsePresenceMessage(null)).toBeNull();
+    expect(parsePresenceMessage('presence:hello')).toBeNull();
+  });
+
+  it('truncates a fractional tile rather than dropping the report', () => {
+    // The declared space is tiles, so 3.7 plainly means the fourth column. Rejecting it
+    // would only teach authors to round before every call.
+    expect(parsePresenceMessage(frame({ t: 'presence:here', col: 3.7, row: -0.5 }))).toEqual({
+      t: 'presence:here',
+      col: 3,
+      row: 0,
+    });
+  });
+
+  it('drops a coordinate that could never be a tile', () => {
+    for (const value of [Number.NaN, Infinity, -Infinity, 1e9, '3', null, undefined]) {
+      expect(parsePresenceMessage(frame({ t: 'presence:here', col: value, row: 1 })), String(value)).toBeNull();
+      expect(parsePresenceMessage(frame({ t: 'presence:here', col: 1, row: value })), String(value)).toBeNull();
+    }
+  });
+});
+
+function Harness({ slug }: { slug?: string }) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  usePresenceBridge(frameRef, slug);
+  return <iframe ref={frameRef} title="game" />;
+}
+
+describe('usePresenceBridge', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let toGame: Array<Record<string, unknown>>;
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    toGame = [];
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = null;
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function mount(slug: string | null = 'wanderers-green') {
+    root = createRoot(container);
+    act(() => root!.render(<Harness slug={slug ?? undefined} />));
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const gameWindow = iframe.contentWindow as Window;
+    vi.spyOn(gameWindow, 'postMessage').mockImplementation(((message: Record<string, unknown>) => {
+      toGame.push(message);
+    }) as typeof gameWindow.postMessage);
+
+    const fromGame = (payload: Record<string, unknown>) => {
+      window.dispatchEvent(new MessageEvent('message', { data: frame(payload), source: gameWindow }));
+    };
+    return { fromGame, gameWindow };
+  }
+
+  async function waitFor(check: () => void, attempts = 50) {
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        check();
+        return;
+      } catch (error) {
+        if (attempt === attempts - 1) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+    }
+  }
+
+  function jsonResponse(body: unknown, status = 200) {
+    return { ok: status < 400, status, json: async () => body } as Response;
+  }
+
+  const roster = {
+    count: 3,
+    peers: [{ tag: 'aaaa1111', col: 3, row: 4 }],
+    visible: true,
+    ttlMs: 40000,
+    heartbeatMs: 12000,
+  };
+
+  function calls(method: string) {
+    return fetchMock.mock.calls.filter(([, init]) => (init?.method ?? 'GET') === method);
+  }
+
+  it('answers a hello with a read, not a heartbeat', async () => {
+    // Reading is what a signed-out visitor gets, and it also means a signed-in player
+    // does not enter the roster before the game has said where they are — otherwise
+    // everybody who opens a world game appears at the origin tile for one poll.
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    expect(toGame[0]).toMatchObject({ t: 'presence:state', available: true, count: 3, visible: true, ttlMs: 40000 });
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/games/wanderers-green/presence');
+    expect(calls('POST')).toHaveLength(0);
+  });
+
+  it('never forwards a uid or any peer field the game did not ask for', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    expect(toGame[0].peers).toEqual([{ tag: 'aaaa1111', col: 3, row: 4 }]);
+  });
+
+  it('reports no roster for a game that declares none', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'presence not found' }, 404));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    expect(toGame[0]).toMatchObject({ t: 'presence:state', available: false });
+  });
+
+  it('reports no roster when the read fails, without throwing at the game', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    expect(toGame[0]).toMatchObject({ t: 'presence:state', available: false });
+  });
+
+  it('beats once when the game first says where it is', async () => {
+    // Waiting out a whole interval would leave a player invisible for twelve seconds
+    // after walking in, which is most of the time anybody spends deciding whether a
+    // world feels inhabited.
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    fromGame({ t: 'presence:here', col: 7, row: 5 });
+
+    await waitFor(() => expect(calls('POST')).toHaveLength(1));
+    expect(JSON.parse(calls('POST')[0][1].body as string)).toEqual({ col: 7, row: 5 });
+  });
+
+  it('does not turn a flood of position reports into a flood of requests', async () => {
+    // The property the whole design exists for. Sixty `here()` calls, one heartbeat.
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    for (let step = 0; step < 60; step++) fromGame({ t: 'presence:here', col: step % 15, row: 1 });
+
+    await waitFor(() => expect(calls('POST')).toHaveLength(1));
+    // Give any stray timer a chance to fire before concluding there was only one.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(calls('POST')).toHaveLength(1);
+  });
+
+  it('sends the newest tile, not the one that triggered the beat', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    fromGame({ t: 'presence:here', col: 1, row: 1 });
+    await waitFor(() => expect(toGame).toHaveLength(2));
+
+    // Walk on, then trigger the next beat the way coming back to the tab does, rather
+    // than sitting out a twelve-second interval.
+    fromGame({ t: 'presence:here', col: 9, row: 8 });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await waitFor(() => expect(calls('POST')).toHaveLength(2));
+    expect(JSON.parse(calls('POST')[1][1].body as string)).toEqual({ col: 9, row: 8 });
+  });
+
+  it('withdraws when the game walks out of its world', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    fromGame({ t: 'presence:here', col: 7, row: 5 });
+    // Wait for the beat's *reply*, not just the call: joining is what the response says.
+    await waitFor(() => expect(toGame).toHaveLength(2));
+
+    fromGame({ t: 'presence:away' });
+
+    await waitFor(() => expect(calls('DELETE')).toHaveLength(1));
+    expect(toGame.at(-1)).toMatchObject({ t: 'presence:state', available: false });
+  });
+
+  it('withdraws when the theater closes, rather than leaving a ghost for the whole TTL', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+    fromGame({ t: 'presence:here', col: 7, row: 5 });
+    await waitFor(() => expect(toGame).toHaveLength(2));
+
+    act(() => root!.unmount());
+    root = null;
+
+    await waitFor(() => expect(calls('DELETE')).toHaveLength(1));
+  });
+
+  it('does not withdraw for a visitor who never joined', async () => {
+    // A signed-out visitor has no slot. Sending a DELETE would be a request whose only
+    // possible answer is 401, on every exit from every world game.
+    fetchMock.mockResolvedValue(jsonResponse({ ...roster, visible: false }));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:hello' });
+    await waitFor(() => expect(toGame).toHaveLength(1));
+
+    act(() => root!.unmount());
+    root = null;
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(calls('DELETE')).toHaveLength(0);
+  });
+
+  it('stays silent for a game that never asks for a roster', async () => {
+    // The bridge is mounted for every published game, so this is the common case: no
+    // hello, no requests, no cost.
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount();
+
+    fromGame({ t: 'presence:here', col: 1, row: 1 });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores traffic from any window but the game frame', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    mount();
+
+    window.dispatchEvent(new MessageEvent('message', { data: frame({ t: 'presence:hello' }), source: window }));
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing at all without a published slug', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(roster));
+    const { fromGame } = mount(null);
+
+    fromGame({ t: 'presence:hello' });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/presence.ts
+++ b/apps/web/src/presence.ts
@@ -1,0 +1,238 @@
+import { useEffect, type MutableRefObject } from 'react';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
+import { beatPresence, fetchPresence, leavePresence, type PresenceSnapshot } from './presenceApi.js';
+
+/**
+ * The shell half of ambient co-presence (docs/persistent-world-plan.md P2.5).
+ *
+ * The same arrangement as the save and world bridges — the game cannot reach the network,
+ * so it postMessages here and this code, ordinary app code on the real origin holding the
+ * session cookie, makes the call. What is genuinely new is that **this side owns the
+ * clock**.
+ *
+ * Saves and world writes are driven by the player doing something. Presence is driven by
+ * time, and that is the whole reason the timer lives here rather than in the module: a
+ * periodic request whose interval was chosen by untrusted code inside a sandboxed iframe
+ * is a denial-of-service surface with a friendly name. The game says *where it is*; the
+ * shell decides *how often anybody hears about it*. A game that calls `here()` sixty
+ * times a second and one that calls it twice produce exactly the same request rate.
+ *
+ * Two more consequences of owning the clock, both of which the module could not have
+ * arranged for itself:
+ *
+ * - **A hidden tab stops beating entirely.** Somebody who alt-tabbed is not in the world
+ *   in any sense a player would recognise, and continuing to report them would make the
+ *   count mean "has this game open" rather than "is here". It also means a backgrounded
+ *   game costs the platform nothing, the same standard `commons` polling holds itself to.
+ * - **Leaving withdraws immediately.** A slot expires on its own, but the gap between
+ *   closing a game and expiring is the whole TTL, and for all of it every other player is
+ *   looking at somebody who is not there.
+ */
+
+/** Mirrors the API's `PRESENCE_HEARTBEAT_MS`; the server's answer overrides it. */
+const DEFAULT_HEARTBEAT_MS = 12_000;
+/** Never beat faster than this, whatever a server response claims the cadence is. */
+const MIN_HEARTBEAT_MS = 5_000;
+/** Position bound. The server clamps to the game's declared grid; this only stops a
+ *  runaway value from becoming a request body at all. */
+const MAX_COORDINATE = 4096;
+
+export type PresenceRequest =
+  { t: 'presence:hello' } | { t: 'presence:here'; col: number; row: number } | { t: 'presence:away' };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCoordinate(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) <= MAX_COORDINATE;
+}
+
+/**
+ * The declared space is tiles, so a fractional report plainly means the tile it falls in
+ * — truncating is friendlier than rejecting, which would only teach authors to round
+ * before every call. `|| 0` is not redundant: `Math.trunc(-0.5)` is `-0`, which survives
+ * a structured clone and compares unequal to `0` under `Object.is`.
+ */
+function toTile(value: number): number {
+  return Math.trunc(value) || 0;
+}
+
+/** Narrows one message out of the game frame. Returns null for anything else. */
+export function parsePresenceMessage(raw: unknown): PresenceRequest | null {
+  if (!isObject(raw) || raw.ns !== BRIDGE_NAMESPACE || raw.v !== PROTOCOL_VERSION) return null;
+  if (raw.t === 'presence:hello') return { t: 'presence:hello' };
+  if (raw.t === 'presence:away') return { t: 'presence:away' };
+  if (raw.t === 'presence:here') {
+    if (!isCoordinate(raw.col) || !isCoordinate(raw.row)) return null;
+    return { t: 'presence:here', col: toTile(raw.col), row: toTile(raw.row) };
+  }
+  return null;
+}
+
+/**
+ * Serves presence for the game running in `frameRef` on the published `slug`.
+ *
+ * Nothing happens until a game says `presence:hello`, exactly as with saves and worlds,
+ * so the bridge being mounted for every published game costs the ones that never ask for
+ * a roster precisely nothing.
+ */
+export function usePresenceBridge(frameRef: MutableRefObject<HTMLIFrameElement | null>, slug: string | undefined) {
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    /** True once a game has asked for a roster — until then this whole effect is inert. */
+    let engaged = false;
+    /** Newest tile the game reported, or null before it has said anything. */
+    let position: { col: number; row: number } | null = null;
+    let timer: number | null = null;
+    let beating = false;
+    let heartbeatMs = DEFAULT_HEARTBEAT_MS;
+    /** True once at least one beat has been sent, so `leave` knows there is a slot. */
+    let joined = false;
+
+    function postToGame(payload: Record<string, unknown>) {
+      if (cancelled) return;
+      // The frame is sandboxed to an opaque origin, so '*' is the only possible target;
+      // the game in turn only accepts messages whose source is its parent.
+      frameRef.current?.contentWindow?.postMessage({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload }, '*');
+    }
+
+    function announce(snapshot: PresenceSnapshot | null) {
+      postToGame(
+        snapshot
+          ? {
+              t: 'presence:state',
+              available: true,
+              visible: snapshot.visible,
+              count: snapshot.count,
+              peers: snapshot.peers,
+              ttlMs: snapshot.ttlMs,
+            }
+          : { t: 'presence:state', available: false },
+      );
+    }
+
+    async function beat() {
+      // One beat at a time. A slow request must not let the next tick start a second,
+      // or a struggling connection turns into a pile-up aimed at the same endpoint.
+      if (beating || cancelled) return;
+      beating = true;
+      try {
+        const snapshot = await beatPresence(slug!, position);
+        if (snapshot) {
+          joined = joined || snapshot.visible;
+          // The server names the cadence, so the two halves cannot drift into disagreeing
+          // about how many missed beats a TTL is worth. Floored, so a bad or hostile
+          // answer cannot turn this into a tight loop.
+          heartbeatMs = Math.max(MIN_HEARTBEAT_MS, snapshot.heartbeatMs || DEFAULT_HEARTBEAT_MS);
+        }
+        announce(snapshot);
+      } catch {
+        // A beat that failed is "no presence" as far as the game is concerned, and the
+        // next beat is one interval away by construction — which is why, unlike the save
+        // and world bridges, there is no retry ladder here to get wrong.
+        announce(null);
+      } finally {
+        beating = false;
+      }
+    }
+
+    /**
+     * Chained rather than an interval, the same reasoning `commons` polling uses: each
+     * beat is scheduled only once the previous one has been asked for, so a slow server
+     * can never accumulate a queue of requests that all land at once.
+     */
+    function schedule() {
+      if (timer !== null || cancelled || !engaged) return;
+      timer = window.setTimeout(() => {
+        timer = null;
+        // Never beat for a tab nobody is looking at: somebody who alt-tabbed is not in
+        // the world in any sense a player would recognise. The visibility listener beats
+        // immediately when they come back.
+        if (document.visibilityState !== 'hidden') void beat();
+        schedule();
+      }, heartbeatMs);
+    }
+
+    function stop() {
+      if (timer === null) return;
+      window.clearTimeout(timer);
+      timer = null;
+    }
+
+    async function onMessage(event: MessageEvent) {
+      // Pin to this theater's frame: any other window posting `gdp` traffic is not the
+      // game we are serving, and must not appear in or read this roster.
+      if (!frameRef.current || event.source !== frameRef.current.contentWindow) return;
+      const message = parsePresenceMessage(event.data);
+      if (!message) return;
+
+      if (message.t === 'presence:hello') {
+        engaged = true;
+        // The opening answer is a *read*, not a beat. A signed-out visitor gets the count
+        // this way, and a signed-in one does not enter the roster until the game has had
+        // a chance to say where it is — which stops everybody who opens a world game
+        // appearing for one poll at the origin tile.
+        try {
+          announce(await fetchPresence(slug!));
+        } catch {
+          announce(null);
+        }
+        schedule();
+        return;
+      }
+
+      if (message.t === 'presence:here') {
+        position = { col: message.col, row: message.row };
+        // Only for a game that actually opened a roster. Without this, a game that never
+        // said hello — or one that has already walked away — could still put this side
+        // on the network by posting a position, which is exactly the control the shell
+        // owns the clock in order to keep.
+        if (!engaged) return;
+        // The first position is worth a beat straight away: waiting a full interval would
+        // leave a player invisible for twelve seconds after walking in, which is most of
+        // the time anybody spends deciding whether a world feels inhabited.
+        if (!joined) void beat();
+        return;
+      }
+
+      // presence:away — the game has walked out of its world. Stop beating and withdraw
+      // now rather than letting the slot expire, so nobody is drawn standing where
+      // somebody used to be.
+      stop();
+      engaged = false;
+      position = null;
+      if (joined) {
+        joined = false;
+        void leavePresence(slug!);
+      }
+      announce(null);
+    }
+
+    function onVisibility() {
+      if (document.visibilityState === 'hidden') {
+        stop();
+        return;
+      }
+      if (!engaged) return;
+      // Back from a hidden tab: beat immediately rather than waiting out an interval, so
+      // the player rejoins the world at roughly the moment they look at it again.
+      void beat();
+      schedule();
+    }
+
+    window.addEventListener('message', onMessage);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      stop();
+      window.removeEventListener('message', onMessage);
+      document.removeEventListener('visibilitychange', onVisibility);
+      // Exiting the player is the most common way a session ends. Withdrawing here is
+      // what keeps the count honest: without it every other player in the world spends
+      // the rest of the TTL looking at somebody who has closed the tab.
+      if (joined) void leavePresence(slug);
+    };
+  }, [frameRef, slug]);
+}

--- a/apps/web/src/presenceApi.ts
+++ b/apps/web/src/presenceApi.ts
@@ -1,0 +1,87 @@
+// Client for ambient co-presence in a shared world (docs/persistent-world-plan.md P2.5).
+//
+// Like the world read and unlike a save, looking is public: "12 wanderers here now" is
+// most of why a shared world is worth walking into, and gating it behind a sign-in would
+// show an empty field to precisely the visitor deciding whether an account is worth
+// having. *Appearing* needs a session, and the server decides that, not this client.
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface PresencePeer {
+  /** Opaque per-world, per-process handle. Never an account identity. */
+  tag: string;
+  col: number;
+  row: number;
+}
+
+export interface PresenceSnapshot {
+  /** Everybody in the world, this visitor included when `visible`. */
+  count: number;
+  /** The others. Capped server-side, so this can be shorter than `count` implies. */
+  peers: PresencePeer[];
+  /** False for a signed-out or blocked visitor: they see the world but are not in it. */
+  visible: boolean;
+  /** How long a reported position stays fresh, as the server defines it. */
+  ttlMs: number;
+  /** The cadence the server expects. The shell follows it rather than picking its own. */
+  heartbeatMs: number;
+}
+
+/** Thrown for a failure worth another beat. No presence at all is null, not an error. */
+export class PresenceError extends Error {}
+
+async function parse(res: Response, what: string): Promise<PresenceSnapshot | null> {
+  // 404 means there is no roster here — not published, no world, or a world that
+  // declares no presence. 401 means "you may look but not appear", which the GET below
+  // answers anyway; either way the game is told the same thing and plays on.
+  if (res.status === 404) return null;
+  if (!res.ok) throw new PresenceError(`${what} (${res.status})`);
+  return (await res.json()) as PresenceSnapshot;
+}
+
+export async function fetchPresence(slug: string): Promise<PresenceSnapshot | null> {
+  const res = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/presence`, {
+    credentials: 'include',
+  });
+  return parse(res, 'Presence read failed');
+}
+
+/**
+ * One heartbeat: says this player is still here, and returns the world as they see it.
+ *
+ * Both halves in one request on purpose. Presence is the only feature on the platform
+ * that needs a periodic request at all, so the difference between one call and two is the
+ * difference between doubling that cost and not.
+ */
+export async function beatPresence(
+  slug: string,
+  position: { col: number; row: number } | null,
+): Promise<PresenceSnapshot | null> {
+  const res = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/presence`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(position ?? {}),
+  });
+  // A signed-out visitor cannot beat, but can still look — and should, because the count
+  // is the thing most likely to make them want an account. Falling back rather than
+  // giving up is what makes "sign in to be seen here" a sentence the game can say while
+  // showing the player what they are missing.
+  if (res.status === 401 || res.status === 403) return fetchPresence(slug);
+  return parse(res, 'Presence beat failed');
+}
+
+/**
+ * Withdraw from the roster.
+ *
+ * Not strictly needed — a slot expires on its own — but the gap between closing a game
+ * and expiring is the whole TTL, and during it every other player is looking at somebody
+ * who is not there. `keepalive` because this fires as the theater unmounts.
+ */
+export async function leavePresence(slug: string): Promise<void> {
+  await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/presence`, {
+    method: 'DELETE',
+    credentials: 'include',
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/docs/persistent-world-plan.md
+++ b/docs/persistent-world-plan.md
@@ -1,6 +1,6 @@
 # Persistent shared worlds — concept exploration
 
-Status: **P1 and P2 built 2026-07-28. P3's spike is done and its premise survived
+Status: **P1, P2 and P2.5 built 2026-07-28. P3's spike is done and its premise survived
 ([p3-sim-spike.md](./p3-sim-spike.md)); the phase itself is not scheduled.**
 This document answers the question
 _"if we wanted a game like Ultima Online on this platform, how could we achieve it?"_ —
@@ -9,9 +9,9 @@ written against the shipped party-mode architecture
 decomposes an MMO into steps that are each independently shippable products, so the platform
 can walk toward this without betting on the destination.
 
-**P1 (durable per-player state) and P2 (shared asynchronous worlds) are implemented and
-gated**, in both repos. P3 has been spiked but not built, and nothing beyond P2 is
-committed roadmap.
+**P1 (durable per-player state), P2 (shared asynchronous worlds) and P2.5 (ambient
+presence) are implemented and gated**, in both repos. P3 has been spiked but not built,
+and nothing beyond P2.5 is committed roadmap.
 
 ---
 
@@ -285,10 +285,93 @@ writes and another reads is the hardest part of a shared world, and a bank makes
 possible message one somebody already read. The platform moderates the field regardless,
 so a game that opens it up later changes nothing about the contract.
 
-Not built, deliberately: **presence**. Knowing who is in a world _right now_ is the
-natural next thing to want, but it is a liveness problem rather than a storage one, it
-rides the relay rather than the store, and building it here would have blurred the one
-line P2 is meant to hold — that a world is a document set with rules, not a session.
+Left out of P2 deliberately, and built afterwards as its own phase: **presence**. Knowing
+who is in a world _right now_ is the natural next thing to want, but it is a liveness
+problem rather than a storage one, and building it inside P2 would have blurred the one
+line P2 is meant to hold — that a world is a document set with rules, not a session. It
+is now P2.5, below.
+
+### P2.5 — Ambient presence (part of capability 2, without the authority) ✅ built
+
+"Someone else is here now." A player in a world game sees how many others are in the same
+world and roughly where, with **no server-authoritative simulation of any kind**. Nothing
+validates a position, nothing collides, and two players cannot affect each other's round.
+That restraint is the phase: presence is the part of capability 2 that can be delivered
+under option B, and everything that needs an arbiter stays in P3.
+
+| Piece                      | Where                                                                                                                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GameKit.createPresence()` | games repo `shared/modules/presence.ts` (+ `presence` in `GAME_KIT_MODULES`, both copies of the lockstep contract)                                                                                                    |
+| Author rules and CI        | games repo `tools/validate.ts` **Check 24** — `presence: live` frontmatter, the module, a `createPresence(` call and a `world.presence` grid must all agree, and only on a game that already declares `world: shared` |
+| The declared grid          | each game's `GAME.json` `world.presence` block, parsed by [`world-schema.ts`](../apps/api/src/world-schema.ts)                                                                                                        |
+| Shell half of the bridge   | [`apps/web/src/presence.ts`](../apps/web/src/presence.ts), mounted by `GameTheater` on the published slug                                                                                                             |
+| API                        | [`apps/api/src/presence.ts`](../apps/api/src/presence.ts) — public `GET`, session-gated `POST`/`DELETE /api/games/:slug/presence`                                                                                     |
+| Storage                    | **none** — an in-process `PresenceRegistry` with a TTL                                                                                                                                                                |
+
+**Polling, not push, and the shell owns the clock.** The obvious alternative was a socket
+on `mp.ts`, which already has rooms, admission control and join tokens. It was rejected on
+two counts. A game cannot hold a socket — sandboxed, no `connect-src` — so the shell would
+have to, which means a socket per player per world on a service still pinned at
+`--max-instances 1`, for a fact that changes on a fifteen-second timescale. And P2's
+`commons` already established that a shared world polls: one request every 12 seconds while
+the tab is visible, none at all while it is hidden. Presence rides that same shape, with the
+heartbeat and the roster read combined into one request rather than two.
+
+What is genuinely new is **where the timer lives**. Saves and world writes happen because a
+player did something; presence happens because time passed. A periodic request whose
+interval was chosen by untrusted code inside an iframe is a denial-of-service surface with
+a friendly name — so the game reports _where it is_ (`here(col, row)`, free to call every
+frame) and the shell decides _how often anybody hears about it_. A game calling `here()`
+sixty times a second produces exactly the same request rate as one calling it twice.
+
+**Freshness.** A slot survives 40 s past its last heartbeat — three missed beats, long
+enough that a phone switching networks mid-walk does not blink out, short enough that "here
+now" is not reporting somebody who closed the tab a minute ago. The TTL is handed to the
+game as `ttlMs` precisely so it can draw a peer as vaguely as the number deserves;
+`wanderers-green` draws soft glows rather than sharp figures for that reason.
+
+**Privacy: what a player's presence reveals, and for how long.** That _an account_ is in
+this world, at the tile they last reported, under an eight-character tag — and nothing else.
+For as long as they play, plus the 40 s window. Three specifics:
+
+1. **No uid ever crosses the line**, pinned by a test that serialises the whole response and
+   searches it rather than checking fields one at a time.
+2. **The presence tag is not `worldOwnerTag`.** Different salt, deliberately. Equal tags
+   would let a game tell its players that the wanderer standing over there is the one who
+   planted this — where a real person is, right now, tied to what they have built. The
+   presence salt is also random per process and never persisted, so a tag stops meaning
+   anything on the next deploy, and nobody — including us later — can recompute what it was.
+3. **The grid is capped at 64×64.** This is the number that keeps ambient presence ambient.
+   A game free to declare a 4096-wide grid would be publishing a live movement trace of a
+   real person at roughly pixel resolution, which is not what anybody agreed to when they
+   walked into a world.
+
+**Nothing is stored, and that is the privacy posture rather than a shortcut around it.**
+§7's invariant 4 says every new collection joins the erasure walk the day it is created;
+the cheapest way to honour an erasure obligation is to have nothing to erase. There is no
+presence document, no presence index, no change to `erase-player-signals.ts`, and therefore
+no new way for its indexed-reads-before-writes ordering to be broken. The registry takes no
+`Store` at all, so the absence is in the type rather than only in a comment. Two costs,
+both named rather than discovered: a deploy empties every roster (players reappear within
+one heartbeat), and rosters do not survive a second instance — the same constraint `mp.ts`
+rooms already live under, and when `--max-instances 1` falls (§8) presence needs the same
+zone-directory work rooms do, not a database.
+
+**Reads are public; appearing needs an account.** Straight from P2's lesson — a count
+nobody may look at until they sign in shows an empty world to precisely the visitor
+deciding whether an account is worth having. Requiring a session to _appear_ also settles
+inflation for free: a slot is keyed by uid, so one account is one slot however many tabs it
+opens, and there is no anonymous token anybody can mint a thousand of.
+
+**The first game that uses it** is `wanderers-green` again, which is the point: presence had
+to be something added to a world that was already worth walking alone. Its `TRACE.json`
+moved by exactly one field — `company`, which is `0` at every sampled frame, because under
+capture there is never anybody else on the green. That is the committed evidence that the
+solo round is untouched.
+
+Not built, deliberately: no catalog surface. §9 wants "Enter world — 12 online now" on a
+game's card and this phase does not provide it, because a card-level count means reading
+every world's roster on a page nobody has opened a game from yet.
 
 ### P3 — Authoritative real-time zones (capabilities 2+3+4, "the real thing")
 
@@ -515,7 +598,12 @@ section originally missed.
    The learning that cost the most: a shared world needs enough content of its own to be
    worth visiting empty, or its first visitor — and every CI capture run — sees a field
    with nothing in it.
-3. ~~**P3 paper spike only**: pick the isolate technology and write the determinism CI
+3. ~~**Presence** (P2.5): who is in a world right now~~ — **done** (see §5's P2.5). The
+   design question that turned out to matter was not polling versus push, which the
+   sandbox settles on its own, but _which side owns the timer_ — and the answer that
+   makes the feature safe is the shell, because a periodic request an iframe can set the
+   interval of is a denial-of-service surface with a friendly name.
+4. ~~**P3 paper spike only**: pick the isolate technology and write the determinism CI
    check against an existing captured game — _before_ designing anything else, because if
    agent-written sims can't reliably pass the determinism gate, P3's premise fails and we
    should know early.~~ — **done** ([p3-sim-spike.md](./p3-sim-spike.md)). It did not stay


### PR DESCRIPTION
Ambient co-presence in a shared world: a player sees how many others are in it right now and roughly where. **Paired with gamedevpl/www.gamedev.pl-games#146**, which carries the GameKit module, Check 24 and the proof game — `GAME_KIT_MODULES` moves in both, so `contract:games-repo` stays red until that one merges.

`docs/persistent-world-plan.md` gains a full **§5 P2.5** section with the design record; this description is the summary.

- [x] Design: transport, freshness, privacy posture, storage posture
- [x] `world.presence` grid in the schema, with the platform cap
- [x] API routes + in-memory TTL registry
- [x] Shell bridge (owns the clock) + API client
- [x] Privacy notice, both locales
- [x] Tests, lint, type-check green

## Design

### Polling, not push — and the shell owns the clock

A socket on `mp.ts` was the obvious alternative and lost on two counts. A game cannot hold one (sandboxed, no `connect-src`), so the **shell** would have to — which means a socket per player per world on a service still pinned at `--max-instances 1`, for a fact that changes on a fifteen-second timescale. And P2's `commons` already established the shape a shared world polls in: one request while the tab is visible, none while it is hidden. Presence rides that, with heartbeat and roster read combined into one request rather than two.

What is genuinely new is **where the timer lives**. Saves and world writes happen because a player did something. Presence happens because time passed — and a periodic request whose interval is chosen by untrusted code inside an iframe is a denial-of-service surface with a friendly name. So the game reports *where it is* (`here(col, row)`, free to call every frame) and the shell decides *how often anybody hears about it*. A game calling `here()` sixty times a second produces exactly the same request rate as one calling it twice; `presence.test.tsx` asserts precisely that.

Owning the clock also buys two things the module could not have arranged for itself: a hidden tab stops beating entirely (so the count means "is here", not "has this game open"), and closing the theater withdraws immediately rather than leaving a ghost for the whole TTL.

### Freshness

Heartbeat 12 s, TTL 40 s — three missed beats. Long enough that a phone switching networks mid-walk does not blink out; short enough that "here now" is not reporting somebody who closed the tab a minute ago. The TTL is handed to the game as `ttlMs` specifically so it can draw a peer as vaguely as the number deserves. The server names the cadence and the shell follows it, floored at 5 s, so the two halves cannot drift into disagreeing about how many missed beats a TTL is worth.

### Privacy: what a player's presence reveals, and for how long

That **an account** is in this world, at the tile they last reported, under an eight-character tag — nothing else. For as long as they play, plus the 40 s window. Three specifics, each with a test that fails loudly if it is removed:

1. **No uid crosses the line, in any field.** Asserted by serialising the whole response and searching it, rather than checking fields one at a time — so a uid smuggled into a shape nobody thought of still fails.
2. **The presence tag is deliberately not `worldOwnerTag`.** Different salt. Equal tags would let a game tell its players that the wanderer standing over there is the one who planted this — where a real person is, right now, tied to what they have built. The presence salt is also random per process and never persisted, so a tag stops meaning anything on the next deploy and nobody, us included, can recompute what it was.
3. **The grid is capped at 64×64.** This is the number that keeps ambient presence ambient. A game free to declare a 4096-wide grid would be publishing a live movement trace of a real person at roughly pixel resolution, which is not what anybody agrees to by walking into a world.

Presence is opt-in per world rather than implied by having one: storing what strangers built is not the same decision as announcing who is standing in it, and a malformed `presence` block takes the whole world schema down rather than failing open — same stance P2 takes for a bad field spec.

### Storage and the erase path

**Ephemeral, TTL-only, in memory — nothing durable, and that is the privacy posture rather than a shortcut around it.** §7's invariant 4 says every new collection joins the erasure walk the day it is created; the cheapest way to honour an erasure obligation is to have nothing to erase.

So: no presence document, no presence index, **no change to `erase-player-signals.ts`**, and therefore no new way for its indexed-reads-before-writes ordering to be broken — the invariant is intact by construction, and the tests that pin it are untouched. `PresenceRegistry` takes no `Store` at all, so the absence is visible in the type rather than only in a comment; if presence ever grows a durable half, that constructor is what has to change, in the same commit as the erase path.

Two costs, named rather than left to be discovered:

- A deploy empties every roster. Players reappear within one heartbeat.
- Rosters do not survive a second instance. That is the same constraint `mp.ts` rooms already live under at `--max-instances 1`; when that pin falls (§8), presence needs the same zone-directory work rooms do — not a database.

### Reads public, appearing gated

Straight from P2: a count nobody may look at until they sign in shows an empty world to precisely the visitor deciding whether an account is worth having. Requiring a session to *appear* also settles inflation for free — a slot is keyed by uid, so one account is one slot however many tabs it opens, and there is no anonymous token anybody can mint a thousand of.

## Surface

| Piece | Where |
| --- | --- |
| Schema | `apps/api/src/world-schema.ts` — `world.presence` grid, `MAX_PRESENCE_GRID` |
| API | `apps/api/src/presence.ts` — public `GET`, session-gated `POST`/`DELETE /api/games/:slug/presence` |
| Registry | same file — `PresenceRegistry`, LRU-bounded per world and across worlds, swept on read |
| Shell | `apps/web/src/presence.ts` + `presenceApi.ts`, mounted by `GameTheater` on the published slug |
| Privacy | `apps/web/src/legal/privacy.{en,pl}.ts` — one new row |

## Two bugs the tests caught

- A game that never opened a roster could still put the shell on the network by posting a position. `presence:here` is now inert unless the game said hello.
- `Math.trunc(-0.5)` is `-0`, which survives a structured clone and compares unequal to `0` under `Object.is`. Tile coordinates are normalised.

## One pre-existing drift fixed

Found while editing the same constant: games-repo #113 raised the `gfx3d` allowance 32,000 → 40,000 without its paired change here, so `GAMEKIT_PLATFORM_BYTES` was 8,000 short of the games repo's `MAX_BUNDLE_BYTES` and `contract:games-repo` was reporting drift on a number nothing in this PR had touched. Fixed here rather than left for the next person to rediscover — 358,027 → 366,027, which now matches `shared/assemble-contract.json` exactly. No behaviour changes with it: the constant is a serve-time assertion about what the games repo will hand us, not a limit this repo enforces.

## Two things reviewers should decide, not me

- **`LEGAL_EFFECTIVE_DATE` is untouched.** The privacy notice gains a data row in both locales, and §11 promises 14 days' notice before material changes take effect. Whether this row is material enough to bump the date and notify is an operator call.
- **No catalog surface.** §9 wants "Enter world — 12 online now" on a game's card. Not built here, because a card-level count means reading every world's roster on a page nobody has opened a game from yet.

## Checks

`npm test` (1,003 + 494 + 23 + 12 across workspaces), `npm run lint`, `npm run type-check` — all green. 19 new API tests, 17 new shell tests, 4 new schema tests. `contract:games-repo` will report drift on `GAME_KIT_MODULES` until the games-repo PR merges; that is the lockstep working, not a failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hCgviyssFPcSL2a3U3mvQ)_