### PR TITLE
Stop setup-monitoring.sh hanging when the alpha/beta components are missing

### DIFF
--- a/infra/setup-backups.sh
+++ b/infra/setup-backups.sh
@@ -30,6 +30,11 @@
 # This script is idempotent — safe to re-run after changing any of the knobs above.
 set -euo pipefail
 
+# Every gcloud call here is GA, so none should prompt — but the existence checks below
+# discard both streams, so any prompt that did appear would be invisible and the script
+# would wait on stdin forever. setup-monitoring.sh hung exactly that way. Prompts off.
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 # The bucket must live where the database lives: Firestore refuses to export across
 # locations, and this database is in europe-central2 (the app is in europe-west1 —

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -24,6 +24,25 @@
 # Idempotent: policies are matched by display name and updated rather than duplicated.
 set -euo pipefail
 
+# gcloud asks for confirmation on stderr — including "you do not have this command group
+# installed, continue?" for alpha/beta. A script that redirects stderr then waits on stdin
+# forever, showing nothing: this script hung on step 2 for exactly that reason. Prompts off
+# means every gcloud call below either works or fails, and never waits.
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+# Neither command group used here is GA — notification channels live in `gcloud beta`,
+# alert policies in `gcloud alpha`. Probe both up front so a missing component is one clear
+# line in the first second rather than a mystery several steps in. Probing beats parsing
+# `gcloud components list`, which is disabled entirely on package-manager installs.
+for GROUP in alpha beta; do
+  if ! gcloud "$GROUP" monitoring --help >/dev/null 2>&1; then
+    echo "Error: the gcloud '${GROUP}' component is required but not available." >&2
+    echo "  gcloud components install alpha beta" >&2
+    echo "If gcloud came from apt/yum, install its matching -alpha and -beta packages." >&2
+    exit 1
+  fi
+done
+
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 REGION="${REGION:-europe-west1}"
 SERVICE="${SERVICE:-gamedev-app}"
@@ -39,7 +58,7 @@ echo "==> 2/4 Ensuring the email notification channel"
 CHANNEL_NAME="$(gcloud beta monitoring channels list \
   --project "$PROJECT_ID" \
   --filter="type=email AND labels.email_address=${ALERT_EMAIL}" \
-  --format='value(name)' 2>/dev/null | head -n 1)"
+  --format='value(name)' | head -n 1)"
 if [ -z "$CHANNEL_NAME" ]; then
   CHANNEL_NAME="$(gcloud beta monitoring channels create \
     --project "$PROJECT_ID" \
@@ -60,7 +79,7 @@ echo "==> 3/4 Ensuring the uptime check on https://${HOST}/api/health"
 UPTIME_NAME="$(gcloud monitoring uptime list-configs \
   --project "$PROJECT_ID" \
   --filter="displayName='gamedev-app health'" \
-  --format='value(name)' 2>/dev/null | head -n 1)"
+  --format='value(name)' | head -n 1)"
 if [ -z "$UPTIME_NAME" ]; then
   gcloud monitoring uptime create 'gamedev-app health' \
     --project "$PROJECT_ID" \
@@ -294,7 +313,7 @@ for FILE in "${POLICY_DIR}"/*.json; do
   EXISTING="$(gcloud alpha monitoring policies list \
     --project "$PROJECT_ID" \
     --filter="displayName='${DISPLAY}'" \
-    --format='value(name)' 2>/dev/null | head -n 1)"
+    --format='value(name)' | head -n 1)"
   # update replaces the policy definition wholesale, so every field the policy needs has
   # to be in the file — including notificationChannels. Omitting it there would leave the
   # policies present and visibly "enabled" while silently emailing nobody, which is the


### PR DESCRIPTION
Found by running the script for real: it hung on step 2/4 with no output for minutes.

## Cause

The channel-list call is the script's first `gcloud beta` command. When the `beta` component isn't installed, gcloud asks *"You do not currently have this command group installed… continue (Y/n)?"* — **on stderr** — and that call redirected stderr to `/dev/null`. So the prompt was invisible and the script waited on stdin forever. Step 4/4 would have done the same for `alpha`.

## Fix

- **`CLOUDSDK_CORE_DISABLE_PROMPTS=1`** — no gcloud call in either script can wait for input; it either works or fails.
- **A preflight** probing `alpha` and `beta`, exiting with the install command. A missing component should be one clear line in the first second, not a mystery several steps in. It probes rather than reading `gcloud components list`, which is disabled outright on package-manager installs.
- **Dropped `2>/dev/null` from the three list calls.** They return empty and exit 0 when nothing matches, so the redirect bought nothing while hiding both the prompt and any real permission error.

The same prompt guard goes on `setup-backups.sh`. Its calls are all GA so it shouldn't prompt, but its existence checks discard both streams — the same trap was waiting there.

## Verification

`bash -n` on both. Preflight failure path exercised with a stubbed `gcloud` to confirm it prints the install hint and exits 1 rather than continuing. The real run is unblocked by `gcloud components install alpha beta`, which is now what the script tells you.

This is the fourth defect in this pack found by using it rather than reading it, and the pattern is consistent: each one looked fine and behaved wrong. Cheap to find here; expensive to find during an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWTR7Zp7siY2NB5iEpcedT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWTR7Zp7siY2NB5iEpcedT)_