### PR TITLE
Fix studio Up chevron bouncing back to Build

### DIFF
--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -188,9 +188,11 @@ describe('navUpTarget', () => {
     expect(navUpTarget({ view: 'studio', token: 'tok', tab: 'playtest' })).toBeNull();
   });
 
-  it('walks studio tab → game → shelf → home', () => {
+  it('walks studio game work surfaces to the shelf, then home', () => {
+    // Tab → shelf (not `/studio/:token`): a bare token URL is rewritten back onto
+    // the default tab, which would cancel the Up for in-progress Build views.
     expect(navUpTarget({ view: 'studio', token: 'tok', tab: 'build' })).toEqual({
-      path: '/studio/tok',
+      path: '/studio',
       labelKey: 'upStudio',
     });
     expect(navUpTarget({ view: 'studio', token: 'tok' })).toEqual({

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -192,9 +192,10 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
     case 'studio':
       // Playtest is a full-viewport theater with its own Close back to overview.
       if (route.tab === 'playtest') return null;
-      if (route.token && route.tab) {
-        return { path: studioPath(route.token), labelKey: 'upStudio' };
-      }
+      // Any selected-game URL (with or without a tab) goes to the shelf — not to
+      // `/studio/:token`. CreatorStudioView canonicalizes a bare token URL onto the
+      // default tab (Build for in-progress games), which would immediately undo an
+      // Up that only stripped the tab and make the chevron look broken.
       if (route.token) {
         return { path: studioPath(), labelKey: 'upStudio' };
       }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -102,7 +102,9 @@ a {
   gap: 8px;
 }
 
-/* Android-style Up — parent path, not browser history. 44px tap floor on phones. */
+/* Android-style Up — parent path, not browser history. 44px tap floor on phones.
+   `no-drag` keeps the control clickable in Chromium desktop PWAs, where the top
+   of the window can otherwise be claimed as a caption/drag region. */
 .nav-up {
   display: inline-flex;
   align-items: center;
@@ -117,6 +119,8 @@ a {
   background: transparent;
   color: var(--text);
   cursor: pointer;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .nav-up:hover {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The header Up chevron looked broken on Creator Studio Build (exactly the Mac Chrome PWA case in the report).

**Cause:** Up from `/studio/:token/build` went to `/studio/:token`. `CreatorStudioView` then canonicalizes a bare token URL onto the default tab — **Build** for in-progress games — so the URL snapped straight back and nothing appeared to change.

**Fix:** Any selected-game studio URL now Ups to the shelf (`/studio`). Shelf still Ups to home. Also marks the control `-webkit-app-region: no-drag` for Chromium desktop PWAs.

## Test plan

- [ ] On an in-progress game Build tab, tap Up → land on Studio shelf (not Build again)
- [ ] On Studio shelf, tap Up → home
- [ ] Chrome PWA on macOS: Up remains clickable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

