### PR TITLE
fix(studio): stop false preview errors when a channel draft works

### DIFF
--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -891,6 +891,83 @@ describe('submission preview route', () => {
     await app.close();
   });
 
+  it('caches a draft preview by head SHA and serves the last known draft when GitHub fails', async () => {
+    const linkedPr: LinkedPullRequest = { ...openPreviewPr, headRefOid: 'sha-1' };
+    const { githubClient, getGameSources, findLinkedPR } = createGithubClientStub({
+      linkedPr,
+      gameSources: sampleSources,
+    });
+    let currentTime = 100_000;
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      now: () => currentTime,
+    });
+    const token = mintToken(123, secret);
+
+    const first = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
+    expect(first.statusCode).toBe(200);
+    expect(getGameSources).toHaveBeenCalledTimes(1);
+
+    // Same SHA within the TTL — no second GitHub fan-out.
+    const second = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
+    expect(second.statusCode).toBe(200);
+    expect(second.json().html).toBe(first.json().html);
+    expect(getGameSources).toHaveBeenCalledTimes(1);
+
+    // GitHub rate-limits the next refresh (new SHA). Creators mid-build would
+    // rather play the previous assemble than see a red error under Studio.
+    findLinkedPR.mockResolvedValue({ ...linkedPr, headRefOid: 'sha-2' });
+    getGameSources.mockRejectedValueOnce(new Error('github contents request failed with status 403'));
+    const third = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
+    expect(third.statusCode).toBe(200);
+    expect(third.json().html).toBe(first.json().html);
+    expect(getGameSources).toHaveBeenCalledTimes(2);
+
+    // After TTL expiry with the same SHA, we do hit GitHub again.
+    currentTime += 5 * 60_000 + 1;
+    findLinkedPR.mockResolvedValue(linkedPr);
+    getGameSources.mockResolvedValueOnce(sampleSources);
+    const fourth = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
+    expect(fourth.statusCode).toBe(200);
+    expect(getGameSources).toHaveBeenCalledTimes(3);
+
+    await app.close();
+  });
+
+  it('coalesces concurrent draft preview misses into one GitHub fan-out', async () => {
+    let resolveSources!: (value: GameSources) => void;
+    const { githubClient, getGameSources } = createGithubClientStub({
+      linkedPr: { ...openPreviewPr, headRefOid: 'sha-coalesce' },
+    });
+    getGameSources.mockImplementation(
+      () =>
+        new Promise<GameSources>((resolve) => {
+          resolveSources = resolve;
+        }),
+    );
+
+    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret });
+    const token = mintToken(123, secret);
+
+    const pending = Promise.all([
+      app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders }),
+      app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders }),
+    ]);
+    // Both requests must be waiting on the same in-flight assemble.
+    await vi.waitFor(() => expect(getGameSources).toHaveBeenCalled());
+    expect(getGameSources).toHaveBeenCalledTimes(1);
+    resolveSources(sampleSources);
+
+    const [a, b] = await pending;
+    expect(a.statusCode).toBe(200);
+    expect(b.statusCode).toBe(200);
+    expect(a.json().html).toBe(b.json().html);
+    expect(getGameSources).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+
   it('falls back to the slug as title when SPEC.md has none', async () => {
     const { githubClient } = createGithubClientStub({
       linkedPr: openPreviewPr,

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -92,6 +92,7 @@ async function createApp(params: {
   dailyFeedbackQuota?: number;
   translator?: Translator;
   contentChecker?: ContentChecker;
+  maxCachedDraftPreviews?: number;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
   await store.upsertUser({ uid: 'g:test-user' });
@@ -108,6 +109,7 @@ async function createApp(params: {
       dailySubmissionQuota: params.dailySubmissionQuota,
       dailyFeedbackQuota: params.dailyFeedbackQuota,
       translator: params.translator ?? new NoopTranslator(),
+      maxCachedDraftPreviews: params.maxCachedDraftPreviews,
     },
   });
   return { app, store, authHeaders: getAuthHeaders('g:test-user') };
@@ -931,6 +933,49 @@ describe('submission preview route', () => {
     const fourth = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
     expect(fourth.statusCode).toBe(200);
     expect(getGameSources).toHaveBeenCalledTimes(3);
+
+    await app.close();
+  });
+
+  it('evicts the oldest draft preview when the cache is full', async () => {
+    // Cap at 2 so three successful assembles force the first issue out. After
+    // eviction, a GitHub failure on that issue must 502 — there is no last-known
+    // draft left to fall back on.
+    const linkedPr: LinkedPullRequest = { ...openPreviewPr, headRefOid: 'sha-1' };
+    const { githubClient, getGameSources, findLinkedPR } = createGithubClientStub({
+      linkedPr,
+      gameSources: sampleSources,
+    });
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      maxCachedDraftPreviews: 2,
+    });
+
+    for (const issueNumber of [1, 2, 3]) {
+      const token = mintToken(issueNumber, secret);
+      const res = await app.inject({ method: 'GET', url: `/api/submissions/${token}/preview`, headers: authHeaders });
+      expect(res.statusCode).toBe(200);
+    }
+    expect(getGameSources).toHaveBeenCalledTimes(3);
+
+    findLinkedPR.mockRejectedValueOnce(new Error('github request failed with status 403'));
+    const evicted = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(1, secret)}/preview`,
+      headers: authHeaders,
+    });
+    expect(evicted.statusCode).toBe(502);
+
+    // Issue 3 is still cached — a resolve failure serves its last-known draft.
+    findLinkedPR.mockRejectedValueOnce(new Error('github request failed with status 403'));
+    const kept = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(3, secret)}/preview`,
+      headers: authHeaders,
+    });
+    expect(kept.statusCode).toBe(200);
+    expect(kept.json().slug).toBe('foo');
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -191,6 +191,12 @@ export interface SubmissionRoutesOptions {
    * GitHub, never a requirement — see game-snapshot.ts.
    */
   snapshotReader?: GameSnapshotReader | null;
+  /**
+   * Cap on in-memory assembled draft previews (HTML can be large). Defaults to
+   * 50; tests pass a smaller value to exercise eviction without minting dozens
+   * of issues.
+   */
+  maxCachedDraftPreviews?: number;
 }
 
 function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {
@@ -619,14 +625,31 @@ export async function registerSubmissionRoutes(
   // whenever GitHub 403'd the fan-out. Cache by head SHA (a push still refreshes),
   // coalesce concurrent misses, and fall back to the last assembled document for
   // this issue when a refresh throws. Cap per IP still applies as a safety net.
+  //
+  // The entry count is bounded: each value holds a full assembled HTML document,
+  // so an uncapped Map would grow with every Studio build this instance has ever
+  // served. Insertion order + delete-before-set makes the oldest (or longest-idle)
+  // entry the first one out, matching mediaCache.
   const previewRateLimitWindowMs = 60 * 1000;
   const maxPreviewsPerWindow = 30;
   const previewsByIp = new Map<string, number[]>();
   const draftPreviewTtlMs = 5 * 60_000;
+  const maxCachedDraftPreviews = options.maxCachedDraftPreviews ?? 50;
   type DraftPreviewValue = { slug: string; title: string; html: string };
   type CachedDraftPreview = { value: DraftPreviewValue; headSha: string; expiresAt: number };
   const draftPreviewCache = new Map<number, CachedDraftPreview>();
   const draftPreviewRefreshes = new Map<string, Promise<DraftPreviewValue>>();
+
+  function rememberDraftPreview(issueNumber: number, entry: CachedDraftPreview): void {
+    // Move to the newest slot so a creator still watching their build outlives
+    // abandoned ones when we have to prune.
+    draftPreviewCache.delete(issueNumber);
+    if (draftPreviewCache.size >= maxCachedDraftPreviews) {
+      const oldestKey = draftPreviewCache.keys().next().value;
+      if (oldestKey !== undefined) draftPreviewCache.delete(oldestKey);
+    }
+    draftPreviewCache.set(issueNumber, entry);
+  }
 
   // Feedback posts a GitHub comment (which re-triggers the agent), so cap it tightly.
   const feedbackRateLimitWindowMs = 60 * 60 * 1000;
@@ -1679,7 +1702,7 @@ export async function registerSubmissionRoutes(
       if (!inFlight) draftPreviewRefreshes.set(refreshKey, refresh);
 
       const value = await refresh;
-      draftPreviewCache.set(issueNumber, { value, headSha, expiresAt: now() + draftPreviewTtlMs });
+      rememberDraftPreview(issueNumber, { value, headSha, expiresAt: now() + draftPreviewTtlMs });
       return reply.send(value);
     } catch (error) {
       if (

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -612,11 +612,21 @@ export async function registerSubmissionRoutes(
     };
   }
 
-  // Previews are heavier (several GitHub reads + assembly) and never cached — a
-  // fresh preview must reflect the branch's latest commit — so cap them per IP.
+  // Draft previews are heavier (several GitHub Contents reads + esbuild) and used
+  // to hit GitHub on every request. Status polls were coalesced + stale-served after
+  // the same token got rate-limited; the preview path was not, so a creator watching
+  // a build saw a working channel draft and a red "couldn't load preview" under it
+  // whenever GitHub 403'd the fan-out. Cache by head SHA (a push still refreshes),
+  // coalesce concurrent misses, and fall back to the last assembled document for
+  // this issue when a refresh throws. Cap per IP still applies as a safety net.
   const previewRateLimitWindowMs = 60 * 1000;
   const maxPreviewsPerWindow = 30;
   const previewsByIp = new Map<string, number[]>();
+  const draftPreviewTtlMs = 5 * 60_000;
+  type DraftPreviewValue = { slug: string; title: string; html: string };
+  type CachedDraftPreview = { value: DraftPreviewValue; headSha: string; expiresAt: number };
+  const draftPreviewCache = new Map<number, CachedDraftPreview>();
+  const draftPreviewRefreshes = new Map<string, Promise<DraftPreviewValue>>();
 
   // Feedback posts a GitHub comment (which re-triggers the agent), so cap it tightly.
   const feedbackRateLimitWindowMs = 60 * 60 * 1000;
@@ -1601,10 +1611,19 @@ export async function registerSubmissionRoutes(
     reply: FastifyReply,
     issueNumber: number,
   ): Promise<FastifyReply> {
+    const serveLastKnown = (reason: string, err?: unknown): FastifyReply | null => {
+      const lastKnown = draftPreviewCache.get(issueNumber);
+      if (!lastKnown) return null;
+      request.log.warn({ err, issueNumber, headSha: lastKnown.headSha }, reason);
+      return reply.send(lastKnown.value);
+    };
+
     let linkedPr: LinkedPullRequest | null;
     try {
       linkedPr = await githubClient!.findLinkedPR(issueNumber);
     } catch (error) {
+      const stale = serveLastKnown('preview PR resolve failed; serving last known draft', error);
+      if (stale) return stale;
       request.log.error({ err: error }, 'failed to resolve submission for preview');
       return reply.status(502).send({ error: 'failed to load preview' });
     }
@@ -1618,32 +1637,50 @@ export async function registerSubmissionRoutes(
       return reply.status(409).send({ error: 'no preview available for this submission yet' });
     }
 
-    let sources: Awaited<ReturnType<GitHubClient['getGameSources']>>;
-    try {
-      sources = await githubClient!.getGameSources(linkedPr.headRefName, slug);
-    } catch (error) {
-      request.log.error({ err: error, slug }, 'failed to fetch preview sources');
-      const detail = error instanceof Error ? error.message.replace(/\s+/g, ' ').trim().slice(0, 240) : 'unknown error';
-      return reply.status(502).send({ error: 'failed to load preview', detail });
+    const headRefName = linkedPr.headRefName;
+    // Prefer the commit OID so a push invalidates the cache; fall back to the
+    // branch name when fixtures (or a sparse GraphQL payload) omit the SHA.
+    const headSha = linkedPr.headRefOid ?? headRefName;
+    const cached = draftPreviewCache.get(issueNumber);
+    if (cached && cached.headSha === headSha && cached.expiresAt > now()) {
+      return reply.send(cached.value);
     }
 
-    if (!sources) {
-      return reply.status(409).send({ error: 'no preview available for this submission yet' });
-    }
+    const refreshKey = `${issueNumber}:${headSha}`;
+    const assembleDraft = async (): Promise<DraftPreviewValue> => {
+      const sources = await githubClient!.getGameSources(headRefName, slug);
+      if (!sources) {
+        const notReady = new Error('no preview sources');
+        notReady.name = 'DraftNotReadyError';
+        throw notReady;
+      }
 
-    const project: GameProject = {
-      title: sources.title ?? slug,
-      description: '',
-      html: sources.indexHtml,
-      js: sources.gameJs,
-      css: sources.styleCss,
-    };
+      const project: GameProject = {
+        title: sources.title ?? slug,
+        description: '',
+        html: sources.indexHtml,
+        js: sources.gameJs,
+        css: sources.styleCss,
+      };
 
-    try {
       // restrictNetwork: this is unreviewed code, so lock it to its own inline
       // assets — it cannot fetch, beacon, or load anything from the network.
       const html = assembleGameHtml(project, { restrictNetwork: true });
-      return reply.send({ slug, title: project.title, html });
+      return { slug, title: project.title, html };
+    };
+
+    try {
+      const inFlight = draftPreviewRefreshes.get(refreshKey);
+      const refresh =
+        inFlight ??
+        assembleDraft().finally(() => {
+          draftPreviewRefreshes.delete(refreshKey);
+        });
+      if (!inFlight) draftPreviewRefreshes.set(refreshKey, refresh);
+
+      const value = await refresh;
+      draftPreviewCache.set(issueNumber, { value, headSha, expiresAt: now() + draftPreviewTtlMs });
+      return reply.send(value);
     } catch (error) {
       if (
         error instanceof EmptyProjectError ||
@@ -1653,7 +1690,20 @@ export async function registerSubmissionRoutes(
         request.log.warn({ err: error, slug }, 'preview failed hygiene checks');
         return reply.status(422).send({ error: 'this game could not be previewed' });
       }
-      throw error;
+      if (error instanceof Error && error.name === 'DraftNotReadyError') {
+        // Incomplete tree on this SHA — still prefer a previous successful assemble
+        // over telling the creator nothing is playable.
+        const stale = serveLastKnown('preview sources incomplete; serving last known draft');
+        if (stale) return stale;
+        return reply.status(409).send({ error: 'no preview available for this submission yet' });
+      }
+
+      const stale = serveLastKnown('failed to fetch preview sources; serving last known draft', error);
+      if (stale) return stale;
+
+      request.log.error({ err: error, slug }, 'failed to fetch preview sources');
+      const detail = error instanceof Error ? error.message.replace(/\s+/g, ' ').trim().slice(0, 240) : 'unknown error';
+      return reply.status(502).send({ error: 'failed to load preview', detail });
     }
   }
 

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -126,6 +126,50 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('does not show a preview error when a channel draft loaded but the PR preview failed', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    // The Studio screenshot case: open PR (so we try the branch assemble) + a
+    // channel playable that already works. GitHub 502s the PR path; the channel
+    // path succeeds. Creators must not see a red banner under a live Play card.
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      preview: { slug: 'jump-rope-rhythm' },
+      progress: { headSha: 'sha-stuck', commits: [], checklist: [] },
+      playable: [
+        {
+          ref: 'channel-1',
+          slug: 'rope-jumper',
+          label: 'You can already play — draft version',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    mockedGetSubmissionPreview.mockRejectedValue(Object.assign(new Error('failed to load preview'), { status: 502 }));
+    mockedGetChannelPlayable.mockResolvedValue('<!doctype html><canvas></canvas>');
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/dual-preview-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'dual-preview-token' }));
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(mockedGetChannelPlayable).toHaveBeenCalled();
+    expect(container.querySelector('.status-play-cta')).not.toBeNull();
+    expect(container.textContent).not.toContain("We couldn't load the preview right now");
+    expect(container.querySelector('p.error')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('shows agent channel updates while the build is still queued, with translated step labels', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // No PR yet — so no `progress` at all. This is exactly the stretch where the

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -315,11 +315,14 @@ export function SubmissionStatusView({
       .then((html) => {
         setChannelHtml(html);
         loadedChannelRef.current = latest.ref;
+        // A working channel draft is enough to play — clear any PR-preview failure
+        // so we don't leave a red banner under a live "Play the draft" card.
+        setPreviewError(null);
       })
       .catch((err: unknown) => {
         const apiError = err as SubmissionApiError;
         setChannelHtml(null);
-        setPreviewError(apiError.message || t('statusView.previewError'));
+        setPreviewError(apiError.status === 409 ? t('statusView.previewNotReady') : t('statusView.previewError'));
       })
       .finally(() => {
         channelInFlightRef.current = false;
@@ -503,7 +506,10 @@ export function SubmissionStatusView({
               pendingRevisions={pendingRevisions}
             />
 
-            {previewError && !preview ? <p className="error">{previewError}</p> : null}
+            {/* Only alarm when nothing is playable. A channel draft can succeed while
+                the PR-branch assemble 502s (GitHub rate limits); showing both a Play
+                card and this error was the Studio bug creators hit mid-build. */}
+            {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}
 
             {/* Embedded in Creator Studio the panel is a tab, not a page: the header
                 already carries "Back to home", and a second escape hatch a screen


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Studio showed **"Nie udało się teraz wczytać podglądu"** under a working **"Play the draft"** card when an open PR's branch assemble failed (often GitHub 403 rate limits) while a channel playable had already loaded.

## Changes

- **UI:** Only show `previewError` when nothing is playable (`!preview && !channelHtml`); clear the error when a channel draft loads successfully.
- **API:** Cache draft previews by head SHA, coalesce concurrent misses, and serve the last known assemble when GitHub fails — same approach status polls already use under token pressure.

## Test plan

- [x] `SubmissionStatusView` regression: channel draft + failed PR preview → Play card, no red error
- [x] Preview route: cache hit by SHA, stale fallback on 403, concurrent coalesce
- [x] type-check + lint
- [ ] After deploy: open a mid-build Studio game that has a channel playable; confirm no false preview error when `/preview` is under GitHub pressure
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fdd1092-e877-46d7-bfab-6eef2ced7451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fdd1092-e877-46d7-bfab-6eef2ced7451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

