### PR TITLE
Watch the zone host, which fails without a symptom

### DIFF
--- a/docs/persistent-world-plan.md
+++ b/docs/persistent-world-plan.md
@@ -373,7 +373,7 @@ Not built, deliberately: no catalog surface. §9 wants "Enter world — 12 onlin
 game's card and this phase does not provide it, because a card-level count means reading
 every world's roster on a page nobody has opened a game from yet.
 
-### P3 — Authoritative real-time zones (capabilities 2+3+4, "the real thing")
+### P3 — Authoritative real-time zones (capabilities 2+3+4, "the real thing") ✅ built
 
 Option C: the game ships a **deterministic sim** (§6) that the platform runs in a caged
 isolate per active zone. The relay evolves from input-forwarder into a zone host that feeds
@@ -385,10 +385,12 @@ through a separate view entry point.
 - The world scales by zones, not by world: each zone is a room-sized problem, which is
   exactly the size `mp.ts` already handles.
 
-**The spike is done** (2026-07-28) — see [p3-sim-spike.md](./p3-sim-spike.md) for the
-measurements. The phase itself is still unscheduled; what exists is the contract, the CI
-gate and one game split across it, all in the games repo and inert for everything else.
-Four results change how the rest of P3 should be planned:
+**Built and live** (2026-07-29). `gamedev-world` is deployed, Ember Watch runs on it, and
+a second game (biplane-skirmish) selects the module. What follows is kept because it is
+the reasoning the build rests on, not a plan for work still to come.
+
+**The spike came first** (2026-07-28) — see [p3-sim-spike.md](./p3-sim-spike.md) for the
+measurements. Four of its results shaped everything after it:
 
 1. **The premise holds.** Of 261 modules in the catalog, **two read a clock and none
    touch the DOM** — and one of those two is a cosmetic pulse inside a renderer. Checks 6
@@ -413,8 +415,8 @@ Four results change how the rest of P3 should be planned:
    random stream spans a zone's lifetime and a woken sim can be put back on it by
    counting draws.
 
-The first task of P3 proper is now a small one: inject that math shim into the client
-bundle, closing the single gap the spike left open.
+The first task of P3 proper was a small one: inject that math shim into the client
+bundle, closing the single gap the spike left open. That is done.
 
 **The host is now built** — `packages/zone-core` (the cage, the tick loop, the
 hibernation) and `apps/world` (the socket, the Firestore snapshots), with the shell half

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,12 +12,13 @@ hour, possibly on a phone.
 3. **Fix them when they turn out to be wrong** — same self-improvement clause as the
    agent playbooks. A runbook that lies during an incident is worse than no runbook.
 
-| Runbook | When |
-| --- | --- |
-| [`site-down-triage.md`](./site-down-triage.md) | Alert A1 or A2 fired, or the site is unreachable. **Start here** |
-| [`rollback-deploy.md`](./rollback-deploy.md) | A deploy broke production |
-| [`restore-firestore.md`](./restore-firestore.md) | Data was lost, corrupted, or wrongly deleted |
-| [`rotate-secrets.md`](./rotate-secrets.md) | Routine rotation, an expiring PAT, or a suspected leak. The expiry ledger itself is in the ops repo |
+| Runbook                                          | When                                                                                                |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| [`site-down-triage.md`](./site-down-triage.md)   | Alert A1 or A2 fired, or the site is unreachable. **Start here**                                    |
+| [`zones-down-triage.md`](./zones-down-triage.md) | Alert A6 or A7 fired — shared worlds are failing while the site looks fine                          |
+| [`rollback-deploy.md`](./rollback-deploy.md)     | A deploy broke production                                                                           |
+| [`restore-firestore.md`](./restore-firestore.md) | Data was lost, corrupted, or wrongly deleted                                                        |
+| [`rotate-secrets.md`](./rotate-secrets.md)       | Routine rotation, an expiring PAT, or a suspected leak. The expiry ledger itself is in the ops repo |
 
 Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch spike) and
 `launch-day.md` (the spike procedure). Both are Gate O2/O3 items.
@@ -26,13 +27,21 @@ Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch sp
 
 Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 
-| # | Fires when | Go to |
-| --- | --- | --- |
-| A1 | Uptime check on `/api/health` fails from most probers for 5 min | [`site-down-triage.md`](./site-down-triage.md) |
-| A2 | Cloud Run 5xx sustained over 10 min | [`site-down-triage.md`](./site-down-triage.md) |
-| A3 | A scheduled job fails repeatedly (notify-sweep, or the daily export) | §below |
-| A4 | The daily Firestore export has not succeeded in 36h | [`restore-firestore.md`](./restore-firestore.md) |
-| A5 | Billing budget at 50 / 90 / 100% | Cost review — see the ops repo's readiness plan |
+| #   | Fires when                                                               | Go to                                            |
+| --- | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| A1  | Uptime check on `/api/health` fails from most probers for 5 min          | [`site-down-triage.md`](./site-down-triage.md)   |
+| A2  | Cloud Run 5xx sustained over 10 min                                      | [`site-down-triage.md`](./site-down-triage.md)   |
+| A3  | A scheduled job fails repeatedly (notify-sweep, or the daily export)     | §below                                           |
+| A4  | The daily Firestore export has not succeeded in 36h                      | [`restore-firestore.md`](./restore-firestore.md) |
+| A5  | Billing budget at 50 / 90 / 100%                                         | Cost review — see the ops repo's readiness plan  |
+| A6  | The zone host could not start a zone (log-based, rate-limited to hourly) | [`zones-down-triage.md`](./zones-down-triage.md) |
+| A7  | `gamedev-world` 5xx sustained over 10 min                                | [`zones-down-triage.md`](./zones-down-triage.md) |
+
+**A6 has no uptime check behind it, on purpose.** Probing a scale-to-zero service every
+five minutes keeps an instance warm around the clock and turns `$0` at rest into roughly
+`$65`/month to learn whether something nobody is using is up. A probe is traffic, and
+that service bills for traffic. A6 watches a log line instead, and A7 covers the case
+where the host dies before it can write one.
 
 **A3 covers two different jobs.** Check `job_id` on the alert:
 
@@ -46,5 +55,5 @@ Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 The gaps are known, not forgotten — they are tracked as numbered items in the
 operational readiness plan in the **private ops repo** (`www.gamedev.pl-ops`), which is
 where ops planning lives now. Notably absent from this folder: takedown operations, the
-load-shedding procedure, and anything about the party relay or zone host as separate
-services.
+load-shedding procedure, and anything about the party relay as a separate service. The
+zone host is covered as of A6/A7 above.

--- a/docs/runbooks/zones-down-triage.md
+++ b/docs/runbooks/zones-down-triage.md
@@ -1,0 +1,115 @@
+# Runbook: zones are dead and the site is fine
+
+Entry point for alerts **A6** (zone admission failing) and **A7** (world service 5xx).
+
+**Last drilled: never.**
+
+Read this first, because it changes what "working" looks like: when the zone host refuses
+a join, the shell falls back to solo play **without telling the player**. That is correct
+— a game must be playable alone — and it is why this failure has no symptom. The site is
+up, every request is a 200, `/health` is green, and each player is alone in a world they
+think is shared. Both faults on this service's first day looked exactly like this.
+
+So do not try to confirm the outage by loading the game. One browser window cannot tell a
+working host from a dead one. Step 4 is how you actually check.
+
+```bash
+PROJECT_ID=gamedevpl; REGION=europe-west1; WORLD=gamedev-world
+WORLD_URL="$(gcloud run services describe "$WORLD" --region "$REGION" \
+  --project "$PROJECT_ID" --format='value(status.url)')"
+echo "$WORLD_URL"
+```
+
+## 0. If you need it off right now
+
+```bash
+gcloud run services update gamedev-app --region "$REGION" --project "$PROJECT_ID" \
+  --remove-env-vars ZONE_HOST_URL
+```
+
+Every game immediately plays as it did before zones existed. Nothing else is affected, no
+redeploy is needed, and `gamedev-world` costs nothing left running while you diagnose.
+This is a cheap, reversible stop — use it and take your time rather than debugging live.
+
+## 1. What is the host actually saying?
+
+```bash
+gcloud run services logs read "$WORLD" --region "$REGION" --project "$PROJECT_ID" --limit 100
+```
+
+The wire reason a client gets (`zone_unavailable`) is deliberately uninformative — it
+would otherwise tell someone holding a stolen ticket which part they got wrong. **The
+cause is only in this log.** A6 fires on the line `zone admission failed`; the `err`
+attached to it is the diagnosis.
+
+Two causes have happened before and are worth checking by eye first:
+
+- **`not a constructor` / anything about `Isolate`** — the isolate cage loaded but is not
+  usable. The host boots, passes its own cage assertion, serves `/health`, and fails
+  every join. Fixed once in `packages/zone-core/src/cage.ts`; a recurrence most likely
+  means the image was built without the native addon.
+- **a missing seat, or an error naming a zone that should exist** — a zone was reaped
+  mid-admission. `ZoneHost` holds a zone while a join is in flight for exactly this
+  reason; if this reappears, the hold is the thing that broke.
+
+## 2. Is the host even reachable, and does it think it has zones?
+
+```bash
+curl -sS "$WORLD_URL/health"
+```
+
+`{"ok":true,"zones":N,...}` — `zones` is how many worlds are live in memory. **Zero is
+not a fault**: an idle host has no zones and that is the entire cost model. Zero _while
+somebody is playing_ is the fault.
+
+No answer at all means the service is not running: go to step 3.
+
+## 3. Did it refuse to start?
+
+```bash
+gcloud run revisions list --service "$WORLD" --region "$REGION" --project "$PROJECT_ID" \
+  --format='table(metadata.name, status.conditions[0].message, metadata.creationTimestamp)' \
+  --sort-by=~metadata.creationTimestamp --limit 5
+```
+
+The host **exits rather than downgrade** when the `isolated-vm` cage is unavailable, and
+that is intended: `node:vm` passes every test in the repo and is not a security boundary,
+so running production on it would silently delete the whole safety argument. A revision
+that will not come up with a cage error in its log is the system working.
+
+Do not "fix" this by setting `ZONE_CAGE` or relaxing `NODE_ENV`. Rebuild the image
+(`infra/deploy-world.sh`) — the addon needs Node 22 at both build and runtime, and npm
+skips it _silently_ on an engine mismatch, so an image that built cleanly can still have
+no addon in it.
+
+## 4. Confirm it is fixed — two windows, not one
+
+Sign in and open the game in two separate browser sessions (two profiles, or one
+incognito). Both watchers must appear in the **same** world and see each other move.
+
+Two sessions that each look fine is the failure, not the fix.
+
+```bash
+# While both are connected:
+curl -sS "$WORLD_URL/health"   # zones must be 1, not 0
+```
+
+## 5. Is the app still pointed at it?
+
+```bash
+gcloud run services describe gamedev-app --region "$REGION" --project "$PROJECT_ID" \
+  --format='value(spec.template.spec.containers[0].env)' | tr ',' '\n' | grep -i zone
+```
+
+`ZONE_HOST_URL` must be present and match `$WORLD_URL`. If it is missing and nobody
+removed it deliberately, an app deploy wiped it — `--set-env-vars` replaces the whole map.
+Both deploy paths thread it through, so this should not happen; if it did, that is the
+bug, not the host.
+
+## What this runbook does not cover
+
+Zone _state_ problems — a world that loads but is wrong, stuck, or unplayable. That is a
+game's simulation, not the platform, and the host will report itself perfectly healthy
+throughout. The zone document lives at `zones/{zoneId}` in Firestore; deleting it while
+the zone is empty gives the next visitor a fresh world and is the blunt instrument of
+last resort.

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 #
-# The alerting floor: an uptime check and the four alert policies that decide whether a
-# night of 5xx is discovered by monitoring or by a user.
+# The alerting floor: an uptime check and the alert policies that decide whether a night
+# of 5xx — or a zone host quietly turning every player away — is discovered by monitoring
+# or by a user.
 # OWNER-RUN: needs `gcloud` authenticated against the project.
 #
 # Usage:
 #   ALERT_EMAIL=you@example.com ./infra/setup-monitoring.sh
 #
-# Override via env: PROJECT_ID, REGION, SERVICE, HOST, ALERT_EMAIL, BACKUP_BUCKET.
+# Override via env: PROJECT_ID, REGION, SERVICE, WORLD_SERVICE, HOST, ALERT_EMAIL,
+# BACKUP_BUCKET.
 #
 # What this deliberately is and is not:
 #
@@ -25,6 +27,7 @@ set -euo pipefail
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 REGION="${REGION:-europe-west1}"
 SERVICE="${SERVICE:-gamedev-app}"
+WORLD_SERVICE="${WORLD_SERVICE:-gamedev-world}"
 HOST="${HOST:-www.gamedev.pl}"
 BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backups}"
 : "${ALERT_EMAIL:?set ALERT_EMAIL to the address that should receive alerts}"
@@ -210,6 +213,82 @@ cat > "${POLICY_DIR}/a4.json" <<EOF
 }
 EOF
 
+# A6 — zones are dead while the site is fine.
+#
+# This is the alert the zone host actually needs, and it is not an uptime check. When
+# admission fails the shell falls back to solo play without saying anything — which is
+# the right thing for a player and the reason nobody finds out. The host keeps answering
+# /health, every request is a 200, and each player gets a private world. Both faults on
+# the service's first day looked exactly like this, and what found them was a human
+# opening two browser windows.
+#
+# So the signal is the log line the host writes when it cannot start a zone
+# (apps/world/src/app.ts): the wire reason is deliberately uninformative, so the cause
+# goes to the log and this is the only thing watching it. One entry means one player was
+# turned away and does not warrant an email; the rate limit below is what turns "a join
+# failed" into "joins are failing", and a host that can start no zone at all will trip it
+# on the first arrival after the hour turns over.
+cat > "${POLICY_DIR}/a6.json" <<EOF
+{
+  "displayName": "A6 zone admission failing",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "the world service could not start a zone",
+    "conditionMatchedLog": {
+      "filter": "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${WORLD_SERVICE}\" AND jsonPayload.msg=\"zone admission failed\""
+    }
+  }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
+  "alertStrategy": {
+    "notificationRateLimit": { "period": "3600s" },
+    "autoClose": "86400s"
+  },
+  "documentation": {
+    "content": "${WORLD_SERVICE} refused a join it should have accepted. Players are silently playing alone and the site looks healthy. The logged error is the diagnosis — the wire reason never says. Triage: docs/runbooks/zones-down-triage.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
+# A7 — the world service is crash-looping.
+#
+# The complement to A6, and the reason A6 is not enough on its own: a host that dies
+# before it can serve anything writes no admission failures either, and on a
+# scale-to-zero service "no logs" is also what a quiet night looks like. Absence proves
+# nothing here, so this watches for what a crash-loop does produce.
+#
+# Deliberately NOT an uptime check. Probing a scale-to-zero service every five minutes
+# keeps an instance warm around the clock, which converts the whole cost model in
+# docs/p3-zone-host-infra.md — \$0 at rest — into roughly \$65/month to find out whether
+# something nobody is using is up. A probe is traffic, and this service bills for traffic.
+cat > "${POLICY_DIR}/a7.json" <<EOF
+{
+  "displayName": "A7 world service 5xx rate elevated",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "5xx responses sustained over 10 minutes",
+    "conditionThreshold": {
+      "filter": "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.label.\"service_name\"=\"${WORLD_SERVICE}\" AND metric.label.\"response_code_class\"=\"5xx\"",
+      "aggregations": [{
+        "alignmentPeriod": "600s",
+        "perSeriesAligner": "ALIGN_RATE",
+        "crossSeriesReducer": "REDUCE_SUM"
+      }],
+      "comparison": "COMPARISON_GT",
+      "thresholdValue": 0.03,
+      "duration": "600s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
+  "alertStrategy": { "autoClose": "86400s" },
+  "documentation": {
+    "content": "Sustained 5xx from ${WORLD_SERVICE}. Most likely a bad image or a refusal to start — the host exits rather than downgrade when the isolate cage is unavailable, which is intended. Triage: docs/runbooks/zones-down-triage.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
 for FILE in "${POLICY_DIR}"/*.json; do
   DISPLAY="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['displayName'])" "$FILE")"
   EXISTING="$(gcloud alpha monitoring policies list \
@@ -236,7 +315,7 @@ for FILE in "${POLICY_DIR}"/*.json; do
 done
 
 echo ""
-echo "==> Done. Uptime check + A1-A4 wired to ${ALERT_EMAIL}."
+echo "==> Done. Uptime check + A1-A4, A6-A7 wired to ${ALERT_EMAIL}."
 echo ""
 echo "    A5 (billing budget) is NOT here: budgets live on the billing account, not the"
 echo "    project, and need roles this script does not assume. Create it once by hand:"
@@ -247,3 +326,13 @@ echo "    Then prove it works, because an untested alert is a decoration:"
 echo "      gcloud scheduler jobs pause notify-sweep --location ${REGION} --project ${PROJECT_ID}"
 echo "      # wait ~15 min for A3 to fire, confirm the email, then:"
 echo "      gcloud scheduler jobs resume notify-sweep --location ${REGION} --project ${PROJECT_ID}"
+echo ""
+echo "    A6 matches a log field rather than a metric, so confirm the field path is what"
+echo "    this project's logs actually carry — a filter that matches nothing creates a"
+echo "    policy that looks armed and never fires, which is the failure this file exists"
+echo "    to avoid. One query settles it:"
+echo "      gcloud logging read \\"
+echo "        'resource.labels.service_name=\"${WORLD_SERVICE}\" AND jsonPayload.msg=\"zone admission failed\"' \\"
+echo "        --project ${PROJECT_ID} --limit 5 --freshness 30d"
+echo "      # No rows and no known incident is inconclusive; drop the jsonPayload.msg"
+echo "      # clause and look at how a real log line from that service is shaped."


### PR DESCRIPTION
Infra script and docs. The O1 alerting floor (#332) is scoped to `gamedev-app` — `SERVICE=gamedev-app` in `infra/setup-monitoring.sh`. `gamedev-world` had no alert, no runbook, and after this still has no uptime check, deliberately.

## Why this service needs different treatment

**Its characteristic failure is silent by design.** When admission fails the shell falls back to solo play without telling the player. That is correct — a game must be playable alone — and it is precisely why nobody finds out. The host answers `/health`, every request is a 200, and each player is alone in a world they believe is shared.

Both faults on the service's first day looked exactly like that, and what found them was a person opening two browser windows. A 5xx-rate alert would never have fired.

## A6 — zone admission failing

Log-based, matching the line the host writes when it cannot start a zone. The wire reason (`zone_unavailable`) is deliberately uninformative — telling a caller which part of a stolen ticket was wrong helps only them — so the cause goes to the log, and until now nothing read it.

Rate-limited to hourly: one turned-away player is not an email; joins failing is. A host that can start no zone at all trips it on the first arrival after the hour turns over.

## A7 — world service 5xx

The complement, and the reason A6 cannot stand alone: a host that dies before serving anything writes no admission failures either, and on a scale-to-zero service *no logs* is also what a quiet night looks like. Absence proves nothing here, so this watches what a crash-loop does produce.

## No uptime check, on purpose

Probing a scale-to-zero service every five minutes keeps an instance warm around the clock. That converts the cost model in `docs/p3-zone-host-infra.md` — `$0` at rest — into roughly `$65`/month to learn whether something nobody is using is up. A probe is traffic, and this service bills for traffic.

## The runbook

`docs/runbooks/zones-down-triage.md`, wired into the index. Two things it does differently:

- **It opens with the kill switch, not a diagnosis.** Removing `ZONE_HOST_URL` restores every game's pre-zones behaviour instantly, needs no redeploy, and lets the operator debug something that is no longer live.
- **It says one browser window cannot tell a working host from a dead one.** Without that, the natural first move — load the game, it looks fine — reads as "resolved".

It also records what step 3 must not do: a host that refuses to start because the isolate cage is unavailable is the system working, and `ZONE_CAGE` / `NODE_ENV` are not the fix.

`Last drilled: never`, per the folder's own rule.

## One thing to confirm on first run

A6 matches a **log field** rather than a metric, and a filter that matches nothing produces a policy that looks armed and never fires — the exact failure that file exists to prevent. I could not verify the field path (`jsonPayload.msg`) against this project's real logs from here; it is inferred from Fastify's pino logger, which `apps/world/src/server.ts` enables. The script now prints the `gcloud logging read` query that settles it, and says what an empty result does and does not prove.

## Also here

`docs/persistent-world-plan.md` §5 still said of P3 "The phase itself is still unscheduled." Separate commit. Agents read that document to choose work, so a stale phase status invites somebody to build a thing that already exists.

Lint clean; contract suites green. No application code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4xHU2Ca1sZHqoP59Pvxx4)_