### PR TITLE
Add pull-to-refresh for the installed PWA

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,7 @@ import { ContactPage } from './ContactPage.js';
 import { NotFoundPage } from './NotFoundPage.js';
 import { AppUpdateBanner } from './AppUpdateBanner.js';
 import { InstallPrompt } from './InstallPrompt.js';
+import { PullToRefresh } from './PullToRefresh.js';
 import { SiteFooter } from './SiteFooter.js';
 import { resolveDocumentTitle } from './pageTitle.js';
 import { useDocumentTitle } from './useDocumentTitle.js';
@@ -255,7 +256,10 @@ export function App() {
     if (route.view !== 'home') return;
 
     let cancelled = false;
-    setCatalogStatus('loading');
+    // Soft refreshes (Retry, pull-to-refresh) keep the last-good grid on screen —
+    // flipping to `loading` would blank the arcade for every pull. First load and
+    // recovering from an error still show the busy mascot.
+    setCatalogStatus((prev) => (prev === 'ready' ? 'ready' : 'loading'));
 
     void fetchCatalog()
       .then((entries) => {
@@ -266,9 +270,11 @@ export function App() {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setCatalogEntries([]);
+        // Keep whatever was on screen if a soft refresh fails — a transient 502
+        // should not erase a catalog the visitor was already browsing.
+        setCatalogEntries((prev) => (prev.length > 0 ? prev : []));
         setCatalogError(err instanceof Error ? err.message : null);
-        setCatalogStatus('error');
+        setCatalogStatus((prev) => (prev === 'ready' ? 'ready' : 'error'));
       });
 
     return () => {
@@ -278,6 +284,21 @@ export function App() {
 
   const handleRetryCatalog = useCallback(() => {
     setCatalogReloadKey((n) => n + 1);
+  }, []);
+
+  // Soft-refresh the home surfaces the installed PWA cannot reach with the browser's
+  // own pull-to-refresh (standalone display mode has no chrome gesture). Bumping the
+  // same keys Retry / post-play already use keeps recommendations and "My games" in
+  // sync with the catalog list.
+  const handlePullToRefresh = useCallback(async () => {
+    setCatalogReloadKey((n) => n + 1);
+    setRecommendationsRefreshKey((n) => n + 1);
+    setMyGamesRefreshKey((n) => n + 1);
+    // Give the catalog effect a beat to settle before the indicator dismisses. The
+    // fetch itself is raced by the effect; we only need the gesture to feel finished.
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 450);
+    });
   }, []);
 
   // Bring the clarifying-questions panel into view when the refiner returns some.
@@ -598,6 +619,10 @@ export function App() {
         onHome={() => navigate('/')}
         onStudio={() => navigate(studioPath())}
       />
+
+      {/* Standalone PWA has no browser pull-to-refresh; this restores it on home only,
+          and stays inert while a game covers the viewport (player-open). */}
+      <PullToRefresh enabled={route.view === 'home' && !stageContent} onRefresh={handlePullToRefresh} />
 
       <main className="content">
         {route.view === 'health' ? (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -260,6 +260,9 @@ export function App() {
     // flipping to `loading` would blank the arcade for every pull. First load and
     // recovering from an error still show the busy mascot.
     setCatalogStatus((prev) => (prev === 'ready' ? 'ready' : 'loading'));
+    // Clear a previous soft-refresh notice as soon as another attempt starts, so the
+    // banner does not linger over a grid that is already being re-fetched.
+    setCatalogError(null);
 
     void fetchCatalog()
       .then((entries) => {
@@ -271,7 +274,10 @@ export function App() {
       .catch((err: unknown) => {
         if (cancelled) return;
         // Keep whatever was on screen if a soft refresh fails — a transient 502
-        // should not erase a catalog the visitor was already browsing.
+        // should not erase a catalog the visitor was already browsing. The error
+        // still lands in `catalogError` so ArcadeCatalog can show a non-blocking
+        // refresh-failed banner above the last-good grid (full error UI only when
+        // there was nothing to keep).
         setCatalogEntries((prev) => (prev.length > 0 ? prev : []));
         setCatalogError(err instanceof Error ? err.message : null);
         setCatalogStatus((prev) => (prev === 'ready' ? 'ready' : 'error'));

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -234,3 +234,59 @@ describe('ArcadeCatalog shared-world badge', () => {
     });
   });
 });
+
+describe('ArcadeCatalog soft-refresh failure', () => {
+  beforeEach(async () => {
+    installIntersectionObserverMock();
+    sessionStorage.setItem(
+      'gdpl.catalogSortSignals',
+      JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }),
+    );
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps the grid and shows a retryable banner when ready but catalogError is set', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
+    const onRetryCatalog = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: '502 Bad Gateway',
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog,
+        }),
+      );
+      await flushEffects();
+    });
+
+    const banner = container.querySelector('.catalog-refresh-error');
+    expect(banner?.textContent).toMatch(/Could not refresh the catalog/);
+    expect(banner?.textContent).toContain('502 Bad Gateway');
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.catalog-refresh-error__retry')?.click();
+    });
+    expect(onRetryCatalog).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -326,13 +326,7 @@ function initialSignals(): { signals: CatalogSortSignals; ready: boolean } {
   return { signals: payloadToSignals(cached), ready: true };
 }
 
-function InProgressCard({
-  item,
-  onOpenStatus,
-}: {
-  item: CreatorGameItem;
-  onOpenStatus: (token: string) => void;
-}) {
+function InProgressCard({ item, onOpenStatus }: { item: CreatorGameItem; onOpenStatus: (token: string) => void }) {
   const { t, i18n } = useTranslation();
   const status = item.status;
   const isLive = status !== null && CREATOR_LIVE_STATUSES.has(status);
@@ -463,15 +457,8 @@ export function ArcadeCatalog({
   const orderedEntries = useMemo(() => {
     // Ignore a sticky your_games pref when signed out or you have nothing yours —
     // otherwise the whole catalog would look empty for no good reason.
-    const activeFilters = canFilterYourGames
-      ? filters
-      : new Set([...filters].filter((id) => id !== 'your_games'));
-    const filtered = applyCatalogFilters(
-      catalogEntries,
-      activeFilters,
-      signals.affinityLastPlayed,
-      mySlugs,
-    );
+    const activeFilters = canFilterYourGames ? filters : new Set([...filters].filter((id) => id !== 'your_games'));
+    const filtered = applyCatalogFilters(catalogEntries, activeFilters, signals.affinityLastPlayed, mySlugs);
     return orderCatalogEntries(filtered, sortMode, signals, mySlugs);
   }, [catalogEntries, sortMode, filters, signals, mySlugs, canFilterYourGames]);
 
@@ -499,10 +486,7 @@ export function ArcadeCatalog({
     });
   }
   const awaitingSignals =
-    catalogStatus === 'ready' &&
-    catalogEntries.length > 0 &&
-    catalogSortNeedsSignals(sortMode) &&
-    !signalsReady;
+    catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
 
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
@@ -584,7 +568,11 @@ export function ArcadeCatalog({
                           aria-checked={sortMode === mode}
                           onClick={() => handleSortChange(mode)}
                         >
-                          {sortMode === mode ? <PixelIcon name="check" size={12} /> : <span className="catalog-sort-check-spacer" />}
+                          {sortMode === mode ? (
+                            <PixelIcon name="check" size={12} />
+                          ) : (
+                            <span className="catalog-sort-check-spacer" />
+                          )}
                           <span className="catalog-sort-option-label">{t(`catalog.sort.${mode}`)}</span>
                         </button>
                       </li>
@@ -596,6 +584,15 @@ export function ArcadeCatalog({
           </div>
         ) : null}
       </div>
+
+      {catalogStatus === 'ready' && catalogError ? (
+        <div className="catalog-refresh-error" role="status">
+          <p className="catalog-refresh-error__text">{t('catalog.refreshError', { message: catalogError })}</p>
+          <button type="button" className="secondary-btn catalog-refresh-error__retry" onClick={onRetryCatalog}>
+            <PixelIcon name="undo" size={13} /> {t('catalog.retry')}
+          </button>
+        </div>
+      ) : null}
 
       {catalogStatus === 'loading' || awaitingSignals ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
@@ -622,9 +619,7 @@ export function ArcadeCatalog({
       ) : (
         <div className="catalog-grid">
           {onOpenStatus
-            ? inProgress.map((item) => (
-                <InProgressCard key={item.token} item={item} onOpenStatus={onOpenStatus} />
-              ))
+            ? inProgress.map((item) => <InProgressCard key={item.token} item={item} onOpenStatus={onOpenStatus} />)
             : null}
           {orderedEntries.map((entry) => (
             <CatalogCard

--- a/apps/web/src/PullToRefresh.tsx
+++ b/apps/web/src/PullToRefresh.tsx
@@ -1,0 +1,41 @@
+/**
+ * Visible half of pull-to-refresh: a slim indicator that grows under the sticky
+ * header as the visitor pulls, then spins while the home catalog soft-refreshes.
+ *
+ * The gesture itself lives in {@link usePullToRefresh}; this is only the chrome.
+ * Hidden while idle so it costs nothing on every other visit.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { usePullToRefresh } from './usePullToRefresh.js';
+
+export type PullToRefreshProps = {
+  /** When false (game open, non-home route, …) the gesture is inert. */
+  enabled: boolean;
+  onRefresh: () => void | Promise<void>;
+};
+
+export function PullToRefresh({ enabled, onRefresh }: PullToRefreshProps) {
+  const { t } = useTranslation();
+  const { status, pullDistance } = usePullToRefresh({ enabled, onRefresh });
+
+  if (status === 'idle' && pullDistance === 0) return null;
+
+  const label =
+    status === 'refreshing' ? t('pwa.pullRefreshing') : status === 'ready' ? t('pwa.pullRelease') : t('pwa.pullHint');
+
+  return (
+    <div
+      className={`pull-to-refresh${status === 'refreshing' ? ' pull-to-refresh--busy' : ''}${status === 'ready' ? ' pull-to-refresh--ready' : ''}`}
+      style={{ height: Math.max(pullDistance, status === 'refreshing' ? 48 : 0) }}
+      role="status"
+      aria-live="polite"
+      aria-busy={status === 'refreshing'}
+    >
+      <div className="pull-to-refresh__inner">
+        <span className="pull-to-refresh__spinner" aria-hidden="true" />
+        <span className="pull-to-refresh__label">{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -129,6 +129,7 @@
     "gameLoading": "Loading game…",
     "gameLoadError": "Could not load this game.",
     "retry": "Retry",
+    "refreshError": "Could not refresh the catalog. {{message}}",
     "empty": "No published games yet. Type a concept above to build the very first one!",
     "error": "Could not load the catalog. {{message}}",
     "genre": "Genre",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -614,6 +614,9 @@
     "dismiss": "Not now",
     "updateTitle": "A new version of Gamedev.pl is ready.",
     "updateAction": "Reload",
-    "updateDismiss": "Dismiss"
+    "updateDismiss": "Dismiss",
+    "pullHint": "Pull to refresh",
+    "pullRelease": "Release to refresh",
+    "pullRefreshing": "Refreshing…"
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -129,6 +129,7 @@
     "gameLoading": "Wczytywanie gry…",
     "gameLoadError": "Nie udało się wczytać tej gry.",
     "retry": "Spróbuj ponownie",
+    "refreshError": "Nie udało się odświeżyć katalogu. {{message}}",
     "empty": "Brak jeszcze opublikowanych gier. Wpisz pomysł powyżej, aby stworzyć pierwszą z nich!",
     "error": "Nie udało się wczytać katalogu. {{message}}",
     "genre": "Gatunek",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -614,6 +614,9 @@
     "dismiss": "Nie teraz",
     "updateTitle": "Nowa wersja Gamedev.pl jest gotowa.",
     "updateAction": "Odśwież",
-    "updateDismiss": "Zamknij"
+    "updateDismiss": "Zamknij",
+    "pullHint": "Pociągnij, aby odświeżyć",
+    "pullRelease": "Puść, aby odświeżyć",
+    "pullRefreshing": "Odświeżanie…"
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7061,3 +7061,67 @@ body.player-open {
    at 360px wide while the Google widget stayed at its fixed 240 — a visible mismatch in
    exactly the viewport most creators use. Google's widget does not shrink, so neither
    does this one; whatever the narrow-width behaviour is, the two share it. */
+
+/* Pull-to-refresh — restored for the installed PWA (and tabs without a native gesture).
+   Sits under the sticky header; height tracks the rubber-banded pull. Hidden while idle. */
+.pull-to-refresh {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+  pointer-events: none;
+  color: var(--muted);
+  transition: height 0.12s ease-out;
+}
+
+.pull-to-refresh--busy {
+  transition: none;
+}
+
+.pull-to-refresh__inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px 12px;
+}
+
+.pull-to-refresh__spinner {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.25);
+  border-top-color: var(--turquoise);
+  transform: rotate(0deg);
+  transition: transform 0.12s linear;
+}
+
+.pull-to-refresh--ready .pull-to-refresh__spinner,
+.pull-to-refresh--busy .pull-to-refresh__spinner {
+  border-top-color: var(--turquoise);
+}
+
+.pull-to-refresh--busy .pull-to-refresh__spinner {
+  animation: pull-to-refresh-spin 0.75s linear infinite;
+}
+
+.pull-to-refresh__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+@keyframes pull-to-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pull-to-refresh {
+    transition: none;
+  }
+
+  .pull-to-refresh--busy .pull-to-refresh__spinner {
+    animation: none;
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2205,6 +2205,31 @@ body.player-open {
   max-width: 36rem;
 }
 
+/* Soft-refresh failure: last-good grid stays; this sits above it with Retry. */
+.catalog-refresh-error {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 16px;
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  border-radius: 10px;
+  background: rgba(255, 107, 107, 0.08);
+}
+
+.catalog-refresh-error__text {
+  margin: 0;
+  flex: 1 1 12rem;
+  color: var(--error);
+  font-size: 0.92rem;
+}
+
+.catalog-refresh-error__retry {
+  flex: none;
+}
+
 .game-viewport-container .load-error {
   min-height: 100%;
 }

--- a/apps/web/src/usePullToRefresh.test.ts
+++ b/apps/web/src/usePullToRefresh.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dampPull, usePullToRefresh, type PullToRefreshStatus } from './usePullToRefresh.js';
+
+function Probe({
+  onChange,
+  enabled,
+  onRefresh,
+  thresholdPx,
+  wheelThresholdPx,
+}: {
+  onChange: (state: { status: PullToRefreshStatus; pullDistance: number }) => void;
+  enabled?: boolean;
+  onRefresh: () => void | Promise<void>;
+  thresholdPx?: number;
+  wheelThresholdPx?: number;
+}) {
+  const state = usePullToRefresh({ enabled, onRefresh, thresholdPx, wheelThresholdPx });
+  useEffect(() => {
+    onChange(state);
+  }, [state, onChange]);
+  return null;
+}
+
+async function mountProbe(props: {
+  onChange: (state: { status: PullToRefreshStatus; pullDistance: number }) => void;
+  enabled?: boolean;
+  onRefresh: () => void | Promise<void>;
+  thresholdPx?: number;
+  wheelThresholdPx?: number;
+}) {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(Probe, props));
+  });
+  return { container, root };
+}
+
+describe('dampPull', () => {
+  it('returns 0 for non-positive input and approaches the max asymptotically', () => {
+    expect(dampPull(0, 100)).toBe(0);
+    expect(dampPull(-10, 100)).toBe(0);
+    expect(dampPull(50, 100)).toBeGreaterThan(0);
+    expect(dampPull(50, 100)).toBeLessThan(50);
+    // Raw input is capped at 2× max, so the asymptote tops out around 1−e⁻² ≈ 0.86×max.
+    expect(dampPull(1000, 100)).toBeLessThan(100);
+    expect(dampPull(1000, 100)).toBeGreaterThan(80);
+  });
+});
+
+describe('usePullToRefresh', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 0 });
+    document.body.className = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+    vi.restoreAllMocks();
+  });
+
+  it('stays idle until a downward pull starts at the top of the page', async () => {
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    await mountProbe({ onChange, onRefresh, thresholdPx: 60 });
+
+    expect(onChange).toHaveBeenLastCalledWith({ status: 'idle', pullDistance: 0 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 40 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 100 } as Touch],
+        }),
+      );
+    });
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { status: PullToRefreshStatus; pullDistance: number };
+    expect(last.status).toBe('ready');
+    expect(last.pullDistance).toBeGreaterThan(0);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('fires onRefresh when the pull is released past the threshold', async () => {
+    const onChange = vi.fn();
+    let resolveRefresh!: () => void;
+    const onRefresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    await mountProbe({ onChange, onRefresh, thresholdPx: 60 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 20 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 100 } as Touch],
+        }),
+      );
+      window.dispatchEvent(new TouchEvent('touchend'));
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'refreshing' });
+
+    await act(async () => {
+      resolveRefresh();
+      await Promise.resolve();
+    });
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ status: 'idle', pullDistance: 0 });
+  });
+
+  it('snaps back without refreshing when released below the threshold', async () => {
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    await mountProbe({ onChange, onRefresh, thresholdPx: 80 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 20 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 50 } as Touch],
+        }),
+      );
+      window.dispatchEvent(new TouchEvent('touchend'));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ status: 'idle', pullDistance: 0 });
+  });
+
+  it('ignores pulls while the page is scrolled away from the top', async () => {
+    Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 40 });
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    await mountProbe({ onChange, onRefresh, thresholdPx: 60 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 20 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 120 } as Touch],
+        }),
+      );
+      window.dispatchEvent(new TouchEvent('touchend'));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ status: 'idle', pullDistance: 0 });
+  });
+
+  it('ignores pulls while a game player has locked the page', async () => {
+    document.body.classList.add('player-open');
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    await mountProbe({ onChange, onRefresh, thresholdPx: 60 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 20 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 120 } as Touch],
+        }),
+      );
+      window.dispatchEvent(new TouchEvent('touchend'));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', async () => {
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    await mountProbe({ onChange, onRefresh, enabled: false, thresholdPx: 60 });
+
+    await act(async () => {
+      window.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientY: 20 } as Touch] }));
+      window.dispatchEvent(
+        new TouchEvent('touchmove', {
+          cancelable: true,
+          touches: [{ clientY: 120 } as Touch],
+        }),
+      );
+      window.dispatchEvent(new TouchEvent('touchend'));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ status: 'idle', pullDistance: 0 });
+  });
+
+  it('refreshes from an upward trackpad wheel burst at the top', async () => {
+    const onChange = vi.fn();
+    const onRefresh = vi.fn(async () => undefined);
+    await mountProbe({ onChange, onRefresh, wheelThresholdPx: 80 });
+
+    await act(async () => {
+      window.dispatchEvent(new WheelEvent('wheel', { deltaY: -50, cancelable: true }));
+      window.dispatchEvent(new WheelEvent('wheel', { deltaY: -50, cancelable: true }));
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/usePullToRefresh.ts
+++ b/apps/web/src/usePullToRefresh.ts
@@ -1,0 +1,277 @@
+/**
+ * Pull-down-to-refresh for the installed PWA (and browser tabs that lack a native
+ * gesture). Standalone display mode does not get the browser chrome's pull-to-refresh,
+ * so a phone or desktop trackpad overscroll at the top of the page would otherwise do
+ * nothing. This restores that habit without fighting gameplay — callers disable it
+ * while `body.player-open` (see styles.css) so a downward swipe stays a game input.
+ *
+ * Touch and pointer cover phones and mouse drags; wheel covers desktop trackpads.
+ * The page must already be scrolled to the top before a pull starts counting.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type PullToRefreshStatus = 'idle' | 'pulling' | 'ready' | 'refreshing';
+
+export type UsePullToRefreshOptions = {
+  /** When false, listeners stay quiet and any in-flight pull resets. */
+  enabled?: boolean;
+  /** Called once the pull crosses the threshold and the finger/wheel releases. */
+  onRefresh: () => void | Promise<void>;
+  /** How far (CSS px) the pull must travel before release triggers a refresh. */
+  thresholdPx?: number;
+  /** Cap on the rubber-band distance shown while pulling. */
+  maxPullPx?: number;
+  /** Wheel delta (px) that counts as one full threshold pull at the top. */
+  wheelThresholdPx?: number;
+};
+
+export type UsePullToRefreshResult = {
+  status: PullToRefreshStatus;
+  /** Visual pull distance, damped so it feels rubbery rather than 1:1 with the finger. */
+  pullDistance: number;
+};
+
+const DEFAULT_THRESHOLD_PX = 72;
+const DEFAULT_MAX_PULL_PX = 120;
+const DEFAULT_WHEEL_THRESHOLD_PX = 120;
+/** Near-zero scroll counts as "at top" — sub-pixel / rubber-band noise. */
+const AT_TOP_PX = 2;
+/** Ignore tiny touch jitter before treating a move as a pull. */
+const ARM_SLOP_PX = 8;
+
+function scrollTop(): number {
+  return window.scrollY || document.documentElement.scrollTop || 0;
+}
+
+function isPlayerOpen(): boolean {
+  return document.body.classList.contains('player-open');
+}
+
+/** Rubber-band: maps raw finger travel into a softer visual distance. */
+export function dampPull(rawPx: number, maxPullPx: number): number {
+  if (rawPx <= 0) return 0;
+  const capped = Math.min(rawPx, maxPullPx * 2);
+  return maxPullPx * (1 - Math.exp(-capped / maxPullPx));
+}
+
+export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRefreshResult {
+  const {
+    enabled = true,
+    onRefresh,
+    thresholdPx = DEFAULT_THRESHOLD_PX,
+    maxPullPx = DEFAULT_MAX_PULL_PX,
+    wheelThresholdPx = DEFAULT_WHEEL_THRESHOLD_PX,
+  } = options;
+
+  const [status, setStatus] = useState<PullToRefreshStatus>('idle');
+  const [pullDistance, setPullDistance] = useState(0);
+
+  const statusRef = useRef<PullToRefreshStatus>('idle');
+  const pullRawRef = useRef(0);
+  const startYRef = useRef<number | null>(null);
+  const trackingRef = useRef(false);
+  const pointerIdRef = useRef<number | null>(null);
+  const wheelAccRef = useRef(0);
+  const wheelResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  const setStatusBoth = useCallback((next: PullToRefreshStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const resetPull = useCallback(() => {
+    pullRawRef.current = 0;
+    startYRef.current = null;
+    trackingRef.current = false;
+    pointerIdRef.current = null;
+    setPullDistance(0);
+    if (statusRef.current !== 'refreshing') {
+      setStatusBoth('idle');
+    }
+  }, [setStatusBoth]);
+
+  const applyPull = useCallback(
+    (rawPx: number) => {
+      pullRawRef.current = rawPx;
+      const visual = dampPull(rawPx, maxPullPx);
+      setPullDistance(visual);
+      if (statusRef.current === 'refreshing') return;
+      setStatusBoth(rawPx >= thresholdPx ? 'ready' : rawPx > 0 ? 'pulling' : 'idle');
+    },
+    [maxPullPx, setStatusBoth, thresholdPx],
+  );
+
+  const triggerRefresh = useCallback(async () => {
+    if (statusRef.current === 'refreshing') return;
+    setStatusBoth('refreshing');
+    setPullDistance(dampPull(thresholdPx, maxPullPx));
+    try {
+      await onRefreshRef.current();
+    } finally {
+      pullRawRef.current = 0;
+      startYRef.current = null;
+      trackingRef.current = false;
+      pointerIdRef.current = null;
+      wheelAccRef.current = 0;
+      setPullDistance(0);
+      setStatusBoth('idle');
+    }
+  }, [maxPullPx, setStatusBoth, thresholdPx]);
+
+  useEffect(() => {
+    if (!enabled) {
+      resetPull();
+      return;
+    }
+    if (typeof window === 'undefined') return;
+
+    const canStart = () => enabled && statusRef.current !== 'refreshing' && scrollTop() <= AT_TOP_PX && !isPlayerOpen();
+
+    const onTouchStart = (event: TouchEvent) => {
+      if (!canStart() || event.touches.length !== 1) return;
+      startYRef.current = event.touches[0].clientY;
+      trackingRef.current = true;
+      pullRawRef.current = 0;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (!trackingRef.current || startYRef.current == null) return;
+      if (isPlayerOpen() || statusRef.current === 'refreshing') {
+        resetPull();
+        return;
+      }
+      const y = event.touches[0].clientY;
+      const delta = y - startYRef.current;
+      if (delta < ARM_SLOP_PX && pullRawRef.current === 0) return;
+      if (scrollTop() > AT_TOP_PX && pullRawRef.current === 0) {
+        trackingRef.current = false;
+        return;
+      }
+      if (delta <= 0) {
+        applyPull(0);
+        return;
+      }
+      // Own the overscroll so the browser does not rubber-band / native-PTR under us.
+      if (event.cancelable) event.preventDefault();
+      applyPull(delta);
+    };
+
+    const onTouchEnd = () => {
+      if (!trackingRef.current) return;
+      const shouldRefresh = pullRawRef.current >= thresholdPx;
+      trackingRef.current = false;
+      startYRef.current = null;
+      if (shouldRefresh) {
+        void triggerRefresh();
+      } else {
+        resetPull();
+      }
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      // Touch is handled above (more reliable preventDefault). Mouse/pen only here.
+      if (event.pointerType === 'touch') return;
+      if (!canStart() || event.button !== 0) return;
+      startYRef.current = event.clientY;
+      trackingRef.current = true;
+      pointerIdRef.current = event.pointerId;
+      pullRawRef.current = 0;
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!trackingRef.current || pointerIdRef.current !== event.pointerId) return;
+      if (startYRef.current == null) return;
+      if (isPlayerOpen() || statusRef.current === 'refreshing') {
+        resetPull();
+        return;
+      }
+      const delta = event.clientY - startYRef.current;
+      if (delta < ARM_SLOP_PX && pullRawRef.current === 0) return;
+      if (scrollTop() > AT_TOP_PX && pullRawRef.current === 0) {
+        trackingRef.current = false;
+        return;
+      }
+      if (delta <= 0) {
+        applyPull(0);
+        return;
+      }
+      if (event.cancelable) event.preventDefault();
+      applyPull(delta);
+    };
+
+    const onPointerUp = (event: PointerEvent) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      if (!trackingRef.current) return;
+      const shouldRefresh = pullRawRef.current >= thresholdPx;
+      trackingRef.current = false;
+      startYRef.current = null;
+      pointerIdRef.current = null;
+      if (shouldRefresh) {
+        void triggerRefresh();
+      } else {
+        resetPull();
+      }
+    };
+
+    const clearWheelReset = () => {
+      if (wheelResetTimer.current) {
+        clearTimeout(wheelResetTimer.current);
+        wheelResetTimer.current = null;
+      }
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (statusRef.current === 'refreshing' || isPlayerOpen()) return;
+      // Only accumulate upward scrolls (negative deltaY) while parked at the top.
+      if (scrollTop() > AT_TOP_PX || event.deltaY >= 0) {
+        if (wheelAccRef.current > 0 || statusRef.current !== 'idle') {
+          wheelAccRef.current = 0;
+          resetPull();
+        }
+        return;
+      }
+      if (event.cancelable) event.preventDefault();
+      wheelAccRef.current += -event.deltaY;
+      applyPull(wheelAccRef.current);
+      clearWheelReset();
+      if (wheelAccRef.current >= wheelThresholdPx) {
+        wheelAccRef.current = 0;
+        void triggerRefresh();
+        return;
+      }
+      // If the user stops scrolling up, snap back rather than leaving a stuck indicator.
+      wheelResetTimer.current = setTimeout(() => {
+        wheelAccRef.current = 0;
+        if (statusRef.current !== 'refreshing') resetPull();
+      }, 180);
+    };
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: false });
+    window.addEventListener('touchend', onTouchEnd);
+    window.addEventListener('touchcancel', onTouchEnd);
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+    window.addEventListener('wheel', onWheel, { passive: false });
+
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', onTouchEnd);
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+      window.removeEventListener('wheel', onWheel);
+      clearWheelReset();
+    };
+  }, [applyPull, enabled, resetPull, thresholdPx, triggerRefresh, wheelThresholdPx]);
+
+  return { status, pullDistance };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Standalone PWA mode has no browser chrome, so the usual pull-down-to-refresh gesture was missing on both phone and desktop. This restores it on the home screen.

## Changes

- New `usePullToRefresh` hook: touch + pointer + trackpad wheel, only when scrolled to the top
- `PullToRefresh` indicator under the sticky header
- Soft-refreshes catalog, recommendations, and creator games (same keys as Retry / post-play)
- Disabled while a game is open (`player-open`) so downward swipes stay game input
- Soft refresh no longer blanks the catalog grid when a last-good list is already on screen
- Failed soft refresh keeps the grid and shows a Retry banner (addresses Copilot review)

## Test plan

- [ ] Install / open the PWA (or use a browser tab), scroll to the top of home, pull down — indicator appears and catalog refreshes
- [ ] On desktop, overscroll up with a trackpad at the top of home — same refresh
- [ ] Open a game — pull-to-refresh must not fire
- [ ] Force a catalog failure after a successful load — last-good grid stays, refresh-error banner with Retry appears
- [ ] `npm run type-check && npm run lint && npm run test && npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

