### PR TITLE
Keep what actually failed when an admission is refused

### DIFF
--- a/apps/world/src/app.ts
+++ b/apps/world/src/app.ts
@@ -187,7 +187,16 @@ export async function buildWorldApp(options: WorldAppOptions): Promise<WorldApp>
           // cannot start any zone at all answers `zone_unavailable` to every join and logs
           // nothing, and reads from the outside exactly like a host with no traffic. The
           // cause goes to the log, where the person who can fix it is the only one reading.
-          if (reason === 'zone_unavailable') app.log.error({ err: error }, 'zone admission failed');
+          //
+          // `err` is the *cause* rather than the wrapper, because the wrapper's stack
+          // begins where the error was caught and its message is the wire reason repeated.
+          // Logging it was logging the fact that something failed to whoever already knew.
+          // The unwrapped case keeps the error itself — that is a fault that escaped the
+          // admission path entirely, and its own stack is the informative one.
+          if (reason === 'zone_unavailable') {
+            const cause = error instanceof ZoneAdmissionError ? error.cause : undefined;
+            app.log.error({ err: cause ?? error, reason }, 'zone admission failed');
+          }
           connection.close(reason);
         } finally {
           admitting = false;

--- a/apps/world/src/host.test.ts
+++ b/apps/world/src/host.test.ts
@@ -9,7 +9,7 @@ import {
   type ZoneSnapshot,
   type ZoneSnapshotStore,
 } from '@gamedevpl/zone-core';
-import { ZoneHost, type ZoneConnection } from './host.js';
+import { ZoneAdmissionError, ZoneHost, type ZoneConnection } from './host.js';
 
 /**
  * The host's own bookkeeping, which `app.test.ts` cannot reach through a socket.
@@ -48,6 +48,15 @@ function memoryStore(): ZoneSnapshotStore {
   return {
     load: async (id) => saved.get(id) ?? null,
     save: async (id, snapshot) => void saved.set(id, snapshot),
+  };
+}
+
+/** A source that fails the way the network does: after the join has already begun. */
+function failingSource(error: Error): SimSource {
+  return {
+    load: async () => {
+      throw error;
+    },
   };
 }
 
@@ -157,6 +166,28 @@ describe('ZoneHost admission', () => {
     const later = await host.admit(ticketFor('p3'), silentConnection());
     expect(later.zone).toBe(a.zone);
     expect(host.liveZoneCount).toBe(1);
+    host.shutdown?.();
+  });
+});
+
+describe('a refused admission', () => {
+  it('carries what actually failed, not just the word for it', async () => {
+    // The wire reason is one of a handful of fixed strings and is meant to be incurious,
+    // so the operator's only supply of truth is the cause. It used to be dropped at the
+    // wrap: the first `zone_unavailable` the alerting ever caught arrived with a stack
+    // beginning inside `admit` and a message that was the wire reason repeated, which is
+    // the exact blindness the log line was added to end. An alert that fires without a
+    // cause is a doorbell.
+    const boom = new Error('games repo said no');
+    const host = makeHost(failingSource(boom));
+
+    await expect(host.admit(ticketFor('p1'), silentConnection())).rejects.toThrow(ZoneAdmissionError);
+
+    const error = await host.admit(ticketFor('p2'), silentConnection()).catch((caught) => caught);
+    expect(error).toBeInstanceOf(ZoneAdmissionError);
+    expect((error as ZoneAdmissionError).reason).toBe('zone_unavailable');
+    expect((error as ZoneAdmissionError).cause).toBe(boom);
+
     host.shutdown?.();
   });
 });

--- a/apps/world/src/host.ts
+++ b/apps/world/src/host.ts
@@ -171,8 +171,8 @@ export class ZoneHost {
         this.zones.delete(claims.zone);
         this.members.delete(claims.zone);
       }
-      if (error instanceof ZoneFullError) throw new ZoneAdmissionError('zone_full');
-      throw new ZoneAdmissionError('zone_unavailable');
+      if (error instanceof ZoneFullError) throw new ZoneAdmissionError('zone_full', { cause: error });
+      throw new ZoneAdmissionError('zone_unavailable', { cause: error });
     } finally {
       const pending = (this.admitting.get(claims.zone) ?? 1) - 1;
       if (pending > 0) this.admitting.set(claims.zone, pending);
@@ -252,9 +252,22 @@ export class ZoneHost {
   }
 }
 
+/**
+ * Why a join was refused — and, when something threw, what actually threw.
+ *
+ * The `reason` is what goes on the wire and it is deliberately incurious: telling a
+ * caller which part of a ticket was wrong helps only somebody holding a stolen one. That
+ * makes the `cause` the operator's entire supply of truth, so it must survive being
+ * wrapped. It did not, at first: the first `zone_unavailable` this alerting ever caught
+ * arrived with a stack that began inside `admit` and said nothing about what `join` had
+ * hit, which is precisely the blindness the log line was added to end.
+ */
 export class ZoneAdmissionError extends Error {
-  constructor(public readonly reason: string) {
-    super(reason);
+  constructor(
+    public readonly reason: string,
+    options?: { cause?: unknown },
+  ) {
+    super(reason, options);
     this.name = 'ZoneAdmissionError';
   }
 }


### PR DESCRIPTION
A6 fired for real within hours of being armed (#342), and told us nothing. That is the failure the alert was written to prevent, reproduced one layer down.

## What the alert caught

```
jsonPayload:
  err:
    message: zone_unavailable
    name: ZoneAdmissionError
    reason: zone_unavailable
    stack: |-
      ZoneAdmissionError: zone_unavailable
          at ZoneHost.admit (host.js:121:19)
  msg: zone admission failed
revision_name: gamedev-world-00004-kq8      # the current, fixed revision
timestamp: '2026-07-29T22:11:17Z'
```

A genuine join failure on the live host, and nothing in it says what went wrong. The message is the wire reason repeated and the stack begins where the error was *caught*.

## Why

`admit` catches whatever `join` threw and rethrows `ZoneAdmissionError`, whose constructor took only a reason string — so the cause was dropped at the wrap, before the log line ever ran.

The wire reason is deliberately incurious: telling a caller which part of a ticket was wrong helps only somebody holding a stolen one. That is what makes the cause the operator's *entire* supply of truth, and it was the one thing not kept.

Worth noting how the earlier incident looked informative by accident. The `seats is not iterable` entry from the pre-fix revision was legible because that `TypeError` was thrown before the `try` that wraps, so it escaped raw with its own stack. The path designed to be diagnostic was the one that said nothing.

## The change

- `ZoneAdmissionError` takes a `cause`.
- Both wrapping throws (`zone_full`, `zone_unavailable`) pass the original error.
- The log records the **cause** as `err`, with `reason` beside it. The unwrapped case still logs the error itself — a fault that escaped the admission path entirely already has the informative stack.

No wire change: callers see the same fixed reason strings they did before. Nothing about what a client can learn moves.

## Verification

The new test fails without the fix — I checked by reverting the throw and watching it go red (`expected undefined to be Error: games repo said no`), rather than assuming. Full website suite, type-check and lint green.

## Still open, and not fixed here

**We do not know what failed at 22:11 UTC.** This change means the next one will say; it cannot recover the one already lost. If the surrounding logs from that instance still exist they may name it:

```bash
gcloud logging read \
  'resource.labels.service_name="gamedev-world" AND
   timestamp>="2026-07-29T22:10:00Z" AND timestamp<="2026-07-29T22:13:00Z"' \
  --project gamedevpl --limit 50 --order asc
```

A single failed join is not necessarily a defect — a transient games-repo fetch or Firestore read would do it, and the host recovering on the next attempt is the design working. But it is unexplained, and worth explaining before it is assumed benign.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4xHU2Ca1sZHqoP59Pvxx4)_