### PR TITLE
ops: the O1 floor — Firestore backups, the alert floor, and four runbooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ survives only in this repo's early history.
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions              |
 | [`path-routing-plan.md`](./path-routing-plan.md)                   | ✅ Path URLs for deep links (`/play/<slug>`, …) — History API, no hashbang                             |
 | [`recommendations.md`](./recommendations.md)                       | ✅ Home arcade sort from scorecards + signed-in play affinity                                          |
+| [`runbooks/`](./runbooks/README.md)                                | ✅ Incident procedures: site-down triage, deploy rollback, Firestore restore, secret rotation           |
 | [`contributing-for-agents.md`](./contributing-for-agents.md)       | How agents run, structure, and contribute to this repository                                           |
 | [`local-development.md`](./local-development.md)                   | ✅ Running the whole product on a laptop with no keys — start here to contribute                       |
 | [`multiplayer-plan.md`](./multiplayer-plan.md)                     | ✅ Party mode: shared screen, phones as controllers, slot model, in-process relay                      |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,7 +17,7 @@ hour, possibly on a phone.
 | [`site-down-triage.md`](./site-down-triage.md) | Alert A1 or A2 fired, or the site is unreachable. **Start here** |
 | [`rollback-deploy.md`](./rollback-deploy.md) | A deploy broke production |
 | [`restore-firestore.md`](./restore-firestore.md) | Data was lost, corrupted, or wrongly deleted |
-| [`rotate-secrets.md`](./rotate-secrets.md) | Routine rotation, an expiring PAT, or a suspected leak. Holds the **expiry ledger** |
+| [`rotate-secrets.md`](./rotate-secrets.md) | Routine rotation, an expiring PAT, or a suspected leak. The expiry ledger itself is in the ops repo |
 
 Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch spike) and
 `launch-day.md` (the spike procedure). Both are Gate O2/O3 items.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -31,7 +31,7 @@ Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 | A1 | Uptime check on `/api/health` fails from most probers for 5 min | [`site-down-triage.md`](./site-down-triage.md) |
 | A2 | Cloud Run 5xx sustained over 10 min | [`site-down-triage.md`](./site-down-triage.md) |
 | A3 | A scheduled job fails repeatedly (notify-sweep, or the daily export) | §below |
-| A4 | No write to the backup bucket in 36h | [`restore-firestore.md`](./restore-firestore.md) |
+| A4 | The daily Firestore export has not succeeded in 36h | [`restore-firestore.md`](./restore-firestore.md) |
 | A5 | Billing budget at 50 / 90 / 100% | Cost review — see the ops repo's readiness plan |
 
 **A3 covers two different jobs.** Check `job_id` on the alert:
@@ -39,7 +39,7 @@ Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 - `notify-sweep` — creators stop being notified of build transitions. The site looks
   fine, which is why this needs an alert at all. It is also a free synthetic monitor of
   auth + Firestore + the app in one request, so its failure often means something larger.
-- `firestore-daily-export` — backups are not running. Treat with the same urgency as A4.
+- `firestore-daily-export` — backups are failing. A4 is its counterpart: A3 fires when the job runs and fails, A4 when it stops running at all (paused, deleted, never scheduled), where there are no failures to count.
 
 ## What is not covered yet
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,50 @@
+# Runbooks
+
+Procedures for when something is broken, or before it is. Written to be followed by
+whoever is holding the pager — which today is one person, possibly at an inconvenient
+hour, possibly on a phone.
+
+**Rules for this folder:**
+
+1. **Commands, not prose.** Copy-pasteable, with the project/region already filled in.
+2. **A runbook is not done until it has been executed once** while nothing was wrong.
+   Each file carries a "Last drilled" line; `never` means it is an untested hypothesis.
+3. **Fix them when they turn out to be wrong** — same self-improvement clause as the
+   agent playbooks. A runbook that lies during an incident is worse than no runbook.
+
+| Runbook | When |
+| --- | --- |
+| [`site-down-triage.md`](./site-down-triage.md) | Alert A1 or A2 fired, or the site is unreachable. **Start here** |
+| [`rollback-deploy.md`](./rollback-deploy.md) | A deploy broke production |
+| [`restore-firestore.md`](./restore-firestore.md) | Data was lost, corrupted, or wrongly deleted |
+| [`rotate-secrets.md`](./rotate-secrets.md) | Routine rotation, an expiring PAT, or a suspected leak. Holds the **expiry ledger** |
+
+Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch spike) and
+`launch-day.md` (the spike procedure). Both are Gate O2/O3 items.
+
+## Alerts and where they land
+
+Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
+
+| # | Fires when | Go to |
+| --- | --- | --- |
+| A1 | Uptime check on `/api/health` fails from most probers for 5 min | [`site-down-triage.md`](./site-down-triage.md) |
+| A2 | Cloud Run 5xx sustained over 10 min | [`site-down-triage.md`](./site-down-triage.md) |
+| A3 | A scheduled job fails repeatedly (notify-sweep, or the daily export) | §below |
+| A4 | No write to the backup bucket in 36h | [`restore-firestore.md`](./restore-firestore.md) |
+| A5 | Billing budget at 50 / 90 / 100% | Cost review — see the ops repo's readiness plan |
+
+**A3 covers two different jobs.** Check `job_id` on the alert:
+
+- `notify-sweep` — creators stop being notified of build transitions. The site looks
+  fine, which is why this needs an alert at all. It is also a free synthetic monitor of
+  auth + Firestore + the app in one request, so its failure often means something larger.
+- `firestore-daily-export` — backups are not running. Treat with the same urgency as A4.
+
+## What is not covered yet
+
+The gaps are known, not forgotten — they are tracked as numbered items in the
+operational readiness plan in the **private ops repo** (`www.gamedev.pl-ops`), which is
+where ops planning lives now. Notably absent from this folder: takedown operations, the
+load-shedding procedure, and anything about the party relay or zone host as separate
+services.

--- a/docs/runbooks/restore-firestore.md
+++ b/docs/runbooks/restore-firestore.md
@@ -1,0 +1,136 @@
+# Runbook: restore Firestore
+
+**Last drilled: never.** ⚠️ Until a date appears here, this document is a hypothesis, not
+a procedure — and the backups it describes are unproven. Drill it once (§4), then record
+the date and anything that turned out to be wrong.
+
+Provisioned by [`infra/setup-backups.sh`](../../infra/setup-backups.sh): point-in-time
+recovery with a 7-day window, plus a daily export to `gs://gamedevpl-firestore-backups`
+kept 30 days.
+
+## 0. Which mechanism, and how to choose fast
+
+| Situation | Use | Why |
+| --- | --- | --- |
+| Bad write, wrong-collection delete, a script that ran twice — **within 7 days** | **PITR** (§2) | Exact, to the microsecond, no staleness |
+| Discovered later than 7 days | **Export** (§3) | Only copy that still exists |
+| Database or project itself lost | **Export** (§3) | PITR died with the database |
+| Not sure yet what broke | **Export a snapshot first** (§1), then investigate | Buys time without committing |
+
+**The one irreversible move to avoid:** restoring *over* the live database before
+capturing its current state. Whatever is wrong, the present is still evidence — and if
+the diagnosis is wrong, it is also the only copy of anything written since the incident.
+Always do §1 first.
+
+## 1. Before anything: freeze the present
+
+```bash
+PROJECT_ID=gamedevpl
+gcloud firestore export "gs://${PROJECT_ID}-firestore-backups/incident-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --project "$PROJECT_ID"
+```
+
+This runs against the live database and does not modify it. It takes minutes on this
+data volume. Do it even when in a hurry — especially then.
+
+## 2. PITR restore (within the 7-day window)
+
+PITR restores into a **new database**; it cannot overwrite `(default)` in place. That is
+a feature — it means the restore is inspectable before anything switches.
+
+```bash
+PROJECT_ID=gamedevpl
+# Timestamps must be whole seconds, RFC3339, inside the window. Pick a moment
+# comfortably BEFORE the bad event, not the instant of it.
+RESTORE_AT="2026-07-29T14:00:00Z"
+
+gcloud firestore databases restore \
+  --source-database='(default)' \
+  --snapshot-time="$RESTORE_AT" \
+  --destination-database='restore-check' \
+  --project "$PROJECT_ID"
+```
+
+Inspect before promoting — the point of restoring beside rather than over:
+
+```bash
+gcloud firestore export "gs://${PROJECT_ID}-firestore-backups/verify-restore" \
+  --database='restore-check' --project "$PROJECT_ID"
+# or read a few documents directly in the console against the restore-check database
+```
+
+Then choose:
+
+- **Targeted repair (preferred).** If only one collection is damaged, copy those
+  documents from `restore-check` into `(default)` and leave everything else alone. This
+  loses nothing written since the incident.
+- **Full cutover.** Only when the whole database is bad. The app reads `(default)` and
+  has no database-name env var, so cutover means deleting `(default)` and renaming — a
+  destructive step that also loses every write since `RESTORE_AT`. Think twice; §1's
+  export is what makes that survivable.
+
+Delete the scratch database when finished — it bills like any other:
+
+```bash
+gcloud firestore databases delete --database='restore-check' --project "$PROJECT_ID"
+```
+
+## 3. Export restore (older than 7 days, or database lost)
+
+```bash
+PROJECT_ID=gamedevpl
+gcloud storage ls "gs://${PROJECT_ID}-firestore-backups/exports/"   # pick a run
+EXPORT_PATH="gs://${PROJECT_ID}-firestore-backups/exports/2026-07-29T03:17:00_12345"
+
+# Import into a scratch database first, for the same reason as above.
+gcloud firestore databases create --database='restore-check' \
+  --location=europe-central2 --type=firestore-native --project "$PROJECT_ID"
+
+gcloud firestore import "$EXPORT_PATH" \
+  --database='restore-check' --project "$PROJECT_ID"
+```
+
+Import is **merge, not replace**: documents in the export overwrite same-id documents,
+and anything not in the export is left untouched. Importing an old export straight over
+a live database therefore resurrects deleted documents without removing new ones — a
+specific and confusing kind of mess. Import to scratch, verify, then copy what is needed.
+
+Single-collection restore, which is the common real case:
+
+```bash
+gcloud firestore import "$EXPORT_PATH" \
+  --collection-ids='submissions' \
+  --database='restore-check' --project "$PROJECT_ID"
+```
+
+## 4. The drill (do this once, now — not during an incident)
+
+The whole point of this runbook is that it has been executed at least once when nothing
+was on fire.
+
+1. Run the export job on demand and confirm an object lands:
+   ```bash
+   gcloud scheduler jobs run firestore-daily-export --location europe-central2 --project gamedevpl
+   gcloud storage ls gs://gamedevpl-firestore-backups/exports/
+   ```
+2. Import it into a `restore-check` database (§3).
+3. Read back one known document — a `users` doc or a `submissions` doc you can identify.
+4. Delete the scratch database.
+5. **Record the date at the top of this file**, along with anything that did not work as
+   written. Fix the text while it is fresh; a runbook that lies is worse than none.
+
+## Data being restored, and why some of it is irreplaceable
+
+| Collection | Replaceable? |
+| --- | --- |
+| `users` (+ `notifications`, `pushSubscriptions`) | ❌ Identity, consent, push endpoints |
+| `waitlist` | ❌ The beta access list |
+| `submissions` (+ `events`, `messages`, `shots`) | ❌ Creator history and attribution |
+| `usage/{uid}/counters` | ❌ Quota state (restoring stale counters grants free quota) |
+| `games/{slug}/votes` | ❌ |
+| `accessTokens` | ⚠️ Revocable and re-mintable; prefer re-minting over restoring |
+| `telemetry/{date}/…` | ⚠️ History only; losing it hurts the improvement loop, breaks nothing |
+
+Published game content is **not** in Firestore — it lives in the games repo and the
+snapshot bucket. See [`games-snapshot.md`](../games-snapshot.md) for rolling that back,
+which is a pointer rewrite, not a database restore.

--- a/docs/runbooks/rollback-deploy.md
+++ b/docs/runbooks/rollback-deploy.md
@@ -1,0 +1,88 @@
+# Runbook: roll back a bad deploy
+
+**Last drilled: never.** ⚠️ Run §4 once against production while nothing is wrong, and
+record the date and elapsed time here. A rollback path first attempted during an outage
+is a rollback path that fails during an outage.
+
+Rollback is **traffic reassignment, not a rebuild**: the previous image is still in
+Artifact Registry and its revision still exists on the service. Nothing needs to
+compile, and it does not depend on GitHub, CI, or this repo being in a good state —
+which matters, because a bad deploy is exactly when those may not be available.
+
+## 1. Find out what is actually serving
+
+```bash
+PROJECT_ID=gamedevpl; REGION=europe-west1; SERVICE=gamedev-app
+
+gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format='value(status.traffic[].revisionName, status.traffic[].percent)'
+
+# Revisions newest-first, with their creation times:
+gcloud run revisions list --service "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format='table(metadata.name, metadata.creationTimestamp, status.conditions[0].status)' \
+  --sort-by=~metadata.creationTimestamp --limit 10
+```
+
+## 2. Roll back
+
+```bash
+PREVIOUS=<revision-name-from-step-1>
+
+gcloud run services update-traffic "$SERVICE" \
+  --region "$REGION" --project "$PROJECT_ID" \
+  --to-revisions "${PREVIOUS}=100"
+```
+
+Effective in seconds. Then confirm, rather than assuming:
+
+```bash
+curl -si https://www.gamedev.pl/api/health | head -n 1
+gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format='value(status.traffic[].revisionName)'
+```
+
+**Party rooms die on rollback**, as they do on any revision change — rooms are
+per-instance memory. Nothing to do about it; just know that "the party broke" reports
+after a rollback are expected and self-resolving (guests rejoin with the same code).
+
+## 3. Then stop the pipeline from re-deploying the bad commit
+
+Traffic is now on the old revision, but `master` still contains whatever broke it. The
+next merge — or a re-run of the deploy workflow — will put it straight back.
+
+Pick one, in preference order:
+
+1. **Revert the commit on `master`** (`git revert <sha>`, push). The deploy that follows
+   is green and the rollback becomes permanent by the normal path. Preferred: it leaves
+   the repo honest.
+2. **Fix forward** if the defect is understood and small.
+3. **Disable the deploy workflow** in the Actions tab only if neither is possible right
+   now and something else is on fire. Re-enable it the same day, and leave a note in the
+   channel — a silently disabled deploy pipeline is its own future incident.
+
+## 4. The drill
+
+Do this once on a quiet afternoon:
+
+1. Note the current revision.
+2. Shift traffic to the previous revision (§2), timing how long the command takes to
+   take effect at the edge.
+3. Verify `/api/health` and load the site.
+4. Shift back to latest: `gcloud run services update-traffic "$SERVICE" --to-latest
+   --region "$REGION" --project "$PROJECT_ID"`.
+5. Record here: the date, and the wall-clock seconds from decision to healthy.
+
+## Other services
+
+The same procedure applies to every Cloud Run service; only `SERVICE` changes.
+
+| Service | Deploy path | Notes |
+| --- | --- | --- |
+| `gamedev-app` | `.github/workflows/deploy.yml`, [`infra/deploy-api.sh`](../../infra/deploy-api.sh) | The site |
+| `gamedev-world` | [`infra/deploy-world.sh`](../../infra/deploy-world.sh) | Zone host; inert unless `ZONE_HOST_URL` is set |
+| party relay | see [`multiplayer-plan.md`](../multiplayer-plan.md) | Same image as the app, role chosen by env |
+
+When more than one service is live, roll back **only the one that broke**, and check
+whether the two are version-coupled before assuming they are independent: the relay and
+the app ship from the same image, so a rollback of one can leave a protocol mismatch
+with the other. If in doubt, roll both to the same previously-good image tag.

--- a/docs/runbooks/rotate-secrets.md
+++ b/docs/runbooks/rotate-secrets.md
@@ -1,42 +1,30 @@
-# Runbook: rotate secrets, and the PAT expiry ledger
+# Runbook: rotate secrets
 
 The *recipes* for each secret live in [`deployment.md`](../deployment.md). This runbook
-adds what that page does not: the **order**, the **verification step**, and the
-**expiry ledger** — because the failure mode here is not a bad rotation, it is a token
-quietly expiring on a Tuesday.
+adds what that page does not: the **order**, and the **verification step** — because the
+failure mode here is not a bad rotation, it is a token quietly expiring on a Tuesday.
 
-## 1. The expiry ledger ⚠️
+## 1. The expiry ledger lives in the ops repo
 
-Fine-grained PATs expire. Expiry is a **scheduled, silent outage** that no monitoring
-catches, because nothing is wrong until the moment it is. Keep this table current, and
-set a calendar reminder ~2 weeks before each date.
+Fine-grained PATs expire, and expiry is a **scheduled, silent outage** that no monitoring
+catches — nothing is wrong until the moment it is. So the dates have to be written down
+somewhere, with a calendar reminder ~2 weeks ahead of each.
 
-| Credential | Lives in | Grants | Expires | Reminder set |
-| --- | --- | --- | --- | --- |
-| `github-token` | GCP Secret Manager | Issues rw + PRs r + Contents r on the games repo | ⚠️ **unrecorded — fill this in** | ☐ |
-| `GAMES_REPO_TOKEN` | GitHub Actions secret (platform repo) | Contents:read on the games repo | ⚠️ **unrecorded — fill this in** | ☐ |
-| `SITE_DISPATCH_TOKEN` | GitHub Actions secret (**games** repo) | Contents:**read+write** on the platform repo | ⚠️ **unrecorded — fill this in** | ☐ |
+**That inventory is not here.** A table of every credential, what each one grants, when it
+expires, and what breaks when it does is a map of the credential surface — useful to an
+operator and equally useful to an attacker. It lives in the private ops repo
+(`gamedevpl/www.gamedev.pl-ops`, `docs/credential-ledger.md`) along with the risk
+register; see the `internal-ops-repo` skill for access.
 
-Read the real dates from GitHub → Settings → Developer settings → Fine-grained tokens,
-and replace the placeholders above. Doing that is item 7 of the O1 gate.
+What stays here is everything that is *already* public knowledge from
+[`deployment.md`](../deployment.md) — the secret names and how to rotate each one.
 
-**On `SITE_DISPATCH_TOKEN` specifically:** `repository_dispatch` cannot be granted more
-narrowly than Contents: read+write, so despite its name this is a *write-capable*
-credential on the platform repo, held by the games repo. Treat a leak of it as a
-compromise of the platform repo, not as a nuisance. Scope it to that single repository
-and nothing else.
-
-### What breaks when each one expires
-
-| Credential | Symptom |
-| --- | --- |
-| `github-token` | Submissions fail; previews and drafts fail. Published play keeps working (snapshot) |
-| `GAMES_REPO_TOKEN` | The games-repo contract check fails in CI; **the snapshot bake fails**, so the catalog silently freezes at its last good bake |
-| `SITE_DISPATCH_TOKEN` | No symptom at all — merges to the games repo stop triggering bakes, and the site serves a stale catalog until the nightly safety bake covers it |
-
-The last row is the one to worry about: it fails *invisibly*. The nightly bake bounds the
-damage to a day, and the games-repo workflow warns rather than failing when the secret is
-absent — which is friendly, and also why nobody would notice.
+One property worth stating in the open, because it constrains how the credential may be
+scoped and anyone touching the workflow needs it: **`SITE_DISPATCH_TOKEN` cannot be
+granted narrowly.** `repository_dispatch` is gated by Contents: read+write, so despite its
+name it is a *write-capable* credential on the platform repo, held by the games repo.
+Scope it to that single repository, and treat a leak of it as a compromise of the platform
+repo rather than a nuisance.
 
 ## 2. Rotation order
 
@@ -76,7 +64,7 @@ second.** A broken site is recoverable; an attacker with a live token is not bou
 
 1. Revoke the credential at its source (GitHub token settings, or disable the Secret
    Manager version).
-2. Assess the blast radius using the table in §1 — `SITE_DISPATCH_TOKEN` and
+2. Assess the blast radius using the ledger in the ops repo — `SITE_DISPATCH_TOKEN` and
    `github-token` both imply *write* access to a repository.
 3. Check what was done with it: the games repo's and platform repo's audit log, recent
    commits, workflow runs, and any issues or PRs created.

--- a/docs/runbooks/rotate-secrets.md
+++ b/docs/runbooks/rotate-secrets.md
@@ -1,0 +1,84 @@
+# Runbook: rotate secrets, and the PAT expiry ledger
+
+The *recipes* for each secret live in [`deployment.md`](../deployment.md). This runbook
+adds what that page does not: the **order**, the **verification step**, and the
+**expiry ledger** — because the failure mode here is not a bad rotation, it is a token
+quietly expiring on a Tuesday.
+
+## 1. The expiry ledger ⚠️
+
+Fine-grained PATs expire. Expiry is a **scheduled, silent outage** that no monitoring
+catches, because nothing is wrong until the moment it is. Keep this table current, and
+set a calendar reminder ~2 weeks before each date.
+
+| Credential | Lives in | Grants | Expires | Reminder set |
+| --- | --- | --- | --- | --- |
+| `github-token` | GCP Secret Manager | Issues rw + PRs r + Contents r on the games repo | ⚠️ **unrecorded — fill this in** | ☐ |
+| `GAMES_REPO_TOKEN` | GitHub Actions secret (platform repo) | Contents:read on the games repo | ⚠️ **unrecorded — fill this in** | ☐ |
+| `SITE_DISPATCH_TOKEN` | GitHub Actions secret (**games** repo) | Contents:**read+write** on the platform repo | ⚠️ **unrecorded — fill this in** | ☐ |
+
+Read the real dates from GitHub → Settings → Developer settings → Fine-grained tokens,
+and replace the placeholders above. Doing that is item 7 of the O1 gate.
+
+**On `SITE_DISPATCH_TOKEN` specifically:** `repository_dispatch` cannot be granted more
+narrowly than Contents: read+write, so despite its name this is a *write-capable*
+credential on the platform repo, held by the games repo. Treat a leak of it as a
+compromise of the platform repo, not as a nuisance. Scope it to that single repository
+and nothing else.
+
+### What breaks when each one expires
+
+| Credential | Symptom |
+| --- | --- |
+| `github-token` | Submissions fail; previews and drafts fail. Published play keeps working (snapshot) |
+| `GAMES_REPO_TOKEN` | The games-repo contract check fails in CI; **the snapshot bake fails**, so the catalog silently freezes at its last good bake |
+| `SITE_DISPATCH_TOKEN` | No symptom at all — merges to the games repo stop triggering bakes, and the site serves a stale catalog until the nightly safety bake covers it |
+
+The last row is the one to worry about: it fails *invisibly*. The nightly bake bounds the
+damage to a day, and the games-repo workflow warns rather than failing when the secret is
+absent — which is friendly, and also why nobody would notice.
+
+## 2. Rotation order
+
+Rotate one at a time, verifying between each. Nothing here is coupled, so a single bad
+rotation should never cascade — but only if you can tell which one broke.
+
+1. **Create the new credential** (do not revoke the old one yet).
+2. **Store it** — Secret Manager version, or GitHub secret.
+3. **Make it take effect**: Secret Manager values are read at container start, so a
+   rotated GCP secret needs a new revision — redeploy, or
+   `gcloud run services update gamedev-app --region europe-west1 --project gamedevpl
+   --update-env-vars ROTATED_AT=$(date -u +%s)` to force one. GitHub Actions secrets take
+   effect on the next workflow run.
+4. **Verify** (§3).
+5. **Only then revoke the old credential.** Reversing steps 4 and 5 is how a rotation
+   becomes an outage.
+
+## 3. Verification per secret
+
+| Secret | Verify |
+| --- | --- |
+| `github-token` | Submit a test spec, or `curl -s https://www.gamedev.pl/api/health` then check logs for GitHub auth errors |
+| `GAMES_REPO_TOKEN` | Re-run the *Publish games snapshot* workflow — it reads the games repo and must go green |
+| `SITE_DISPATCH_TOKEN` | Merge anything trivial to the games repo `main`; a *Publish games snapshot* run must appear in the platform repo within a minute |
+| `session-secret` | ⚠️ Rotating this **invalidates every session** — every user is signed out. Not a routine rotation; do it deliberately, ideally announced |
+| `submission-token-secret` | ⚠️ Invalidates outstanding submission status links. Same caution |
+| `resend-api-key` | `npm run beta:invite -w @gamedevpl/api -- you@example.com --dry-run`, then a real send to yourself |
+| `vapid-private-key` | ⚠️ Invalidates every existing push subscription; users must re-subscribe |
+
+The three marked ⚠️ are **user-visible** rotations. They are not emergencies to be done
+quickly — they are changes to be scheduled.
+
+## 4. Compromise, rather than routine rotation
+
+Order changes when a credential is believed leaked: **revoke first, restore service
+second.** A broken site is recoverable; an attacker with a live token is not bounded.
+
+1. Revoke the credential at its source (GitHub token settings, or disable the Secret
+   Manager version).
+2. Assess the blast radius using the table in §1 — `SITE_DISPATCH_TOKEN` and
+   `github-token` both imply *write* access to a repository.
+3. Check what was done with it: the games repo's and platform repo's audit log, recent
+   commits, workflow runs, and any issues or PRs created.
+4. Then rotate normally (§2).
+5. Write the incident up in the ops repo.

--- a/docs/runbooks/site-down-triage.md
+++ b/docs/runbooks/site-down-triage.md
@@ -1,0 +1,113 @@
+# Runbook: the site is down
+
+Entry point for alerts **A1** (uptime check failing) and **A2** (sustained 5xx).
+
+Work top to bottom — the order is by descending likelihood, and each step is cheap.
+Resist diagnosing before step 1: "what changed" answers this most of the time.
+
+## 1. What changed in the last hour?
+
+```bash
+PROJECT_ID=gamedevpl; REGION=europe-west1; SERVICE=gamedev-app
+
+# Did something deploy?
+gcloud run revisions list --service "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format='table(metadata.name, metadata.creationTimestamp)' \
+  --sort-by=~metadata.creationTimestamp --limit 5
+```
+
+A revision created shortly before the alert makes this a deploy problem: go straight to
+[`rollback-deploy.md`](./rollback-deploy.md), roll back first, and diagnose afterwards
+from a healthy site. Rolling back is cheap and reversible; debugging a live outage is
+neither.
+
+## 2. What is the service actually saying?
+
+```bash
+gcloud logging read \
+  "resource.type=cloud_run_revision AND resource.labels.service_name=${SERVICE} AND severity>=ERROR" \
+  --project "$PROJECT_ID" --limit 30 --format='value(timestamp, jsonPayload.msg, textPayload)'
+```
+
+Match the message against the table below.
+
+| What you see | Cause | Action |
+| --- | --- | --- |
+| `snapshot catalog unavailable` / 503 from `/api/catalog` | The snapshot bucket is unreachable or `current.json` is missing | §3 |
+| `failed to load game` with 502, specific slugs | A game is in the catalog but was never baked | Re-run the publish workflow (§3) |
+| Firestore permission / deadline errors | Firestore or its IAM | §4 |
+| Container fails to start, "cannot find module" | Bad image — a workspace package missing from the build | Roll back (§1). This has happened before |
+| Nothing at ERROR, but 5xx in metrics | Look at the load balancer / instance count | §5 |
+
+## 3. Published games are failing (snapshot path)
+
+**This is now a hard dependency, not a fast path.** Published catalog and play are served
+from `gs://gamedevpl-games-snapshots`; there is deliberately **no GitHub fallback** for
+published games — unavailable maps to 503 and a missing baked object to 502. See
+[`games-snapshot.md`](../games-snapshot.md).
+
+```bash
+# Is the pointer there and sane?
+gcloud storage cat gs://gamedevpl-games-snapshots/current.json --project gamedevpl
+
+# Can the runtime SA still read the bucket? (a broken IAM change looks exactly like an outage)
+gcloud storage buckets get-iam-policy gs://gamedevpl-games-snapshots --project gamedevpl \
+  | grep -A 3 objectViewer
+```
+
+- **Pointer missing or malformed** → re-bake: run the *Publish games snapshot* workflow
+  (`workflow_dispatch`) in the platform repo. It writes a fresh snapshot and moves the
+  pointer atomically.
+- **Pointer fine, one game 502s** → that game failed its bake. Re-run the same workflow;
+  if it fails again, the game itself is the problem — check the workflow log for its slug.
+- **Rollback to an earlier snapshot**: snapshot prefixes are immutable, so rolling back
+  means pointing `current.json` at an older `snapshots/<id>/`. Procedure in
+  [`games-snapshot.md`](../games-snapshot.md).
+
+## 4. Firestore
+
+```bash
+gcloud firestore databases describe --database='(default)' --project gamedevpl
+```
+
+Check the [status dashboard](https://status.cloud.google.com/) for europe-central2. A
+regional Firestore outage is not something to fix — it is something to communicate.
+Sign-in, submissions, quotas and notifications all fail; **published play keeps working**,
+since it reads the snapshot bucket rather than the database. Say so, rather than saying
+"the site is down".
+
+## 5. Capacity / instances
+
+```bash
+gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format='value(spec.template.metadata.annotations)'
+```
+
+While the app is pinned to a single instance, saturation shows up as queueing then 429/5xx
+with no errors in the logs. Under a genuine traffic burst, degrade in this order — the
+ladder exists so the decision is not improvised at 2am:
+
+1. Pause creation (global cap / `SUBMISSIONS_PAUSED`).
+2. Sample or drop telemetry writes — losing metrics beats losing play.
+3. Refuse new party rooms with an honest message.
+4. The play path goes down last.
+
+## 6. When it is not us
+
+Before concluding the platform is broken, check the dependencies that can fail
+independently:
+
+| Dependency | Affects | Check |
+| --- | --- | --- |
+| Cloud Storage (europe-west1) | Published catalog + play | [status.cloud.google.com](https://status.cloud.google.com/) |
+| Firestore (europe-central2) | Everything requiring identity | as above |
+| GitHub API | Creation, previews, drafts — **not** published play | [githubstatus.com](https://www.githubstatus.com/) |
+| Resend | Invite + notification email only | Resend dashboard |
+| Route 53 / DNS | Everything, including the uptime check | `dig www.gamedev.pl` |
+
+## 7. Afterwards
+
+Write down what happened while it is fresh — in the ops repo, not here. Two questions
+worth answering every time, because they are what turn an incident into a system change:
+**what would have caught this sooner**, and **what would have made the fix faster**. If
+either answer is "an alert that does not exist", add it.

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,6 +6,24 @@ Manual or local builds continue to be supported via `infra/deploy-api.sh`.
 
 No Terraform configuration is used or required for this repository.
 
+## Scripts
+
+All are idempotent and **owner-run** — they need `gcloud` authenticated against the
+project, which agent tooling can read but not write.
+
+| Script | What it provisions | When to run |
+| --- | --- | --- |
+| `setup-wif.sh` | Workload Identity Federation for GitHub Actions | Once, before the first deploy |
+| `setup-gcp.sh` | Firestore, IAM, session secret, telemetry TTL, snapshot bucket | Once, then after adding a resource it manages |
+| `setup-backups.sh` | Firestore PITR + daily export to GCS, export SA and its IAM | Once. **Then drill the restore** — see `docs/runbooks/restore-firestore.md` |
+| `setup-monitoring.sh` | Uptime check + alert policies A1–A4, email channel | Once, per `ALERT_EMAIL`. Prints the manual step for A5 (billing budget) |
+| `deploy-api.sh` | Manual deploy of the app service | Rarely — CI deploys on merge to `master` |
+| `deploy-world.sh` | Manual deploy of the zone host | Rarely; inert unless `ZONE_HOST_URL` is set |
+
+Backups and alerting exist because neither Cloud Run nor Firestore provides them by
+default: without `setup-backups.sh` a wrong delete is unrecoverable, and without
+`setup-monitoring.sh` an outage is discovered by whoever next opens the site.
+
 ## Prerequisites (Owner-Run Setup)
 
 Before `.github/workflows/deploy.yml` can deploy from GitHub Actions, the owner must set up Workload Identity Federation in GCP:

--- a/infra/setup-backups.sh
+++ b/infra/setup-backups.sh
@@ -7,7 +7,12 @@
 #   ./infra/setup-backups.sh
 #
 # Override via env: PROJECT_ID, FIRESTORE_REGION, BACKUP_BUCKET, EXPORT_SCHEDULE,
-# EXPORT_RETENTION_DAYS, PITR_RETENTION.
+# EXPORT_RETENTION_DAYS, EXPORT_SA_NAME.
+#
+# PITR's window is deliberately absent from that list: Firestore fixes it at 7 days and
+# `databases update` takes no retention argument, so a knob here could only ever print a
+# number the database does not honour — a false statement about the recovery window, in
+# the one script where that is least acceptable. Longer horizons come from the exports.
 #
 # Why both mechanisms, when either alone sounds sufficient:
 #
@@ -33,7 +38,6 @@ FIRESTORE_REGION="${FIRESTORE_REGION:-europe-central2}"
 BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backups}"
 EXPORT_SCHEDULE="${EXPORT_SCHEDULE:-17 3 * * *}"
 EXPORT_RETENTION_DAYS="${EXPORT_RETENTION_DAYS:-30}"
-PITR_RETENTION="${PITR_RETENTION:-7d}"
 EXPORT_SA_NAME="${EXPORT_SA_NAME:-firestore-export}"
 EXPORT_SA="${EXPORT_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
@@ -42,7 +46,7 @@ gcloud services enable firestore.googleapis.com storage.googleapis.com \
   cloudscheduler.googleapis.com \
   --project "$PROJECT_ID"
 
-echo "==> 2/6 Enabling point-in-time recovery (${PITR_RETENTION} window)"
+echo "==> 2/6 Enabling point-in-time recovery (7-day window, fixed by Firestore)"
 # PITR is a database-level flag, not a per-collection one, so this covers every
 # collection including ones added later. Enabling it on a database that already has it
 # is a no-op that still exits 0.
@@ -157,7 +161,7 @@ else
 fi
 
 echo ""
-echo "==> Done. PITR (${PITR_RETENTION}) + daily export to gs://${BACKUP_BUCKET}."
+echo "==> Done. PITR (7 days) + daily export to gs://${BACKUP_BUCKET} (${EXPORT_RETENTION_DAYS}-day retention)."
 echo ""
 echo "    Verify now, rather than trusting this output:"
 echo "      gcloud scheduler jobs run firestore-daily-export --location ${FIRESTORE_REGION} --project ${PROJECT_ID}"

--- a/infra/setup-backups.sh
+++ b/infra/setup-backups.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# Firestore backups: point-in-time recovery plus a daily export to Cloud Storage.
+# OWNER-RUN: needs `gcloud` authenticated against a project with billing.
+#
+# Usage:
+#   ./infra/setup-backups.sh
+#
+# Override via env: PROJECT_ID, FIRESTORE_REGION, BACKUP_BUCKET, EXPORT_SCHEDULE,
+# EXPORT_RETENTION_DAYS, PITR_RETENTION.
+#
+# Why both mechanisms, when either alone sounds sufficient:
+#
+#   PITR rewinds the *live* database to any microsecond in its retention window. It is
+#   the right tool for the likely accident — a bad script, a wrong-collection delete —
+#   and it needs no storage plan of its own. What it cannot survive is the database
+#   itself going away: delete the database (or lose the project) and its recovery
+#   window goes with it.
+#
+#   Exports are dumb files in a different service, under a different failure domain.
+#   They are slower to restore and only as fresh as the last run, but they survive the
+#   thing PITR does not. Neither is a backup strategy on its own; together they cover
+#   both the fat-finger and the catastrophe.
+#
+# This script is idempotent — safe to re-run after changing any of the knobs above.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gamedevpl}"
+# The bucket must live where the database lives: Firestore refuses to export across
+# locations, and this database is in europe-central2 (the app is in europe-west1 —
+# see docs/deployment.md; that split is deliberate and predates the domain mapping).
+FIRESTORE_REGION="${FIRESTORE_REGION:-europe-central2}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backups}"
+EXPORT_SCHEDULE="${EXPORT_SCHEDULE:-17 3 * * *}"
+EXPORT_RETENTION_DAYS="${EXPORT_RETENTION_DAYS:-30}"
+PITR_RETENTION="${PITR_RETENTION:-7d}"
+EXPORT_SA_NAME="${EXPORT_SA_NAME:-firestore-export}"
+EXPORT_SA="${EXPORT_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo "==> 1/6 Enabling required APIs"
+gcloud services enable firestore.googleapis.com storage.googleapis.com \
+  cloudscheduler.googleapis.com \
+  --project "$PROJECT_ID"
+
+echo "==> 2/6 Enabling point-in-time recovery (${PITR_RETENTION} window)"
+# PITR is a database-level flag, not a per-collection one, so this covers every
+# collection including ones added later. Enabling it on a database that already has it
+# is a no-op that still exits 0.
+gcloud firestore databases update \
+  --database='(default)' \
+  --enable-pitr \
+  --project "$PROJECT_ID" \
+  >/dev/null
+echo "    PITR enabled."
+
+echo "==> 3/6 Ensuring the backup bucket gs://${BACKUP_BUCKET} exists"
+if gcloud storage buckets describe "gs://${BACKUP_BUCKET}" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    Bucket already exists."
+else
+  # Uniform access, and deliberately NOT public by any path: these objects are a full
+  # copy of every user record in the system. The only readers are the export job and
+  # an operator performing a restore.
+  gcloud storage buckets create "gs://${BACKUP_BUCKET}" \
+    --location="$FIRESTORE_REGION" \
+    --uniform-bucket-level-access \
+    --project="$PROJECT_ID"
+  echo "    Created in ${FIRESTORE_REGION} (must match the database's location)."
+fi
+
+# Retention costs pennies at this data volume, and the window is what decides whether a
+# corruption discovered late is recoverable. 30 days is well past the point where anyone
+# would notice; shorten it only if the bill ever argues otherwise.
+LIFECYCLE_FILE="$(mktemp)"
+cat > "$LIFECYCLE_FILE" <<EOF
+{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": { "type": "Delete" },
+        "condition": { "age": ${EXPORT_RETENTION_DAYS} }
+      }
+    ]
+  }
+}
+EOF
+gcloud storage buckets update "gs://${BACKUP_BUCKET}" \
+  --lifecycle-file="$LIFECYCLE_FILE" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+rm -f "$LIFECYCLE_FILE"
+echo "    ${EXPORT_RETENTION_DAYS}-day lifecycle applied."
+
+echo "==> 4/6 Ensuring the export service account exists"
+if gcloud iam service-accounts describe "$EXPORT_SA" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    Service account already exists."
+else
+  gcloud iam service-accounts create "$EXPORT_SA_NAME" \
+    --display-name="Firestore scheduled export" \
+    --project="$PROJECT_ID"
+  echo "    Created ${EXPORT_SA}."
+fi
+
+echo "==> 5/6 Granting the export SA exactly what it needs"
+# datastore.importExportAdmin can start an export but cannot read document contents,
+# and objectCreator can write new objects but cannot read or delete existing ones. So a
+# compromise of this identity cannot exfiltrate the database and cannot destroy older
+# backups — which is the property that makes a backup worth having during an incident.
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${EXPORT_SA}" \
+  --role="roles/datastore.importExportAdmin" \
+  --condition=None \
+  >/dev/null
+gcloud storage buckets add-iam-policy-binding "gs://${BACKUP_BUCKET}" \
+  --member="serviceAccount:${EXPORT_SA}" \
+  --role="roles/storage.objectCreator" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+echo "    importExportAdmin + objectCreator granted (no read, no delete)."
+
+echo "==> 6/6 Ensuring the daily export job"
+# Scheduler calls the Firestore REST API directly with an OAuth token rather than going
+# through a Cloud Function: fewer moving parts, nothing to deploy, and no second
+# codebase that can rot.
+#
+# The prefix is fixed and Firestore creates a timestamped folder beneath it per run
+# (Scheduler has no date templating of its own), so runs never overwrite each other and
+# the lifecycle rule ages whole exports out together.
+EXPORT_URI="https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default):exportDocuments"
+EXPORT_BODY='{"outputUriPrefix":"gs://'"${BACKUP_BUCKET}"'/exports"}'
+
+if gcloud scheduler jobs describe firestore-daily-export --location "$FIRESTORE_REGION" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud scheduler jobs update http firestore-daily-export \
+    --location "$FIRESTORE_REGION" \
+    --project "$PROJECT_ID" \
+    --schedule "$EXPORT_SCHEDULE" \
+    --time-zone 'Etc/UTC' \
+    --uri "$EXPORT_URI" \
+    --http-method POST \
+    --headers 'Content-Type=application/json' \
+    --message-body "$EXPORT_BODY" \
+    --oauth-service-account-email "$EXPORT_SA" \
+    >/dev/null
+  echo "    Updated existing job."
+else
+  gcloud scheduler jobs create http firestore-daily-export \
+    --location "$FIRESTORE_REGION" \
+    --project "$PROJECT_ID" \
+    --schedule "$EXPORT_SCHEDULE" \
+    --time-zone 'Etc/UTC' \
+    --uri "$EXPORT_URI" \
+    --http-method POST \
+    --headers 'Content-Type=application/json' \
+    --message-body "$EXPORT_BODY" \
+    --oauth-service-account-email "$EXPORT_SA" \
+    >/dev/null
+  echo "    Created job (schedule: ${EXPORT_SCHEDULE} UTC)."
+fi
+
+echo ""
+echo "==> Done. PITR (${PITR_RETENTION}) + daily export to gs://${BACKUP_BUCKET}."
+echo ""
+echo "    Verify now, rather than trusting this output:"
+echo "      gcloud scheduler jobs run firestore-daily-export --location ${FIRESTORE_REGION} --project ${PROJECT_ID}"
+echo "      # wait a minute or two, then:"
+echo "      gcloud storage ls gs://${BACKUP_BUCKET}/exports/"
+echo ""
+echo "    A backup nobody has restored is a hypothesis. Run the drill in"
+echo "    docs/runbooks/restore-firestore.md once, and record the date there."

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# The alerting floor: an uptime check and the four alert policies that decide whether a
+# night of 5xx is discovered by monitoring or by a user.
+# OWNER-RUN: needs `gcloud` authenticated against the project.
+#
+# Usage:
+#   ALERT_EMAIL=you@example.com ./infra/setup-monitoring.sh
+#
+# Override via env: PROJECT_ID, REGION, SERVICE, HOST, ALERT_EMAIL, BACKUP_BUCKET.
+#
+# What this deliberately is and is not:
+#
+#   It is GCP-native and email-only. One operator, no rotation, no PagerDuty — the
+#   response-time expectation is hours, not minutes, and the SLO is written to match.
+#   Adding a vendor here would cost a bill and a DPA to tell us the same things.
+#
+#   The bar for a policy living in this file: would the operator act on it within a day?
+#   Anything else belongs on a dashboard, not in an inbox. An alert nobody acts on
+#   trains the operator to ignore the channel, which is worse than not having it.
+#
+# Idempotent: policies are matched by display name and updated rather than duplicated.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gamedevpl}"
+REGION="${REGION:-europe-west1}"
+SERVICE="${SERVICE:-gamedev-app}"
+HOST="${HOST:-www.gamedev.pl}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backups}"
+: "${ALERT_EMAIL:?set ALERT_EMAIL to the address that should receive alerts}"
+
+echo "==> 1/4 Enabling the Monitoring API"
+gcloud services enable monitoring.googleapis.com --project "$PROJECT_ID"
+
+echo "==> 2/4 Ensuring the email notification channel"
+CHANNEL_NAME="$(gcloud beta monitoring channels list \
+  --project "$PROJECT_ID" \
+  --filter="type=email AND labels.email_address=${ALERT_EMAIL}" \
+  --format='value(name)' 2>/dev/null | head -n 1)"
+if [ -z "$CHANNEL_NAME" ]; then
+  CHANNEL_NAME="$(gcloud beta monitoring channels create \
+    --project "$PROJECT_ID" \
+    --display-name="Ops email" \
+    --type=email \
+    --channel-labels="email_address=${ALERT_EMAIL}" \
+    --format='value(name)')"
+  echo "    Created channel ${CHANNEL_NAME}."
+else
+  echo "    Channel already exists."
+fi
+
+echo "==> 3/4 Ensuring the uptime check on https://${HOST}/api/health"
+# /api/health is the right probe target precisely because it is not walled: it answers
+# 200 without a session, so a failure means the service is genuinely unreachable rather
+# than that the beta gate did its job. Checking a walled route would alert on 401 or,
+# worse, teach us to ignore the alert that fires every time.
+UPTIME_NAME="$(gcloud monitoring uptime list-configs \
+  --project "$PROJECT_ID" \
+  --filter="displayName='gamedev-app health'" \
+  --format='value(name)' 2>/dev/null | head -n 1)"
+if [ -z "$UPTIME_NAME" ]; then
+  gcloud monitoring uptime create 'gamedev-app health' \
+    --project "$PROJECT_ID" \
+    --resource-type=uptime-url \
+    --resource-labels="host=${HOST},project_id=${PROJECT_ID}" \
+    --path='/api/health' \
+    --port=443 \
+    --protocol=https \
+    --period=5 \
+    --timeout=10 \
+    >/dev/null
+  echo "    Created (5-minute cadence from multiple regions)."
+else
+  echo "    Uptime check already exists."
+fi
+
+echo "==> 4/4 Ensuring alert policies"
+POLICY_DIR="$(mktemp -d)"
+trap 'rm -rf "$POLICY_DIR"' EXIT
+
+# A1 — the site is down. Multi-region agreement is what separates "Cloud Run is gone"
+# from "one prober had a bad minute", which is why the uptime check fans out and this
+# policy waits for 300s of sustained failure before it speaks.
+cat > "${POLICY_DIR}/a1.json" <<EOF
+{
+  "displayName": "A1 site down (uptime check failing)",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "uptime check failing for 5 minutes",
+    "conditionThreshold": {
+      "filter": "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\"",
+      "aggregations": [{
+        "alignmentPeriod": "300s",
+        "perSeriesAligner": "ALIGN_FRACTION_TRUE",
+        "crossSeriesReducer": "REDUCE_MEAN"
+      }],
+      "comparison": "COMPARISON_LT",
+      "thresholdValue": 0.4,
+      "duration": "300s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "alertStrategy": { "autoClose": "86400s" },
+  "documentation": {
+    "content": "https://${HOST}/api/health is failing from most probers. Triage: docs/runbooks/site-down-triage.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
+# A2 — 5xx rate. Scale-to-zero means low absolute traffic, where a *ratio* alone is
+# noise: two errors out of three requests at 04:00 is 66% and means nothing. Hence a
+# rate condition rather than a ratio, tuned to fire on a broken deploy (which errors
+# continuously) and stay quiet for the occasional one-off.
+cat > "${POLICY_DIR}/a2.json" <<EOF
+{
+  "displayName": "A2 Cloud Run 5xx rate elevated",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "5xx responses sustained over 10 minutes",
+    "conditionThreshold": {
+      "filter": "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.label.\"service_name\"=\"${SERVICE}\" AND metric.label.\"response_code_class\"=\"5xx\"",
+      "aggregations": [{
+        "alignmentPeriod": "600s",
+        "perSeriesAligner": "ALIGN_RATE",
+        "crossSeriesReducer": "REDUCE_SUM"
+      }],
+      "comparison": "COMPARISON_GT",
+      "thresholdValue": 0.03,
+      "duration": "600s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "alertStrategy": { "autoClose": "86400s" },
+  "documentation": {
+    "content": "Sustained 5xx from ${SERVICE}. Most likely: a bad deploy, the snapshot bucket unreachable (published play now 503s rather than falling back), or Firestore. Triage: docs/runbooks/site-down-triage.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
+# A3 — the notify sweep. It already runs every 2 minutes against auth, Firestore and the
+# app in one request, which makes it a synthetic monitor we are getting for free; all
+# that was missing was anyone listening. Its failure is also a real user-facing outage
+# (creators stop being notified) even when every page still loads.
+cat > "${POLICY_DIR}/a3.json" <<EOF
+{
+  "displayName": "A3 notify-sweep failing",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "scheduler job failing repeatedly",
+    "conditionThreshold": {
+      "filter": "metric.type=\"cloudscheduler.googleapis.com/job/attempt_count\" AND resource.type=\"cloud_scheduler_job\" AND metric.label.\"response_code\"!=\"200\"",
+      "aggregations": [{
+        "alignmentPeriod": "900s",
+        "perSeriesAligner": "ALIGN_SUM",
+        "crossSeriesReducer": "REDUCE_SUM",
+        "groupByFields": ["resource.label.\"job_id\""]
+      }],
+      "comparison": "COMPARISON_GT",
+      "thresholdValue": 2,
+      "duration": "0s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "alertStrategy": { "autoClose": "86400s" },
+  "documentation": {
+    "content": "A scheduled job is failing. Covers notify-sweep (creator notifications) and firestore-daily-export (backups) — check which job_id fired.",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
+# A4 — the backup watching itself. A silently broken export is indistinguishable from a
+# working one until the day it is needed, which is the worst possible day to find out.
+# Absence of data is the signal here, so this alerts on the *metric going missing*.
+cat > "${POLICY_DIR}/a4.json" <<EOF
+{
+  "displayName": "A4 no fresh Firestore export",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "backup bucket has taken no writes in 36 hours",
+    "conditionAbsent": {
+      "filter": "metric.type=\"storage.googleapis.com/api/request_count\" AND resource.type=\"gcs_bucket\" AND resource.label.\"bucket_name\"=\"${BACKUP_BUCKET}\"",
+      "aggregations": [{
+        "alignmentPeriod": "3600s",
+        "perSeriesAligner": "ALIGN_SUM",
+        "crossSeriesReducer": "REDUCE_SUM"
+      }],
+      "duration": "129600s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "alertStrategy": { "autoClose": "604800s" },
+  "documentation": {
+    "content": "No write activity on gs://${BACKUP_BUCKET} for 36h — the daily export is not running. Restore procedure and job details: docs/runbooks/restore-firestore.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
+for FILE in "${POLICY_DIR}"/*.json; do
+  DISPLAY="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['displayName'])" "$FILE")"
+  EXISTING="$(gcloud alpha monitoring policies list \
+    --project "$PROJECT_ID" \
+    --filter="displayName='${DISPLAY}'" \
+    --format='value(name)' 2>/dev/null | head -n 1)"
+  if [ -n "$EXISTING" ]; then
+    gcloud alpha monitoring policies update "$EXISTING" \
+      --project "$PROJECT_ID" \
+      --policy-from-file="$FILE" \
+      >/dev/null
+    echo "    Updated: ${DISPLAY}"
+  else
+    gcloud alpha monitoring policies create \
+      --project "$PROJECT_ID" \
+      --policy-from-file="$FILE" \
+      --notification-channels="$CHANNEL_NAME" \
+      >/dev/null
+    echo "    Created: ${DISPLAY}"
+  fi
+done
+
+echo ""
+echo "==> Done. Uptime check + A1-A4 wired to ${ALERT_EMAIL}."
+echo ""
+echo "    A5 (billing budget) is NOT here: budgets live on the billing account, not the"
+echo "    project, and need roles this script does not assume. Create it once by hand:"
+echo "      Console → Billing → Budgets & alerts → Create budget"
+echo "      Scope: project ${PROJECT_ID}; thresholds 50/90/100%; email ${ALERT_EMAIL}"
+echo ""
+echo "    Then prove it works, because an untested alert is a decoration:"
+echo "      gcloud scheduler jobs pause notify-sweep --location ${REGION} --project ${PROJECT_ID}"
+echo "      # wait ~15 min for A3 to fire, confirm the email, then:"
+echo "      gcloud scheduler jobs resume notify-sweep --location ${REGION} --project ${PROJECT_ID}"

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -100,6 +100,7 @@ cat > "${POLICY_DIR}/a1.json" <<EOF
       "trigger": { "count": 1 }
     }
   }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
   "alertStrategy": { "autoClose": "86400s" },
   "documentation": {
     "content": "https://${HOST}/api/health is failing from most probers. Triage: docs/runbooks/site-down-triage.md",
@@ -131,6 +132,7 @@ cat > "${POLICY_DIR}/a2.json" <<EOF
       "trigger": { "count": 1 }
     }
   }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
   "alertStrategy": { "autoClose": "86400s" },
   "documentation": {
     "content": "Sustained 5xx from ${SERVICE}. Most likely: a bad deploy, the snapshot bucket unreachable (published play now 503s rather than falling back), or Firestore. Triage: docs/runbooks/site-down-triage.md",
@@ -163,6 +165,7 @@ cat > "${POLICY_DIR}/a3.json" <<EOF
       "trigger": { "count": 1 }
     }
   }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
   "alertStrategy": { "autoClose": "86400s" },
   "documentation": {
     "content": "A scheduled job is failing. Covers notify-sweep (creator notifications) and firestore-daily-export (backups) — check which job_id fired.",
@@ -173,15 +176,22 @@ EOF
 
 # A4 — the backup watching itself. A silently broken export is indistinguishable from a
 # working one until the day it is needed, which is the worst possible day to find out.
-# Absence of data is the signal here, so this alerts on the *metric going missing*.
+#
+# Measured on the export job's own *successful* attempts, not on bucket activity: the
+# GCS request_count metric counts reads too, so an operator running `gcloud storage ls`
+# to check on backups would suppress the very alert that tells them backups stopped —
+# and the restore runbook tells them to run exactly that. This also complements A3
+# rather than duplicating it: A3 catches a job that runs and fails, while absence
+# catches a job that is paused, deleted, or never scheduled, where there are no failed
+# attempts to count because there are no attempts at all.
 cat > "${POLICY_DIR}/a4.json" <<EOF
 {
-  "displayName": "A4 no fresh Firestore export",
+  "displayName": "A4 no successful Firestore export",
   "combiner": "OR",
   "conditions": [{
-    "displayName": "backup bucket has taken no writes in 36 hours",
+    "displayName": "export job has not succeeded in 36 hours",
     "conditionAbsent": {
-      "filter": "metric.type=\"storage.googleapis.com/api/request_count\" AND resource.type=\"gcs_bucket\" AND resource.label.\"bucket_name\"=\"${BACKUP_BUCKET}\"",
+      "filter": "metric.type=\"cloudscheduler.googleapis.com/job/attempt_count\" AND resource.type=\"cloud_scheduler_job\" AND resource.label.\"job_id\"=\"firestore-daily-export\" AND metric.label.\"response_code\"=\"200\"",
       "aggregations": [{
         "alignmentPeriod": "3600s",
         "perSeriesAligner": "ALIGN_SUM",
@@ -191,9 +201,10 @@ cat > "${POLICY_DIR}/a4.json" <<EOF
       "trigger": { "count": 1 }
     }
   }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
   "alertStrategy": { "autoClose": "604800s" },
   "documentation": {
-    "content": "No write activity on gs://${BACKUP_BUCKET} for 36h — the daily export is not running. Restore procedure and job details: docs/runbooks/restore-firestore.md",
+    "content": "The daily Firestore export has not succeeded for 36h — backups are stale or stopped. A 200 from the job means the export was *accepted*; that objects actually land is what the restore drill proves. Procedure: docs/runbooks/restore-firestore.md",
     "mimeType": "text/markdown"
   }
 }
@@ -205,6 +216,10 @@ for FILE in "${POLICY_DIR}"/*.json; do
     --project "$PROJECT_ID" \
     --filter="displayName='${DISPLAY}'" \
     --format='value(name)' 2>/dev/null | head -n 1)"
+  # update replaces the policy definition wholesale, so every field the policy needs has
+  # to be in the file — including notificationChannels. Omitting it there would leave the
+  # policies present and visibly "enabled" while silently emailing nobody, which is the
+  # one failure mode worse than having no alerting at all.
   if [ -n "$EXISTING" ]; then
     gcloud alpha monitoring policies update "$EXISTING" \
       --project "$PROJECT_ID" \
@@ -215,7 +230,6 @@ for FILE in "${POLICY_DIR}"/*.json; do
     gcloud alpha monitoring policies create \
       --project "$PROJECT_ID" \
       --policy-from-file="$FILE" \
-      --notification-channels="$CHANNEL_NAME" \
       >/dev/null
     echo "    Created: ${DISPLAY}"
   fi


### PR DESCRIPTION
Neither Cloud Run nor Firestore backs anything up or alerts on anything by default. Today a wrong `gcloud firestore` command is unrecoverable, and an outage at 03:00 is discovered whenever someone next opens the site — which is what happened this week, when a bad merge left master undeployable for ~40 minutes and nothing announced it.

This adds the provisioning and the procedures. **The `gcloud` runs themselves are owner work** — the scripts are idempotent and print their own verification steps.

## What's here

**`infra/setup-backups.sh`** — PITR (7-day window) *and* a daily managed export to a same-region bucket. Both, because they fail differently: PITR is exact and rewinds the live database, but dies with it; an export is stale by up to a day but survives the database, the project, and a bad IAM change. The export service account gets `datastore.importExportAdmin` + `storage.objectCreator` only — it can start an export and write new objects, but cannot read document contents or delete older backups, so compromising it neither exfiltrates the database nor destroys the backups.

**`infra/setup-monitoring.sh`** — uptime check plus policies A1–A4, email channel, idempotent by display name. Three choices worth reviewing:
- The uptime check probes `/api/health` because it is *unwalled* — a failure means genuinely unreachable, not that the beta gate did its job. Probing a walled route would alert on 401 forever.
- A2 is a **rate**, not a ratio. With scale-to-zero, two errors out of three requests at 04:00 is "66% error rate" and means nothing; a rate fires on a broken deploy and stays quiet for one-offs.
- A5 (billing budget) is deliberately *not* scripted — budgets live on the billing account, not the project, and need roles this script shouldn't assume. It prints the console steps instead.

**`docs/runbooks/`** — site-down triage (the alert entry point), deploy rollback, Firestore restore, and secret rotation. Each carries a **"Last drilled: never"** line, which is the honest status and stays until someone runs it.

The triage and rotation runbooks are written against the *current* serving model, not the one from a week ago: published play reads the snapshot bucket with no GitHub fallback, so a Cloud Storage problem is an outage while a GitHub problem is not; and an expiring `SITE_DISPATCH_TOKEN` freezes the catalog with no symptom at all, since the games-repo step warns rather than fails.

## Public vs. private split

The **rotation procedure** is here; the **credential inventory** is not. A table of every credential, what it grants, when it expires, and what breaks when it lapses is a map of the credential surface — the "what breaks" column especially is an attack-planning aid — so it lives in the private ops repo alongside the risk register, and this runbook points at it. `SITE_DISPATCH_TOKEN`'s scope stays documented here, because it constrains how the credential may be granted and anyone touching that workflow needs to know there is no dispatch-only permission.

Scripts stay in this repo rather than moving to ops, deliberately: `infra/` is coupled to code that CI already enforces (`firestore-indexes.test.ts` reads `setup-gcp.sh` and fails when an index is missing), `setup-monitoring.sh` names services that live in `deploy.yml`, and Copilot — which only sees public repos — needs to be able to read provisioning it might otherwise duplicate.

## What this does not do

Nothing runs automatically and nothing changes production. Merging this changes no behaviour — it only means the commands and procedures exist. The follow-up is four owner actions (~an evening), tracked in the private ops repo's status doc.

Rebased on current master; shell syntax checked (`bash -n`); docs index and `infra/README.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWTR7Zp7siY2NB5iEpcedT