### PR TITLE
Write down which half of a budget move merges first

### DIFF
--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -5,6 +5,14 @@
  * half of this lockstep. A stale copy here 502s every published game while
  * catalog/media still look fine (issue #247). CI re-checks the live games repo
  * when `GAMES_REPO_TOKEN` is set (`npm run contract:games-repo`).
+ *
+ * **Raising a budget? Merge this side first.** The two PRs are not order-neutral.
+ * Games-repo-first opens a window where the build ceiling is above the serve one,
+ * and a game that grows into it bakes as a failure — quietly, because a partial
+ * bake leaves the pointer on the previous snapshot, so the site keeps serving and
+ * merged games simply never appear. Website-first cannot do that: a serve cap above
+ * the build cap means no assemblable game is refused here. See
+ * docs/games-repo-validation-spec.md §2.
  */
 
 /** Canonical GameKit module order — must match games-repo `GAME_KIT_MODULES`. */

--- a/docs/games-repo-validation-spec.md
+++ b/docs/games-repo-validation-spec.md
@@ -31,6 +31,25 @@ This specification defines the quality gates enforced on incoming pull requests 
   `apps/api/src/assemble.ts` re-exports as `MAX_PROJECT_BYTES` — do not restate them
   here, or this page becomes a third copy to keep in lockstep.
 
+#### Raising the cap: merge the website half first
+
+A budget move is two PRs, and the order they land in is not a matter of taste.
+
+Merging the games-repo half first opens a window where the build-time ceiling is higher
+than the serve-time one. Any game that grows into that gap passes `validate` over there
+and then fails to bake here — and the failure is quiet, because a partial bake
+deliberately leaves the pointer on the previous snapshot. The site keeps serving, the
+catalog looks right, and nothing published moves until somebody re-runs the publish. The
+symptom is not an error page; it is games merged hours ago that never appear.
+
+Merging the website half first inverts it harmlessly. A serve cap above the build cap
+means no game can be assembled that this side would refuse, so the window is empty and
+the games-repo merge publishes on its own dispatch with nothing to recover.
+
+This is not hypothetical: it is what happened when `zone` got its reserve (games-repo
+#163 / website #339), and the recovery was a manual `workflow_dispatch` of
+`publish-games.yml`. See `docs/games-snapshot.md` for that escape hatch.
+
 ### 3. Headless Browser Boot Smoke Test
 
 - Run a headless browser test (JSDOM / Playwright) loading `index.html`.


### PR DESCRIPTION
Docs only. Follow-up to #339.

A cross-repo budget move is two PRs, and the order they land in is not a matter of taste.

**Games-repo-first** opens a window where the build-time ceiling is above the serve-time one. A game that grows into that gap passes `validate` over there and then fails to bake here — and the failure is quiet, because a partial bake deliberately leaves the pointer on the previous snapshot. The site keeps serving, the catalog looks right, and the symptom is not an error page: it is games merged hours ago that never appear.

**Website-first** cannot do that. A serve cap above the build cap means no assemblable game is refused on this side, so the window is empty and the games-repo merge publishes on its own dispatch with nothing to recover.

Not hypothetical — it is what happened giving `zone` its reserve in games-repo #163 / #339. The automatic publish failed on `biplane-skirmish: generated project is 429819 bytes, over the 429687 cap`, 91 games baked and the pointer stayed put, and recovery was a manual `workflow_dispatch` of `publish-games.yml`.

Written in two places on purpose:

- `docs/games-repo-validation-spec.md` §2 — where the rule belongs.
- the header of `apps/api/src/games-repo-contract.ts` — where somebody about to get it wrong is actually looking, since that is the file a budget move edits. A rule filed only in the spec is a rule you find after the incident.

No code change. Type-check, lint and the contract suites are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4xHU2Ca1sZHqoP59Pvxx4)_