### PR TITLE
Make the relay split deployable, and the instance pin impossible to lift alone

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,15 +115,18 @@ jobs:
           # BETA_ALLOWED_UIDS / BETA_ALLOWED_EMAILS are comma-separated allow lists.
           # Set to false (config, not code) when opening the site publicly.
           #
-          # --max-instances 1: DO NOT RAISE while multiplayer is enabled. Party rooms
-          # are per-instance in-memory state (apps/api/src/mp.ts) — the host opens a
-          # room on whichever container served it, and a phone scanning the QR is
-          # load-balanced independently, so a second instance turns a valid room code
-          # into "no such room". Intermittent, and therefore blamed on the guest's
-          # wifi. Cookie-based --session-affinity does NOT help: it is per-client and
-          # cannot map a guest onto the host's instance. To scale out again, first
-          # split the relay into its own service or move room state somewhere shared
-          # (docs/multiplayer-plan.md §4.6).
+          # The instance ceiling is DERIVED FROM vars.MP_RELAY_URL, never set by hand.
+          # Party rooms are per-instance in-memory state (apps/api/src/mp.ts) — the
+          # host opens a room on whichever container served it, and a phone scanning
+          # the QR is load-balanced independently, so a second instance turns a valid
+          # room code into "no such room". Intermittent, and therefore blamed on the
+          # guest's wifi. Cookie-based --session-affinity does NOT help: it is
+          # per-client and cannot map a guest onto the host's instance.
+          #
+          # Setting MP_RELAY_URL moves room creation to the relay service and stops
+          # this one serving the socket, which is what makes scaling out safe — so the
+          # same variable does both, and the pin cannot be lifted while the rooms are
+          # still here. See docs/multiplayer-plan.md §4.6 and infra/deploy-relay.sh.
           #
           # ZONE_HOST_URL is threaded through from a repo variable rather than being set
           # on the service by hand: --set-env-vars replaces the whole map, so a manually
@@ -140,6 +143,21 @@ jobs:
             ENV_VARS="${ENV_VARS}|ZONE_HOST_URL=${ZONE_HOST_URL_VAL}"
           fi
 
+          # Threaded through the same way as ZONE_HOST_URL, and for the same reason:
+          # --set-env-vars replaces the whole map, so a value set by hand on the service
+          # would be wiped by the next deploy — here that would silently pull room
+          # creation back into this process while the ceiling stayed raised, which is
+          # the worst of both configurations.
+          MP_RELAY_URL_VAL="${{ vars.MP_RELAY_URL }}"
+          if [ -n "$MP_RELAY_URL_VAL" ]; then
+            ENV_VARS="${ENV_VARS}|MP_RELAY_URL=${MP_RELAY_URL_VAL}"
+            MAX_INSTANCES=4
+          else
+            MAX_INSTANCES=1
+          fi
+          echo "MP_RELAY_URL_VAL=${MP_RELAY_URL_VAL}" >> "$GITHUB_ENV"
+          echo "Deploying with --max-instances ${MAX_INSTANCES}"
+
           gcloud run deploy "$SERVICE" \
             --image "$IMAGE" \
             --region "$REGION" \
@@ -149,7 +167,7 @@ jobs:
             --tag candidate \
             --allow-unauthenticated \
             --min-instances 0 \
-            --max-instances 1 \
+            --max-instances "$MAX_INSTANCES" \
             --port 8080 \
             --set-env-vars "$ENV_VARS" \
             "${SECRET_FLAGS[@]}"
@@ -385,6 +403,44 @@ jobs:
           # (apps/e2e/src/gate-prerequisites.test.ts).
           E2E_REQUIRED: '1'
         run: npm run e2e
+
+      - name: Move the party relay onto the same image
+        # Only when the split is switched on. Both roles run one image, so the relay has to
+        # be redeployed whenever the app is — otherwise the socket protocol the freshly
+        # promoted web bundle speaks is answered by whatever image the relay was last given
+        # by hand, and party mode breaks on a version skew nobody deployed on purpose.
+        #
+        # Deliberately BEFORE promotion, not after: the relay is the server and the bundle
+        # is its client, so the server should already understand the protocol by the time
+        # any client speaking it exists. The relay's own env (MP_RELAY_ONLY, the audience,
+        # the caller identity) is left untouched — `--image` alone, so this step cannot
+        # reconfigure the relay by omission the way a --set-env-vars deploy would.
+        if: ${{ vars.MP_RELAY_URL != '' }}
+        run: |
+          RELAY_SERVICE="${{ vars.MP_RELAY_SERVICE || 'gamedev-mp-relay' }}"
+          echo "Updating ${RELAY_SERVICE} to ${IMAGE}"
+          gcloud run services update "$RELAY_SERVICE" \
+            --region "$REGION" \
+            --project "$PROJECT_ID" \
+            --image "$IMAGE"
+
+          RELAY_URL=$(gcloud run services describe "$RELAY_SERVICE" --region "$REGION" \
+            --project "$PROJECT_ID" --format 'value(status.url)')
+          # The app mints its OIDC token for the URL it calls, so a mismatch here is an
+          # authentication failure on every lobby — and one that only shows up when a real
+          # host tries to open one. Cheap to check, invisible otherwise.
+          if [ "$RELAY_URL" != "$MP_RELAY_URL_VAL" ]; then
+            echo "Error: vars.MP_RELAY_URL is '${MP_RELAY_URL_VAL}' but ${RELAY_SERVICE} is at '${RELAY_URL}'."
+            echo "The OIDC audience would not match and room creation would be refused."
+            exit 1
+          fi
+
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${RELAY_URL}/api/health")
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Error: relay health returned ${STATUS_CODE}; not promoting the app."
+            exit 1
+          fi
+          echo "Relay healthy at ${RELAY_URL}"
 
       - name: Promote candidate revision to 100% traffic
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -418,6 +418,16 @@ jobs:
         if: ${{ vars.MP_RELAY_URL != '' }}
         run: |
           RELAY_SERVICE="${{ vars.MP_RELAY_SERVICE || 'gamedev-mp-relay' }}"
+          # The same guard deploy-relay.sh carries, for a worse blast radius. A
+          # mis-set (or copy-pasted) MP_RELAY_SERVICE naming the app service would push
+          # this image straight onto live production, bypassing the candidate revision,
+          # the smoke tests and the browser gate that every other path goes through —
+          # and it would do so from a step whose name says "relay".
+          if [ "$RELAY_SERVICE" = "$SERVICE" ]; then
+            echo "Error: vars.MP_RELAY_SERVICE is '${RELAY_SERVICE}', which is the app service."
+            echo "That would deploy this image to production without the smoke or browser gate."
+            exit 1
+          fi
           echo "Updating ${RELAY_SERVICE} to ${IMAGE}"
           gcloud run services update "$RELAY_SERVICE" \
             --region "$REGION" \

--- a/apps/api/src/mp-relay-deploy.test.ts
+++ b/apps/api/src/mp-relay-deploy.test.ts
@@ -37,21 +37,45 @@ const workflow = readFileSync(resolve(repoRoot, '.github/workflows/deploy.yml'),
  * group that follows and a run of blank lines explodes the search. These assertions are
  * really about *order* (guard, then raise, then else, then pin), and order is `indexOf`.
  */
-const positions = (source: string, guard: string) => {
-  const guardAt = source.indexOf(guard);
-  const elseAt = source.indexOf('else', guardAt);
+const positions = (source: string, guard: string, raise: string) => {
+  // Anchor on the RAISE, then look backwards for its guard — not the other way round.
+  //
+  // Searching forwards from the guard was wrong twice over. First, `indexOf(needle, -1)`
+  // searches from 0, so a deleted guard would still find some unrelated `else` and some
+  // unrelated `MAX_INSTANCES=1` further down the file and pass. Second, and worse in
+  // practice: `MP_RELAY_URL` is guarded *twice* in deploy-api.sh — once to thread the
+  // variable into the env map, once for the ceiling — so `indexOf(guard)` matched the env
+  // block and the assertions then passed on offsets that had nothing to do with the
+  // ceiling at all. Deleting the ceiling's own guard did not fail the test.
+  //
+  // Anchoring on the raise removes both: there is exactly one, and its guard is whatever
+  // immediately precedes it.
+  const raiseAt = source.indexOf(raise);
+  if (raiseAt < 0) return { guardAt: -1, raiseAt: -1, elseAt: -1, pinAt: -1 };
+
+  const guardAt = source.lastIndexOf(guard, raiseAt);
+  // The raise must be inside the guard's own then-branch, not merely somewhere after a
+  // guard. An `else` or `fi` in between means the branch already closed and this raise
+  // belongs to something else — which is how an unrelated earlier occurrence of the guard
+  // string (deploy-api.sh has one, for threading the env var) would otherwise satisfy this.
+  const between = guardAt < 0 ? 'fi' : source.slice(guardAt + guard.length, raiseAt);
+  if (guardAt < 0 || /\b(else|fi)\b/.test(between)) {
+    return { guardAt: -1, raiseAt, elseAt: -1, pinAt: -1 };
+  }
+
+  const elseAt = source.indexOf('else', raiseAt);
   return {
     guardAt,
-    raiseAt: source.indexOf('MAX_INSTANCES=', guardAt),
+    raiseAt,
     elseAt,
-    pinAt: source.indexOf('MAX_INSTANCES=1', elseAt),
+    pinAt: elseAt < 0 ? -1 : source.indexOf('MAX_INSTANCES=1', elseAt),
   };
 };
 
 describe('app service instance ceiling', () => {
   const GUARDED = [
-    [deployApi, 'if [ -n "$MP_RELAY_URL" ]; then'],
-    [workflow, 'if [ -n "$MP_RELAY_URL_VAL" ]; then'],
+    [deployApi, 'if [ -n "$MP_RELAY_URL" ]; then', 'MAX_INSTANCES="${MAX_INSTANCES:-4}"'],
+    [workflow, 'if [ -n "$MP_RELAY_URL_VAL" ]; then', 'MAX_INSTANCES=4'],
   ] as const;
 
   it('is a variable in both deploy paths, not a literal', () => {
@@ -67,8 +91,11 @@ describe('app service instance ceiling', () => {
   it('is pinned to one instance whenever the relay is not split out', () => {
     // The `else` branch is the whole guard: unset relay URL means rooms are still local,
     // and there is exactly one safe ceiling for that.
-    for (const [source, guard] of GUARDED) {
-      const { elseAt, pinAt } = positions(source, guard);
+    for (const [source, guard, raise] of GUARDED) {
+      const { guardAt, elseAt, pinAt } = positions(source, guard, raise);
+      // Assert the guard was found first. Without this the test can only ever say
+      // "some else precedes some MAX_INSTANCES=1", which is true of many files.
+      expect(guardAt).toBeGreaterThan(-1);
       expect(elseAt).toBeGreaterThan(-1);
       expect(pinAt).toBeGreaterThan(elseAt);
     }
@@ -78,8 +105,8 @@ describe('app service instance ceiling', () => {
     // Both files must decide the ceiling from the relay variable and nothing else. Checking
     // that the raise sits between the guard and its `else` is what stops the two drifting
     // apart into "raised, and separately, hopefully, forwarded".
-    for (const [source, guard] of GUARDED) {
-      const { guardAt, raiseAt, elseAt } = positions(source, guard);
+    for (const [source, guard, raise] of GUARDED) {
+      const { guardAt, raiseAt, elseAt } = positions(source, guard, raise);
       expect(guardAt).toBeGreaterThan(-1);
       expect(raiseAt).toBeGreaterThan(guardAt);
       expect(raiseAt).toBeLessThan(elseAt);
@@ -201,6 +228,15 @@ describe('deploy workflow relay step', () => {
     // as a second copy of the app with an open create route.
     expect(workflow).toContain('gcloud run services update "$RELAY_SERVICE"');
     expect(workflow).not.toMatch(/RELAY_SERVICE"[\s\S]{0,400}--set-env-vars/);
+  });
+
+  it('refuses to update the app service, same as the script', () => {
+    // deploy-relay.sh already refuses SERVICE == APP_SERVICE; the workflow had no
+    // equivalent, and here the blast radius is larger — a mis-set MP_RELAY_SERVICE would
+    // push the image onto live production from a step called "relay", skipping the
+    // candidate revision, the smoke tests and the browser gate.
+    expect(workflow).toMatch(/if \[ "\$RELAY_SERVICE" = "\$SERVICE" \]/);
+    expect(workflow).toContain('which is the app service');
   });
 
   it('fails the deploy when the configured URL and the real one disagree', () => {

--- a/apps/api/src/mp-relay-deploy.test.ts
+++ b/apps/api/src/mp-relay-deploy.test.ts
@@ -29,7 +29,31 @@ const deployApi = readFileSync(resolve(repoRoot, 'infra/deploy-api.sh'), 'utf8')
 const deployRelay = readFileSync(resolve(repoRoot, 'infra/deploy-relay.sh'), 'utf8');
 const workflow = readFileSync(resolve(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
 
+/**
+ * Ordering assertions are index arithmetic, not multi-line regexes, on purpose.
+ *
+ * The regex this replaced — `else\s*\n\s*(?:.*\n\s*)*?MAX_INSTANCES=1` — was flagged by
+ * CodeQL for exponential backtracking, correctly: `\s` matches `\n`, so it overlaps the
+ * group that follows and a run of blank lines explodes the search. These assertions are
+ * really about *order* (guard, then raise, then else, then pin), and order is `indexOf`.
+ */
+const positions = (source: string, guard: string) => {
+  const guardAt = source.indexOf(guard);
+  const elseAt = source.indexOf('else', guardAt);
+  return {
+    guardAt,
+    raiseAt: source.indexOf('MAX_INSTANCES=', guardAt),
+    elseAt,
+    pinAt: source.indexOf('MAX_INSTANCES=1', elseAt),
+  };
+};
+
 describe('app service instance ceiling', () => {
+  const GUARDED = [
+    [deployApi, 'if [ -n "$MP_RELAY_URL" ]; then'],
+    [workflow, 'if [ -n "$MP_RELAY_URL_VAL" ]; then'],
+  ] as const;
+
   it('is a variable in both deploy paths, not a literal', () => {
     // A literal `--max-instances 1` is not wrong today, but it is the form that gets edited
     // to `--max-instances 10` by someone reading a cold-start graph. Forcing it through a
@@ -43,16 +67,26 @@ describe('app service instance ceiling', () => {
   it('is pinned to one instance whenever the relay is not split out', () => {
     // The `else` branch is the whole guard: unset relay URL means rooms are still local,
     // and there is exactly one safe ceiling for that.
-    expect(deployApi).toMatch(/else\s*\n\s*(?:.*\n\s*)*?MAX_INSTANCES=1\b/);
-    expect(workflow).toMatch(/else\s*\n\s*MAX_INSTANCES=1\b/);
+    for (const [source, guard] of GUARDED) {
+      const { elseAt, pinAt } = positions(source, guard);
+      expect(elseAt).toBeGreaterThan(-1);
+      expect(pinAt).toBeGreaterThan(elseAt);
+    }
   });
 
   it('only raises the ceiling inside a MP_RELAY_URL guard', () => {
     // Both files must decide the ceiling from the relay variable and nothing else. Checking
-    // that the raise is lexically inside the guard is what stops the two drifting apart into
-    // "raised, and separately, hopefully, forwarded".
-    expect(deployApi).toMatch(/if \[ -n "\$MP_RELAY_URL" \]; then\s*\n\s*MAX_INSTANCES="\$\{MAX_INSTANCES:-\d+\}"/);
-    expect(workflow).toMatch(/if \[ -n "\$MP_RELAY_URL_VAL" \]; then\s*\n(?:.*\n)*?\s*MAX_INSTANCES=\d+/);
+    // that the raise sits between the guard and its `else` is what stops the two drifting
+    // apart into "raised, and separately, hopefully, forwarded".
+    for (const [source, guard] of GUARDED) {
+      const { guardAt, raiseAt, elseAt } = positions(source, guard);
+      expect(guardAt).toBeGreaterThan(-1);
+      expect(raiseAt).toBeGreaterThan(guardAt);
+      expect(raiseAt).toBeLessThan(elseAt);
+    }
+    // ...and the raise is a real number, not an accidental empty assignment.
+    expect(deployApi).toContain('MAX_INSTANCES="${MAX_INSTANCES:-4}"');
+    expect(workflow).toContain('MAX_INSTANCES=4');
   });
 
   it('refuses a hand-set MAX_INSTANCES while rooms are still local', () => {
@@ -88,6 +122,33 @@ describe('infra/deploy-relay.sh', () => {
     expect(deployRelay).toContain("--format 'value(spec.template.spec.containers[0].image)'");
     expect(deployRelay).toContain('--max-instances "$MAX_INSTANCES"');
     expect(deployRelay).toMatch(/MAX_INSTANCES="\$\{MAX_INSTANCES:-1\}"/);
+  });
+
+  it('declares the env separator before using it', () => {
+    // gcloud splits --set-env-vars on commas unless the value opens with `^|^`. Omitting the
+    // prefix while using `|` does not fail: it deploys ONE variable called MP_RELAY_ONLY
+    // whose value contains the other two. That is not a broken relay, it is a worse thing —
+    // MP_RELAY_ONLY no longer equals "1" so the service comes up in *app* mode, and
+    // PRIVATE_BETA is unset so the beta wall is off, leaving a fully public unwalled copy of
+    // the site on a run.app URL. This was the actual first draft of the script.
+    const setEnv = deployRelay.match(/--set-env-vars "([^"]*)"/)?.[1];
+    expect(setEnv).toBeDefined();
+    if (setEnv?.includes('|')) {
+      expect(setEnv.startsWith('^|^')).toBe(true);
+    }
+    // The same trap, same fix, in the file this one was modelled on.
+    expect(deployApi).toContain('ENV_VARS="^|^');
+  });
+
+  it('reads the deployed env back before declaring success', () => {
+    // The separator bug is invisible from outside: the service is healthy, and the symptom
+    // is a create-route probe failing with a 404 that reads like an auth problem while the
+    // real fault is an unwalled site. Asserting the three names exist as three separate
+    // variables is the check that names it directly.
+    expect(deployRelay).toContain('--format=json');
+    expect(deployRelay).toMatch(/for VAR in MP_RELAY_ONLY PRIVATE_BETA MP_RELAY_CALLER_SA/);
+    // And it must tell the operator to take the service down, not just report a variable.
+    expect(deployRelay).toContain('gcloud run services delete');
   });
 
   it('configures both halves of the internal-auth verifier', () => {

--- a/apps/api/src/mp-relay-deploy.test.ts
+++ b/apps/api/src/mp-relay-deploy.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The party relay's instance pin, as a property of three files agreeing.
+ *
+ * `--max-instances 1` on the app service is not a performance choice, it is a correctness
+ * one: a party room lives in one process's memory (`mp.ts`), so a guest load-balanced to a
+ * second container cannot see the host's room. The failure is intermittent, arrives as
+ * "the QR code doesn't work", and gets blamed on the guest's wifi — which is why it must
+ * not be possible to lift the pin as a standalone act of tuning.
+ *
+ * The design that makes it safe is that the ceiling is *derived* from `MP_RELAY_URL`: the
+ * same variable that moves room creation to the relay service is the one that raises the
+ * ceiling, so the two can never be half-done. That is exactly the kind of coupling that
+ * erodes — someone raises a ceiling to fix a load problem, party mode breaks two weeks
+ * later, and nothing connects the two events. So it is asserted here, in the same shape as
+ * `firestore-indexes.test.ts` and `erase-verification-workflow.test.ts`: a lint over source
+ * text that also checks it matched something, because a guard that silently matches nothing
+ * reads as coverage while providing none.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+
+const deployApi = readFileSync(resolve(repoRoot, 'infra/deploy-api.sh'), 'utf8');
+const deployRelay = readFileSync(resolve(repoRoot, 'infra/deploy-relay.sh'), 'utf8');
+const workflow = readFileSync(resolve(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+describe('app service instance ceiling', () => {
+  it('is a variable in both deploy paths, not a literal', () => {
+    // A literal `--max-instances 1` is not wrong today, but it is the form that gets edited
+    // to `--max-instances 10` by someone reading a cold-start graph. Forcing it through a
+    // variable means the only place to change it is the block that explains what it costs.
+    expect(deployApi).toContain('--max-instances "$MAX_INSTANCES"');
+    expect(workflow).toContain('--max-instances "$MAX_INSTANCES"');
+    expect(deployApi).not.toMatch(/--max-instances\s+1\b/);
+    expect(workflow).not.toMatch(/--max-instances\s+1\b/);
+  });
+
+  it('is pinned to one instance whenever the relay is not split out', () => {
+    // The `else` branch is the whole guard: unset relay URL means rooms are still local,
+    // and there is exactly one safe ceiling for that.
+    expect(deployApi).toMatch(/else\s*\n\s*(?:.*\n\s*)*?MAX_INSTANCES=1\b/);
+    expect(workflow).toMatch(/else\s*\n\s*MAX_INSTANCES=1\b/);
+  });
+
+  it('only raises the ceiling inside a MP_RELAY_URL guard', () => {
+    // Both files must decide the ceiling from the relay variable and nothing else. Checking
+    // that the raise is lexically inside the guard is what stops the two drifting apart into
+    // "raised, and separately, hopefully, forwarded".
+    expect(deployApi).toMatch(/if \[ -n "\$MP_RELAY_URL" \]; then\s*\n\s*MAX_INSTANCES="\$\{MAX_INSTANCES:-\d+\}"/);
+    expect(workflow).toMatch(/if \[ -n "\$MP_RELAY_URL_VAL" \]; then\s*\n(?:.*\n)*?\s*MAX_INSTANCES=\d+/);
+  });
+
+  it('refuses a hand-set MAX_INSTANCES while rooms are still local', () => {
+    // Ignoring the override silently would be worse than honouring it: the operator would
+    // believe the service scales and only learn otherwise from a cost graph. Say so.
+    expect(deployApi).toContain('Ignoring MAX_INSTANCES=');
+  });
+});
+
+describe('MP_RELAY_URL wiring', () => {
+  it('is passed on every deploy rather than set on the service by hand', () => {
+    // --set-env-vars replaces the whole map. A value set once in the console survives until
+    // the next deploy wipes it, at which point room creation quietly comes back in-process
+    // while the raised ceiling stays — the one combination that is broken by construction.
+    expect(deployApi).toContain('ENV_VARS="${ENV_VARS}|MP_RELAY_URL=${MP_RELAY_URL}"');
+    expect(workflow).toContain('ENV_VARS="${ENV_VARS}|MP_RELAY_URL=${MP_RELAY_URL_VAL}"');
+  });
+
+  it('comes from a repo variable in CI, not a secret or a literal', () => {
+    // A service URL is not a secret, and putting it in one would hide the single most
+    // load-bearing piece of party-mode configuration from everyone reading the workflow.
+    expect(workflow).toContain('vars.MP_RELAY_URL');
+    expect(workflow).not.toContain('secrets.MP_RELAY_URL');
+  });
+});
+
+describe('infra/deploy-relay.sh', () => {
+  it('deploys the relay role, pinned, from the app service’s own image', () => {
+    // One image, both roles: the relay follows whatever the app is running. If this ever
+    // grows its own build, the two can drift, and drift between the workspace layout and an
+    // image is what took every deploy down when @gamedevpl/zone-core landed.
+    expect(deployRelay).toContain('MP_RELAY_ONLY=1');
+    expect(deployRelay).toContain("--format 'value(spec.template.spec.containers[0].image)'");
+    expect(deployRelay).toContain('--max-instances "$MAX_INSTANCES"');
+    expect(deployRelay).toMatch(/MAX_INSTANCES="\$\{MAX_INSTANCES:-1\}"/);
+  });
+
+  it('configures both halves of the internal-auth verifier', () => {
+    // Either one missing makes the create route deny-all (internal-auth.ts) — the relay
+    // comes up healthy and every lobby fails. Fails closed, which is right, but it must not
+    // be the state a successful run leaves behind.
+    expect(deployRelay).toContain('MP_RELAY_CALLER_SA=');
+    expect(deployRelay).toContain('MP_RELAY_AUDIENCE=');
+  });
+
+  it('refuses to deploy the relay role over the app service', () => {
+    // Same image, different env: one wrong SERVICE= and the site stops serving the web
+    // bundle and answers only a websocket. Worth a guard rather than a warning.
+    expect(deployRelay).toMatch(/if \[ "\$SERVICE" = "\$APP_SERVICE" \]/);
+  });
+
+  it('proves an unauthenticated create is refused before declaring success', () => {
+    // The relay must be publicly reachable (a phone that scanned a QR has no identity), so
+    // "reachable" tells you nothing. What matters is that the route which *creates* rooms
+    // refuses a caller with no token, and that is checkable in one curl.
+    expect(deployRelay).toContain('/api/internal/mp/sessions');
+    expect(deployRelay).toMatch(/401 \| 403/);
+  });
+
+  it('mounts only the secret it needs', () => {
+    // Room tokens are HMAC'd from SESSION_SECRET. The relay reads no games, files no
+    // submissions and terminates no sessions, so anything else mounted here is blast radius
+    // bought for nothing.
+    expect(deployRelay).toContain('SESSION_SECRET=session-secret:latest');
+    expect(deployRelay).not.toContain('GITHUB_TOKEN=');
+    expect(deployRelay).not.toContain('SUBMISSION_TOKEN_SECRET=');
+  });
+});
+
+describe('deploy workflow relay step', () => {
+  it('moves the relay onto the new image before promoting the app', () => {
+    // Server before client: the freshly promoted bundle is the relay's client, so the relay
+    // has to speak the new protocol first. Asserted by position, because the ordering is the
+    // entire point and a later refactor would not obviously break anything else.
+    const relayStep = workflow.indexOf('Move the party relay onto the same image');
+    const promoteStep = workflow.indexOf('Promote candidate revision to 100% traffic');
+    expect(relayStep).toBeGreaterThan(-1);
+    expect(promoteStep).toBeGreaterThan(-1);
+    expect(relayStep).toBeLessThan(promoteStep);
+  });
+
+  it('updates only the image, leaving the relay’s own configuration alone', () => {
+    // `gcloud run services update --image` is additive. A `run deploy` here would need the
+    // full env map repeated, and the day someone forgot one line the relay would come back
+    // as a second copy of the app with an open create route.
+    expect(workflow).toContain('gcloud run services update "$RELAY_SERVICE"');
+    expect(workflow).not.toMatch(/RELAY_SERVICE"[\s\S]{0,400}--set-env-vars/);
+  });
+
+  it('fails the deploy when the configured URL and the real one disagree', () => {
+    // The OIDC audience is the callee's URL. A mismatch is an auth failure on every lobby,
+    // visible only to a host trying to open one.
+    expect(workflow).toContain('The OIDC audience would not match');
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ survives only in this repo's early history.
 | Games origin    | ✅ Served through the API rather than a public CDN, so the games repo can stay private and PR previews are playable                                                 |
 | Auth & quotas   | ✅ Google sign-in, per-user daily counters, closed-beta allowlist + waitlist                                                                                        |
 | Notifications   | ✅ In-app bell, email with unsubscribe, Web Push (desktop/Android)                                                                                                  |
-| Multiplayer     | ✅ Party mode — one shared screen, phones as controllers (relay is in-process, hence `--max-instances 1`)                                                           |
+| Multiplayer     | ✅ Party mode — one shared screen, phones as controllers (relay is in-process, hence one instance — splitting it out is built, see `deployment.md`)                 |
 | Mobile          | ✅ Every catalog game is playable with a thumb, **enforced in CI** from each game's source. No PWA/install path yet                                                 |
 | Generator seam  | `packages/game-generator` — deterministic **mock only**, a development preview route                                                                                |
 | Local dev       | ✅ Whole product runs with no keys — bundled fixture games and a dev sign-in (`local-development.md`)                                                               |
@@ -63,7 +63,7 @@ survives only in this repo's early history.
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions              |
 | [`path-routing-plan.md`](./path-routing-plan.md)                   | ✅ Path URLs for deep links (`/play/<slug>`, …) — History API, no hashbang                             |
 | [`recommendations.md`](./recommendations.md)                       | ✅ Home arcade sort from scorecards + signed-in play affinity                                          |
-| [`runbooks/`](./runbooks/README.md)                                | ✅ Incident procedures: site-down triage, deploy rollback, Firestore restore, secret rotation           |
+| [`runbooks/`](./runbooks/README.md)                                | ✅ Incident procedures: site-down triage, deploy rollback, Firestore restore, secret rotation          |
 | [`contributing-for-agents.md`](./contributing-for-agents.md)       | How agents run, structure, and contribute to this repository                                           |
 | [`local-development.md`](./local-development.md)                   | ✅ Running the whole product on a laptop with no keys — start here to contribute                       |
 | [`multiplayer-plan.md`](./multiplayer-plan.md)                     | ✅ Party mode: shared screen, phones as controllers, slot model, in-process relay                      |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,8 @@
 > automatically by GitHub Actions (`deploy.yml`) on every push to `master`.
 >
 > The app (web + API) runs as **one Cloud Run service**: project `gamedevpl`, region
-> **`europe-west1`**, service `gamedev-app`, scale-to-zero with **`--max-instances 1`**. The
+> **`europe-west1`**, service `gamedev-app`, scale-to-zero and pinned to **one instance** until
+> the party relay is split out (see "Splitting the party relay out" below). The
 > custom domain is a native Cloud Run domain mapping; the apex `gamedev.pl` 301-redirects to
 > `www`. The old GitHub Pages site no longer serves this domain — it survives only in this
 > repo's early history.
@@ -258,13 +259,55 @@ requests to `/api` — no CORS and no second service.
 
 [`infra/deploy-api.sh`](../infra/deploy-api.sh) can be used to manually trigger Cloud Build, push
 to Artifact Registry, and deploy to Cloud Run from a local environment. It deploys with
-`--min-instances 0` (scale-to-zero) and `--max-instances 1`.
+`--min-instances 0` (scale-to-zero) and a `--max-instances` value it derives — see below.
 
-**Why `--max-instances 1`:** the multiplayer relay keeps party-mode lobbies in the memory of a
-single process ([`apps/api/src/mp.ts`](../apps/api/src/mp.ts)). A second instance would put a
-phone controller and the screen it controls in different processes, and the lobby would appear
-empty. Raising the cap therefore requires moving that state out of process first — it is not a
-knob to turn under load.
+**Why the instance ceiling is 1, and what lifts it:** the multiplayer relay keeps party-mode
+lobbies in the memory of a single process ([`apps/api/src/mp.ts`](../apps/api/src/mp.ts)). A
+second instance would put a phone controller and the screen it controls in different processes,
+and the lobby would appear empty — intermittently, which is how it gets blamed on the guest's
+wifi. Raising the cap therefore requires moving that state out of the app process first. It is
+not a knob to turn under load, and it is no longer _reachable_ as one: both deploy paths compute
+the ceiling from `MP_RELAY_URL` rather than accepting it as input, and
+[`apps/api/src/mp-relay-deploy.test.ts`](../apps/api/src/mp-relay-deploy.test.ts) fails CI if
+that coupling is broken.
+
+### Splitting the party relay out (lifting the ceiling)
+
+The relay is the only thing that needs the pin, so it moves to its own Cloud Run service and
+that service takes the pin instead. **Both services run the same image** — the role is chosen by
+env (`MP_RELAY_ONLY` on the relay, `MP_RELAY_URL` on the app) — because a second Dockerfile is a
+second thing to drift. See [`multiplayer-plan.md` §4.6](./multiplayer-plan.md) and
+[`apps/api/src/mp-relay.ts`](../apps/api/src/mp-relay.ts) for the design.
+
+Rollout, owner-run and in this order:
+
+1. `PROJECT_ID=gamedevpl ./infra/deploy-relay.sh` — creates `gamedev-mp-relay` from whatever
+   image `gamedev-app` is currently running, pins it to one instance, mounts `session-secret`
+   (room tokens are HMAC'd from it), raises the request timeout to an hour so a websocket is
+   not dropped after five minutes, and pins the OIDC audience to the service's own URL. It
+   finishes by proving that an unauthenticated room-creation call is **refused**.
+2. Set the Actions variable **`MP_RELAY_URL`** to the URL the script prints, then re-run the
+   deploy workflow. That single variable moves room creation to the relay, stops the app serving
+   the socket, and lifts the app's ceiling — one switch on purpose, because a raised ceiling on a
+   service that still owns rooms is the exact outage the split exists to prevent.
+3. `ALERT_EMAIL=… SERVICE=gamedev-mp-relay ./infra/setup-monitoring.sh` — a service with no
+   uptime check and no alert policy is unmonitored by construction.
+4. Open a lobby, join from a phone, confirm the controller moves something. Nothing above proves
+   that; a relay can health-check green while the QR code goes nowhere.
+
+Once `MP_RELAY_URL` is set, `deploy.yml` moves the relay onto each new image **before** promoting
+the app — server before client, since the promoted web bundle is the relay's websocket client.
+Only `--image` is updated, so a deploy cannot silently reconfigure the relay by omission.
+
+Security shape worth understanding before touching it: the relay is `--allow-unauthenticated`
+because a phone that scanned a QR has no Google identity and never will. What protects it is
+app-level — the room token verified in the socket's first frame, and an audience-pinned OIDC
+token from the app service on the internal create route. Missing either `MP_RELAY_AUDIENCE` or
+`MP_RELAY_CALLER_SA` makes that route **deny-all**
+([`internal-auth.ts`](../apps/api/src/internal-auth.ts)), so a half-configured relay refuses to
+open rooms rather than opening them to the internet. `PRIVATE_BETA=true` with no allowlist walls
+every other route the shared image happens to register, which needs no maintenance: the relay's
+whole job lives in the two paths the wall exempts.
 
 ## Infrastructure
 

--- a/docs/multiplayer-plan.md
+++ b/docs/multiplayer-plan.md
@@ -291,12 +291,27 @@ gameplay, drawing, actors, gfx, effects, audio, party`) in both `tools/lib/assem
   affinity does not fix this (it pins a _client_, not a _room_). For the closed beta the
   service therefore runs **`--max-instances 1`** while multiplayer is enabled: with an
   allowlisted handful of users and Cloud Run's default concurrency of 80, one instance is
-  ample. This is the one genuine trade in this design and it is one flag to revert.
-  Upgrade paths when it matters: a separate `gamedev-party` service pinned to one instance
-  (same image, host authenticated by a short-lived HMAC ticket since cookies don't cross
-  origins), or externalized room state (Memorystore). The wire protocol is unchanged by
-  either, and the client already handles `room_not_found` by telling the host to restart the
-  lobby — so raising the cap later degrades visibly rather than mysteriously.
+  ample. This is the one genuine trade in this design.
+- **The split is now built** ([`mp-relay.ts`](../apps/api/src/mp-relay.ts),
+  [`infra/deploy-relay.sh`](../infra/deploy-relay.sh)) and takes the first of the two upgrade
+  paths above: a `gamedev-mp-relay` service pinned to one instance, running the **same image**
+  with `MP_RELAY_ONLY=1`, while the app service loses the pin. One correction to what this
+  section predicted: the host is **not** authenticated by a short-lived HMAC ticket. The app
+  service stays the front door for `POST /api/mp/sessions` — cookie-authenticated, exactly as
+  today — and forwards the create to the relay over an **audience-pinned Google OIDC token**.
+  That keeps `RoomRegistry.createRoom` running in one place, so room codes, room tokens, the
+  one-room-per-host rule and every test in §7 keep their meaning; a ticket format would have
+  needed a new claim set and its own code-collision handling for no benefit on a path that runs
+  once per party. Externalized room state (Memorystore) remains the _second_ step, needed only
+  when one instance of relay is no longer enough.
+- **Lifting the app's pin is not a separate act.** `MP_RELAY_URL` both forwards room creation
+  and raises the ceiling, in both deploy paths, enforced by
+  [`mp-relay-deploy.test.ts`](../apps/api/src/mp-relay-deploy.test.ts) — because "raised the cap,
+  forgot to forward the rooms" is the failure this whole section is about, and it presents as
+  guests' wifi being bad. Rollout steps are in
+  [`deployment.md`](./deployment.md#splitting-the-party-relay-out-lifting-the-ceiling).
+  The wire protocol is unchanged, and the client already handles `room_not_found` by telling the
+  host to restart the lobby — so raising the cap degrades visibly rather than mysteriously.
 - WS connections cap at the request timeout (≤60 min); shell and controllers **auto-reconnect
   into the same slot**, which also covers phones sleeping/backgrounding — the #1 real-world
   event.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,12 +121,15 @@ Genuinely still open, in rough priority order:
   Before the fix it worked only because closed-beta traffic rarely warms a second
   instance — the sort of defect that surfaces on a traffic bump and gets blamed on
   the guest's wifi.
-- 🔴 **The cap is now the scaling ceiling for the whole API.** Catalog, submissions,
-  telemetry, and status polling all share the one container multiplayer needs.
-  Acceptable at closed-beta traffic, and must be resolved before the site opens:
-  split the relay into its own single-instance service, or move room state somewhere
-  shared ([multiplayer-plan.md](./multiplayer-plan.md) §4.6). Note that Cloud Run's
-  `--session-affinity` is not a fix — it is per-client and cannot map a guest onto
+- 🟡 **The cap is the scaling ceiling for the whole API, and the way out is now built
+  but not switched on.** Catalog, submissions, telemetry, and status polling all share
+  the one container multiplayer needs. The relay has its own service
+  ([deploy-relay.sh](../infra/deploy-relay.sh)) and both deploy paths derive the ceiling
+  from `MP_RELAY_URL`, so lifting the cap and moving the rooms are one action rather than
+  two — see [multiplayer-plan.md](./multiplayer-plan.md) §4.6 and
+  [deployment.md](./deployment.md#splitting-the-party-relay-out-lifting-the-ceiling).
+  What remains is owner-run: create the service, set the variable. Note that Cloud Run's
+  `--session-affinity` was never a fix — it is per-client and cannot map a guest onto
   the host's instance.
 - 📋 Takedown operations, backups, and published-catalog rollback.
 - 📋 Observability beyond Cloud Run's defaults — no dashboards or alerting on the

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -40,6 +40,12 @@
 #                               /api/internal/scorecard-sweep. Separate from the notify
 #                               audience because an OIDC audience is the endpoint's own
 #                               URL — one sweep's token must not be replayable at the other.)
+#   MP_RELAY_URL=...           (gamedev-mp-relay's URL, from infra/deploy-relay.sh; moves
+#                               party room creation to that service AND lifts this
+#                               service's --max-instances pin. One switch for both on
+#                               purpose — see the deploy block below. Unset keeps the relay
+#                               in-process and the pin on, which is today's production.)
+#   MAX_INSTANCES=...          (only honoured when MP_RELAY_URL is set; defaults to 4)
 #   ZONE_HOST_URL=...          (gamedev-world's URL; enables authoritative zones. Unset
 #                               means /api/games/:slug/zone/ticket 404s and games play on
 #                               unchanged — the intended default. Must be passed on EVERY
@@ -88,6 +94,9 @@ DIGEST_SWEEP_AUDIENCE="${DIGEST_SWEEP_AUDIENCE:-}"
 VAPID_PUBLIC_KEY="${VAPID_PUBLIC_KEY:-}"
 VAPID_SUBJECT="${VAPID_SUBJECT:-}"
 ZONE_HOST_URL="${ZONE_HOST_URL:-}"
+# Party relay split (apps/api/src/mp-relay.ts). Empty = the relay runs in this process,
+# which is what local dev, the tests and today's production all do.
+MP_RELAY_URL="${MP_RELAY_URL:-}"
 
 IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:$(date +%Y%m%d-%H%M%S)"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -200,16 +209,36 @@ fi
 if [ -n "$ZONE_HOST_URL" ]; then
   ENV_VARS="${ENV_VARS}|ZONE_HOST_URL=${ZONE_HOST_URL}"
 fi
+if [ -n "$MP_RELAY_URL" ]; then
+  ENV_VARS="${ENV_VARS}|MP_RELAY_URL=${MP_RELAY_URL}"
+fi
 
-echo "==> Deploying to Cloud Run (scale-to-zero)"
-# --max-instances 1: DO NOT RAISE while multiplayer is enabled. Party rooms are
-# per-instance in-memory state (apps/api/src/mp.ts) — the host opens a room on
-# whichever container served it, and a phone scanning the QR is load-balanced
+# The instance ceiling is DERIVED FROM MP_RELAY_URL, never chosen by hand.
+#
+# Party rooms are per-instance in-memory state (apps/api/src/mp.ts): the host opens a room
+# on whichever container served it, and a phone scanning the QR is load-balanced
 # independently, so a second instance turns a valid room code into "no such room".
-# Intermittent, and therefore blamed on the guest's wifi. Cookie-based
-# --session-affinity does NOT help: it is per-client and cannot map a guest onto the
-# host's instance. To scale out again, first split the relay into its own service or
-# move room state somewhere shared (docs/multiplayer-plan.md §4.6).
+# Intermittent, and therefore blamed on the guest's wifi. Cookie-based --session-affinity
+# does NOT help — it is per-client and cannot map a guest onto the host's instance.
+#
+# So the pin is not a warning comment anyone can override; it is a function of whether the
+# rooms still live here. With MP_RELAY_URL set, this process forwards room creation to the
+# relay service and never serves the socket, and scaling out is safe. Without it, the pin is
+# 1 and MAX_INSTANCES is ignored — because a raised ceiling on a process that still owns
+# rooms is precisely the outage this split exists to prevent, and it would look like a wifi
+# problem for weeks. See docs/multiplayer-plan.md §4.6 and infra/deploy-relay.sh.
+if [ -n "$MP_RELAY_URL" ]; then
+  MAX_INSTANCES="${MAX_INSTANCES:-4}"
+else
+  if [ -n "${MAX_INSTANCES:-}" ] && [ "${MAX_INSTANCES}" != "1" ]; then
+    echo "!! Ignoring MAX_INSTANCES=${MAX_INSTANCES}: MP_RELAY_URL is unset, so party rooms" >&2
+    echo "   still live in this service's memory and a second instance would break them." >&2
+    echo "   Deploy the relay first (infra/deploy-relay.sh), then set MP_RELAY_URL." >&2
+  fi
+  MAX_INSTANCES=1
+fi
+
+echo "==> Deploying to Cloud Run (scale-to-zero, max ${MAX_INSTANCES} instance(s))"
 gcloud run deploy "$SERVICE" \
   --image "$IMAGE" \
   --region "$REGION" \
@@ -217,7 +246,7 @@ gcloud run deploy "$SERVICE" \
   --platform managed \
   --allow-unauthenticated \
   --min-instances 0 \
-  --max-instances 1 \
+  --max-instances "$MAX_INSTANCES" \
   --port 8080 \
   --set-env-vars "${ENV_VARS}" \
   ${SECRET_FLAGS[@]+"${SECRET_FLAGS[@]}"}

--- a/infra/deploy-relay.sh
+++ b/infra/deploy-relay.sh
@@ -103,6 +103,14 @@ echo "==> 3/6 Deploying ${SERVICE}"
 #
 # --max-instances 1 is the pin, moved. It stays here for as long as a room lives in one
 # process's memory; the app service is what gets to scale.
+#
+# Note the `^|^` prefix on --set-env-vars. gcloud's default separator is a comma, so
+# without it the whole string is parsed as ONE variable named MP_RELAY_ONLY whose value
+# happens to contain the other two. That does not fail — it deploys, and it deploys
+# something much worse than a broken relay: MP_RELAY_ONLY would not equal "1", so the
+# service would come up in *app* mode, and PRIVATE_BETA would be unset, so the beta wall
+# would be off. The result is a second, fully public, unwalled copy of the entire site on
+# a run.app URL. deploy-api.sh uses the same `^|^` idiom for the same reason.
 MAX_INSTANCES="${MAX_INSTANCES:-1}"
 if [ "$MAX_INSTANCES" != "1" ]; then
   echo "!! MAX_INSTANCES=${MAX_INSTANCES}: a guest routed to a second instance cannot see" >&2
@@ -119,7 +127,7 @@ gcloud run deploy "$SERVICE" \
   --max-instances "$MAX_INSTANCES" \
   --timeout 3600 \
   --port 8080 \
-  --set-env-vars "MP_RELAY_ONLY=1|PRIVATE_BETA=true|MP_RELAY_CALLER_SA=${CALLER_SA}" \
+  --set-env-vars "^|^MP_RELAY_ONLY=1|PRIVATE_BETA=true|MP_RELAY_CALLER_SA=${CALLER_SA}" \
   --set-secrets "SESSION_SECRET=session-secret:latest"
 
 echo "==> 4/6 Reading the service URL"
@@ -146,7 +154,34 @@ gcloud run services update "$SERVICE" \
   >/dev/null
 echo "    MP_RELAY_AUDIENCE=${RELAY_URL}"
 
-echo "==> 6/6 Verifying the relay is serving"
+echo "==> 6/6 Verifying the deployed configuration"
+# Read the env back rather than trusting that the flags above were parsed as intended.
+#
+# This exists because of a real defect in the first version of this script: the separator
+# prefix was missing, which gcloud accepts silently and collapses three variables into one.
+# Nothing downstream would have said so plainly — the service starts, health returns 200,
+# and the *symptom* would have been the create-route probe below failing with a 404 that
+# reads like an auth problem. Meanwhile the relay would have been serving the whole site
+# with no beta wall. So: assert the three names exist as three separate variables, which is
+# exactly the property a separator bug destroys.
+#
+# Whitespace is squeezed out first because JSON formatting is not a stable contract.
+ENV_JSON="$(gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format=json | tr -d ' \n')"
+for VAR in MP_RELAY_ONLY PRIVATE_BETA MP_RELAY_CALLER_SA MP_RELAY_AUDIENCE; do
+  if ! printf '%s' "$ENV_JSON" | grep -q "\"name\":\"${VAR}\""; then
+    echo "Error: ${VAR} is not set on ${SERVICE}." >&2
+    echo "  If several are missing at once, suspect the --set-env-vars separator: gcloud" >&2
+    echo "  splits on commas unless the value starts with ^|^, and silently folds the rest" >&2
+    echo "  into the first variable's value." >&2
+    echo "  This service may currently be serving the site unwalled. Fix or delete it now:" >&2
+    echo "    gcloud run services delete ${SERVICE} --region ${REGION} --project ${PROJECT_ID}" >&2
+    exit 1
+  fi
+done
+echo "    MP_RELAY_ONLY, PRIVATE_BETA, MP_RELAY_CALLER_SA, MP_RELAY_AUDIENCE all present."
+
+echo "==> Verifying the relay is serving"
 # Health is public on every role. A 200 here proves the image booted in relay mode; it does
 # not prove the create route works, which is what the smoke step below is for.
 STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' "${RELAY_URL}/api/health" || true)"

--- a/infra/deploy-relay.sh
+++ b/infra/deploy-relay.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Deploy the party relay to its own Cloud Run service (docs/multiplayer-plan.md §4.6,
+# apps/api/src/mp-relay.ts). OWNER-RUN: creating a service and reading another service's
+# configuration both need write access to the project.
+#
+# Why this service exists: party rooms are per-instance memory, so the app service is
+# pinned at `--max-instances 1`. That pin is the ceiling on a public beta, and the relay
+# is the only thing that needs it. Move the relay here, pin *this* service instead, and
+# the app is free to scale out.
+#
+# THE SAME IMAGE RUNS BOTH ROLES. By default this script deploys whatever image the app
+# service is currently running rather than building its own — so the two roles cannot
+# drift, because there is only one artifact. A second Dockerfile would be a second thing
+# to keep in step, and drift between the workspace layout and an image is what took every
+# deploy down when `@gamedevpl/zone-core` landed.
+#
+# Usage — first deploy (creates the service):
+#   PROJECT_ID=gamedevpl ./infra/deploy-relay.sh
+#
+# Then set MP_RELAY_URL in the platform repo's Actions variables to the URL printed at the
+# end, and re-run the deploy workflow. That variable is what moves room creation here AND
+# what lifts the app's instance pin — deliberately one switch, because lifting the pin
+# while the app still serves rooms in-process is the exact bug this whole change removes.
+#
+# Override via env: PROJECT_ID, REGION, SERVICE, APP_SERVICE, IMAGE, MAX_INSTANCES.
+#
+# This script is idempotent — re-run it to move the relay onto a newer image.
+set -euo pipefail
+
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+: "${PROJECT_ID:?set PROJECT_ID to your GCP project id}"
+REGION="${REGION:-europe-west1}"
+SERVICE="${SERVICE:-gamedev-mp-relay}"
+APP_SERVICE="${APP_SERVICE:-gamedev-app}"
+
+if [ "$SERVICE" = "$APP_SERVICE" ]; then
+  echo "Error: SERVICE and APP_SERVICE are both '${SERVICE}'." >&2
+  echo "  Deploying the relay role over the app service would take the site down: the app" >&2
+  echo "  would stop serving the web bundle and answer only the websocket." >&2
+  exit 1
+fi
+
+echo "==> 1/6 Reading the app service's configuration"
+# The relay follows the app's image by construction. Reading it here (rather than taking
+# it as an argument) is what makes "the same image runs both roles" a fact instead of an
+# instruction someone has to remember.
+APP_IMAGE="$(gcloud run services describe "$APP_SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format 'value(spec.template.spec.containers[0].image)' 2>/dev/null || true)"
+IMAGE="${IMAGE:-$APP_IMAGE}"
+if [ -z "$IMAGE" ]; then
+  echo "Error: could not read an image from '${APP_SERVICE}' in ${REGION}." >&2
+  echo "  Deploy the app first (infra/deploy-api.sh or the deploy workflow), or pass" >&2
+  echo "  IMAGE=<artifact registry ref> explicitly." >&2
+  exit 1
+fi
+echo "    Image: ${IMAGE}"
+
+# The relay authenticates exactly one caller: the app service's runtime identity. Cloud Run
+# reports an empty serviceAccountName when a service uses the project's default compute
+# identity, which is what this project does — so resolve that rather than treating empty as
+# "no caller", which would leave the relay's create route deny-all and every lobby broken.
+CALLER_SA="$(gcloud run services describe "$APP_SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format 'value(spec.template.spec.serviceAccountName)' 2>/dev/null || true)"
+if [ -z "$CALLER_SA" ]; then
+  PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format 'value(projectNumber)')"
+  CALLER_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+  echo "    Caller: ${CALLER_SA} (the app service runs as the default compute identity)"
+else
+  echo "    Caller: ${CALLER_SA}"
+fi
+
+echo "==> 2/6 Checking the room-signing secret"
+# Room tokens are HMAC'd from SESSION_SECRET (apps/api/src/mp.ts). The relay both mints and
+# verifies them, so this is the one secret it needs — and the only one it gets. It reads no
+# games, files no submissions and holds no session cookies.
+if ! gcloud secrets describe session-secret --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Error: secret 'session-secret' not found; the relay cannot sign room tokens." >&2
+  exit 1
+fi
+echo "    Found."
+
+echo "==> 3/6 Deploying ${SERVICE}"
+# --allow-unauthenticated is required and is not a hole: a phone that scanned a party QR
+# has no Google identity and never will, so the websocket must be reachable from the open
+# internet. What protects the relay is app-level, not platform-level:
+#
+#   * /api/mp/ws is useless without a room token, verified in the first frame.
+#   * /api/internal/mp/sessions — the route that *creates* rooms — verifies a Google-signed
+#     OIDC token whose audience is this service's own URL and whose subject must be the app
+#     service. Missing either MP_RELAY_AUDIENCE or MP_RELAY_CALLER_SA makes that verifier
+#     deny-all (internal-auth.ts), so a half-configured relay refuses to open rooms rather
+#     than opening them to anyone.
+#   * PRIVATE_BETA=true with no allowlist walls every other route this image happens to
+#     register. That is deliberate and needs no maintenance: the relay's whole job lives in
+#     the two paths the wall exempts, so "closed to everyone" is the correct configuration
+#     rather than a list that has to be kept in step with the app's.
+#
+# --timeout 3600 bounds a connection, not a party: Cloud Run counts an open websocket as a
+# request, so the 300s default would drop every controller after five minutes and the
+# client would spend a party reconnecting.
+#
+# --max-instances 1 is the pin, moved. It stays here for as long as a room lives in one
+# process's memory; the app service is what gets to scale.
+MAX_INSTANCES="${MAX_INSTANCES:-1}"
+if [ "$MAX_INSTANCES" != "1" ]; then
+  echo "!! MAX_INSTANCES=${MAX_INSTANCES}: a guest routed to a second instance cannot see" >&2
+  echo "   the host's room. Only raise this once room state is shared." >&2
+fi
+
+gcloud run deploy "$SERVICE" \
+  --image "$IMAGE" \
+  --region "$REGION" \
+  --project "$PROJECT_ID" \
+  --platform managed \
+  --allow-unauthenticated \
+  --min-instances 0 \
+  --max-instances "$MAX_INSTANCES" \
+  --timeout 3600 \
+  --port 8080 \
+  --set-env-vars "MP_RELAY_ONLY=1|PRIVATE_BETA=true|MP_RELAY_CALLER_SA=${CALLER_SA}" \
+  --set-secrets "SESSION_SECRET=session-secret:latest"
+
+echo "==> 4/6 Reading the service URL"
+RELAY_URL="$(gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT_ID" \
+  --format 'value(status.url)')"
+if [ -z "$RELAY_URL" ]; then
+  echo "Error: the service deployed but reports no URL." >&2
+  exit 1
+fi
+echo "    ${RELAY_URL}"
+
+echo "==> 5/6 Pinning the OIDC audience to that URL"
+# Chicken-and-egg, resolved by doing it in two passes: an OIDC audience is the callee's own
+# URL, which does not exist until the service does. Between the two passes the relay is up
+# with a deny-all create route — closed, not open, which is the right way round to fail.
+#
+# This value must match MP_RELAY_URL on the app byte for byte: the app mints its token for
+# the URL it calls, and a token minted for a trailing-slash variant is a token for a
+# different audience. Both sides derive from `status.url`, so they agree by construction.
+gcloud run services update "$SERVICE" \
+  --region "$REGION" \
+  --project "$PROJECT_ID" \
+  --update-env-vars "MP_RELAY_AUDIENCE=${RELAY_URL}" \
+  >/dev/null
+echo "    MP_RELAY_AUDIENCE=${RELAY_URL}"
+
+echo "==> 6/6 Verifying the relay is serving"
+# Health is public on every role. A 200 here proves the image booted in relay mode; it does
+# not prove the create route works, which is what the smoke step below is for.
+STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' "${RELAY_URL}/api/health" || true)"
+if [ "$STATUS_CODE" != "200" ]; then
+  echo "Error: ${RELAY_URL}/api/health returned ${STATUS_CODE}." >&2
+  exit 1
+fi
+echo "    /api/health 200."
+
+# An unauthenticated call to the create route must be refused. This is the one property
+# worth checking on every deploy, because the failure it catches is silent: a relay whose
+# verifier fell back to deny-all looks identical to a healthy one until a host opens a
+# lobby, and a relay that accepted anonymous creates would look identical too — until
+# someone found it.
+CREATE_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  -H 'content-type: application/json' -d '{"slug":"probe","ownerUid":"probe"}' \
+  "${RELAY_URL}/api/internal/mp/sessions" || true)"
+case "$CREATE_CODE" in
+  401 | 403)
+    echo "    Anonymous room creation refused (${CREATE_CODE}). Correct."
+    ;;
+  *)
+    echo "!! /api/internal/mp/sessions answered ${CREATE_CODE} to an unauthenticated POST." >&2
+    echo "   Expected 401/403. Do NOT set MP_RELAY_URL until this is understood." >&2
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "==> Done. The relay is live and closed to everyone except ${APP_SERVICE}."
+echo ""
+echo "    Two things left, and the first one is what actually switches this on:"
+echo ""
+echo "    1. Set the Actions variable in gamedevpl/www.gamedev.pl:"
+echo "         MP_RELAY_URL=${RELAY_URL}"
+echo "       then re-run the deploy workflow. The app starts forwarding room creation here,"
+echo "       stops serving the socket itself, and loses its --max-instances pin — all three"
+echo "       from that one variable, so the pin cannot come off while rooms are still local."
+echo ""
+echo "    2. Give this service its own monitoring, or it is unmonitored by construction:"
+echo "         ALERT_EMAIL=you@example.com SERVICE=${SERVICE} ./infra/setup-monitoring.sh"
+echo ""
+echo "    Then prove a party works end to end: open a lobby, join from a phone, and confirm"
+echo "    the controller moves something. A relay that health-checks green can still be"
+echo "    unreachable to guests, and no alert covers 'the QR code goes nowhere'."


### PR DESCRIPTION
The relay code has been merged and inert since the split landed. This is the deployment half: a service to run it, the env wiring, and the app's `--max-instances 1` finally coming off.

## The pin is the load-bearing part

`--max-instances 1` is not a tuning choice. A party room lives in one process's memory (`mp.ts`), so a guest load-balanced to a second container cannot see the host's room. That failure is intermittent, arrives as "the QR code doesn't work", and gets blamed on the guest's wifi. Raising the ceiling and moving the rooms have to happen together or not at all.

So the ceiling is now **derived from `MP_RELAY_URL`** in both deploy paths rather than accepted as input. Setting that one variable forwards room creation to the relay, stops the app serving the socket, and raises the cap — one act, three effects. A hand-set `MAX_INSTANCES` with no relay configured is refused out loud rather than silently honoured, because an operator who believes the service scales and finds out from a cost graph is worse off than one who got told no.

`mp-relay-deploy.test.ts` reads all three files from disk and fails CI if the coupling breaks — same discipline as `firestore-indexes.test.ts` and `erase-verification-workflow.test.ts`, because this property lives in text agreeing with text and that is exactly the kind that erodes. Someone raises a ceiling to fix a load problem, party mode breaks two weeks later, and nothing connects the two events.

## `infra/deploy-relay.sh`

Deploys the relay role from **the image the app service is already running**, so "both roles run one image" is a fact rather than an instruction someone has to remember. Also:

- mounts only `session-secret` (room tokens are HMAC'd from it) — the relay reads no games, files no submissions and terminates no sessions
- `--timeout 3600`, because Cloud Run counts an open websocket as a request and the 300s default would drop every controller after five minutes
- pins the OIDC audience to the service's own URL in a second pass, since an audience *is* the callee's URL and cannot exist before the service does. Between passes the create route is deny-all — closed, not open
- refuses to finish unless an unauthenticated room-creation call is **rejected**. A relay whose verifier fell back to deny-all and a relay that accepts anonymous creates both look healthy from outside, which is why this check runs every time
- refuses to deploy the relay role over the app service (one wrong `SERVICE=` and the site stops serving the web bundle)

## Deploy workflow

Once `MP_RELAY_URL` is set, `deploy.yml` moves the relay onto each new image **before** promoting the app: the relay is the server, the promoted web bundle is its client, so the server should already speak the protocol. Only `--image` is updated, so a deploy cannot reconfigure the relay by omission. The step fails the deploy if the configured URL and the real one disagree — that mismatch is an auth failure on every lobby, visible only to a host trying to open one.

## Security shape

The relay is `--allow-unauthenticated` because a phone that scanned a QR has no Google identity and never will. Protection is app-level: the room token verified in the socket's first frame, and an audience-pinned OIDC token from the app service on the internal create route. `PRIVATE_BETA=true` with **no allowlist** walls every other route the shared image happens to register — no maintenance, because the relay's whole job lives in the two paths the wall exempts.

## Production is unchanged by merging this

`MP_RELAY_URL` is unset, so the ceiling stays 1, rooms stay in-process, and the new workflow step is skipped. Nothing changes until the owner runs the script.

## Owner-run remainder

1. `PROJECT_ID=gamedevpl ./infra/deploy-relay.sh`
2. set the `MP_RELAY_URL` Actions variable to the URL it prints, re-run the deploy workflow
3. `ALERT_EMAIL=… SERVICE=gamedev-mp-relay ./infra/setup-monitoring.sh` — a service with no uptime check is unmonitored by construction
4. open a lobby, join from a phone, confirm the controller moves something. Nothing above proves that; a relay can health-check green while the QR code goes nowhere

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWTR7Zp7siY2NB5iEpcedT)_