### PR TITLE
Splash mascot occasionally does pull-ups on the card rim

### DIFF
--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -40,6 +40,7 @@ export function ClosedBetaSplash() {
           className="beta-splash__mascot"
           idleEmotion="wave"
           reactsToTilt
+          doesPullUps
           size={96}
           pokeLabel={t('mascot.poke')}
         />

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -223,12 +223,13 @@ describe('Mascot', () => {
     });
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__legs-together')).not.toBeNull();
+    expect(container.querySelector('.mascot__hang-limb-covers')).not.toBeNull();
+    expect(container.querySelector('.mascot__feet-together')).not.toBeNull();
     expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
     expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
     // Arms flex with the body; only the grip hands sit outside.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__body-group .mascot__legs-together')).not.toBeNull();
+    expect(container.querySelector('.mascot__body-group .mascot__feet-together')).not.toBeNull();
     expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).toBeNull();
     expect(container.querySelector('.mascot--hanging')).not.toBeNull();
@@ -238,7 +239,8 @@ describe('Mascot', () => {
     });
     expect(container.querySelector('.mascot__hang-arms')).toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
-    expect(container.querySelector('.mascot__legs-together')).toBeNull();
+    expect(container.querySelector('.mascot__hang-limb-covers')).toBeNull();
+    expect(container.querySelector('.mascot__feet-together')).toBeNull();
     expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
 
@@ -469,17 +471,16 @@ describe('InteractiveMascot', () => {
   it('still peeks on hover when prefers-reduced-motion is set', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const originalMatchMedia = window.matchMedia;
-    window.matchMedia = ((query: string) =>
-      ({
-        matches: query.includes('prefers-reduced-motion'),
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      })) as typeof window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -556,17 +557,16 @@ describe('InteractiveMascot', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.useFakeTimers();
     const originalMatchMedia = window.matchMedia;
-    window.matchMedia = ((query: string) =>
-      ({
-        matches: query.includes('prefers-reduced-motion'),
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      })) as typeof window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
 
     const { PULLUP_FIRST_DELAY_MS } = await import('./Mascot.js');
     const container = document.createElement('div');

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -212,7 +212,7 @@ describe('Mascot', () => {
     });
   });
 
-  it('draws raised arms from the shoulders when hanging, and hides the wave arm', async () => {
+  it('uses the baked silhouette when hanging — no redrawn limbs — and seals the mouth', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -221,26 +221,19 @@ describe('Mascot', () => {
     await act(async () => {
       root.render(createElement(Mascot, { emotion: 'wave', hanging: true, size: 48 }));
     });
-    expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
-    expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__hang-limb-covers')).not.toBeNull();
-    expect(container.querySelector('.mascot__feet-together')).not.toBeNull();
+    // No fake raised arms / covered stubs / merged feet — those looked wrong.
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
+    expect(container.querySelector('.mascot__hang-limb-covers')).toBeNull();
+    expect(container.querySelector('.mascot__feet-together')).toBeNull();
     expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
     expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
-    // Arms flex with the body; only the grip hands sit outside.
-    expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__body-group .mascot__feet-together')).not.toBeNull();
-    expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).toBeNull();
     expect(container.querySelector('.mascot--hanging')).not.toBeNull();
 
     await act(async () => {
       root.render(createElement(Mascot, { emotion: 'wave', hanging: false, size: 48 }));
     });
-    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
-    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
-    expect(container.querySelector('.mascot__hang-limb-covers')).toBeNull();
-    expect(container.querySelector('.mascot__feet-together')).toBeNull();
     expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
 
@@ -525,25 +518,24 @@ describe('InteractiveMascot', () => {
 
     const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive')!;
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
-    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
 
     await act(async () => {
       vi.advanceTimersByTime(PULLUP_FIRST_DELAY_MS);
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
-    expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
-    expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
     expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
     expect(container.querySelector('.mascot--proud')).not.toBeNull();
-    // Hands are outside the body group so chin-ups can bob the body alone.
-    expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
-    expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
+    expect(container.querySelector('.mascot--hanging')).not.toBeNull();
+    // No redrawn limbs — silhouette stays intact.
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
-    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
     expect(container.querySelector('.mascot--excited')).not.toBeNull();
 
     await act(async () => {

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -225,8 +225,8 @@ describe('Mascot', () => {
     expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
     expect(container.querySelector('.mascot__arm-stub-covers')).not.toBeNull();
     expect(container.querySelector('.mascot__legs-together')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-hold')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-breathe')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-hold')).toBeNull();
     // Arms flex with the body; only the grip hands sit outside.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
     expect(container.querySelector('.mascot__body-group .mascot__legs-together')).not.toBeNull();
@@ -533,7 +533,7 @@ describe('InteractiveMascot', () => {
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-hold')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
     expect(container.querySelector('.mascot--proud')).not.toBeNull();
     // Hands are outside the body group so chin-ups can bob the body alone.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -520,7 +520,9 @@ describe('InteractiveMascot', () => {
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
-    expect(container.querySelector('.mascot--busy')).not.toBeNull();
+    expect(container.querySelector('.mascot--proud')).not.toBeNull();
+    // Hands are outside the body group so chin-ups can bob the body alone.
+    expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -212,30 +212,19 @@ describe('Mascot', () => {
     });
   });
 
-  it('uses the baked silhouette when hanging — no redrawn limbs — and seals the mouth', async () => {
+  it('does not take a hanging pose prop — pull-ups are motion on InteractiveMascot', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
     await act(async () => {
-      root.render(createElement(Mascot, { emotion: 'wave', hanging: true, size: 48 }));
+      root.render(createElement(Mascot, { emotion: 'wave', size: 48 }));
     });
-    // No fake raised arms / covered stubs / merged feet — those looked wrong.
-    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
-    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
-    expect(container.querySelector('.mascot__hang-limb-covers')).toBeNull();
-    expect(container.querySelector('.mascot__feet-together')).toBeNull();
-    expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
-    expect(container.querySelector('.mascot__wave-arm')).toBeNull();
-    expect(container.querySelector('.mascot--hanging')).not.toBeNull();
-
-    await act(async () => {
-      root.render(createElement(Mascot, { emotion: 'wave', hanging: false, size: 48 }));
-    });
-    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
+    expect(container.querySelector('.mascot--wave')).not.toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
+    expect(container.querySelector('.mascot--hanging')).toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -518,24 +507,20 @@ describe('InteractiveMascot', () => {
 
     const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive')!;
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
-    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
 
     await act(async () => {
       vi.advanceTimersByTime(PULLUP_FIRST_DELAY_MS);
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
-    expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
-    expect(container.querySelector('.mascot--proud')).not.toBeNull();
-    expect(container.querySelector('.mascot--hanging')).not.toBeNull();
-    // No redrawn limbs — silhouette stays intact.
-    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
-    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
+    // Still the splash wave guy — identity stays, motion does the gag.
+    expect(container.querySelector('.mascot--wave')).not.toBeNull();
+    expect(container.querySelector('.mascot--hanging')).toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
-    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
     expect(container.querySelector('.mascot--excited')).not.toBeNull();
 
     await act(async () => {

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -212,7 +212,7 @@ describe('Mascot', () => {
     });
   });
 
-  it('draws hang arms when hanging, and hides the wave arm', async () => {
+  it('draws raised arms from the shoulders when hanging, and hides the wave arm', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -222,6 +222,15 @@ describe('Mascot', () => {
       root.render(createElement(Mascot, { emotion: 'wave', hanging: true, size: 48 }));
     });
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
+    expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
+    expect(container.querySelector('.mascot__arm-stub-covers')).not.toBeNull();
+    expect(container.querySelector('.mascot__legs-together')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-hold')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-breathe')).not.toBeNull();
+    // Arms flex with the body; only the grip hands sit outside.
+    expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
+    expect(container.querySelector('.mascot__body-group .mascot__legs-together')).not.toBeNull();
+    expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).toBeNull();
     expect(container.querySelector('.mascot--hanging')).not.toBeNull();
 
@@ -229,6 +238,9 @@ describe('Mascot', () => {
       root.render(createElement(Mascot, { emotion: 'wave', hanging: false, size: 48 }));
     });
     expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
+    expect(container.querySelector('.mascot__arm-stub-covers')).toBeNull();
+    expect(container.querySelector('.mascot__legs-together')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
 
     await act(async () => {
@@ -520,9 +532,12 @@ describe('InteractiveMascot', () => {
     });
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
+    expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth--hang-hold')).not.toBeNull();
     expect(container.querySelector('.mascot--proud')).not.toBeNull();
     // Hands are outside the body group so chin-ups can bob the body alone.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -223,10 +223,9 @@ describe('Mascot', () => {
     });
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__arm-stub-covers')).not.toBeNull();
     expect(container.querySelector('.mascot__legs-together')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
     expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-hold')).toBeNull();
     // Arms flex with the body; only the grip hands sit outside.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arm-strokes')).not.toBeNull();
     expect(container.querySelector('.mascot__body-group .mascot__legs-together')).not.toBeNull();
@@ -239,8 +238,8 @@ describe('Mascot', () => {
     });
     expect(container.querySelector('.mascot__hang-arms')).toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).toBeNull();
-    expect(container.querySelector('.mascot__arm-stub-covers')).toBeNull();
     expect(container.querySelector('.mascot__legs-together')).toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).toBeNull();
     expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
 
     await act(async () => {
@@ -533,7 +532,7 @@ describe('InteractiveMascot', () => {
     expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
     expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
     expect(container.querySelector('.mascot__hang-arm-strokes')).not.toBeNull();
-    expect(container.querySelector('.mascot__mouth--hang-breath')).not.toBeNull();
+    expect(container.querySelector('.mascot__mouth-seal')).not.toBeNull();
     expect(container.querySelector('.mascot--proud')).not.toBeNull();
     // Hands are outside the body group so chin-ups can bob the body alone.
     expect(container.querySelector('.mascot__body-group .mascot__hang-arms')).toBeNull();

--- a/apps/web/src/Mascot.test.tsx
+++ b/apps/web/src/Mascot.test.tsx
@@ -212,6 +212,30 @@ describe('Mascot', () => {
     });
   });
 
+  it('draws hang arms when hanging, and hides the wave arm', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'wave', hanging: true, size: 48 }));
+    });
+    expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
+    expect(container.querySelector('.mascot__wave-arm')).toBeNull();
+    expect(container.querySelector('.mascot--hanging')).not.toBeNull();
+
+    await act(async () => {
+      root.render(createElement(Mascot, { emotion: 'wave', hanging: false, size: 48 }));
+    });
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot__wave-arm')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('mounts the pocket phone only when scrolling is driven, and toggles the live class', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement('div');
@@ -461,6 +485,93 @@ describe('InteractiveMascot', () => {
     expect(container.querySelector('.mascot--curious')).not.toBeNull();
     // Tilt/look stay off under reduced motion.
     expect(container.querySelector('.mascot__face-features')?.getAttribute('transform')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('occasionally climbs for pull-ups when idle, and a poke cancels them', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    const { PULLUP_FIRST_DELAY_MS, PULLUP_SESSION_MS } = await import('./Mascot.js');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(InteractiveMascot, {
+          pokeLabel: 'Poke',
+          idleEmotion: 'wave',
+          doesPullUps: true,
+          size: 64,
+        }),
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('button.mascot-interactive')!;
+    expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(PULLUP_FIRST_DELAY_MS);
+    });
+    expect(button.classList.contains('mascot-interactive--pullups')).toBe(true);
+    expect(container.querySelector('.mascot__hang-arms')).not.toBeNull();
+    expect(container.querySelector('.mascot--busy')).not.toBeNull();
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(button.classList.contains('mascot-interactive--pullups')).toBe(false);
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
+    expect(container.querySelector('.mascot--excited')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    // Silence unused if tree-shaken oddly — session length is part of the contract with CSS.
+    expect(PULLUP_SESSION_MS).toBeGreaterThan(0);
+  });
+
+  it('skips pull-ups under prefers-reduced-motion', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+
+    const { PULLUP_FIRST_DELAY_MS } = await import('./Mascot.js');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(InteractiveMascot, {
+          pokeLabel: 'Poke',
+          doesPullUps: true,
+          size: 64,
+        }),
+      );
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(PULLUP_FIRST_DELAY_MS + 1_000);
+    });
+    expect(container.querySelector('.mascot-interactive--pullups')).toBeNull();
+    expect(container.querySelector('.mascot__hang-arms')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -212,7 +212,7 @@ const MOUTH_CURIOUS =
   'M20 13 L24 20 L28 12 L32 21 L36 11 L40 21 L44 12 L48 20 L52 13 L52 32 L48 26 L44 34 L40 25 L36 35 L32 26 L28 34 L24 27 L20 32 Z';
 const MOUTH_BUSY =
   'M20 13 L25 20 L30 12 L35 21 L40 11 L45 21 L50 13 L50 32 L45 26 L40 34 L35 25 L30 33 L25 26 L20 31 Z';
-/** Open mouth — scaled flat in CSS to seal the lips at each chin-up peak. */
+/** Open mouth while hanging — sealed by `.mascot__mouth-seal` at chin-up peaks. */
 const MOUTH_HANG_BREATHE = 'M26 18 C30 30 40 30 44 18 C40 26 30 26 26 18 Z';
 
 // Traced once at module load — the spans never change.
@@ -220,9 +220,8 @@ const IDLE_PATH = spansToOutlinePath(MASCOT_IDLE_SPANS);
 const SOLID_PATH = spansToOutlinePath(MASCOT_SOLID_SPANS);
 
 function cutoutsFor(emotion: MascotEmotion, hanging = false): ReactElement | null {
-  // Pull-ups: one mouth shape, CSS scaleY seals it at chin-up peaks (hold breath)
-  // and opens it on the way down (breathe). Dual-opacity cutouts inside SVG masks
-  // were unreliable about which state won at the peak.
+  // Pull-ups: open mouth cutout stays punched; a body-coloured seal outside the
+  // mask covers it at chin-up peaks (hold breath) and lifts on the way down.
   if (hanging) {
     return (
       <>
@@ -316,28 +315,12 @@ function BlinkLids() {
 }
 
 /**
- * Cover the silhouette's baked side-arm stubs so a second pair of hands does not
- * show under the raised arms. Filled with the splash card panel colour.
- * Lives inside `.mascot__body-group` so it rides the chin-up with the torso.
- */
-function ArmStubCovers() {
-  return (
-    <g className="mascot__arm-stub-covers" aria-hidden="true">
-      <rect className="mascot__arm-stub-cover mascot__arm-stub-cover--left" x="2.5" y="40.5" width="7.5" height="13" rx="1.2" />
-      <rect className="mascot__arm-stub-cover mascot__arm-stub-cover--right" x="60" y="40.5" width="7.5" height="12" rx="1.2" />
-    </g>
-  );
-}
-
-/**
- * Merge the silhouette's split feet into one dangling column while hanging —
- * legs together for the chin-ups. Erase uses the card panel colour; the replacement
- * shape is body-coloured.
+ * One dangling column while hanging — the hang clip path has already removed the
+ * baked split feet, so this just paints the replacement.
  */
 function LegsTogether() {
   return (
     <g className="mascot__legs-together" aria-hidden="true">
-      <rect className="mascot__legs-together-erase" x="19.5" y="49" width="31" height="11" />
       <path
         className="mascot__legs-together-shape"
         fill="currentColor"
@@ -382,6 +365,24 @@ function HangHands() {
       <ellipse className="mascot__hang-hand mascot__hang-hand--left" cx="14" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
       <ellipse className="mascot__hang-hand mascot__hang-hand--right" cx="56" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
     </g>
+  );
+}
+
+/**
+ * Body-coloured plug that seals the open hang-mouth hole at chin-up peaks.
+ * Lives outside the face mask so the breath animation is not fighting mask opacity.
+ */
+function HangMouthSeal() {
+  return (
+    <ellipse
+      className="mascot__mouth-seal"
+      cx="35"
+      cy="24"
+      rx="11"
+      ry="9"
+      fill="currentColor"
+      aria-hidden="true"
+    />
   );
 }
 
@@ -466,6 +467,7 @@ export function Mascot({
 }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
+  const hangClipId = `mascot-hang-clip-${reactId}`;
   const phoneClipId = `mascot-phone-clip-${reactId}`;
   const height = Math.round((size * 60) / 70);
   const classes = [
@@ -502,33 +504,53 @@ export function Mascot({
       {title ? <title>{title}</title> : null}
 
       <g className="mascot__body-group">
-        {isIdle ? (
-          <g className="mascot__pixels" fill="currentColor">
-            <path d={IDLE_PATH} />
-          </g>
-        ) : (
-          <>
-            <defs>
-              <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
-                <path fill="#fff" d={SOLID_PATH} />
-                <g fill="#000" className="mascot__face-features" transform={lookTransform}>
-                  {cutouts}
-                </g>
-              </mask>
-            </defs>
-            <rect
-              className="mascot__face"
-              x="0"
-              y="0"
-              width="70"
-              height="60"
-              fill="currentColor"
-              mask={`url(#${maskId})`}
-            />
-          </>
-        )}
+        {hanging ? (
+          <defs>
+            {/*
+              Clip off baked side stubs and the split feet so raised arms + the
+              merged leg are the only limbs. More reliable than painting panel-coloured
+              covers (those fail if the card background is not exactly `--panel`).
+            */}
+            <clipPath id={hangClipId} clipPathUnits="userSpaceOnUse">
+              <path
+                d={
+                  'M0 0H70V60H0ZM2 40H10.5V54H2ZM59.5 40H68V53H59.5ZM20 49H31V60H20ZM39 49H50V60H39Z'
+                }
+                clipRule="evenodd"
+              />
+            </clipPath>
+          </defs>
+        ) : null}
 
-        {hanging ? <ArmStubCovers /> : null}
+        <g clipPath={hanging ? `url(#${hangClipId})` : undefined}>
+          {isIdle ? (
+            <g className="mascot__pixels" fill="currentColor">
+              <path d={IDLE_PATH} />
+            </g>
+          ) : (
+            <>
+              <defs>
+                <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
+                  <path fill="#fff" d={SOLID_PATH} />
+                  <g fill="#000" className="mascot__face-features" transform={lookTransform}>
+                    {cutouts}
+                  </g>
+                </mask>
+              </defs>
+              <rect
+                className="mascot__face"
+                x="0"
+                y="0"
+                width="70"
+                height="60"
+                fill="currentColor"
+                mask={`url(#${maskId})`}
+              />
+            </>
+          )}
+        </g>
+
+        {hanging ? <HangMouthSeal /> : null}
         {hanging ? <LegsTogether /> : null}
         {hanging ? <HangArmStrokes /> : null}
 

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -62,8 +62,8 @@ type MascotProps = {
   /**
    * Reach both arms up to grip the splash card's top border. Raised arm strokes
    * ride with the body; hands stay outside `.mascot__body-group` on the rim so
-   * chin-ups bob the torso toward a planted grip. Side stubs are covered so he
-   * does not grow a second pair of hands.
+   * chin-ups bob the torso toward a planted grip. Baked side stubs and splayed
+   * feet are covered so he keeps one pair of each.
    */
   hanging?: boolean;
 };
@@ -315,39 +315,50 @@ function BlinkLids() {
 }
 
 /**
- * One dangling column while hanging — the hang clip path has already removed the
- * baked split feet, so this just paints the replacement.
+ * Paint out the silhouette's side-arm stubs and splayed feet while hanging.
+ * Uses the splash card panel colour — more reliable than nested SVG masks, which
+ * left the stubs visible on top of the raised arms.
  */
-function LegsTogether() {
+function HangLimbCovers() {
   return (
-    <g className="mascot__legs-together" aria-hidden="true">
-      <path
-        className="mascot__legs-together-shape"
-        fill="currentColor"
-        d="M29.5 49h11v8c0 2.1-2.1 3.2-5.5 3.2S29.5 59.1 29.5 57z"
-      />
+    <g className="mascot__hang-limb-covers" aria-hidden="true">
+      <rect className="mascot__hang-cover mascot__hang-cover--arm-left" x="1" y="36" width="12" height="18" rx="1" />
+      <rect className="mascot__hang-cover mascot__hang-cover--arm-right" x="57" y="36" width="12" height="17" rx="1" />
+      <rect className="mascot__hang-cover mascot__hang-cover--foot-left" x="19" y="48.5" width="13" height="11.5" />
+      <rect className="mascot__hang-cover mascot__hang-cover--foot-right" x="38" y="48.5" width="13" height="11.5" />
     </g>
   );
 }
 
 /**
- * Raised arms from the shoulders up toward the rim. Inside the body group so they
- * tuck toward the fixed hands on each chin-up (reads as arms flexing, not a second
- * floating pair grown from the head).
+ * Two stubby feet drawn close together — not one merged column (that read as a
+ * single awkward appendage). The hang covers have already erased the splayed pair.
+ */
+function FeetTogether() {
+  return (
+    <g className="mascot__feet-together" aria-hidden="true" fill="currentColor">
+      <rect className="mascot__foot mascot__foot--left" x="26" y="50" width="7" height="8" rx="2" />
+      <rect className="mascot__foot mascot__foot--right" x="37" y="50" width="7" height="8" rx="2" />
+    </g>
+  );
+}
+
+/**
+ * Raised arms from the shoulders up to the rim. Chunkier filled shapes so they
+ * read as his real arms moved up, not thin sticks grown from the head.
+ * Inside the body group so they tuck toward the fixed hands on each chin-up.
  */
 function HangArmStrokes() {
   return (
-    <g
-      className="mascot__hang-arm-strokes"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="7"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path className="mascot__hang-arm mascot__hang-arm--left" d="M9 39 C5 28 7 14 14 4" />
-      <path className="mascot__hang-arm mascot__hang-arm--right" d="M61 39 C65 28 63 14 56 4" />
+    <g className="mascot__hang-arm-strokes" fill="currentColor" aria-hidden="true">
+      <path
+        className="mascot__hang-arm mascot__hang-arm--left"
+        d="M12 37 C8 29 9 18 13 6 C14.5 4.5 16 4.5 17 6 C14 17 15 28 17 37 Z"
+      />
+      <path
+        className="mascot__hang-arm mascot__hang-arm--right"
+        d="M58 37 C62 29 61 18 57 6 C55.5 4.5 54 4.5 53 6 C56 17 55 28 53 37 Z"
+      />
     </g>
   );
 }
@@ -364,18 +375,18 @@ function HangHands() {
     <g className="mascot__hang-arms" aria-hidden="true">
       <ellipse
         className="mascot__hang-hand mascot__hang-hand--left"
-        cx="14"
-        cy="2.4"
-        rx="5.2"
-        ry="2.9"
+        cx="15"
+        cy="2.6"
+        rx="5.5"
+        ry="3"
         fill="currentColor"
       />
       <ellipse
         className="mascot__hang-hand mascot__hang-hand--right"
-        cx="56"
-        cy="2.4"
-        rx="5.2"
-        ry="2.9"
+        cx="55"
+        cy="2.6"
+        rx="5.5"
+        ry="3"
         fill="currentColor"
       />
     </g>
@@ -466,7 +477,6 @@ export function Mascot({
 }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
-  const hangClipId = `mascot-hang-clip-${reactId}`;
   const phoneClipId = `mascot-phone-clip-${reactId}`;
   const height = Math.round((size * 60) / 70);
   const classes = [
@@ -503,54 +513,41 @@ export function Mascot({
       {title ? <title>{title}</title> : null}
 
       <g className="mascot__body-group">
-        {hanging ? (
-          <defs>
-            {/*
-              Mask off baked side stubs and the split feet so raised arms + the
-              merged leg are the only limbs. A mask (white keep / black drop) is
-              more reliable across browsers than an evenodd clipPath with holes.
-            */}
-            <mask id={hangClipId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
-              <rect x="0" y="0" width="70" height="60" fill="#fff" />
-              <rect x="1.5" y="38" width="10" height="16" fill="#000" />
-              <rect x="58.5" y="38" width="10" height="15" fill="#000" />
-              <rect x="19" y="48.5" width="12.5" height="11.5" fill="#000" />
-              <rect x="38.5" y="48.5" width="12.5" height="11.5" fill="#000" />
-            </mask>
-          </defs>
-        ) : null}
+        {isIdle ? (
+          <g className="mascot__pixels" fill="currentColor">
+            <path d={IDLE_PATH} />
+          </g>
+        ) : (
+          <>
+            <defs>
+              <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
+                <path fill="#fff" d={SOLID_PATH} />
+                <g fill="#000" className="mascot__face-features" transform={lookTransform}>
+                  {cutouts}
+                </g>
+              </mask>
+            </defs>
+            <rect
+              className="mascot__face"
+              x="0"
+              y="0"
+              width="70"
+              height="60"
+              fill="currentColor"
+              mask={`url(#${maskId})`}
+            />
+          </>
+        )}
 
-        <g mask={hanging ? `url(#${hangClipId})` : undefined}>
-          {isIdle ? (
-            <g className="mascot__pixels" fill="currentColor">
-              <path d={IDLE_PATH} />
-            </g>
-          ) : (
-            <>
-              <defs>
-                <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
-                  <path fill="#fff" d={SOLID_PATH} />
-                  <g fill="#000" className="mascot__face-features" transform={lookTransform}>
-                    {cutouts}
-                  </g>
-                </mask>
-              </defs>
-              <rect
-                className="mascot__face"
-                x="0"
-                y="0"
-                width="70"
-                height="60"
-                fill="currentColor"
-                mask={`url(#${maskId})`}
-              />
-            </>
-          )}
-        </g>
-
-        {hanging ? <HangMouthSeal /> : null}
-        {hanging ? <LegsTogether /> : null}
+        {/*
+          Order matters: covers erase baked stubs/feet, then feet+arms paint on top
+          so he has one pair of each — not stubs under raised arms, and not one
+          merged leg column.
+        */}
+        {hanging ? <HangLimbCovers /> : null}
+        {hanging ? <FeetTogether /> : null}
         {hanging ? <HangArmStrokes /> : null}
+        {hanging ? <HangMouthSeal /> : null}
 
         <BlinkLids />
 

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -60,9 +60,9 @@ type MascotProps = {
    */
   scrolling?: boolean;
   /**
-   * Reach both arms up to grip a bar — used while the splash mascot does pull-ups
-   * on the card rim. Arms paint above the viewBox; `.mascot { overflow: visible }`
-   * is what lets them show.
+   * Reach both arms up to grip the splash card's top border. Arms paint above the
+   * viewBox; `.mascot { overflow: visible }` is what lets them show. Rendered
+   * outside `.mascot__body-group` so chin-ups can bob the body while hands stay put.
    */
   hanging?: boolean;
 };
@@ -301,16 +301,22 @@ function BlinkLids() {
   );
 }
 
-/** Both arms up, gripping an implied bar above his head — the pull-up pose. */
+/**
+ * Both arms up, gripping the splash card's top border.
+ *
+ * Hands sit at the top of the viewBox (not above it): the climb parks that edge
+ * on the card's 1px border, so the rim is the real border — we never draw a bar.
+ * Kept outside `.mascot__body-group` so chin-ups bob only the body.
+ */
 function HangArms() {
   return (
     <g className="mascot__hang-arms" aria-hidden="true">
-      <g fill="none" stroke="currentColor" strokeWidth="2.8" strokeLinecap="round">
-        <path className="mascot__hang-arm mascot__hang-arm--left" d="M20 10 Q12 2 10 -6" />
-        <path className="mascot__hang-arm mascot__hang-arm--right" d="M50 10 Q58 2 60 -6" />
+      <g fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+        <path className="mascot__hang-arm mascot__hang-arm--left" d="M22 16 Q15 8 13 2" />
+        <path className="mascot__hang-arm mascot__hang-arm--right" d="M48 16 Q55 8 57 2" />
       </g>
-      <circle className="mascot__hang-hand mascot__hang-hand--left" cx="10" cy="-6" r="2.4" fill="currentColor" />
-      <circle className="mascot__hang-hand mascot__hang-hand--right" cx="60" cy="-6" r="2.4" fill="currentColor" />
+      <circle className="mascot__hang-hand mascot__hang-hand--left" cx="13" cy="2" r="2.6" fill="currentColor" />
+      <circle className="mascot__hang-hand mascot__hang-hand--right" cx="57" cy="2" r="2.6" fill="currentColor" />
     </g>
   );
 }
@@ -465,10 +471,15 @@ export function Mascot({
           </g>
         ) : null}
 
-        {hanging ? <HangArms /> : null}
-
         {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
       </g>
+
+      {/*
+        Hands sit outside the body group on purpose: the chin-up bobs only the body
+        toward the card rim while the grip stays planted on the border. Put them
+        inside and the whole sprite floats, which does not read as a pull-up.
+      */}
+      {hanging ? <HangArms /> : null}
     </svg>
   );
 }
@@ -480,8 +491,8 @@ const POKE_HOLD_MS = 1400;
 
 /** First quiet stretch before he notices the card rim and climbs it. */
 export const PULLUP_FIRST_DELAY_MS = 9_000;
-/** One climb + a few reps + drop — matches `mascot-pullups-session` in CSS. */
-export const PULLUP_SESSION_MS = 3_400;
+/** One climb + a few reps + drop — matches `mascot-pullups-climb` / `-chin` in CSS. */
+export const PULLUP_SESSION_MS = 3_600;
 /** Quiet time between pull-up sessions once he has done the first. */
 export const PULLUP_GAP_MIN_MS = 12_000;
 export const PULLUP_GAP_MAX_MS = 20_000;
@@ -653,7 +664,8 @@ export function InteractiveMascot({
       }
       pullupsRef.current = true;
       setPullups(true);
-      setEmotion('busy');
+      // Proud crescents — strained / pleased with himself — not the idle wave.
+      setEmotion('proud');
       if (pullupEndTimer.current) clearTimeout(pullupEndTimer.current);
       pullupEndTimer.current = setTimeout(() => {
         pullupEndTimer.current = null;
@@ -803,7 +815,13 @@ export function InteractiveMascot({
         <Mascot
           emotion={emotion}
           size={size}
-          look={reduceMotion || pullups ? undefined : effectiveLook}
+          look={
+            reduceMotion
+              ? undefined
+              : pullups
+                ? { x: 0, y: -0.85 }
+                : effectiveLook
+          }
           hanging={pullups}
         />
       </span>

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -60,9 +60,10 @@ type MascotProps = {
    */
   scrolling?: boolean;
   /**
-   * Reach both arms up to grip the splash card's top border. Arms paint above the
-   * viewBox; `.mascot { overflow: visible }` is what lets them show. Rendered
-   * outside `.mascot__body-group` so chin-ups can bob the body while hands stay put.
+   * Reach both arms up to grip the splash card's top border. Raised arm strokes
+   * ride with the body; hands stay outside `.mascot__body-group` on the rim so
+   * chin-ups bob the torso toward a planted grip. Side stubs are covered so he
+   * does not grow a second pair of hands.
    */
   hanging?: boolean;
 };
@@ -211,12 +212,26 @@ const MOUTH_CURIOUS =
   'M20 13 L24 20 L28 12 L32 21 L36 11 L40 21 L44 12 L48 20 L52 13 L52 32 L48 26 L44 34 L40 25 L36 35 L32 26 L28 34 L24 27 L20 32 Z';
 const MOUTH_BUSY =
   'M20 13 L25 20 L30 12 L35 21 L40 11 L45 21 L50 13 L50 32 L45 26 L40 34 L35 25 L30 33 L25 26 L20 31 Z';
+/** Sealed lips — hold breath at the top of a chin-up. */
+const MOUTH_HANG_HOLD = 'M27 23 C31 25.2 39 25.2 43 23 C39 24.4 31 24.4 27 23 Z';
+/** Open mouth — breathe at the bottom of a chin-up. */
+const MOUTH_HANG_BREATHE = 'M26 18 C30 30 40 30 44 18 C40 26 30 26 26 18 Z';
 
 // Traced once at module load — the spans never change.
 const IDLE_PATH = spansToOutlinePath(MASCOT_IDLE_SPANS);
 const SOLID_PATH = spansToOutlinePath(MASCOT_SOLID_SPANS);
 
-function cutoutsFor(emotion: MascotEmotion): ReactElement | null {
+function cutoutsFor(emotion: MascotEmotion, hanging = false): ReactElement | null {
+  // Pull-ups swap the emotion mouth for a breath cycle synced to the chin keyframes.
+  if (hanging) {
+    return (
+      <>
+        {eyeCrescents()}
+        <path className="mascot__mouth mascot__mouth--hang-hold" d={MOUTH_HANG_HOLD} />
+        <path className="mascot__mouth mascot__mouth--hang-breathe" d={MOUTH_HANG_BREATHE} />
+      </>
+    );
+  }
   switch (emotion) {
     case 'idle':
       return null;
@@ -302,21 +317,71 @@ function BlinkLids() {
 }
 
 /**
- * Both arms up, gripping the splash card's top border.
- *
- * Hands sit at the top of the viewBox (not above it): the climb parks that edge
- * on the card's 1px border, so the rim is the real border — we never draw a bar.
- * Kept outside `.mascot__body-group` so chin-ups bob only the body.
+ * Cover the silhouette's baked side-arm stubs so a second pair of hands does not
+ * show under the raised arms. Filled with the splash card panel colour.
+ * Lives inside `.mascot__body-group` so it rides the chin-up with the torso.
  */
-function HangArms() {
+function ArmStubCovers() {
+  return (
+    <g className="mascot__arm-stub-covers" aria-hidden="true">
+      <rect className="mascot__arm-stub-cover mascot__arm-stub-cover--left" x="2.5" y="40.5" width="7.5" height="13" rx="1.2" />
+      <rect className="mascot__arm-stub-cover mascot__arm-stub-cover--right" x="60" y="40.5" width="7.5" height="12" rx="1.2" />
+    </g>
+  );
+}
+
+/**
+ * Merge the silhouette's split feet into one dangling column while hanging —
+ * legs together for the chin-ups. Erase uses the card panel colour; the replacement
+ * shape is body-coloured.
+ */
+function LegsTogether() {
+  return (
+    <g className="mascot__legs-together" aria-hidden="true">
+      <rect className="mascot__legs-together-erase" x="20" y="49.5" width="30" height="10" />
+      <path
+        className="mascot__legs-together-shape"
+        fill="currentColor"
+        d="M30 49.5h10v7.2c0 1.9-1.9 3-5 3s-5-1.1-5-3z"
+      />
+    </g>
+  );
+}
+
+/**
+ * Raised arms from the shoulders up toward the rim. Inside the body group so they
+ * tuck toward the fixed hands on each chin-up (reads as arms flexing, not a second
+ * floating pair grown from the head).
+ */
+function HangArmStrokes() {
+  return (
+    <g
+      className="mascot__hang-arm-strokes"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path className="mascot__hang-arm mascot__hang-arm--left" d="M9 39 C5 28 7 14 14 4" />
+      <path className="mascot__hang-arm mascot__hang-arm--right" d="M61 39 C65 28 63 14 56 4" />
+    </g>
+  );
+}
+
+/**
+ * Hands gripping the splash card's top border.
+ *
+ * Sit at the top of the viewBox: the climb parks that edge on the card's 1px
+ * border, so the rim is the real bar — we never draw one. Outside
+ * `.mascot__body-group` so chin-ups bob only the body while the grip stays put.
+ */
+function HangHands() {
   return (
     <g className="mascot__hang-arms" aria-hidden="true">
-      <g fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
-        <path className="mascot__hang-arm mascot__hang-arm--left" d="M22 16 Q15 8 13 2" />
-        <path className="mascot__hang-arm mascot__hang-arm--right" d="M48 16 Q55 8 57 2" />
-      </g>
-      <circle className="mascot__hang-hand mascot__hang-hand--left" cx="13" cy="2" r="2.6" fill="currentColor" />
-      <circle className="mascot__hang-hand mascot__hang-hand--right" cx="57" cy="2" r="2.6" fill="currentColor" />
+      <ellipse className="mascot__hang-hand mascot__hang-hand--left" cx="14" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
+      <ellipse className="mascot__hang-hand mascot__hang-hand--right" cx="56" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
     </g>
   );
 }
@@ -414,8 +479,9 @@ export function Mascot({
   ]
     .filter(Boolean)
     .join(' ');
-  const cutouts = cutoutsFor(emotion);
-  const isIdle = emotion === 'idle' || cutouts == null;
+  const cutouts = cutoutsFor(emotion, hanging);
+  // Hanging always uses the solid+mask body so raised arms and breath mouths work.
+  const isIdle = !hanging && (emotion === 'idle' || cutouts == null);
   const showWaveArm = !hanging && (emotion === 'wave' || emotion === 'excited');
   const showPhone = scrolling !== undefined;
   // Keep the nudge small — past ~3px the mouth starts to clip the silhouette.
@@ -463,6 +529,10 @@ export function Mascot({
           </>
         )}
 
+        {hanging ? <ArmStubCovers /> : null}
+        {hanging ? <LegsTogether /> : null}
+        {hanging ? <HangArmStrokes /> : null}
+
         <BlinkLids />
 
         {showWaveArm ? (
@@ -478,8 +548,9 @@ export function Mascot({
         Hands sit outside the body group on purpose: the chin-up bobs only the body
         toward the card rim while the grip stays planted on the border. Put them
         inside and the whole sprite floats, which does not read as a pull-up.
+        Arm strokes stay in the body group so they flex toward these hands.
       */}
-      {hanging ? <HangArms /> : null}
+      {hanging ? <HangHands /> : null}
     </svg>
   );
 }

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -362,8 +362,22 @@ function HangArmStrokes() {
 function HangHands() {
   return (
     <g className="mascot__hang-arms" aria-hidden="true">
-      <ellipse className="mascot__hang-hand mascot__hang-hand--left" cx="14" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
-      <ellipse className="mascot__hang-hand mascot__hang-hand--right" cx="56" cy="2.4" rx="5.2" ry="2.9" fill="currentColor" />
+      <ellipse
+        className="mascot__hang-hand mascot__hang-hand--left"
+        cx="14"
+        cy="2.4"
+        rx="5.2"
+        ry="2.9"
+        fill="currentColor"
+      />
+      <ellipse
+        className="mascot__hang-hand mascot__hang-hand--right"
+        cx="56"
+        cy="2.4"
+        rx="5.2"
+        ry="2.9"
+        fill="currentColor"
+      />
     </g>
   );
 }
@@ -374,15 +388,7 @@ function HangHands() {
  */
 function HangMouthSeal() {
   return (
-    <ellipse
-      className="mascot__mouth-seal"
-      cx="35"
-      cy="24"
-      rx="11"
-      ry="9"
-      fill="currentColor"
-      aria-hidden="true"
-    />
+    <ellipse className="mascot__mouth-seal" cx="35" cy="24" rx="11" ry="9" fill="currentColor" aria-hidden="true" />
   );
 }
 
@@ -442,14 +448,7 @@ function ScrollPhone({ clipId }: { clipId: string }) {
             <rect x="50.5" y="51" width="10" height="2.2" rx="0.5" opacity="0.4" />
           </g>
         </g>
-        <ellipse
-          className="mascot__phone-thumb"
-          cx="65.5"
-          cy="30"
-          rx="3.2"
-          ry="5"
-          fill="currentColor"
-        />
+        <ellipse className="mascot__phone-thumb" cx="65.5" cy="30" rx="3.2" ry="5" fill="currentColor" />
       </g>
     </g>
   );
@@ -507,22 +506,21 @@ export function Mascot({
         {hanging ? (
           <defs>
             {/*
-              Clip off baked side stubs and the split feet so raised arms + the
-              merged leg are the only limbs. More reliable than painting panel-coloured
-              covers (those fail if the card background is not exactly `--panel`).
+              Mask off baked side stubs and the split feet so raised arms + the
+              merged leg are the only limbs. A mask (white keep / black drop) is
+              more reliable across browsers than an evenodd clipPath with holes.
             */}
-            <clipPath id={hangClipId} clipPathUnits="userSpaceOnUse">
-              <path
-                d={
-                  'M0 0H70V60H0ZM2 40H10.5V54H2ZM59.5 40H68V53H59.5ZM20 49H31V60H20ZM39 49H50V60H39Z'
-                }
-                clipRule="evenodd"
-              />
-            </clipPath>
+            <mask id={hangClipId} maskUnits="userSpaceOnUse" x="0" y="0" width="70" height="60">
+              <rect x="0" y="0" width="70" height="60" fill="#fff" />
+              <rect x="1.5" y="38" width="10" height="16" fill="#000" />
+              <rect x="58.5" y="38" width="10" height="15" fill="#000" />
+              <rect x="19" y="48.5" width="12.5" height="11.5" fill="#000" />
+              <rect x="38.5" y="48.5" width="12.5" height="11.5" fill="#000" />
+            </mask>
           </defs>
         ) : null}
 
-        <g clipPath={hanging ? `url(#${hangClipId})` : undefined}>
+        <g mask={hanging ? `url(#${hangClipId})` : undefined}>
           {isIdle ? (
             <g className="mascot__pixels" fill="currentColor">
               <path d={IDLE_PATH} />
@@ -584,7 +582,7 @@ const POKE_HOLD_MS = 1400;
 /** First quiet stretch before he notices the card rim and climbs it. */
 export const PULLUP_FIRST_DELAY_MS = 9_000;
 /** One climb + a few reps + drop — matches `mascot-pullups-climb` / `-chin` in CSS. */
-export const PULLUP_SESSION_MS = 3_600;
+export const PULLUP_SESSION_MS = 3_800;
 /** Quiet time between pull-up sessions once he has done the first. */
 export const PULLUP_GAP_MIN_MS = 12_000;
 export const PULLUP_GAP_MAX_MS = 20_000;
@@ -862,11 +860,12 @@ export function InteractiveMascot({
   const pointerLeads = look.x !== 0 || look.y !== 0;
   const effectiveLook = pointerLeads || !device.active ? look : device.tilt;
 
-  const tiltStyle: CSSProperties | undefined = reduceMotion || pullups
-    ? undefined
-    : {
-        transform: `rotate(${(effectiveLook.x * 7).toFixed(2)}deg) translateY(${(effectiveLook.y * 2).toFixed(2)}px)`,
-      };
+  const tiltStyle: CSSProperties | undefined =
+    reduceMotion || pullups
+      ? undefined
+      : {
+          transform: `rotate(${(effectiveLook.x * 7).toFixed(2)}deg) translateY(${(effectiveLook.y * 2).toFixed(2)}px)`,
+        };
 
   return (
     <button
@@ -907,13 +906,7 @@ export function InteractiveMascot({
         <Mascot
           emotion={emotion}
           size={size}
-          look={
-            reduceMotion
-              ? undefined
-              : pullups
-                ? { x: 0, y: -0.85 }
-                : effectiveLook
-          }
+          look={reduceMotion ? undefined : pullups ? { x: 0, y: -0.85 } : effectiveLook}
           hanging={pullups}
         />
       </span>

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -13,7 +13,7 @@
  * reactions, and the face tracks the pointer a little. With `reactsToTilt` he also
  * leans with the phone's own orientation and gets dizzy when it is shaken.
  * With `doesPullUps` (splash only) he occasionally climbs the card rim for a few
- * chin-ups when nothing else is happening.
+ * chin-ups when nothing else is happening — motion only, no redrawn limbs.
  *
  * Pass `scrolling` (boolean) on the header mark: he pulls a tiny phone and mimes
  * scrolling a feed while the page moves. Omit the prop everywhere else so the
@@ -60,10 +60,9 @@ type MascotProps = {
    */
   scrolling?: boolean;
   /**
-   * Reach both arms up to grip the splash card's top border. Raised arm strokes
-   * ride with the body; hands stay outside `.mascot__body-group` on the rim so
-   * chin-ups bob the torso toward a planted grip. Baked side stubs and splayed
-   * feet are covered so he keeps one pair of each.
+   * Pull-up pose on the splash card rim: same baked silhouette (no redrawn limbs —
+   * those always looked like a second pair of arms). Climb + chin bob + mouth seal
+   * carry the gag; the card border is the bar.
    */
   hanging?: boolean;
 };
@@ -315,85 +314,6 @@ function BlinkLids() {
 }
 
 /**
- * Paint out the silhouette's side-arm stubs and splayed feet while hanging.
- * Uses the splash card panel colour — more reliable than nested SVG masks, which
- * left the stubs visible on top of the raised arms.
- */
-function HangLimbCovers() {
-  return (
-    <g className="mascot__hang-limb-covers" aria-hidden="true">
-      <rect className="mascot__hang-cover mascot__hang-cover--arm-left" x="1" y="36" width="12" height="18" rx="1" />
-      <rect className="mascot__hang-cover mascot__hang-cover--arm-right" x="57" y="36" width="12" height="17" rx="1" />
-      <rect className="mascot__hang-cover mascot__hang-cover--foot-left" x="19" y="48.5" width="13" height="11.5" />
-      <rect className="mascot__hang-cover mascot__hang-cover--foot-right" x="38" y="48.5" width="13" height="11.5" />
-    </g>
-  );
-}
-
-/**
- * Two stubby feet drawn close together — not one merged column (that read as a
- * single awkward appendage). The hang covers have already erased the splayed pair.
- */
-function FeetTogether() {
-  return (
-    <g className="mascot__feet-together" aria-hidden="true" fill="currentColor">
-      <rect className="mascot__foot mascot__foot--left" x="26" y="50" width="7" height="8" rx="2" />
-      <rect className="mascot__foot mascot__foot--right" x="37" y="50" width="7" height="8" rx="2" />
-    </g>
-  );
-}
-
-/**
- * Raised arms from the shoulders up to the rim. Chunkier filled shapes so they
- * read as his real arms moved up, not thin sticks grown from the head.
- * Inside the body group so they tuck toward the fixed hands on each chin-up.
- */
-function HangArmStrokes() {
-  return (
-    <g className="mascot__hang-arm-strokes" fill="currentColor" aria-hidden="true">
-      <path
-        className="mascot__hang-arm mascot__hang-arm--left"
-        d="M12 37 C8 29 9 18 13 6 C14.5 4.5 16 4.5 17 6 C14 17 15 28 17 37 Z"
-      />
-      <path
-        className="mascot__hang-arm mascot__hang-arm--right"
-        d="M58 37 C62 29 61 18 57 6 C55.5 4.5 54 4.5 53 6 C56 17 55 28 53 37 Z"
-      />
-    </g>
-  );
-}
-
-/**
- * Hands gripping the splash card's top border.
- *
- * Sit at the top of the viewBox: the climb parks that edge on the card's 1px
- * border, so the rim is the real bar — we never draw one. Outside
- * `.mascot__body-group` so chin-ups bob only the body while the grip stays put.
- */
-function HangHands() {
-  return (
-    <g className="mascot__hang-arms" aria-hidden="true">
-      <ellipse
-        className="mascot__hang-hand mascot__hang-hand--left"
-        cx="15"
-        cy="2.6"
-        rx="5.5"
-        ry="3"
-        fill="currentColor"
-      />
-      <ellipse
-        className="mascot__hang-hand mascot__hang-hand--right"
-        cx="55"
-        cy="2.6"
-        rx="5.5"
-        ry="3"
-        fill="currentColor"
-      />
-    </g>
-  );
-}
-
-/**
  * Body-coloured plug that seals the open hang-mouth hole at chin-up peaks.
  * Lives outside the face mask so the breath animation is not fighting mask opacity.
  */
@@ -539,14 +459,6 @@ export function Mascot({
           </>
         )}
 
-        {/*
-          Order matters: covers erase baked stubs/feet, then feet+arms paint on top
-          so he has one pair of each — not stubs under raised arms, and not one
-          merged leg column.
-        */}
-        {hanging ? <HangLimbCovers /> : null}
-        {hanging ? <FeetTogether /> : null}
-        {hanging ? <HangArmStrokes /> : null}
         {hanging ? <HangMouthSeal /> : null}
 
         <BlinkLids />
@@ -559,14 +471,6 @@ export function Mascot({
 
         {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
       </g>
-
-      {/*
-        Hands sit outside the body group on purpose: the chin-up bobs only the body
-        toward the card rim while the grip stays planted on the border. Put them
-        inside and the whole sprite floats, which does not read as a pull-up.
-        Arm strokes stay in the body group so they flex toward these hands.
-      */}
-      {hanging ? <HangHands /> : null}
     </svg>
   );
 }

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -13,7 +13,7 @@
  * reactions, and the face tracks the pointer a little. With `reactsToTilt` he also
  * leans with the phone's own orientation and gets dizzy when it is shaken.
  * With `doesPullUps` (splash only) he occasionally climbs the card rim for a few
- * chin-ups when nothing else is happening — motion only, no redrawn limbs.
+ * chin-ups when nothing else is happening — same face and limbs, just motion.
  *
  * Pass `scrolling` (boolean) on the header mark: he pulls a tiny phone and mimes
  * scrolling a feed while the page moves. Omit the prop everywhere else so the
@@ -59,12 +59,6 @@ type MascotProps = {
    * every other instance.
    */
   scrolling?: boolean;
-  /**
-   * Pull-up pose on the splash card rim: same baked silhouette (no redrawn limbs —
-   * those always looked like a second pair of arms). Climb + chin bob + mouth seal
-   * carry the gag; the card border is the bar.
-   */
-  hanging?: boolean;
 };
 
 type Span = readonly [number, number, number];
@@ -211,24 +205,12 @@ const MOUTH_CURIOUS =
   'M20 13 L24 20 L28 12 L32 21 L36 11 L40 21 L44 12 L48 20 L52 13 L52 32 L48 26 L44 34 L40 25 L36 35 L32 26 L28 34 L24 27 L20 32 Z';
 const MOUTH_BUSY =
   'M20 13 L25 20 L30 12 L35 21 L40 11 L45 21 L50 13 L50 32 L45 26 L40 34 L35 25 L30 33 L25 26 L20 31 Z';
-/** Open mouth while hanging — sealed by `.mascot__mouth-seal` at chin-up peaks. */
-const MOUTH_HANG_BREATHE = 'M26 18 C30 30 40 30 44 18 C40 26 30 26 26 18 Z';
 
 // Traced once at module load — the spans never change.
 const IDLE_PATH = spansToOutlinePath(MASCOT_IDLE_SPANS);
 const SOLID_PATH = spansToOutlinePath(MASCOT_SOLID_SPANS);
 
-function cutoutsFor(emotion: MascotEmotion, hanging = false): ReactElement | null {
-  // Pull-ups: open mouth cutout stays punched; a body-coloured seal outside the
-  // mask covers it at chin-up peaks (hold breath) and lifts on the way down.
-  if (hanging) {
-    return (
-      <>
-        {eyeCrescents()}
-        <path className="mascot__mouth mascot__mouth--hang-breath" d={MOUTH_HANG_BREATHE} />
-      </>
-    );
-  }
+function cutoutsFor(emotion: MascotEmotion): ReactElement | null {
   switch (emotion) {
     case 'idle':
       return null;
@@ -314,16 +296,6 @@ function BlinkLids() {
 }
 
 /**
- * Body-coloured plug that seals the open hang-mouth hole at chin-up peaks.
- * Lives outside the face mask so the breath animation is not fighting mask opacity.
- */
-function HangMouthSeal() {
-  return (
-    <ellipse className="mascot__mouth-seal" cx="35" cy="24" rx="11" ry="9" fill="currentColor" aria-hidden="true" />
-  );
-}
-
-/**
  * Pocket phone the header mark pulls while the page scrolls.
  *
  * Sized for the 35px logo mark (0.5 of the 70-unit viewBox). A phone that fits
@@ -393,7 +365,6 @@ export function Mascot({
   staticPose = false,
   look,
   scrolling,
-  hanging = false,
 }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
@@ -404,15 +375,13 @@ export function Mascot({
     `mascot--${emotion}`,
     staticPose ? 'mascot--static' : null,
     scrolling ? 'mascot--scrolling' : null,
-    hanging ? 'mascot--hanging' : null,
     className,
   ]
     .filter(Boolean)
     .join(' ');
-  const cutouts = cutoutsFor(emotion, hanging);
-  // Hanging always uses the solid+mask body so raised arms and breath mouths work.
-  const isIdle = !hanging && (emotion === 'idle' || cutouts == null);
-  const showWaveArm = !hanging && (emotion === 'wave' || emotion === 'excited');
+  const cutouts = cutoutsFor(emotion);
+  const isIdle = emotion === 'idle' || cutouts == null;
+  const showWaveArm = emotion === 'wave' || emotion === 'excited';
   const showPhone = scrolling !== undefined;
   // Keep the nudge small — past ~3px the mouth starts to clip the silhouette.
   const lookTransform =
@@ -459,8 +428,6 @@ export function Mascot({
           </>
         )}
 
-        {hanging ? <HangMouthSeal /> : null}
-
         <BlinkLids />
 
         {showWaveArm ? (
@@ -482,8 +449,8 @@ const POKE_HOLD_MS = 1400;
 
 /** First quiet stretch before he notices the card rim and climbs it. */
 export const PULLUP_FIRST_DELAY_MS = 9_000;
-/** One climb + a few reps + drop — matches `mascot-pullups-climb` / `-chin` in CSS. */
-export const PULLUP_SESSION_MS = 3_800;
+/** Climb + chin-ups + land — matches `mascot-pullups` in CSS. */
+export const PULLUP_SESSION_MS = 3_200;
 /** Quiet time between pull-up sessions once he has done the first. */
 export const PULLUP_GAP_MIN_MS = 12_000;
 export const PULLUP_GAP_MAX_MS = 20_000;
@@ -655,8 +622,7 @@ export function InteractiveMascot({
       }
       pullupsRef.current = true;
       setPullups(true);
-      // Proud crescents — strained / pleased with himself — not the idle wave.
-      setEmotion('proud');
+      // Stay himself — pull-ups are motion on the splash button, not a new face.
       if (pullupEndTimer.current) clearTimeout(pullupEndTimer.current);
       pullupEndTimer.current = setTimeout(() => {
         pullupEndTimer.current = null;
@@ -804,12 +770,7 @@ export function InteractiveMascot({
       {/* Tilt lives on an inner span so the button can still run the poke squash. */}
       <span className="mascot-interactive__tilt" style={tiltStyle}>
         {/* Button owns the accessible name; keep the SVG presentational to avoid a double announce. */}
-        <Mascot
-          emotion={emotion}
-          size={size}
-          look={reduceMotion ? undefined : pullups ? { x: 0, y: -0.85 } : effectiveLook}
-          hanging={pullups}
-        />
+        <Mascot emotion={emotion} size={size} look={reduceMotion ? undefined : effectiveLook} />
       </span>
     </button>
   );

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -212,9 +212,7 @@ const MOUTH_CURIOUS =
   'M20 13 L24 20 L28 12 L32 21 L36 11 L40 21 L44 12 L48 20 L52 13 L52 32 L48 26 L44 34 L40 25 L36 35 L32 26 L28 34 L24 27 L20 32 Z';
 const MOUTH_BUSY =
   'M20 13 L25 20 L30 12 L35 21 L40 11 L45 21 L50 13 L50 32 L45 26 L40 34 L35 25 L30 33 L25 26 L20 31 Z';
-/** Sealed lips — hold breath at the top of a chin-up. */
-const MOUTH_HANG_HOLD = 'M27 23 C31 25.2 39 25.2 43 23 C39 24.4 31 24.4 27 23 Z';
-/** Open mouth — breathe at the bottom of a chin-up. */
+/** Open mouth — scaled flat in CSS to seal the lips at each chin-up peak. */
 const MOUTH_HANG_BREATHE = 'M26 18 C30 30 40 30 44 18 C40 26 30 26 26 18 Z';
 
 // Traced once at module load — the spans never change.
@@ -222,13 +220,14 @@ const IDLE_PATH = spansToOutlinePath(MASCOT_IDLE_SPANS);
 const SOLID_PATH = spansToOutlinePath(MASCOT_SOLID_SPANS);
 
 function cutoutsFor(emotion: MascotEmotion, hanging = false): ReactElement | null {
-  // Pull-ups swap the emotion mouth for a breath cycle synced to the chin keyframes.
+  // Pull-ups: one mouth shape, CSS scaleY seals it at chin-up peaks (hold breath)
+  // and opens it on the way down (breathe). Dual-opacity cutouts inside SVG masks
+  // were unreliable about which state won at the peak.
   if (hanging) {
     return (
       <>
         {eyeCrescents()}
-        <path className="mascot__mouth mascot__mouth--hang-hold" d={MOUTH_HANG_HOLD} />
-        <path className="mascot__mouth mascot__mouth--hang-breathe" d={MOUTH_HANG_BREATHE} />
+        <path className="mascot__mouth mascot__mouth--hang-breath" d={MOUTH_HANG_BREATHE} />
       </>
     );
   }
@@ -338,11 +337,11 @@ function ArmStubCovers() {
 function LegsTogether() {
   return (
     <g className="mascot__legs-together" aria-hidden="true">
-      <rect className="mascot__legs-together-erase" x="20" y="49.5" width="30" height="10" />
+      <rect className="mascot__legs-together-erase" x="19.5" y="49" width="31" height="11" />
       <path
         className="mascot__legs-together-shape"
         fill="currentColor"
-        d="M30 49.5h10v7.2c0 1.9-1.9 3-5 3s-5-1.1-5-3z"
+        d="M29.5 49h11v8c0 2.1-2.1 3.2-5.5 3.2S29.5 59.1 29.5 57z"
       />
     </g>
   );

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -12,6 +12,8 @@
  * `InteractiveMascot` wraps the SVG in a button: hover peeks, click cycles
  * reactions, and the face tracks the pointer a little. With `reactsToTilt` he also
  * leans with the phone's own orientation and gets dizzy when it is shaken.
+ * With `doesPullUps` (splash only) he occasionally climbs the card rim for a few
+ * chin-ups when nothing else is happening.
  *
  * Pass `scrolling` (boolean) on the header mark: he pulls a tiny phone and mimes
  * scrolling a feed while the page moves. Omit the prop everywhere else so the
@@ -57,6 +59,12 @@ type MascotProps = {
    * every other instance.
    */
   scrolling?: boolean;
+  /**
+   * Reach both arms up to grip a bar — used while the splash mascot does pull-ups
+   * on the card rim. Arms paint above the viewBox; `.mascot { overflow: visible }`
+   * is what lets them show.
+   */
+  hanging?: boolean;
 };
 
 type Span = readonly [number, number, number];
@@ -293,6 +301,20 @@ function BlinkLids() {
   );
 }
 
+/** Both arms up, gripping an implied bar above his head — the pull-up pose. */
+function HangArms() {
+  return (
+    <g className="mascot__hang-arms" aria-hidden="true">
+      <g fill="none" stroke="currentColor" strokeWidth="2.8" strokeLinecap="round">
+        <path className="mascot__hang-arm mascot__hang-arm--left" d="M20 10 Q12 2 10 -6" />
+        <path className="mascot__hang-arm mascot__hang-arm--right" d="M50 10 Q58 2 60 -6" />
+      </g>
+      <circle className="mascot__hang-hand mascot__hang-hand--left" cx="10" cy="-6" r="2.4" fill="currentColor" />
+      <circle className="mascot__hang-hand mascot__hang-hand--right" cx="60" cy="-6" r="2.4" fill="currentColor" />
+    </g>
+  );
+}
+
 /**
  * Pocket phone the header mark pulls while the page scrolls.
  *
@@ -370,6 +392,7 @@ export function Mascot({
   staticPose = false,
   look,
   scrolling,
+  hanging = false,
 }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
@@ -380,13 +403,14 @@ export function Mascot({
     `mascot--${emotion}`,
     staticPose ? 'mascot--static' : null,
     scrolling ? 'mascot--scrolling' : null,
+    hanging ? 'mascot--hanging' : null,
     className,
   ]
     .filter(Boolean)
     .join(' ');
   const cutouts = cutoutsFor(emotion);
   const isIdle = emotion === 'idle' || cutouts == null;
-  const showWaveArm = emotion === 'wave' || emotion === 'excited';
+  const showWaveArm = !hanging && (emotion === 'wave' || emotion === 'excited');
   const showPhone = scrolling !== undefined;
   // Keep the nudge small — past ~3px the mouth starts to clip the silhouette.
   const lookTransform =
@@ -441,6 +465,8 @@ export function Mascot({
           </g>
         ) : null}
 
+        {hanging ? <HangArms /> : null}
+
         {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
       </g>
     </svg>
@@ -451,6 +477,14 @@ export function Mascot({
 const POKE_REACTIONS: readonly MascotEmotion[] = ['excited', 'happy', 'curious', 'proud', 'thinking', 'confused'];
 
 const POKE_HOLD_MS = 1400;
+
+/** First quiet stretch before he notices the card rim and climbs it. */
+export const PULLUP_FIRST_DELAY_MS = 9_000;
+/** One climb + a few reps + drop — matches `mascot-pullups-session` in CSS. */
+export const PULLUP_SESSION_MS = 3_400;
+/** Quiet time between pull-up sessions once he has done the first. */
+export const PULLUP_GAP_MIN_MS = 12_000;
+export const PULLUP_GAP_MAX_MS = 20_000;
 
 type InteractiveMascotProps = {
   size?: number;
@@ -464,6 +498,11 @@ type InteractiveMascotProps = {
    * Off by default: it costs two window listeners and, on iOS, a permission prompt.
    */
   reactsToTilt?: boolean;
+  /**
+   * When nothing else is happening, occasionally climb the splash card rim and do
+   * a few pull-ups. Opt-in — only the closed-beta splash wants this gag.
+   */
+  doesPullUps?: boolean;
 };
 
 /**
@@ -476,16 +515,21 @@ export function InteractiveMascot({
   idleEmotion = 'wave',
   pokeLabel,
   reactsToTilt = false,
+  doesPullUps = false,
 }: InteractiveMascotProps) {
   const rootRef = useRef<HTMLButtonElement>(null);
   const pokeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pullupWaitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pullupEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionIndex = useRef(0);
   const hoveredRef = useRef(false);
   const pokingRef = useRef(false);
+  const pullupsRef = useRef(false);
   const lookRef = useRef<MascotLook>({ x: 0, y: 0 });
   const [emotion, setEmotion] = useState<MascotEmotion>(idleEmotion);
   const [look, setLook] = useState<MascotLook>({ x: 0, y: 0 });
   const [poking, setPoking] = useState(false);
+  const [pullups, setPullups] = useState(false);
   /** Which gesture is currently being answered, for the one-shot motion classes. */
   const [flourish, setFlourish] = useState<MascotGesture | null>(null);
   const upsideDownRef = useRef(false);
@@ -512,12 +556,25 @@ export function InteractiveMascot({
   useEffect(() => {
     return () => {
       if (pokeTimer.current) clearTimeout(pokeTimer.current);
+      if (pullupWaitTimer.current) clearTimeout(pullupWaitTimer.current);
+      if (pullupEndTimer.current) clearTimeout(pullupEndTimer.current);
     };
   }, []);
 
   // Tilting the phone is the same gesture as moving the pointer, as far as he is
   // concerned — both end up as a look vector. Reduced motion opts out entirely.
   const device = useDeviceTilt(reactsToTilt && !reduceMotion);
+
+  const stopPullups = (nextEmotion?: MascotEmotion) => {
+    if (pullupEndTimer.current) {
+      clearTimeout(pullupEndTimer.current);
+      pullupEndTimer.current = null;
+    }
+    if (!pullupsRef.current) return;
+    pullupsRef.current = false;
+    setPullups(false);
+    if (nextEmotion !== undefined) setEmotion(nextEmotion);
+  };
 
   /*
    * How he answers each thing you can do to the phone. Skips the first render:
@@ -541,6 +598,7 @@ export function InteractiveMascot({
               ? 'excited'
               : 'confused';
 
+    stopPullups();
     pokingRef.current = true;
     setPoking(true);
     setEmotion(reaction);
@@ -562,6 +620,71 @@ export function InteractiveMascot({
   }, [device.gestureSeq]);
 
   upsideDownRef.current = device.upsideDown;
+
+  /*
+   * Occasional pull-ups on the splash card rim — only when he is otherwise idle.
+   * Interaction (poke, hover, tilt gesture) cancels a session in progress; reduced
+   * motion opts out entirely. Gaps are jittered so two visitors rarely sync up.
+   */
+  useEffect(() => {
+    if (!doesPullUps || reduceMotion) {
+      stopPullups();
+      if (pullupWaitTimer.current) {
+        clearTimeout(pullupWaitTimer.current);
+        pullupWaitTimer.current = null;
+      }
+      return;
+    }
+
+    let cancelled = false;
+
+    const clearWait = () => {
+      if (pullupWaitTimer.current) {
+        clearTimeout(pullupWaitTimer.current);
+        pullupWaitTimer.current = null;
+      }
+    };
+
+    const startSession = () => {
+      if (cancelled) return;
+      if (pokingRef.current || hoveredRef.current || upsideDownRef.current) {
+        scheduleNext(4_000);
+        return;
+      }
+      pullupsRef.current = true;
+      setPullups(true);
+      setEmotion('busy');
+      if (pullupEndTimer.current) clearTimeout(pullupEndTimer.current);
+      pullupEndTimer.current = setTimeout(() => {
+        pullupEndTimer.current = null;
+        pullupsRef.current = false;
+        setPullups(false);
+        if (!pokingRef.current) {
+          setEmotion(hoveredRef.current ? 'curious' : idleEmotion);
+        }
+        scheduleNext(PULLUP_GAP_MIN_MS + Math.random() * (PULLUP_GAP_MAX_MS - PULLUP_GAP_MIN_MS));
+      }, PULLUP_SESSION_MS);
+    };
+
+    const scheduleNext = (delay: number) => {
+      clearWait();
+      pullupWaitTimer.current = setTimeout(() => {
+        pullupWaitTimer.current = null;
+        startSession();
+      }, delay);
+    };
+
+    scheduleNext(PULLUP_FIRST_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearWait();
+      if (pullupEndTimer.current) {
+        clearTimeout(pullupEndTimer.current);
+        pullupEndTimer.current = null;
+      }
+    };
+  }, [doesPullUps, reduceMotion, idleEmotion]);
 
   // Reduced motion still gets the emotion swap — only tilt/boop are suppressed.
   const settleEmotion = () => (hoveredRef.current ? 'curious' : idleEmotion);
@@ -611,6 +734,7 @@ export function InteractiveMascot({
      */
     if (reactsToTilt) device.request();
 
+    stopPullups();
     const next = POKE_REACTIONS[reactionIndex.current % POKE_REACTIONS.length]!;
     reactionIndex.current += 1;
     pokingRef.current = true;
@@ -634,7 +758,7 @@ export function InteractiveMascot({
   const pointerLeads = look.x !== 0 || look.y !== 0;
   const effectiveLook = pointerLeads || !device.active ? look : device.tilt;
 
-  const tiltStyle: CSSProperties | undefined = reduceMotion
+  const tiltStyle: CSSProperties | undefined = reduceMotion || pullups
     ? undefined
     : {
         transform: `rotate(${(effectiveLook.x * 7).toFixed(2)}deg) translateY(${(effectiveLook.y * 2).toFixed(2)}px)`,
@@ -647,6 +771,7 @@ export function InteractiveMascot({
       className={[
         'mascot-interactive',
         poking ? 'mascot-interactive--poking' : null,
+        pullups ? 'mascot-interactive--pullups' : null,
         device.upsideDown ? 'mascot-interactive--upside-down' : null,
         flourish ? `mascot-interactive--${flourish}` : null,
         className,
@@ -657,24 +782,30 @@ export function InteractiveMascot({
       onClick={handlePoke}
       onPointerEnter={() => {
         hoveredRef.current = true;
+        stopPullups('curious');
         if (!pokingRef.current) setEmotion('curious');
       }}
       onPointerLeave={() => {
         hoveredRef.current = false;
         resetLook();
-        if (!pokingRef.current) setEmotion(idleEmotion);
+        if (!pokingRef.current && !pullupsRef.current) setEmotion(idleEmotion);
       }}
       onPointerMove={handlePointerMove}
       onBlur={() => {
         hoveredRef.current = false;
         resetLook();
-        if (!pokingRef.current) setEmotion(idleEmotion);
+        if (!pokingRef.current && !pullupsRef.current) setEmotion(idleEmotion);
       }}
     >
       {/* Tilt lives on an inner span so the button can still run the poke squash. */}
       <span className="mascot-interactive__tilt" style={tiltStyle}>
         {/* Button owns the accessible name; keep the SVG presentational to avoid a double announce. */}
-        <Mascot emotion={emotion} size={size} look={reduceMotion ? undefined : effectiveLook} />
+        <Mascot
+          emotion={emotion}
+          size={size}
+          look={reduceMotion || pullups ? undefined : effectiveLook}
+          hanging={pullups}
+        />
       </span>
     </button>
   );

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -25,9 +25,7 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(css).toMatch(/--pullup-hang/);
     expect(css).toMatch(/--pullup-chin-lift/);
     // Body-only chin-ups — if hang-arms lived inside body-group this would float.
-    expect(css).toMatch(
-      /\.mascot-interactive--pullups \.mascot__body-group \{[\s\S]*?animation: mascot-pullups-chin/,
-    );
+    expect(css).toMatch(/\.mascot-interactive--pullups \.mascot__body-group \{[\s\S]*?animation: mascot-pullups-chin/);
   });
 
   it('covers baked side stubs and breathes with the chin', () => {
@@ -35,15 +33,15 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(css).toMatch(/@keyframes mascot-hang-mouth-seal/);
     expect(css).toMatch(/\.mascot__mouth-seal/);
     // Fall → squash → rebound → settle.
-    expect(css).toMatch(/scale\(1\.18,\s*0\.76\)/);
-    expect(css).toMatch(/scale\(0\.96,\s*1\.07\)/);
+    expect(css).toMatch(/scale\(1\.22,\s*0\.7\)/);
+    expect(css).toMatch(/scale\(0\.94,\s*1\.1\)/);
     const mascot = read('Mascot.tsx');
     expect(mascot).toMatch(/hangClipId/);
-    expect(mascot).toMatch(/clipRule="evenodd"/);
     expect(mascot).toMatch(/LegsTogether/);
     expect(mascot).toMatch(/HangArmStrokes/);
     expect(mascot).toMatch(/HangMouthSeal/);
     expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
+    expect(mascot).toMatch(/PULLUP_SESSION_MS = 3_800/);
   });
 
   it('lets the card rim show his hands', () => {

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -34,8 +34,8 @@ describe('the splash mascot does idle pull-ups', () => {
     const css = read('styles.css');
     expect(css).toMatch(/\.mascot__arm-stub-cover/);
     expect(css).toMatch(/\.mascot__legs-together-erase/);
-    expect(css).toMatch(/@keyframes mascot-hang-mouth-hold/);
-    expect(css).toMatch(/@keyframes mascot-hang-mouth-breathe/);
+    expect(css).toMatch(/@keyframes mascot-hang-mouth-breath/);
+    expect(css).toMatch(/scaleY\(0\.12\)/);
     // Fall → squash → rebound → settle.
     expect(css).toMatch(/scale\(1\.18,\s*0\.76\)/);
     expect(css).toMatch(/scale\(0\.96,\s*1\.07\)/);
@@ -43,8 +43,8 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(mascot).toMatch(/ArmStubCovers/);
     expect(mascot).toMatch(/LegsTogether/);
     expect(mascot).toMatch(/HangArmStrokes/);
-    expect(mascot).toMatch(/MOUTH_HANG_HOLD/);
     expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
+    expect(mascot).toMatch(/mascot__mouth--hang-breath/);
   });
 
   it('lets the card rim show his hands', () => {

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -17,12 +17,17 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(mascot![0]).toMatch(/doesPullUps/);
   });
 
-  it('animates a climb-and-chin-up session on the card rim', () => {
+  it('animates a climb then chin-ups against the card rim', () => {
     const css = read('styles.css');
     expect(css).toMatch(/\.mascot-interactive--pullups/);
-    expect(css).toMatch(/@keyframes mascot-pullups-session/);
+    expect(css).toMatch(/@keyframes mascot-pullups-climb/);
+    expect(css).toMatch(/@keyframes mascot-pullups-chin/);
     expect(css).toMatch(/--pullup-hang/);
-    expect(css).toMatch(/--pullup-chin/);
+    expect(css).toMatch(/--pullup-chin-lift/);
+    // Body-only chin-ups — if hang-arms lived inside body-group this would float.
+    expect(css).toMatch(
+      /\.mascot-interactive--pullups \.mascot__body-group \{[\s\S]*?animation: mascot-pullups-chin/,
+    );
   });
 
   it('lets the card rim show his hands', () => {

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -32,19 +32,18 @@ describe('the splash mascot does idle pull-ups', () => {
 
   it('covers baked side stubs and breathes with the chin', () => {
     const css = read('styles.css');
-    expect(css).toMatch(/\.mascot__arm-stub-cover/);
-    expect(css).toMatch(/\.mascot__legs-together-erase/);
-    expect(css).toMatch(/@keyframes mascot-hang-mouth-breath/);
-    expect(css).toMatch(/scaleY\(0\.12\)/);
+    expect(css).toMatch(/@keyframes mascot-hang-mouth-seal/);
+    expect(css).toMatch(/\.mascot__mouth-seal/);
     // Fall → squash → rebound → settle.
     expect(css).toMatch(/scale\(1\.18,\s*0\.76\)/);
     expect(css).toMatch(/scale\(0\.96,\s*1\.07\)/);
     const mascot = read('Mascot.tsx');
-    expect(mascot).toMatch(/ArmStubCovers/);
+    expect(mascot).toMatch(/hangClipId/);
+    expect(mascot).toMatch(/clipRule="evenodd"/);
     expect(mascot).toMatch(/LegsTogether/);
     expect(mascot).toMatch(/HangArmStrokes/);
+    expect(mascot).toMatch(/HangMouthSeal/);
     expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
-    expect(mascot).toMatch(/mascot__mouth--hang-breath/);
   });
 
   it('lets the card rim show his hands', () => {

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -24,31 +24,28 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(css).toMatch(/@keyframes mascot-pullups-chin/);
     expect(css).toMatch(/--pullup-hang/);
     expect(css).toMatch(/--pullup-chin-lift/);
-    // Body-only chin-ups — if hang-arms lived inside body-group this would float.
     expect(css).toMatch(/\.mascot-interactive--pullups \.mascot__body-group \{[\s\S]*?animation: mascot-pullups-chin/);
   });
 
-  it('covers baked side stubs and breathes with the chin', () => {
+  it('keeps the baked silhouette and only seals the mouth for breath', () => {
     const css = read('styles.css');
-    expect(css).toMatch(/\.mascot__hang-cover/);
     expect(css).toMatch(/@keyframes mascot-hang-mouth-seal/);
     expect(css).toMatch(/\.mascot__mouth-seal/);
     // Fall → squash → rebound → settle.
     expect(css).toMatch(/scale\(1\.22,\s*0\.7\)/);
     expect(css).toMatch(/scale\(0\.94,\s*1\.1\)/);
     const mascot = read('Mascot.tsx');
-    expect(mascot).toMatch(/HangLimbCovers/);
-    expect(mascot).toMatch(/FeetTogether/);
-    expect(mascot).toMatch(/HangArmStrokes/);
     expect(mascot).toMatch(/HangMouthSeal/);
     expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
     expect(mascot).toMatch(/PULLUP_SESSION_MS = 3_800/);
-    // Two feet, not one merged column.
-    expect(mascot).toMatch(/mascot__foot--left/);
-    expect(mascot).toMatch(/mascot__foot--right/);
+    // No redrawn limbs — those always looked like a second pair / a weird foot column.
+    expect(mascot).not.toMatch(/HangLimbCovers/);
+    expect(mascot).not.toMatch(/FeetTogether/);
+    expect(mascot).not.toMatch(/HangArmStrokes/);
+    expect(mascot).not.toMatch(/HangHands/);
   });
 
-  it('lets the card rim show his hands', () => {
+  it('lets the climb reach the card rim', () => {
     const css = read('styles.css');
     const card = css.slice(css.indexOf('.beta-splash__card {'), css.indexOf('.beta-splash__logo {'));
     expect(card).toMatch(/overflow:\s*visible/);

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -30,18 +30,22 @@ describe('the splash mascot does idle pull-ups', () => {
 
   it('covers baked side stubs and breathes with the chin', () => {
     const css = read('styles.css');
+    expect(css).toMatch(/\.mascot__hang-cover/);
     expect(css).toMatch(/@keyframes mascot-hang-mouth-seal/);
     expect(css).toMatch(/\.mascot__mouth-seal/);
     // Fall → squash → rebound → settle.
     expect(css).toMatch(/scale\(1\.22,\s*0\.7\)/);
     expect(css).toMatch(/scale\(0\.94,\s*1\.1\)/);
     const mascot = read('Mascot.tsx');
-    expect(mascot).toMatch(/hangClipId/);
-    expect(mascot).toMatch(/LegsTogether/);
+    expect(mascot).toMatch(/HangLimbCovers/);
+    expect(mascot).toMatch(/FeetTogether/);
     expect(mascot).toMatch(/HangArmStrokes/);
     expect(mascot).toMatch(/HangMouthSeal/);
     expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
     expect(mascot).toMatch(/PULLUP_SESSION_MS = 3_800/);
+    // Two feet, not one merged column.
+    expect(mascot).toMatch(/mascot__foot--left/);
+    expect(mascot).toMatch(/mascot__foot--right/);
   });
 
   it('lets the card rim show his hands', () => {

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -30,6 +30,23 @@ describe('the splash mascot does idle pull-ups', () => {
     );
   });
 
+  it('covers baked side stubs and breathes with the chin', () => {
+    const css = read('styles.css');
+    expect(css).toMatch(/\.mascot__arm-stub-cover/);
+    expect(css).toMatch(/\.mascot__legs-together-erase/);
+    expect(css).toMatch(/@keyframes mascot-hang-mouth-hold/);
+    expect(css).toMatch(/@keyframes mascot-hang-mouth-breathe/);
+    // Fall → squash → rebound → settle.
+    expect(css).toMatch(/scale\(1\.18,\s*0\.76\)/);
+    expect(css).toMatch(/scale\(0\.96,\s*1\.07\)/);
+    const mascot = read('Mascot.tsx');
+    expect(mascot).toMatch(/ArmStubCovers/);
+    expect(mascot).toMatch(/LegsTogether/);
+    expect(mascot).toMatch(/HangArmStrokes/);
+    expect(mascot).toMatch(/MOUTH_HANG_HOLD/);
+    expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
+  });
+
   it('lets the card rim show his hands', () => {
     const css = read('styles.css');
     const card = css.slice(css.indexOf('.beta-splash__card {'), css.indexOf('.beta-splash__logo {'));

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Splash pull-ups are a wiring + CSS gag: the prop lives on ClosedBetaSplash and
+ * the climb distances live in keyframes. Asserted from source so we do not have
+ * to mount AuthContext just to prove a boolean made it onto the button.
+ */
+const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, import.meta.url)), 'utf8');
+
+describe('the splash mascot does idle pull-ups', () => {
+  it('opts the splash InteractiveMascot into pull-ups', () => {
+    const splash = read('ClosedBetaSplash.tsx');
+    const mascot = splash.match(/<InteractiveMascot[\s\S]*?\/>/);
+    expect(mascot).not.toBeNull();
+    expect(mascot![0]).toMatch(/doesPullUps/);
+  });
+
+  it('animates a climb-and-chin-up session on the card rim', () => {
+    const css = read('styles.css');
+    expect(css).toMatch(/\.mascot-interactive--pullups/);
+    expect(css).toMatch(/@keyframes mascot-pullups-session/);
+    expect(css).toMatch(/--pullup-hang/);
+    expect(css).toMatch(/--pullup-chin/);
+  });
+
+  it('lets the card rim show his hands', () => {
+    const css = read('styles.css');
+    const card = css.slice(css.indexOf('.beta-splash__card {'), css.indexOf('.beta-splash__logo {'));
+    expect(card).toMatch(/overflow:\s*visible/);
+    expect(card).toMatch(/position:\s*relative/);
+  });
+
+  it('still kills the session under prefers-reduced-motion', () => {
+    const css = read('styles.css');
+    const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
+    expect(reduced).toMatch(/\.mascot-interactive--pullups/);
+  });
+});

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Splash pull-ups are a wiring + CSS gag: the prop lives on ClosedBetaSplash and
- * the climb distances live in keyframes. Asserted from source so we do not have
- * to mount AuthContext just to prove a boolean made it onto the button.
+ * one timeline climbs / chins / lands the whole button. No hang face, no redrawn
+ * limbs — he stays the normal logo mascot.
  */
 const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, import.meta.url)), 'utf8');
 
@@ -17,32 +17,30 @@ describe('the splash mascot does idle pull-ups', () => {
     expect(mascot![0]).toMatch(/doesPullUps/);
   });
 
-  it('animates a climb then chin-ups against the card rim', () => {
+  it('runs one climb-chin-land timeline on the button', () => {
     const css = read('styles.css');
     expect(css).toMatch(/\.mascot-interactive--pullups/);
-    expect(css).toMatch(/@keyframes mascot-pullups-climb/);
-    expect(css).toMatch(/@keyframes mascot-pullups-chin/);
+    expect(css).toMatch(/@keyframes mascot-pullups/);
     expect(css).toMatch(/--pullup-hang/);
-    expect(css).toMatch(/--pullup-chin-lift/);
-    expect(css).toMatch(/\.mascot-interactive--pullups \.mascot__body-group \{[\s\S]*?animation: mascot-pullups-chin/);
+    expect(css).toMatch(/--pullup-chin/);
+    // Whole-button motion — not a separate body-only chin track.
+    expect(css).not.toMatch(/@keyframes mascot-pullups-chin/);
+    expect(css).not.toMatch(/@keyframes mascot-pullups-climb/);
   });
 
-  it('keeps the baked silhouette and only seals the mouth for breath', () => {
-    const css = read('styles.css');
-    expect(css).toMatch(/@keyframes mascot-hang-mouth-seal/);
-    expect(css).toMatch(/\.mascot__mouth-seal/);
-    // Fall → squash → rebound → settle.
-    expect(css).toMatch(/scale\(1\.22,\s*0\.7\)/);
-    expect(css).toMatch(/scale\(0\.94,\s*1\.1\)/);
+  it('does not invent a hang face or redrawn limbs', () => {
     const mascot = read('Mascot.tsx');
-    expect(mascot).toMatch(/HangMouthSeal/);
-    expect(mascot).toMatch(/MOUTH_HANG_BREATHE/);
-    expect(mascot).toMatch(/PULLUP_SESSION_MS = 3_800/);
-    // No redrawn limbs — those always looked like a second pair / a weird foot column.
+    expect(mascot).toMatch(/PULLUP_SESSION_MS = 3_200/);
+    expect(mascot).not.toMatch(/hanging\?:/);
+    expect(mascot).not.toMatch(/HangMouthSeal/);
     expect(mascot).not.toMatch(/HangLimbCovers/);
-    expect(mascot).not.toMatch(/FeetTogether/);
     expect(mascot).not.toMatch(/HangArmStrokes/);
     expect(mascot).not.toMatch(/HangHands/);
+    expect(mascot).not.toMatch(/FeetTogether/);
+    expect(mascot).not.toMatch(/MOUTH_HANG/);
+    const css = read('styles.css');
+    expect(css).not.toMatch(/mascot-hang-mouth-seal/);
+    expect(css).not.toMatch(/mascot__mouth-seal/);
   });
 
   it('lets the climb reach the card rim', () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5224,6 +5224,80 @@ body.player-open {
   animation: mascot-pullups-chin 3.6s ease-in-out !important;
 }
 
+/* Hide baked side stubs / split feet — same fill as the splash card. */
+.mascot__arm-stub-cover,
+.mascot__legs-together-erase {
+  fill: var(--panel);
+}
+
+/*
+ * Breath with the chin: sealed lips at the top of each rep, open mouth on the way
+ * down. Keyframe times match `mascot-pullups-chin`. Opacity in the SVG mask
+ * controls how hard each mouth punches the face.
+ */
+.mascot--hanging .mascot__mouth--hang-hold {
+  opacity: 0;
+  animation: mascot-hang-mouth-hold 3.6s ease-in-out;
+}
+
+.mascot--hanging .mascot__mouth--hang-breathe {
+  opacity: 1;
+  animation: mascot-hang-mouth-breathe 3.6s ease-in-out;
+}
+
+@keyframes mascot-hang-mouth-hold {
+  0%,
+  14% {
+    opacity: 0;
+  }
+  /* Rep tops — hold breath. */
+  24% {
+    opacity: 1;
+  }
+  32% {
+    opacity: 0;
+  }
+  44% {
+    opacity: 1;
+  }
+  52% {
+    opacity: 0;
+  }
+  64% {
+    opacity: 1;
+  }
+  74%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes mascot-hang-mouth-breathe {
+  0%,
+  14% {
+    opacity: 1;
+  }
+  24% {
+    opacity: 0;
+  }
+  32% {
+    opacity: 1;
+  }
+  44% {
+    opacity: 0;
+  }
+  52% {
+    opacity: 1;
+  }
+  64% {
+    opacity: 0;
+  }
+  74%,
+  100% {
+    opacity: 1;
+  }
+}
+
 @keyframes mascot-pullups-climb {
   0% {
     transform: translateY(0) scale(1, 1);
@@ -5233,13 +5307,22 @@ body.player-open {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
   /* Hold through the chin-up reps. */
-  82% {
+  80% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
-  /* Drop with a land squash. */
-  93% {
-    transform: translateY(4px) scale(1.06, 0.9);
+  /* Let go — stretch on the fall. */
+  88% {
+    transform: translateY(calc(-0.28 * var(--pullup-hang))) scale(0.94, 1.1);
   }
+  /* Impact squash. */
+  93% {
+    transform: translateY(8px) scale(1.18, 0.76);
+  }
+  /* Short rebound. */
+  97% {
+    transform: translateY(-3px) scale(0.96, 1.07);
+  }
+  /* Settle. */
   100% {
     transform: translateY(0) scale(1, 1);
   }
@@ -5272,7 +5355,8 @@ body.player-open {
   74% {
     transform: translateY(0) scale(0.96, 1.05);
   }
-  82%,
+  /* Quiet for the drop + landing — body rides the climb keyframes. */
+  80%,
   100% {
     transform: translateY(0) scale(1, 1);
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5224,48 +5224,48 @@ body.player-open {
   animation: mascot-pullups-chin 3.6s ease-in-out !important;
 }
 
-/* Hide baked side stubs / split feet — same fill as the splash card. */
-.mascot__arm-stub-cover,
-.mascot__legs-together-erase {
-  fill: var(--panel);
-}
-
 /*
- * Breath with the chin: scale the mouth flat at each chin-up peak (hold breath),
- * open it on the way down. One path + scaleY — dual-opacity cutouts inside an SVG
- * mask flipped which state won at the peak in Chromium. Times match
+ * Breath with the chin: a body-coloured seal covers the open mouth hole at each
+ * chin-up peak (hold breath) and lifts on the way down. The seal lives outside the
+ * face mask so the animation is not fighting mask opacity/transforms. Times match
  * `mascot-pullups-chin`.
  */
-.mascot--hanging .mascot__mouth--hang-breath {
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: mascot-hang-mouth-breath 3.6s ease-in-out;
+.mascot--hanging .mascot__mouth-seal {
+  transform-origin: 35px 24px;
+  animation: mascot-hang-mouth-seal 3.6s ease-in-out;
 }
 
-@keyframes mascot-hang-mouth-breath {
+@keyframes mascot-hang-mouth-seal {
   0%,
   14% {
-    transform: scaleY(1);
+    transform: scaleY(0);
+    opacity: 0;
   }
   /* Chin-up peaks — seal lips, hold breath. */
   24% {
-    transform: scaleY(0.12);
+    transform: scaleY(1);
+    opacity: 1;
   }
   32% {
-    transform: scaleY(1);
+    transform: scaleY(0);
+    opacity: 0;
   }
   44% {
-    transform: scaleY(0.12);
+    transform: scaleY(1);
+    opacity: 1;
   }
   52% {
-    transform: scaleY(1);
+    transform: scaleY(0);
+    opacity: 0;
   }
   64% {
-    transform: scaleY(0.12);
+    transform: scaleY(1);
+    opacity: 1;
   }
   74%,
   100% {
-    transform: scaleY(1);
+    transform: scaleY(0);
+    opacity: 0;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5202,7 +5202,7 @@ body.player-open {
   /* Body travel toward the hands — large enough to read as a chin-up at splash size. */
   --pullup-chin-lift: 26px;
   transform-origin: 50% 0%;
-  animation: mascot-pullups-climb 3.6s ease-in-out;
+  animation: mascot-pullups-climb 3.8s ease-in-out;
 }
 
 @media (max-height: 720px) {
@@ -5221,7 +5221,7 @@ body.player-open {
 /* Chin-ups: body only. Hands stay on the rim (they live outside this group). */
 .mascot-interactive--pullups .mascot__body-group {
   transform-origin: 35px 4px;
-  animation: mascot-pullups-chin 3.6s ease-in-out !important;
+  animation: mascot-pullups-chin 3.8s ease-in-out !important;
 }
 
 /*
@@ -5232,37 +5232,37 @@ body.player-open {
  */
 .mascot--hanging .mascot__mouth-seal {
   transform-origin: 35px 24px;
-  animation: mascot-hang-mouth-seal 3.6s ease-in-out;
+  animation: mascot-hang-mouth-seal 3.8s ease-in-out;
 }
 
 @keyframes mascot-hang-mouth-seal {
   0%,
-  14% {
+  13% {
     transform: scaleY(0);
     opacity: 0;
   }
   /* Chin-up peaks — seal lips, hold breath. */
-  24% {
+  23% {
     transform: scaleY(1);
     opacity: 1;
   }
-  32% {
+  31% {
     transform: scaleY(0);
     opacity: 0;
   }
-  44% {
+  42% {
     transform: scaleY(1);
     opacity: 1;
   }
-  52% {
+  50% {
     transform: scaleY(0);
     opacity: 0;
   }
-  64% {
+  61% {
     transform: scaleY(1);
     opacity: 1;
   }
-  74%,
+  71%,
   100% {
     transform: scaleY(0);
     opacity: 0;
@@ -5274,26 +5274,29 @@ body.player-open {
     transform: translateY(0) scale(1, 1);
   }
   /* Climb and plant hands on the card border. */
-  14% {
+  13% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
   /* Hold through the chin-up reps. */
-  80% {
+  76% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
   /* Let go — stretch on the fall. */
-  88% {
-    transform: translateY(calc(-0.28 * var(--pullup-hang))) scale(0.94, 1.1);
+  84% {
+    transform: translateY(calc(-0.22 * var(--pullup-hang))) scale(0.9, 1.14);
   }
-  /* Impact squash. */
+  /* Impact squash — held a beat so it reads. */
+  90% {
+    transform: translateY(10px) scale(1.22, 0.7);
+  }
   93% {
     transform: translateY(8px) scale(1.18, 0.76);
   }
   /* Short rebound. */
-  97% {
-    transform: translateY(-3px) scale(0.96, 1.07);
+  96% {
+    transform: translateY(-4px) scale(0.94, 1.1);
   }
-  /* Settle. */
+  /* Settle and hold so the land is not cut by session end. */
   100% {
     transform: translateY(0) scale(1, 1);
   }
@@ -5302,32 +5305,32 @@ body.player-open {
 @keyframes mascot-pullups-chin {
   /* Quiet while climbing. */
   0%,
-  14% {
+  13% {
     transform: translateY(0) scale(1, 1);
   }
   /* Rep 1 — chin to the rim. */
-  24% {
+  23% {
     transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
   }
-  32% {
+  31% {
     transform: translateY(0) scale(0.96, 1.05);
   }
   /* Rep 2 */
-  44% {
+  42% {
     transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
   }
-  52% {
+  50% {
     transform: translateY(0) scale(0.96, 1.05);
   }
   /* Rep 3 — a little higher. */
-  64% {
+  61% {
     transform: translateY(calc(-1 * var(--pullup-chin-lift) - 4px)) scale(1.1, 0.88);
   }
-  74% {
+  71% {
     transform: translateY(0) scale(0.96, 1.05);
   }
   /* Quiet for the drop + landing — body rides the climb keyframes. */
-  80%,
+  76%,
   100% {
     transform: translateY(0) scale(1, 1);
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5191,22 +5191,24 @@ body.player-open {
 }
 
 /*
- * Idle pull-ups on the splash card rim. He climbs to the top border, does a few
- * chin-ups (hands stay put via transform-origin at the top), then drops back.
- * Distances are CSS variables so the compact splash (less padding) can shorten
- * the climb without a second keyframes block.
+ * Idle pull-ups on the splash card rim. The card border IS the bar — nothing is
+ * drawn for it. Climb moves the whole sprite so his hands meet that border; then
+ * only `.mascot__body-group` chin-ups toward the fixed hands. Animate the whole
+ * sprite for the reps and it reads as floating, not as a pull-up.
  */
 .mascot-interactive--pullups {
-  --pullup-hang: 40px;
-  --pullup-chin: 56px;
+  /* ~card padding-top so hands land on the 1px border, not short of it. */
+  --pullup-hang: 44px;
+  /* Body travel toward the hands — large enough to read at splash size. */
+  --pullup-chin-lift: 24px;
   transform-origin: 50% 0%;
-  animation: mascot-pullups-session 3.4s ease-in-out;
+  animation: mascot-pullups-climb 3.6s ease-in-out;
 }
 
 @media (max-height: 720px) {
   .mascot-interactive--pullups {
-    --pullup-hang: 22px;
-    --pullup-chin: 34px;
+    --pullup-hang: 20px;
+    --pullup-chin-lift: 14px;
   }
 }
 
@@ -5215,47 +5217,61 @@ body.player-open {
   transform: none;
 }
 
-/* Park emotion body motion — the session keyframes own his travel. */
+/* Chin-ups: body only. Hands stay on the rim (they live outside this group). */
 .mascot-interactive--pullups .mascot__body-group {
-  animation: none !important;
+  transform-origin: 35px 4px;
+  animation: mascot-pullups-chin 3.6s ease-in-out !important;
 }
 
-@keyframes mascot-pullups-session {
+@keyframes mascot-pullups-climb {
   0% {
     transform: translateY(0) scale(1, 1);
   }
-  /* Climb and grab the rim. */
-  10% {
+  /* Climb and plant hands on the card border. */
+  14% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
-  /* Rep 1 */
-  22% {
-    transform: translateY(calc(-1 * var(--pullup-chin))) scale(1.04, 0.94);
+  /* Hold through the chin-up reps. */
+  82% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
-  30% {
-    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  /* Drop with a land squash. */
+  93% {
+    transform: translateY(4px) scale(1.06, 0.9);
+  }
+  100% {
+    transform: translateY(0) scale(1, 1);
+  }
+}
+
+@keyframes mascot-pullups-chin {
+  /* Quiet while climbing. */
+  0%,
+  14% {
+    transform: translateY(0) scale(1, 1);
+  }
+  /* Rep 1 — chin to the rim. */
+  24% {
+    transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
+  }
+  32% {
+    transform: translateY(0) scale(0.96, 1.05);
   }
   /* Rep 2 */
-  42% {
-    transform: translateY(calc(-1 * var(--pullup-chin))) scale(1.04, 0.94);
+  44% {
+    transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
   }
-  50% {
-    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  52% {
+    transform: translateY(0) scale(0.96, 1.05);
   }
-  /* Rep 3 — a little higher, showing off. */
-  62% {
-    transform: translateY(calc(-1 * var(--pullup-chin) - 3px)) scale(1.05, 0.93);
+  /* Rep 3 — a little higher. */
+  64% {
+    transform: translateY(calc(-1 * var(--pullup-chin-lift) - 4px)) scale(1.1, 0.88);
   }
-  72% {
-    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  74% {
+    transform: translateY(0) scale(0.96, 1.05);
   }
-  /* Hang a beat, then drop with a land squash. */
-  80% {
-    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
-  }
-  92% {
-    transform: translateY(3px) scale(1.06, 0.92);
-  }
+  82%,
   100% {
     transform: translateY(0) scale(1, 1);
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5192,14 +5192,14 @@ body.player-open {
 
 /*
  * Idle pull-ups on the splash card rim. The card border IS the bar — nothing is
- * drawn for it. Climb moves the whole sprite so his hands meet that border; then
- * only `.mascot__body-group` chin-ups toward the fixed hands. Animate the whole
- * sprite for the reps and it reads as floating, not as a pull-up.
+ * drawn for it, and we do not redraw his limbs (fake raised arms always read as a
+ * second pair). Climb moves the whole sprite so his head meets that border; then
+ * `.mascot__body-group` chin-ups toward the rim. Mouth seal syncs with the reps.
  */
 .mascot-interactive--pullups {
-  /* Card padding-top (48) + button padding (4) so hands meet the 1px border. */
+  /* Card padding-top (48) + button padding (4) so the head meets the 1px border. */
   --pullup-hang: 52px;
-  /* Body travel toward the hands — large enough to read as a chin-up at splash size. */
+  /* Body travel toward the rim — large enough to read as a chin-up at splash size. */
   --pullup-chin-lift: 26px;
   transform-origin: 50% 0%;
   animation: mascot-pullups-climb 3.8s ease-in-out;
@@ -5218,18 +5218,10 @@ body.player-open {
   transform: none;
 }
 
-/* Chin-ups: body only. Hands stay on the rim (they live outside this group). */
+/* Chin-ups: body bob toward the rim while the button holds the hang height. */
 .mascot-interactive--pullups .mascot__body-group {
   transform-origin: 35px 4px;
   animation: mascot-pullups-chin 3.8s ease-in-out !important;
-}
-
-/*
- * Erase baked side stubs / splayed feet while hanging. Must match the splash
- * card background — nested SVG masks left the stubs showing under the raised arms.
- */
-.mascot__hang-cover {
-  fill: var(--panel);
 }
 
 /*
@@ -5281,7 +5273,7 @@ body.player-open {
   0% {
     transform: translateY(0) scale(1, 1);
   }
-  /* Climb and plant hands on the card border. */
+  /* Climb and plant the head on the card border. */
   13% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5231,70 +5231,41 @@ body.player-open {
 }
 
 /*
- * Breath with the chin: sealed lips at the top of each rep, open mouth on the way
- * down. Keyframe times match `mascot-pullups-chin`. Opacity in the SVG mask
- * controls how hard each mouth punches the face.
+ * Breath with the chin: scale the mouth flat at each chin-up peak (hold breath),
+ * open it on the way down. One path + scaleY — dual-opacity cutouts inside an SVG
+ * mask flipped which state won at the peak in Chromium. Times match
+ * `mascot-pullups-chin`.
  */
-.mascot--hanging .mascot__mouth--hang-hold {
-  opacity: 0;
-  animation: mascot-hang-mouth-hold 3.6s ease-in-out;
+.mascot--hanging .mascot__mouth--hang-breath {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: mascot-hang-mouth-breath 3.6s ease-in-out;
 }
 
-.mascot--hanging .mascot__mouth--hang-breathe {
-  opacity: 1;
-  animation: mascot-hang-mouth-breathe 3.6s ease-in-out;
-}
-
-@keyframes mascot-hang-mouth-hold {
+@keyframes mascot-hang-mouth-breath {
   0%,
   14% {
-    opacity: 0;
+    transform: scaleY(1);
   }
-  /* Rep tops — hold breath. */
+  /* Chin-up peaks — seal lips, hold breath. */
   24% {
-    opacity: 1;
+    transform: scaleY(0.12);
   }
   32% {
-    opacity: 0;
+    transform: scaleY(1);
   }
   44% {
-    opacity: 1;
+    transform: scaleY(0.12);
   }
   52% {
-    opacity: 0;
+    transform: scaleY(1);
   }
   64% {
-    opacity: 1;
+    transform: scaleY(0.12);
   }
   74%,
   100% {
-    opacity: 0;
-  }
-}
-
-@keyframes mascot-hang-mouth-breathe {
-  0%,
-  14% {
-    opacity: 1;
-  }
-  24% {
-    opacity: 0;
-  }
-  32% {
-    opacity: 1;
-  }
-  44% {
-    opacity: 0;
-  }
-  52% {
-    opacity: 1;
-  }
-  64% {
-    opacity: 0;
-  }
-  74%,
-  100% {
-    opacity: 1;
+    transform: scaleY(1);
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3276,6 +3276,9 @@ body.player-open {
   width: 100%;
   text-align: center;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  /* Pull-ups hang past the top padding onto the rim — don't clip his hands. */
+  position: relative;
+  overflow: visible;
 }
 
 .beta-splash__logo {
@@ -5187,6 +5190,77 @@ body.player-open {
   animation: mascot-interactive-boop 0.45s ease-out;
 }
 
+/*
+ * Idle pull-ups on the splash card rim. He climbs to the top border, does a few
+ * chin-ups (hands stay put via transform-origin at the top), then drops back.
+ * Distances are CSS variables so the compact splash (less padding) can shorten
+ * the climb without a second keyframes block.
+ */
+.mascot-interactive--pullups {
+  --pullup-hang: 40px;
+  --pullup-chin: 56px;
+  transform-origin: 50% 0%;
+  animation: mascot-pullups-session 3.4s ease-in-out;
+}
+
+@media (max-height: 720px) {
+  .mascot-interactive--pullups {
+    --pullup-hang: 22px;
+    --pullup-chin: 34px;
+  }
+}
+
+.mascot-interactive--pullups .mascot-interactive__tilt {
+  transition: none;
+  transform: none;
+}
+
+/* Park emotion body motion — the session keyframes own his travel. */
+.mascot-interactive--pullups .mascot__body-group {
+  animation: none !important;
+}
+
+@keyframes mascot-pullups-session {
+  0% {
+    transform: translateY(0) scale(1, 1);
+  }
+  /* Climb and grab the rim. */
+  10% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
+  }
+  /* Rep 1 */
+  22% {
+    transform: translateY(calc(-1 * var(--pullup-chin))) scale(1.04, 0.94);
+  }
+  30% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  }
+  /* Rep 2 */
+  42% {
+    transform: translateY(calc(-1 * var(--pullup-chin))) scale(1.04, 0.94);
+  }
+  50% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  }
+  /* Rep 3 — a little higher, showing off. */
+  62% {
+    transform: translateY(calc(-1 * var(--pullup-chin) - 3px)) scale(1.05, 0.93);
+  }
+  72% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.03);
+  }
+  /* Hang a beat, then drop with a land squash. */
+  80% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
+  }
+  92% {
+    transform: translateY(3px) scale(1.06, 0.92);
+  }
+  100% {
+    transform: translateY(0) scale(1, 1);
+  }
+}
+
 @keyframes mascot-interactive-boop {
   0% {
     transform: scale(1, 1);
@@ -5256,7 +5330,8 @@ body.player-open {
 @media (prefers-reduced-motion: reduce) {
   .mascot-interactive,
   .mascot-interactive__tilt,
-  .mascot-interactive--poking {
+  .mascot-interactive--poking,
+  .mascot-interactive--pullups {
     transition: none;
     animation: none;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5197,18 +5197,19 @@ body.player-open {
  * sprite for the reps and it reads as floating, not as a pull-up.
  */
 .mascot-interactive--pullups {
-  /* ~card padding-top so hands land on the 1px border, not short of it. */
-  --pullup-hang: 44px;
-  /* Body travel toward the hands — large enough to read at splash size. */
-  --pullup-chin-lift: 24px;
+  /* Card padding-top (48) + button padding (4) so hands meet the 1px border. */
+  --pullup-hang: 52px;
+  /* Body travel toward the hands — large enough to read as a chin-up at splash size. */
+  --pullup-chin-lift: 26px;
   transform-origin: 50% 0%;
   animation: mascot-pullups-climb 3.6s ease-in-out;
 }
 
 @media (max-height: 720px) {
   .mascot-interactive--pullups {
-    --pullup-hang: 20px;
-    --pullup-chin-lift: 14px;
+    /* Compact splash padding is 24px + button pad. */
+    --pullup-hang: 28px;
+    --pullup-chin-lift: 16px;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5225,6 +5225,14 @@ body.player-open {
 }
 
 /*
+ * Erase baked side stubs / splayed feet while hanging. Must match the splash
+ * card background — nested SVG masks left the stubs showing under the raised arms.
+ */
+.mascot__hang-cover {
+  fill: var(--panel);
+}
+
+/*
  * Breath with the chin: a body-coloured seal covers the open mouth hole at each
  * chin-up peak (hold breath) and lifts on the way down. The seal lives outside the
  * face mask so the animation is not fighting mask opacity/transforms. Times match

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3276,7 +3276,7 @@ body.player-open {
   width: 100%;
   text-align: center;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
-  /* Pull-ups hang past the top padding onto the rim — don't clip his hands. */
+  /* Pull-ups climb onto the rim — don't clip him. */
   position: relative;
   overflow: visible;
 }
@@ -5191,25 +5191,22 @@ body.player-open {
 }
 
 /*
- * Idle pull-ups on the splash card rim. The card border IS the bar — nothing is
- * drawn for it, and we do not redraw his limbs (fake raised arms always read as a
- * second pair). Climb moves the whole sprite so his head meets that border; then
- * `.mascot__body-group` chin-ups toward the rim. Mouth seal syncs with the reps.
+ * Idle pull-ups on the splash card rim. One animation on the whole button — he
+ * stays the normal logo mascot (same face, same limbs). The card border is the
+ * bar; nothing extra is drawn. Climb → a few chin bobs near the rim → drop + land.
  */
 .mascot-interactive--pullups {
-  /* Card padding-top (48) + button padding (4) so the head meets the 1px border. */
-  --pullup-hang: 52px;
-  /* Body travel toward the rim — large enough to read as a chin-up at splash size. */
-  --pullup-chin-lift: 26px;
-  transform-origin: 50% 0%;
-  animation: mascot-pullups-climb 3.8s ease-in-out;
+  /* Card padding-top (48) + button pad so his head meets the 1px border. */
+  --pullup-hang: 48px;
+  --pullup-chin: 20px;
+  transform-origin: 50% 100%;
+  animation: mascot-pullups 3.2s ease-in-out;
 }
 
 @media (max-height: 720px) {
   .mascot-interactive--pullups {
-    /* Compact splash padding is 24px + button pad. */
-    --pullup-hang: 28px;
-    --pullup-chin-lift: 16px;
+    --pullup-hang: 26px;
+    --pullup-chin: 12px;
   }
 }
 
@@ -5218,119 +5215,51 @@ body.player-open {
   transform: none;
 }
 
-/* Chin-ups: body bob toward the rim while the button holds the hang height. */
+/* Kill the idle body bob while the pull-up timeline owns transform. */
 .mascot-interactive--pullups .mascot__body-group {
-  transform-origin: 35px 4px;
-  animation: mascot-pullups-chin 3.8s ease-in-out !important;
+  animation: none !important;
 }
 
-/*
- * Breath with the chin: a body-coloured seal covers the open mouth hole at each
- * chin-up peak (hold breath) and lifts on the way down. The seal lives outside the
- * face mask so the animation is not fighting mask opacity/transforms. Times match
- * `mascot-pullups-chin`.
- */
-.mascot--hanging .mascot__mouth-seal {
-  transform-origin: 35px 24px;
-  animation: mascot-hang-mouth-seal 3.8s ease-in-out;
-}
-
-@keyframes mascot-hang-mouth-seal {
-  0%,
-  13% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
-  /* Chin-up peaks — seal lips, hold breath. */
-  23% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
-  31% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
-  42% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
-  61% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
-  71%,
-  100% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
-}
-
-@keyframes mascot-pullups-climb {
+@keyframes mascot-pullups {
   0% {
     transform: translateY(0) scale(1, 1);
   }
-  /* Climb and plant the head on the card border. */
-  13% {
+  /* Hop up and grab the rim. */
+  14% {
     transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
   }
-  /* Hold through the chin-up reps. */
-  76% {
-    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
+  /* Chin-up 1 */
+  24% {
+    transform: translateY(calc(-1 * var(--pullup-hang) - var(--pullup-chin))) scale(1.05, 0.94);
   }
-  /* Let go — stretch on the fall. */
-  84% {
-    transform: translateY(calc(-0.22 * var(--pullup-hang))) scale(0.9, 1.14);
+  32% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.04);
   }
-  /* Impact squash — held a beat so it reads. */
-  90% {
-    transform: translateY(10px) scale(1.22, 0.7);
-  }
-  93% {
-    transform: translateY(8px) scale(1.18, 0.76);
-  }
-  /* Short rebound. */
-  96% {
-    transform: translateY(-4px) scale(0.94, 1.1);
-  }
-  /* Settle and hold so the land is not cut by session end. */
-  100% {
-    transform: translateY(0) scale(1, 1);
-  }
-}
-
-@keyframes mascot-pullups-chin {
-  /* Quiet while climbing. */
-  0%,
-  13% {
-    transform: translateY(0) scale(1, 1);
-  }
-  /* Rep 1 — chin to the rim. */
-  23% {
-    transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
-  }
-  31% {
-    transform: translateY(0) scale(0.96, 1.05);
-  }
-  /* Rep 2 */
+  /* Chin-up 2 */
   42% {
-    transform: translateY(calc(-1 * var(--pullup-chin-lift))) scale(1.08, 0.9);
+    transform: translateY(calc(-1 * var(--pullup-hang) - var(--pullup-chin))) scale(1.05, 0.94);
   }
   50% {
-    transform: translateY(0) scale(0.96, 1.05);
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.04);
   }
-  /* Rep 3 — a little higher. */
-  61% {
-    transform: translateY(calc(-1 * var(--pullup-chin-lift) - 4px)) scale(1.1, 0.88);
+  /* Chin-up 3 — a little higher */
+  60% {
+    transform: translateY(calc(-1 * var(--pullup-hang) - var(--pullup-chin) - 4px)) scale(1.06, 0.92);
   }
-  71% {
-    transform: translateY(0) scale(0.96, 1.05);
+  68% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(0.98, 1.04);
   }
-  /* Quiet for the drop + landing — body rides the climb keyframes. */
-  76%,
+  /* Hold, then drop. */
+  74% {
+    transform: translateY(calc(-1 * var(--pullup-hang))) scale(1, 1);
+  }
+  /* Land squash + short bounce. */
+  86% {
+    transform: translateY(6px) scale(1.12, 0.84);
+  }
+  93% {
+    transform: translateY(-3px) scale(0.97, 1.05);
+  }
   100% {
     transform: translateY(0) scale(1, 1);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Splash mascot occasionally does pull-ups on the closed-beta card rim when idle.

### From scratch (this revision)
Previous hang poses (redrawn arms, merged feet, mouth seals, proud face) made him lose his identity. Pull-ups are now **motion only**:

- Same wave face and limbs as the splash mascot
- One CSS timeline on the button: climb → chin bobs → land squash
- Card border is the bar; nothing extra is drawn
- Poke / hover / reduced-motion still cancel

## Test plan
- [x] Unit tests
- [x] Green gate
- [ ] Visual check — still looks like himself

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fada5-61b7-7bee-8386-4c2aa40fba42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fada5-61b7-7bee-8386-4c2aa40fba42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

