### PR TITLE
Global creation cap + pause switch (the cost circuit-breaker)

### DIFF
--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { InMemoryStore, type Scorecard, type TelemetryEvent, type VisitEvent } from './store.js';
-import type { HealthResponse, ScorecardsResponse, VisitsResponse } from './admin.js';
+import type { CreationLimitsResponse, HealthResponse, ScorecardsResponse, VisitsResponse } from './admin.js';
 import { runScorecardSweep } from './scorecard.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -426,6 +426,112 @@ describe('GET /api/admin/suggestions', () => {
     // The game's own error text reaches the operator, under the name that says so.
     expect(body.suggestions[0].untrustedContext.errorSamples[0].message).toContain('TypeError');
     expect(body.computedFrom).toBe('2026-07-28T03:00:00.000Z');
+    await app.close();
+  });
+});
+
+/**
+ * The operator's half of the creation breaker. Session-only, like every operator write —
+ * a leaked access token must not be able to pause the product.
+ */
+describe('/api/admin/creation-limits', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:player' });
+  });
+
+  it('reports what is in force before anything has been set', async () => {
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CreationLimitsResponse;
+    // Nothing stored is the normal state, and it must read as "the deployed default is
+    // in force", never as "there is no ceiling".
+    expect(body.stored).toBeNull();
+    expect(body.effective.paused).toBe(false);
+    expect(body.effective.globalDailySubmissionCap).toBeGreaterThan(0);
+    expect(body.today).toMatchObject({ dateStr: today, submissions: 0 });
+    await app.close();
+  });
+
+  it('pauses creation and records who did it', async () => {
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+      payload: { paused: true, globalDailySubmissionCap: 25 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CreationLimitsResponse;
+    expect(body.effective).toEqual({ paused: true, globalDailySubmissionCap: 25 });
+    // A pause left on by accident is this feature's own failure mode, so the record of
+    // who set it is part of the deliverable.
+    expect(body.stored).toMatchObject({ paused: true, updatedBy: 'g:boss' });
+    expect(await store.getCreationLimits()).toMatchObject({ paused: true, globalDailySubmissionCap: 25 });
+    await app.close();
+  });
+
+  it('takes a partial change without clearing the other field', async () => {
+    await store.setCreationLimits({ paused: true, globalDailySubmissionCap: 25 }, 'g:boss');
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+      payload: { paused: false },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as CreationLimitsResponse).effective).toEqual({
+      paused: false,
+      globalDailySubmissionCap: 25,
+    });
+    await app.close();
+  });
+
+  it('rejects an empty patch rather than pretending to change something', async () => {
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('is invisible to everyone else, read and write alike', async () => {
+    const app = await appWith(store);
+
+    for (const headers of [authHeaders('g:player'), {}]) {
+      const read = await app.inject({ method: 'GET', url: '/api/admin/creation-limits', headers });
+      expect(read.statusCode).toBe(404);
+      const write = await app.inject({
+        method: 'POST',
+        url: '/api/admin/creation-limits',
+        headers,
+        payload: { paused: true },
+      });
+      expect(write.statusCode).toBe(404);
+    }
+    // The refusals are refusals, not silent no-ops.
+    expect(await store.getCreationLimits()).toBeNull();
     await app.close();
   });
 });

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -10,8 +10,10 @@ import {
 import { routeAll, type Suggestion } from './suggestions.js';
 import { summarizeVisitFunnel, type VisitFunnel } from './visit-funnel.js';
 import { summarizeCreatorMetrics, type CreatorMetrics } from './creator-metrics.js';
+import { DEFAULT_CREATION_LIMITS_TTL_MS, resolveDefaultGlobalDailyCap } from './creation-limits.js';
 import {
   BOT_UID_PREFIX,
+  type CreationLimits,
   type Scorecard,
   type Store,
   type TelemetryEvent,
@@ -60,7 +62,41 @@ export interface AdminRoutesOptions {
   /** Uids permitted to read. Empty means the routes exist but admit nobody. */
   adminUids?: Set<string>;
   now?: () => number;
+  /** Mirrors the submission routes' fallback ceiling, for the breaker view below. */
+  globalDailySubmissionCap?: number;
+  /** How long submission routes cache the breaker config — reported as the flip delay. */
+  creationLimitsTtlMs?: number;
 }
+
+/**
+ * The creation circuit-breaker as an operator sees it: what is stored, what is actually
+ * in force, and how much of today's shared allowance is gone.
+ *
+ * This exists because the breaker is only worth having if pulling it is fast. Editing a
+ * Firestore document in the console works and needs no deploy, but under incident
+ * conditions it is a lot of clicks to get a boolean wrong in, and it shows the operator
+ * nothing about whether the cap is anywhere near tripping.
+ */
+export interface CreationLimitsResponse {
+  /** Null when nothing has ever been written — the defaults below are what is in force. */
+  stored: CreationLimits | null;
+  effective: { paused: boolean; globalDailySubmissionCap: number };
+  today: { dateStr: string; submissions: number };
+  /** Upper bound, in ms, on how long a change takes to reach every instance. */
+  propagationMs: number;
+}
+
+const CreationLimitsPatchSchema = z
+  .object({
+    paused: z.boolean().optional(),
+    // null clears the stored ceiling and hands the decision back to the deployed
+    // default, which is a different intent from setting a number.
+    globalDailySubmissionCap: z.number().int().min(0).max(100_000).nullable().optional(),
+  })
+  .refine(
+    (patch) => patch.paused !== undefined || patch.globalDailySubmissionCap !== undefined,
+    'nothing to change: send paused and/or globalDailySubmissionCap',
+  );
 
 export interface HealthResponse {
   /**
@@ -141,6 +177,58 @@ const REQUEST_BUDGET: PartitionScanBudget = { perDay: MAX_EVENTS_PER_DAY, total:
 export async function registerAdminRoutes(app: FastifyInstance, options: AdminRoutesOptions): Promise<void> {
   const { store, adminUids } = options;
   const now = options.now ?? Date.now;
+  const defaultGlobalCap = resolveDefaultGlobalDailyCap(options.globalDailySubmissionCap);
+  const creationLimitsTtlMs = options.creationLimitsTtlMs ?? DEFAULT_CREATION_LIMITS_TTL_MS;
+
+  /** Reads the stored breaker plus today's spend, uncached — an operator wants truth. */
+  async function readCreationLimits(): Promise<CreationLimitsResponse> {
+    const dateStr = new Date(now()).toISOString().slice(0, 10);
+    const [stored, submissions] = await Promise.all([
+      store.getCreationLimits(),
+      store.getGlobalSubmissionCount(dateStr),
+    ]);
+    return {
+      stored,
+      effective: {
+        paused: stored?.paused === true,
+        globalDailySubmissionCap: stored?.globalDailySubmissionCap ?? defaultGlobalCap,
+      },
+      today: { dateStr, submissions },
+      propagationMs: creationLimitsTtlMs,
+    };
+  }
+
+  app.get('/api/admin/creation-limits', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    return reply.status(200).send(await readCreationLimits());
+  });
+
+  /**
+   * Pulls (or resets) the breaker. Session-only like every operator write, so a leaked
+   * access token cannot pause the product.
+   *
+   * The change lands in Firestore rather than in the environment, so it needs no new
+   * revision — which is the entire point: a redeploy mid-incident would drop every party
+   * room in flight. Instances converge within `propagationMs`.
+   */
+  app.post('/api/admin/creation-limits', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = CreationLimitsPatchSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+    }
+
+    await store.setCreationLimits(parsed.data, request.user!.uid);
+    // Log it: a pause left on by accident is the failure mode here, and the record of
+    // who set it and when is what makes that legible later.
+    app.log.warn({ patch: parsed.data, by: request.user!.uid }, 'creation limits changed by operator');
+    return reply.status(200).send(await readCreationLimits());
+  });
 
   app.get('/api/admin/telemetry/health', async (request, reply) => {
     // 404 rather than 403 for a signed-in non-admin: the existence of an operator

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -315,7 +315,15 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // let into the closed beta is not the same as being allowed to read every game's
   // numbers. Unset means the route admits nobody, which is the right default for a
   // surface whose whole purpose is seeing across other people's games.
-  await registerAdminRoutes(app, { store, adminUids });
+  // The creation-breaker knobs come from the submission-route options so the operator
+  // surface reports the same ceiling and the same propagation delay the gate actually
+  // enforces, rather than a second copy of the defaults that could drift from it.
+  await registerAdminRoutes(app, {
+    store,
+    adminUids,
+    globalDailySubmissionCap: options.submissionRoutes?.globalDailySubmissionCap,
+    creationLimitsTtlMs: options.submissionRoutes?.creationLimitsTtlMs,
+  });
 
   // The nightly Distill step (docs/improvement-loop-plan.md IL-2): rolls the telemetry
   // window plus vote/feedback counts into one scorecard per game. Authenticated by the

--- a/apps/api/src/creation-limits.test.ts
+++ b/apps/api/src/creation-limits.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createCreationGate,
+  DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP,
+  resolveDefaultGlobalDailyCap,
+  type CreationGateOptions,
+} from './creation-limits.js';
+import type { CreationLimits, Store } from './store.js';
+
+const today = '2026-07-30';
+
+/**
+ * Only the four store methods the breaker touches. A partial fake rather than an
+ * InMemoryStore so a test can make a *read* fail, which is the interesting case.
+ */
+function fakeStore(
+  params: {
+    limits?: CreationLimits | null;
+    getLimits?: () => Promise<CreationLimits | null>;
+    increment?: (dateStr: string, limit: number) => Promise<{ allowed: boolean; current: number }>;
+  } = {},
+) {
+  let count = 0;
+  const getCreationLimits = vi.fn(params.getLimits ?? (async () => params.limits ?? null));
+  const checkAndIncrementGlobalSubmissions = vi.fn(
+    params.increment ??
+      (async (_dateStr: string, limit: number) => {
+        if (count >= limit) return { allowed: false, current: count };
+        count += 1;
+        return { allowed: true, current: count };
+      }),
+  );
+  return {
+    store: { getCreationLimits, checkAndIncrementGlobalSubmissions } as unknown as Store,
+    getCreationLimits,
+    checkAndIncrementGlobalSubmissions,
+  };
+}
+
+function gate(store: Store, overrides: Partial<CreationGateOptions> = {}) {
+  return createCreationGate({ store, defaultGlobalDailyCap: 3, ttlMs: 60_000, ...overrides });
+}
+
+describe('resolveDefaultGlobalDailyCap', () => {
+  it('treats a blank or unparseable env var as "not configured"', () => {
+    // Number('') is 0, and reading that as a cap would close creation on an empty var.
+    expect(resolveDefaultGlobalDailyCap(undefined, {})).toBe(DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP);
+    expect(resolveDefaultGlobalDailyCap(undefined, { GLOBAL_DAILY_SUBMISSION_CAP: '  ' })).toBe(
+      DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP,
+    );
+    expect(resolveDefaultGlobalDailyCap(undefined, { GLOBAL_DAILY_SUBMISSION_CAP: 'lots' })).toBe(
+      DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP,
+    );
+  });
+
+  it('honours an explicit zero, because "accept nothing" is a real intent', () => {
+    expect(resolveDefaultGlobalDailyCap(undefined, { GLOBAL_DAILY_SUBMISSION_CAP: '0' })).toBe(0);
+    expect(resolveDefaultGlobalDailyCap(0, {})).toBe(0);
+  });
+
+  it('prefers an explicit override over the environment', () => {
+    expect(resolveDefaultGlobalDailyCap(12, { GLOBAL_DAILY_SUBMISSION_CAP: '99' })).toBe(12);
+  });
+});
+
+describe('the creation breaker', () => {
+  it('spends a global slot per admitted request and refuses at the ceiling', async () => {
+    const fake = fakeStore();
+    const breaker = gate(fake.store);
+
+    expect(await breaker.checkAndSpend('g:one', today)).toEqual({ allowed: true });
+    expect(await breaker.checkAndSpend('g:two', today)).toEqual({ allowed: true });
+    expect(await breaker.checkAndSpend('g:three', today)).toEqual({ allowed: true });
+    // The cap is shared, so the fourth request is refused however many people made
+    // the first three — that is the whole difference from a per-user quota.
+    expect(await breaker.checkAndSpend('g:four', today)).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('refuses while paused without touching the counter', async () => {
+    const fake = fakeStore({ limits: { paused: true, globalDailySubmissionCap: null } });
+
+    expect(await gate(fake.store).checkAndSpend('g:one', today)).toEqual({ allowed: false, reason: 'paused' });
+    expect(fake.checkAndIncrementGlobalSubmissions).not.toHaveBeenCalled();
+  });
+
+  it('reads the stored cap in preference to the deployed default', async () => {
+    const fake = fakeStore({ limits: { paused: false, globalDailySubmissionCap: 1 } });
+    const breaker = gate(fake.store);
+
+    expect(await breaker.checkAndSpend('g:one', today)).toEqual({ allowed: true });
+    expect(await breaker.checkAndSpend('g:two', today)).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('closes on a stored cap of zero rather than reading it as "no limit"', async () => {
+    const fake = fakeStore({ limits: { paused: false, globalDailySubmissionCap: 0 } });
+
+    expect(await gate(fake.store).checkAndSpend('g:one', today)).toEqual({
+      allowed: false,
+      reason: 'over_capacity',
+    });
+  });
+
+  it('lets bot: accounts through a closed breaker, and does not count them', async () => {
+    // Pausing creation is an incident response; the deploy pipeline's own checks run as
+    // bot: accounts, and losing the ability to ship a fix mid-incident is backwards.
+    const fake = fakeStore({ limits: { paused: true, globalDailySubmissionCap: 0 } });
+
+    expect(await gate(fake.store).checkAndSpend('bot:ci', today)).toEqual({ allowed: true });
+    expect(fake.getCreationLimits).not.toHaveBeenCalled();
+    expect(fake.checkAndIncrementGlobalSubmissions).not.toHaveBeenCalled();
+  });
+
+  it('reads the config once per TTL, then picks up a change with no restart', async () => {
+    let stored: CreationLimits = { paused: false, globalDailySubmissionCap: 10 };
+    let clock = 1_000_000;
+    const fake = fakeStore({ getLimits: async () => stored });
+    const breaker = gate(fake.store, { now: () => clock, ttlMs: 60_000 });
+
+    expect(await breaker.checkAndSpend('g:one', today)).toEqual({ allowed: true });
+    stored = { paused: true, globalDailySubmissionCap: 10 };
+    // Still cached: the flip is not instant, and pretending otherwise would mean a
+    // document read on every submission.
+    expect(await breaker.checkAndSpend('g:two', today)).toEqual({ allowed: true });
+    expect(fake.getCreationLimits).toHaveBeenCalledTimes(1);
+
+    clock += 61_000;
+    expect(await breaker.checkAndSpend('g:three', today)).toEqual({ allowed: false, reason: 'paused' });
+    expect(fake.getCreationLimits).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves the last known config when the read fails', async () => {
+    let fail = false;
+    let clock = 1_000_000;
+    const fake = fakeStore({
+      getLimits: async () => {
+        if (fail) throw new Error('firestore unavailable');
+        return { paused: true, globalDailySubmissionCap: 10 };
+      },
+    });
+    const breaker = gate(fake.store, { now: () => clock, ttlMs: 60_000 });
+
+    expect(await breaker.checkAndSpend('g:one', today)).toEqual({ allowed: false, reason: 'paused' });
+    fail = true;
+    clock += 61_000;
+
+    // A blip must not un-pause a paused product. The value only changes when an
+    // operator changes it, so stale is the correct answer.
+    expect(await breaker.checkAndSpend('g:two', today)).toEqual({ allowed: false, reason: 'paused' });
+  });
+
+  it('falls back to the deployed default when the config was never readable', async () => {
+    const fake = fakeStore({
+      getLimits: async () => {
+        throw new Error('firestore unavailable');
+      },
+    });
+    const breaker = gate(fake.store, { defaultGlobalDailyCap: 1 });
+
+    // Fails open to a real ceiling, not to infinity: an unreadable document must not be
+    // a creation outage, but it must not be an unbounded one either.
+    expect(await breaker.checkAndSpend('g:one', today)).toEqual({ allowed: true });
+    expect(await breaker.checkAndSpend('g:two', today)).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('admits the request when the counter itself is unreachable', async () => {
+    const logWarn = vi.fn();
+    const fake = fakeStore({
+      increment: async () => {
+        throw new Error('firestore unavailable');
+      },
+    });
+
+    // A Firestore outage is not "the site is over capacity", and the submission is
+    // about to fail on its own terms anyway — it cannot be recorded either.
+    expect(await gate(fake.store, { logWarn }).checkAndSpend('g:one', today)).toEqual({ allowed: true });
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('warns before the cap trips, so a creator is not the one who discovers it', async () => {
+    const logWarn = vi.fn();
+    const breaker = gate(fakeStore().store, { logWarn, defaultGlobalDailyCap: 3 });
+
+    await breaker.checkAndSpend('g:one', today);
+    expect(logWarn).not.toHaveBeenCalled();
+    await breaker.checkAndSpend('g:two', today);
+    await breaker.checkAndSpend('g:three', today);
+    expect(logWarn.mock.calls.some(([, message]) => String(message).includes('80%'))).toBe(true);
+  });
+
+  it('reports what is in force, including where it came from', async () => {
+    const stored: CreationLimits = { paused: true, globalDailySubmissionCap: 7, updatedBy: 'g:admin' };
+    expect(await gate(fakeStore({ limits: stored }).store).readLimits()).toMatchObject({
+      paused: true,
+      globalDailySubmissionCap: 7,
+      updatedBy: 'g:admin',
+      source: 'stored',
+    });
+  });
+});

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -1,0 +1,192 @@
+import { BOT_UID_PREFIX, type CreationLimits, type Store } from './store.js';
+
+/**
+ * The global creation circuit-breaker (private ops repo, readiness item 6).
+ *
+ * Until now every ceiling on creation was per-user: N invited creators times a daily
+ * quota of 5, which means total spend was bounded by nothing but the invite count. An
+ * agent build is the most expensive thing the product does, so the arithmetic that
+ * matters for opening the beta wider is the *aggregate*, and there was no number for
+ * it — nor any way to stop creation short of editing an env var and redeploying, which
+ * mid-incident also drops every party room in flight.
+ *
+ * So there are two controls here, and both are read from a Firestore document at
+ * request time rather than from the environment:
+ *
+ *   paused                    — refuse creation outright
+ *   globalDailySubmissionCap  — accept at most N submissions per UTC day, everyone
+ *                               together
+ *
+ * ## Why a document, not an env var
+ *
+ * The whole value of a breaker is that pulling it is cheaper than the incident. An env
+ * var needs a new Cloud Run revision: a minute or two of rollout, plus every live party
+ * room dropped, to change a boolean. A document is a console edit that every instance
+ * picks up within `ttlMs`. The cost is one document read per instance per TTL — at 60s
+ * that is under 1,500 reads a day, which rounds to nothing against Firestore's free
+ * tier, and the read is off the hot path for everything except creation.
+ *
+ * ## Failure and default behaviour
+ *
+ * A missing document is normal (nothing has ever been set) and means "not paused, use
+ * the caller's default cap". An *unreadable* document serves the last value this
+ * instance saw, and falls back to the default cap when it has never read one — the same
+ * shape as the snapshot pointer's stale-on-error branch, and for the same reason: a
+ * transient Firestore blip must not become a creation outage. What makes that safe is
+ * that the default cap is a real number rather than infinity, so the fallback still has
+ * a ceiling, and the per-user quota and per-IP limiter are untouched underneath.
+ */
+
+/** Applies when no document has been written, and when one cannot be read. */
+export const DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP = 50;
+
+/** How long a read config is trusted. The upper bound on how long a flip takes. */
+export const DEFAULT_CREATION_LIMITS_TTL_MS = 60_000;
+
+/**
+ * The ceiling in force when the document sets none. Env-tunable so the *floor* can move
+ * with a deploy while day-to-day changes need no deploy at all.
+ *
+ * A blank env var is "not configured", not zero — `Number('')` is 0, and reading that as
+ * a cap of zero would close creation on an empty variable. An explicit `0` is honoured,
+ * because "accept nothing" is a legitimate thing to want to say.
+ */
+export function resolveDefaultGlobalDailyCap(override?: number, env: NodeJS.ProcessEnv = process.env): number {
+  if (typeof override === 'number' && Number.isFinite(override) && override >= 0) return override;
+  const raw = env.GLOBAL_DAILY_SUBMISSION_CAP?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP;
+}
+
+export type CreationRefusal = 'paused' | 'over_capacity';
+
+export type CreationGateOutcome = { allowed: true } | { allowed: false; reason: CreationRefusal };
+
+export interface CreationGateOptions {
+  store: Store;
+  now?: () => number;
+  /** Config cache lifetime; tests set it to 0 or step a clock past it. */
+  ttlMs?: number;
+  /** Ceiling used when the document says nothing; defaults via GLOBAL_DAILY_SUBMISSION_CAP. */
+  defaultGlobalDailyCap?: number;
+  /** Structured warning sink — the operator's early notice that the day is filling up. */
+  logWarn?: (payload: Record<string, unknown>, message: string) => void;
+}
+
+export interface CreationGate {
+  /**
+   * Decides, and on success **spends** one of the day's global slots. Call it after
+   * moderation and before the per-user quota or any GitHub write, so a refusal costs
+   * the creator nothing.
+   */
+  checkAndSpend(uid: string, dateStr: string): Promise<CreationGateOutcome>;
+  /** The effective config, cache included — what the operator surface reports. */
+  readLimits(): Promise<CreationLimits & { source: 'stored' | 'default' }>;
+}
+
+/**
+ * Automation accounts are outside the breaker entirely: not paused, not capped, and
+ * not counted.
+ *
+ * The reason is operational rather than generous. Pausing creation is an incident
+ * response, and the deploy pipeline's own smoke checks run as `bot:` accounts — a
+ * tripped cap or an active pause that turned the deploy gate red would take away the
+ * ability to ship a fix at exactly the moment one is needed. Bots are already the
+ * "not a creator" namespace (creator metrics and the digest both exclude them by this
+ * prefix), so counting them against a creator-spend ceiling would also be measuring
+ * the wrong thing.
+ *
+ * This is safe rather than a hole because a `bot:` account is still an ordinary
+ * standard-tier user for the *per-user* quota, tokens are admin-minted and revocable,
+ * and the namespace cannot be self-assigned.
+ */
+function bypassesBreaker(uid: string): boolean {
+  return uid.startsWith(BOT_UID_PREFIX);
+}
+
+export function createCreationGate(options: CreationGateOptions): CreationGate {
+  const { store } = options;
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? DEFAULT_CREATION_LIMITS_TTL_MS;
+  const defaultCap = resolveDefaultGlobalDailyCap(options.defaultGlobalDailyCap);
+  const logWarn = options.logWarn ?? (() => {});
+
+  const defaults: CreationLimits = { paused: false, globalDailySubmissionCap: null };
+  let cache: { value: CreationLimits; expiresAt: number } | null = null;
+
+  async function limits(): Promise<{ value: CreationLimits; source: 'stored' | 'default' }> {
+    if (cache && cache.expiresAt > now()) {
+      return { value: cache.value, source: 'stored' };
+    }
+    try {
+      const stored = (await store.getCreationLimits()) ?? defaults;
+      cache = { value: stored, expiresAt: now() + ttlMs };
+      return { value: stored, source: 'stored' };
+    } catch (error) {
+      if (cache) {
+        // Stale beats an outage: the value changes only when an operator changes it.
+        logWarn({ err: error }, 'creation limits unreadable; using the last known values');
+        return { value: cache.value, source: 'stored' };
+      }
+      logWarn({ err: error }, 'creation limits unreadable and never read; using defaults');
+      return { value: defaults, source: 'default' };
+    }
+  }
+
+  return {
+    async readLimits() {
+      const { value, source } = await limits();
+      return { ...value, source };
+    },
+
+    async checkAndSpend(uid, dateStr) {
+      if (bypassesBreaker(uid)) return { allowed: true };
+
+      const { value } = await limits();
+      if (value.paused) {
+        return { allowed: false, reason: 'paused' };
+      }
+
+      const cap = value.globalDailySubmissionCap ?? defaultCap;
+      // A cap of 0 is a legitimate way to say "closed", and negative is nonsense that
+      // should also close rather than silently open.
+      if (cap <= 0) {
+        return { allowed: false, reason: 'over_capacity' };
+      }
+
+      let spent: { allowed: boolean; current: number };
+      try {
+        spent = await store.checkAndIncrementGlobalSubmissions(dateStr, cap);
+      } catch (error) {
+        // The counter is unreachable. Admitting the request is right: the per-user
+        // quota still applies, and a Firestore blip must not read as "the whole
+        // product is over capacity" — a submission cannot be recorded at all in that
+        // state, so the request is about to fail on its own terms anyway.
+        logWarn({ err: error, dateStr }, 'global submission counter unreachable; admitting the request');
+        return { allowed: true };
+      }
+
+      if (!spent.allowed) {
+        logWarn({ dateStr, cap, current: spent.current }, 'global daily creation cap reached; refusing submissions');
+        return { allowed: false, reason: 'over_capacity' };
+      }
+
+      // The point of warning early is that the alternative — noticing when creators
+      // start being refused — means the first person to find out is a creator.
+      if (spent.current >= Math.ceil(cap * 0.8)) {
+        logWarn({ dateStr, cap, current: spent.current }, 'global daily creation cap is over 80% spent');
+      }
+
+      return { allowed: true };
+    },
+  };
+}
+
+/** Wire error codes, so the web app can say something true about which limit was hit. */
+export const CREATION_REFUSAL_CODES: Record<CreationRefusal, string> = {
+  paused: 'creation_paused',
+  over_capacity: 'creation_over_capacity',
+};

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -485,3 +485,61 @@ describe('the fake itself', () => {
     ).rejects.toThrow(/Cannot use "undefined" as a Firestore value/);
   });
 });
+
+/**
+ * The creation breaker's two documents. Worth Firestore-shaped coverage for the reason at
+ * the top of this file: the in-memory store accepts anything, and these are written by an
+ * operator under incident conditions — the worst time to discover a rejected write.
+ */
+describe('FirestoreStore creation limits', () => {
+  it('writes the breaker with no undefined fields, cap included', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    const limits = await store.setCreationLimits({ paused: true, globalDailySubmissionCap: 25 }, 'g:boss');
+
+    expect(limits).toMatchObject({ paused: true, globalDailySubmissionCap: 25, updatedBy: 'g:boss' });
+    expect(docs.get(key('opsConfig', 'creationLimits'))).toMatchObject({ paused: true, globalDailySubmissionCap: 25 });
+  });
+
+  it('stores a cleared cap as null rather than as an absent field', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    // Firestore refuses `undefined`, and "no stored ceiling" has to survive the round
+    // trip as an explicit null or the reader cannot tell it from a missing document.
+    await store.setCreationLimits({ paused: false, globalDailySubmissionCap: null }, 'g:boss');
+
+    expect(docs.get(key('opsConfig', 'creationLimits'))!.globalDailySubmissionCap).toBeNull();
+    expect(await store.getCreationLimits()).toMatchObject({ paused: false, globalDailySubmissionCap: null });
+  });
+
+  it('merges a partial change rather than dropping the other field', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.setCreationLimits({ paused: true, globalDailySubmissionCap: 25 }, 'g:boss');
+    await store.setCreationLimits({ paused: false }, 'g:boss');
+
+    expect(await store.getCreationLimits()).toMatchObject({ paused: false, globalDailySubmissionCap: 25 });
+  });
+
+  it('answers null before anyone has set a breaker', async () => {
+    const { db } = fakeFirestore();
+    expect(await new FirestoreStore(db).getCreationLimits()).toBeNull();
+  });
+
+  it('counts the day’s submissions globally and stops at the cap', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    expect(await store.checkAndIncrementGlobalSubmissions('2026-07-30', 2)).toEqual({ allowed: true, current: 1 });
+    expect(await store.checkAndIncrementGlobalSubmissions('2026-07-30', 2)).toEqual({ allowed: true, current: 2 });
+    expect(await store.checkAndIncrementGlobalSubmissions('2026-07-30', 2)).toEqual({ allowed: false, current: 2 });
+
+    expect(await store.getGlobalSubmissionCount('2026-07-30')).toBe(2);
+    // One document per UTC day, so yesterday's spend can never refuse today's request.
+    expect(await store.getGlobalSubmissionCount('2026-07-29')).toBe(0);
+    expect(docs.get(key('globalUsage', '2026-07-30'))).toMatchObject({ submissions: 2 });
+  });
+});

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -191,6 +191,33 @@ export interface BuildPreview {
 /** A preview without its bytes — what a listing needs. */
 export type BuildPreviewSummary = Omit<BuildPreview, 'data'>;
 
+/**
+ * The creation circuit-breaker, stored rather than deployed.
+ *
+ * Per-user quotas bound what one creator costs; nothing bounded what *everyone*
+ * costs, so total spend was bounded only by the invite count. These two fields are
+ * the ceiling and the off switch.
+ *
+ * They live in Firestore instead of in the environment because an env change means a
+ * new Cloud Run revision, and a redeploy mid-incident drops every party room in
+ * flight — a breaker you cannot pull without breaking something else is not a
+ * breaker. Readers cache with a short TTL, so a flip takes effect within about a
+ * minute on every instance and costs a document read a minute in between.
+ */
+export interface CreationLimits {
+  /** Refuse new game creation entirely, with a message that says so honestly. */
+  paused: boolean;
+  /**
+   * Ceiling on submissions accepted per UTC day across every account. `null` means
+   * no stored ceiling, in which case the reader's own default applies — "unset"
+   * must never read as "unlimited".
+   */
+  globalDailySubmissionCap: number | null;
+  /** Who last changed this and when, so a leftover pause is legible as a leftover. */
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
 export interface UsageCounters {
   submissions: number;
   previews: number;
@@ -776,6 +803,18 @@ export interface Store {
     limit: number,
     action: keyof UsageCounters,
   ): Promise<{ allowed: boolean; current: number; tier: User['tier'] }>;
+  /** The stored circuit-breaker, or null when nobody has ever set one. */
+  getCreationLimits(): Promise<CreationLimits | null>;
+  /** Merges a change into the stored breaker and returns the result. */
+  setCreationLimits(patch: Partial<Omit<CreationLimits, 'updatedAt'>>, updatedBy: string): Promise<CreationLimits>;
+  /** How many submissions everyone together has made on `dateStr`. */
+  getGlobalSubmissionCount(dateStr: string): Promise<number>;
+  /**
+   * The global counterpart of checkAndIncrementQuota: takes one slot out of the day's
+   * shared allowance, or refuses. Transactional for the same reason the per-user
+   * version is — a cap that a burst can walk past is not a cap.
+   */
+  checkAndIncrementGlobalSubmissions(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   upsertWaitlistEntry(entry: { uid: string; email?: string; name?: string; locale?: string }): Promise<WaitlistEntry>;
   getWaitlistEntry(uid: string): Promise<WaitlistEntry | null>;
   isWaitlistApproved(uid: string, email?: string): Promise<boolean>;
@@ -1002,6 +1041,9 @@ export class InMemoryStore implements Store {
   private buildPreviews = new Map<number, BuildPreview[]>();
   private creatorMessages = new Map<number, CreatorMessage[]>();
   private usage = new Map<string, UsageCounters>();
+  // yyyy-mm-dd -> submissions accepted that day across every account
+  private globalSubmissions = new Map<string, number>();
+  private creationLimits: CreationLimits | null = null;
   private waitlist = new Map<string, WaitlistEntry>();
   // yyyymmdd -> events recorded that day
   private telemetry = new Map<string, TelemetryEvent[]>();
@@ -1351,6 +1393,43 @@ export class InMemoryStore implements Store {
     this.usage.set(key, newCounters);
 
     return { allowed: true, current: newCounters[action], tier };
+  }
+
+  async getCreationLimits(): Promise<CreationLimits | null> {
+    return this.creationLimits ? { ...this.creationLimits } : null;
+  }
+
+  async setCreationLimits(
+    patch: Partial<Omit<CreationLimits, 'updatedAt'>>,
+    updatedBy: string,
+  ): Promise<CreationLimits> {
+    const merged: CreationLimits = {
+      paused: patch.paused ?? this.creationLimits?.paused ?? false,
+      globalDailySubmissionCap:
+        patch.globalDailySubmissionCap !== undefined
+          ? patch.globalDailySubmissionCap
+          : (this.creationLimits?.globalDailySubmissionCap ?? null),
+      updatedAt: new Date().toISOString(),
+      updatedBy,
+    };
+    this.creationLimits = merged;
+    return { ...merged };
+  }
+
+  async getGlobalSubmissionCount(dateStr: string): Promise<number> {
+    return this.globalSubmissions.get(dateStr) ?? 0;
+  }
+
+  async checkAndIncrementGlobalSubmissions(
+    dateStr: string,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const current = this.globalSubmissions.get(dateStr) ?? 0;
+    if (current >= limit) {
+      return { allowed: false, current };
+    }
+    this.globalSubmissions.set(dateStr, current + 1);
+    return { allowed: true, current: current + 1 };
   }
 
   async upsertWaitlistEntry(entry: {
@@ -2170,6 +2249,81 @@ export class FirestoreStore implements Store {
       transaction.set(counterRef, { [action]: nextVal }, { merge: true });
 
       return { allowed: true, current: nextVal, tier };
+    });
+  }
+
+  /**
+   * One document, read on a short TTL by every instance and written only by an
+   * operator. Deliberately a *document* rather than an environment variable: see
+   * CreationLimits. Nothing here is per-user, so there is no query and no index.
+   */
+  private creationLimitsRef() {
+    return this.db.collection('opsConfig').doc('creationLimits');
+  }
+
+  /** The day's shared allowance. One document per UTC day, so history is free. */
+  private globalUsageRef(dateStr: string) {
+    return this.db.collection('globalUsage').doc(dateStr);
+  }
+
+  async getCreationLimits(): Promise<CreationLimits | null> {
+    const snap = await this.creationLimitsRef().get();
+    if (!snap.exists) return null;
+    const data = snap.data() as Partial<CreationLimits> | undefined;
+    return {
+      paused: data?.paused === true,
+      globalDailySubmissionCap:
+        typeof data?.globalDailySubmissionCap === 'number' ? data.globalDailySubmissionCap : null,
+      ...(data?.updatedAt ? { updatedAt: data.updatedAt } : {}),
+      ...(data?.updatedBy ? { updatedBy: data.updatedBy } : {}),
+    };
+  }
+
+  async setCreationLimits(
+    patch: Partial<Omit<CreationLimits, 'updatedAt'>>,
+    updatedBy: string,
+  ): Promise<CreationLimits> {
+    const ref = this.creationLimitsRef();
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const existing = snap.exists ? (snap.data() as Partial<CreationLimits>) : {};
+      const merged: CreationLimits = {
+        paused: patch.paused ?? existing.paused ?? false,
+        globalDailySubmissionCap:
+          patch.globalDailySubmissionCap !== undefined
+            ? patch.globalDailySubmissionCap
+            : (existing.globalDailySubmissionCap ?? null),
+        updatedAt: new Date().toISOString(),
+        updatedBy,
+      };
+      transaction.set(ref, merged);
+      return merged;
+    });
+  }
+
+  async getGlobalSubmissionCount(dateStr: string): Promise<number> {
+    const snap = await this.globalUsageRef(dateStr).get();
+    const value = snap.data()?.submissions;
+    return typeof value === 'number' ? value : 0;
+  }
+
+  async checkAndIncrementGlobalSubmissions(
+    dateStr: string,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const ref = this.globalUsageRef(dateStr);
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const value = snap.data()?.submissions;
+      const current = typeof value === 'number' ? value : 0;
+
+      if (current >= limit) {
+        return { allowed: false, current };
+      }
+
+      const nextVal = current + 1;
+      transaction.set(ref, { submissions: nextVal }, { merge: true });
+      return { allowed: true, current: nextVal };
     });
   }
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -90,6 +90,8 @@ async function createApp(params: {
   store?: Store;
   dailySubmissionQuota?: number;
   dailyFeedbackQuota?: number;
+  globalDailySubmissionCap?: number;
+  creationLimitsTtlMs?: number;
   translator?: Translator;
   contentChecker?: ContentChecker;
   maxCachedDraftPreviews?: number;
@@ -108,6 +110,8 @@ async function createApp(params: {
       now: params.now,
       dailySubmissionQuota: params.dailySubmissionQuota,
       dailyFeedbackQuota: params.dailyFeedbackQuota,
+      globalDailySubmissionCap: params.globalDailySubmissionCap,
+      creationLimitsTtlMs: params.creationLimitsTtlMs,
       translator: params.translator ?? new NoopTranslator(),
       maxCachedDraftPreviews: params.maxCachedDraftPreviews,
     },
@@ -262,6 +266,128 @@ describe('submission routes authentication & quota', () => {
 
     expect(res.statusCode).toBe(403);
     expect(res.json()).toEqual({ error: 'account is blocked' });
+
+    await app.close();
+  });
+});
+
+/**
+ * The cost circuit-breaker (readiness item 6). Per-user quotas bound one creator; these
+ * bound everyone at once, and can be pulled without a redeploy.
+ */
+describe('global creation cap and pause switch', () => {
+  const body = { title: 'Game idea', concept: 'A concept long enough to pass validation rules.' };
+
+  async function submit(app: FastifyInstance, headers: Record<string, string>, title = body.title) {
+    return app.inject({ method: 'POST', url: '/api/submissions', headers, payload: { ...body, title } });
+  }
+
+  it('refuses at the shared daily ceiling and leaves the creator’s own allowance unspent', async () => {
+    const stub = createGithubClientStub({});
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      submissionTokenSecret: secret,
+      dailySubmissionQuota: 5,
+      globalDailySubmissionCap: 2,
+      creationLimitsTtlMs: 0,
+    });
+
+    expect((await submit(app, authHeaders, 'One')).statusCode).toBe(200);
+    expect((await submit(app, authHeaders, 'Two')).statusCode).toBe(200);
+
+    const refused = await submit(app, authHeaders, 'Three');
+    expect(refused.statusCode).toBe(429);
+    // A distinct code, because the creator's own allowance is intact and a message
+    // implying otherwise is one they can check against the counter on the hero.
+    expect(refused.json()).toEqual({ error: 'creation_over_capacity' });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    expect((await store.getUsage('g:test-user', dateStr)).submissions).toBe(2);
+    // And nothing was filed, so the refusal cost an agent run as well as a quota slot.
+    expect(stub.createIssue).toHaveBeenCalledTimes(2);
+
+    await app.close();
+  });
+
+  it('blocks every creation while paused, before spending anything', async () => {
+    const stub = createGithubClientStub({});
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      submissionTokenSecret: secret,
+      creationLimitsTtlMs: 0,
+    });
+    await store.setCreationLimits({ paused: true }, 'g:admin');
+
+    const refused = await submit(app, authHeaders);
+    expect(refused.statusCode).toBe(429);
+    expect(refused.json()).toEqual({ error: 'creation_paused' });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    expect((await store.getUsage('g:test-user', dateStr)).submissions).toBe(0);
+    expect(stub.createIssue).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('leaves per-user quota behaviour exactly as it was', async () => {
+    const stub = createGithubClientStub({});
+    const { app, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      submissionTokenSecret: secret,
+      dailySubmissionQuota: 1,
+      globalDailySubmissionCap: 100,
+      creationLimitsTtlMs: 0,
+    });
+
+    expect((await submit(app, authHeaders, 'One')).statusCode).toBe(200);
+    const exceeded = await submit(app, authHeaders, 'Two');
+    expect(exceeded.statusCode).toBe(429);
+    // The global gate must not shadow the per-user one, or the honest message would be
+    // the wrong one: this creator really has used their allowance.
+    expect(exceeded.json()).toEqual({ error: 'daily submission quota exceeded' });
+
+    await app.close();
+  });
+
+  it('takes effect on a running app, with no restart and no redeploy', async () => {
+    const stub = createGithubClientStub({});
+    let clock = Date.UTC(2026, 6, 30, 12, 0, 0);
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      submissionTokenSecret: secret,
+      now: () => clock,
+      creationLimitsTtlMs: 60_000,
+    });
+
+    expect((await submit(app, authHeaders, 'Before')).statusCode).toBe(200);
+
+    // The whole reason the config is a Firestore document rather than an env var: an
+    // env change needs a new revision, and a redeploy mid-incident drops every party
+    // room in flight.
+    await store.setCreationLimits({ paused: true }, 'g:admin');
+    clock += 61_000;
+
+    const refused = await submit(app, authHeaders, 'After');
+    expect(refused.statusCode).toBe(429);
+    expect(refused.json()).toEqual({ error: 'creation_paused' });
+
+    await app.close();
+  });
+
+  it('lets bot: accounts through a closed breaker, so a pause cannot redden the deploy gate', async () => {
+    const stub = createGithubClientStub({});
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'bot:ci' });
+    await store.setCreationLimits({ paused: true, globalDailySubmissionCap: 0 }, 'g:admin');
+    const { app } = await createApp({
+      githubClient: stub.githubClient,
+      submissionTokenSecret: secret,
+      store,
+      creationLimitsTtlMs: 0,
+    });
+
+    const res = await submit(app, getAuthHeaders('bot:ci'));
+    expect(res.statusCode).toBe(200);
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-channel.js';
 import { mintAgentToken } from './agent-token.js';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
+import { createCreationGate, CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js';
 import {
   createGitHubClient,
   type CatalogGameEntry,
@@ -170,6 +171,16 @@ export interface SubmissionRoutesOptions {
   now?: () => number;
   store?: Store;
   dailySubmissionQuota?: number;
+  /**
+   * The global creation breaker (pause switch + shared daily ceiling). Built from the
+   * store by default; an explicit null disables it, which is what the tests that assert
+   * pre-breaker behaviour pass.
+   */
+  creationGate?: CreationGate | null;
+  /** Global ceiling used when the Firestore config doc sets none. See creation-limits.ts. */
+  globalDailySubmissionCap?: number;
+  /** How long the breaker's config is cached — the delay on a flip taking effect. */
+  creationLimitsTtlMs?: number;
   dailyFeedbackQuota?: number;
   /** Separate from submissions so improving a live game does not crowd out creating one. */
   dailyImprovementQuota?: number;
@@ -280,6 +291,23 @@ export async function registerSubmissionRoutes(
   const now = options.now ?? Date.now;
   const store = options.store;
   const dailySubmissionQuota = options.dailySubmissionQuota ?? 5;
+
+  // Per-user quotas bound one creator; this bounds everyone at once, and can be pulled
+  // without a redeploy (creation-limits.ts explains why that mattered enough to put the
+  // config in Firestore). Absent a store there is nothing to count in, so no breaker.
+  const creationGate =
+    options.creationGate === undefined
+      ? store
+        ? createCreationGate({
+            store,
+            now,
+            ttlMs: options.creationLimitsTtlMs,
+            defaultGlobalDailyCap: options.globalDailySubmissionCap,
+            logWarn: (payload, message) => app.log.warn(payload, message),
+          })
+        : null
+      : options.creationGate;
+
   const dailyFeedbackQuota = options.dailyFeedbackQuota ?? 20;
   // Start small (docs/improvement-loop-plan.md): agent runs are scarce, and a published
   // improvement is a real implementer job — not a draft tweak.
@@ -930,7 +958,22 @@ export async function registerSubmissionRoutes(
       return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
     }
 
-    // 5. User daily quota check (only increment after payload & IP checks pass)
+    // 5. The global circuit-breaker: the pause switch and everyone's shared daily
+    // ceiling (creation-limits.ts). Deliberately ahead of the per-user quota and of
+    // every GitHub write, so a request refused here costs the creator nothing — which
+    // is precisely what the message they get promises. `bot:` accounts are outside it;
+    // the reason is in creation-limits.ts.
+    if (creationGate) {
+      const gate = await creationGate.checkAndSpend(request.user!.uid, dateStr);
+      if (!gate.allowed) {
+        // A distinct code rather than the shared "quota" wording: the creator's own
+        // allowance is intact, and a message implying otherwise would be a lie they
+        // could check.
+        return reply.status(429).send({ error: CREATION_REFUSAL_CODES[gate.reason] });
+      }
+    }
+
+    // 6. User daily quota check (only increment after payload & IP checks pass)
     if (store) {
       const quota = await store.checkAndIncrementQuota(request.user!.uid, dateStr, dailySubmissionQuota, 'submissions');
       if (!quota.allowed) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -431,6 +431,13 @@ export function App() {
       const category = err instanceof Error ? (err as SubmissionApiError).category : undefined;
       if (message === 'content_rejected') {
         setSubmissionError(t(`errors.contentRejected.${category ?? 'other'}`));
+      } else if (message === 'creation_paused') {
+        setSubmissionError(t('errors.creationPaused'));
+        // Site-wide limits, not this creator's — checked before the quota branch below
+        // because saying "you've used your allowance" here would be untrue, and the
+        // creator can see their remaining count on the hero to check it.
+      } else if (message === 'creation_over_capacity') {
+        setSubmissionError(t('errors.creationOverCapacity'));
       } else if (message.includes('quota')) {
         setSubmissionError(t('auth.quotaExceeded'));
       } else if (message.includes('blocked')) {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -475,6 +475,8 @@
   },
   "errors": {
     "generic": "Something went wrong",
+    "creationPaused": "New games are paused for a moment while we look at something on our side. Your daily allowance hasn't been touched — please try again shortly.",
+    "creationOverCapacity": "We've hit today's ceiling on new games across the whole site, so we can't start another one right now. Your own allowance is untouched and still there tomorrow.",
     "contentRejected": {
       "profanity": "That includes language we can't publish. Please rephrase and try again.",
       "adult": "That describes adult content, which we can't generate. Please rephrase and try again.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -475,6 +475,8 @@
   },
   "errors": {
     "generic": "Coś poszło nie tak",
+    "creationPaused": "Tworzenie nowych gier jest na chwilę wstrzymane — sprawdzamy coś u nas. Twój dzienny limit pozostaje nietknięty, spróbuj ponownie za moment.",
+    "creationOverCapacity": "Osiągnęliśmy dzisiejszy limit nowych gier w całym serwisie, więc nie możemy teraz zacząć kolejnej. Twój własny limit jest nietknięty i będzie czekał jutro.",
     "contentRejected": {
       "profanity": "To zawiera słownictwo, którego nie możemy opublikować. Popraw treść i spróbuj ponownie.",
       "adult": "To opisuje treści dla dorosłych, których nie możemy wygenerować. Popraw treść i spróbuj ponownie.",

--- a/docs/auth-and-usage-plan.md
+++ b/docs/auth-and-usage-plan.md
@@ -72,6 +72,12 @@ submissions/{issueNumber}
 
 usage/{uid}/counters/{yyyy-mm-dd}
   submissions: n, previews: n, mocks: n   # transactional increments; quota reads hit this doc only
+
+globalUsage/{yyyy-mm-dd}
+  submissions: n                          # everyone together, for the global cap below
+
+opsConfig/creationLimits                  # the circuit-breaker; operator-written, no deploy
+  paused: bool, globalDailySubmissionCap: n | null, updatedAt, updatedBy
 ```
 
 No events collection (rethink #3). Google `sub` is stable for the life of the account.
@@ -148,6 +154,52 @@ the coarse outer layer (and is the only limiter on `/api/auth/*`).
 - **M2 — Read-side decision + UX.** (IN PROGRESS — quota UX & public read decision implemented) Owner decided public catalog/play reads; quota-exceeded and blocked UX; status links stay shareable read-only.
 - **M3 — Retire Basic-Auth.** (NOT STARTED — awaiting owner authorization) Delete `site-basic-auth` + hook; smoke tests flip to session-only checks. Google sign-in is the single auth boundary.
 - **M4 — Visibility + reach.** Admin usage view (allowlisted uids) / BigQuery log sink; optionally add GitHub as a second provider for power-creators.
+
+## The global cap and pause switch (built 2026-07-30)
+
+Per-user quotas bound what **one** creator costs. Nothing bounded what everyone costs
+together, so total spend was bounded only by the invite count — which is not a control,
+it is an accident of how many invitations have gone out. And there was no way to stop
+creation at all short of editing an environment variable and redeploying, which
+mid-incident also drops every party room in flight.
+
+Two controls now sit beside the per-user quota, both in
+[`creation-limits.ts`](../apps/api/src/creation-limits.ts):
+
+| Control                    | Effect                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `paused`                   | `POST /api/submissions` refuses with `creation_paused`                                |
+| `globalDailySubmissionCap` | at most N submissions per UTC day across every account, then `creation_over_capacity` |
+
+Both live in the `opsConfig/creationLimits` document rather than in the environment,
+**because a breaker is only worth having if pulling it is cheaper than the incident.**
+Readers cache for 60s, so a change reaches every instance within about a minute and costs
+one document read per instance per minute in between. `GLOBAL_DAILY_SUBMISSION_CAP` sets
+the fallback ceiling that applies when the document sets none — a real number (default 50),
+never infinity, so an unwritten or unreadable document still has a ceiling.
+
+Operating it (admin session required; `ADMIN_UIDS`):
+
+```bash
+curl -s -b cookies.txt https://www.gamedev.pl/api/admin/creation-limits          # what is in force + today's spend
+curl -s -b cookies.txt -X POST -H 'content-type: application/json' \
+  -d '{"paused":true}' https://www.gamedev.pl/api/admin/creation-limits          # stop creation
+  # …and '{"paused":false}' to resume, '{"globalDailySubmissionCap":25}' to retune.
+```
+
+Three deliberate choices worth knowing:
+
+- **Refusals cost the creator nothing.** The gate runs after moderation but before the
+  per-user quota is spent and before any GitHub write, so a creator turned away by a
+  site-wide limit still has their whole daily allowance — which is what the message they
+  see says, in both languages.
+- **`bot:` accounts bypass it entirely** — not paused, not capped, not counted. Pausing
+  creation is an incident response, and the deploy pipeline's own smoke checks run as
+  `bot:` accounts; a tripped cap that reddened the deploy gate would remove the ability to
+  ship a fix at exactly the wrong moment. They remain standard-tier for the _per-user_
+  quota, and the namespace cannot be self-assigned (see `docs/agent-access-tokens.md`).
+- **`trusted` accounts do not bypass it.** They skip the per-user quota, which makes them
+  precisely the accounts a global spend ceiling exists to bound.
 
 ## Adjacent safeguards (unchanged from v1, still required)
 


### PR DESCRIPTION
Readiness item **6** (private ops repo): the cost circuit-breaker that opening the beta wider assumes exists.

## The problem

Quotas were **per-user only**: 5 submissions/day × however many creators have been invited. That is not a spend ceiling, it is an accident of the invite count. And there was no way to stop creation short of editing an env var and redeploying — which mid-incident also drops every party room in flight. A breaker you cannot pull without breaking something else is not a breaker.

## What this adds

| Control | Effect |
| --- | --- |
| `globalDailySubmissionCap` | at most N submissions per UTC day across **every** account, then `creation_over_capacity` |
| `paused` | `POST /api/submissions` refuses with `creation_paused` |

New: `apps/api/src/creation-limits.ts` (the gate), `globalUsage/{yyyy-mm-dd}` and `opsConfig/creationLimits` in the store, `GET`/`POST /api/admin/creation-limits`, and bilingual strings.

## Decisions a reviewer should second-guess

**1. Firestore config document, not env vars.** Both controls are read from `opsConfig/creationLimits` with a 60s TTL cache. An env change needs a new Cloud Run revision: a minute or two of rollout plus every live party room dropped, to change a boolean — the exact cost the breaker exists to avoid paying. A document is one request, and every instance converges within ~60s. Cost is one document read per instance per minute, and only on the creation path.

The trade-off accepted: **a flip is not instant** (≤60s), and there is no cross-instance invalidation. I chose a uniform TTL over invalidating the writing instance's cache because "within a minute, everywhere" is a rule an operator can hold in their head, where "instant here, a minute over there" is not. `GLOBAL_DAILY_SUBMISSION_CAP` still exists as the *deployed floor* that applies when the document says nothing.

**2. `bot:` accounts bypass the breaker entirely** — not paused, not capped, not counted. Pausing creation is an incident response, and the deploy pipeline's smoke checks run as `bot:` accounts; a tripped cap or an active pause that reddened the deploy gate would remove the ability to ship a fix at exactly the moment one is needed. Today's smoke test does not POST a submission (it only asserts 401 unauthenticated), so this is pre-emptive rather than a fix — but item 6 should not plant that landmine.

Why it is not a hole: `bot:` uids are already the "not a creator" namespace (creator metrics and the digest exclude them by the same prefix), a `bot:` account is still standard-tier for the **per-user** quota, tokens are admin-minted and revocable, and the namespace cannot be self-assigned. If you would rather bots were capped-but-not-paused, it is a one-line change in `bypassesBreaker`.

`trusted` accounts deliberately **do not** bypass it — they skip the per-user quota, which makes them precisely the accounts a global ceiling exists to bound.

**3. Default cap of 50/day.** ~10 creators at full quota. Chosen to be well above current beta traffic and well below anything alarming; it is the number to revisit as invites go out. Crossing 80% logs a warning, because the alternative — noticing when creators start being refused — means the first person to find out is a creator.

**4. Ordering: after moderation, before the per-user quota.** As specified, so a refusal costs the creator nothing (no quota slot, no GitHub write, no filed issue — all asserted). Worth flagging: this means a *paused* system still pays for one Vertex moderation call per attempt. Moving the pause check ahead of moderation would close that, at the cost of changing the established moderation-first ordering. Happy to move it if you want the Vertex spend cut too.

**5. Fail-open, to a real ceiling.** An unreadable config serves the last value this instance saw, and falls back to the default cap when it has never read one — "unset" must never mean "unlimited", and a Firestore blip must not become a creation outage. Similarly if the *counter* is unreachable the request is admitted: a Firestore outage is not "the site is over capacity", and the submission cannot be recorded in that state anyway. A stored cap of `0` closes (that is a legitimate "accept nothing"); a blank env var reads as unconfigured rather than as zero (`Number('')` is 0 — that one would have closed creation on an empty variable).

## Honest UX, en + pl

New keys `errors.creationPaused` / `errors.creationOverCapacity`, both of which say plainly that the site is over capacity **and that the creator's own allowance is untouched**. Distinct error codes rather than reusing the quota wording, because "you have used your allowance" would be a lie the creator can check against the counter on the hero.

## Operating it

```bash
curl -s -b cookies.txt https://www.gamedev.pl/api/admin/creation-limits            # in force + today's spend
curl -s -b cookies.txt -X POST -H 'content-type: application/json' \
  -d '{"paused":true}' https://www.gamedev.pl/api/admin/creation-limits
```

Session-only, like every operator write, so a leaked access token cannot pause the product; 404 (not 403) to everyone else. Every change is logged with who made it — a pause left on by accident is this feature's own failure mode. Documented in `docs/auth-and-usage-plan.md`.

## Tests

**+29 API tests (1062 → 1091); full suite, lint, type-check and build all green.**

- `creation-limits.test.ts` (14): cap trips at the boundary; pause refuses without touching the counter; stored cap beats the default; cap 0 closes; bot bypass touches neither read nor counter; config read once per TTL then a change picked up with no restart; stale config on read failure; default-ceiling fallback when never readable; admits when the counter throws; the 80% warning; env parsing.
- `submissions.test.ts` (+5, route level): refuses at the shared ceiling **and the creator's per-user usage is still 2 of 5 with only 2 issues filed**; pause blocks with the friendly code, spending nothing; per-user quota behaviour unchanged (still `daily submission quota exceeded`, not shadowed); a flip on a running app takes effect with no restart (clock stepped past the TTL); a `bot:` account gets through a fully closed breaker.
- `admin.test.ts` (+5): reports the default when nothing is stored; pauses and records `updatedBy`; partial patch keeps the other field; empty patch is a 400; 404 to non-admins and anonymous, read and write.
- `store-firestore.test.ts` (+5): both documents written through the strict Firestore fake — a cleared cap round-trips as an explicit `null`, partial merge works, and the day counter is per-day.

**No collection-group query**, so `CG_INDEXES` in `infra/setup-gcp.sh` is unchanged and `firestore-indexes.test.ts` still passes.

## Not done

The 4-line error-code→string mapping in `App.tsx` has no web test; the existing `quota` and `blocked` branches beside it have none either, and I did not add a harness for it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
