### PR TITLE
docs(mp): party input key state is `d`, not `v`

### DIFF
--- a/apps/web/src/mp/PartyStage.tsx
+++ b/apps/web/src/mp/PartyStage.tsx
@@ -56,6 +56,8 @@ export function PartyStage({ game, session, onExit }: PartyStageProps) {
           return;
         }
         if (frame.t === 'input') {
+          // `d` is key down/up. Do not rename to `v` — every bridge frame already
+          // carries `v` as PROTOCOL_VERSION, and the game reads `d` for held state.
           postToGame({ t: 'input', slot: frame.slot, k: frame.k, d: frame.d });
           return;
         }

--- a/docs/multiplayer-plan.md
+++ b/docs/multiplayer-plan.md
@@ -187,14 +187,16 @@ connection):
 
 | Direction      | Frames                                                                         |
 | -------------- | ------------------------------------------------------------------------------ |
-| guest → server | `hello { code, token, nick }`, `input { k, v }`, `bye`                         |
+| guest → server | `hello { code, token, nick }`, `input { k, d }`, `bye`                         |
 | server → guest | `welcome { slot, color, nick, phase }`, `phase { phase }`, `closed { reason }` |
 | host → server  | `hello { code, token }`, `phase { phase }`, `kick { slot }`                    |
-| server → host  | `roster { slots }`, `input { slot, k, v }`, `closed { reason }`                |
+| server → host  | `roster { slots }`, `input { slot, k, d }`, `closed { reason }`                |
 
-`k` is one of `up|down|left|right|a` (the v1 layout) and `v` is `0|1`. The server is a **relay
-with admission control**, not a game engine: it validates, tags with the slot number,
-rate-limits (token bucket, ~40 frames/s/connection), and forwards.
+`k` is one of `up|down|left|right|a` (the v1 layout) and `d` is `0|1` (down/up). Every frame
+already carries `v` as the protocol version, so key state cannot reuse that field — a release
+of `0` would look like a version mismatch and be dropped. The server is a **relay with
+admission control**, not a game engine: it validates, tags with the slot number, rate-limits
+(token bucket, ~40 frames/s/connection), and forwards.
 
 ### 4.3 Join security (the QR that lets strangers in)
 
@@ -245,7 +247,7 @@ lobby, in hot-seat, and in the deterministic capture harness.
 | Direction    | Messages                                                      |
 | ------------ | ------------------------------------------------------------- |
 | game → shell | `hello { slots }` (announce slot count), `phase { phase }`    |
-| shell → game | `roster { slots }`, `input { slot, k, v }`, `phase { phase }` |
+| shell → game | `roster { slots }`, `input { slot, k, d }`, `phase { phase }` |
 
 Bridge rules in the shell (`GameFrame` gains an optional `bridge` prop):
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the party input field rename that the wire protocol and `PartyStage` already use: key down/up is `d`, while `v` remains the protocol version on every frame.

Also adds a short comment next to the game-bridge forward in `PartyStage` so this does not get “helpfully” renamed back to `v`.

Companion fix in `www.gamedev.pl-games` updates `shared/modules/party.ts`, which was still reading `data.v === 1` and left phone paddles stuck after the first touch.

## Test plan

- [x] Docs/comment-only change; no runtime behavior change in this repo
- [ ] Skim `docs/multiplayer-plan.md` wire + bridge tables for consistency with `protocol.ts` (`d` for key state)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0bb8435-7484-4da2-bed9-bfb808eb90fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0bb8435-7484-4da2-bed9-bfb808eb90fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

