### PR TITLE
Header mascot mimes scrolling on a pocket phone

### DIFF
--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -212,6 +212,49 @@ describe('Mascot', () => {
     });
   });
 
+  it('mounts the pocket phone only when scrolling is driven, and toggles the live class', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'idle', size: 35, className: 'mascot--logo' }));
+    });
+    expect(container.querySelector('.mascot__phone')).toBeNull();
+
+    await act(async () => {
+      root.render(
+        createElement(Mascot, {
+          emotion: 'idle',
+          size: 35,
+          className: 'mascot--logo',
+          scrolling: false,
+        }),
+      );
+    });
+    expect(container.querySelector('.mascot__phone')).not.toBeNull();
+    expect(container.querySelector('.mascot--scrolling')).toBeNull();
+    expect(container.querySelector('.mascot__phone-feed-track')).not.toBeNull();
+    expect(container.querySelector('.mascot__phone-thumb')).not.toBeNull();
+
+    await act(async () => {
+      root.render(
+        createElement(Mascot, {
+          emotion: 'idle',
+          size: 35,
+          className: 'mascot--logo',
+          scrolling: true,
+        }),
+      );
+    });
+    expect(container.querySelector('.mascot.mascot--scrolling')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   // Regression: the body used to be one <rect> per span. Separate rects are
   // composited separately, so an antialiasing renderer left a seam on every row —
   // horizontal banding on the body, speckle once downscaled. One path fills solid.

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -6,11 +6,16 @@
  * (`MASCOT_SOLID_SPANS`), then punch new eyes/mouth via an SVG mask.
  *
  * Animation lives in layered SVG groups + CSS (bob, bounce, sway, blink lids,
- * waving arm). `staticPose` freezes everything; `prefers-reduced-motion` does too.
+ * waving arm, scroll-phone mime). `staticPose` freezes everything;
+ * `prefers-reduced-motion` does too.
  *
  * `InteractiveMascot` wraps the SVG in a button: hover peeks, click cycles
  * reactions, and the face tracks the pointer a little. With `reactsToTilt` he also
  * leans with the phone's own orientation and gets dizzy when it is shaken.
+ *
+ * Pass `scrolling` (boolean) on the header mark: he pulls a tiny phone and mimes
+ * scrolling a feed while the page moves. Omit the prop everywhere else so the
+ * phone markup never lands on splash / empty-state instances.
  */
 
 import {
@@ -45,6 +50,13 @@ type MascotProps = {
   staticPose?: boolean;
   /** Nudge face cutouts toward a point — no-op on the baked idle silhouette. */
   look?: MascotLook;
+  /**
+   * When set, mounts the pocket-phone prop and toggles `mascot--scrolling` so CSS
+   * can pull it out and scroll the fake feed. Always pass a boolean from the
+   * header (true while the page is scrolling) so put-away can transition; omit on
+   * every other instance.
+   */
+  scrolling?: boolean;
 };
 
 type Span = readonly [number, number, number];
@@ -281,16 +293,87 @@ function BlinkLids() {
   );
 }
 
-export function Mascot({ emotion = 'idle', size = 48, className, title, staticPose = false, look }: MascotProps) {
+/**
+ * Pocket phone the header mark pulls while the page scrolls.
+ *
+ * Kept inside the 70×60 viewBox so mobile's `overflow: hidden` on the logo still
+ * shows the gag. The bezel is `currentColor` (turquoise); the screen is dark so
+ * the scrolling feed bars read as content, not chrome.
+ */
+function ScrollPhone({ clipId }: { clipId: string }) {
+  return (
+    <g className="mascot__phone" aria-hidden="true">
+      <path
+        className="mascot__phone-arm"
+        d="M50 44 Q56 40 58 34"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+      />
+      <g className="mascot__phone-device">
+        <rect className="mascot__phone-bezel" x="50" y="20" width="15" height="24" rx="2" fill="currentColor" />
+        <rect className="mascot__phone-screen" x="52" y="23" width="11" height="18" rx="0.8" fill="#071018" />
+        <defs>
+          <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+            <rect x="52" y="23" width="11" height="18" rx="0.8" />
+          </clipPath>
+        </defs>
+        <g className="mascot__phone-feed" clipPath={`url(#${clipId})`}>
+          <g className="mascot__phone-feed-track" fill="currentColor">
+            <rect x="53.2" y="12" width="8.6" height="1.6" rx="0.4" opacity="0.85" />
+            <rect x="53.2" y="15.2" width="6.2" height="1.2" rx="0.3" opacity="0.4" />
+            <rect x="53.2" y="18.4" width="8.6" height="1.6" rx="0.4" opacity="0.75" />
+            <rect x="53.2" y="21.6" width="5.4" height="1.2" rx="0.3" opacity="0.35" />
+            <rect x="53.2" y="24.8" width="8.6" height="1.6" rx="0.4" opacity="0.9" />
+            <rect x="53.2" y="28" width="7" height="1.2" rx="0.3" opacity="0.4" />
+            <rect x="53.2" y="31.2" width="8.6" height="1.6" rx="0.4" opacity="0.8" />
+            <rect x="53.2" y="34.4" width="5.8" height="1.2" rx="0.3" opacity="0.35" />
+            <rect x="53.2" y="37.6" width="8.6" height="1.6" rx="0.4" opacity="0.85" />
+            <rect x="53.2" y="40.8" width="6.4" height="1.2" rx="0.3" opacity="0.4" />
+            <rect x="53.2" y="44" width="8.6" height="1.6" rx="0.4" opacity="0.75" />
+            <rect x="53.2" y="47.2" width="5.2" height="1.2" rx="0.3" opacity="0.35" />
+          </g>
+        </g>
+        <ellipse
+          className="mascot__phone-thumb"
+          cx="63.5"
+          cy="34"
+          rx="2.2"
+          ry="3.4"
+          fill="currentColor"
+        />
+      </g>
+    </g>
+  );
+}
+
+export function Mascot({
+  emotion = 'idle',
+  size = 48,
+  className,
+  title,
+  staticPose = false,
+  look,
+  scrolling,
+}: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
+  const phoneClipId = `mascot-phone-clip-${reactId}`;
   const height = Math.round((size * 60) / 70);
-  const classes = ['mascot', `mascot--${emotion}`, staticPose ? 'mascot--static' : null, className]
+  const classes = [
+    'mascot',
+    `mascot--${emotion}`,
+    staticPose ? 'mascot--static' : null,
+    scrolling ? 'mascot--scrolling' : null,
+    className,
+  ]
     .filter(Boolean)
     .join(' ');
   const cutouts = cutoutsFor(emotion);
   const isIdle = emotion === 'idle' || cutouts == null;
   const showWaveArm = emotion === 'wave' || emotion === 'excited';
+  const showPhone = scrolling !== undefined;
   // Keep the nudge small — past ~3px the mouth starts to clip the silhouette.
   const lookTransform =
     look && !isIdle ? `translate(${(look.x * 2.4).toFixed(2)} ${(look.y * 1.8).toFixed(2)})` : undefined;
@@ -343,6 +426,8 @@ export function Mascot({ emotion = 'idle', size = 48, className, title, staticPo
             <path d="M64 36 Q70 26 67 14" />
           </g>
         ) : null}
+
+        {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
       </g>
     </svg>
   );

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -296,51 +296,65 @@ function BlinkLids() {
 /**
  * Pocket phone the header mark pulls while the page scrolls.
  *
- * Kept inside the 70×60 viewBox so mobile's `overflow: hidden` on the logo still
- * shows the gag. The bezel is `currentColor` (turquoise); the screen is dark so
- * the scrolling feed bars read as content, not chrome.
+ * Sized for the 35px logo mark (0.5 of the 70-unit viewBox). A phone that fits
+ * politely next to him disappears at that scale — same lesson as the idle hop —
+ * so this one is chunky and overlaps his lower-right body. The bezel is dark with
+ * a turquoise stroke: a same-colour bezel dissolved into his body and the gag
+ * became invisible. Still inside the viewBox so mobile's `overflow: hidden` on
+ * the logo does not clip it.
  */
 function ScrollPhone({ clipId }: { clipId: string }) {
   return (
     <g className="mascot__phone" aria-hidden="true">
       <path
         className="mascot__phone-arm"
-        d="M50 44 Q56 40 58 34"
+        d="M46 48 Q54 44 56 36"
         fill="none"
         stroke="currentColor"
-        strokeWidth="2.6"
+        strokeWidth="3.2"
         strokeLinecap="round"
       />
       <g className="mascot__phone-device">
-        <rect className="mascot__phone-bezel" x="50" y="20" width="15" height="24" rx="2" fill="currentColor" />
-        <rect className="mascot__phone-screen" x="52" y="23" width="11" height="18" rx="0.8" fill="#071018" />
+        <rect
+          className="mascot__phone-bezel"
+          x="46"
+          y="14"
+          width="22"
+          height="34"
+          rx="2.6"
+          fill="#0a121c"
+          stroke="currentColor"
+          strokeWidth="1.8"
+        />
+        <rect className="mascot__phone-screen" x="49" y="18" width="16" height="26" rx="1.2" fill="#152033" />
         <defs>
           <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
-            <rect x="52" y="23" width="11" height="18" rx="0.8" />
+            <rect x="49" y="18" width="16" height="26" rx="1.2" />
           </clipPath>
         </defs>
         <g className="mascot__phone-feed" clipPath={`url(#${clipId})`}>
           <g className="mascot__phone-feed-track" fill="currentColor">
-            <rect x="53.2" y="12" width="8.6" height="1.6" rx="0.4" opacity="0.85" />
-            <rect x="53.2" y="15.2" width="6.2" height="1.2" rx="0.3" opacity="0.4" />
-            <rect x="53.2" y="18.4" width="8.6" height="1.6" rx="0.4" opacity="0.75" />
-            <rect x="53.2" y="21.6" width="5.4" height="1.2" rx="0.3" opacity="0.35" />
-            <rect x="53.2" y="24.8" width="8.6" height="1.6" rx="0.4" opacity="0.9" />
-            <rect x="53.2" y="28" width="7" height="1.2" rx="0.3" opacity="0.4" />
-            <rect x="53.2" y="31.2" width="8.6" height="1.6" rx="0.4" opacity="0.8" />
-            <rect x="53.2" y="34.4" width="5.8" height="1.2" rx="0.3" opacity="0.35" />
-            <rect x="53.2" y="37.6" width="8.6" height="1.6" rx="0.4" opacity="0.85" />
-            <rect x="53.2" y="40.8" width="6.4" height="1.2" rx="0.3" opacity="0.4" />
-            <rect x="53.2" y="44" width="8.6" height="1.6" rx="0.4" opacity="0.75" />
-            <rect x="53.2" y="47.2" width="5.2" height="1.2" rx="0.3" opacity="0.35" />
+            {/* Period is 8 units — keyframes translate by -16 so the loop is seamless. */}
+            <rect x="50.5" y="6" width="13" height="3.2" rx="0.7" opacity="0.95" />
+            <rect x="50.5" y="11" width="9" height="2.2" rx="0.5" opacity="0.45" />
+            <rect x="50.5" y="14" width="13" height="3.2" rx="0.7" opacity="0.9" />
+            <rect x="50.5" y="19" width="10" height="2.2" rx="0.5" opacity="0.4" />
+            <rect x="50.5" y="22" width="13" height="3.2" rx="0.7" opacity="0.95" />
+            <rect x="50.5" y="27" width="9" height="2.2" rx="0.5" opacity="0.45" />
+            <rect x="50.5" y="30" width="13" height="3.2" rx="0.7" opacity="0.9" />
+            <rect x="50.5" y="35" width="10" height="2.2" rx="0.5" opacity="0.4" />
+            <rect x="50.5" y="38" width="13" height="3.2" rx="0.7" opacity="0.95" />
+            <rect x="50.5" y="43" width="9" height="2.2" rx="0.5" opacity="0.45" />
+            <rect x="50.5" y="46" width="13" height="3.2" rx="0.7" opacity="0.9" />
+            <rect x="50.5" y="51" width="10" height="2.2" rx="0.5" opacity="0.4" />
           </g>
         </g>
         <ellipse
           className="mascot__phone-thumb"
-          cx="63.5"
-          cy="34"
-          rx="2.2"
-          ry="3.4"
+          cx="65.5"
+          cy="30"
+          rx="3.2"
+          ry="5"
           fill="currentColor"
         />
       </g>

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -6,6 +6,7 @@ import { LanguageSwitcher } from './LanguageSwitcher.js';
 import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
+import { usePageScrolling } from './usePageScrolling.js';
 import githubIcon from './assets/github-mark-white.svg';
 
 type NavHeaderProps = {
@@ -23,6 +24,8 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio }: Na
   const { user, logout } = useAuth();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  // Header mark mimes the visitor: pull a phone and scroll a tiny feed while the page moves.
+  const pageScrolling = usePageScrolling();
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -41,7 +44,13 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio }: Na
     <header className="app-header">
       <div className="logo-brand">
         <a href="/" className="logo" onClick={handleLogoClick}>
-          <Mascot className="mascot--logo" emotion="idle" size={35} title={t('header.logoAlt')} />
+          <Mascot
+            className="mascot--logo"
+            emotion="idle"
+            size={35}
+            title={t('header.logoAlt')}
+            scrolling={pageScrolling}
+          />
           gamedev<span className="turquoise">.pl</span>
         </a>
       </div>

--- a/apps/web/src/headerMascot.test.ts
+++ b/apps/web/src/headerMascot.test.ts
@@ -11,15 +11,26 @@ import { describe, expect, it } from 'vitest';
  * Both halves of that are asserted from source rather than from a render: the prop is
  * a one-word regression that a rendered-DOM test would have to reach through
  * AuthContext and i18n to catch, and the hover rule has no DOM footprint at all.
+ *
+ * The scroll-phone mime is the same kind of regression: wiring lives in NavHeader +
+ * CSS, and a DOM test would need a full header mount just to prove a class name.
  */
 const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, import.meta.url)), 'utf8');
 
 describe('the header mascot is alive', () => {
   it('does not freeze the nav mark', () => {
     const navHeader = read('NavHeader.tsx');
-    const logoMascot = navHeader.match(/<Mascot[^>]*mascot--logo[^>]*\/>/s);
+    const logoMascot = navHeader.match(/<Mascot[\s\S]*?\/>/);
     expect(logoMascot).not.toBeNull();
     expect(logoMascot![0]).not.toMatch(/staticPose/);
+    expect(logoMascot![0]).toMatch(/mascot--logo/);
+  });
+
+  it('wires page scrolling into the logo mark so he can mime a phone scroll', () => {
+    const navHeader = read('NavHeader.tsx');
+    expect(navHeader).toMatch(/usePageScrolling/);
+    const logoMascot = navHeader.match(/<Mascot[\s\S]*?\/>/);
+    expect(logoMascot![0]).toMatch(/scrolling=\{pageScrolling\}/);
   });
 
   it('promotes the idle breath to a hop while the logo is hovered', () => {
@@ -52,11 +63,29 @@ describe('the header mascot is alive', () => {
     expect(hoverAt).toBeGreaterThan(idleAt);
   });
 
+  it('parks the idle hop for a phone lean while the page is scrolling', () => {
+    const css = read('styles.css');
+    expect(css).toMatch(
+      /\.mascot\.mascot--logo:not\(\.mascot--static\)\.mascot--scrolling \.mascot__body-group/,
+    );
+    expect(css).toMatch(/animation: mascot-logo-scroll-lean/);
+    expect(css).toMatch(/@keyframes mascot-phone-feed/);
+    expect(css).toMatch(/@keyframes mascot-phone-thumb/);
+    // Scrolling lean must beat both idle and hover, or the hop keeps fighting the phone.
+    const scrollAt = css.indexOf(
+      '.mascot.mascot--logo:not(.mascot--static).mascot--scrolling .mascot__body-group',
+    );
+    const hoverAt = css.indexOf('.logo:hover .mascot--logo:not(.mascot--static) .mascot__body-group');
+    expect(scrollAt).toBeGreaterThan(hoverAt);
+  });
+
   it('still lets prefers-reduced-motion win over both', () => {
     const css = read('styles.css');
     const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
     // `!important` is what beats the hover rule — a plain `animation: none` there
     // loses to it on specificity and the hop would survive the media query.
     expect(reduced).toMatch(/\.mascot \.mascot__body-group,[\s\S]{0,200}?animation: none !important/);
+    // Phone mime is motion by definition — hide the prop under reduced motion too.
+    expect(reduced).toMatch(/\.mascot \.mascot__phone-device/);
   });
 });

--- a/apps/web/src/headerMascot.test.ts
+++ b/apps/web/src/headerMascot.test.ts
@@ -17,20 +17,23 @@ import { describe, expect, it } from 'vitest';
  */
 const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, import.meta.url)), 'utf8');
 
+/** The header mark specifically — not whichever `<Mascot` happens to appear first. */
+function logoMascotSource(navHeader: string): string {
+  const match = navHeader.match(/<Mascot[\s\S]*?mascot--logo[\s\S]*?\/>/);
+  expect(match).not.toBeNull();
+  return match![0];
+}
+
 describe('the header mascot is alive', () => {
   it('does not freeze the nav mark', () => {
-    const navHeader = read('NavHeader.tsx');
-    const logoMascot = navHeader.match(/<Mascot[\s\S]*?\/>/);
-    expect(logoMascot).not.toBeNull();
-    expect(logoMascot![0]).not.toMatch(/staticPose/);
-    expect(logoMascot![0]).toMatch(/mascot--logo/);
+    const markup = logoMascotSource(read('NavHeader.tsx'));
+    expect(markup).not.toMatch(/staticPose/);
   });
 
   it('wires page scrolling into the logo mark so he can mime a phone scroll', () => {
     const navHeader = read('NavHeader.tsx');
     expect(navHeader).toMatch(/usePageScrolling/);
-    const logoMascot = navHeader.match(/<Mascot[\s\S]*?\/>/);
-    expect(logoMascot![0]).toMatch(/scrolling=\{pageScrolling\}/);
+    expect(logoMascotSource(navHeader)).toMatch(/scrolling=\{pageScrolling\}/);
   });
 
   it('promotes the idle breath to a hop while the logo is hovered', () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5013,6 +5013,98 @@ body.player-open {
   animation: mascot-bounce 0.55s ease-in-out infinite;
 }
 
+/*
+ * Scroll mime — the header mark pulls a pocket phone and pretends to scroll a feed
+ * while the visitor scrolls the page. Phone stays inside the 70×60 viewBox so the
+ * mobile logo's overflow:hidden still shows it. Put-away is a CSS transition so the
+ * phone can tuck away after `mascot--scrolling` drops, rather than vanishing.
+ */
+.mascot__phone {
+  pointer-events: none;
+}
+
+.mascot__phone-arm {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.mascot__phone-device {
+  opacity: 0;
+  transform: translate(2px, 16px) rotate(22deg);
+  transform-origin: 57px 44px;
+  transition:
+    opacity 0.22s ease,
+    transform 0.38s cubic-bezier(0.34, 1.35, 0.64, 1);
+}
+
+.mascot__phone-thumb {
+  transform-origin: 63.5px 30px;
+}
+
+.mascot:not(.mascot--static).mascot--scrolling .mascot__phone-arm {
+  opacity: 1;
+  transition-delay: 0.08s;
+}
+
+.mascot:not(.mascot--static).mascot--scrolling .mascot__phone-device {
+  opacity: 1;
+  transform: translate(0, 0) rotate(-8deg);
+}
+
+.mascot:not(.mascot--static).mascot--scrolling .mascot__phone-feed-track {
+  animation: mascot-phone-feed 0.85s linear infinite;
+}
+
+.mascot:not(.mascot--static).mascot--scrolling .mascot__phone-thumb {
+  animation: mascot-phone-thumb 0.85s ease-in-out infinite;
+}
+
+/*
+ * While he is on the phone, park the idle hop and lean toward the screen instead —
+ * otherwise the hop fights the phone pull and the gag reads as two animations at once.
+ * Same five-class weight as the logo idle rule so source order decides the winner;
+ * this rule must stay below that idle and above (or after) the hover hop.
+ */
+.mascot.mascot--logo:not(.mascot--static).mascot--scrolling .mascot__body-group,
+.logo:hover .mascot--logo:not(.mascot--static).mascot--scrolling .mascot__body-group {
+  animation: mascot-logo-scroll-lean 1.1s ease-in-out infinite;
+}
+
+@keyframes mascot-logo-scroll-lean {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  40% {
+    transform: translateY(1px) rotate(4deg);
+  }
+  70% {
+    transform: translateY(0) rotate(2deg);
+  }
+}
+
+@keyframes mascot-phone-feed {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-12.8px);
+  }
+}
+
+@keyframes mascot-phone-thumb {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  45% {
+    transform: translateY(4px);
+  }
+  55% {
+    transform: translateY(4px);
+  }
+}
+
 .mascot-moment {
   display: flex;
   flex-direction: column;
@@ -5316,8 +5408,17 @@ body.player-open {
   .mascot .mascot__body-group,
   .mascot .mascot__lid,
   .mascot .mascot__wave-arm,
-  .mascot .mascot__eyes {
+  .mascot .mascot__eyes,
+  .mascot .mascot__phone-feed-track,
+  .mascot .mascot__phone-thumb {
     animation: none !important;
+  }
+
+  .mascot .mascot__phone-arm,
+  .mascot .mascot__phone-device {
+    transition: none !important;
+    opacity: 0 !important;
+    transform: none !important;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5030,33 +5030,33 @@ body.player-open {
 
 .mascot__phone-device {
   opacity: 0;
-  transform: translate(2px, 16px) rotate(22deg);
-  transform-origin: 57px 44px;
+  transform: translate(4px, 22px) rotate(28deg) scale(0.55);
+  transform-origin: 57px 48px;
   transition:
-    opacity 0.22s ease,
-    transform 0.38s cubic-bezier(0.34, 1.35, 0.64, 1);
+    opacity 0.2s ease,
+    transform 0.42s cubic-bezier(0.34, 1.45, 0.64, 1);
 }
 
 .mascot__phone-thumb {
-  transform-origin: 63.5px 30px;
+  transform-origin: 65.5px 24px;
 }
 
 .mascot:not(.mascot--static).mascot--scrolling .mascot__phone-arm {
   opacity: 1;
-  transition-delay: 0.08s;
+  transition-delay: 0.06s;
 }
 
 .mascot:not(.mascot--static).mascot--scrolling .mascot__phone-device {
   opacity: 1;
-  transform: translate(0, 0) rotate(-8deg);
+  transform: translate(0, 0) rotate(-10deg) scale(1);
 }
 
 .mascot:not(.mascot--static).mascot--scrolling .mascot__phone-feed-track {
-  animation: mascot-phone-feed 0.85s linear infinite;
+  animation: mascot-phone-feed 0.7s linear infinite;
 }
 
 .mascot:not(.mascot--static).mascot--scrolling .mascot__phone-thumb {
-  animation: mascot-phone-thumb 0.85s ease-in-out infinite;
+  animation: mascot-phone-thumb 0.7s ease-in-out infinite;
 }
 
 /*
@@ -5067,7 +5067,7 @@ body.player-open {
  */
 .mascot.mascot--logo:not(.mascot--static).mascot--scrolling .mascot__body-group,
 .logo:hover .mascot--logo:not(.mascot--static).mascot--scrolling .mascot__body-group {
-  animation: mascot-logo-scroll-lean 1.1s ease-in-out infinite;
+  animation: mascot-logo-scroll-lean 0.9s ease-in-out infinite;
 }
 
 @keyframes mascot-logo-scroll-lean {
@@ -5076,10 +5076,10 @@ body.player-open {
     transform: translateY(0) rotate(0deg);
   }
   40% {
-    transform: translateY(1px) rotate(4deg);
+    transform: translateY(1px) rotate(5deg);
   }
   70% {
-    transform: translateY(0) rotate(2deg);
+    transform: translateY(0) rotate(3deg);
   }
 }
 
@@ -5088,7 +5088,7 @@ body.player-open {
     transform: translateY(0);
   }
   to {
-    transform: translateY(-12.8px);
+    transform: translateY(-16px);
   }
 }
 
@@ -5097,11 +5097,11 @@ body.player-open {
   100% {
     transform: translateY(0);
   }
-  45% {
-    transform: translateY(4px);
+  40% {
+    transform: translateY(7px);
   }
   55% {
-    transform: translateY(4px);
+    transform: translateY(7px);
   }
 }
 

--- a/apps/web/src/usePageScrolling.test.ts
+++ b/apps/web/src/usePageScrolling.test.ts
@@ -142,6 +142,42 @@ describe('usePageScrolling', () => {
     });
   });
 
+  it('lets slow sub-threshold steps accumulate into a real scroll', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, settleMs: 200, thresholdPx: 3 }));
+    });
+
+    // Three 1px steps never each clear the threshold, but together they do —
+    // lastY must stay put until the threshold is met, or a trackpad crawl is silent.
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 1;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 2;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 3;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('stays false when prefers-reduced-motion is on', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     stubMatchMedia(true);

--- a/apps/web/src/usePageScrolling.test.ts
+++ b/apps/web/src/usePageScrolling.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePageScrolling } from './usePageScrolling.js';
+
+function Probe({
+  onChange,
+  settleMs,
+  thresholdPx,
+}: {
+  onChange: (scrolling: boolean) => void;
+  settleMs?: number;
+  thresholdPx?: number;
+}) {
+  const scrolling = usePageScrolling({ settleMs, thresholdPx });
+  useEffect(() => {
+    onChange(scrolling);
+  }, [scrolling, onChange]);
+  return null;
+}
+
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>();
+  const media = {
+    matches,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: (_: string, listener: () => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_: string, listener: () => void) => {
+      listeners.delete(listener);
+    },
+    addListener: (listener: () => void) => {
+      listeners.add(listener);
+    },
+    removeListener: (listener: () => void) => {
+      listeners.delete(listener);
+    },
+    dispatchEvent: () => false,
+  };
+  vi.stubGlobal('matchMedia', () => media);
+  return {
+    setMatches(next: boolean) {
+      media.matches = next;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+describe('usePageScrolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubMatchMedia(false);
+    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 0 });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('stays false until the page actually moves', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, settleMs: 200 }));
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    // First scroll only seeds lastY — no delta yet.
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('turns true on a real scroll delta and settles after the idle window', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, settleMs: 200, thresholdPx: 2 }));
+    });
+
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 40;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('ignores sub-threshold jitter', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, settleMs: 200, thresholdPx: 5 }));
+    });
+
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 3;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('stays false when prefers-reduced-motion is on', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    stubMatchMedia(true);
+    const onChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Probe, { onChange, settleMs: 200 }));
+    });
+
+    await act(async () => {
+      (window as Window & { scrollY: number }).scrollY = 80;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/usePageScrolling.ts
+++ b/apps/web/src/usePageScrolling.ts
@@ -14,7 +14,7 @@ export type UsePageScrollingOptions = {
   thresholdPx?: number;
 };
 
-const DEFAULT_SETTLE_MS = 480;
+const DEFAULT_SETTLE_MS = 700;
 const DEFAULT_THRESHOLD_PX = 2;
 
 export function usePageScrolling(options: UsePageScrollingOptions = {}): boolean {

--- a/apps/web/src/usePageScrolling.ts
+++ b/apps/web/src/usePageScrolling.ts
@@ -71,9 +71,15 @@ export function usePageScrolling(options: UsePageScrollingOptions = {}): boolean
     const onScroll = () => {
       const y = window.scrollY || document.documentElement.scrollTop || 0;
       const prev = lastY.current;
-      lastY.current = y;
-      if (prev == null) return;
+      if (prev == null) {
+        lastY.current = y;
+        return;
+      }
+      // Leave `lastY` alone until the threshold is met so slow 1px trackpad
+      // steps accumulate against the last committed position instead of each
+      // resetting the baseline and never firing.
       if (Math.abs(y - prev) < thresholdPx) return;
+      lastY.current = y;
       markScrolling();
     };
 

--- a/apps/web/src/usePageScrolling.ts
+++ b/apps/web/src/usePageScrolling.ts
@@ -1,0 +1,97 @@
+/**
+ * True while the page is being scrolled, then false shortly after it settles.
+ *
+ * Used by the header mark so he can pull a phone and mime scrolling along with
+ * the visitor. Opted out under `prefers-reduced-motion` — the gag is motion.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+export type UsePageScrollingOptions = {
+  /** How long after the last scroll event before we call it settled. */
+  settleMs?: number;
+  /** Ignore sub-pixel / trackpad noise below this many CSS pixels. */
+  thresholdPx?: number;
+};
+
+const DEFAULT_SETTLE_MS = 480;
+const DEFAULT_THRESHOLD_PX = 2;
+
+export function usePageScrolling(options: UsePageScrollingOptions = {}): boolean {
+  const settleMs = options.settleMs ?? DEFAULT_SETTLE_MS;
+  const thresholdPx = options.thresholdPx ?? DEFAULT_THRESHOLD_PX;
+  const [scrolling, setScrolling] = useState(false);
+  const lastY = useRef<number | null>(null);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollingRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    let reduceMotion = false;
+    let media: MediaQueryList | null = null;
+    const syncReduce = () => {
+      reduceMotion = media?.matches ?? false;
+      if (reduceMotion && scrollingRef.current) {
+        scrollingRef.current = false;
+        setScrolling(false);
+      }
+    };
+    if (typeof matchMedia === 'function') {
+      media = matchMedia('(prefers-reduced-motion: reduce)');
+      syncReduce();
+      if (typeof media.addEventListener === 'function') {
+        media.addEventListener('change', syncReduce);
+      } else {
+        media.addListener(syncReduce);
+      }
+    }
+
+    const clearSettle = () => {
+      if (settleTimer.current) {
+        clearTimeout(settleTimer.current);
+        settleTimer.current = null;
+      }
+    };
+
+    const markScrolling = () => {
+      if (reduceMotion) return;
+      if (!scrollingRef.current) {
+        scrollingRef.current = true;
+        setScrolling(true);
+      }
+      clearSettle();
+      settleTimer.current = setTimeout(() => {
+        scrollingRef.current = false;
+        setScrolling(false);
+        settleTimer.current = null;
+      }, settleMs);
+    };
+
+    const onScroll = () => {
+      const y = window.scrollY || document.documentElement.scrollTop || 0;
+      const prev = lastY.current;
+      lastY.current = y;
+      if (prev == null) return;
+      if (Math.abs(y - prev) < thresholdPx) return;
+      markScrolling();
+    };
+
+    lastY.current = window.scrollY || document.documentElement.scrollTop || 0;
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      clearSettle();
+      if (media) {
+        if (typeof media.removeEventListener === 'function') {
+          media.removeEventListener('change', syncReduce);
+        } else {
+          media.removeListener(syncReduce);
+        }
+      }
+    };
+  }, [settleMs, thresholdPx]);
+
+  return scrolling;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the visitor scrolls the page, the header logo mascot pulls out a tiny phone and pretends to scroll a feed on its screen — then puts the phone away once scrolling settles.

[mascot-scroll-phone-demo.mp4](https://cursor.com/agents/bc-019fada5-61b7-7bee-8386-4c2aa40fba42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmascot-scroll-phone-demo.mp4)

[Scrolling with phone](https://cursor.com/agents/bc-019fada5-61b7-7bee-8386-4c2aa40fba42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-scrolling.png)

## Details

- New `usePageScrolling` hook: true while the window is scrolling, false ~700ms after it stops; no-ops under `prefers-reduced-motion`
- `Mascot` accepts optional `scrolling`; when set, mounts a pocket-phone SVG prop (dark bezel + turquoise outline, scrolling feed bars, flicking thumb) and toggles `mascot--scrolling`
- CSS: phone pull-out / put-away transitions, feed + thumb loops, idle hop replaced by a slight lean while on the phone
- Phone stays inside the 70×60 viewBox so mobile `overflow: hidden` on the logo still shows it
- Wired only on the NavHeader logo mark
- Sized and contrasted for the 35px mark (same lesson as the idle hop): a same-colour bezel was invisible against his body

## Copilot review

Addressed both comments:
1. **Slow-scroll threshold** — `lastY` no longer advances on sub-threshold deltas, so 1px trackpad steps accumulate
2. **Brittle logo source test** — match is pinned to `mascot--logo` and null-checked via a helper

## Test plan

- [x] Unit tests for `usePageScrolling`, Mascot phone mount/class toggle, and header source/CSS regressions
- [x] Green gate (`type-check`, `lint`, `test`, `build`)
- [x] Headless Chrome: scroll adds `mascot--scrolling`, phone opacity → 1, settles after idle
- [x] Demo video: idle → phone + scrolling feed → tuck away
- [x] Copilot review fixes + regression test for accumulated slow scrolls
- [ ] Manually: open home, scroll — mascot pulls phone and feed scrolls; stop — phone tucks away
- [ ] Manually: `prefers-reduced-motion` — no phone mime
- [ ] Manually: mobile narrow header — phone still visible inside the mark


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fada5-61b7-7bee-8386-4c2aa40fba42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fada5-61b7-7bee-8386-4c2aa40fba42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

