### PR TITLE
Add My games filter toggle beside Not played

### DIFF
--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -452,9 +452,20 @@ export function ArcadeCatalog({
   );
 
   const orderedEntries = useMemo(() => {
-    const filtered = applyCatalogFilters(catalogEntries, filters, signals.affinityLastPlayed);
+    // Signed-out visitors never filter to "my games" even if the pref is sticky —
+    // that would empty the whole catalog.
+    const activeFilters =
+      user || !filters.has('your_games')
+        ? filters
+        : new Set([...filters].filter((id) => id !== 'your_games'));
+    const filtered = applyCatalogFilters(
+      catalogEntries,
+      activeFilters,
+      signals.affinityLastPlayed,
+      mySlugs,
+    );
     return orderCatalogEntries(filtered, sortMode, signals, mySlugs);
-  }, [catalogEntries, sortMode, filters, signals, mySlugs]);
+  }, [catalogEntries, sortMode, filters, signals, mySlugs, user]);
 
   function handleSortChange(mode: CatalogSortMode) {
     setSortMode(mode);
@@ -462,11 +473,19 @@ export function ArcadeCatalog({
     setSortMenuOpen(false);
   }
 
-  function toggleNotPlayed() {
+  function toggleFilter(id: CatalogFilterId) {
     setFilters((prev) => {
       const next = new Set(prev);
-      if (next.has('not_played')) next.delete('not_played');
-      else next.add('not_played');
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      writeCatalogFilters(next);
+      return next;
+    });
+  }
+
+  function clearFilters() {
+    setFilters(() => {
+      const next = new Set<CatalogFilterId>();
       writeCatalogFilters(next);
       return next;
     });
@@ -475,7 +494,9 @@ export function ArcadeCatalog({
   const hasCatalog = catalogStatus === 'ready' && catalogEntries.length > 0;
   const hasBuilds = inProgress.length > 0;
   const showControls = hasCatalog || hasBuilds;
+  const yourGamesOnly = Boolean(user) && filters.has('your_games');
   const notPlayedOnly = filters.has('not_played');
+  const filtersActive = yourGamesOnly || notPlayedOnly;
   const awaitingSignals =
     catalogStatus === 'ready' &&
     catalogEntries.length > 0 &&
@@ -483,7 +504,13 @@ export function ArcadeCatalog({
     !signalsReady;
 
   const emptyMessage =
-    notPlayedOnly && catalogEntries.length > 0 ? t('catalog.emptyNotPlayed') : t('catalog.empty');
+    yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
+      ? t('catalog.emptyYourGamesNotPlayed')
+      : yourGamesOnly
+        ? t('catalog.emptyYourGames')
+        : notPlayedOnly && catalogEntries.length > 0
+          ? t('catalog.emptyNotPlayed')
+          : t('catalog.empty');
   const showEmpty =
     !awaitingSignals &&
     catalogStatus !== 'loading' &&
@@ -510,12 +537,22 @@ export function ArcadeCatalog({
         </div>
         {showControls ? (
           <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>
+            {hasCatalog && user ? (
+              <button
+                type="button"
+                className={`catalog-filter-trigger${yourGamesOnly ? ' is-active' : ''}`}
+                aria-pressed={yourGamesOnly}
+                onClick={() => toggleFilter('your_games')}
+              >
+                {t('catalog.filter.your_games')}
+              </button>
+            ) : null}
             {hasCatalog ? (
               <button
                 type="button"
                 className={`catalog-filter-trigger${notPlayedOnly ? ' is-active' : ''}`}
                 aria-pressed={notPlayedOnly}
-                onClick={toggleNotPlayed}
+                onClick={() => toggleFilter('not_played')}
               >
                 {t('catalog.filter.not_played')}
               </button>
@@ -575,8 +612,8 @@ export function ArcadeCatalog({
       ) : showEmpty ? (
         <MascotMoment className="catalog-state" emotion="curious" size={64} title={t('mascot.curiousAlt')}>
           <p>{emptyMessage}</p>
-          {notPlayedOnly && catalogEntries.length > 0 ? (
-            <button type="button" className="secondary-btn" onClick={toggleNotPlayed}>
+          {filtersActive && (catalogEntries.length > 0 || mySlugs.size > 0 || hasBuilds) ? (
+            <button type="button" className="secondary-btn" onClick={clearFilters}>
               {t('catalog.clearFilters')}
             </button>
           ) : null}

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -451,13 +451,21 @@ export function ArcadeCatalog({
     [inProgress],
   );
 
+  const hasCatalog = catalogStatus === 'ready' && catalogEntries.length > 0;
+  const hasBuilds = inProgress.length > 0;
+  // My games only makes sense when signed in and you actually have something yours.
+  const canFilterYourGames = Boolean(user) && (mySlugs.size > 0 || hasBuilds);
+  const showControls = hasCatalog || hasBuilds;
+  const yourGamesOnly = canFilterYourGames && filters.has('your_games');
+  const notPlayedOnly = filters.has('not_played');
+  const filtersActive = yourGamesOnly || notPlayedOnly;
+
   const orderedEntries = useMemo(() => {
-    // Signed-out visitors never filter to "my games" even if the pref is sticky —
-    // that would empty the whole catalog.
-    const activeFilters =
-      user || !filters.has('your_games')
-        ? filters
-        : new Set([...filters].filter((id) => id !== 'your_games'));
+    // Ignore a sticky your_games pref when signed out or you have nothing yours —
+    // otherwise the whole catalog would look empty for no good reason.
+    const activeFilters = canFilterYourGames
+      ? filters
+      : new Set([...filters].filter((id) => id !== 'your_games'));
     const filtered = applyCatalogFilters(
       catalogEntries,
       activeFilters,
@@ -465,7 +473,7 @@ export function ArcadeCatalog({
       mySlugs,
     );
     return orderCatalogEntries(filtered, sortMode, signals, mySlugs);
-  }, [catalogEntries, sortMode, filters, signals, mySlugs, user]);
+  }, [catalogEntries, sortMode, filters, signals, mySlugs, canFilterYourGames]);
 
   function handleSortChange(mode: CatalogSortMode) {
     setSortMode(mode);
@@ -490,13 +498,6 @@ export function ArcadeCatalog({
       return next;
     });
   }
-
-  const hasCatalog = catalogStatus === 'ready' && catalogEntries.length > 0;
-  const hasBuilds = inProgress.length > 0;
-  const showControls = hasCatalog || hasBuilds;
-  const yourGamesOnly = Boolean(user) && filters.has('your_games');
-  const notPlayedOnly = filters.has('not_played');
-  const filtersActive = yourGamesOnly || notPlayedOnly;
   const awaitingSignals =
     catalogStatus === 'ready' &&
     catalogEntries.length > 0 &&
@@ -537,7 +538,7 @@ export function ArcadeCatalog({
         </div>
         {showControls ? (
           <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>
-            {hasCatalog && user ? (
+            {hasCatalog && canFilterYourGames ? (
               <button
                 type="button"
                 className={`catalog-filter-trigger${yourGamesOnly ? ' is-active' : ''}`}

--- a/apps/web/src/catalogSort.test.ts
+++ b/apps/web/src/catalogSort.test.ts
@@ -159,6 +159,26 @@ describe('catalog filters', () => {
     ]);
   });
 
+  it('keeps only the creator’s published games for your_games', () => {
+    const mine = new Set(['alpha', 'mid']);
+    expect(
+      applyCatalogFilters(catalog, new Set(['your_games']), new Map(), mine).map((e) => e.slug),
+    ).toEqual(['alpha', 'mid']);
+  });
+
+  it('combines your_games and not_played', () => {
+    rememberRecentPlay('mid');
+    const mine = new Set(['alpha', 'mid', 'zeta']);
+    expect(
+      applyCatalogFilters(
+        catalog,
+        new Set(['your_games', 'not_played']),
+        new Map([['alpha', '2026-07-28T12:00:00.000Z']]),
+        mine,
+      ).map((e) => e.slug),
+    ).toEqual(['zeta']);
+  });
+
   it('migrates the legacy not_played sort into filters', () => {
     localStorage.setItem('gdpl.catalogSort', 'not_played');
     expect([...readCatalogFilters()]).toEqual(['not_played']);
@@ -171,8 +191,8 @@ describe('catalog filters', () => {
     expect([...readCatalogFilters()]).toEqual(['not_played']);
   });
 
-  it('drops obsolete your_games filter ids from storage', () => {
+  it('round-trips your_games and not_played in storage', () => {
     localStorage.setItem('gdpl.catalogFilters', JSON.stringify(['your_games', 'not_played']));
-    expect([...readCatalogFilters()]).toEqual(['not_played']);
+    expect([...readCatalogFilters()].sort()).toEqual(['not_played', 'your_games']);
   });
 });

--- a/apps/web/src/catalogSort.ts
+++ b/apps/web/src/catalogSort.ts
@@ -13,10 +13,10 @@ export const CATALOG_SORT_MODES: CatalogSortMode[] = [
 
 export const DEFAULT_CATALOG_SORT: CatalogSortMode = 'recommended';
 
-/** Only Not played is a filter today; Your games are pinned first, not filtered. */
-export type CatalogFilterId = 'not_played';
+/** Catalog filters — independent of sort. Your games also pin first when the filter is off. */
+export type CatalogFilterId = 'your_games' | 'not_played';
 
-export const CATALOG_FILTER_IDS: CatalogFilterId[] = ['not_played'];
+export const CATALOG_FILTER_IDS: CatalogFilterId[] = ['your_games', 'not_played'];
 
 const SORT_STORAGE_KEY = 'gdpl.catalogSort';
 const FILTERS_STORAGE_KEY = 'gdpl.catalogFilters';
@@ -53,7 +53,6 @@ export function writeCatalogSortMode(mode: CatalogSortMode): void {
 
 /**
  * Active catalog filters. Migrates legacy not-played prefs into the set once.
- * Ignores obsolete `your_games` entries left in storage from an earlier build.
  */
 export function readCatalogFilters(): Set<CatalogFilterId> {
   const filters = new Set<CatalogFilterId>();
@@ -144,16 +143,24 @@ export function filterUnplayedEntries<T extends { slug: string }>(
 }
 
 /**
- * Apply active filters. Today only `not_played`; Your games are pinned first via
- * {@link orderCatalogEntries}, not filtered out.
+ * Apply active filters. `your_games` keeps only the creator’s published slugs
+ * (in-progress builds stay visible separately). Filters combine with AND.
+ * When the filter is off, {@link orderCatalogEntries} still pins yours first.
  */
 export function applyCatalogFilters<T extends { slug: string }>(
   entries: T[],
   filters: ReadonlySet<CatalogFilterId>,
   affinityLastPlayed: ReadonlyMap<string, string>,
+  mySlugs: ReadonlySet<string> = new Set(),
 ): T[] {
-  if (filters.has('not_played')) return filterUnplayedEntries(entries, affinityLastPlayed);
-  return entries;
+  let result = entries;
+  if (filters.has('your_games')) {
+    result = result.filter((entry) => mySlugs.has(entry.slug));
+  }
+  if (filters.has('not_played')) {
+    result = filterUnplayedEntries(result, affinityLastPlayed);
+  }
+  return result;
 }
 
 /**

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -152,9 +152,12 @@
     "toolbarLabel": "Catalog filters and sort",
     "yoursBadge": "Yours",
     "filter": {
+      "your_games": "My games",
       "not_played": "Not played"
     },
     "emptyNotPlayed": "You've played every game here.",
+    "emptyYourGames": "You haven't published a game yet.",
+    "emptyYourGamesNotPlayed": "You've played all of your games here.",
     "clearFilters": "Show all games",
     "sort": {
       "recommended": "Recommended",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -152,9 +152,12 @@
     "toolbarLabel": "Filtry i sortowanie katalogu",
     "yoursBadge": "Twoje",
     "filter": {
+      "your_games": "Moje gry",
       "not_played": "Niegrane"
     },
     "emptyNotPlayed": "Grałeś już we wszystkie gry tutaj.",
+    "emptyYourGames": "Nie opublikowałeś jeszcze żadnej gry.",
+    "emptyYourGamesNotPlayed": "Grałeś już we wszystkie swoje gry tutaj.",
     "clearFilters": "Pokaż wszystkie gry",
     "sort": {
       "recommended": "Polecane",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1009,7 +1009,7 @@ button:disabled {
   justify-content: flex-end;
   gap: 0.4rem;
   min-width: 0;
-  max-width: min(100%, 18rem);
+  max-width: min(100%, 26rem);
 }
 
 .catalog-sort-menu {
@@ -2962,7 +2962,7 @@ body.player-open {
   }
 
   .catalog-toolbar {
-    max-width: min(100%, 14.5rem);
+    max-width: min(100%, 22rem);
   }
 
   .catalog-filter-trigger,

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -2,8 +2,9 @@
 
 > Status: ✅ Built (2026-07-29). The home-page arcade grid can be sorted several
 > ways. **Recommended** is the default; players can also pick Newest, Most played,
-> Last played, or A–Z. **Not played** is a filter. A signed-in creator’s published
-> games are pinned to the front of the same gallery (additive — not a filter).
+> Last played, or A–Z. **My games** and **Not played** are filters. A signed-in
+> creator’s published games are pinned to the front of the same gallery when the
+> My games filter is off.
 
 ## Sort modes
 
@@ -31,15 +32,16 @@ heading when you have builds or published games. Published slugs come from
 
 | Filter | Effect |
 | ------ | ------ |
+| My games | Show only the signed-in creator’s published games (plus in-progress builds). Hidden when signed out. |
 | Not played | Show only games with no play affinity and no device-local recent open |
 
-Sort preference is remembered in `localStorage` (`gdpl.catalogSort`); the Not played
-filter in `gdpl.catalogFilters`. The last recommendations payload is cached in
-`sessionStorage` (`gdpl.catalogSortSignals`) so a reload does not flash
-catalog-default order before the network returns.
+Filters combine with AND. Sort preference is remembered in `localStorage`
+(`gdpl.catalogSort`); filters in `gdpl.catalogFilters`. The last recommendations
+payload is cached in `sessionStorage` (`gdpl.catalogSortSignals`) so a reload does
+not flash catalog-default order before the network returns.
 
-Controls sit on one row beside the Games heading: Not played toggle + Sort ▾
-(menu closes on outside tap / Escape).
+Controls sit on one row beside the Games heading: My games (when signed in) +
+Not played + Sort ▾ (menu closes on outside tap / Escape).
 
 ## Signals & privacy
 
@@ -76,7 +78,7 @@ games-repo order rather than inventing a shuffle.
 
 ## UI
 
-[`ArcadeCatalog`](../apps/web/src/ArcadeCatalog.tsx) shows the Not played toggle and
-Sort dropdown beside the Games heading, pins the creator’s published games first,
-then filters/reorders the same grid. Logic lives in
-[`catalogSort.ts`](../apps/web/src/catalogSort.ts).
+[`ArcadeCatalog`](../apps/web/src/ArcadeCatalog.tsx) shows the My games / Not played
+toggles and Sort dropdown beside the Games heading, pins the creator’s published
+games first when My games is off, then filters/reorders the same grid. Logic lives
+in [`catalogSort.ts`](../apps/web/src/catalogSort.ts).

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -32,7 +32,7 @@ heading when you have builds or published games. Published slugs come from
 
 | Filter | Effect |
 | ------ | ------ |
-| My games | Show only the signed-in creator’s published games (plus in-progress builds). Hidden when signed out. |
+| My games | Show only the signed-in creator’s published games (plus in-progress builds). Hidden when signed out or when you have no builds/published games. |
 | Not played | Show only games with no play affinity and no device-local recent open |
 
 Filters combine with AND. Sort preference is remembered in `localStorage`
@@ -40,8 +40,8 @@ Filters combine with AND. Sort preference is remembered in `localStorage`
 payload is cached in `sessionStorage` (`gdpl.catalogSortSignals`) so a reload does
 not flash catalog-default order before the network returns.
 
-Controls sit on one row beside the Games heading: My games (when signed in) +
-Not played + Sort ▾ (menu closes on outside tap / Escape).
+Controls sit on one row beside the Games heading: My games (when you have
+games) + Not played + Sort ▾ (menu closes on outside tap / Escape).
 
 ## Signals & privacy
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **My games** filter toggle next to **Not played** on the Games gallery toolbar.

Visibility:
- **Hidden** when signed out
- **Hidden** when signed in but you have no published games and no in-progress builds
- **Shown** only when you have something yours to filter to

Behavior when on: only your published games (+ in-progress builds). Off: yours still pinned first, full catalog after. Combines with Not played (AND). Persists as `your_games` in `gdpl.catalogFilters`.

## Screenshots

Toolbar with My games | Not played | Sort:

[Desktop Games toolbar with My games filter](https://cursor.com/agents/bc-019fae15-fba5-70bc-bf03-576937d05fa4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmy-games-filter-desktop.png)

## Test plan

- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] Unit: `catalogSort` your_games / combined filters / storage round-trip
- [x] Manual: My games appears beside Not played when you have games
- [ ] Guest: no My games toggle
- [ ] Signed-in, no games: no My games toggle
- [ ] Signed-in with builds/published: toggle filters to yours
- [ ] My games + Not played combine; preference survives reload

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fae15-fba5-70bc-bf03-576937d05fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

