### PR TITLE
Catalog sort dropdown + Not played as a filter

### DIFF
--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -4,8 +4,11 @@ import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.
 import {
   CATALOG_SORT_MODES,
   DEFAULT_CATALOG_SORT,
+  filterUnplayedEntries,
+  readCatalogNotPlayedFilter,
   readCatalogSortMode,
   sortCatalogEntries,
+  writeCatalogNotPlayedFilter,
   writeCatalogSortMode,
   type CatalogSortMode,
   type CatalogSortSignals,
@@ -297,6 +300,11 @@ export function ArcadeCatalog({
   const [sortMode, setSortMode] = useState<CatalogSortMode>(() =>
     typeof localStorage === 'undefined' ? DEFAULT_CATALOG_SORT : readCatalogSortMode(),
   );
+  const [notPlayedOnly, setNotPlayedOnly] = useState(() =>
+    typeof localStorage === 'undefined' ? false : readCatalogNotPlayedFilter(),
+  );
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
+  const sortMenuRef = useRef<HTMLDivElement | null>(null);
   const [signals, setSignals] = useState<CatalogSortSignals>(EMPTY_SIGNALS);
 
   useEffect(() => {
@@ -319,37 +327,100 @@ export function ArcadeCatalog({
     };
   }, [catalogStatus, catalogEntries, recommendationsRefreshKey]);
 
-  const orderedEntries = useMemo(
-    () => sortCatalogEntries(catalogEntries, sortMode, signals),
-    [catalogEntries, sortMode, signals],
-  );
+  // Close the sort menu on outside tap or Escape — phones have no hover to dismiss it.
+  useEffect(() => {
+    if (!sortMenuOpen) return;
+    const onPointer = (event: PointerEvent) => {
+      if (sortMenuRef.current && !sortMenuRef.current.contains(event.target as Node)) {
+        setSortMenuOpen(false);
+      }
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSortMenuOpen(false);
+    };
+    const timer = window.setTimeout(() => {
+      document.addEventListener('pointerdown', onPointer);
+    }, 0);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('pointerdown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [sortMenuOpen]);
+
+  const orderedEntries = useMemo(() => {
+    const filtered = notPlayedOnly
+      ? filterUnplayedEntries(catalogEntries, signals.affinityLastPlayed)
+      : catalogEntries;
+    return sortCatalogEntries(filtered, sortMode, signals);
+  }, [catalogEntries, sortMode, notPlayedOnly, signals]);
 
   function handleSortChange(mode: CatalogSortMode) {
     setSortMode(mode);
     writeCatalogSortMode(mode);
+    setSortMenuOpen(false);
   }
+
+  function handleNotPlayedToggle() {
+    setNotPlayedOnly((prev) => {
+      const next = !prev;
+      writeCatalogNotPlayedFilter(next);
+      return next;
+    });
+  }
+
+  const showControls = catalogStatus === 'ready' && catalogEntries.length > 0;
+  const emptyMessage =
+    notPlayedOnly && catalogEntries.length > 0 ? t('catalog.emptyNotPlayed') : t('catalog.empty');
 
   return (
     <section id="arcade" className="arcade-section">
       <div className="arcade-header">
         <h2 className="arcade-title">{t('catalog.title')}</h2>
-        {catalogStatus === 'ready' && catalogEntries.length > 0 ? (
-          <div className="catalog-sort" role="group" aria-label={t('catalog.sortLabel')}>
-            {CATALOG_SORT_MODES.map((mode) => (
+        {showControls ? (
+          <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>
+            <button
+              type="button"
+              className={`catalog-filter-btn${notPlayedOnly ? ' is-active' : ''}`}
+              aria-pressed={notPlayedOnly}
+              onClick={handleNotPlayedToggle}
+            >
+              {t('catalog.filter.notPlayed')}
+            </button>
+            <div className={`catalog-sort-menu${sortMenuOpen ? ' is-open' : ''}`} ref={sortMenuRef}>
               <button
-                key={mode}
                 type="button"
-                className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
-                aria-pressed={sortMode === mode}
-                onClick={(event) => {
-                  handleSortChange(mode);
-                  // Keep the active chip in view on the horizontal phone strip.
-                  event.currentTarget.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' });
-                }}
+                className="catalog-sort-trigger"
+                aria-expanded={sortMenuOpen}
+                aria-haspopup="listbox"
+                aria-label={t('catalog.sortLabel')}
+                onClick={() => setSortMenuOpen((open) => !open)}
               >
-                {t(`catalog.sort.${mode}`)}
+                <span className="catalog-sort-trigger-label">{t(`catalog.sort.${sortMode}`)}</span>
+                <span className="catalog-sort-caret" aria-hidden="true">
+                  ▾
+                </span>
               </button>
-            ))}
+              {sortMenuOpen ? (
+                <ul className="catalog-sort-panel" role="listbox" aria-label={t('catalog.sortLabel')}>
+                  {CATALOG_SORT_MODES.map((mode) => (
+                    <li key={mode} role="presentation">
+                      <button
+                        type="button"
+                        role="option"
+                        className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
+                        aria-selected={sortMode === mode}
+                        onClick={() => handleSortChange(mode)}
+                      >
+                        {sortMode === mode ? <PixelIcon name="check" size={12} /> : <span className="catalog-sort-check-spacer" />}
+                        <span>{t(`catalog.sort.${mode}`)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </div>
@@ -369,7 +440,12 @@ export function ArcadeCatalog({
         </MascotMoment>
       ) : orderedEntries.length === 0 ? (
         <MascotMoment className="catalog-state" emotion="curious" size={64} title={t('mascot.curiousAlt')}>
-          <p>{t('catalog.empty')}</p>
+          <p>{emptyMessage}</p>
+          {notPlayedOnly && catalogEntries.length > 0 ? (
+            <button type="button" className="secondary-btn" onClick={handleNotPlayedToggle}>
+              {t('catalog.clearNotPlayedFilter')}
+            </button>
+          ) : null}
         </MascotMoment>
       ) : (
         <div className="catalog-grid">

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -393,7 +393,7 @@ export function ArcadeCatalog({
                 type="button"
                 className="catalog-sort-trigger"
                 aria-expanded={sortMenuOpen}
-                aria-haspopup="listbox"
+                aria-haspopup="menu"
                 aria-label={t('catalog.sortLabel')}
                 onClick={() => setSortMenuOpen((open) => !open)}
               >
@@ -403,18 +403,18 @@ export function ArcadeCatalog({
                 </span>
               </button>
               {sortMenuOpen ? (
-                <ul className="catalog-sort-panel" role="listbox" aria-label={t('catalog.sortLabel')}>
+                <ul className="catalog-sort-panel" role="menu" aria-label={t('catalog.sortLabel')}>
                   {CATALOG_SORT_MODES.map((mode) => (
-                    <li key={mode} role="presentation">
+                    <li key={mode} role="none">
                       <button
                         type="button"
-                        role="option"
+                        role="menuitemradio"
                         className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
-                        aria-selected={sortMode === mode}
+                        aria-checked={sortMode === mode}
                         onClick={() => handleSortChange(mode)}
                       >
                         {sortMode === mode ? <PixelIcon name="check" size={12} /> : <span className="catalog-sort-check-spacer" />}
-                        <span>{t(`catalog.sort.${mode}`)}</span>
+                        <span className="catalog-sort-option-label">{t(`catalog.sort.${mode}`)}</span>
                       </button>
                     </li>
                   ))}

--- a/apps/web/src/catalogSort.test.ts
+++ b/apps/web/src/catalogSort.test.ts
@@ -2,7 +2,13 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { CatalogEntry } from './catalog.js';
-import { sortCatalogEntries, type CatalogSortSignals } from './catalogSort.js';
+import {
+  filterUnplayedEntries,
+  readCatalogNotPlayedFilter,
+  readCatalogSortMode,
+  sortCatalogEntries,
+  type CatalogSortSignals,
+} from './catalogSort.js';
 import { rememberRecentPlay } from './recentPlays.js';
 
 function entry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, 'slug' | 'title'>): CatalogEntry {
@@ -99,18 +105,30 @@ describe('sortCatalogEntries', () => {
       'alpha',
     ]);
   });
+});
 
-  it('puts unplayed games first for not_played', () => {
+describe('filterUnplayedEntries', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('keeps only games with no affinity and no local recent play', () => {
     rememberRecentPlay('mid');
-    const signals: CatalogSortSignals = {
-      ...emptySignals,
-      recommended: ['zeta', 'alpha', 'mid'],
-      affinityLastPlayed: new Map([['alpha', '2026-07-28T12:00:00.000Z']]),
-    };
-    expect(sortCatalogEntries(catalog, 'not_played', signals).map((e) => e.slug)).toEqual([
-      'zeta',
-      'alpha',
-      'mid',
-    ]);
+    const affinity = new Map([['alpha', '2026-07-28T12:00:00.000Z']]);
+    expect(filterUnplayedEntries(catalog, affinity).map((e) => e.slug)).toEqual(['zeta']);
+  });
+});
+
+describe('catalog preference migration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('migrates the legacy not_played sort into the filter', () => {
+    localStorage.setItem('gdpl.catalogSort', 'not_played');
+    expect(readCatalogNotPlayedFilter()).toBe(true);
+    expect(readCatalogSortMode()).toBe('recommended');
+    expect(localStorage.getItem('gdpl.catalogNotPlayed')).toBe('1');
+    expect(localStorage.getItem('gdpl.catalogSort')).toBe('recommended');
   });
 });

--- a/apps/web/src/catalogSort.ts
+++ b/apps/web/src/catalogSort.ts
@@ -1,26 +1,23 @@
 import type { CatalogEntry } from './catalog.js';
 import { getRecentPlays } from './recentPlays.js';
 
-export type CatalogSortMode =
-  | 'recommended'
-  | 'newest'
-  | 'most_played'
-  | 'last_played'
-  | 'not_played'
-  | 'alpha';
+export type CatalogSortMode = 'recommended' | 'newest' | 'most_played' | 'last_played' | 'alpha';
 
 export const CATALOG_SORT_MODES: CatalogSortMode[] = [
   'recommended',
   'newest',
   'most_played',
   'last_played',
-  'not_played',
   'alpha',
 ];
 
 export const DEFAULT_CATALOG_SORT: CatalogSortMode = 'recommended';
 
-const STORAGE_KEY = 'gdpl.catalogSort';
+const SORT_STORAGE_KEY = 'gdpl.catalogSort';
+const NOT_PLAYED_FILTER_KEY = 'gdpl.catalogNotPlayed';
+
+/** Legacy sort value from when Not played was a sort mode, not a filter. */
+const LEGACY_NOT_PLAYED_SORT = 'not_played';
 
 export function isCatalogSortMode(value: unknown): value is CatalogSortMode {
   return typeof value === 'string' && (CATALOG_SORT_MODES as string[]).includes(value);
@@ -28,7 +25,8 @@ export function isCatalogSortMode(value: unknown): value is CatalogSortMode {
 
 export function readCatalogSortMode(): CatalogSortMode {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(SORT_STORAGE_KEY);
+    if (raw === LEGACY_NOT_PLAYED_SORT) return DEFAULT_CATALOG_SORT;
     return isCatalogSortMode(raw) ? raw : DEFAULT_CATALOG_SORT;
   } catch {
     return DEFAULT_CATALOG_SORT;
@@ -37,7 +35,35 @@ export function readCatalogSortMode(): CatalogSortMode {
 
 export function writeCatalogSortMode(mode: CatalogSortMode): void {
   try {
-    localStorage.setItem(STORAGE_KEY, mode);
+    localStorage.setItem(SORT_STORAGE_KEY, mode);
+  } catch {
+    // Private mode — preference simply does not persist.
+  }
+}
+
+/**
+ * Whether the catalog shows only games this visitor has not opened.
+ * Migrates the old `not_played` sort preference into this filter once.
+ */
+export function readCatalogNotPlayedFilter(): boolean {
+  try {
+    const stored = localStorage.getItem(NOT_PLAYED_FILTER_KEY);
+    if (stored === '1') return true;
+    if (stored === '0') return false;
+    if (localStorage.getItem(SORT_STORAGE_KEY) === LEGACY_NOT_PLAYED_SORT) {
+      localStorage.setItem(NOT_PLAYED_FILTER_KEY, '1');
+      localStorage.setItem(SORT_STORAGE_KEY, DEFAULT_CATALOG_SORT);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function writeCatalogNotPlayedFilter(enabled: boolean): void {
+  try {
+    localStorage.setItem(NOT_PLAYED_FILTER_KEY, enabled ? '1' : '0');
   } catch {
     // Private mode — preference simply does not persist.
   }
@@ -76,6 +102,15 @@ export function playedSlugSet(affinityLastPlayed: ReadonlyMap<string, string>): 
   const played = new Set<string>(affinityLastPlayed.keys());
   for (const slug of getRecentPlays()) played.add(slug);
   return played;
+}
+
+/** Keep only games the visitor has not opened yet. */
+export function filterUnplayedEntries<T extends { slug: string }>(
+  entries: T[],
+  affinityLastPlayed: ReadonlyMap<string, string>,
+): T[] {
+  const played = playedSlugSet(affinityLastPlayed);
+  return entries.filter((entry) => !played.has(entry.slug));
 }
 
 /**
@@ -121,23 +156,6 @@ function orderAlpha<T extends { title: string; slug: string }>(entries: T[]): T[
   );
 }
 
-/**
- * Unplayed games first (recommended order among them), then already-played games
- * (most recently played last so the fresh stuff stays on top).
- */
-function orderByNotPlayed<T extends { slug: string }>(
-  entries: T[],
-  signals: CatalogSortSignals,
-): T[] {
-  const played = playedSlugSet(signals.affinityLastPlayed);
-  const unplayed = entries.filter((entry) => !played.has(entry.slug));
-  const already = entries.filter((entry) => played.has(entry.slug));
-  return [
-    ...orderBySlugList(unplayed, signals.recommended),
-    ...orderByLastPlayed(already, signals.affinityLastPlayed),
-  ];
-}
-
 export function sortCatalogEntries(
   entries: CatalogEntry[],
   mode: CatalogSortMode,
@@ -152,8 +170,6 @@ export function sortCatalogEntries(
       return orderByMostPlayed(entries, signals.sessions);
     case 'last_played':
       return orderByLastPlayed(entries, signals.affinityLastPlayed);
-    case 'not_played':
-      return orderByNotPlayed(entries, signals);
     case 'alpha':
       return orderAlpha(entries);
     default:

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -149,12 +149,17 @@
     "worldBadge": "Shared world",
     "savesBadge": "Saves progress",
     "sortLabel": "Sort games",
+    "toolbarLabel": "Catalog filters and sort",
+    "filter": {
+      "notPlayed": "Not played"
+    },
+    "emptyNotPlayed": "You've played every game here.",
+    "clearNotPlayedFilter": "Show all games",
     "sort": {
       "recommended": "Recommended",
       "newest": "Newest",
       "most_played": "Most played",
       "last_played": "Last played",
-      "not_played": "Not played",
       "alpha": "A–Z"
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -149,12 +149,17 @@
     "worldBadge": "Wspólny świat",
     "savesBadge": "Zapisuje postępy",
     "sortLabel": "Sortuj gry",
+    "toolbarLabel": "Filtry i sortowanie katalogu",
+    "filter": {
+      "notPlayed": "Niegrane"
+    },
+    "emptyNotPlayed": "Grałeś już we wszystkie gry tutaj.",
+    "clearNotPlayedFilter": "Pokaż wszystkie gry",
     "sort": {
       "recommended": "Polecane",
       "newest": "Najnowsze",
       "most_played": "Najczęściej grane",
       "last_played": "Ostatnio grane",
-      "not_played": "Niegrane",
       "alpha": "A–Z"
     }
   },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -920,9 +920,11 @@ button:disabled {
 .arcade-header {
   margin-bottom: 16px;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
+  flex-wrap: nowrap;
 }
 
 /* A quiet section label, not a banner — the grid of games below speaks for itself. */
@@ -932,6 +934,8 @@ button:disabled {
   color: var(--turquoise);
   margin: 0;
   letter-spacing: -0.3px;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .arcade-subtitle {
@@ -942,35 +946,28 @@ button:disabled {
 }
 
 /*
- * Full-width horizontal scroller under the title. On a phone six options will not fit;
- * bleed + edge fades advertise the swipe the same way the suggestion chip strip does.
+ * Compact toolbar beside the Games heading: a Not-played filter toggle plus a
+ * sort dropdown. One row on phone and desktop — no chip strip that wraps.
  */
-.catalog-sort {
+.catalog-toolbar {
   display: flex;
-  flex-wrap: nowrap;
-  gap: 0.35rem;
-  width: 100%;
-  max-width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-  overscroll-behavior-x: contain;
-  scroll-snap-type: x proximity;
-  scroll-padding: 0 2px;
-  margin: 0;
-  padding: 2px;
-  -webkit-mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
-  mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
-}
-
-.catalog-sort::-webkit-scrollbar {
-  display: none;
-}
-
-.catalog-sort-option {
   flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  min-width: 0;
+  max-width: min(100%, 18rem);
+}
+
+.catalog-filter-btn,
+.catalog-sort-trigger {
+  flex: 0 1 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   min-height: 40px;
-  padding: 0.4rem 0.85rem;
+  padding: 0.4rem 0.75rem;
   border: 1px solid var(--panel-border);
   border-radius: 6px;
   background: var(--panel);
@@ -979,13 +976,97 @@ button:disabled {
   font-size: 0.85rem;
   cursor: pointer;
   white-space: nowrap;
-  scroll-snap-align: start;
   touch-action: manipulation;
 }
 
-.catalog-sort-option.is-active {
+.catalog-filter-btn.is-active,
+.catalog-sort-menu.is-open .catalog-sort-trigger {
   border-color: var(--turquoise);
   color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.08);
+}
+
+.catalog-sort-menu {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 11rem;
+}
+
+.catalog-sort-trigger {
+  width: 100%;
+  max-width: 100%;
+  justify-content: space-between;
+}
+
+.catalog-sort-trigger-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.catalog-sort-caret {
+  flex: none;
+  font-size: 0.75rem;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.catalog-sort-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: max(100%, 11.5rem);
+  max-width: min(18rem, calc(100vw - 24px));
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: rgba(16, 22, 28, 0.98);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.catalog-sort-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.catalog-sort-option:hover,
+.catalog-sort-option:focus-visible {
+  background: rgba(0, 228, 172, 0.12);
+  color: var(--turquoise);
+  outline: none;
+}
+
+.catalog-sort-option.is-active {
+  color: var(--turquoise);
+}
+
+.catalog-sort-option > svg,
+.catalog-sort-check-spacer {
+  flex: none;
+  width: 12px;
+  height: 12px;
 }
 
 .catalog-grid {
@@ -2813,14 +2894,13 @@ body.player-open {
     grid-template-columns: 1fr;
   }
 
-  /* Same bleed pattern as .chip-container: sort chips reach the content edge so a
-     half-visible sixth option advertises the swipe. Content padding is 12px here. */
-  .catalog-sort {
-    margin: 0 -12px;
-    padding: 2px 12px;
-    width: auto;
-    max-width: none;
-    scroll-padding: 0 12px;
+  .catalog-toolbar {
+    max-width: min(100%, 14.5rem);
+  }
+
+  .catalog-filter-btn,
+  .catalog-sort-trigger {
+    min-height: 44px;
   }
 
   .transparency-grid {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1051,6 +1051,14 @@ button:disabled {
   touch-action: manipulation;
 }
 
+.catalog-sort-option-label {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .catalog-sort-option:hover,
 .catalog-sort-option:focus-visible {
   background: rgba(0, 228, 172, 0.12);

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -45,6 +45,20 @@ games-repo order rather than inventing a shuffle.
 ## API
 
 - `POST /api/games/:slug/played` — session optional; writes affinity for signed-in
-  humans; always 204 for bots / anonymous
-- `GET /api/recommendations?recent=slug,slug` — returns `{ items, popularity, lastPlayed, newest }`
-  for the catalog toolbar (`apps/web/src/recommendationsApi.ts`)
+  non-bot users; `204` otherwise.
+- `GET /api/recommendations?recent=slug1,slug2` — returns ranking plus sort helpers:
+
+```json
+{
+  "items": [{ "slug": "…", "reason": "popular" }],
+  "popularity": [{ "slug": "…", "sessions": 12 }],
+  "lastPlayed": [{ "slug": "…", "lastPlayedAt": "…" }],
+  "newest": ["slug-a", "slug-b"]
+}
+```
+
+## UI
+
+[`ArcadeCatalog`](../apps/web/src/ArcadeCatalog.tsx) shows a Not played filter toggle
+and a sort dropdown beside the Games heading, then reorders/filters the same grid.
+Logic lives in [`catalogSort.ts`](../apps/web/src/catalogSort.ts).

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -2,7 +2,8 @@
 
 > Status: ✅ Built (2026-07-29). The home-page arcade grid can be sorted several
 > ways. **Recommended** is the default; players can also pick Newest, Most played,
-> Last played, Not played, or A–Z.
+> Last played, or A–Z. **Not played** is a separate filter (hide games already
+> opened), not a sort mode.
 
 ## Sort modes
 
@@ -12,11 +13,17 @@
 | Newest | Submission `publishedAt` when known; otherwise reverse catalog order |
 | Most played | Scorecard session counts |
 | Last played | Signed-in play affinity timestamps, else device-local recent plays |
-| Not played | Unplayed first (recommended order), then already-played |
 | A–Z | Title, case-insensitive |
 
-Preference is remembered in `localStorage` (`gdpl.catalogSort`). On phones the sort
-control is a full-width swipeable strip under the Games heading.
+## Filters
+
+| Filter | Effect |
+| ------ | ------ |
+| Not played | Show only games with no play affinity and no device-local recent open |
+
+Sort preference is remembered in `localStorage` (`gdpl.catalogSort`); the Not played
+filter in `gdpl.catalogNotPlayed`. Controls sit on one row beside the Games heading:
+filter toggle + sort dropdown (menu closes on outside tap / Escape).
 
 ## Signals & privacy
 
@@ -38,20 +45,6 @@ games-repo order rather than inventing a shuffle.
 ## API
 
 - `POST /api/games/:slug/played` — session optional; writes affinity for signed-in
-  non-bot users; `204` otherwise.
-- `GET /api/recommendations?recent=slug1,slug2` — returns ranking plus sort helpers:
-
-```json
-{
-  "items": [{ "slug": "…", "reason": "popular" }],
-  "popularity": [{ "slug": "…", "sessions": 12 }],
-  "lastPlayed": [{ "slug": "…", "lastPlayedAt": "…" }],
-  "newest": ["slug-a", "slug-b"]
-}
-```
-
-## UI
-
-[`ArcadeCatalog`](../apps/web/src/ArcadeCatalog.tsx) shows a sort control next to the
-Games heading and reorders the same grid. Sort logic lives in
-[`catalogSort.ts`](../apps/web/src/catalogSort.ts).
+  humans; always 204 for bots / anonymous
+- `GET /api/recommendations?recent=slug,slug` — returns `{ items, popularity, lastPlayed, newest }`
+  for the catalog toolbar (`apps/web/src/recommendationsApi.ts`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #333: the chip strip wrapped / spilled on phones. This replaces it with a compact one-row toolbar.

### UX
- **Sort**: dropdown beside the Games heading (current mode label + ▾). Menu has 44px rows; closes on outside tap or Escape.
- **Not played**: filter toggle — hides games already opened (affinity + device recent), works with any sort.
- One row on phone and desktop; long sort labels ellipsize.

### Persistence
- Sort: `gdpl.catalogSort`
- Filter: `gdpl.catalogNotPlayed`
- Legacy `not_played` sort preference migrates into the filter once.

### Copilot review
Addressed both comments:
1. Switched dropdown to `aria-haspopup=\"menu\"` / `role=\"menu\"` / `menuitemradio` (matches GameTheater-style popovers).
2. Forced single-line + ellipsis on dropdown option labels.

### Checks
- Green gate previously passed; type-check + targeted tests after review fixes.
- Mobile (390×844): header stays one row; filter keeps only unplayed; dropdown selects Newest

<img alt=\"Mobile sort dropdown\" src=\"/opt/cursor/artifacts/screenshots/catalog-sort-dropdown-mobile.png\" />
<img alt=\"Not played filter active\" src=\"/opt/cursor/artifacts/screenshots/catalog-not-played-filter-mobile.png\" />
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

