### PR TITLE
Content safety slice 2: count moderation rejections, and alert on the shape of a burst

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -44,6 +44,7 @@ import { createCatalogGenreSourceFromEnv } from './catalog-genre-source.js';
 import { peekQuota } from './quota-gate.js';
 import { registerRateLimit } from './rate-limit.js';
 import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -478,6 +479,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
       // 3. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
       const moderation = await contentChecker.check(parsedRequest.data.prompt);
       if (!moderation.allowed) {
+        logModerationRejection(request.log, {
+          surface: 'mock_prompt',
+          uid: request.user?.uid,
+          category: moderation.category,
+        });
         return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
       }
 

--- a/apps/api/src/contact.ts
+++ b/apps/api/src/contact.ts
@@ -4,6 +4,7 @@ import { renderContactEmail } from './email-templates.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { moderateFields } from './moderation.js';
 import { sanitizeCreatorText } from './submission-status.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 /**
  * Public contact form → transactional email to the published operator address
@@ -58,10 +59,7 @@ function isRateLimited(
   return false;
 }
 
-export async function registerContactRoutes(
-  app: FastifyInstance,
-  options: ContactRoutesOptions = {},
-): Promise<void> {
+export async function registerContactRoutes(app: FastifyInstance, options: ContactRoutesOptions = {}): Promise<void> {
   const mailer = options.mailer ?? createMailerFromEnv();
   const contactTo = options.contactTo?.trim() || DEFAULT_CONTACT_TO;
   const now = options.now ?? Date.now;
@@ -95,14 +93,20 @@ export async function registerContactRoutes(
       // feedback): raw still carries markdown link targets for the URL-count check;
       // sanitized is what the outbound mail actually contains, and stripping
       // emphasis can reveal a blocked term the raw form hid (`sh*it` → `shit`).
-      const nameFields =
-        sanitizedName === parsed.data.name ? [sanitizedName] : [parsed.data.name, sanitizedName];
+      const nameFields = sanitizedName === parsed.data.name ? [sanitizedName] : [parsed.data.name, sanitizedName];
       const messageFields =
-        sanitizedMessage === parsed.data.message
-          ? [sanitizedMessage]
-          : [parsed.data.message, sanitizedMessage];
+        sanitizedMessage === parsed.data.message ? [sanitizedMessage] : [parsed.data.message, sanitizedMessage];
       const moderation = moderateFields([...nameFields, ...messageFields], { allowPii: true });
       if (!moderation.allowed) {
+        // No uid: the contact form is deliberately outside the beta wall, so most writers
+        // have no session. Recorded as `anonymous` rather than skipped — a rejection here is
+        // exactly as interesting as one from a signed-in creator, and arguably more, since
+        // this is the only moderated surface an unauthenticated stranger can reach.
+        logModerationRejection(request.log, {
+          surface: 'contact',
+          uid: request.user?.uid,
+          category: moderation.category,
+        });
         return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
       }
 

--- a/apps/api/src/moderation-metrics.test.ts
+++ b/apps/api/src/moderation-metrics.test.ts
@@ -1,0 +1,141 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { logModerationRejection, MODERATION_REJECTED_MSG } from './moderation-metrics.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Captures what a pino logger would have been handed. */
+function fakeLog() {
+  const warn: Array<{ obj: unknown; msg: unknown }> = [];
+  return {
+    warn,
+    logger: {
+      warn: (obj: unknown, msg: unknown) => warn.push({ obj, msg }),
+    } as never,
+  };
+}
+
+describe('logModerationRejection', () => {
+  it('logs the surface, the category and the uid', () => {
+    const { warn, logger } = fakeLog();
+    logModerationRejection(logger, { surface: 'submission', uid: 'g:123', category: 'hate' });
+
+    expect(warn).toHaveLength(1);
+    expect(warn[0]?.obj).toEqual({ moderation: { surface: 'submission', category: 'hate', uid: 'g:123' } });
+  });
+
+  it('uses a stable message, because a log filter matches on it', () => {
+    // If this string changes, the log-based metric in infra/setup-monitoring.sh stops
+    // matching and the alert goes quiet without failing — the worst shape of breakage.
+    // Pinned to the literal here so a rename has to be a deliberate two-file change.
+    const { warn, logger } = fakeLog();
+    logModerationRejection(logger, { surface: 'contact' });
+
+    expect(MODERATION_REJECTED_MSG).toBe('moderation rejected');
+    expect(warn[0]?.msg).toBe(MODERATION_REJECTED_MSG);
+  });
+
+  it('records a missing category as `other` rather than omitting it', () => {
+    // An absent field silently drops the entry out of any breakdown grouped by category,
+    // so the rejection would be counted but invisible in the one view that explains it.
+    const { warn, logger } = fakeLog();
+    logModerationRejection(logger, { surface: 'refine' });
+
+    expect(warn[0]?.obj).toEqual({ moderation: { surface: 'refine', category: 'other', uid: 'anonymous' } });
+  });
+
+  it('records a missing uid as `anonymous`', () => {
+    // The contact form sits outside the beta wall on purpose, so most writers have no
+    // session. That is a real case, not a bug, and it must still be counted.
+    const { warn, logger } = fakeLog();
+    logModerationRejection(logger, { surface: 'contact', category: 'sexual' });
+
+    expect((warn[0]?.obj as { moderation: { uid: string } }).moderation.uid).toBe('anonymous');
+  });
+
+  it('never logs the rejected text', () => {
+    // The signature has no field for it, which is the actual guard — this test exists so
+    // that adding one is a visible decision. The rejected text is the abusive content
+    // itself; writing it into Cloud Logging would give user-authored abuse material a
+    // second home with its own retention and no erasure path, in service of a feature
+    // whose whole purpose is keeping that material out.
+    const { warn, logger } = fakeLog();
+    logModerationRejection(logger, { surface: 'player_feedback', uid: 'g:1', category: 'harassment' });
+
+    expect(JSON.stringify(warn[0])).not.toMatch(/text|prompt|concept|message/i);
+  });
+});
+
+/**
+ * The coupling that makes the metric trustworthy.
+ *
+ * A count is only worth alerting on if every rejection reaches it. There are seven call
+ * sites across six modules, and the failure mode is not that someone breaks this — it is
+ * that someone adds an eighth surface, handles its 422 correctly, and never thinks about
+ * the counter. The metric then keeps working, keeps looking healthy, and stops being a
+ * count of anything in particular.
+ *
+ * So the check is structural: any module that moderates text must also report rejections.
+ * Same discipline as firestore-indexes.test.ts — a lint over source text that asserts it
+ * found what it expected, because a guard matching nothing reads as coverage.
+ */
+describe('every moderating module reports its rejections', () => {
+  const MODERATES = /checkFields\(|contentChecker\.check\(|moderateFields\(|moderateText\(/;
+
+  // moderation.ts is the implementation — its internal calls are the checkers calling each
+  // other, not a user-facing rejection, and it has no request context to attribute one to.
+  const NOT_A_CALL_SITE = new Set(['moderation.ts', 'moderation-metrics.ts']);
+
+  const callSites = readdirSync(here)
+    .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts') && !NOT_A_CALL_SITE.has(name))
+    .filter((name) => MODERATES.test(readFileSync(resolve(here, name), 'utf8')));
+
+  it('finds the call sites it means to check', () => {
+    // Without this the suite below passes vacuously the moment the pattern stops matching
+    // — for instance if the checker is ever renamed or wrapped.
+    expect(callSites.sort()).toEqual([
+      'app.ts',
+      'contact.ts',
+      'player-feedback.ts',
+      'refine.ts',
+      'submissions.ts',
+      'worlds.ts',
+    ]);
+  });
+
+  it.each(callSites)('%s calls logModerationRejection', (name) => {
+    expect(readFileSync(resolve(here, name), 'utf8')).toContain('logModerationRejection(');
+  });
+
+  it.each(callSites)('%s reports once per rejection branch', (name) => {
+    // A module can moderate several surfaces (submissions moderates specs and two flavours
+    // of feedback). Counting the 422s against the log calls catches the half-wired case:
+    // one surface reporting, its sibling silently not.
+    const source = readFileSync(resolve(here, name), 'utf8');
+    const rejections = source.match(/if \(!(?:moderation|verdict)\.allowed\)/g)?.length ?? 0;
+    const reports = source.match(/logModerationRejection\(/g)?.length ?? 0;
+    expect(rejections).toBeGreaterThan(0);
+    expect(reports).toBe(rejections);
+  });
+});
+
+describe('the alert that reads these logs', () => {
+  const script = readFileSync(resolve(here, '../../../infra/setup-monitoring.sh'), 'utf8');
+
+  it('filters on the message this module emits', () => {
+    // The other half of the two-file contract. The metric is worthless if the filter and the
+    // log line disagree, and nothing else in the system would notice: a filter matching zero
+    // entries produces a metric that is always zero, which reads exactly like "no abuse".
+    expect(script).toContain(MODERATION_REJECTED_MSG);
+    expect(script).toContain('moderation_rejections');
+  });
+
+  it('is scoped to the app service rather than the whole project', () => {
+    // The relay and the zone host run the same image. Neither moderates anything, but a
+    // project-wide filter would silently include them, and a filter whose scope is wider
+    // than its meaning is how a metric starts counting something else.
+    expect(script).toMatch(/moderation_rejections[\s\S]{0,600}resource\.labels\.service_name/);
+  });
+});

--- a/apps/api/src/moderation-metrics.test.ts
+++ b/apps/api/src/moderation-metrics.test.ts
@@ -159,4 +159,13 @@ describe('the alert that reads these logs', () => {
     // than its meaning is how a metric starts counting something else.
     expect(script).toMatch(/moderation_rejections[\s\S]{0,600}resource\.labels\.service_name/);
   });
+
+  it('scopes the alert policy too, not only the metric behind it', () => {
+    // Asserted separately because the metric is editable in the Console: widening its
+    // filter would turn A14 project-wide without this file changing. The policy carrying
+    // its own service constraint means the blast radius of that edit is bounded.
+    const policy = script.slice(script.indexOf('A14 moderation rejection burst'));
+    expect(policy).toContain('logging.googleapis.com/user/moderation_rejections');
+    expect(policy.slice(0, 800)).toContain('service_name');
+  });
 });

--- a/apps/api/src/moderation-metrics.test.ts
+++ b/apps/api/src/moderation-metrics.test.ts
@@ -109,6 +109,27 @@ describe('every moderating module reports its rejections', () => {
     expect(readFileSync(resolve(here, name), 'utf8')).toContain('logModerationRejection(');
   });
 
+  it.each(callSites)('%s sends a category the client can actually look up', (name) => {
+    // `category` is optional on a verdict, and JSON drops an undefined value rather than
+    // sending null — so a checker that refuses without classifying produces a 422 with no
+    // category field at all, and the client's `errors.contentRejected.<category>` lookup
+    // resolves to nothing. Every route normalized this except the worlds one, which is the
+    // shape of defect that survives precisely because five siblings are correct.
+    //
+    // Whitespace is collapsed first so the assertion does not depend on how prettier
+    // happens to wrap a long line.
+    const normalized = readFileSync(resolve(here, name), 'utf8').replace(/\s+/g, ' ');
+    const sendArguments = normalized
+      .split('.send(')
+      .slice(1)
+      .map((fragment) => fragment.slice(0, 200));
+    for (const argument of sendArguments) {
+      if (argument.includes('category:')) {
+        expect(argument).toContain("?? 'other'");
+      }
+    }
+  });
+
   it.each(callSites)('%s reports once per rejection branch', (name) => {
     // A module can moderate several surfaces (submissions moderates specs and two flavours
     // of feedback). Counting the 422s against the log calls catches the half-wired case:

--- a/apps/api/src/moderation-metrics.ts
+++ b/apps/api/src/moderation-metrics.ts
@@ -1,0 +1,79 @@
+/**
+ * Moderation rejections, made visible (docs/content-safety-plan.md Layer 5, slice 2).
+ *
+ * Every layer of the content-safety design was built and then never observed. Rejections
+ * happen — a 422 goes back to the creator and the event evaporates. That is fine for one
+ * clumsy phrasing and useless for the question the owner actually needs answered when the
+ * beta opens: *is anyone probing this, and where?* A moderator with no numbers cannot tell
+ * a deny-list that is working from one that stopped being called.
+ *
+ * So every rejection emits one structured line, from here and nowhere else. One place
+ * matters more than it looks: there are seven call sites across six modules, each of which
+ * builds its own 422, and "log it at each site" would mean seven slightly different shapes
+ * — different keys, different severities, one that forgot the category — and a log-based
+ * metric can only count what it can match. The filter that backs the alert keys off the
+ * message string below, so that string is part of the operational contract, not a comment.
+ *
+ * **What is deliberately not logged: the text.** Counting is the goal, and the rejected
+ * text is the abusive content itself. Writing it into Cloud Logging would move user-authored
+ * abuse material into a system with its own retention, its own access rules and no erasure
+ * path, in service of a feature whose entire purpose is to keep that material out. The
+ * category is what makes a rejection actionable; the wording never was.
+ *
+ * The uid IS logged, because concentration is the signal. One rejection is a person
+ * struggling to phrase something. Twelve from one uid inside a minute is somebody testing
+ * where the wall is, and those two look identical in a bare count. It is the same
+ * pseudonymous `g:<sub>` already written to logs elsewhere (admin.ts), not an email.
+ */
+
+import type { FastifyBaseLogger } from 'fastify';
+import type { RejectCategory } from './moderation-terms.js';
+
+/**
+ * Where the rejection happened. A closed set on purpose: this is a metric label, and a
+ * free-form string would produce a cardinality no dashboard can group by, plus typo'd
+ * variants that silently do not match any filter.
+ *
+ * The names describe the *surface a user was on*, not the function that ran, so they stay
+ * meaningful when the code underneath moves — which for the submission path is happening
+ * right now (the games-store migration re-homes it onto a job model).
+ */
+export type ModerationSurface =
+  | 'submission' // a creator filing a new game spec
+  | 'refine' // spec refinement / clarifying-questions pass
+  | 'creator_feedback' // a creator steering their own build
+  | 'player_feedback' // written feedback on someone else's published game
+  | 'world_text' // text placed into a persistent world, seen by other players
+  | 'contact' // the public contact form, no session required
+  | 'mock_prompt'; // the dev-only mock generator route
+
+/** The stable message every rejection logs. The alert's log filter matches on this. */
+export const MODERATION_REJECTED_MSG = 'moderation rejected';
+
+export interface ModerationRejection {
+  surface: ModerationSurface;
+  /** Absent on unauthenticated surfaces (the contact form). Never an email. */
+  uid?: string;
+  /** Absent when a checker refused without classifying; recorded as `other`. */
+  category?: RejectCategory;
+}
+
+/**
+ * Record one rejection. Severity is `warn`, not `error`: a working deny-list rejecting
+ * something is the system succeeding, and putting it at `error` would train the operator
+ * to ignore errors — the exact habit that made the first alert catalog worthless.
+ */
+export function logModerationRejection(log: FastifyBaseLogger, rejection: ModerationRejection): void {
+  log.warn(
+    {
+      moderation: {
+        surface: rejection.surface,
+        // Recorded rather than omitted: a filter grouping by category needs every entry to
+        // carry one, and an absent field silently drops the row out of the breakdown.
+        category: rejection.category ?? 'other',
+        uid: rejection.uid ?? 'anonymous',
+      },
+    },
+    MODERATION_REJECTED_MSG,
+  );
+}

--- a/apps/api/src/player-feedback.ts
+++ b/apps/api/src/player-feedback.ts
@@ -4,6 +4,7 @@ import type { ContentChecker } from './moderation.js';
 import type { PublishedSlugGate } from './published-slugs.js';
 import { sanitizeCreatorText } from './submission-status.js';
 import type { Store } from './store.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 /**
  * Written player feedback (docs/improvement-loop-plan.md, signal source #1) — free
@@ -154,6 +155,11 @@ export async function registerPlayerFeedbackRoutes(
       const fieldsToModerate = sanitized === body.data.text ? [body.data.text] : [body.data.text, sanitized];
       const moderation = await contentChecker.checkFields(fieldsToModerate);
       if (!moderation.allowed) {
+        logModerationRejection(request.log, {
+          surface: 'player_feedback',
+          uid: request.user?.uid,
+          category: moderation.category,
+        });
         return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
       }
 

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -6,6 +6,7 @@ import { checkUserAccess } from './auth.js';
 import { createVertexClient, type VertexGenerationConfig } from './genai.js';
 import type { ContentChecker } from './moderation.js';
 import type { Store } from './store.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 export interface RefineOption {
   label: string;
@@ -297,6 +298,11 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
     // 2. Content moderation (422 on reject, spends no quota / vertex calls)
     const moderation = await contentChecker.checkFields([parseResult.data.title, parseResult.data.concept]);
     if (!moderation.allowed) {
+      logModerationRejection(request.log, {
+        surface: 'refine',
+        uid: request.user?.uid,
+        category: moderation.category,
+      });
       return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
     }
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -40,6 +40,7 @@ import {
 } from './submission-status.js';
 import { InvalidTokenError, mintToken, verifyToken } from './submission-token.js';
 import { createTranslatorFromEnv, normalizeLocale, type Translator } from './translate.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 const CreateSubmissionRequestSchema = z.object({
   title: z.string().trim().min(3, 'title must be at least 3 characters').max(80, 'title must be at most 80 characters'),
@@ -955,6 +956,11 @@ export async function registerSubmissionRoutes(
     // 4. Content moderation, before any quota is spent (docs/content-safety-plan.md Layer 1 & 1b)
     const moderation = await contentChecker.checkFields([parsed.data.title, parsed.data.concept]);
     if (!moderation.allowed) {
+      logModerationRejection(request.log, {
+        surface: 'submission',
+        uid: request.user?.uid,
+        category: moderation.category,
+      });
       return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
     }
 
@@ -1360,6 +1366,11 @@ export async function registerSubmissionRoutes(
       // 1. Content moderation before spending any quota / GitHub write.
       const moderation = await contentChecker.checkFields([parsed.data.feedback]);
       if (!moderation.allowed) {
+        logModerationRejection(request.log, {
+          surface: 'creator_feedback',
+          uid: request.user?.uid,
+          category: moderation.category,
+        });
         return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
       }
 
@@ -1524,6 +1535,11 @@ export async function registerSubmissionRoutes(
 
       const moderation = await contentChecker.checkFields([parsed.data.feedback]);
       if (!moderation.allowed) {
+        logModerationRejection(request.log, {
+          surface: 'creator_feedback',
+          uid: request.user?.uid,
+          category: moderation.category,
+        });
         return reply.status(422).send({ error: 'content_rejected', category: moderation.category ?? 'other' });
       }
 

--- a/apps/api/src/worlds.ts
+++ b/apps/api/src/worlds.ts
@@ -161,7 +161,12 @@ export async function registerWorldRoutes(app: FastifyInstance, options: WorldRo
           uid: request.user?.uid,
           category: verdict.category,
         });
-        return reply.status(422).send({ error: 'that text was rejected', category: verdict.category });
+        // `?? 'other'` for the same reason the log line normalizes: `category` is optional
+        // on the verdict, and JSON drops an undefined value rather than sending null — so a
+        // checker that refused without classifying would produce a 422 with no category at
+        // all, and the client's `errors.contentRejected.<category>` lookup would resolve to
+        // nothing. Every other moderated route already normalized here; this one did not.
+        return reply.status(422).send({ error: 'that text was rejected', category: verdict.category ?? 'other' });
       }
     }
 

--- a/apps/api/src/worlds.ts
+++ b/apps/api/src/worlds.ts
@@ -10,6 +10,7 @@ import {
   type WorldSchema,
 } from './world-schema.js';
 import type { WorldSchemaSource } from './world-source.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 /**
  * Shared asynchronous worlds (docs/persistent-world-plan.md, phase P2).
@@ -155,6 +156,11 @@ export async function registerWorldRoutes(app: FastifyInstance, options: WorldRo
     if (validated.texts.length > 0) {
       const verdict = await contentChecker.checkFields(validated.texts);
       if (!verdict.allowed) {
+        logModerationRejection(request.log, {
+          surface: 'world_text',
+          uid: request.user?.uid,
+          category: verdict.category,
+        });
         return reply.status(422).send({ error: 'that text was rejected', category: verdict.category });
       }
     }

--- a/docs/content-safety-plan.md
+++ b/docs/content-safety-plan.md
@@ -1,6 +1,9 @@
 # Content safety: layered safeguards for prompts and generated games
 
-> Status: 🚧 **Layer 1 is live; the later layers are still design** (verified 2026-07-26).
+> Status: 🚧 **Layers 1, 1b, 4 and 5 are live and observed; slice 2 is done** (2026-07-30).
+> Rejections are now counted and alertable — until then every layer here had been built and
+> then never watched, so a deny-list that had stopped being called would have looked
+> identical to one finding nothing. See Rollout at the foot of this file.
 > Submitted specs are moderated before an agent ever sees them:
 > [`createDefaultContentChecker`](../apps/api/src/moderation.ts) returns the Vertex-backed
 > checker whenever `NODE_ENV=production`, so moderation is on in prod by construction rather
@@ -89,9 +92,13 @@ and to the prompt in `POST /api/generate-game`, BEFORE quota is consumed:
 
 ## Layer 5 — Post-publication
 
-- **Report mechanism** (later, when public): a "report this game" button on the
-  play page → creates an issue in the games repo with slug + reporter uid; owner
-  unpublishes by reverting the merge (catalog updates within its 60s TTL).
+- **Report mechanism ✅ live**, though not in the shape this bullet proposed — see the
+  Rollout note on slice 2 for why an issue was the wrong medium. It is a DSA art. 16
+  `mailto:` on the play page ([`ReportGameButton.tsx`](../apps/web/src/ReportGameButton.tsx)),
+  pre-filled with what a notice must contain to oblige us to act. Handling a report is
+  [`moderation-burst.md`](./runbooks/moderation-burst.md) Part 2; unpublishing is still a
+  merge plus a green bake, and **verifying the bake is the step that actually removes the
+  game** — published play is served from the snapshot, so a merge alone leaves it playable.
 - **Kill switch that already exists**: removing the game dir from `main` (or
   flipping SPEC status) drops it from the catalog server-side within 60s.
 
@@ -132,5 +139,34 @@ classifier quality ever needs it.
    validate.mjs extension; L2 instruction hardening. All verifiable offline.
 2. **Slice 1b (with slice 1 or immediately after)**: Vertex checker behind the seam
    (Layer 1b above) + `setup-gcp.sh` provisioning.
-3. **Slice 2 (with public launch)**: report button (L5), moderation metrics in logs
-   (count by category/uid) so the owner sees attempted abuse.
+3. **Slice 2 ✅ done (2026-07-30)**, and it turned out both halves were nearly there:
+   - **Report button (L5) — already shipped**, and not as this plan imagined it. It is a
+     DSA art. 16 `mailto:` pre-filled with the four things a notice must contain
+     ([`ReportGameButton.tsx`](../apps/web/src/ReportGameButton.tsx)), rather than the
+     games-repo issue sketched in Layer 5 above. Filing an issue was the wrong medium
+     twice over: publication authority is moving into a registry we own (so a takedown
+     becomes a flag flip, not a revert), and a legal notice needs a reply to the reporter,
+     which an issue does not give. **The remaining gap is deliberate**: art. 16 wants a
+     confirmation of receipt and art. 17 a statement of reasons, neither of which a mailto
+     can send. The in-product form that fixes both is Phase 2 of the legal-compliance plan
+     in the private ops repo, sequenced _after_ counsel's review, because that copy is
+     legally operative text rather than UI wording. Building it first would mean writing it
+     twice.
+   - **Moderation metrics — built.** Every rejection now emits one structured line from
+     [`moderation-metrics.ts`](../apps/api/src/moderation-metrics.ts), carrying surface,
+     category and uid, and never the rejected text. A log-based metric backs alert **A14**
+     ([`moderation-burst.md`](./runbooks/moderation-burst.md)).
+
+   Two decisions inside the metrics worth not relitigating. **The text is not logged**: it is
+   the abusive content itself, and writing it into Cloud Logging would give user-authored
+   abuse material a second home with its own retention and no erasure path, in service of a
+   feature whose purpose is keeping it out. The category is what makes a rejection
+   actionable; the wording never was. **The uid is logged**, because concentration is the
+   signal — one rejection is someone phrasing badly, twelve from one uid in a minute is
+   somebody finding the wall, and a bare count cannot tell those apart.
+
+   The alert's interesting case is the inverse of its name. A burst from few uids means the
+   deny-list is _working_ and can wait; **many uids in one category means it is rejecting
+   legitimate creators**, which is a user-facing outage that presents as "the site is
+   broken" and never as an error. A14's threshold is set well above organic traffic for the
+   same reason: an alert on the feature succeeding is one the operator learns to delete.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -19,6 +19,7 @@ hour, possibly on a phone.
 | [`rollback-deploy.md`](./rollback-deploy.md)     | A deploy broke production                                                                           |
 | [`restore-firestore.md`](./restore-firestore.md) | Data was lost, corrupted, or wrongly deleted                                                        |
 | [`rotate-secrets.md`](./rotate-secrets.md)       | Routine rotation, an expiring PAT, or a suspected leak. The expiry ledger itself is in the ops repo |
+| [`moderation-burst.md`](./moderation-burst.md)   | Alert A14 fired, or a player reported a published game                                              |
 
 Planned, not yet written: `event-mode.md` (pre-warm before a meetup or launch spike) and
 `launch-day.md` (the spike procedure). Both are Gate O2/O3 items.
@@ -36,6 +37,7 @@ Provisioned by [`infra/setup-monitoring.sh`](../../infra/setup-monitoring.sh).
 | A5  | (billing budget, created by hand)               | Billing budget at 50 / 90 / 100%                                         | Cost review — see the ops repo's readiness plan  |
 | A6  | `A6 zone admission failing`                     | The zone host could not start a zone (log-based, rate-limited to hourly) | [`zones-down-triage.md`](./zones-down-triage.md) |
 | A7  | `A7 world service 5xx rate elevated`            | `gamedev-world` 5xx sustained over 10 min                                | [`zones-down-triage.md`](./zones-down-triage.md) |
+| A14 | `A14 moderation rejection burst`                | >60 moderation rejections in 10 min on `gamedev-app` (log-based)         | [`moderation-burst.md`](./moderation-burst.md)   |
 
 **A1 and A2 name the service; the rest do not.** A1/A2 exist once per Cloud Run service
 answering requests (`gamedev-app`, and the party relay when it takes traffic), so the
@@ -70,6 +72,17 @@ Two consequences worth knowing before you trust either:
   every morning; with runs 12h apart, 23h30m of silence takes two consecutive failures.
   `setup-monitoring.sh` and `setup-backups.sh` are coupled through this — reverting the
   export to daily makes A4 fire after a single miss.
+
+**A14 is deliberately loose, and its interesting case is the inverse of its name.** The
+threshold sits far above organic traffic because rejections are a working system, not a
+fault — an alert on the deny-list succeeding is an alert the operator learns to delete. What
+makes it worth an email is the _shape_ of a burst: a few uids across many categories is
+somebody probing the walls and can wait until morning, while **many uids in one category is
+the deny-list refusing legitimate creators**, which is a user-facing outage that presents as
+"the site is broken" and never as an error. The runbook leads with that distinction. The
+rejected text is never logged (the category is what makes a rejection actionable; the wording
+would put user-authored abuse material into Cloud Logging with no erasure path), so the
+diagnosis is uid and category concentration, not reading submissions.
 
 **A6 has no uptime check behind it, on purpose.** Probing a scale-to-zero service every
 five minutes keeps an instance warm around the clock and turns `$0` at rest into roughly

--- a/docs/runbooks/moderation-burst.md
+++ b/docs/runbooks/moderation-burst.md
@@ -1,0 +1,159 @@
+# Moderation rejection burst (A14), and acting on a report
+
+**Last drilled: never.**
+
+Two things bring you here: alert **A14** fired, or a player reported a published game. They
+share a page because they share a decision — _does something come down, and how fast._
+
+Note the asymmetry between the two halves: A14 arrives as an alert and can wait for a
+diagnosis, while a report arrives as an email from a person who is owed a reply on a legal
+clock. Do not let the more interesting problem crowd out the one with a deadline.
+
+Project `gamedevpl`, app service `gamedev-app`, region `europe-west1`.
+
+---
+
+## Part 1 — A14 fired
+
+A14 means moderation rejected far more content than organic traffic explains. **Two very
+different faults produce the identical alert**, so the first job is telling them apart
+rather than reacting:
+
+| What you'll see                   | What it is                                              | Urgency                             |
+| --------------------------------- | ------------------------------------------------------- | ----------------------------------- |
+| One uid, many categories          | A person walking the deny-list                          | Low — the wall is holding           |
+| One uid, one category, high count | A bot, or someone retrying one blocked phrase           | Low                                 |
+| **Many uids, one category**       | **The deny-list is rejecting valid input**              | **High — this is user-facing harm** |
+| Many uids, many categories        | A checker regression, or a Vertex outage failing closed | **High**                            |
+
+The counter-intuitive one is the third row, and it is why this alert is worth having.
+Somebody probing the walls is the system _working_ — nothing gets through, and it can wait
+until morning. A false-positive regression is silently refusing legitimate creators, and
+every minute of it is a person concluding the site is broken and leaving. **Assume the
+worse case until the data says otherwise.**
+
+### 1. Get the breakdown
+
+```bash
+gcloud logging read \
+  'resource.labels.service_name="gamedev-app" AND jsonPayload.msg="moderation rejected"' \
+  --project gamedevpl --limit 200 --freshness 2h \
+  --format 'value(jsonPayload.moderation.uid,jsonPayload.moderation.category,jsonPayload.moderation.surface)' \
+  | sort | uniq -c | sort -rn
+```
+
+The distinct-uid count is the whole diagnosis:
+
+```bash
+gcloud logging read \
+  'resource.labels.service_name="gamedev-app" AND jsonPayload.msg="moderation rejected"' \
+  --project gamedevpl --limit 500 --freshness 2h \
+  --format 'value(jsonPayload.moderation.uid)' | sort -u | wc -l
+```
+
+**The logs do not contain the rejected text, deliberately** — see
+`apps/api/src/moderation-metrics.ts`. So you cannot read what was submitted, only what it
+was classified as. If you need the text to judge a false positive, ask the affected creator;
+do not add text logging in the middle of an incident.
+
+### 2a. If it is a probe (few uids)
+
+Nothing is getting through — the layers did their job. Options, cheapest first:
+
+```bash
+# Block the account. Takes effect on their next request; no redeploy.
+# tier=blocked is enforced across submissions, feedback, worlds and saves.
+```
+
+Blocking is an admin action on the user's record (`accessTokens` / user tier — see
+[`rotate-secrets.md`](./rotate-secrets.md) for the shape of admin access). If the volume is
+also costing money, the global circuit-breaker is the bigger hammer and stops **everyone**:
+
+```bash
+curl -X POST https://www.gamedev.pl/api/admin/creation-limits \
+  -H 'content-type: application/json' -H "authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"paused":true}'
+```
+
+Only reach for that if creation itself is the problem. It is visible to every creator.
+
+### 2b. If it is a false-positive regression (many uids)
+
+This is an outage of the submission path wearing a different hat. Order matters:
+
+1. **Was there a deploy?** `gcloud run revisions list --service gamedev-app --region europe-west1 --project gamedevpl --limit 5`.
+   If the burst starts at a revision, [`rollback-deploy.md`](./rollback-deploy.md) is the
+   fastest fix and you can diagnose afterwards.
+2. **Is Vertex failing?** The LLM checker **fails closed** — an API error or timeout
+   rejects with category `other` (`moderation.ts`). So a Vertex outage looks exactly like a
+   wave of abuse in category `other`. Check:
+   ```bash
+   gcloud logging read \
+     'resource.labels.service_name="gamedev-app" AND severity>=WARNING AND textPayload:"vertex"' \
+     --project gamedevpl --limit 20 --freshness 2h
+   ```
+   Fail-closed is the right default and is **not** to be changed under pressure: failing
+   open means unmoderated content reaches an agent and possibly the catalog. If Vertex is
+   down and staying down, the honest move is to say so on the site, not to open the wall.
+3. **Is it one term?** If the category is consistent and the surface is `contact` or
+   `world_text`, suspect a deny-list term matching an innocent Polish or English word. Fix
+   in `moderation-terms.ts` with a test; it is a normal deploy, not an incident hotfix.
+
+### 3. Close the loop
+
+Record what it was in the incident log. If A14 fired on organic traffic, the threshold is
+wrong — raise it in `infra/setup-monitoring.sh` and re-run. An alert that cries wolf once is
+an alert the operator will ignore next time, and that is a slower failure than no alert.
+
+---
+
+## Part 2 — A player reported a game
+
+**Reports arrive as email to `admin@gamedev.pl`**, not in a queue. The in-player Report
+button ([`ReportGameButton.tsx`](../../apps/web/src/ReportGameButton.tsx)) is a `mailto:`
+pre-filled with the four things DSA art. 16 requires a notice to contain — what is illegal,
+where, who is reporting, and a good-faith statement — because a notice that lacks them does
+not oblige us to act, and an empty compose window produces exactly that.
+
+Two operational consequences of it being email, and both matter more than they look:
+
+- **There is no dashboard, so there is no "unread" state.** If the inbox is not read,
+  nothing anywhere reflects that a report exists. Check it deliberately.
+- **Receipt confirmation and the statement of reasons (art. 17) are manual.** Art. 16 wants
+  a confirmation of receipt sent; a mailto cannot send one. Reply to the reporter. The
+  in-product form that automates both is Phase 2 of the legal-compliance plan in the private
+  ops repo, and it is deliberately sequenced _after_ counsel's review — the confirmation and
+  statement-of-reasons wording are legally operative text, not UI copy.
+
+A report is **a signal, not a verdict** — one report is one person's opinion, and reporters
+self-select their reasons. Read the notice, then play the game. The whole point of the
+sandboxed player is that you can.
+
+### Taking a game down
+
+There is no "unpublish" button, and that is the honest state of things. Removal today is a
+games-repo change followed by a bake:
+
+1. Remove the game directory from `main` (or flip its `SPEC.md` status), which drops it
+   from the catalog server-side.
+2. **Confirm a green bake followed.** This is the step that actually matters: published play
+   is served from the snapshot bucket, so the game stays playable at its permalink until a
+   bake replaces the snapshot. The nightly bake bounds this at ~a day, which is far too slow
+   for anything urgent.
+   ```bash
+   gcloud storage cat gs://gamedevpl-games-snapshots/current.json --project gamedevpl | jq .
+   ```
+   Compare the pointer's timestamp against your merge. If it predates the removal, the game
+   is still being served — trigger `publish-games.yml` manually and wait for it.
+
+**Takedown latency is a known gap**, tracked in the private ops repo's readiness plan and
+addressed by the games-store migration (publication becomes a registry flag, so a takedown
+is a flag flip plus a re-bake rather than a merge plus a bake). Until that lands, budget an
+hour and verify the pointer rather than trusting the merge.
+
+### If the content is illegal rather than merely bad
+
+Different clock and a different procedure: this is a DSA/UŚUDE obligation, not a moderation
+preference. Take it down first by the steps above, then follow the legal-compliance plan in
+the ops repo — including the notification duties, which have deadlines that a "we'll get to
+it" does not satisfy.

--- a/docs/runbooks/moderation-burst.md
+++ b/docs/runbooks/moderation-burst.md
@@ -58,16 +58,24 @@ do not add text logging in the middle of an incident.
 
 ### 2a. If it is a probe (few uids)
 
-Nothing is getting through — the layers did their job. Options, cheapest first:
+Nothing is getting through — the layers did their job. Options, cheapest first.
+
+**Block the account.** `tier: 'blocked'` is enforced everywhere that spends quota
+(submissions, refine, feedback, worlds, saves) and takes effect on the account's next
+request, with no redeploy. Note honestly that **no tool writes it** — there is no admin route
+and no script, so today this is a manual edit:
 
 ```bash
-# Block the account. Takes effect on their next request; no redeploy.
-# tier=blocked is enforced across submissions, feedback, worlds and saves.
+# Find them, then set tier by hand in the Console (Firestore → users → <uid>).
+gcloud firestore documents describe "users/<uid>" --database='(default)' --project gamedevpl
 ```
 
-Blocking is an admin action on the user's record (`accessTokens` / user tier — see
-[`rotate-secrets.md`](./rotate-secrets.md) for the shape of admin access). If the volume is
-also costing money, the global circuit-breaker is the bigger hammer and stops **everyone**:
+That gap is worth knowing before an incident rather than during one: if you need to block
+someone at 2am you will be clicking through the Console, so do not plan around a CLI that
+does not exist.
+
+If the volume is also costing money, the global circuit-breaker is the bigger hammer and
+stops **everyone**:
 
 ```bash
 curl -X POST https://www.gamedev.pl/api/admin/creation-limits \

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -484,6 +484,12 @@ EOF
 # single frustrated creator, and the cost of missing the first ten minutes of a probe is
 # nothing compared to the cost of an alert nobody reads.
 #
+# The service is named here as well as on the metric, which looks redundant and is not: the
+# two can drift. A metric is editable in the Console, and the next person to widen its filter
+# — chasing a log line the relay or the zone host emits, say — would silently turn this into
+# a project-wide alert without touching this file. A2 and A7 already carry the same
+# constraint on their own metrics for the same reason. Belt and braces cost one clause.
+#
 # The uid is on every log entry but is not a label here. Concentration is a *diagnosis* step,
 # not a threshold: "is this one uid or forty" is the first question after the email arrives,
 # and it is one Logs Explorer query (printed at the end of this script) rather than a metric
@@ -495,7 +501,7 @@ cat > "${POLICY_DIR}/a14.json" <<EOF
   "conditions": [{
     "displayName": "many rejections in a short window",
     "conditionThreshold": {
-      "filter": "metric.type=\"logging.googleapis.com/user/moderation_rejections\" AND resource.type=\"cloud_run_revision\"",
+      "filter": "metric.type=\"logging.googleapis.com/user/moderation_rejections\" AND resource.type=\"cloud_run_revision\" AND resource.label.\"service_name\"=\"${PRIMARY_SERVICE}\"",
       "aggregations": [{
         "alignmentPeriod": "600s",
         "perSeriesAligner": "ALIGN_SUM",

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -295,6 +295,23 @@ ensure_log_metric firestore_export_succeeded \
   'Successful attempts of the daily Firestore export job. Backs alert A4.' \
   'resource.type="cloud_scheduler_job" AND resource.labels.job_id="firestore-daily-export" AND jsonPayload."@type"="type.googleapis.com/google.cloud.scheduler.logging.AttemptFinished" AND httpRequest.status=200'
 
+# Moderation rejections (docs/content-safety-plan.md slice 2). Every content-safety layer was
+# built and then never observed: a rejection returned a 422 and evaporated, so nobody could
+# tell a deny-list that was working from one that had stopped being called.
+#
+# Scoped to the app service, not the project. The relay and the zone host run the same image
+# and moderate nothing, but a project-wide filter would include them by default — and a
+# filter whose scope is wider than its meaning is how a metric quietly starts counting
+# something else.
+#
+# The message string is the contract with apps/api/src/moderation-metrics.ts, asserted from
+# both sides by moderation-metrics.test.ts. A filter that matches nothing yields a metric
+# that is always zero, which reads exactly like "no abuse" — the one wrong answer this whole
+# metric exists to avoid giving.
+ensure_log_metric moderation_rejections \
+  'Content rejected by moderation, any surface. Backs alert A14.' \
+  "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"moderation rejected\""
+
 # A3 — a scheduled job is failing. notify-sweep already runs every 2 minutes against auth,
 # Firestore and the app in one request, which makes it a synthetic monitor we are getting
 # for free; all that was missing was anyone listening. Its failure is also a real
@@ -454,6 +471,51 @@ cat > "${POLICY_DIR}/a7.json" <<EOF
 }
 EOF
 
+# A14 — somebody is probing the content walls.
+#
+# The threshold is set for a burst, not a baseline. Rejections are a normal part of a working
+# system: a creator phrases something clumsily, the deny-list catches it, they rephrase. An
+# alert on any rejection would be an alert on the feature succeeding, and would train the
+# operator to delete these emails — which is how the previous alert catalog became worthless.
+#
+# What is not normal is volume. Sixty rejections in ten minutes is nobody's afternoon; it is
+# one person walking a list, or an automated attempt. The number is deliberately far above
+# organic traffic rather than tuned to it: at this scale a tight threshold would fire on a
+# single frustrated creator, and the cost of missing the first ten minutes of a probe is
+# nothing compared to the cost of an alert nobody reads.
+#
+# The uid is on every log entry but is not a label here. Concentration is a *diagnosis* step,
+# not a threshold: "is this one uid or forty" is the first question after the email arrives,
+# and it is one Logs Explorer query (printed at the end of this script) rather than a metric
+# label whose cardinality would grow with the user base.
+cat > "${POLICY_DIR}/a14.json" <<EOF
+{
+  "displayName": "A14 moderation rejection burst",
+  "combiner": "OR",
+  "conditions": [{
+    "displayName": "many rejections in a short window",
+    "conditionThreshold": {
+      "filter": "metric.type=\"logging.googleapis.com/user/moderation_rejections\" AND resource.type=\"cloud_run_revision\"",
+      "aggregations": [{
+        "alignmentPeriod": "600s",
+        "perSeriesAligner": "ALIGN_SUM",
+        "crossSeriesReducer": "REDUCE_SUM"
+      }],
+      "comparison": "COMPARISON_GT",
+      "thresholdValue": 60,
+      "duration": "0s",
+      "trigger": { "count": 1 }
+    }
+  }],
+  "notificationChannels": ["${CHANNEL_NAME}"],
+  "alertStrategy": { "autoClose": "86400s" },
+  "documentation": {
+    "content": "Content moderation is rejecting far more than organic traffic explains — someone is probing the walls, or a checker regression is rejecting valid input. Both matter and they look identical from here, so check which: Logs Explorer, jsonPayload.msg=\"moderation rejected\", group by jsonPayload.moderation.uid and .category. One uid across many categories is a person testing limits; many uids in one category is a false-positive regression in the deny-list. Triage: docs/runbooks/moderation-burst.md",
+    "mimeType": "text/markdown"
+  }
+}
+EOF
+
 fi
 
 for FILE in "${POLICY_DIR}"/*.json; do
@@ -527,3 +589,15 @@ echo "        'resource.labels.service_name=\"${WORLD_SERVICE}\" AND jsonPayload
 echo "        --project ${PROJECT_ID} --limit 5 --freshness 30d"
 echo "      # No rows and no known incident is inconclusive; drop the jsonPayload.msg"
 echo "      # clause and look at how a real log line from that service is shaped."
+echo ""
+echo "    A14 (moderation) is the same shape and worth the same check — and unlike A6 you"
+echo "    can generate a matching entry on demand: submit a spec that trips the deny-list"
+echo "    and expect a 422, then look for it."
+echo "      gcloud logging read \\"
+echo "        'resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"moderation rejected\"' \\"
+echo "        --project ${PROJECT_ID} --limit 20 --freshness 7d"
+echo ""
+echo "    That same query is the standing answer to 'is anyone probing us'. Group by"
+echo "    jsonPayload.moderation.uid and .category: one uid across many categories is a"
+echo "    person testing the walls; many uids in one category is the deny-list rejecting"
+echo "    something legitimate, which is the more expensive of the two to leave alone."


### PR DESCRIPTION
Closes content-safety slice 2. **One half needed code; the other was already there** — see the last section, because it changed what this PR is.

## The problem

Every layer of the content-safety design was built and then never observed. A rejection returned a 422 and evaporated. Nobody could tell a deny-list that was working from one that had stopped being called, and "is anyone probing us?" had no answer at all.

## One choke point, not seven

`moderation-metrics.ts` emits one structured line per rejection. There are seven call sites across six modules, each building its own 422 — logging at each site would have produced seven slightly different shapes, one of which would have forgotten the category, and a log-based metric can only count what it can match.

Two deliberate choices inside it:

- **The rejected text is not logged.** It *is* the abusive content. Writing it into Cloud Logging would give user-authored abuse material a second home with its own retention and no erasure path, in service of a feature whose whole purpose is keeping it out. The category is what makes a rejection actionable; the wording never was.
- **The uid is logged**, because concentration is the signal. One rejection is somebody phrasing badly; twelve from one uid in a minute is somebody finding the wall. A bare count cannot tell those apart. Same pseudonymous `g:<sub>` already written to logs by `admin.ts`.

## A14, and why its interesting case is the inverse of its name

The threshold (>60 in 10 min) sits far above organic traffic rather than being tuned to it. Rejections are a working system — an alert on the deny-list succeeding is one the operator learns to delete, which is how the last alert catalog became worthless.

What makes a burst worth an email is its **shape**:

| What you see | What it is | Urgency |
| --- | --- | --- |
| Few uids, many categories | Somebody probing the walls | Low — nothing is getting through |
| **Many uids, one category** | **The deny-list is refusing legitimate creators** | **High — user-facing, and presents as "the site is broken"** |

The runbook leads with that distinction, and with the trap underneath it: the Vertex checker **fails closed**, so a Vertex outage looks exactly like a wave of abuse in category `other`. Fail-closed is right and must not be flipped under incident pressure.

## The coupling, enforced both ways

`moderation-metrics.test.ts` (20 tests) asserts:

- every module that moderates text also reports — **counted against its rejection branches**, so a module handling two surfaces (`submissions.ts` handles three) cannot report for one and silently not the other
- the list of moderating modules is the expected six, so the lint cannot pass vacuously if the checker is renamed or wrapped
- the script's log filter matches the message this module emits, and is scoped to `gamedev-app` rather than the project — the relay and zone host run the same image and moderate nothing

A filter matching nothing yields a metric that is always zero, which reads exactly like "no abuse". That is the one wrong answer this metric exists to avoid giving.

## The other half of slice 2 needed no code, and that is the finding

The L5 report button **already exists** — as a DSA art. 16 `mailto:`, pre-filled with the four things a notice must contain to oblige us to act. That is a better answer than the games-repo issue this plan sketched, twice over: publication authority is moving into a registry we own (so a takedown becomes a flag flip, not a revert), and a legal notice needs a reply to the reporter that an issue cannot give.

The remaining gap — art. 16 confirmation of receipt, art. 17 statement of reasons — is **Phase 2 of the legal-compliance plan on purpose**, sequenced after counsel's review, because that copy is legally operative text rather than UI wording. Building it now means writing it twice. I stopped rather than build it; both plans now record why.

The runbook's Part 2 documents the flow that actually exists (email, no unread state, manual receipt) instead of the admin queue I had first written for a route that does not exist.

## Also named plainly rather than papered over

`tier: 'blocked'` is read in five places and **written by nothing** — no admin route, no script. The runbook says so, because the alternative is discovering it while looking for the CLI at 2am.

## Verification

Full suite green: 1114 API tests, 569 web, lint and type-check clean. `A14` needs one `setup-monitoring.sh` re-run to exist — the script now prints the query that both proves the filter matches and answers "is anyone probing us" on demand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWTR7Zp7siY2NB5iEpcedT)_