### PR TITLE
Add Not played catalog sort (mobile-friendly)

### DIFF
--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -341,7 +341,11 @@ export function ArcadeCatalog({
                 type="button"
                 className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
                 aria-pressed={sortMode === mode}
-                onClick={() => handleSortChange(mode)}
+                onClick={(event) => {
+                  handleSortChange(mode);
+                  // Keep the active chip in view on the horizontal phone strip.
+                  event.currentTarget.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' });
+                }}
               >
                 {t(`catalog.sort.${mode}`)}
               </button>

--- a/apps/web/src/catalogSort.test.ts
+++ b/apps/web/src/catalogSort.test.ts
@@ -1,9 +1,9 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { CatalogEntry } from './catalog.js';
 import { sortCatalogEntries, type CatalogSortSignals } from './catalogSort.js';
 import { rememberRecentPlay } from './recentPlays.js';
-
-// @vitest-environment jsdom
 
 function entry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, 'slug' | 'title'>): CatalogEntry {
   return {
@@ -97,6 +97,20 @@ describe('sortCatalogEntries', () => {
       'mid',
       'zeta',
       'alpha',
+    ]);
+  });
+
+  it('puts unplayed games first for not_played', () => {
+    rememberRecentPlay('mid');
+    const signals: CatalogSortSignals = {
+      ...emptySignals,
+      recommended: ['zeta', 'alpha', 'mid'],
+      affinityLastPlayed: new Map([['alpha', '2026-07-28T12:00:00.000Z']]),
+    };
+    expect(sortCatalogEntries(catalog, 'not_played', signals).map((e) => e.slug)).toEqual([
+      'zeta',
+      'alpha',
+      'mid',
     ]);
   });
 });

--- a/apps/web/src/catalogSort.ts
+++ b/apps/web/src/catalogSort.ts
@@ -1,13 +1,20 @@
 import type { CatalogEntry } from './catalog.js';
 import { getRecentPlays } from './recentPlays.js';
 
-export type CatalogSortMode = 'recommended' | 'newest' | 'most_played' | 'last_played' | 'alpha';
+export type CatalogSortMode =
+  | 'recommended'
+  | 'newest'
+  | 'most_played'
+  | 'last_played'
+  | 'not_played'
+  | 'alpha';
 
 export const CATALOG_SORT_MODES: CatalogSortMode[] = [
   'recommended',
   'newest',
   'most_played',
   'last_played',
+  'not_played',
   'alpha',
 ];
 
@@ -64,6 +71,13 @@ function orderBySlugList<T extends { slug: string }>(entries: T[], order: string
   return ordered;
 }
 
+/** Slugs this visitor has opened — affinity (signed-in) plus device-local recent. */
+export function playedSlugSet(affinityLastPlayed: ReadonlyMap<string, string>): Set<string> {
+  const played = new Set<string>(affinityLastPlayed.keys());
+  for (const slug of getRecentPlays()) played.add(slug);
+  return played;
+}
+
 /**
  * Last-played order: signed-in affinity timestamps win when present; otherwise the
  * device-local recent list (newest first). Unplayed games keep catalog order at the end.
@@ -107,6 +121,23 @@ function orderAlpha<T extends { title: string; slug: string }>(entries: T[]): T[
   );
 }
 
+/**
+ * Unplayed games first (recommended order among them), then already-played games
+ * (most recently played last so the fresh stuff stays on top).
+ */
+function orderByNotPlayed<T extends { slug: string }>(
+  entries: T[],
+  signals: CatalogSortSignals,
+): T[] {
+  const played = playedSlugSet(signals.affinityLastPlayed);
+  const unplayed = entries.filter((entry) => !played.has(entry.slug));
+  const already = entries.filter((entry) => played.has(entry.slug));
+  return [
+    ...orderBySlugList(unplayed, signals.recommended),
+    ...orderByLastPlayed(already, signals.affinityLastPlayed),
+  ];
+}
+
 export function sortCatalogEntries(
   entries: CatalogEntry[],
   mode: CatalogSortMode,
@@ -121,6 +152,8 @@ export function sortCatalogEntries(
       return orderByMostPlayed(entries, signals.sessions);
     case 'last_played':
       return orderByLastPlayed(entries, signals.affinityLastPlayed);
+    case 'not_played':
+      return orderByNotPlayed(entries, signals);
     case 'alpha':
       return orderAlpha(entries);
     default:

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -154,6 +154,7 @@
       "newest": "Newest",
       "most_played": "Most played",
       "last_played": "Last played",
+      "not_played": "Not played",
       "alpha": "A–Z"
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -154,6 +154,7 @@
       "newest": "Najnowsze",
       "most_played": "Najczęściej grane",
       "last_played": "Ostatnio grane",
+      "not_played": "Niegrane",
       "alpha": "A–Z"
     }
   },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -920,10 +920,9 @@ button:disabled {
 .arcade-header {
   margin-bottom: 16px;
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 12px 20px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
 }
 
 /* A quiet section label, not a banner — the grid of games below speaks for itself. */
@@ -942,14 +941,26 @@ button:disabled {
   max-width: 42rem;
 }
 
+/*
+ * Full-width horizontal scroller under the title. On a phone six options will not fit;
+ * bleed + edge fades advertise the swipe the same way the suggestion chip strip does.
+ */
 .catalog-sort {
   display: flex;
   flex-wrap: nowrap;
-  gap: 0.25rem;
+  gap: 0.35rem;
+  width: 100%;
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  scroll-padding: 0 2px;
+  margin: 0;
+  padding: 2px;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
+  mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
 }
 
 .catalog-sort::-webkit-scrollbar {
@@ -958,8 +969,8 @@ button:disabled {
 
 .catalog-sort-option {
   flex: 0 0 auto;
-  min-height: 36px;
-  padding: 0.35rem 0.75rem;
+  min-height: 40px;
+  padding: 0.4rem 0.85rem;
   border: 1px solid var(--panel-border);
   border-radius: 6px;
   background: var(--panel);
@@ -968,6 +979,8 @@ button:disabled {
   font-size: 0.85rem;
   cursor: pointer;
   white-space: nowrap;
+  scroll-snap-align: start;
+  touch-action: manipulation;
 }
 
 .catalog-sort-option.is-active {
@@ -2798,6 +2811,16 @@ body.player-open {
 
   .catalog-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Same bleed pattern as .chip-container: sort chips reach the content edge so a
+     half-visible sixth option advertises the swipe. Content padding is 12px here. */
+  .catalog-sort {
+    margin: 0 -12px;
+    padding: 2px 12px;
+    width: auto;
+    max-width: none;
+    scroll-padding: 0 12px;
   }
 
   .transparency-grid {

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -2,7 +2,7 @@
 
 > Status: ✅ Built (2026-07-29). The home-page arcade grid can be sorted several
 > ways. **Recommended** is the default; players can also pick Newest, Most played,
-> Last played, or A–Z.
+> Last played, Not played, or A–Z.
 
 ## Sort modes
 
@@ -12,9 +12,11 @@
 | Newest | Submission `publishedAt` when known; otherwise reverse catalog order |
 | Most played | Scorecard session counts |
 | Last played | Signed-in play affinity timestamps, else device-local recent plays |
+| Not played | Unplayed first (recommended order), then already-played |
 | A–Z | Title, case-insensitive |
 
-Preference is remembered in `localStorage` (`gdpl.catalogSort`).
+Preference is remembered in `localStorage` (`gdpl.catalogSort`). On phones the sort
+control is a full-width swipeable strip under the Games heading.
 
 ## Signals & privacy
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Not played** sort mode to the Games catalog strip, and tightens the sort control for phones.

### Behavior
- **Not played**: games with no affinity / device-local recent play first (recommended order among them), then already-played (last-played order).
- Preference still persists via `gdpl.catalogSort`.

### Mobile
- Sort chips stay in a full-width horizontal strip under the Games heading.
- On ≤768px the strip bleeds into content padding (same pattern as suggestion chips), with edge fades and scroll-into-view on the active option.
- Verified at 390×844: strip scrolls (~589px content), **Not played** activates and reorders (unplayed → played).

### Docs / i18n
- EN/PL labels: “Not played” / “Niegrane”
- `docs/recommendations.md` updated

### Checks
- Green gate: type-check, lint, test, build — all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

