### PR TITLE
ops: put a deadline on snapshot reads, and alert per service

### DIFF
--- a/apps/api/src/game-snapshot.test.ts
+++ b/apps/api/src/game-snapshot.test.ts
@@ -8,6 +8,7 @@ import {
   mediaContentType,
   mediaObject,
   POINTER_OBJECT,
+  SnapshotUnavailableError,
   type SnapshotPointer,
 } from './game-snapshot.js';
 
@@ -214,6 +215,66 @@ describe('pointer caching', () => {
 
     // Snapshot prefixes are immutable, so a stale pointer still serves correct
     // games — briefly-old beats an outage.
+    expect(await store.getPointer()).toEqual(pointer());
+  });
+});
+
+describe('read deadline', () => {
+  it('gives up on a hung read instead of stalling the play route', async () => {
+    const fake = createFakeStorage();
+    // A socket that accepted the request and will never answer. There is no GitHub
+    // fallback behind published play any more, so without a deadline this is an
+    // indefinite wait rather than a degraded response.
+    fake.raw.mockImplementationOnce(() => new Promise<Response>(() => {}));
+    const store = createGcsSnapshotStore({
+      bucket,
+      fetchImpl: fake.fetchImpl,
+      getAccessToken: async () => 'fake-token',
+      readTimeoutMs: 30,
+    });
+
+    const startedAt = Date.now();
+    // SnapshotUnavailableError is what a transport failure already raises, so serving
+    // maps a hang to the same fast 503 rather than to a new code path.
+    await expect(store.getPointer()).rejects.toThrow(SnapshotUnavailableError);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it('lets a slow-but-answering read finish', async () => {
+    const fake = createFakeStorage({ [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) } });
+    const inner = fake.raw.getMockImplementation()!;
+    fake.raw.mockImplementationOnce(async (...args) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return inner(...args);
+    });
+    const store = createGcsSnapshotStore({
+      bucket,
+      fetchImpl: fake.fetchImpl,
+      getAccessToken: async () => 'fake-token',
+      readTimeoutMs: 2_000,
+    });
+
+    expect(await store.getPointer()).toEqual(pointer());
+  });
+
+  it('serves the last known pointer when a re-read hangs', async () => {
+    const fake = createFakeStorage({ [POINTER_OBJECT]: { body: Buffer.from(JSON.stringify(pointer())) } });
+    let clock = 1_000;
+    const store = createGcsSnapshotStore({
+      bucket,
+      fetchImpl: fake.fetchImpl,
+      getAccessToken: async () => 'fake-token',
+      pointerTtlMs: 60_000,
+      readTimeoutMs: 30,
+      now: () => clock,
+    });
+
+    await store.getPointer();
+    clock += 61_000;
+    fake.raw.mockImplementationOnce(() => new Promise<Response>(() => {}));
+
+    // A timeout has to count as an error, not as a fresh answer, or the stale-pointer
+    // branch would be skipped and the hang would propagate to the visitor.
     expect(await store.getPointer()).toEqual(pointer());
   });
 });

--- a/apps/api/src/game-snapshot.ts
+++ b/apps/api/src/game-snapshot.ts
@@ -163,6 +163,23 @@ export interface GcsSnapshotStoreOptions {
   getAccessToken?: () => Promise<string>;
   /** How long a resolved pointer is trusted before re-reading it. */
   pointerTtlMs?: number;
+  /**
+   * Deadline on a single snapshot *read*, including the token fetch and the body.
+   *
+   * Published catalog and play read Cloud Storage with nothing behind it: a *failed*
+   * connection degrades to a fast 503, but a *hung* one had no deadline at all, so it
+   * stalled the play route — the one route that must never be down — for as long as
+   * the socket stayed open. A timeout raises `SnapshotUnavailableError`, which is the
+   * same error a transport failure already produces, so a hang and a refusal are
+   * indistinguishable to callers: both are a quick 503, and an already-resolved
+   * pointer keeps being served.
+   *
+   * Reads only. Writes are deliberately left untimed — `putGame` uploads a whole
+   * assembled game and the bake job pushes the entire catalog through it, so a
+   * few-second ceiling there would fail large games for no operational gain. The
+   * bake is a batch job with its own wall-clock limit; the play route is not.
+   */
+  readTimeoutMs?: number;
   now?: () => number;
 }
 
@@ -178,6 +195,10 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? Date.now;
   const pointerTtlMs = options.pointerTtlMs ?? 60_000;
+  // Long enough that a healthy read never trips it (Storage in-region answers in tens
+  // of milliseconds), short enough that a visitor waiting on a wedged connection gets
+  // an answer instead of a spinner.
+  const readTimeoutMs = options.readTimeoutMs ?? 3_000;
 
   let auth: GoogleAuth | null = null;
   const getAccessToken =
@@ -193,14 +214,50 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
     return { authorization: `Bearer ${await getAccessToken()}` };
   }
 
+  /**
+   * Runs a read under `readTimeoutMs`, aborting the request when it expires.
+   *
+   * Raced rather than left to the `AbortSignal` alone: aborting is what frees the
+   * socket, but the *guarantee* the play route needs is that this settles by the
+   * deadline whatever the transport does with the signal. The rejection is a
+   * `SnapshotUnavailableError` so a hang lands on the existing degradation path
+   * rather than on a new one.
+   */
+  async function withReadDeadline<T>(name: string, run: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new SnapshotUnavailableError(`snapshot read of ${name} timed out after ${readTimeoutMs}ms`));
+      }, readTimeoutMs);
+    });
+
+    const attempt = run(controller.signal);
+    // The loser of the race still settles. Once we have abandoned it, its abort
+    // rejection is expected — claim it here so it is not an unhandled rejection.
+    attempt.catch(() => {});
+
+    try {
+      return await Promise.race([attempt, deadline]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   async function readObject(name: string): Promise<Buffer | null> {
     const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(name)}?alt=media`;
-    const response = await fetchImpl(url, { headers: await authHeaders() });
-    if (response.status === 404) return null;
-    if (!response.ok) {
-      throw new Error(`snapshot read of ${name} failed: ${response.status} ${await safeBodyText(response)}`);
-    }
-    return Buffer.from(await response.arrayBuffer());
+    // The token fetch and the body read are inside the deadline with the request: both
+    // are network calls (the first to the metadata server), and either can be the thing
+    // that hangs.
+    return withReadDeadline(name, async (signal) => {
+      const response = await fetchImpl(url, { headers: await authHeaders(), signal });
+      if (response.status === 404) return null;
+      if (!response.ok) {
+        throw new Error(`snapshot read of ${name} failed: ${response.status} ${await safeBodyText(response)}`);
+      }
+      return Buffer.from(await response.arrayBuffer());
+    });
   }
 
   async function readJson<T>(name: string): Promise<T | null> {
@@ -213,6 +270,8 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
     }
   }
 
+  // Untimed on purpose — see readTimeoutMs. This carries whole assembled games for a
+  // batch job, not a request a person is waiting on.
   async function writeObject(name: string, body: Buffer, contentType: string, cacheControl: string): Promise<void> {
     const url =
       `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(bucket)}/o` +

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,15 +27,24 @@ Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch sp
 
 Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 
-| #   | Fires when                                                               | Go to                                            |
-| --- | ------------------------------------------------------------------------ | ------------------------------------------------ |
-| A1  | Uptime check on `/api/health` fails from most probers for 5 min          | [`site-down-triage.md`](./site-down-triage.md)   |
-| A2  | Cloud Run 5xx sustained over 10 min                                      | [`site-down-triage.md`](./site-down-triage.md)   |
-| A3  | A scheduled job fails repeatedly (notify-sweep, or the daily export)     | §below                                           |
-| A4  | The daily Firestore export has not succeeded in 36h                      | [`restore-firestore.md`](./restore-firestore.md) |
-| A5  | Billing budget at 50 / 90 / 100%                                         | Cost review — see the ops repo's readiness plan  |
-| A6  | The zone host could not start a zone (log-based, rate-limited to hourly) | [`zones-down-triage.md`](./zones-down-triage.md) |
-| A7  | `gamedev-world` 5xx sustained over 10 min                                | [`zones-down-triage.md`](./zones-down-triage.md) |
+| #   | Policy name                                     | Fires when                                                               | Go to                                            |
+| --- | ----------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| A1  | `A1 <service> site down (uptime check failing)` | That service's uptime check fails from most probers for 5 min            | [`site-down-triage.md`](./site-down-triage.md)   |
+| A2  | `A2 <service> Cloud Run 5xx rate elevated`      | That service's Cloud Run 5xx sustained over 10 min                       | [`site-down-triage.md`](./site-down-triage.md)   |
+| A3  | `A3 notify-sweep failing`                       | A scheduled job fails repeatedly (notify-sweep, or the daily export)     | §below                                           |
+| A4  | `A4 no successful Firestore export`             | The daily Firestore export has not succeeded in 36h                      | [`restore-firestore.md`](./restore-firestore.md) |
+| A5  | (billing budget, created by hand)               | Billing budget at 50 / 90 / 100%                                         | Cost review — see the ops repo's readiness plan  |
+| A6  | `A6 zone admission failing`                     | The zone host could not start a zone (log-based, rate-limited to hourly) | [`zones-down-triage.md`](./zones-down-triage.md) |
+| A7  | `A7 world service 5xx rate elevated`            | `gamedev-world` 5xx sustained over 10 min                                | [`zones-down-triage.md`](./zones-down-triage.md) |
+
+**A1 and A2 name the service; the rest do not.** A1/A2 exist once per Cloud Run service
+answering requests (`gamedev-app`, and the party relay when it takes traffic), so the
+policy name tells you _which_ service is down before you open anything — and A1's
+condition is scoped to that service's own uptime check rather than to "any check in the
+project". Each such service needs its own `SERVICE=… ./infra/setup-monitoring.sh` run or
+it has no A1/A2 at all. A3/A4 watch project-wide Cloud Scheduler jobs and A6/A7 name
+`gamedev-world` directly, so there is exactly one of each and they are written only on the
+primary run.
 
 **A6 has no uptime check behind it, on purpose.** Probing a scale-to-zero service every
 five minutes keeps an instance warm around the clock and turns `$0` at rest into roughly

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,18 +11,37 @@ No Terraform configuration is used or required for this repository.
 All are idempotent and **owner-run** — they need `gcloud` authenticated against the
 project, which agent tooling can read but not write.
 
-| Script | What it provisions | When to run |
-| --- | --- | --- |
-| `setup-wif.sh` | Workload Identity Federation for GitHub Actions | Once, before the first deploy |
-| `setup-gcp.sh` | Firestore, IAM, session secret, telemetry TTL, snapshot bucket | Once, then after adding a resource it manages |
-| `setup-backups.sh` | Firestore PITR + daily export to GCS, export SA and its IAM | Once. **Then drill the restore** — see `docs/runbooks/restore-firestore.md` |
-| `setup-monitoring.sh` | Uptime check + alert policies A1–A4, email channel | Once, per `ALERT_EMAIL`. Prints the manual step for A5 (billing budget) |
-| `deploy-api.sh` | Manual deploy of the app service | Rarely — CI deploys on merge to `master` |
-| `deploy-world.sh` | Manual deploy of the zone host | Rarely; inert unless `ZONE_HOST_URL` is set |
+| Script                | What it provisions                                                            | When to run                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `setup-wif.sh`        | Workload Identity Federation for GitHub Actions                               | Once, before the first deploy                                                                         |
+| `setup-gcp.sh`        | Firestore, IAM, session secret, telemetry TTL, snapshot bucket                | Once, then after adding a resource it manages                                                         |
+| `setup-backups.sh`    | Firestore PITR + daily export to GCS, export SA and its IAM                   | Once. **Then drill the restore** — see `docs/runbooks/restore-firestore.md`                           |
+| `setup-monitoring.sh` | Per-service uptime check + A1/A2, project-wide A3/A4 and A6/A7, email channel | **Once per service** (`SERVICE=…`), per `ALERT_EMAIL`. Prints the manual step for A5 (billing budget) |
+| `deploy-api.sh`       | Manual deploy of the app service                                              | Rarely — CI deploys on merge to `master`                                                              |
+| `deploy-world.sh`     | Manual deploy of the zone host                                                | Rarely; inert unless `ZONE_HOST_URL` is set                                                           |
 
 Backups and alerting exist because neither Cloud Run nor Firestore provides them by
 default: without `setup-backups.sh` a wrong delete is unrecoverable, and without
 `setup-monitoring.sh` an outage is discovered by whoever next opens the site.
+
+`setup-monitoring.sh` is the one script that is **not** once-per-project. A1 (uptime) and
+A2 (5xx) are per-service, so every service taking traffic needs its own run — a service
+nobody ran it for is unmonitored by construction:
+
+```bash
+ALERT_EMAIL=you@example.com ./infra/setup-monitoring.sh                       # gamedev-app
+ALERT_EMAIL=you@example.com SERVICE=gamedev-mp-relay ./infra/setup-monitoring.sh
+```
+
+The host is derived from the service's Cloud Run URL unless `HOST` is set, and
+`HEALTH_PATH` defaults to `/api/health`. A3/A4 (Cloud Scheduler jobs) and A6/A7 (the zone
+host, which the script names directly) are project-wide, so they are created only on the
+`PRIMARY_SERVICE` (default `gamedev-app`) run.
+
+`gamedev-world` is the one service you must **not** onboard this way, and the script
+refuses it: A6/A7 already watch it, deliberately without an uptime check, because probing
+a scale-to-zero service every five minutes keeps an instance warm around the clock (see
+`docs/runbooks/README.md`).
 
 ## Prerequisites (Owner-Run Setup)
 

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -6,10 +6,21 @@
 # OWNER-RUN: needs `gcloud` authenticated against the project.
 #
 # Usage:
-#   ALERT_EMAIL=you@example.com ./infra/setup-monitoring.sh
+#   ALERT_EMAIL=you@example.com ./infra/setup-monitoring.sh                     # the app
+#   ALERT_EMAIL=… SERVICE=gamedev-mp-relay ./infra/setup-monitoring.sh          # + a second service
 #
-# Override via env: PROJECT_ID, REGION, SERVICE, WORLD_SERVICE, HOST, ALERT_EMAIL,
-# BACKUP_BUCKET.
+# Override via env: PROJECT_ID, REGION, SERVICE, PRIMARY_SERVICE, WORLD_SERVICE, HOST,
+# HEALTH_PATH, ALERT_EMAIL, BACKUP_BUCKET.
+#
+# **Run it once per service that answers HTTP requests.** A1 (uptime) and A2 (5xx) are
+# per-service; a service nobody ran this for is unmonitored by construction, which is how
+# the party relay would have gone live. Everything else — A3/A4 (scheduler jobs) and
+# A6/A7 (the world service, which names itself through WORLD_SERVICE) — is project-wide
+# and is written only on the PRIMARY_SERVICE run, so a second service does not get
+# duplicate copies of them.
+#
+# The world service is the exception in the other direction: do NOT onboard it with
+# SERVICE=, and see the guard below for why.
 #
 # What this deliberately is and is not:
 #
@@ -22,6 +33,9 @@
 #   trains the operator to ignore the channel, which is worse than not having it.
 #
 # Idempotent: policies are matched by display name and updated rather than duplicated.
+# Every per-service display name carries the service, so a second service *adds* policies
+# instead of overwriting the first service's — which is what matching on a
+# service-agnostic name ("A1 site down …") would have done.
 set -euo pipefail
 
 # gcloud asks for confirmation on stderr — including "you do not have this command group
@@ -46,10 +60,46 @@ done
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 REGION="${REGION:-europe-west1}"
 SERVICE="${SERVICE:-gamedev-app}"
+# The service that owns the project-wide policies (A3/A4/A6/A7) and answers on the domain.
+PRIMARY_SERVICE="${PRIMARY_SERVICE:-gamedev-app}"
 WORLD_SERVICE="${WORLD_SERVICE:-gamedev-world}"
-HOST="${HOST:-www.gamedev.pl}"
+HEALTH_PATH="${HEALTH_PATH:-/api/health}"
 BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backups}"
 : "${ALERT_EMAIL:?set ALERT_EMAIL to the address that should receive alerts}"
+
+# The world service is watched by A6/A7 and deliberately has no uptime check: a probe
+# every five minutes keeps a scale-to-zero service warm around the clock, which converts
+# \$0 at rest into roughly \$65/month to learn whether something nobody is using is up
+# (docs/p3-zone-host-infra.md). Running this per-service for it would quietly undo that
+# decision *and* duplicate A7 under an A2 name, so it is refused rather than warned about.
+if [ "$SERVICE" = "$WORLD_SERVICE" ]; then
+  echo "Refusing to onboard '${SERVICE}' per-service: it is covered by A6/A7 from the" >&2
+  echo "'${PRIMARY_SERVICE}' run, without an uptime check on purpose. See the note above." >&2
+  exit 1
+fi
+
+# The primary service answers on the domain; anything else is probed on its own Cloud Run
+# hostname, resolved here so adding a service is one variable rather than two.
+if [ -z "${HOST:-}" ]; then
+  if [ "$SERVICE" = "$PRIMARY_SERVICE" ]; then
+    HOST="www.gamedev.pl"
+  else
+    HOST="$(gcloud run services describe "$SERVICE" \
+      --region "$REGION" --project "$PROJECT_ID" \
+      --format='value(status.url)' 2>/dev/null | sed -e 's#^https://##' -e 's#^http://##')"
+    if [ -z "$HOST" ]; then
+      echo "Could not resolve a URL for service '${SERVICE}' in ${REGION}. Set HOST= explicitly." >&2
+      exit 1
+    fi
+  fi
+fi
+
+echo "==> Target: service '${SERVICE}' on https://${HOST}${HEALTH_PATH}"
+if [ "$SERVICE" = "$PRIMARY_SERVICE" ]; then
+  echo "    Primary service — the project-wide policies (A3, A4, A6, A7) are included."
+else
+  echo "    Secondary service — A1/A2 only; the rest belong to '${PRIMARY_SERVICE}'."
+fi
 
 echo "==> 1/4 Enabling the Monitoring API"
 gcloud services enable monitoring.googleapis.com --project "$PROJECT_ID"
@@ -71,30 +121,46 @@ else
   echo "    Channel already exists."
 fi
 
-echo "==> 3/4 Ensuring the uptime check on https://${HOST}/api/health"
+echo "==> 3/4 Ensuring the uptime check on https://${HOST}${HEALTH_PATH}"
 # /api/health is the right probe target precisely because it is not walled: it answers
 # 200 without a session, so a failure means the service is genuinely unreachable rather
 # than that the beta gate did its job. Checking a walled route would alert on 401 or,
 # worse, teach us to ignore the alert that fires every time.
+#
+# The name carries the service: one check per service, and A1 below is scoped to this
+# check's id so a second service's outage cannot be reported as the first one's.
+UPTIME_DISPLAY="${SERVICE} health"
 UPTIME_NAME="$(gcloud monitoring uptime list-configs \
   --project "$PROJECT_ID" \
-  --filter="displayName='gamedev-app health'" \
+  --filter="displayName='${UPTIME_DISPLAY}'" \
   --format='value(name)' | head -n 1)"
 if [ -z "$UPTIME_NAME" ]; then
-  gcloud monitoring uptime create 'gamedev-app health' \
+  gcloud monitoring uptime create "$UPTIME_DISPLAY" \
     --project "$PROJECT_ID" \
     --resource-type=uptime-url \
     --resource-labels="host=${HOST},project_id=${PROJECT_ID}" \
-    --path='/api/health' \
+    --path="$HEALTH_PATH" \
     --port=443 \
     --protocol=https \
     --period=5 \
     --timeout=10 \
     >/dev/null
   echo "    Created (5-minute cadence from multiple regions)."
+  UPTIME_NAME="$(gcloud monitoring uptime list-configs \
+    --project "$PROJECT_ID" \
+    --filter="displayName='${UPTIME_DISPLAY}'" \
+    --format='value(name)' | head -n 1)"
 else
   echo "    Uptime check already exists."
 fi
+# The check_id is the last segment of the config's resource name, and it is the only
+# thing that ties a check_passed time series back to one service.
+CHECK_ID="${UPTIME_NAME##*/}"
+if [ -z "$CHECK_ID" ]; then
+  echo "Could not resolve the uptime check id for '${UPTIME_DISPLAY}'." >&2
+  exit 1
+fi
+echo "    check_id=${CHECK_ID}"
 
 echo "==> 4/4 Ensuring alert policies"
 POLICY_DIR="$(mktemp -d)"
@@ -103,14 +169,18 @@ trap 'rm -rf "$POLICY_DIR"' EXIT
 # A1 — the site is down. Multi-region agreement is what separates "Cloud Run is gone"
 # from "one prober had a bad minute", which is why the uptime check fans out and this
 # policy waits for 300s of sustained failure before it speaks.
+#
+# Scoped to this service's check_id. Without that the condition matches *every* uptime
+# check in the project, so a second service's policy would fire on the first service's
+# outage and both would say the same, wrong thing about which service is down.
 cat > "${POLICY_DIR}/a1.json" <<EOF
 {
-  "displayName": "A1 site down (uptime check failing)",
+  "displayName": "A1 ${SERVICE} site down (uptime check failing)",
   "combiner": "OR",
   "conditions": [{
     "displayName": "uptime check failing for 5 minutes",
     "conditionThreshold": {
-      "filter": "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\"",
+      "filter": "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\" AND metric.label.\"check_id\"=\"${CHECK_ID}\"",
       "aggregations": [{
         "alignmentPeriod": "300s",
         "perSeriesAligner": "ALIGN_FRACTION_TRUE",
@@ -125,7 +195,7 @@ cat > "${POLICY_DIR}/a1.json" <<EOF
   "notificationChannels": ["${CHANNEL_NAME}"],
   "alertStrategy": { "autoClose": "86400s" },
   "documentation": {
-    "content": "https://${HOST}/api/health is failing from most probers. Triage: docs/runbooks/site-down-triage.md",
+    "content": "https://${HOST}${HEALTH_PATH} (service ${SERVICE}) is failing from most probers. Triage: docs/runbooks/site-down-triage.md",
     "mimeType": "text/markdown"
   }
 }
@@ -137,7 +207,7 @@ EOF
 # continuously) and stay quiet for the occasional one-off.
 cat > "${POLICY_DIR}/a2.json" <<EOF
 {
-  "displayName": "A2 Cloud Run 5xx rate elevated",
+  "displayName": "A2 ${SERVICE} Cloud Run 5xx rate elevated",
   "combiner": "OR",
   "conditions": [{
     "displayName": "5xx responses sustained over 10 minutes",
@@ -162,6 +232,14 @@ cat > "${POLICY_DIR}/a2.json" <<EOF
   }
 }
 EOF
+
+# A3, A4, A6 and A7 are project-wide: A3/A4 watch Cloud Scheduler jobs, and A6/A7 name
+# the world service through WORLD_SERVICE rather than deriving it from SERVICE. All four
+# are written only on the primary run. Duplicating them per service would mean N identical
+# emails for one failed job, which is how an operator learns to filter the channel; their
+# display names stay service-free for the same reason.
+# (Heredoc bodies are left unindented: EOF must start the line.)
+if [ "$SERVICE" = "$PRIMARY_SERVICE" ]; then
 
 # A3 — the notify sweep. It already runs every 2 minutes against auth, Firestore and the
 # app in one request, which makes it a synthetic monitor we are getting for free; all
@@ -308,6 +386,8 @@ cat > "${POLICY_DIR}/a7.json" <<EOF
 }
 EOF
 
+fi
+
 for FILE in "${POLICY_DIR}"/*.json; do
   DISPLAY="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['displayName'])" "$FILE")"
   EXISTING="$(gcloud alpha monitoring policies list \
@@ -334,7 +414,19 @@ for FILE in "${POLICY_DIR}"/*.json; do
 done
 
 echo ""
-echo "==> Done. Uptime check + A1-A4, A6-A7 wired to ${ALERT_EMAIL}."
+if [ "$SERVICE" = "$PRIMARY_SERVICE" ]; then
+  echo "==> Done. '${SERVICE}' uptime check + A1/A2, and the project-wide A3/A4 and A6/A7,"
+  echo "    wired to ${ALERT_EMAIL}."
+  echo ""
+  echo "    Every other service answering requests needs its own run, or it is unmonitored:"
+  echo "      ALERT_EMAIL=${ALERT_EMAIL} SERVICE=<service> ./infra/setup-monitoring.sh"
+  echo "    ('${WORLD_SERVICE}' is the exception — A6/A7 above already cover it, without a"
+  echo "    probe that would keep a scale-to-zero service warm.)"
+else
+  echo "==> Done. '${SERVICE}' uptime check + A1/A2 wired to ${ALERT_EMAIL}."
+  echo "    A3/A4 and A6/A7 were skipped — they are project-wide and belong to the"
+  echo "    '${PRIMARY_SERVICE}' run."
+fi
 echo ""
 echo "    A5 (billing budget) is NOT here: budgets live on the billing account, not the"
 echo "    project, and need roles this script does not assume. Create it once by hand:"


### PR DESCRIPTION
Two ops-floor gaps (readiness items **27** and **28**), no user-visible behaviour change.

## 1. Snapshot reads had no deadline (item 27)

Published catalog and play read Cloud Storage with no GitHub fallback behind them. A *failed* connection already degrades correctly (`SnapshotUnavailableError` → 503, missing object → 502); a *hung* one had nothing behind it and no deadline, so it stalled the play route indefinitely. This was the last remaining way that route could hang.

- `readObject` / `readJson` now run under `readTimeoutMs` (default **3s**, an option on `GcsSnapshotStoreOptions` so tests set it low). The deadline covers the ADC token fetch, the request and the body read — any of the three can be the thing that hangs.
- A timeout raises `SnapshotUnavailableError`, the same error transport failures already produce, so a hang lands on the existing degradation path: fast 503, no new code path.
- `getPointer`'s stale-on-error branch still applies — a timeout counts as an error, so an already-resolved pointer keeps being served. Covered by a test, because the opposite (a timeout treated as a fresh answer) would have propagated the hang to the visitor.
- Raced rather than left to the `AbortSignal` alone: aborting is what frees the socket, but the guarantee the play route needs is that the read settles by the deadline *whatever the transport does with the signal*.
- **Writes deliberately stay untimed.** `putGame` carries whole assembled games and the bake job pushes the entire catalog through it; a few-second ceiling there would fail large games for no gain. The bake is a batch job with its own wall-clock limit — the play route is not.

Three new tests: a never-resolving `fetchImpl` rejects within the budget with `SnapshotUnavailableError`; a slow-but-answering read still succeeds; a hung *re-read* serves the last known pointer.

## 2. Alerting was single-service by construction (item 28)

`infra/setup-monitoring.sh` targeted `gamedev-app` only, so the party relay and the zone host would go live unmonitored.

The trap this also fixes: policies are matched and upserted by `displayName`, and those names were service-agnostic (`A1 site down …`), as was the uptime check name (`gamedev-app health`). Running the script for a second service would have **overwritten** the first service's policy instead of adding one — trading monitoring of the app for monitoring of the relay, silently. A1's condition had the same bug in its *filter*: `check_passed AND resource.type="uptime_url"` matches every uptime check in the project.

- Parameterised by `SERVICE`; run once per service. `PRIMARY_SERVICE` (default `gamedev-app`) owns the domain and the project-wide policies.
- Every per-service `displayName` and the uptime check name now carry the service.
- A1 is scoped to its own check's `check_id`, read back from the uptime config's resource name (not guessed from the display name).
- `HOST` is derived from the service's Cloud Run URL when not set, and `HEALTH_PATH` defaults to `/api/health`, so adding a service is one variable.
- **A3/A4 are not duplicated per service.** They watch Cloud Scheduler jobs, which belong to the project; N copies would mean N identical emails for one failed job, which is how an operator learns to filter the channel. They are written only on the primary run, and their names stay service-free.

Renaming the policies is free right now because the alert floor has not been run yet — no uptime checks exist in the project (`gcloud monitoring uptime list-configs` is empty) and item 4 of the readiness plan is still open. Had it been run, the old policies would need deleting by hand after this.

Docs updated: the script table in `infra/README.md` (now "once per service", with the invocation) and the alert table in `docs/runbooks/README.md` (now lists the real policy names and explains why A1/A2 carry a service and A3/A4 do not).

## Verification

- `npm run lint && npm run type-check && npm run test && npm run build` all pass. API suite 1065 tests (was 1062); full suite green.
- `bash -n infra/setup-monitoring.sh` passes.
- Both script paths were driven end-to-end against a `gcloud` test double, and the emitted policy JSON checked: primary run produces A1/A2 named for `gamedev-app` plus project-wide A3/A4; a `SERVICE=gamedev-mp-relay HEALTH_PATH=/healthz` run produces only A1/A2 named for the relay, scoped to the relay's own `check_id`, probing the host derived from its Cloud Run URL. That double also caught a real bug: `sed 's#^https\?://##'` does not strip the scheme under BSD sed, which would have produced `https://https://…` as the probe host on the owner's Mac.

Owner action still required (unchanged): actually running the script — `ALERT_EMAIL=… ./infra/setup-monitoring.sh`, then once more per service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebased onto master 2026-07-30 (after #342 and #343)

#342 landed the zone-host alerts (A6/A7) in this same script an hour before this rebase, so the conflict was semantic, not textual. Resolved deliberately rather than mechanically:

- **A6/A7 are treated like A3/A4** — project-wide, written only on the `PRIMARY_SERVICE` run. They name the world service through `WORLD_SERVICE` rather than deriving it from `SERVICE`, so a per-service run has no business rewriting them.
- **`SERVICE=gamedev-world` is now refused outright**, with the reason printed. #342 deliberately gave the world service *no* uptime check, because probing a scale-to-zero service every five minutes keeps an instance warm around the clock (~$65/month to learn whether something nobody is using is up). Parameterising by `SERVICE` is exactly the thing that invites someone to undo that decision by accident — and it would also duplicate A7 under an A2 name. A guard beats a comment when the invitation is built into the interface.
- The alert table in `docs/runbooks/README.md` keeps #342's A6/A7 rows and its no-uptime-check rationale, with the policy-name column added on top; `infra/README.md` says the same about A6/A7 and the refusal.

Re-verified after the rebase: `bash -n`, the gcloud-double dry run across all three cases (primary → A1/A2 for `gamedev-app` + A3/A4 + A6/A7; `SERVICE=gamedev-mp-relay` → only A1/A2, scoped to the relay's own `check_id`; `SERVICE=gamedev-world` → refused, exit 1), and `lint` / `type-check` / `test` / `build` all green. API suite now **1094** (the 1091 on master after #343, plus this PR's 3).
