### PR TITLE
Accept the golden the gate requires, and refuse a delivery without it

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -543,6 +543,7 @@ describe('agent build channel', () => {
       { path: 'SPEC.md', content: '---\ntitle: A game\n---\n' },
       { path: 'index.html', content: '<!doctype html>' },
       { path: 'game.ts', content: 'export {};' },
+      { path: 'TRACE.json', content: '{"samples":[]}' },
     ];
 
     function stubGamesStore() {

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -12,15 +12,18 @@ const MINIMAL: SourceFile[] = [
   { path: 'SPEC.md', content: '---\ntitle: A game\n---\n' },
   { path: 'index.html', content: '<!doctype html>' },
   { path: 'game.ts', content: 'export {};' },
+  // The behavioural golden is part of a minimal delivery, not an extra: without it the
+  // gate stops at the trace stage and the version can never reach a verdict.
+  { path: 'TRACE.json', content: '{"samples":[]}' },
 ];
 
 describe('validateSourceUpload — the delivery contract', () => {
   it('accepts a minimal game', () => {
-    expect(validateSourceUpload(MINIMAL)).toHaveLength(3);
+    expect(validateSourceUpload(MINIMAL)).toHaveLength(4);
   });
 
   it('accepts the game’s own modules', () => {
-    expect(validateSourceUpload([...MINIMAL, { path: 'entities/player.ts', content: 'export {};' }])).toHaveLength(4);
+    expect(validateSourceUpload([...MINIMAL, { path: 'entities/player.ts', content: 'export {};' }])).toHaveLength(5);
   });
 
   it('refuses harness-shaped paths so a diff visibly respects the boundary', () => {
@@ -56,6 +59,18 @@ describe('validateSourceUpload — the delivery contract', () => {
         { path: 'game.ts', content: 'x' },
       ]),
     ).toThrow(/SPEC.md is required/);
+  });
+
+  it('accepts and requires the behavioural golden the gate checks against', () => {
+    // Both halves, because they failed apart. The games repo's submit tool sends
+    // TRACE.json; this list did not include it, so the server answered 400 and named
+    // every file that *was* deliverable — and a real agent read that message, dropped
+    // the golden, and delivered a version the gate could only fail. A delivery contract
+    // that disagrees with the tool implementing it teaches the agent to route around it.
+    expect(validateSourceUpload(MINIMAL).map((f) => f.path)).toContain('TRACE.json');
+    expect(() => validateSourceUpload(MINIMAL.filter((f) => f.path !== 'TRACE.json'))).toThrow(
+      /TRACE\.json is required/,
+    );
   });
 
   it('caps total upload size', () => {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -34,6 +34,11 @@ export const ALLOWED_SOURCE_FILES = [
   'GAME.json',
   'CAPTURE.json',
   'ACCEPTANCE.json',
+  // The committed behavioural golden. It is not source in the ordinary sense, but the
+  // gate replays CAPTURE.json against our engine and diffs the result against this file,
+  // so a delivery without it is one the gate cannot check — it fails at the trace stage
+  // with `no committed trace`, having proved nothing about the game.
+  'TRACE.json',
   'index.html',
   'game.ts',
   'style.css',
@@ -139,6 +144,18 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
   if (!seen.has('SPEC.md')) throw new InvalidUploadError('SPEC.md is required — it is the spec of record for the game');
   if (!seen.has('index.html') || !seen.has('game.ts')) {
     throw new InvalidUploadError('index.html and game.ts are required — a game must be playable');
+  }
+  // Refused here rather than stored and failed later. Without the golden the gate cannot
+  // reach a verdict at all — it stops at the trace stage having proved nothing — so
+  // accepting the upload would mean storing a version that is dead on arrival, and
+  // telling the agent it had succeeded. It is still running at this moment and can
+  // record the golden and retry; twenty minutes later it is gone.
+  if (!seen.has('TRACE.json')) {
+    throw new InvalidUploadError(
+      'TRACE.json is required — the gate diffs your game against it and cannot verify a ' +
+        'delivery without one. Record it with `npm run trace -- <slug> --accept`, read what ' +
+        'it captured, then deliver again.',
+    );
   }
 
   return files.map((file) => ({ path: file.path.trim(), content: file.content }));


### PR DESCRIPTION
Found by the first real end-to-end build (`tv-tycoon`). The two halves of the delivery contract disagreed, and an agent resolved the disagreement in the worst available way.

## What happened

`tools/submit.mjs` in the games repo sends `TRACE.json`. `ALLOWED_SOURCE_FILES` here did not list it, so the server answered 400 — and, being helpful, the message named every file that *was* deliverable. The agent read that message and worked around it. From the creator's own build log:

> Delivery blocked: submit tool requires TRACE.json locally but the server endpoint rejects it as not deliverable. **Workaround in progress.**

The workaround was to drop the golden. The upload then succeeded, the agent was told it had delivered, and the gate stopped at the trace stage:

```
FAIL trace tv-tycoon: no committed trace
```

That is worse than a plain rejection. A version was stored, an agent finished believing it had shipped, and the gate proved nothing about the game. **A contract that disagrees with the tool implementing it doesn't block an agent — it teaches the agent to route around it**, and the thing routed around here is the check that catches a game behaving differently on our engine than on the agent's.

## The fix

`TRACE.json` is now deliverable, and **required**.

Required rather than merely permitted, because a delivery without it is dead on arrival — the gate cannot reach a verdict at all. The moment to say so is while the agent is still running and can record one; twenty minutes later it is gone and the version is a permanently unverifiable artifact taking up a slot in the game's history.

## Tests

The new test asserts **both** halves — that the golden is accepted, and that its absence is refused — because they failed apart rather than together. The existing `MINIMAL` fixtures in both suites now include it, which is the honest description of a minimal delivery.

`type-check`, `lint`, 1211 API tests, full build: green.

## Related, not fixed here

The draft preview is also broken for native jobs: `replyWithDraft` resolves through `findLinkedPR` and 409s when there is no open PR, and native jobs no longer open one. Creators currently get "this game isn't available yet" for the whole build. Separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9)_