### PR TITLE
Run the erasure proof nightly, as its own credential

### DIFF
--- a/.github/workflows/verify-erase.yml
+++ b/.github/workflows/verify-erase.yml
@@ -1,0 +1,74 @@
+name: Verify erasure
+
+# Re-proves the privacy notice's §8 promise against the live database, nightly.
+#
+# `apps/api/src/erase-player-signals.ts` is the executable half of "account deletion
+# removes the votes and written feedback you left on games". Its failure mode is silent:
+# `player:erase --dry-run` answering `worlds: 0` looks the same whether the person left
+# nothing or a collection-group index was renamed months ago and the query has matched
+# nothing since. Nobody would notice until a deletion request arrived and was answered
+# with a report that found nothing — which is the one moment it must not be wrong.
+#
+# So `verify:erase` plants fixtures, runs the erase path over them, reads the database
+# back after every step, and cleans up. A red X here means erasure is broken now, not
+# that it broke whenever somebody next thought to check by hand.
+#
+# Nightly rather than weekly because the interval is the bound on how long erasure could
+# be quietly broken, and a day is a defensible answer to "when did you last know this
+# worked?" where a week is harder to say out loud. The cost is a handful of Firestore
+# writes per run, all under a synthetic uid, all removed before the job exits.
+
+on:
+  # 47 minutes past, off the top of the hour where GitHub's scheduler is most contended
+  # and a delayed start is likeliest — same reasoning as publish-games.yml.
+  schedule:
+    - cron: '47 3 * * *'
+  # The manual entry point: confirming a fix, or answering "does erasure work right now?"
+  # while a deletion request is open.
+  workflow_dispatch:
+
+# Two runs mint different uids and cannot delete each other's fixtures, so overlap is
+# survivable rather than dangerous. Queued anyway: a scheduled run stacking on a manual
+# one produces two reports of the same thing and only muddies which one an operator is
+# reading.
+concurrency:
+  group: verify-erase
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: 'gamedevpl'
+      WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+      # Deliberately not github-actions-deployer. That account can ship code but has no
+      # Firestore role, and giving it one would hand every deploy the ability to read
+      # every player's data. This account is the inverse: it can touch Firestore and
+      # nothing else, and revoking it stops these runs without touching deploys.
+      WIF_SERVICE_ACCOUNT: 'erase-verifier@gamedevpl.iam.gserviceaccount.com'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+
+      # Fixtures are minted under a `verify:` uid no sign-in path can produce, in a game
+      # slug and world id no published game holds. The command takes no uid argument, so
+      # there is no way for this job to reach a real account.
+      - name: Verify erasure end to end
+        run: npm run verify:erase -w @gamedevpl/api

--- a/.github/workflows/verify-erase.yml
+++ b/.github/workflows/verify-erase.yml
@@ -43,7 +43,16 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     env:
-      PROJECT_ID: 'gamedevpl'
+      # The name the Firestore client actually reads. `new Firestore()` takes no project
+      # argument, and google-auth resolves one from GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT,
+      # the credential file, or the metadata server — a runner has no metadata server and
+      # the WIF credential file carries no project, so without this the job fails with
+      # "Unable to detect a Project Id in the current environment". Set here rather than
+      # left to whatever google-github-actions/auth happens to export, because the failure
+      # is at the end of a job that has already authenticated and looks like a broken
+      # credential rather than a missing variable. Named PROJECT_ID here once; it was
+      # read by nothing.
+      GOOGLE_CLOUD_PROJECT: 'gamedevpl'
       WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
       # Deliberately not github-actions-deployer. That account can ship code but has no
       # Firestore role, and giving it one would hand every deploy the ability to read

--- a/apps/api/src/erase-verification-workflow.test.ts
+++ b/apps/api/src/erase-verification-workflow.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The nightly erasure proof runs as its own credential, and must keep doing so.
+ *
+ * `verify:erase` needs Firestore write access, which the deploy account deliberately does
+ * not have. The tempting repair when the nightly job fails on authentication is to grant
+ * `roles/datastore.user` to `github-actions-deployer` and point the workflow at it — one
+ * line in each file, and the job goes green. What it also does is give every deploy the
+ * ability to read every player's row, permanently and invisibly, in service of a
+ * verification job that was supposed to be about protecting exactly that data.
+ *
+ * Firestore IAM cannot scope a role to collections, so the separation between the two
+ * accounts is the only boundary there is. It is a property of two text files agreeing,
+ * which is precisely the kind that erodes without a test — same reasoning as
+ * firestore-indexes.test.ts, and the same shape of guard: a lint over source text that
+ * also asserts it found what it expected, because a guard silently matching nothing reads
+ * as coverage while providing none.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+
+const workflow = readFileSync(resolve(repoRoot, '.github/workflows/verify-erase.yml'), 'utf8');
+const setupWif = readFileSync(resolve(repoRoot, 'infra/setup-wif.sh'), 'utf8');
+
+const DEPLOYER_SA = 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com';
+const VERIFIER_SA = 'erase-verifier@gamedevpl.iam.gserviceaccount.com';
+
+describe('verify-erase workflow', () => {
+  it('runs the verification command on a schedule', () => {
+    // Without the schedule this is a command nobody runs, which is the state it was built
+    // to end: erasure was last proven whenever somebody last thought to check.
+    expect(workflow).toMatch(/^\s*schedule:$/m);
+    expect(workflow).toMatch(/cron:/);
+    expect(workflow).toContain('npm run verify:erase -w @gamedevpl/api');
+  });
+
+  it('authenticates as the verifier account, never the deployer', () => {
+    expect(workflow).toContain(VERIFIER_SA);
+    expect(workflow.replace(/^\s*#.*$/gm, '')).not.toContain(DEPLOYER_SA);
+  });
+
+  it('asks for no more GitHub permission than it needs', () => {
+    // `id-token: write` is what mints the WIF assertion; `contents: read` checks the repo
+    // out. Anything beyond that is a workflow that can change the thing it is auditing.
+    expect(workflow).toMatch(/permissions:\s*\n\s*contents: read\s*\n\s*id-token: write/);
+  });
+});
+
+describe('setup-wif.sh', () => {
+  it('creates the verifier account and gives it Firestore access', () => {
+    expect(setupWif).toContain('erase-verifier');
+    expect(setupWif).toContain('roles/datastore.user');
+    // The binding, without which the workflow can authenticate as nobody.
+    expect(setupWif).toMatch(/add-iam-policy-binding "\$VERIFIER_SA_EMAIL"/);
+  });
+
+  it('keeps every Firestore role off the deploy account', () => {
+    // The whole point of two accounts. Asserted against the deployer's role list rather
+    // than the file as a whole, since the verifier's grant is in the same file.
+    const deployerRoles = setupWif.match(/^for ROLE in .*$/m)?.[0];
+    expect(deployerRoles).toBeDefined();
+    expect(deployerRoles).not.toMatch(/datastore|firestore/i);
+  });
+});

--- a/apps/api/src/erase-verification-workflow.test.ts
+++ b/apps/api/src/erase-verification-workflow.test.ts
@@ -39,6 +39,16 @@ describe('verify-erase workflow', () => {
     expect(workflow).toContain('npm run verify:erase -w @gamedevpl/api');
   });
 
+  it('names the project in a variable the Firestore client reads', () => {
+    // `new Firestore()` is constructed with no project argument, so google-auth resolves
+    // one from GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT, the credential file, or the metadata
+    // server. A runner has no metadata server and the WIF credential carries no project,
+    // so anything else — a plausible-looking PROJECT_ID, say — leaves the job failing with
+    // "Unable to detect a Project Id" after it has already authenticated, which reads as a
+    // broken credential rather than a misnamed variable.
+    expect(workflow).toMatch(/^\s*(GCLOUD_PROJECT|GOOGLE_CLOUD_PROJECT): 'gamedevpl'$/m);
+  });
+
   it('authenticates as the verifier account, never the deployer', () => {
     expect(workflow).toContain(VERIFIER_SA);
     expect(workflow.replace(/^\s*#.*$/gm, '')).not.toContain(DEPLOYER_SA);

--- a/infra/setup-wif.sh
+++ b/infra/setup-wif.sh
@@ -19,14 +19,20 @@ PROVIDER_NAME="${PROVIDER_NAME:-github-provider}"
 REPO="${REPO:-gamedevpl/www.gamedev.pl}"
 SA_NAME="${SA_NAME:-github-actions-deployer}"
 SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+# The nightly erasure proof (.github/workflows/verify-erase.yml) needs Firestore, which
+# the deployer deliberately does not have. Kept as a second account rather than a role on
+# the first: a deploy credential that can also read every player's data is a much worse
+# thing to leak, and this one can be revoked without stopping deploys.
+VERIFIER_SA_NAME="${VERIFIER_SA_NAME:-erase-verifier}"
+VERIFIER_SA_EMAIL="${VERIFIER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
-echo "==> 1/5 Creating service account '${SA_NAME}'"
+echo "==> 1/8 Creating service account '${SA_NAME}'"
 gcloud iam service-accounts create "$SA_NAME" \
   --display-name="GitHub Actions Deployer" \
   --project="$PROJECT_ID" \
   || echo "    (already exists, continuing)"
 
-echo "==> 2/5 Granting IAM roles to ${SA_EMAIL}"
+echo "==> 2/8 Granting IAM roles to ${SA_EMAIL}"
 for ROLE in roles/run.admin roles/cloudbuild.builds.editor roles/artifactregistry.writer roles/secretmanager.secretAccessor roles/iam.serviceAccountUser roles/serviceusage.serviceUsageConsumer roles/storage.admin; do
   echo "    - ${ROLE}"
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
@@ -36,7 +42,7 @@ for ROLE in roles/run.admin roles/cloudbuild.builds.editor roles/artifactregistr
     >/dev/null
 done
 
-echo "==> 3/5 Creating Workload Identity Pool '${POOL_NAME}'"
+echo "==> 3/8 Creating Workload Identity Pool '${POOL_NAME}'"
 gcloud iam workload-identity-pools create "$POOL_NAME" \
   --location="global" \
   --display-name="GitHub Actions Pool" \
@@ -48,7 +54,7 @@ POOL_ID=$(gcloud iam workload-identity-pools describe "$POOL_NAME" \
   --format="value(name)" \
   --project="$PROJECT_ID")
 
-echo "==> 4/5 Creating Workload Identity Provider '${PROVIDER_NAME}' (locked to repo: ${REPO})"
+echo "==> 4/8 Creating Workload Identity Provider '${PROVIDER_NAME}' (locked to repo: ${REPO})"
 gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_NAME" \
   --location="global" \
   --workload-identity-pool="$POOL_NAME" \
@@ -59,8 +65,38 @@ gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_NAME" \
   --project="$PROJECT_ID" \
   || echo "    (already exists, continuing)"
 
-echo "==> 5/5 Binding repository '${REPO}' to service account"
+echo "==> 5/8 Binding repository '${REPO}' to service account"
 gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${POOL_ID}/attribute.repository/${REPO}" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+
+echo "==> 6/8 Creating service account '${VERIFIER_SA_NAME}' (nightly erasure proof)"
+gcloud iam service-accounts create "$VERIFIER_SA_NAME" \
+  --display-name="Erasure Verifier" \
+  --project="$PROJECT_ID" \
+  || echo "    (already exists, continuing)"
+
+echo "==> 7/8 Granting Firestore access to ${VERIFIER_SA_EMAIL}"
+# datastore.user and nothing else. Worth being plain about what this does and does not
+# bound: Firestore IAM has no collection-level scope, so this account can read and write
+# every document in the database, not merely the fixtures it plants. What the separate
+# account buys is that the *deploy* credential still cannot, that this one can be revoked
+# on its own, and that anything it does is attributable to it rather than to CI at large.
+# The narrowing IAM cannot express is expressed in the command instead: `verify:erase`
+# takes no uid argument and can only address its own synthetic namespace.
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${VERIFIER_SA_EMAIL}" \
+  --role="roles/datastore.user" \
+  --condition=None \
+  >/dev/null
+
+echo "==> 8/8 Binding repository '${REPO}' to ${VERIFIER_SA_NAME}"
+# Same principalSet as the deployer, so any workflow in this repository can assume this
+# account. That is the pool's granularity rather than a decision made here — tightening it
+# means mapping a workflow attribute on the provider and re-binding both accounts.
+gcloud iam service-accounts add-iam-policy-binding "$VERIFIER_SA_EMAIL" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/${POOL_ID}/attribute.repository/${REPO}" \
   --project="$PROJECT_ID" \
@@ -71,4 +107,7 @@ echo "==> Done. deploy.yml should now authenticate as:"
 echo "    workload_identity_provider: ${POOL_ID}/providers/${PROVIDER_NAME}"
 echo "    service_account: ${SA_EMAIL}"
 echo ""
-echo "These already match the values hardcoded in .github/workflows/deploy.yml."
+echo "and verify-erase.yml as:"
+echo "    service_account: ${VERIFIER_SA_EMAIL}"
+echo ""
+echo "These already match the values hardcoded in .github/workflows/."


### PR DESCRIPTION
`verify:erase` (#324) proves the privacy notice's §8 promise still executes, but a command nobody runs proves it only on the day somebody remembers. The interval between runs is the bound on how long erasure could be quietly broken, and the moment it matters is a deletion request arriving — exactly when nobody wants to be finding out. Nightly makes "when did you last know this worked?" answerable in a sentence, at a cost of a handful of Firestore writes under a synthetic uid, all removed before the job exits.

### It runs as its own service account

`erase-verifier`, not `github-actions-deployer`. The deploy account has no Firestore role and this does not give it one.

The failure mode being designed against is a specific future repair: when the nightly job fails on authentication, the one-line fix is to grant `roles/datastore.user` to the deployer and point the workflow at it. That works, goes green, and hands every deploy the ability to read every player's row — in service of a job meant to protect that data. Firestore IAM cannot scope a role to collections, so two accounts is the only boundary available.

`erase-verification-workflow.test.ts` pins both halves, and was mutation-checked against precisely that repair: adding a datastore role to the deployer's role list fails, and pointing the workflow at the deployer fails.

Being plain about what this does *not* bound: `roles/datastore.user` lets the verifier read and write every document, not merely its fixtures. What the separate account buys is that the deploy credential still cannot, that it is revocable on its own, and that its actions are attributable to it rather than to CI at large. The narrowing IAM cannot express is expressed in the command instead — `verify:erase` takes no uid argument, so the credential can only reach its own synthetic namespace however it is invoked. The WIF binding is also repo-wide, matching the deployer's; tightening that means mapping a workflow attribute on the provider and re-binding both accounts, which is a larger change than this one.

### Before this can go green

`infra/setup-wif.sh` grew three steps (6–8) to create the account, grant it `roles/datastore.user`, and bind it to the pool. It is idempotent, so re-running it is safe — **it needs to be run once before the first scheduled fire**, or the job fails on authentication.

Full API suite green (998 tests across 65 files), lint, type-check and prettier clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRVNkEx7A3x4uS691UHz79)_