### PR TITLE
Add a how-to-play panel to the game player

### DIFF
--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -477,7 +477,7 @@ export interface TelemetryEvent {
 export interface VisitEvent {
   /** Per-tab uuid from `sessionStorage`. Dies with the tab; never a uid. */
   visitId: string;
-  type: 'visit_started' | 'route_viewed' | 'play_started' | 'create_step' | 'waitlist_step';
+  type: 'visit_started' | 'route_viewed' | 'play_started' | 'how_to_play_opened' | 'create_step' | 'waitlist_step';
   /** Server-anchored instant, derived like `TelemetryEvent.at`. */
   at: string;
   /** Milliseconds from visit start — the trustworthy measure of within-visit timing. */

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -71,6 +71,25 @@ describe('POST /api/telemetry/visit', () => {
     expect(events.filter((event) => event.type === 'play_started')).toHaveLength(2);
   });
 
+  it('records how_to_play_opened as itself, and without a game identity', async () => {
+    // The mapper ends in a `default` branch that relabels anything unmatched as
+    // `play_started`, so a member with no case of its own is silently mislabelled
+    // rather than rejected — which no schema error would ever reveal.
+    await post(app, {
+      visitId,
+      flushMsSinceStart: 400,
+      events: [
+        { type: 'play_started', msSinceStart: 100 },
+        { type: 'how_to_play_opened', slug: 'space-hop', msSinceStart: 400 },
+      ],
+    });
+
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events.filter((event) => event.type === 'how_to_play_opened')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'play_started')).toHaveLength(1);
+    expect(JSON.stringify(events)).not.toContain('space-hop');
+  });
+
   it('never stores a game identity, even if a client sends one', async () => {
     await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -88,6 +88,7 @@ const EventSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('route_viewed'), route: RouteKindSchema, ...offsetField }),
   z.object({ type: z.literal('play_started'), ...offsetField }),
+  z.object({ type: z.literal('how_to_play_opened'), ...offsetField }),
   z.object({ type: z.literal('create_step'), step: CreateStepSchema, ...offsetField }),
   z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
 ]);
@@ -182,6 +183,8 @@ export async function registerVisitTelemetryRoutes(
         case 'create_step':
         case 'waitlist_step':
           return { ...base, type: event.type, step: event.step };
+        case 'how_to_play_opened':
+          return { ...base, type: event.type };
         default:
           return { ...base, type: 'play_started' };
       }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -930,6 +930,8 @@ export function App() {
                 orientation={stageContent.game.orientation}
                 reportSlug={stageContent.game.slug}
                 submittedBy={stageContent.game.submittedBy}
+                controls={stageContent.game.controls}
+                touch={stageContent.game.touch}
               />
             )}
 

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -171,11 +171,51 @@ describe('GameTheater how-to-play', () => {
 
     // The panel portals to the body, not into the theater's own subtree.
     expect(document.querySelector('.howto-card')).not.toBeNull();
-    expect([...document.querySelectorAll('.howto-list li')].map((li) => li.textContent)).toEqual([
-      'Left/Right to move',
-      'Space to fire',
-      'M to mute',
+    expect(
+      [...document.querySelectorAll('.howto-row')].map((row) => [
+        row.querySelector('dt')?.textContent,
+        row.querySelector('dd')?.textContent,
+      ]),
+    ).toEqual([
+      ['Left/Right', 'move'],
+      ['Space', 'fire'],
+      ['M', 'mute'],
     ]);
+  });
+
+  it('puts focus on the card when opened from the More menu, not on the exit button behind it', async () => {
+    // The phone path: the bar trigger is display:none there, so the menu row is the only
+    // way in. Opening the menu changes `moreOpen`, which used to re-run the theater's
+    // focus effect and pull focus back onto Exit — with the modal card on screen, Enter
+    // then left the game.
+    await draw({ controls: CONTROLS });
+    await click(container.querySelector('.theater-more-btn'));
+    const menuItem = [...container.querySelectorAll('.theater-more-panel .theater-menu-item')].find((el) =>
+      el.textContent?.includes('How to play'),
+    );
+    expect(menuItem).toBeTruthy();
+
+    await click(menuItem ?? null);
+
+    expect(document.querySelector('.howto-card')).not.toBeNull();
+    expect(document.activeElement).toBe(document.querySelector('.howto-close'));
+    expect(container.querySelector('.theater-more.is-open')).toBeNull();
+  });
+
+  it('closes the card when the game goes fullscreen, since the bar holding both triggers unmounts', async () => {
+    await draw({ controls: CONTROLS });
+    await click(container.querySelector('.howto-btn'));
+    expect(document.querySelector('.howto-card')).not.toBeNull();
+
+    const stage = container.querySelector('.stage') as HTMLElement;
+    Object.defineProperty(document, 'fullscreenElement', { value: stage, configurable: true });
+    await act(async () => {
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(container.querySelector('.game-theater-bar')).toBeNull();
+    expect(document.querySelector('.howto-card')).toBeNull();
+    Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true });
   });
 
   it('Escape closes the panel first and only exits the game on a second press', async () => {

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -183,6 +183,17 @@ describe('GameTheater how-to-play', () => {
     ]);
   });
 
+  it('renders both copies of the control, the bar one and the menu one', async () => {
+    // Which one is visible is CSS's job (the bar copy sheds at 900px, earlier than sound
+    // and fullscreen, because otherwise the actions row grows until the vote widget
+    // overlaps the game title). Both must exist so neither breakpoint leaves it
+    // unreachable — jsdom applies no media queries, so this asserts presence, not layout.
+    await draw({ controls: CONTROLS });
+    expect(container.querySelector('.howto-bar')).not.toBeNull();
+    await click(container.querySelector('.theater-more-btn'));
+    expect(container.querySelector('.theater-more-panel .howto-menu')).not.toBeNull();
+  });
+
   it('puts focus on the card when opened from the More menu, not on the exit button behind it', async () => {
     // The phone path: the bar trigger is display:none there, so the menu row is the only
     // way in. Opening the menu changes `moreOpen`, which used to re-run the theater's
@@ -190,9 +201,7 @@ describe('GameTheater how-to-play', () => {
     // then left the game.
     await draw({ controls: CONTROLS });
     await click(container.querySelector('.theater-more-btn'));
-    const menuItem = [...container.querySelectorAll('.theater-more-panel .theater-menu-item')].find((el) =>
-      el.textContent?.includes('How to play'),
-    );
+    const menuItem = container.querySelector('.theater-more-panel .howto-menu');
     expect(menuItem).toBeTruthy();
 
     await click(menuItem ?? null);

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -58,7 +58,7 @@ afterEach(() => {
   container.remove();
 });
 
-async function draw() {
+async function draw(props: { controls?: string; onExit?: () => void } = {}) {
   root = createRoot(container);
   await act(async () => {
     root!.render(
@@ -67,12 +67,25 @@ async function draw() {
         badge={{ icon: 'sparkle', label: 'AI' }}
         source={{ slug: 'brick-storm' }}
         reportSlug="brick-storm"
-        onExit={() => undefined}
+        onExit={props.onExit ?? (() => undefined)}
+        controls={props.controls}
       />,
     );
   });
   await act(async () => {
     await Promise.resolve();
+  });
+}
+
+async function click(element: Element | null) {
+  await act(async () => {
+    element?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+async function pressEscape() {
+  await act(async () => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
   });
 }
 
@@ -129,5 +142,72 @@ describe('GameTheater more menu', () => {
     const widths = [...icons].map((icon) => icon.getAttribute('width'));
     expect(new Set(widths).size).toBe(1);
     expect(widths[0]).toBe('13');
+  });
+});
+
+describe('GameTheater how-to-play', () => {
+  const CONTROLS = 'Left/Right to move; Space to fire; M to mute';
+
+  it('offers no how-to-play control for a game with no controls in the catalog', async () => {
+    // Generated and draft games have no catalog entry, so the prop is absent entirely.
+    await draw();
+    expect(container.querySelector('.howto-btn')).toBeNull();
+
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+    // A deep link that rendered before the catalog landed carries an empty string.
+    await draw({ controls: '' });
+    expect(container.querySelector('.howto-btn')).toBeNull();
+  });
+
+  it('opens the panel from the bar control', async () => {
+    await draw({ controls: CONTROLS });
+    const trigger = container.querySelector('.howto-btn');
+    expect(trigger).not.toBeNull();
+
+    await click(trigger);
+
+    // The panel portals to the body, not into the theater's own subtree.
+    expect(document.querySelector('.howto-card')).not.toBeNull();
+    expect([...document.querySelectorAll('.howto-list li')].map((li) => li.textContent)).toEqual([
+      'Left/Right to move',
+      'Space to fire',
+      'M to mute',
+    ]);
+  });
+
+  it('Escape closes the panel first and only exits the game on a second press', async () => {
+    const onExit = vi.fn();
+    await draw({ controls: CONTROLS, onExit });
+    await click(container.querySelector('.howto-btn'));
+    expect(document.querySelector('.howto-card')).not.toBeNull();
+
+    await pressEscape();
+    expect(document.querySelector('.howto-card')).toBeNull();
+    expect(onExit).not.toHaveBeenCalled();
+
+    await pressEscape();
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('an Escape relayed from inside the sandboxed game also closes the panel first', async () => {
+    const onExit = vi.fn();
+    await draw({ controls: CONTROLS, onExit });
+    await click(container.querySelector('.howto-btn'));
+
+    await act(async () => {
+      // Opaque-origin frames post with origin "null"; the bridge relays the key here.
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { source: 'gdpl-player', type: 'key', key: 'Escape' },
+          origin: 'null',
+        }),
+      );
+    });
+
+    expect(document.querySelector('.howto-card')).toBeNull();
+    expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -138,17 +138,28 @@ export function GameTheater({
   const dismissMore = useCallback(() => setMoreOpen(false), []);
 
   // Escape while the How-to-play card is up must close the card, not throw the player
-  // out of the game. Read through a ref so this callback keeps a stable identity —
-  // rebuilding it would re-run the mount-only focus effect below on every open.
+  // out of the game. Overlay state is read through refs so these callbacks keep a
+  // stable identity and the listener below does not need re-binding on every toggle.
   const howToOpenRef = useRef(howToOpen);
   howToOpenRef.current = howToOpen;
+  const moreOpenRef = useRef(moreOpen);
+  moreOpenRef.current = moreOpen;
+
+  // Closing hands focus to the game, not back to the trigger. In a player the next key
+  // press is meant for the game: leaving focus on the button turns the next Space into
+  // "reopen the card" instead of "fire".
+  const closeHowTo = useCallback(() => {
+    setHowToOpen(false);
+    frameRef.current?.contentWindow?.focus();
+  }, []);
+
   const escapeOrExit = useCallback(() => {
     if (howToOpenRef.current) {
-      setHowToOpen(false);
+      closeHowTo();
       return;
     }
     requestExit();
-  }, [requestExit]);
+  }, [requestExit, closeHowTo]);
 
   // Escape is handled twice on purpose: the window listener below covers the app's
   // own chrome, and this covers the game iframe, which holds focus while playing
@@ -213,7 +224,12 @@ export function GameTheater({
   }, []);
 
   useEffect(() => {
-    if (fullscreen) setMoreOpen(false);
+    if (!fullscreen) return;
+    setMoreOpen(false);
+    // The bar is unmounted while fullscreen, and it holds both of the card's triggers.
+    // A card left open there cannot be reopened from anywhere, and reappears unbidden
+    // when fullscreen ends.
+    setHowToOpen(false);
   }, [fullscreen]);
 
   const toggleFullscreen = useCallback(() => {
@@ -230,21 +246,26 @@ export function GameTheater({
   // The theater takes over the whole viewport, so keyboard focus has to come with
   // it — otherwise focus is left behind on the page underneath, and Escape (the
   // reflex for "get me out of here") does nothing. Focus returns on unmount.
+  //
+  // Mount-only, and separate from the Escape listener below on purpose: this effect
+  // used to carry `moreOpen` in its deps, so opening an overlay re-ran it and the
+  // `exitRef.focus()` here landed *after* the overlay's own focus call (child effects
+  // run before parent effects) — the card opened with focus on the exit button.
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null;
     exitRef.current?.focus();
+    return () => previouslyFocused?.focus?.();
+  }, []);
 
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         // Innermost surface first: the card, then the menu, then leaving the game.
-        // The card's state is read through a ref rather than added to this effect's
-        // deps, because every re-run of this effect hands focus to the exit button —
-        // which would pull it straight back off the card that just opened.
         if (howToOpenRef.current) {
-          setHowToOpen(false);
+          closeHowTo();
           return;
         }
-        if (moreOpen) {
+        if (moreOpenRef.current) {
           setMoreOpen(false);
           return;
         }
@@ -252,12 +273,8 @@ export function GameTheater({
       }
     };
     window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-      previouslyFocused?.focus?.();
-    };
-  }, [requestExit, moreOpen]);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [requestExit, closeHowTo]);
 
   // Close the overflow menu on an outside tap — phones have no hover to dismiss it.
   // Same-document chrome uses pointerdown here. Taps on the sandboxed game are
@@ -435,7 +452,7 @@ export function GameTheater({
         controls={controls ?? ''}
         gameTitle={displayTitle}
         keyboardOnly={touch === 'none'}
-        onClose={() => setHowToOpen(false)}
+        onClose={closeHowTo}
       />
     </section>
   );

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isPlatformAuthor } from './catalog.js';
+import { isPlatformAuthor, type CatalogTouch } from './catalog.js';
 import { GameFrame } from './GameFrame.js';
+import { HowToPlayPanel } from './HowToPlayPanel.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
+import { parseControls } from './howToPlay.js';
 import { PlayerFeedbackWidget } from './PlayerFeedbackWidget.js';
 import { ReportGameButton } from './ReportGameButton.js';
 import { ShareGameButton } from './ShareGameButton.js';
 import { VoteWidget } from './VoteWidget.js';
 import { useGamePlayer } from './gamePlayer.js';
+import { recordVisitEvent } from './visitTelemetry.js';
 import { useGameSaveBridge } from './gameSave.js';
 import { usePresenceBridge } from './presence.js';
 import { useWorldBridge } from './world.js';
@@ -42,6 +45,15 @@ type GameTheaterProps = {
    * platform sentinel read as the site itself; anything else is shown as a byline.
    */
   submittedBy?: string | null;
+  /**
+   * The game's `controls` line from the catalog, which turns on the "How to play"
+   * control. Absent for generated and draft games: they have no catalog entry, and the
+   * frame is sandboxed without `allow-same-origin`, so there is nowhere else to read a
+   * control list from. The control simply does not render for them.
+   */
+  controls?: string;
+  /** Catalog touch support; `none` adds the keyboard-only line to the panel. */
+  touch?: CatalogTouch | null;
 };
 
 /**
@@ -84,6 +96,8 @@ export function GameTheater({
   orientation = 'any',
   reportSlug,
   submittedBy = null,
+  controls,
+  touch = null,
 }: GameTheaterProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
@@ -91,6 +105,13 @@ export function GameTheater({
   const stageRef = useRef<HTMLElement | null>(null);
   const moreRef = useRef<HTMLDivElement | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [howToOpen, setHowToOpen] = useState(false);
+
+  // A deep-linked /play/<slug> renders before the catalog lands, with a placeholder
+  // entry whose `controls` is empty; the real string arrives on a later render. Deriving
+  // this every render (rather than memoizing the first value) is what lets the control
+  // appear when it does.
+  const hasControls = parseControls(controls ?? '').length > 0;
 
   // Playing is the one thing you do here without touching the screen for minutes at
   // a time, which is exactly when a phone dims and sleeps. Hold the screen awake.
@@ -115,10 +136,24 @@ export function GameTheater({
   // relays pointerdown so overlays like More can dismiss without covering the
   // playfield (which would steal that first tap from the game).
   const dismissMore = useCallback(() => setMoreOpen(false), []);
+
+  // Escape while the How-to-play card is up must close the card, not throw the player
+  // out of the game. Read through a ref so this callback keeps a stable identity —
+  // rebuilding it would re-run the mount-only focus effect below on every open.
+  const howToOpenRef = useRef(howToOpen);
+  howToOpenRef.current = howToOpen;
+  const escapeOrExit = useCallback(() => {
+    if (howToOpenRef.current) {
+      setHowToOpen(false);
+      return;
+    }
+    requestExit();
+  }, [requestExit]);
+
   // Escape is handled twice on purpose: the window listener below covers the app's
   // own chrome, and this covers the game iframe, which holds focus while playing
   // and swallows its own key events.
-  const player = useGamePlayer(frameRef, true, requestExit, dismissMore);
+  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore);
 
   // Durable progress for games that ask for it (docs/persistent-world-plan.md P1).
   // Keyed on `reportSlug` — the *published* slug — for the same reason the vote and
@@ -201,6 +236,14 @@ export function GameTheater({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        // Innermost surface first: the card, then the menu, then leaving the game.
+        // The card's state is read through a ref rather than added to this effect's
+        // deps, because every re-run of this effect hands focus to the exit button —
+        // which would pull it straight back off the card that just opened.
+        if (howToOpenRef.current) {
+          setHowToOpen(false);
+          return;
+        }
         if (moreOpen) {
           setMoreOpen(false);
           return;
@@ -253,6 +296,28 @@ export function GameTheater({
     </button>
   );
 
+  // The one thing a player needs before the first key press, and the game's own copy of
+  // it is hidden inside the frame by HIDE_CHROME. Reuses `theater-menu-item` in the
+  // overflow menu so the four hand-enumerated selector lists in styles.css keep working.
+  const howToPlayControl = (className: string) =>
+    hasControls ? (
+      <button
+        type="button"
+        className={className}
+        onClick={() => {
+          setMoreOpen(false);
+          setHowToOpen(true);
+          recordVisitEvent({ type: 'how_to_play_opened' });
+        }}
+        aria-haspopup="dialog"
+        aria-expanded={howToOpen}
+        aria-label={t('player.howToPlay')}
+      >
+        <PixelIcon name="gamepad" size={13} />
+        <span className="btn-label">{t('player.howToPlay')}</span>
+      </button>
+    ) : null;
+
   const fullscreenControl = (className: string) =>
     canFullscreen ? (
       <button
@@ -293,6 +358,7 @@ export function GameTheater({
             {/* Thumbs are first-class: the one signal people expect without hunting. */}
             {reportSlug ? <VoteWidget slug={reportSlug} /> : null}
             {/* Desktop: sound + fullscreen sit on the bar. Phone: they move into More. */}
+            {howToPlayControl('secondary-btn howto-btn theater-desktop-chrome')}
             {soundControl('secondary-btn sound-btn theater-desktop-chrome')}
             {fullscreenControl('secondary-btn fullscreen-btn theater-desktop-chrome')}
             {showMoreMenu && (
@@ -310,6 +376,7 @@ export function GameTheater({
                   <PixelIcon name="menu" size={14} />
                 </button>
                 <div className="theater-more-panel" role="menu">
+                  {howToPlayControl('theater-menu-item theater-mobile-chrome')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
                   {reportSlug && (
@@ -363,6 +430,13 @@ export function GameTheater({
           <PixelIcon name="close" size={16} />
         </button>
       ) : null}
+      <HowToPlayPanel
+        open={howToOpen}
+        controls={controls ?? ''}
+        gameTitle={displayTitle}
+        keyboardOnly={touch === 'none'}
+        onClose={() => setHowToOpen(false)}
+      />
     </section>
   );
 }

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -451,7 +451,7 @@ export function GameTheater({
         open={howToOpen}
         controls={controls ?? ''}
         gameTitle={displayTitle}
-        keyboardOnly={touch === 'none'}
+        touch={touch}
         onClose={closeHowTo}
       />
     </section>

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -375,7 +375,7 @@ export function GameTheater({
             {/* Thumbs are first-class: the one signal people expect without hunting. */}
             {reportSlug ? <VoteWidget slug={reportSlug} /> : null}
             {/* Desktop: sound + fullscreen sit on the bar. Phone: they move into More. */}
-            {howToPlayControl('secondary-btn howto-btn theater-desktop-chrome')}
+            {howToPlayControl('secondary-btn howto-btn howto-bar')}
             {soundControl('secondary-btn sound-btn theater-desktop-chrome')}
             {fullscreenControl('secondary-btn fullscreen-btn theater-desktop-chrome')}
             {showMoreMenu && (
@@ -393,7 +393,7 @@ export function GameTheater({
                   <PixelIcon name="menu" size={14} />
                 </button>
                 <div className="theater-more-panel" role="menu">
-                  {howToPlayControl('theater-menu-item theater-mobile-chrome')}
+                  {howToPlayControl('theater-menu-item howto-menu')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
                   {reportSlug && (

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -142,12 +142,17 @@ describe('HowToPlayPanel', () => {
     outside.remove();
   });
 
-  it('adds the keyboard-only note only for games with no touch path', async () => {
+  it('states touch support from the catalog, and only what the catalog knows', async () => {
     await draw();
     expect(document.querySelector('.howto-note')).toBeNull();
+    expect(rows().some(([key]) => key === 'Touch')).toBe(false);
 
-    await redraw({ keyboardOnly: true });
+    await redraw({ touch: 'gamekit' });
+    expect(rows().at(-1)).toEqual(['Touch', 'On-screen pad on touch screens']);
+
+    await redraw({ touch: 'none' });
     expect(document.querySelector('.howto-note')?.textContent).toContain('keyboard');
+    expect(rows().some(([key]) => key === 'Touch')).toBe(false);
   });
 
   it('renders repeated clauses without a duplicate-key warning', async () => {

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -79,7 +79,9 @@ describe('HowToPlayPanel', () => {
     const labelledBy = card()?.getAttribute('aria-labelledby');
     expect(labelledBy).toBeTruthy();
     expect(document.getElementById(labelledBy!)?.textContent).toContain('How to play');
-    expect(document.querySelector('.howto-game')?.textContent).toBe('Apex Sprint');
+    // The game is named in the close button rather than shown as a subtitle: the theater
+    // bar behind the card already carries the title.
+    expect(document.querySelector('.howto-close')?.getAttribute('aria-label')).toContain('Apex Sprint');
     expect(document.querySelector('.howto-dismiss')?.textContent).toContain('close');
   });
 

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { HowToPlayPanel } from './HowToPlayPanel.js';
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+const CONTROLS = 'A/D or Left/Right to steer; W/Up to accelerate; M to mute';
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+async function draw(props: Partial<Parameters<typeof HowToPlayPanel>[0]> = {}) {
+  const onClose = vi.fn();
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<HowToPlayPanel open controls={CONTROLS} gameTitle="Apex Sprint" onClose={onClose} {...props} />);
+  });
+  return { onClose };
+}
+
+/** The panel portals to document.body, so queries go there rather than to `container`. */
+function card() {
+  return document.querySelector('.howto-card');
+}
+
+describe('HowToPlayPanel', () => {
+  it('renders one row per control clause', async () => {
+    await draw();
+    const rows = [...document.querySelectorAll('.howto-list li')].map((li) => li.textContent);
+    expect(rows).toEqual(['A/D or Left/Right to steer', 'W/Up to accelerate', 'M to mute']);
+  });
+
+  it('is a labelled modal dialog', async () => {
+    await draw();
+    expect(card()?.getAttribute('role')).toBe('dialog');
+    expect(card()?.getAttribute('aria-modal')).toBe('true');
+    const labelledBy = card()?.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toContain('How to play');
+    expect(document.querySelector('.howto-game')?.textContent).toBe('Apex Sprint');
+  });
+
+  it('renders nothing when closed, and nothing when the game has no controls', async () => {
+    await draw({ open: false });
+    expect(card()).toBeNull();
+
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+    await draw({ controls: '   ' });
+    expect(card()).toBeNull();
+  });
+
+  it('closes on the close button and on a backdrop click, but not on a click inside the card', async () => {
+    const { onClose } = await draw();
+
+    await act(async () => {
+      document.querySelector('.howto-close')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      card()?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.querySelector('.howto-backdrop')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('takes focus when it opens so the card is keyboard-reachable', async () => {
+    await draw();
+    expect(document.activeElement).toBe(document.querySelector('.howto-close'));
+  });
+
+  it('adds the keyboard-only note only for games with no touch path', async () => {
+    await draw();
+    expect(document.querySelector('.howto-note')).toBeNull();
+
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+    await draw({ keyboardOnly: true });
+    expect(document.querySelector('.howto-note')?.textContent).toContain('keyboard');
+  });
+
+  it('renders agent-authored control text as literal text, never as markup', async () => {
+    await draw({ controls: '<img src=x onerror=alert(1)> to jump' });
+    expect(document.querySelector('.howto-list img')).toBeNull();
+    expect(document.querySelector('.howto-list li')?.textContent).toBe('<img src=x onerror=alert(1)> to jump');
+  });
+});

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -35,16 +35,41 @@ async function draw(props: Partial<Parameters<typeof HowToPlayPanel>[0]> = {}) {
   return { onClose };
 }
 
+async function redraw(props: Partial<Parameters<typeof HowToPlayPanel>[0]> = {}) {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  return draw(props);
+}
+
 /** The panel portals to document.body, so queries go there rather than to `container`. */
 function card() {
   return document.querySelector('.howto-card');
 }
 
+function rows() {
+  return [...document.querySelectorAll('.howto-row')].map((row) => [
+    row.querySelector('dt')?.textContent ?? '',
+    row.querySelector('dd')?.textContent ?? '',
+  ]);
+}
+
 describe('HowToPlayPanel', () => {
-  it('renders one row per control clause', async () => {
+  it('renders each control as a key/action pair', async () => {
     await draw();
-    const rows = [...document.querySelectorAll('.howto-list li')].map((li) => li.textContent);
-    expect(rows).toEqual(['A/D or Left/Right to steer', 'W/Up to accelerate', 'M to mute']);
+    expect(rows()).toEqual([
+      ['A/D or Left/Right', 'steer'],
+      ['W/Up', 'accelerate'],
+      ['M', 'mute'],
+    ]);
+  });
+
+  it('gives a clause it cannot split a full-width row instead of guessing', async () => {
+    await draw({ controls: 'Press A, S, D, F, or Space in sync with scrolling rhythm note prompts' });
+    const row = document.querySelector('.howto-row');
+    expect(row?.classList.contains('is-wide')).toBe(true);
+    expect(row?.querySelector('dt')).toBeNull();
   });
 
   it('is a labelled modal dialog', async () => {
@@ -55,17 +80,14 @@ describe('HowToPlayPanel', () => {
     expect(labelledBy).toBeTruthy();
     expect(document.getElementById(labelledBy!)?.textContent).toContain('How to play');
     expect(document.querySelector('.howto-game')?.textContent).toBe('Apex Sprint');
+    expect(document.querySelector('.howto-dismiss')?.textContent).toContain('close');
   });
 
   it('renders nothing when closed, and nothing when the game has no controls', async () => {
     await draw({ open: false });
     expect(card()).toBeNull();
 
-    act(() => {
-      root?.unmount();
-    });
-    root = null;
-    await draw({ controls: '   ' });
+    await redraw({ controls: '   ' });
     expect(card()).toBeNull();
   });
 
@@ -93,21 +115,50 @@ describe('HowToPlayPanel', () => {
     expect(document.activeElement).toBe(document.querySelector('.howto-close'));
   });
 
+  it('keeps Tab inside the card — aria-modal does not constrain focus on its own', async () => {
+    await draw();
+    const close = document.querySelector('.howto-close') as HTMLButtonElement;
+    // A button behind the backdrop, of the kind the theater bar renders.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    const forward = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(forward);
+    });
+    // Only one stop in the card, so Tab wraps back onto it rather than leaving.
+    expect(forward.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(close);
+
+    const back = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(back);
+    });
+    expect(back.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(close);
+
+    outside.remove();
+  });
+
   it('adds the keyboard-only note only for games with no touch path', async () => {
     await draw();
     expect(document.querySelector('.howto-note')).toBeNull();
 
-    act(() => {
-      root?.unmount();
-    });
-    root = null;
-    await draw({ keyboardOnly: true });
+    await redraw({ keyboardOnly: true });
     expect(document.querySelector('.howto-note')?.textContent).toContain('keyboard');
+  });
+
+  it('renders repeated clauses without a duplicate-key warning', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await draw({ controls: 'Space to jump; Space to jump' });
+    expect(rows()).toHaveLength(2);
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key');
+    consoleError.mockRestore();
   });
 
   it('renders agent-authored control text as literal text, never as markup', async () => {
     await draw({ controls: '<img src=x onerror=alert(1)> to jump' });
-    expect(document.querySelector('.howto-list img')).toBeNull();
-    expect(document.querySelector('.howto-list li')?.textContent).toBe('<img src=x onerror=alert(1)> to jump');
+    expect(document.querySelector('.howto-keys img')).toBeNull();
+    expect(rows()).toEqual([['<img src=x onerror=alert(1)>', 'jump']]);
   });
 });

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -66,10 +66,16 @@ describe('HowToPlayPanel', () => {
   });
 
   it('gives a clause it cannot split a full-width row instead of guessing', async () => {
-    await draw({ controls: 'Press A, S, D, F, or Space in sync with scrolling rhythm note prompts' });
+    // beat-teacher, verbatim: the semicolons keep the comma-listed keys in one clause,
+    // and that clause has no key/action shape to split on.
+    await draw({
+      controls: 'Press A, S, D, F, or Space in sync with scrolling rhythm note prompts; M to mute',
+    });
     const row = document.querySelector('.howto-row');
     expect(row?.classList.contains('is-wide')).toBe(true);
-    expect(row?.querySelector('dt')).toBeNull();
+    // Still a well-formed dl group: the term is present for assistive tech and hidden by CSS.
+    expect(row?.querySelector('dt')?.textContent).toBe('Control');
+    expect(row?.querySelector('dd')?.textContent).toContain('Press A, S, D, F');
   });
 
   it('is a labelled modal dialog', async () => {
@@ -82,7 +88,7 @@ describe('HowToPlayPanel', () => {
     // The game is named in the close button rather than shown as a subtitle: the theater
     // bar behind the card already carries the title.
     expect(document.querySelector('.howto-close')?.getAttribute('aria-label')).toContain('Apex Sprint');
-    expect(document.querySelector('.howto-dismiss')?.textContent).toContain('close');
+    expect(document.querySelector('.howto-dismiss')?.textContent).toContain('Escape');
   });
 
   it('renders nothing when closed, and nothing when the game has no controls', async () => {
@@ -138,6 +144,31 @@ describe('HowToPlayPanel', () => {
     });
     expect(back.defaultPrevented).toBe(true);
     expect(document.activeElement).toBe(close);
+
+    outside.remove();
+  });
+
+  it('pulls focus back even when it is outside the card, in both directions', async () => {
+    // Clicking the card's own non-focusable text (a dt, the title) leaves activeElement
+    // on body. A Tab from there must not walk into the chrome behind the running game.
+    await draw();
+    const close = document.querySelector('.howto-close') as HTMLButtonElement;
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    for (const shiftKey of [false, true]) {
+      close.blur();
+      expect(document.activeElement).toBe(document.body);
+
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true, cancelable: true });
+      await act(async () => {
+        window.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(close);
+      expect(document.activeElement).not.toBe(outside);
+    }
 
     outside.remove();
   });

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -15,6 +15,8 @@ type HowToPlayPanelProps = {
   onClose: () => void;
 };
 
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 /**
  * The player's "How to play" card.
  *
@@ -25,16 +27,39 @@ type HowToPlayPanelProps = {
  */
 export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false, onClose }: HowToPlayPanelProps) {
   const { t } = useTranslation();
+  const cardRef = useRef<HTMLDivElement | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
-  // Take focus while open and hand it back on close, the same contract GameTheater
-  // keeps for the theater itself — otherwise focus is stranded on a hidden trigger
-  // (the bar and the More menu each render one, and CSS hides whichever does not fit).
+  // Take focus while open. Focus is NOT restored here: the caller hands it back to the
+  // game, because returning it to the trigger leaves the next Space press hitting a
+  // button instead of firing in the game.
   useEffect(() => {
     if (!open) return;
-    const previouslyFocused = document.activeElement as HTMLElement | null;
     closeRef.current?.focus();
-    return () => previouslyFocused?.focus?.();
+  }, [open]);
+
+  // `aria-modal` tells a screen reader the rest of the page is inert; it does nothing to
+  // Tab. Without this, tabbing walks out of the card and into the page chrome behind a
+  // game that is still running, with no way to see where focus went.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !cardRef.current) return;
+      const stops = [...cardRef.current.querySelectorAll<HTMLElement>(FOCUSABLE)];
+      if (stops.length === 0) return;
+      const first = stops[0]!;
+      const last = stops[stops.length - 1]!;
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !cardRef.current.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
   }, [open]);
 
   if (!open) return null;
@@ -52,27 +77,38 @@ export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false
         role="dialog"
         aria-modal="true"
         aria-labelledby="howto-title"
+        ref={cardRef}
         onClick={(event) => event.stopPropagation()}
       >
-        <button
-          type="button"
-          className="howto-close"
-          onClick={onClose}
-          ref={closeRef}
-          aria-label={t('player.howToPlayClose')}
-        >
-          <PixelIcon name="close" size={14} />
-        </button>
-        <h2 className="howto-title" id="howto-title">
-          <PixelIcon name="gamepad" size={16} /> {t('player.howToPlay')}
-        </h2>
-        <p className="howto-game">{gameTitle}</p>
-        <ul className="howto-list">
-          {rows.map((row) => (
-            <li key={row}>{row}</li>
+        <div className="howto-head">
+          <div>
+            <h2 className="howto-title" id="howto-title">
+              <PixelIcon name="gamepad" size={16} /> {t('player.howToPlay')}
+            </h2>
+            <p className="howto-game">{gameTitle}</p>
+          </div>
+          <button
+            type="button"
+            className="howto-close"
+            onClick={onClose}
+            ref={closeRef}
+            aria-label={t('player.howToPlayClose')}
+          >
+            <PixelIcon name="close" size={14} />
+          </button>
+        </div>
+        <dl className="howto-keys">
+          {rows.map((row, index) => (
+            // Keyed by index on purpose: a controls string may repeat a clause, and two
+            // long clauses can truncate to the same text, so the row text is not unique.
+            <div className={row.keys ? 'howto-row' : 'howto-row is-wide'} key={index}>
+              {row.keys ? <dt>{row.keys}</dt> : null}
+              <dd>{row.action}</dd>
+            </div>
           ))}
-        </ul>
+        </dl>
         {keyboardOnly ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
+        <p className="howto-dismiss">{t('player.howToPlayDismiss')}</p>
       </div>
     </div>,
     document.body,

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -8,7 +8,11 @@ type HowToPlayPanelProps = {
   open: boolean;
   /** The game's `controls` string from the catalog. Free text; rendered as text nodes. */
   controls: string;
-  /** Shown as the panel's subtitle so it is obvious which game these keys belong to. */
+  /**
+   * Names the game in the close button's accessible label. It is not shown: the theater
+   * bar behind the card already carries the title, and repeating it in a card this small
+   * costs a row without answering the question the card exists for.
+   */
   gameTitle: string;
   /** Adds the "keyboard only" line, for games the games-repo build found no touch path in. */
   keyboardOnly?: boolean;
@@ -81,18 +85,15 @@ export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false
         onClick={(event) => event.stopPropagation()}
       >
         <div className="howto-head">
-          <div>
-            <h2 className="howto-title" id="howto-title">
-              <PixelIcon name="gamepad" size={16} /> {t('player.howToPlay')}
-            </h2>
-            <p className="howto-game">{gameTitle}</p>
-          </div>
+          <h2 className="howto-title" id="howto-title">
+            {t('player.howToPlay')}
+          </h2>
           <button
             type="button"
             className="howto-close"
             onClick={onClose}
             ref={closeRef}
-            aria-label={t('player.howToPlayClose')}
+            aria-label={t('player.howToPlayClose', { game: gameTitle })}
           >
             <PixelIcon name="close" size={14} />
           </button>

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
+import { parseControls } from './howToPlay.js';
+
+type HowToPlayPanelProps = {
+  open: boolean;
+  /** The game's `controls` string from the catalog. Free text; rendered as text nodes. */
+  controls: string;
+  /** Shown as the panel's subtitle so it is obvious which game these keys belong to. */
+  gameTitle: string;
+  /** Adds the "keyboard only" line, for games the games-repo build found no touch path in. */
+  keyboardOnly?: boolean;
+  onClose: () => void;
+};
+
+/**
+ * The player's "How to play" card.
+ *
+ * It reads the catalog entry the app already holds — never the game. The frame is
+ * sandboxed without `allow-same-origin`, so the parent cannot see inside it, and the
+ * game's own in-shell controls popup is hidden on purpose by the player bridge
+ * (`gamePlayer.ts` HIDE_CHROME) because the theater surfaces this chrome instead.
+ */
+export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false, onClose }: HowToPlayPanelProps) {
+  const { t } = useTranslation();
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  // Take focus while open and hand it back on close, the same contract GameTheater
+  // keeps for the theater itself — otherwise focus is stranded on a hidden trigger
+  // (the bar and the More menu each render one, and CSS hides whichever does not fit).
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+    return () => previouslyFocused?.focus?.();
+  }, [open]);
+
+  if (!open) return null;
+
+  const rows = parseControls(controls);
+  if (rows.length === 0) return null;
+
+  // Portalled to the body: `.game-theater-bar` and `.theater-more-panel` carry a
+  // backdrop-filter, which makes an ancestor the containing block for position:fixed
+  // descendants and would clamp this card inside the bar (the bug AuthModal documents).
+  return createPortal(
+    <div className="howto-backdrop" onClick={onClose}>
+      <div
+        className="howto-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="howto-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="howto-close"
+          onClick={onClose}
+          ref={closeRef}
+          aria-label={t('player.howToPlayClose')}
+        >
+          <PixelIcon name="close" size={14} />
+        </button>
+        <h2 className="howto-title" id="howto-title">
+          <PixelIcon name="gamepad" size={16} /> {t('player.howToPlay')}
+        </h2>
+        <p className="howto-game">{gameTitle}</p>
+        <ul className="howto-list">
+          {rows.map((row) => (
+            <li key={row}>{row}</li>
+          ))}
+        </ul>
+        {keyboardOnly ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import type { CatalogTouch } from './catalog.js';
 import { PixelIcon } from './PixelIcon.js';
 import { parseControls } from './howToPlay.js';
 
@@ -14,8 +15,12 @@ type HowToPlayPanelProps = {
    * costs a row without answering the question the card exists for.
    */
   gameTitle: string;
-  /** Adds the "keyboard only" line, for games the games-repo build found no touch path in. */
-  keyboardOnly?: boolean;
+  /**
+   * Catalog touch support, derived by the games-repo build from the game's own source —
+   * never authored in a spec — so it can be stated as fact. `gamekit` earns a Touch row;
+   * `none` earns the keyboard-only line.
+   */
+  touch?: CatalogTouch | null;
   onClose: () => void;
 };
 
@@ -29,7 +34,7 @@ const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabi
  * game's own in-shell controls popup is hidden on purpose by the player bridge
  * (`gamePlayer.ts` HIDE_CHROME) because the theater surfaces this chrome instead.
  */
-export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false, onClose }: HowToPlayPanelProps) {
+export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClose }: HowToPlayPanelProps) {
   const { t } = useTranslation();
   const cardRef = useRef<HTMLDivElement | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
@@ -107,8 +112,16 @@ export function HowToPlayPanel({ open, controls, gameTitle, keyboardOnly = false
               <dd>{row.action}</dd>
             </div>
           ))}
+          {/* Stated, not guessed: `touch` is derived from the game's own source by the
+              games-repo build, so a pad promised here is a pad that exists. */}
+          {touch === 'gamekit' ? (
+            <div className="howto-row">
+              <dt>{t('player.howToPlayTouch')}</dt>
+              <dd>{t('player.howToPlayTouchPad')}</dd>
+            </div>
+          ) : null}
         </dl>
-        {keyboardOnly ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
+        {touch === 'none' ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
         <p className="howto-dismiss">{t('player.howToPlayDismiss')}</p>
       </div>
     </div>,

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -59,10 +59,15 @@ export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClos
       const first = stops[0]!;
       const last = stops[stops.length - 1]!;
       const active = document.activeElement;
-      if (event.shiftKey && (active === first || !cardRef.current.contains(active))) {
+      // The "outside the card" case has to be handled in both directions. Clicking the
+      // card's own non-focusable text (a `dt`, the title) leaves `activeElement` on
+      // `body`, and a forward Tab from there used to match neither branch and walk into
+      // the chrome behind a running game.
+      const outside = !cardRef.current.contains(active);
+      if (event.shiftKey && (active === first || outside)) {
         event.preventDefault();
         last.focus();
-      } else if (!event.shiftKey && active === last) {
+      } else if (!event.shiftKey && (active === last || outside)) {
         event.preventDefault();
         first.focus();
       }
@@ -108,7 +113,10 @@ export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClos
             // Keyed by index on purpose: a controls string may repeat a clause, and two
             // long clauses can truncate to the same text, so the row text is not unique.
             <div className={row.keys ? 'howto-row' : 'howto-row is-wide'} key={index}>
-              {row.keys ? <dt>{row.keys}</dt> : null}
+              {/* A clause with no key/action shape still gets a term, hidden visually but
+                  read aloud: a `dl` group that is a definition with nothing being defined
+                  is invalid, and a screen reader announces it orphaned. */}
+              <dt>{row.keys || t('player.howToPlayOther')}</dt>
               <dd>{row.action}</dd>
             </div>
           ))}

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -6,20 +6,45 @@ describe('parseControls', () => {
     // apex-sprint, verbatim from the published catalog.
     expect(
       parseControls('A/D or Left/Right to steer; W/Up to accelerate; S/Down to brake; R to restart; M to mute'),
-    ).toEqual(['A/D or Left/Right to steer', 'W/Up to accelerate', 'S/Down to brake', 'R to restart', 'M to mute']);
+    ).toEqual([
+      { keys: 'A/D or Left/Right', action: 'steer' },
+      { keys: 'W/Up', action: 'accelerate' },
+      { keys: 'S/Down', action: 'brake' },
+      { keys: 'R', action: 'restart' },
+      { keys: 'M', action: 'mute' },
+    ]);
   });
 
   it('falls back to the comma so comma-delimited entries do not render as one line', () => {
     // block-cascade, verbatim: no semicolon anywhere, commas are the separator.
-    expect(
-      parseControls('Left/Right (A/D) to shift, Up/W/K to rotate, Down/S to soft drop, Space for hard drop, M to mute'),
-    ).toEqual([
-      'Left/Right (A/D) to shift',
-      'Up/W/K to rotate',
-      'Down/S to soft drop',
-      'Space for hard drop',
-      'M to mute',
+    expect(parseControls('Left/Right (A/D) to shift, Up/W/K to rotate, Space for hard drop, M to mute')).toEqual([
+      { keys: 'Left/Right (A/D)', action: 'shift' },
+      { keys: 'Up/W/K', action: 'rotate' },
+      { keys: 'Space', action: 'hard drop' },
+      { keys: 'M', action: 'mute' },
     ]);
+  });
+
+  it('keeps a clause whole when splitting it would be a guess', () => {
+    // beat-teacher, verbatim. The semicolons are what keep the comma-listed keys in the
+    // first clause together, and that clause has no key/action shape to split on.
+    expect(
+      parseControls('Press A, S, D, F, or Space in sync with scrolling rhythm note prompts; R to restart; M to mute'),
+    ).toEqual([
+      { keys: '', action: 'Press A, S, D, F, or Space in sync with scrolling rhythm note prompts' },
+      { keys: 'R', action: 'restart' },
+      { keys: 'M', action: 'mute' },
+    ]);
+    // paddle-duel, verbatim: comma-delimited, keys in parentheses, no " to " anywhere —
+    // every row stays whole rather than being split on a separator that is not there.
+    expect(parseControls('Player 1 (W/S), Player 2 / AI (Up/Down Arrow), Mute (M)')).toEqual([
+      { keys: '', action: 'Player 1 (W/S)' },
+      { keys: '', action: 'Player 2 / AI (Up/Down Arrow)' },
+      { keys: '', action: 'Mute (M)' },
+    ]);
+    expect(parseControls('Tap anywhere to flap')).toEqual([{ keys: 'Tap anywhere', action: 'flap' }]);
+    // A clause that opens with the separator has no key half worth showing.
+    expect(parseControls('to jump')).toEqual([{ keys: '', action: 'to jump' }]);
   });
 
   it('returns nothing for an empty or separator-only string, which is how the caller hides the control', () => {
@@ -28,25 +53,30 @@ describe('parseControls', () => {
     expect(parseControls(';;')).toEqual([]);
   });
 
-  it('keeps a single clause with no separator as one row', () => {
-    expect(parseControls('Tap anywhere to flap')).toEqual(['Tap anywhere to flap']);
-  });
-
   it('passes markup through as literal text — escaping is the renderer’s job, not this parser’s', () => {
     // `controls` is agent-authored, prompt-influenced free text. It is rendered as a JSX
     // text node (never dangerouslySetInnerHTML); this pins the intent that the parser
     // does not strip, and therefore must never be fed to an HTML sink.
-    expect(parseControls('<b>W</b> to jump')).toEqual(['<b>W</b> to jump']);
+    expect(parseControls('<b>W</b> to jump')).toEqual([{ keys: '<b>W</b>', action: 'jump' }]);
   });
 
   it('caps runaway rows so a prose blob cannot blow the card out of the viewport', () => {
-    const long = `${'x'.repeat(400)}; W to jump`;
-    const rows = parseControls(long);
+    const rows = parseControls(`${'x'.repeat(400)}; W to jump`);
     expect(rows).toHaveLength(2);
-    expect(rows[0]).toHaveLength(160);
-    expect(rows[0]?.endsWith('…')).toBe(true);
+    expect(rows[0]?.keys).toBe('');
+    expect(rows[0]?.action).toHaveLength(160);
+    expect(rows[0]?.action.endsWith('…')).toBe(true);
 
-    const many = Array.from({ length: 40 }, (_, i) => `key ${i}`).join(';');
+    const many = Array.from({ length: 40 }, (_, i) => `key${i} to act`).join(';');
     expect(parseControls(many)).toHaveLength(14);
+  });
+
+  it('keeps repeated clauses rather than deduping them — the renderer must not key on text', () => {
+    // Two identical clauses, and two long clauses that truncate to the same string, both
+    // occur in free text. The panel keys rows by index because of this.
+    expect(parseControls('Space to jump; Space to jump')).toHaveLength(2);
+    const twins = `${'y'.repeat(200)}a; ${'y'.repeat(200)}b`;
+    const truncated = parseControls(twins);
+    expect(truncated[0]?.action).toBe(truncated[1]?.action);
   });
 });

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { parseControls } from './howToPlay.js';
+
+describe('parseControls', () => {
+  it('splits on the semicolon when there is one, keeping commas inside a clause', () => {
+    // apex-sprint, verbatim from the published catalog.
+    expect(
+      parseControls('A/D or Left/Right to steer; W/Up to accelerate; S/Down to brake; R to restart; M to mute'),
+    ).toEqual(['A/D or Left/Right to steer', 'W/Up to accelerate', 'S/Down to brake', 'R to restart', 'M to mute']);
+  });
+
+  it('falls back to the comma so comma-delimited entries do not render as one line', () => {
+    // block-cascade, verbatim: no semicolon anywhere, commas are the separator.
+    expect(
+      parseControls('Left/Right (A/D) to shift, Up/W/K to rotate, Down/S to soft drop, Space for hard drop, M to mute'),
+    ).toEqual([
+      'Left/Right (A/D) to shift',
+      'Up/W/K to rotate',
+      'Down/S to soft drop',
+      'Space for hard drop',
+      'M to mute',
+    ]);
+  });
+
+  it('returns nothing for an empty or separator-only string, which is how the caller hides the control', () => {
+    expect(parseControls('')).toEqual([]);
+    expect(parseControls('   ')).toEqual([]);
+    expect(parseControls(';;')).toEqual([]);
+  });
+
+  it('keeps a single clause with no separator as one row', () => {
+    expect(parseControls('Tap anywhere to flap')).toEqual(['Tap anywhere to flap']);
+  });
+
+  it('passes markup through as literal text — escaping is the renderer’s job, not this parser’s', () => {
+    // `controls` is agent-authored, prompt-influenced free text. It is rendered as a JSX
+    // text node (never dangerouslySetInnerHTML); this pins the intent that the parser
+    // does not strip, and therefore must never be fed to an HTML sink.
+    expect(parseControls('<b>W</b> to jump')).toEqual(['<b>W</b> to jump']);
+  });
+
+  it('caps runaway rows so a prose blob cannot blow the card out of the viewport', () => {
+    const long = `${'x'.repeat(400)}; W to jump`;
+    const rows = parseControls(long);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveLength(160);
+    expect(rows[0]?.endsWith('…')).toBe(true);
+
+    const many = Array.from({ length: 40 }, (_, i) => `key ${i}`).join(';');
+    expect(parseControls(many)).toHaveLength(14);
+  });
+});

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -1,0 +1,26 @@
+/**
+ * Turning a game's `controls` string into rows a player can scan.
+ *
+ * The field is free text an agent authored in the game's SPEC.md frontmatter, and the
+ * catalog ships it unprojected, so both delimiters are in live data: semicolon-separated
+ * clauses that contain commas of their own ("A/D or Left/Right to steer; W/Up to
+ * accelerate; R to restart") and plain comma-separated lists ("Left/Right to move, Space
+ * to fire"). Splitting on the semicolon whenever there is one keeps the first shape's
+ * clauses whole; falling back to the comma stops the second from rendering as a single
+ * run-on line, which is the whole point of the panel.
+ */
+
+/** Enough for the longest catalog entry today (292 chars over 8 clauses) with headroom. */
+const MAX_ROWS = 14;
+/** A clause longer than this is not a control list; it is prose that would blow the card. */
+const MAX_ROW_LENGTH = 160;
+
+export function parseControls(controls: string): string[] {
+  const separator = controls.includes(';') ? ';' : ',';
+  return controls
+    .split(separator)
+    .map((row) => row.trim())
+    .filter((row) => row.length > 0)
+    .slice(0, MAX_ROWS)
+    .map((row) => (row.length > MAX_ROW_LENGTH ? `${row.slice(0, MAX_ROW_LENGTH - 1)}…` : row));
+}

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -14,6 +14,13 @@
  * it far faster than a sentence. The split is deliberately conservative: only the first
  * " to " / " for " counts, and a clause without one is kept whole and rendered across
  * both columns rather than guessed at. A wrong split reads worse than no split.
+ *
+ * Measured against all 92 published entries (326 clauses): 293 split, and every one of the
+ * 33 left whole genuinely has no key/action shape to find — either prose, or the
+ * key-space-action form ("W/S pitch") whose first space is not a reliable boundary
+ * ("Shift boost / Ctrl cut" would split wrong). An earlier length cap on the key column
+ * was removed because it was the only thing keeping real entries like arena-tag's
+ * "D-pad or WASD/arrows/IJKL/numpad to run" from splitting.
  */
 
 /** Enough for the longest catalog entry today (292 chars over 8 clauses) with headroom. */
@@ -37,11 +44,13 @@ function splitClause(clause: string): ControlRow {
     if (at <= 0) continue;
     const keys = clause.slice(0, at).trim();
     const action = clause.slice(at + separator.length).trim();
-    // "Press A, S, D, F, or Space in sync with..." style prose: a key column that long is
-    // not a key column, and the row reads better whole.
-    if (!keys || !action || keys.length > 28) break;
+    if (!keys || !action) break;
     return { keys, action };
   }
+  // No separator at all. Prose ("Press A, S, D, F, or Space in sync with...") and the
+  // key-space-action shape ("W/S pitch") both land here and keep their own row: splitting
+  // the latter on its first space turns "Shift boost / Ctrl cut" into a wrong answer, and
+  // a wrong split reads worse than none.
   return { keys: '', action: clause };
 }
 

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -1,5 +1,5 @@
 /**
- * Turning a game's `controls` string into rows a player can scan.
+ * Turning a game's `controls` string into key/action rows a player can scan.
  *
  * The field is free text an agent authored in the game's SPEC.md frontmatter, and the
  * catalog ships it unprojected, so both delimiters are in live data: semicolon-separated
@@ -7,7 +7,13 @@
  * accelerate; R to restart") and plain comma-separated lists ("Left/Right to move, Space
  * to fire"). Splitting on the semicolon whenever there is one keeps the first shape's
  * clauses whole; falling back to the comma stops the second from rendering as a single
- * run-on line, which is the whole point of the panel.
+ * run-on line.
+ *
+ * Each clause is then split once more into the keys and what they do, because "which key
+ * does what" is the question the panel exists to answer and a two-column reading answers
+ * it far faster than a sentence. The split is deliberately conservative: only the first
+ * " to " / " for " counts, and a clause without one is kept whole and rendered across
+ * both columns rather than guessed at. A wrong split reads worse than no split.
  */
 
 /** Enough for the longest catalog entry today (292 chars over 8 clauses) with headroom. */
@@ -15,12 +21,37 @@ const MAX_ROWS = 14;
 /** A clause longer than this is not a control list; it is prose that would blow the card. */
 const MAX_ROW_LENGTH = 160;
 
-export function parseControls(controls: string): string[] {
+export interface ControlRow {
+  /** The keys, e.g. "A/D or Left/Right". Empty when the clause could not be split. */
+  keys: string;
+  /** What they do, e.g. "steer". Carries the whole clause when `keys` is empty. */
+  action: string;
+}
+
+const SEPARATORS = [' to ', ' for '];
+
+function splitClause(clause: string): ControlRow {
+  for (const separator of SEPARATORS) {
+    const at = clause.indexOf(separator);
+    // A clause starting with the separator ("to jump") has no key half worth showing.
+    if (at <= 0) continue;
+    const keys = clause.slice(0, at).trim();
+    const action = clause.slice(at + separator.length).trim();
+    // "Press A, S, D, F, or Space in sync with..." style prose: a key column that long is
+    // not a key column, and the row reads better whole.
+    if (!keys || !action || keys.length > 28) break;
+    return { keys, action };
+  }
+  return { keys: '', action: clause };
+}
+
+export function parseControls(controls: string): ControlRow[] {
   const separator = controls.includes(';') ? ';' : ',';
   return controls
     .split(separator)
-    .map((row) => row.trim())
-    .filter((row) => row.length > 0)
+    .map((clause) => clause.trim())
+    .filter((clause) => clause.length > 0)
     .slice(0, MAX_ROWS)
-    .map((row) => (row.length > MAX_ROW_LENGTH ? `${row.slice(0, MAX_ROW_LENGTH - 1)}…` : row));
+    .map((clause) => (clause.length > MAX_ROW_LENGTH ? `${clause.slice(0, MAX_ROW_LENGTH - 1)}…` : clause))
+    .map(splitClause);
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -155,9 +155,10 @@
     },
     "howToPlay": "How to play",
     "howToPlayClose": "Close how to play for {{game}}",
-    "howToPlayDismiss": "Click or tap anywhere outside to close",
+    "howToPlayDismiss": "Press Escape, or click or tap anywhere outside, to close",
     "howToPlayTouch": "Touch",
-    "howToPlayTouchPad": "On-screen pad on touch screens"
+    "howToPlayTouchPad": "On-screen pad on touch screens",
+    "howToPlayOther": "Control"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -154,7 +154,7 @@
       "error": "We couldn't send that right now. Please try again in a moment."
     },
     "howToPlay": "How to play",
-    "howToPlayClose": "Close",
+    "howToPlayClose": "Close how to play for {{game}}",
     "howToPlayDismiss": "Click or tap anywhere outside to close"
   },
   "catalog": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -152,7 +152,9 @@
       "sent": "Thanks — your feedback was received.",
       "quota": "You've sent a lot of feedback today — please try again tomorrow.",
       "error": "We couldn't send that right now. Please try again in a moment."
-    }
+    },
+    "howToPlay": "How to play",
+    "howToPlayClose": "Close"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -155,7 +155,9 @@
     },
     "howToPlay": "How to play",
     "howToPlayClose": "Close how to play for {{game}}",
-    "howToPlayDismiss": "Click or tap anywhere outside to close"
+    "howToPlayDismiss": "Click or tap anywhere outside to close",
+    "howToPlayTouch": "Touch",
+    "howToPlayTouchPad": "On-screen pad on touch screens"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -154,7 +154,8 @@
       "error": "We couldn't send that right now. Please try again in a moment."
     },
     "howToPlay": "How to play",
-    "howToPlayClose": "Close"
+    "howToPlayClose": "Close",
+    "howToPlayDismiss": "Click or tap anywhere outside to close"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -154,7 +154,8 @@
       "error": "Nie udało się teraz tego wysłać. Spróbuj ponownie za chwilę."
     },
     "howToPlay": "Jak grać",
-    "howToPlayClose": "Zamknij"
+    "howToPlayClose": "Zamknij",
+    "howToPlayDismiss": "Kliknij lub dotknij obok, aby zamknąć"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -154,7 +154,7 @@
       "error": "Nie udało się teraz tego wysłać. Spróbuj ponownie za chwilę."
     },
     "howToPlay": "Jak grać",
-    "howToPlayClose": "Zamknij",
+    "howToPlayClose": "Zamknij instrukcję gry {{game}}",
     "howToPlayDismiss": "Kliknij lub dotknij obok, aby zamknąć"
   },
   "catalog": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -155,9 +155,10 @@
     },
     "howToPlay": "Jak grać",
     "howToPlayClose": "Zamknij instrukcję gry {{game}}",
-    "howToPlayDismiss": "Kliknij lub dotknij obok, aby zamknąć",
+    "howToPlayDismiss": "Naciśnij Escape lub kliknij obok, aby zamknąć",
     "howToPlayTouch": "Dotyk",
-    "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych"
+    "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych",
+    "howToPlayOther": "Sterowanie"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -155,7 +155,9 @@
     },
     "howToPlay": "Jak grać",
     "howToPlayClose": "Zamknij instrukcję gry {{game}}",
-    "howToPlayDismiss": "Kliknij lub dotknij obok, aby zamknąć"
+    "howToPlayDismiss": "Kliknij lub dotknij obok, aby zamknąć",
+    "howToPlayTouch": "Dotyk",
+    "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -152,7 +152,9 @@
       "sent": "Dzięki — otrzymaliśmy Twoją opinię.",
       "quota": "Wysłałeś dziś dużo opinii — spróbuj ponownie jutro.",
       "error": "Nie udało się teraz tego wysłać. Spróbuj ponownie za chwilę."
-    }
+    },
+    "howToPlay": "Jak grać",
+    "howToPlayClose": "Zamknij"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3460,7 +3460,22 @@ body.player-open {
   opacity: 1;
 }
 
-/* AUTH MODAL */
+/* This control sheds to the More menu earlier than sound and fullscreen do (900px, not
+   768px). Measured at 800px: with it on the bar, the actions row grows until the vote
+   widget overlaps the game title, because the meta column does not shrink. Below the
+   breakpoint the bar copy is hidden and the menu copy takes over; above it, the reverse. */
+@media (max-width: 900px) {
+  .game-theater-actions .howto-bar {
+    display: none !important;
+  }
+}
+
+@media (min-width: 901px) {
+  .game-theater-actions .theater-more-panel .howto-menu {
+    display: none !important;
+  }
+}
+
 /* HOW TO PLAY
    The player's controls card. Portalled to the body, so it sits above the theater bar
    (which carries a backdrop-filter and would otherwise become its containing block) and
@@ -3560,6 +3575,18 @@ body.player-open {
 }
 
 /* A clause with no "X to Y" shape keeps its own line rather than being guessed apart. */
+.howto-row.is-wide dt {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .howto-row.is-wide dd {
   grid-column: 1 / -1;
 }
@@ -3579,6 +3606,7 @@ body.player-open {
   flex: 0 0 auto;
 }
 
+/* AUTH MODAL */
 .modal-backdrop {
   position: fixed;
   top: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3477,22 +3477,34 @@ body.player-open {
 }
 
 .howto-card {
-  position: relative;
+  display: flex;
+  flex-direction: column;
   width: min(30rem, 100%);
   max-height: calc(100dvh - 32px);
-  overflow-y: auto;
-  padding: 20px 22px;
+  padding: 18px 20px;
   background: var(--panel);
   border: 1px solid var(--panel-border);
   border-radius: 12px;
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
   text-align: left;
+  /* Matches the player underneath: a long press on the card must not raise the iOS
+     selection loupe and Copy / Look Up callout over a running game. */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* The head stays put while the rows scroll — the close button used to be absolutely
+   positioned inside the scroll box and slid out of reach on a long controls list. */
+.howto-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
 .howto-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
   display: flex;
   padding: 6px;
   background: none;
@@ -3511,37 +3523,62 @@ body.player-open {
   align-items: center;
   gap: 8px;
   margin: 0;
-  padding-right: 28px;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   color: var(--turquoise);
 }
 
 .howto-game {
-  margin: 4px 0 14px;
+  margin: 2px 0 0;
   color: var(--muted);
   font-size: 0.85rem;
 }
 
-.howto-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
+/* Key on the left, what it does on the right — the two-column reading answers "which
+   key does what" at a glance, which a sentence per row does not. */
+.howto-keys {
   display: grid;
-  gap: 8px;
+  grid-template-columns: auto 1fr;
+  gap: 6px 14px;
+  margin: 14px 0 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
 }
 
-.howto-list li {
-  padding: 8px 12px;
-  background: var(--panel-card);
-  border-radius: 8px;
-  font-size: 0.9rem;
+.howto-row {
+  display: contents;
+}
+
+.howto-keys dt {
+  font-weight: 700;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.howto-keys dd {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
   line-height: 1.35;
 }
 
+/* A clause with no "X to Y" shape keeps its own line rather than being guessed apart. */
+.howto-row.is-wide dd {
+  grid-column: 1 / -1;
+}
+
 .howto-note {
-  margin: 14px 0 0;
+  margin: 12px 0 0;
   color: var(--muted);
   font-size: 0.8rem;
+  flex: 0 0 auto;
+}
+
+.howto-dismiss {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+  opacity: 0.75;
+  flex: 0 0 auto;
 }
 
 .modal-backdrop {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3461,6 +3461,89 @@ body.player-open {
 }
 
 /* AUTH MODAL */
+/* HOW TO PLAY
+   The player's controls card. Portalled to the body, so it sits above the theater bar
+   (which carries a backdrop-filter and would otherwise become its containing block) and
+   above the game's own fixed on-screen touch pad. */
+.howto-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 10, 20, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 1000;
+}
+
+.howto-card {
+  position: relative;
+  width: min(30rem, 100%);
+  max-height: calc(100dvh - 32px);
+  overflow-y: auto;
+  padding: 20px 22px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  text-align: left;
+}
+
+.howto-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  padding: 6px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.howto-close:hover,
+.howto-close:focus-visible {
+  color: var(--text);
+}
+
+.howto-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding-right: 28px;
+  font-size: 1.1rem;
+  color: var(--turquoise);
+}
+
+.howto-game {
+  margin: 4px 0 14px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.howto-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.howto-list li {
+  padding: 8px 12px;
+  background: var(--panel-card);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.howto-note {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
 .modal-backdrop {
   position: fixed;
   top: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3519,18 +3519,10 @@ body.player-open {
 }
 
 .howto-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   margin: 0;
-  font-size: 1.05rem;
-  color: var(--turquoise);
-}
-
-.howto-game {
-  margin: 2px 0 0;
-  color: var(--muted);
-  font-size: 0.85rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
 }
 
 /* Key on the left, what it does on the right — the two-column reading answers "which
@@ -3559,6 +3551,12 @@ body.player-open {
   color: var(--muted);
   font-size: 0.85rem;
   line-height: 1.35;
+}
+
+/* The action reads as a label ("Steer"), not as the tail of a sentence — but only the
+   first letter, because `capitalize` would also title-case "hard drop". */
+.howto-keys dd::first-letter {
+  text-transform: uppercase;
 }
 
 /* A clause with no "X to Y" shape keeps its own line rather than being guessed apart. */

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -41,6 +41,12 @@ export type VisitEvent =
   | { type: 'route_viewed'; route: VisitRouteKind }
   /** A published game began playing. Intentionally carries no slug. */
   | { type: 'play_started' }
+  /**
+   * The player opened the "How to play" card. No slug, for the same reason
+   * `play_started` carries none: the visit stream must stay unjoinable with the play
+   * stream. What this answers is how often players need the controls spelled out.
+   */
+  | { type: 'how_to_play_opened' }
   /** A step of the creation funnel was reached. Carries no prompt text, ever. */
   | { type: 'create_step'; step: CreateStep }
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */


### PR DESCRIPTION
Players arrive at a game with no idea which keys it takes. The catalog has carried a per-game `controls` string all along — required in every SPEC, non-empty for all 92 published games, already typed as `CatalogEntry.controls` in the browser — but the player never showed it; only two marketing surfaces did.

This adds a **How to play** control to the theater bar (and to the More menu on a phone) that opens a card of key → action rows, built from that string.

## What it looks like

Apex Sprint, entered from the arcade. Every row is that game's own `controls` string from the
catalog, split into keys and action; the Touch row is stated from `entry.touch`, which the
games-repo build derives from the game's source rather than from a spec claim.

![How to play, desktop](https://raw.githubusercontent.com/jactan77/www.gamedev.pl/pr-356-screenshots/screenshots/how-to-play-desktop.png)

The control sits on the theater bar next to Sound and Fullscreen:

![Theater bar](https://raw.githubusercontent.com/jactan77/www.gamedev.pl/pr-356-screenshots/screenshots/how-to-play-bar.png)

On a phone the bar has no room for it, so it moves into the More menu, and the card fills the
width above the game's on-screen pad:

| More menu | Card |
| --- | --- |
| ![More menu on a phone](https://raw.githubusercontent.com/jactan77/www.gamedev.pl/pr-356-screenshots/screenshots/how-to-play-phone-menu.png) | ![How to play on a phone](https://raw.githubusercontent.com/jactan77/www.gamedev.pl/pr-356-screenshots/screenshots/how-to-play-phone.png) |

## Why this is host chrome and not something inside the game

The player injects `#game-title,#game-desc,.game-controls,.hint{display:none!important}` into every game document (`gamePlayer.ts`), because the theater shows the title, description and sound instead. A controls affordance built into a game's own shell is therefore invisible here by construction. `HIDE_CHROME` is unchanged and `gamePlayer.test.ts` is untouched — that is deliberate, not an oversight.

Nothing is read across the iframe boundary: the card is built from the catalog entry the app already holds, so the sandbox invariant (`allow-scripts allow-pointer-lock`, no `allow-same-origin`) is untouched. No games-repo change and no snapshot re-bake is needed; this ships with a normal web deploy.

## Parsing `controls`

The field is free text an agent authored in a SPEC, and two delimiters are live in the catalog: semicolon-separated clauses that contain their own commas, and plain comma-separated lists. Each clause is then split once, at its first `" to "` / `" for "`, into a key column and an action column.

The split is deliberately conservative, and the threshold was measured rather than guessed: across all 92 entries (326 clauses) 293 split cleanly, and every one of the 33 left whole genuinely has no key/action shape — either prose (`Press A, S, D, F, or Space in sync with...`) or the key-space-action form (`W/S pitch`), whose first space is not a reliable boundary because `Shift boost / Ctrl cut` would split wrong. A clause that cannot be split keeps its own full-width row.

`controls` is prompt-influenced text, so it renders as JSX text nodes, never through an HTML sink, and a test pins that intent.

## Accessibility and player behaviour

- Escape closes the card before it closes the game, in **both** paths — the window listener and the Escape the sandboxed frame relays over the player bridge. Without that, reaching for the controls and pressing Escape throws you out of the game.
- Closing hands focus back to the game frame, not to the trigger: in a player the next key press is meant for the game, and focus left on a button turns the next Space into "reopen the card" instead of "fire".
- The card traps Tab. `aria-modal` is an assistive-tech hint and does not constrain focus on its own, so without this, tabbing walks into the chrome behind a running game.
- Entering fullscreen closes the card, because the bar that holds both triggers unmounts there.
- The card is portalled to the body: the theater bar carries a `backdrop-filter`, which would otherwise become the containing block for its fixed position — the bug `AuthModal` already documents.
- A long press does not raise the iOS selection loupe over a running game, matching the player everywhere else.

## Telemetry

`how_to_play_opened` carries no slug, keeping the visit stream unjoinable with the play stream exactly as `play_started` does. It has a route-level test: the mapper ends in a `default` branch that relabels anything unmatched as `play_started`, so a missing case is mislabelled data rather than an error — which no schema failure would ever reveal.

## Known gap

On a direct `/play/<slug>` link the control does not appear. The catalog is fetched on the home route only and `App.catalog.test.ts` pins that ("a direct game link costs the game and nothing else"), so the player holds a placeholder entry whose `controls` is empty — the same reason the byline and orientation are placeholders there today. I tried closing it and reverted: the fix broke that test, and honouring the repo's decision seemed right. Closing it properly needs a per-game catalog read the API does not currently offer.

Generated and draft games have no catalog entry and so no controls; the control does not render for them.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` — all green. New tests: `howToPlay.test.ts` (parser, against verbatim catalog strings), `HowToPlayPanel.test.tsx` (rows, dialog semantics, focus, Tab trap, duplicate clauses, escaping), additions to `GameTheater.test.tsx` (control visibility, both Escape paths, focus on open from the More menu, fullscreen) and to `visit-telemetry.test.ts`.

Also driven in a real browser against a local build serving the live catalog of 92 games — which is how the pointer-lock/deep-link behaviour above was found rather than assumed.
