### PR TITLE
Align game theater overflow menu for mobile UX

### DIFF
--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -115,4 +115,19 @@ describe('GameTheater more menu', () => {
 
     expect(container.querySelector('.theater-more.is-open')).toBeNull();
   });
+
+  it('keeps menu-row icons the same size so labels share one left edge', async () => {
+    await draw();
+    const panel = container.querySelector('.theater-more-panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    const icons = panel.querySelectorAll(
+      '.theater-menu-item > svg, .feedback-btn > svg, .share-btn > svg, .report-btn > svg',
+    );
+    expect(icons.length).toBeGreaterThanOrEqual(3);
+
+    const widths = [...icons].map((icon) => icon.getAttribute('width'));
+    expect(new Set(widths).size).toBe(1);
+    expect(widths[0]).toBe('13');
+  });
 });

--- a/apps/web/src/ReportGameButton.tsx
+++ b/apps/web/src/ReportGameButton.tsx
@@ -46,7 +46,7 @@ export function ReportGameButton({ slug, title }: { slug: string; title: string 
       aria-label={t('report.action')}
       title={t('report.action')}
     >
-      <PixelIcon name="flag" size={12} />
+      <PixelIcon name="flag" size={13} />
       <span className="btn-label">{t('report.action')}</span>
     </a>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1651,18 +1651,17 @@ body.player-open {
   outline: none;
 }
 
-/* Fixed icon column so every label starts on the same x — pixel glyphs have uneven
-   ink bounds, and Report previously rendered at a smaller size than the others. */
+/* Fixed icon column without CSS-scaling the SVG — PixelIcon’s width/height
+   attributes stay authoritative (15×15 crispEdges grid). Equal size={13} props
+   already put every label on the same x; flex:none keeps the glyph from
+   stretching inside the row. */
 .game-theater-actions .theater-more-panel .theater-menu-item > svg,
 .game-theater-actions .theater-more-panel .share-btn > svg,
 .game-theater-actions .theater-more-panel .report-btn > svg,
 .game-theater-actions .theater-more-panel .feedback-btn > svg {
-  flex: 0 0 18px;
-  width: 18px;
-  height: 18px;
+  flex: none;
   display: block;
   margin: 0;
-  vertical-align: unset;
 }
 
 .game-theater-actions .theater-more-panel .btn-label {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1578,9 +1578,9 @@ body.player-open {
   z-index: 40;
   flex-direction: column;
   align-items: stretch;
-  gap: 4px;
+  gap: 2px;
   min-width: 220px;
-  padding: 8px;
+  padding: 6px;
   border-radius: 12px;
   background: rgba(22, 28, 34, 0.96);
   -webkit-backdrop-filter: blur(16px);
@@ -1596,24 +1596,30 @@ body.player-open {
   display: flex;
 }
 
+/* Full-bleed within the panel padding — inset margins made the rule look off-center
+   against equally padded rows. */
 .theater-menu-divider {
   height: 1px;
-  margin: 4px 6px;
+  margin: 4px 0;
   background: var(--panel-border);
   border: 0;
+  align-self: stretch;
 }
 
-/* Uniform menu rows — strip the mismatched secondary-btn / ghost / solid looks. */
-.theater-more-panel .theater-menu-item,
-.theater-more-panel .share-btn,
-.theater-more-panel .report-btn,
-.theater-more-panel .feedback-btn {
+/* Uniform menu rows — strip the mismatched secondary-btn / ghost / solid looks.
+   Specificity beats `.game-theater-actions button` so gap/padding stay consistent
+   even though the panel lives inside the actions row. */
+.game-theater-actions .theater-more-panel .theater-menu-item,
+.game-theater-actions .theater-more-panel .share-btn,
+.game-theater-actions .theater-more-panel .report-btn,
+.game-theater-actions .theater-more-panel .feedback-btn {
   display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-start;
+  gap: 12px;
   width: 100%;
   margin: 0;
-  padding: 10px 14px;
+  padding: 10px 12px;
   min-height: 44px;
   border-radius: 8px;
   border: 1px solid transparent;
@@ -1622,31 +1628,54 @@ body.player-open {
   font: inherit;
   font-size: 0.95rem;
   font-weight: 500;
+  line-height: 1.25;
   text-decoration: none;
   text-align: left;
   cursor: pointer;
   box-shadow: none;
+  box-sizing: border-box;
 }
 
-.theater-more-panel .theater-menu-item:hover,
-.theater-more-panel .theater-menu-item:focus-visible,
-.theater-more-panel .share-btn:hover,
-.theater-more-panel .share-btn:focus-visible,
-.theater-more-panel .report-btn:hover,
-.theater-more-panel .report-btn:focus-visible,
-.theater-more-panel .feedback-btn:hover,
-.theater-more-panel .feedback-btn:focus-visible {
+.game-theater-actions .theater-more-panel .theater-menu-item:hover,
+.game-theater-actions .theater-more-panel .theater-menu-item:focus-visible,
+.game-theater-actions .theater-more-panel .share-btn:hover,
+.game-theater-actions .theater-more-panel .share-btn:focus-visible,
+.game-theater-actions .theater-more-panel .report-btn:hover,
+.game-theater-actions .theater-more-panel .report-btn:focus-visible,
+.game-theater-actions .theater-more-panel .feedback-btn:hover,
+.game-theater-actions .theater-more-panel .feedback-btn:focus-visible {
   background: rgba(0, 228, 172, 0.12);
   color: var(--turquoise);
   border-color: transparent;
   outline: none;
 }
 
+/* Fixed icon column so every label starts on the same x — pixel glyphs have uneven
+   ink bounds, and Report previously rendered at a smaller size than the others. */
+.game-theater-actions .theater-more-panel .theater-menu-item > svg,
+.game-theater-actions .theater-more-panel .share-btn > svg,
+.game-theater-actions .theater-more-panel .report-btn > svg,
+.game-theater-actions .theater-more-panel .feedback-btn > svg {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  display: block;
+  margin: 0;
+  vertical-align: unset;
+}
+
+.game-theater-actions .theater-more-panel .btn-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: block;
+  line-height: 1.25;
+}
+
 /* Hidden on desktop; the matching media query reveals them as menu rows on a phone.
    Must come after the shared `.theater-menu-item { display: flex }` rule and beat it
    on specificity, or those rows stay visible on wide screens too. */
-.theater-more-panel .theater-menu-item.theater-mobile-chrome,
-.theater-more-panel .theater-menu-divider.theater-mobile-chrome {
+.game-theater-actions .theater-more-panel .theater-menu-item.theater-mobile-chrome,
+.game-theater-actions .theater-more-panel .theater-menu-divider.theater-mobile-chrome {
   display: none;
 }
 
@@ -1656,10 +1685,6 @@ body.player-open {
 
 .theater-more-panel .feedback-btn {
   width: 100%;
-}
-
-.theater-more-panel .btn-label {
-  display: inline;
 }
 
 /* Written player feedback: a header control like the vote widget, but revealing a
@@ -1888,21 +1913,26 @@ body.player-open {
     display: none !important;
   }
 
-  .theater-more-panel .theater-menu-item.theater-mobile-chrome {
+  .game-theater-actions .theater-more-panel .theater-menu-item.theater-mobile-chrome {
     display: flex;
   }
 
-  .theater-more-panel .theater-menu-divider.theater-mobile-chrome {
+  .game-theater-actions .theater-more-panel .theater-menu-divider.theater-mobile-chrome {
     display: block;
   }
 
+  /* Align the menu with the right edge of the action cluster (exit sits past the
+     hamburger: 44px thumb target + 6px gap). Flush with the trigger alone left a
+     gap under the close control that read as misaligned on phones. */
   .theater-more-panel {
-    min-width: 200px;
+    right: calc(-1 * (44px + 6px));
+    min-width: 220px;
+    max-width: min(280px, calc(100vw - 24px));
   }
 
   /* Labels stay visible inside the open menu — icon-only there is opaque. */
   .theater-more-panel .btn-label {
-    display: inline !important;
+    display: block !important;
   }
 }
 
@@ -1916,8 +1946,11 @@ body.player-open {
     font-size: 0.85rem;
   }
 
-  .game-theater-actions button,
-  .game-theater-actions .report-btn {
+  /* Shrink bar chrome only — leave the overflow menu rows at their thumb target. */
+  .game-theater-actions > button,
+  .game-theater-actions .theater-more-btn,
+  .game-theater-actions .exit-btn,
+  .game-theater-actions > .report-btn {
     min-height: 36px;
     padding: 7px 9px;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1579,10 +1579,11 @@ body.player-open {
   flex-direction: column;
   align-items: stretch;
   gap: 2px;
-  min-width: 220px;
-  padding: 6px;
+  min-width: 240px;
+  padding: 8px;
   border-radius: 12px;
-  background: rgba(22, 28, 34, 0.96);
+  /* Near-opaque so menu rows stay readable over bright game pixels underneath. */
+  background: rgba(16, 22, 28, 0.98);
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
   border: 1px solid var(--panel-border);
@@ -1596,12 +1597,12 @@ body.player-open {
   display: flex;
 }
 
-/* Full-bleed within the panel padding — inset margins made the rule look off-center
-   against equally padded rows. */
+/* Full-bleed within the panel padding. Use a lighter hairline than --panel-border
+   so the rule stays visible against the near-opaque panel fill. */
 .theater-menu-divider {
   height: 1px;
-  margin: 4px 0;
-  background: var(--panel-border);
+  margin: 6px 0;
+  background: rgba(255, 255, 255, 0.12);
   border: 0;
   align-self: stretch;
 }
@@ -1619,7 +1620,7 @@ body.player-open {
   gap: 12px;
   width: 100%;
   margin: 0;
-  padding: 10px 12px;
+  padding: 12px 14px;
   min-height: 44px;
   border-radius: 8px;
   border: 1px solid transparent;
@@ -1926,8 +1927,8 @@ body.player-open {
      gap under the close control that read as misaligned on phones. */
   .theater-more-panel {
     right: calc(-1 * (44px + 6px));
-    min-width: 220px;
-    max-width: min(280px, calc(100vw - 24px));
+    min-width: 240px;
+    max-width: min(300px, calc(100vw - 24px));
   }
 
   /* Labels stay visible inside the open menu — icon-only there is opaque. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes misalignments in the game player “more” dropdown (hamburger menu) so it meets common mobile overflow-menu patterns.

[Aligned mobile overflow menu](https://cursor.com/agents/bc-019fadd1-39e9-7c13-92f0-e2a68e4afa0a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmenu-mobile-polished-390.png)

### What was wrong
- Report used a smaller icon (`12`) than Sound / Feedback / Share (`13`), so labels didn’t share a left edge
- No fixed icon column — uneven pixel-glyph ink made the icon stack look jagged
- Divider used asymmetric inset margins and a near-invisible color against the panel
- Panel was right-aligned only to the hamburger, leaving a gap under the close control
- Landscape bar-shrink rules also hit menu rows and broke their padding
- Menu rows lost gap/padding to lower-specificity `.game-theater-actions button` rules

### Fix
- Consistent icon size (`13`) for every menu row; `flex: none` layout without CSS-scaling the SVG (keeps the 15×15 crispEdges grid sharp)
- Balanced row padding (`12px 14px`), 44px+ touch targets, and a full-bleed visible divider
- On narrow screens, align the panel with the right edge of the action cluster (hamburger + exit)
- Raise selector specificity so theater-actions button rules don’t override menu gap/padding
- Near-opaque panel fill so labels stay readable over bright game pixels
- Regression test that menu-row icons share one size

### Copilot review
Addressed: stopped overriding `PixelIcon` width/height via CSS (would scale 15→18 and risk blur).

## Test plan
- [x] Open a published game on a phone-width viewport, open the hamburger menu
- [x] Confirm icons form a straight column and labels share one left edge
- [x] Confirm divider spans the panel evenly and is visible
- [x] Confirm menu right edge lines up with the exit button
- [x] `npm run type-check && npm run lint && npm run test` (targeted + prior full green gate)
- [ ] Spot-check desktop: sound/fullscreen still on the bar; more menu still usable

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fadd1-39e9-7c13-92f0-e2a68e4afa0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fadd1-39e9-7c13-92f0-e2a68e4afa0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

