### PR TITLE
Give the zone module a reserve of its own (paired with games-repo #163)

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -36,9 +36,10 @@
     "headroom": 75237,
     "gfx3d": 96000,
     "lookControls": 4683,
-    "spatialAudio": 2977
+    "spatialAudio": 2977,
+    "zone": 12000
   },
-  "maxProjectBytes": 429687,
+  "maxProjectBytes": 441687,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(429_687);
+    expect(MAX_PROJECT_BYTES).toBe(441_687);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(429_687);
+    expect(MAX_PROJECT_BYTES).toBe(441_687);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -100,6 +100,7 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_GFX3D_BYTES = 96_000;
       const GAMEKIT_LOOK_CONTROLS_BYTES = 4_683;
       const GAMEKIT_SPATIAL_AUDIO_BYTES = 2_977;
+      const GAMEKIT_ZONE_BYTES = 12_000;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -116,7 +117,8 @@ describe('games-repo source extractors', () => {
         GAMEKIT_HEADROOM_BYTES +
         GAMEKIT_GFX3D_BYTES +
         GAMEKIT_LOOK_CONTROLS_BYTES +
-        GAMEKIT_SPATIAL_AUDIO_BYTES;
+        GAMEKIT_SPATIAL_AUDIO_BYTES +
+        GAMEKIT_ZONE_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -25,10 +25,9 @@ export const GAME_KIT_MODULES = [
   'commons',
   'presence',
   'mascot',
-  // P3's zone module (docs/persistent-world-plan.md). Opt-in and, at ~9 KiB transpiled,
-  // charged to the author budget the way `save` and `commons` are rather than to the
-  // platform allowances — so MAX_PROJECT_BYTES does not move for it. Only `gfx3d` was
-  // large enough to need a reserve of its own.
+  // P3's zone module (docs/persistent-world-plan.md). Opt-in, and since games-repo #163
+  // it has a reserve of its own rather than coming out of the author budget — see the
+  // note on GAMEKIT_PLATFORM_BYTES for what changed that.
   'zone',
 ] as const;
 
@@ -42,9 +41,16 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * music, touch hint, progress, universal input, pointer poll, draw surface,
  * pointer release, host pause, mascot draw, headroom, gfx3d, look, spatial, …). Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (429_687, matching games-repo `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB.
+ * (441_687, matching games-repo `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB.
  *
- * Last moved by games-repo #124 (Scene3D B11 scene management): `gfx3d`
+ * Last moved by games-repo #163: +12_000 for a named `zone` reserve, 429_687 → 441_687.
+ * The module shipped charged to the author budget, on the reasoning that it is small and
+ * opt-in the way `save` and `commons` are. biplane-skirmish disproved that on arrival —
+ * the first published game to select `zone` landed 20 bytes under the ceiling, which made
+ * the next byte spent anywhere in the shared kit a break in a live game rather than a cost
+ * to the author who spent it. That is the same argument `gfx3d` has a reserve for.
+ *
+ * Before that, games-repo #124 (Scene3D B11 scene management): `gfx3d`
  * 80_000 → 96_000 (+16_000, 413_687 → 429_687).
  *
  * Before that, games-repo #123 (Scene3D B10 effects): `gfx3d` 56_000 → 80_000
@@ -76,7 +82,7 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Before that, games-repo #102: +679 (`mascotDraw`) and +75_237 (`headroom`) — 30% of
  * the 250_790 ceiling — plus earlier host-pause / touch steer raises.
  */
-export const GAMEKIT_PLATFORM_BYTES = 224_887;
+export const GAMEKIT_PLATFORM_BYTES = 236_887;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
The website half of the lockstep for [games-repo #163](https://github.com/gamedevpl/www.gamedev.pl-games/pull/163), which is merged. `MAX_PROJECT_BYTES` 429_687 → 441_687, and the fixture and mirrored constants move with it.

## Why the budget moves

`zone` shipped charged to the author budget, on the reasoning that it is small and opt-in the way `save` and `commons` are. That was decided when no shipped game selected it.

biplane-skirmish disproved it on arrival. The first published game to select the module landed **20 bytes** under the Check 4 ceiling — and at that margin, the next byte spent anywhere in the shared kit is not a cost to the author who spent it, it is a break in somebody else's live game. That is what happened: a 390-byte fix to `shared/modules/zone.ts` in #163 turned into a red build on a game the change had nothing to do with.

A ~10 KiB module that only inlines when a `GAME.json` asks for it is exactly the shape `gfx3d` already has a named reserve for, so `zone` now has the same: `GAMEKIT_ZONE_BYTES = 12_000`, measured at 10_037 transpiled.

## What changed here

- `GAMEKIT_PLATFORM_BYTES` 224_887 → 236_887, with the history note extended and the now-wrong comment on the `zone` entry in `GAME_KIT_MODULES` corrected — it claimed the module does not move `MAX_PROJECT_BYTES`.
- `apps/api/fixtures/games-repo/shared/assemble-contract.json`: `zone: 12000`, `maxProjectBytes: 441687`.
- The two pinned totals in `assemble.test.ts` and `games-repo-contract.test.ts`, and the mirrored `MAX_BUNDLE_BYTES` expression the extractor test parses.

Nothing behavioural. This is the serve-time ceiling agreeing with the build-time one — a stale copy here 502s every published game while catalog and media still look fine (issue #247), which is why the check exists.

## Verification

Type-check and lint clean, all website suites green. `contract:games-repo` could not run locally (`GAMES_REPO_TOKEN` unset — it skips the live fetch rather than passing vacuously); CI does the real comparison, and now that #163 is merged into games `main` it has something to agree with.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4xHU2Ca1sZHqoP59Pvxx4)_