### PR TITLE
Publish a green game, show the operator the queue, and stop losing undelivered work

### DIFF
--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -30,6 +30,23 @@ export interface BuildBrief {
   apiBaseUrl: string;
   /** Set for a revision round: what the creator asked to change. Untrusted text. */
   feedback?: string;
+  /**
+   * Set when the previous session ended without delivering.
+   *
+   * Distinct from `feedback` because it is not the creator speaking — nobody asked for
+   * anything, the work may well be finished, and the round exists only because it was
+   * never uploaded. Told apart so the brief can lead with the omission instead of
+   * inventing a change request the creator never made.
+   */
+  undelivered?: boolean;
+  /**
+   * The workspace the previous session worked in, when this round needs to find it.
+   *
+   * Only meaningful alongside `undelivered`. Every other round reads its starting point
+   * from the store, which is the whole reason workspaces are disposable — but work that
+   * was never uploaded is not in the store, and that branch is the only copy of it.
+   */
+  previousWorkspace?: string;
 }
 
 /** What a backend hands back after starting work, recorded on the job. */

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -822,3 +822,47 @@ describe('agent build channel', () => {
     });
   });
 });
+
+describe('the delivery reminder on every channel call', () => {
+  it('tells an undelivered build that pushing is not delivering', async () => {
+    // The brief says this too, but the brief is read at the start of a session and the
+    // omission happens at the end of one. A live session has been observed doing the
+    // whole job, pushing its branch, and stopping — thousands of tokens after being
+    // told. This rides along with something the agent is already doing.
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    const app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(),
+      payload: { text: 'Working on the maze.' },
+    });
+
+    expect(response.json().control.delivered).toBe(false);
+    expect(response.json().control.mustDeliver).toContain('npm run submit');
+
+    await app.close();
+  });
+
+  it('stops nagging once the build has actually delivered', async () => {
+    // Derived from what we stored, not from anything the session claims about itself.
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    const app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(),
+      payload: { text: 'Polishing.' },
+    });
+
+    expect(response.json().control.delivered).toBe(true);
+    expect(response.json().control.mustDeliver).toBeUndefined();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2,7 +2,8 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { InvalidAgentTokenError, readBearerToken, verifyAgentToken } from './agent-token.js';
 import { InvalidUploadError, type GamesStore } from './games-store.js';
-import type { CreatorMessage, Store, SubmissionRecord } from './store.js';
+import { canTransition } from './job-state.js';
+import { isNativeJobId, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 
 /**
@@ -569,6 +570,23 @@ export async function registerAgentChannelRoutes(
         // not anything ever verifies it. The gate decides whether it may be *published*,
         // which is a different question from whether its author can watch it.
         await store?.setSubmissionDeliveredVersion(issueNumber, version);
+        // Past the agent, and recorded as such. Without this the job stays `building`,
+        // and the agent's own session then reports `completed` with a candidate present
+        // — which the reconciler reads as "done, ready for review". That would promote a
+        // game to the review queue on the agent's say-so, before our gate had run and
+        // whatever it might have said. `submitted` is the state the reconciler refuses
+        // to move, which is exactly the protection this needs.
+        if (store && isNativeJobId(issueNumber)) {
+          const current = record.state ?? 'building';
+          if (canTransition(current, 'submitted')) {
+            await store.recordJobTransition(issueNumber, {
+              to: 'submitted',
+              at: new Date().toISOString(),
+              by: 'agent',
+              reason: 'sources_delivered',
+            });
+          }
+        }
         await options.onSourcesDelivered?.({ issueNumber, slug, version });
         options.onEvent?.(issueNumber);
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -294,6 +294,23 @@ export async function registerAgentChannelRoutes(
         ...(reason ? { reason } : {}),
         // The creator's language, so the agent can write its next update in it.
         locale: record.locale ?? 'en',
+        // Whether the one step that makes any of this real has happened yet.
+        //
+        // Said on every call rather than once in the brief, because the brief is read
+        // at the start of a session and the omission happens at the end of it. A live
+        // session has been observed doing the whole job, pushing its branch, and
+        // stopping — the instruction was there, thousands of tokens ago, and losing to
+        // a tool that felt like finishing. This rides along with something the agent
+        // is already doing, and it is derived from what we actually stored rather than
+        // from anything the session believes about itself.
+        delivered: Boolean(record.deliveredVersion),
+        ...(record.deliveredVersion
+          ? {}
+          : {
+              mustDeliver:
+                'Nothing has been delivered for this build yet. Pushing a branch is not delivering — ' +
+                'run `npm run submit -- <slug>` before you finish, or this session produces nothing.',
+            }),
       },
     };
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -376,7 +376,18 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // The build queue, answered from the store alone. Until jobs carried their own state
   // there was nothing to answer it with: deriving every in-flight submission's status on
   // demand is the fan-out that has rate-limited the site before.
-  await registerJobAdminRoutes(app, { store, adminUids });
+  await registerJobAdminRoutes(app, {
+    store,
+    adminUids,
+    // The same store the delivery path writes to — resolved the same way, so publishing
+    // and delivery can never end up pointed at different buckets. Publishing re-reads
+    // the gate verdict off the manifest rather than trusting the job's derived state.
+    gamesStore:
+      options.submissionRoutes?.agentChannel?.gamesStore ??
+      (process.env.GAMES_STORE_BUCKET?.trim()
+        ? createGcsGamesStore({ bucket: process.env.GAMES_STORE_BUCKET.trim() })
+        : undefined),
+  });
 
   // Creator control panel (docs/improvement-loop-plan.md IL-2 creator surface). Own
   // shelf + per-game health for games this uid owns — not the operator catalog view.

--- a/apps/api/src/copilot-backend.ts
+++ b/apps/api/src/copilot-backend.ts
@@ -53,15 +53,37 @@ const DEFAULT_MODEL: AgentTaskModel = 'claude-sonnet-4.6';
 export function buildPrompt(brief: BuildBrief): string {
   const slug = brief.slug ?? '(the slug named in your first progress report)';
   const lines = [
-    brief.feedback
-      ? `The creator played the draft of \`${slug}\` and asked for changes. Continue that game — revise it, do not rebuild it.`
-      : `Build a new browser game in \`games/${slug}/\`.`,
+    brief.undelivered
+      ? `Your previous session on \`${slug}\` ended without delivering it. The work may well be finished — that is not the problem. Nothing downstream reads the branch, so a game that was not uploaded does not exist as far as the site or the creator can tell. Check what is there, then deliver it.`
+      : brief.feedback
+        ? `The creator played the draft of \`${slug}\` and asked for changes. Continue that game — revise it, do not rebuild it.`
+        : `Build a new browser game in \`games/${slug}/\`.`,
     '',
     // The branch is not the source of truth and must not be treated as one: a session
     // can start on a fresh branch with none of the earlier work in it, and an agent
     // that "continues" from an empty directory silently delivers a different game than
     // the one the creator gave feedback on. The store has every delivery, exactly.
-    ...(brief.feedback
+    // An undelivered round is the one case where the branch *is* the source of truth:
+    // nothing was uploaded, so the store has nothing to restore, and that branch holds
+    // the only copy of the work. It is deliberately not deleted while this round runs.
+    ...(brief.undelivered && brief.previousWorkspace
+      ? [
+          '## Where your previous work is',
+          '',
+          `It is on \`${brief.previousWorkspace}\`, which was never uploaded. Recover it before`,
+          'you redo any of it:',
+          '',
+          '```bash',
+          `git fetch origin ${brief.previousWorkspace}`,
+          `git checkout origin/${brief.previousWorkspace} -- games/${slug}`,
+          '```',
+          '',
+          'Check it over — run the game’s checks — and if it is good, deliver it. If that',
+          'branch turns out to be empty or broken, build the game as you normally would.',
+          '',
+        ]
+      : []),
+    ...(brief.feedback && !brief.undelivered
       ? [
           '## Before you change anything',
           '',

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -15,12 +15,12 @@ const MANIFEST: VersionManifest = {
 };
 
 function stubStore(overrides: Partial<GamesStore> = {}) {
-  const derived: Array<{ name: string; bytes: number }> = [];
+  const derived: Array<{ name: string; bytes: number; body: Buffer }> = [];
   const store = {
     getManifest: async () => MANIFEST,
     getSourceFile: async (_slug: string, _version: string, filePath: string) => `contents of ${filePath}`,
     putDerivedArtifact: async (_s: string, _v: string, name: string, body: Buffer) => {
-      derived.push({ name, bytes: body.length });
+      derived.push({ name, bytes: body.length, body });
     },
     putCandidateSources: vi.fn(),
     putGateResult: vi.fn(),
@@ -33,6 +33,14 @@ function stubStore(overrides: Partial<GamesStore> = {}) {
 async function harnessDir() {
   return mkdtemp(path.join(tmpdir(), 'gate-'));
 }
+
+/**
+ * Stands in for the real assembler, which needs a full games-repo tree (GAME.json, the
+ * GameKit modules it imports, esbuild) that these fixtures deliberately do not have.
+ * What the real one produces is covered where it lives; what matters here is that the
+ * gate stores its output rather than the repo's build.
+ */
+const stubAssemble: NonNullable<GateRunnerDeps['assembleBundle']> = async () => '<!doctype html>assembled';
 
 describe('runGate', () => {
   it('materializes the candidate into the harness and runs the full check', async () => {
@@ -50,6 +58,7 @@ describe('runGate', () => {
       store,
       prepareHarness: async () => harness,
       run,
+      assembleBundle: stubAssemble,
     });
 
     expect(outcome.green).toBe(true);
@@ -64,7 +73,7 @@ describe('runGate', () => {
     const { store } = stubStore();
     const run = vi.fn(async () => ({ code: 0, output: '' }));
 
-    await runGate('comet-courier', 'v1', { store, prepareHarness: harnessDir, run });
+    await runGate('comet-courier', 'v1', { store, prepareHarness: harnessDir, run, assembleBundle: stubAssemble });
 
     expect(run.mock.calls[0]![1]).not.toContain('--accept');
   });
@@ -75,7 +84,12 @@ describe('runGate', () => {
     const { store } = stubStore();
     const prepareHarness = vi.fn(async () => harnessDir());
 
-    await runGate('comet-courier', 'v1', { store, prepareHarness, run: async () => ({ code: 0, output: '' }) });
+    await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness,
+      run: async () => ({ code: 0, output: '' }),
+      assembleBundle: stubAssemble,
+    });
 
     expect(prepareHarness).toHaveBeenCalledWith('abc123');
   });
@@ -117,9 +131,8 @@ describe('runGate', () => {
     const outcome = await runGate('comet-courier', 'v1', {
       store,
       prepareHarness: async () => harness,
+      assembleBundle: stubAssemble,
       run: async () => {
-        await mkdir(path.join(harness, 'dist/games/comet-courier'), { recursive: true });
-        await writeFile(path.join(harness, 'dist/games/comet-courier/index.html'), '<!doctype html>');
         await mkdir(path.join(harness, 'games/comet-courier/media'), { recursive: true });
         await writeFile(path.join(harness, 'games/comet-courier/media/opening.png'), 'png-bytes');
         await writeFile(path.join(harness, 'games/comet-courier/media/gameplay.mp4'), 'mp4-bytes');
@@ -135,6 +148,66 @@ describe('runGate', () => {
       'media/opening.png',
     ]);
     expect(outcome.artifacts).toContain('bundle.html');
+  });
+
+  it('serves the assembler’s document, not the games repo’s own build output', async () => {
+    // The repo's `dist/` build is its idea of a playable page. Serve-time policy — the
+    // restrictive CSP, the provenance marking, the credential scan, the byte budget —
+    // lives in `assembleGameHtml` and in none of that output, so storing the build was
+    // storing a document with none of it.
+    const harness = await harnessDir();
+    const { store, derived } = stubStore();
+
+    await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: async () => harness,
+      assembleBundle: async () => '<!doctype html><meta name="ai-provenance" content="x" />assembled',
+      run: async () => {
+        await mkdir(path.join(harness, 'dist/games/comet-courier'), { recursive: true });
+        await writeFile(path.join(harness, 'dist/games/comet-courier/index.html'), 'repo build output');
+        return { code: 0, output: '' };
+      },
+    });
+
+    const bundle = derived.find((entry) => entry.name === 'bundle.html');
+    expect(bundle?.body.toString('utf8')).toContain('assembled');
+    expect(bundle?.body.toString('utf8')).not.toContain('repo build output');
+  });
+
+  it('fails the gate when a checked game cannot be assembled into a servable document', async () => {
+    // The assembler refuses things `check:game` accepts — a credential-like string is
+    // the case that matters. That has to be a red verdict with a reason, not a crash:
+    // a run that dies leaves the version with no verdict, which reads as a gate that
+    // never ran rather than one that said no.
+    const { store, derived } = stubStore();
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run: async () => ({ code: 0, output: '' }),
+      assembleBundle: async () => {
+        throw new Error('generated project contains credential-like strings');
+      },
+    });
+
+    expect(outcome.green).toBe(false);
+    expect(outcome.report).toContain('credential-like strings');
+    // Nothing servable was stored, and the verdict is recorded rather than thrown.
+    expect(derived.find((entry) => entry.name === 'bundle.html')).toBeUndefined();
+  });
+
+  it('fails the gate rather than passing a version with nothing to serve', async () => {
+    const { store } = stubStore();
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run: async () => ({ code: 0, output: '' }),
+      assembleBundle: async () => null,
+    });
+
+    expect(outcome.green).toBe(false);
+    expect(outcome.report).toContain('could not be assembled');
   });
 
   it('refuses a version that does not exist rather than checking nothing and passing', async () => {

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -21,7 +21,10 @@
 
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { GameProject } from '@gamedevpl/game-generator';
+import { assembleGameHtml } from './assemble.js';
 import type { GamesStore, VersionManifest } from './games-store.js';
+import { createLocalGamesClient } from './local-games-repo.js';
 
 export interface GateOutcome {
   green: boolean;
@@ -44,13 +47,49 @@ export interface GateRunnerDeps {
   run(command: string, args: string[], cwd: string): Promise<{ code: number; output: string }>;
   now?: () => number;
   /** Where to look for artifacts the check produced, relative to the harness root. */
-  artifactRoots?: { bundle: (slug: string) => string; media: (slug: string) => string };
+  artifactRoots?: { media: (slug: string) => string };
+  /**
+   * Builds the document that will actually be served, from the checked harness.
+   * Injected so the runner can be tested without esbuild or a games-repo tree.
+   */
+  assembleBundle?: (harness: string, slug: string) => Promise<string | null>;
 }
 
 const DEFAULT_ARTIFACT_ROOTS = {
-  bundle: (slug: string) => path.join('dist', 'games', slug, 'index.html'),
   media: (slug: string) => path.join('games', slug, 'media'),
 };
+
+/**
+ * Assembles the served document from the harness the check just passed against.
+ *
+ * Deliberately *not* the games repo's own `dist/` build output, which is what this used
+ * to store. That output is the repo's idea of a playable page; it is not ours, and the
+ * difference is the whole of serve-time policy — the restrictive CSP that stops a game
+ * calling home, the AI Act art. 50(2) provenance marking, the credential scan, the byte
+ * budget. All four live in `assembleGameHtml`, none of them are in `tools/build.ts`, and
+ * shipping the repo's build meant shipping a document with none of them.
+ *
+ * Assembling here rather than at serve time is what keeps one definition of "what a
+ * served game is" across the three things that need one: the creator's draft preview,
+ * the published game, and the snapshot bake. It also belongs here for the reason the
+ * gate itself does — this repo owns the policy, and the harness is already checked out
+ * with the GameKit modules the assembler has to resolve.
+ */
+async function assembleFromHarness(harness: string, slug: string): Promise<string | null> {
+  const client = createLocalGamesClient({ rootDir: harness });
+  const sources = await client.getGameSources('main', slug);
+  if (!sources) return null;
+  const project: GameProject = {
+    title: sources.title ?? slug,
+    description: '',
+    html: sources.indexHtml,
+    js: sources.gameJs,
+    css: sources.styleCss,
+  };
+  // Matches the bake and the play route exactly: a game is self-contained by repo
+  // policy, so it is locked to its own inline assets.
+  return assembleGameHtml(project, { restrictNetwork: true });
+}
 
 /**
  * Files the capture harness produces that are worth keeping.
@@ -114,7 +153,22 @@ export async function runGate(slug: string, version: string, deps: GateRunnerDep
       };
     }
 
-    const artifacts = await collectArtifacts(deps, slug, version, harness, roots);
+    let artifacts: string[];
+    try {
+      artifacts = await collectArtifacts(deps, slug, version, harness, roots);
+    } catch (error) {
+      // A game the repo's own check accepts can still be one we refuse to serve: the
+      // credential scan and the byte budget live in the assembler, not in `check:game`.
+      // That is a red verdict with a reason the agent can act on, not a crash — a run
+      // that dies here would leave the version with no verdict at all, which reads as a
+      // gate that never ran rather than one that said no.
+      return {
+        green: false,
+        report: error instanceof Error ? error.message : String(error),
+        artifacts: [],
+        durationMs: now() - startedAt,
+      };
+    }
 
     return {
       green: true,
@@ -154,12 +208,20 @@ async function collectArtifacts(
 ): Promise<string[]> {
   const stored: string[] = [];
 
-  const bundlePath = path.join(harness, roots.bundle(slug));
-  const bundle = await readFile(bundlePath).catch(() => null);
-  if (bundle) {
-    await deps.store.putDerivedArtifact(slug, version, 'bundle.html', bundle, 'text/html; charset=utf-8');
-    stored.push('bundle.html');
-  }
+  // A green check with no servable document is not a pass. Letting it through would
+  // store a version that reads as publishable and has nothing to publish — and the
+  // failure would surface later, as a creator's preview that never appears, rather
+  // than here where the run that caused it is still in front of someone.
+  const bundle = await (deps.assembleBundle ?? assembleFromHarness)(harness, slug);
+  if (bundle === null) throw new Error(`check:game passed for ${slug} but its sources could not be assembled`);
+  await deps.store.putDerivedArtifact(
+    slug,
+    version,
+    'bundle.html',
+    Buffer.from(bundle, 'utf8'),
+    'text/html; charset=utf-8',
+  );
+  stored.push('bundle.html');
 
   const mediaDir = path.join(harness, roots.media(slug));
   const { readdir } = await import('node:fs/promises');

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1109,29 +1109,8 @@ ${gameJs}`;
         if (specMd === null) {
           continue;
         }
-        const frontmatter = parseSpecFrontmatter(specMd);
-        const title = frontmatter.title;
-        if (!title) {
-          continue;
-        }
-        // A spec with no status is published — merging it is what publishes it.
-        // Only an explicit archived/disabled withdraws a game from the site.
-        const rawStatus = frontmatter.status ?? '';
-        const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
-        const mediaMetadata = status === 'published' ? (files.get(`games/${slug}/media/metadata.json`) ?? null) : null;
-        entries.push({
-          slug,
-          title,
-          genre: frontmatter.genre ?? '',
-          controls: frontmatter.controls ?? '',
-          status,
-          media: parseGameMedia(mediaMetadata),
-          multiplayer: parseMultiplayer(frontmatter),
-          saves: parseSaves(frontmatter.saves),
-          world: parseWorld(frontmatter.world),
-          orientation: parseOrientation(frontmatter),
-          submittedBy: parseSubmittedBy(frontmatter.submitted_by),
-        });
+        const entry = catalogEntryFromSpec(slug, specMd, (name) => files.get(`games/${slug}/${name}`) ?? null);
+        if (entry) entries.push(entry);
       }
 
       return entries;
@@ -1302,6 +1281,45 @@ function parseGameMedia(metadataJson: string | null): CatalogGameMedia | null {
  * lenient `key: value` format the games repo's tools/lib/spec.mjs uses (no nested
  * YAML). Lines that don't look like `key: value` are skipped.
  */
+/**
+ * Builds one catalog entry from a game's `SPEC.md`.
+ *
+ * Exported because games now reach the catalog two ways — committed to the games repo,
+ * or delivered to the store and published from there — and both have to describe a game
+ * identically. A second implementation for the store path would be a second answer to
+ * "what genre is this game", diverging silently the first time a frontmatter field is
+ * added. `readSibling` is how the caller supplies files next to the spec (`media/
+ * metadata.json` today), since one side has them in a tree listing and the other in a
+ * bucket. Returns null for a spec with no title, which is not a game we can list.
+ */
+export function catalogEntryFromSpec(
+  slug: string,
+  specMd: string,
+  readSibling: (name: string) => string | null,
+): CatalogGameEntry | null {
+  const frontmatter = parseSpecFrontmatter(specMd);
+  const title = frontmatter.title;
+  if (!title) return null;
+  // A spec with no status is published — merging it is what publishes it. Only an
+  // explicit archived/disabled withdraws a game from the site.
+  const rawStatus = frontmatter.status ?? '';
+  const status = rawStatus === 'archived' || rawStatus === 'disabled' ? rawStatus : 'published';
+  const mediaMetadata = status === 'published' ? readSibling('media/metadata.json') : null;
+  return {
+    slug,
+    title,
+    genre: frontmatter.genre ?? '',
+    controls: frontmatter.controls ?? '',
+    status,
+    media: parseGameMedia(mediaMetadata),
+    multiplayer: parseMultiplayer(frontmatter),
+    saves: parseSaves(frontmatter.saves),
+    world: parseWorld(frontmatter.world),
+    orientation: parseOrientation(frontmatter),
+    submittedBy: parseSubmittedBy(frontmatter.submitted_by),
+  };
+}
+
 function parseSpecFrontmatter(specMd: string): Record<string, string> {
   const matched = /^---\s*\n([\s\S]*?)\n---/.exec(specMd);
   if (!matched?.[1]) {

--- a/apps/api/src/job-admin-routes.test.ts
+++ b/apps/api/src/job-admin-routes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { GamesStore } from './games-store.js';
 import { buildJobQueue } from './job-admin-routes.js';
-import type { SubmissionRecord } from './store.js';
+import { InMemoryStore, type SubmissionRecord } from './store.js';
 
 const NOW = Date.parse('2026-07-30T12:00:00Z');
 const MINUTE = 60_000;
@@ -138,5 +141,118 @@ describe('buildJobQueue', () => {
     );
 
     expect(queue.jobs[0].stall).toBe('awaiting_input');
+  });
+});
+
+describe('POST /api/admin/jobs/:issueNumber/publish', () => {
+  const sessionSecret = 'dev-session-secret-change-me';
+  const adminHeaders = { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:boss', sessionSecret)}` };
+
+  /** A store holding one delivered version, gated as told. */
+  function gamesStoreWith(gate: { green: boolean } | null, bundle = '<!doctype html>assembled') {
+    return {
+      getManifest: async () => ({
+        slug: 'comet-courier',
+        version: 'v1',
+        createdAt: '2026-07-30T10:00:00Z',
+        issueNumber: 1_000_001,
+        sourceFiles: ['SPEC.md'],
+        ...(gate ? { gate: { ...gate, ranAt: '2026-07-30T11:00:00Z' } } : {}),
+      }),
+      getSourceFile: async () => '---\ntitle: Comet Courier\n---\n',
+      getDerivedArtifact: async () => Buffer.from(bundle, 'utf8'),
+      putCandidateSources: async () => ({ version: 'v1', manifest: {} }),
+      putGateResult: async () => {},
+      putDerivedArtifact: async () => {},
+    } as unknown as GamesStore;
+  }
+
+  async function appWithJob(gamesStore: GamesStore) {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_001, 'g:boss', 'Comet Courier');
+    await store.setSubmissionSlug(1_000_001, 'comet-courier');
+    await store.setSubmissionDeliveredVersion(1_000_001, 'v1');
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      adminUids: 'g:boss',
+      submissionRoutes: { agentChannel: { gamesStore } },
+    });
+    return { app, store };
+  }
+
+  it('publishes a gate-green build and records how it got there', async () => {
+    const { app, store } = await appWithJob(gamesStoreWith({ green: true }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/jobs/1000001/publish',
+      headers: adminHeaders,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await store.getPublication('comet-courier')).toMatchObject({
+      slug: 'comet-courier',
+      state: 'published',
+      currentVersion: 'v1',
+    });
+    // Through `publishing`, not straight to `published`: the intermediate state is what
+    // a failed publish has to fall back from, and skipping it leaves no record it existed.
+    const record = await store.getSubmission(1_000_001);
+    expect(record?.state).toBe('published');
+    expect(record?.transitions?.map((entry) => entry.to)).toEqual(['publishing', 'published']);
+    expect(record?.publishedAt).toBeTruthy();
+
+    await app.close();
+  });
+
+  it('refuses to publish a version our own gate failed', async () => {
+    const { app, store } = await appWithJob(gamesStoreWith({ green: false }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/jobs/1000001/publish',
+      headers: adminHeaders,
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toBe('gate_red');
+    expect(await store.getPublication('comet-courier')).toBeNull();
+
+    await app.close();
+  });
+
+  it('refuses a version nothing has gated yet', async () => {
+    const { app, store } = await appWithJob(gamesStoreWith(null));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/jobs/1000001/publish',
+      headers: adminHeaders,
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toBe('not_gated');
+    expect(await store.getPublication('comet-courier')).toBeNull();
+
+    await app.close();
+  });
+
+  it('is invisible to a non-admin, like the rest of the operator surface', async () => {
+    const { app, store } = await appWithJob(gamesStoreWith({ green: true }));
+    await store.upsertUser({ uid: 'g:someone' });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/jobs/1000001/publish',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:someone', sessionSecret)}` },
+    });
+
+    // 404 rather than 403: the operator surface does not confirm its own existence.
+    expect(response.statusCode).toBe(404);
+    expect(await store.getPublication('comet-courier')).toBeNull();
+
+    await app.close();
   });
 });

--- a/apps/api/src/job-admin-routes.ts
+++ b/apps/api/src/job-admin-routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { isAdminSession } from './admin.js';
 import { detectStall, isTerminal, toSubmissionStatus, type JobStall, type JobState } from './job-state.js';
+import type { GamesStore } from './games-store.js';
 import type { Store, SubmissionRecord } from './store.js';
 
 /**
@@ -123,9 +124,9 @@ function jobStateFromLastStatus(status: SubmissionRecord['lastStatus']): JobStat
 
 export async function registerJobAdminRoutes(
   app: FastifyInstance,
-  options: { store?: Store; adminUids?: Set<string>; now?: () => number },
+  options: { store?: Store; adminUids?: Set<string>; gamesStore?: GamesStore; now?: () => number },
 ): Promise<void> {
-  const { store, adminUids } = options;
+  const { store, adminUids, gamesStore } = options;
   const now = options.now ?? Date.now;
 
   app.get('/api/admin/jobs', async (request, reply) => {
@@ -138,5 +139,59 @@ export async function registerJobAdminRoutes(
 
     const records = await store.listActiveSubmissions();
     return reply.send(buildJobQueue(records, now()));
+  });
+
+  /**
+   * Publishes a gate-green build. This is the moderation boundary, exercised.
+   *
+   * Deliberately an operator action rather than something the gate does on green. The
+   * gate answers "does this run"; a human answers "may this be on the site", and those
+   * are different questions — the second is the one the DSA and the AI Act care about,
+   * and automating it would delete the boundary while leaving every document that claims
+   * we have one. So the gate records a verdict, and this is where someone acts on it.
+   *
+   * The green check is re-read from the manifest here rather than trusted from the job's
+   * state. Job state is derived on a poll and can be stale or adopted from an older
+   * record; the manifest is what the gate actually wrote. Publishing is the one action
+   * where the difference could put an unverified game in front of players.
+   */
+  app.post<{ Params: { issueNumber: string } }>('/api/admin/jobs/:issueNumber/publish', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.code(404).send({ error: 'not_found' });
+    }
+    if (!store || !gamesStore) {
+      return reply.code(503).send({ error: 'store_unavailable' });
+    }
+
+    const issueNumber = Number(request.params.issueNumber);
+    if (!Number.isInteger(issueNumber)) {
+      return reply.code(400).send({ error: 'invalid_job' });
+    }
+
+    const record = await store.getSubmission(issueNumber);
+    if (!record) return reply.code(404).send({ error: 'not_found' });
+    if (!record.slug || !record.deliveredVersion) {
+      return reply.code(409).send({ error: 'nothing_delivered' });
+    }
+
+    const manifest = await gamesStore.getManifest(record.slug, record.deliveredVersion);
+    if (!manifest?.gate) return reply.code(409).send({ error: 'not_gated' });
+    if (!manifest.gate.green) return reply.code(409).send({ error: 'gate_red' });
+
+    const at = new Date(now()).toISOString();
+    // Through `publishing` rather than straight to `published`: the intermediate state is
+    // what a job is in while this is happening, and skipping it would leave no record
+    // that it ever was — which is the state a failed publish has to fall back from.
+    await store.recordJobTransition(issueNumber, { to: 'publishing', at, by: 'operator', reason: 'approved' });
+    await store.setPublication({
+      slug: record.slug,
+      state: 'published',
+      currentVersion: record.deliveredVersion,
+      publishedAt: at,
+    });
+    await store.recordJobTransition(issueNumber, { to: 'published', at, by: 'operator', reason: 'published' });
+    await store.setSubmissionPublishedAt(issueNumber, at);
+
+    return reply.send({ ok: true, slug: record.slug, version: record.deliveredVersion, publishedAt: at });
   });
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -88,6 +88,15 @@ export interface SubmissionRecord {
    */
   deliveredVersion?: string;
   /**
+   * How many times this job has been sent back for finishing without delivering.
+   *
+   * Counted rather than inferred from the transition history, which is capped and drops
+   * its oldest entries — a long job would quietly earn fresh nudges as the evidence of
+   * the old ones aged out. Each nudge is a real agent session and a real premium
+   * request, so the ceiling has to hold for the life of the job.
+   */
+  deliveryNudges?: number;
+  /**
    * When we first observed the game published. Together with createdAt it is the
    * only record of how long a build actually took, which is what lets the status
    * page answer "how long will this take?" with a real number instead of a shrug.
@@ -833,6 +842,8 @@ export interface Store {
   setSubmissionSlug(issueNumber: number, slug: string): Promise<void>;
   /** Records the candidate version a delivery just stored, for the preview to read. */
   setSubmissionDeliveredVersion(issueNumber: number, version: string): Promise<void>;
+  /** Counts a send-back for finishing without delivering. Returns the new total. */
+  recordDeliveryNudge(issueNumber: number): Promise<number>;
   /** Stamps the moment a submission was first seen published (for build-time stats). */
   setSubmissionPublishedAt(issueNumber: number, at: string): Promise<void>;
   /** Marks a submission abandoned by its creator. */
@@ -1361,6 +1372,14 @@ export class InMemoryStore implements Store {
   async setSubmissionDeliveredVersion(issueNumber: number, version: string): Promise<void> {
     const sub = this.submissions.get(issueNumber);
     if (sub) this.submissions.set(issueNumber, { ...sub, deliveredVersion: version });
+  }
+
+  async recordDeliveryNudge(issueNumber: number): Promise<number> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return 0;
+    const deliveryNudges = (sub.deliveryNudges ?? 0) + 1;
+    this.submissions.set(issueNumber, { ...sub, deliveryNudges });
+    return deliveryNudges;
   }
 
   async getSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {
@@ -2281,6 +2300,19 @@ export class FirestoreStore implements Store {
       .collection('submissions')
       .doc(String(issueNumber))
       .set({ deliveredVersion: version }, { merge: true });
+  }
+
+  async recordDeliveryNudge(issueNumber: number): Promise<number> {
+    // Transactional: two pollers can observe the same undelivered session at once, and
+    // a lost increment here buys the job an extra agent session it was not owed.
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return 0;
+      const nudges = ((snap.data() as SubmissionRecord).deliveryNudges ?? 0) + 1;
+      tx.set(ref, { deliveryNudges: nudges }, { merge: true });
+      return nudges;
+    });
   }
 
   async setSubmissionPublishedAt(issueNumber: number, at: string): Promise<void> {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2694,3 +2694,105 @@ describe('status route under GitHub pressure', () => {
     await app.close();
   });
 });
+
+describe('games published from the store rather than the repo', () => {
+  /** A store holding one published version: its spec, and the bundle the gate assembled. */
+  function publishedGamesStore(bundle = '<!doctype html><meta name="ai-provenance" content="x" />game') {
+    return {
+      getSourceFile: async (_slug: string, _version: string, path: string) =>
+        path === 'SPEC.md' ? '---\ntitle: Comet Courier\ngenre: arcade\n---\n' : null,
+      getDerivedArtifact: async () => Buffer.from(bundle, 'utf8'),
+      getManifest: async () => null,
+      putCandidateSources: async () => ({ version: 'v1', manifest: {} }),
+      putGateResult: async () => {},
+      putDerivedArtifact: async () => {},
+    } as unknown as GamesStore;
+  }
+
+  async function appWithPublication(
+    gamesStore: GamesStore,
+    catalog: CatalogGameEntry[] = [],
+    gameSources: GameSources | null = null,
+  ) {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.setPublication({
+      slug: 'comet-courier',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-30T12:00:00Z',
+    });
+    const { githubClient } = createGithubClientStub({ catalog, gameSources });
+    const { app } = await createApp({
+      githubClient,
+      store,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+    return { app, store };
+  }
+
+  it('lists a store-published game the games repo has never heard of', async () => {
+    // A delivered game is never committed, so the repo catalog cannot see it. Without
+    // this the operator publishes a game and the site it was published to shows nothing.
+    const { app } = await appWithPublication(publishedGamesStore());
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const entry = response.json().find((item: CatalogGameEntry) => item.slug === 'comet-courier');
+    // Described by the same parser the repo path uses, so the two cannot disagree about
+    // what a game's genre is.
+    expect(entry).toMatchObject({ title: 'Comet Courier', genre: 'arcade', status: 'published' });
+
+    await app.close();
+  });
+
+  it('serves the gate’s own assembled document, so the played bytes are the checked ones', async () => {
+    const { app } = await appWithPublication(publishedGamesStore());
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/comet-courier' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ slug: 'comet-courier', title: 'Comet Courier' });
+    // The provenance marking is the visible proof it came through assembleGameHtml
+    // rather than the games repo's own build.
+    expect(response.json().html).toContain('ai-provenance');
+
+    await app.close();
+  });
+
+  it('does not list one game twice while it exists on both sides', async () => {
+    // During the migration a slug can be both committed and delivered. Two cards for
+    // one game is worse than either source winning, and the repo copy is what the bake
+    // serves — so it keeps the slug.
+    const { app } = await appWithPublication(publishedGamesStore(), [catalogEntry('comet-courier')]);
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.json().filter((item: CatalogGameEntry) => item.slug === 'comet-courier')).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it('falls through to the repo rather than 404ing when a publication has no bundle', async () => {
+    // A store record with no artifact must not take a working repo game off the site.
+    const gamesStore = {
+      ...publishedGamesStore(),
+      getDerivedArtifact: async () => null,
+    } as unknown as GamesStore;
+    const { app } = await appWithPublication(gamesStore, [catalogEntry('comet-courier')], {
+      indexHtml: '<div id="game"></div>',
+      gameJs: 'const repoCopy = true;',
+      styleCss: 'body{}',
+      title: 'Comet Courier',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/comet-courier' });
+
+    // Served from the repo path (the stub's sources), not refused.
+    expect(response.statusCode).toBe(200);
+
+    await app.close();
+  });
+});

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2796,3 +2796,109 @@ describe('games published from the store rather than the repo', () => {
     await app.close();
   });
 });
+
+describe('a session that finishes without delivering', () => {
+  /** Observes a finished session; `hasCandidate` comes from the record, not the stub. */
+  function finishedBackend() {
+    const { backend, briefs } = createBackendStub();
+    return {
+      briefs,
+      backend: {
+        ...backend,
+        observe: async (_ref: string, opts: { hasCandidate: boolean }) => ({
+          state: 'completed' as const,
+          hasCandidate: opts.hasCandidate,
+        }),
+      },
+    };
+  }
+
+  async function jobWithFinishedSession(overrides: { maxDeliveryNudges?: number } = {}) {
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend, briefs } = finishedBackend();
+    const clock = { t: Date.now() };
+    const cleanup = vi.fn(async () => {});
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: { ...backend, cleanup },
+      submissionTokenSecret: secret,
+      now: () => clock.t,
+      ...overrides,
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setDispatchWorkspace(job.issueNumber, 'copilot/has-the-work');
+    return { app, store, job, briefs, clock, cleanup, token: mintToken(job.issueNumber, secret) };
+  }
+
+  it('sends the session back to deliver instead of failing the build', async () => {
+    // The work is very likely done and sitting on a branch — only the upload is
+    // missing. Asking is far cheaper than the round it would otherwise cost.
+    const { app, store, job, briefs, clock, token } = await jobWithFinishedSession();
+
+    clock.t += 3 * 60 * 1000;
+    const status = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+
+    expect(status.statusCode).toBe(200);
+    const brief = briefs.at(-1);
+    expect(brief?.undelivered).toBe(true);
+    // The branch is the only copy of undelivered work, so the round is told where it is.
+    expect(brief?.previousWorkspace).toBe('copilot/has-the-work');
+    // Building again, not failed: the creator is not shown an error about a round that
+    // is at this moment running.
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('building');
+
+    await app.close();
+  });
+
+  it('keeps the branch holding the undelivered work', async () => {
+    // Every other round deletes the previous workspace, because the store has the
+    // truth. Here it does not — deleting would destroy what the new round was sent
+    // to recover.
+    const { app, cleanup, clock, token } = await jobWithFinishedSession();
+
+    clock.t += 3 * 60 * 1000;
+    await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+
+    expect(cleanup).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('asks once, then reports the failure rather than retrying forever', async () => {
+    // A setup that cannot deliver fails the same way however many times it is asked,
+    // and every attempt is a real agent session against a real quota.
+    const { app, store, job, briefs, clock, token } = await jobWithFinishedSession();
+
+    clock.t += 3 * 60 * 1000;
+    await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+    const afterFirst = briefs.length;
+
+    // The re-sent session finishes without delivering too.
+    clock.t += 3 * 60 * 1000;
+    const status = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+
+    expect(briefs.length).toBe(afterFirst);
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('failed');
+    expect(status.json().failure).toEqual({ reason: 'task_completed_without_delivery' });
+
+    await app.close();
+  });
+
+  it('leaves a session that did deliver alone', async () => {
+    const { app, store, job, briefs, clock, token } = await jobWithFinishedSession();
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+
+    clock.t += 3 * 60 * 1000;
+    await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+
+    expect(briefs.at(-1)?.undelivered).toBeUndefined();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -242,6 +242,8 @@ export interface SubmissionRoutesOptions {
    * of issues.
    */
   maxCachedDraftPreviews?: number;
+  /** How many times a job may be sent back for finishing without delivering. */
+  maxDeliveryNudges?: number;
 }
 
 function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {
@@ -457,6 +459,8 @@ export async function registerSubmissionRoutes(
     feedback: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
+    /** Set when this round exists only because the last one never uploaded. */
+    undelivered?: boolean;
   }): Promise<void> {
     if (!agentBackend || !submissionTokenSecret || !store) return;
     const record = await store.getSubmission(input.issueNumber);
@@ -470,6 +474,9 @@ export async function registerSubmissionRoutes(
         locale: input.locale,
         channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret),
         apiBaseUrl: notifyAppBaseUrl,
+        ...(input.undelivered
+          ? { undelivered: true, ...(previous?.workspace ? { previousWorkspace: previous.workspace } : {}) }
+          : {}),
       };
       const result = previous?.refs.length
         ? await agentBackend.resume(brief, {
@@ -486,7 +493,11 @@ export async function registerSubmissionRoutes(
       // round that follows restores the game from the store rather than from a branch.
       // Deleted after the dispatch succeeds, never before — a round that failed to
       // start is a round whose old branch is still the most recent thing we have.
-      if (previous?.workspace && previous.workspace !== result.workspace) {
+      //
+      // Except after a round that never delivered. Nothing was uploaded, so the store
+      // has nothing to restore and that branch is the only copy of the work — deleting
+      // it here would be deleting the very thing the new round was sent to recover.
+      if (!input.undelivered && previous?.workspace && previous.workspace !== result.workspace) {
         await releaseWorkspace(input.issueNumber, previous.workspace, input.log);
       }
       const transition = record?.state
@@ -1084,6 +1095,17 @@ export async function registerSubmissionRoutes(
   const observeQuietMs = 2 * 60 * 1000;
 
   /**
+   * How many times a job may be sent back for finishing without delivering.
+   *
+   * One. A session that forgot the last step takes the reminder; a setup that cannot
+   * deliver at all — a broken token, an agent whose instructions genuinely conflict —
+   * fails the same way however many times it is asked, and each attempt is a real agent
+   * session against a real quota. The second failure is information, not bad luck, and
+   * it belongs in front of an operator rather than in another retry.
+   */
+  const maxDeliveryNudges = options.maxDeliveryNudges ?? 1;
+
+  /**
    * Asks the backend what actually happened to a job whose agent has gone quiet.
    *
    * This is what stands between a dead session and a page that says "building" until
@@ -1124,6 +1146,40 @@ export async function registerSubmissionRoutes(
       }
       const result = reconcileAgentObservation(state, observation);
       if (!result) return null;
+
+      // A session that ran to completion and uploaded nothing is the one failure worth
+      // answering rather than recording. Everything else here is the agent being unable
+      // to continue — crashed, timed out, killed for quota — and sending it back would
+      // just buy the same ending twice. This one finished: the work is very likely done
+      // and sitting on a branch, and the only thing missing is the upload. That is
+      // recoverable by asking, and asking is far cheaper than the round it would
+      // otherwise cost the creator.
+      //
+      // Checked deterministically, from our own record of what was delivered, rather
+      // than from anything the session claims about itself.
+      if (result.reason === 'task_completed_without_delivery' && (record.deliveryNudges ?? 0) < maxDeliveryNudges) {
+        const nudges = await store.recordDeliveryNudge(record.issueNumber);
+        // Counted before dispatching, so a dispatch that throws still spends the budget.
+        // The alternative retries forever against whatever is refusing to start.
+        if (nudges <= maxDeliveryNudges) {
+          app.log.warn(
+            { issueNumber: record.issueNumber, nudge: nudges, workspace: record.dispatch?.workspace },
+            'session finished without delivering; sending it back',
+          );
+          await resumeBuild({
+            issueNumber: record.issueNumber,
+            feedback: '',
+            locale: record.locale ?? 'en',
+            log: app.log,
+            undelivered: true,
+          });
+          // `resumeBuild` has already moved the job back to building. Reporting the
+          // failure here as well would show the creator an error about a round that is
+          // at this moment running again.
+          return null;
+        }
+      }
+
       const transition: JobTransition = {
         to: result.to,
         at: new Date(now()).toISOString(),

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -7,6 +7,7 @@ import { mintAgentToken } from './agent-token.js';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { createCreationGate, CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js';
 import {
+  catalogEntryFromSpec,
   createGitHubClient,
   type CatalogGameEntry,
   type CatalogGameMedia,
@@ -22,6 +23,7 @@ import {
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import type { AgentBackend } from './agent-backend.js';
 import {
+  canTransition,
   detectStall,
   fromSubmissionStatus,
   planObservedStatusTransition,
@@ -836,6 +838,10 @@ export async function registerSubmissionRoutes(
   // a published game only changes on a new merge to main.
   const catalogTtlMs = 10 * 60_000;
   let catalogCache: { expiresAt: number; entries: CatalogGameEntry[] } | null = null;
+  // Store-published games, cached on the same window as the repo catalog above: this
+  // route is hit by every visitor, and each entry costs a stored-object read.
+  const storeCatalogTtlMs = catalogTtlMs;
+  let storeCatalogCache: { expiresAt: number; value: CatalogGameEntry[] } | null = null;
   let catalogRefresh: Promise<CatalogGameEntry[]> | null = null;
   /**
    * Last time isSlugPublished forced a cache bypass. Status polls for a
@@ -1130,6 +1136,46 @@ export async function registerSubmissionRoutes(
       // Best effort by design: the answer to "observation failed" is the status the
       // record already has, not an error on a page that was only ever polling.
       app.log.error({ err: error, issueNumber: record.issueNumber }, 'agent observation failed');
+      return null;
+    }
+  }
+
+  /**
+   * Reads our own gate's verdict off the delivered version and moves the job on it.
+   *
+   * The gate runs in Cloud Build, writes its verdict to the version manifest, and exits.
+   * Nothing told the job — so a delivered game sat in `submitted` forever no matter what
+   * the gate said, and the creator watched a page that had stopped meaning anything.
+   *
+   * Read here rather than pushed back by the gate because the verdict is already durable
+   * in the store: a callback would need its own credential, its own retry, and would
+   * still be a second source of a fact the manifest already holds. A poll that reads it
+   * cannot disagree with the store, and a gate run that dies before reporting is
+   * indistinguishable from one that never ran — which is the honest reading.
+   */
+  async function reconcileGateVerdict(record: SubmissionRecord): Promise<JobTransition | null> {
+    const gamesStore = options.agentChannel?.gamesStore;
+    if (!gamesStore || !store || !record.deliveredVersion || !record.slug) return null;
+    const state = record.state ?? 'queued';
+    if (state !== 'submitted' && state !== 'gating') return null;
+    try {
+      const manifest = await gamesStore.getManifest(record.slug, record.deliveredVersion);
+      const verdict = manifest?.gate;
+      if (!verdict) return null;
+      // Green means publishable, never published: the human review this waits for is the
+      // moderation boundary, and a gate that promoted past it would quietly delete it.
+      const to = verdict.green ? 'ready_for_review' : 'needs_changes';
+      if (!canTransition(state, to)) return null;
+      const transition: JobTransition = {
+        to,
+        at: verdict.ranAt,
+        by: 'gate',
+        reason: verdict.green ? 'gate_green' : 'gate_red',
+      };
+      const recorded = await store.recordJobTransition(record.issueNumber, transition);
+      return recorded ? transition : null;
+    } catch (error) {
+      app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not read the gate verdict');
       return null;
     }
   }
@@ -1518,7 +1564,10 @@ export async function registerSubmissionRoutes(
       if (isNativeJobId(issueNumber)) {
         let record = await store?.getSubmission(issueNumber);
         if (record) {
-          const observed = await reconcileNativeJob(record);
+          // Two things can have moved the job since the last poll, and they own different
+          // stretches of it: the agent's own session up to delivery, our gate after it.
+          // Neither fires on both, so asking for both costs one of them nothing.
+          const observed = (await reconcileNativeJob(record)) ?? (await reconcileGateVerdict(record));
           if (observed) {
             record = {
               ...record,
@@ -2537,6 +2586,80 @@ export async function registerSubmissionRoutes(
     return replyWithDraft(request, reply, record.issueNumber);
   });
 
+  /**
+   * The playable document for a store-published game, or null if this is not one.
+   *
+   * Returns the gate's own `bundle.html`: the gate assembles it through the same
+   * `assembleGameHtml` the bake uses, so the CSP, the AI Act provenance marking and the
+   * credential scan are already applied to the exact bytes that passed the check. There
+   * is nothing left to build at serve time, which is why store games need no bake.
+   *
+   * A publication whose bundle is missing returns null rather than throwing, so the
+   * request falls through to the repo path — during the migration a slug can legitimately
+   * exist on both sides, and a store record with no artifact must not take a working
+   * game off the site.
+   */
+  async function storePublishedGame(slug: string): Promise<{ slug: string; title: string; html: string } | null> {
+    const gamesStore = options.agentChannel?.gamesStore;
+    if (!store || !gamesStore) return null;
+    const publication = await store.getPublication(slug);
+    if (publication?.state !== 'published') return null;
+    const bundle = await gamesStore.getDerivedArtifact(slug, publication.currentVersion, 'bundle.html');
+    if (!bundle) {
+      app.log.error({ slug, version: publication.currentVersion }, 'published game has no stored bundle');
+      return null;
+    }
+    const spec = await gamesStore.getSourceFile(slug, publication.currentVersion, 'SPEC.md');
+    const title = (spec && catalogEntryFromSpec(slug, spec, () => null)?.title) || slug;
+    return { slug, title, html: bundle.toString('utf8') };
+  }
+
+  /**
+   * The catalog entries for games published from the store rather than from the repo.
+   *
+   * A delivered game is never committed, so the games-repo catalog cannot see it and a
+   * published game would be invisible on the site that published it. Read from the
+   * publication registry, described by the same `catalogEntryFromSpec` the repo path
+   * uses, and given the same cache window as the rest of the catalog: this is one
+   * Firestore read plus a small object read per store game, on a route the whole site
+   * hits.
+   *
+   * Repo slugs win. During the migration a game can exist on both sides — delivered to
+   * the store and still committed — and listing it twice would put two cards for one
+   * game in front of players. The repo copy is the one the snapshot bake serves, so it
+   * is the one that keeps the slug.
+   */
+  async function storeCatalogEntries(repoSlugs: string[]): Promise<CatalogGameEntry[]> {
+    const gamesStore = options.agentChannel?.gamesStore;
+    if (!store || !gamesStore) return [];
+    const cached = storeCatalogCache;
+    if (cached && cached.expiresAt > now()) return cached.value;
+
+    try {
+      const taken = new Set(repoSlugs);
+      const publications = (await store.listPublications()).filter(
+        (record) => record.state === 'published' && !taken.has(record.slug),
+      );
+      const entries: CatalogGameEntry[] = [];
+      for (const record of publications) {
+        const spec = await gamesStore.getSourceFile(record.slug, record.currentVersion, 'SPEC.md');
+        if (spec === null) continue;
+        const entry = catalogEntryFromSpec(record.slug, spec, () => null);
+        // Published is a decision the operator already made and recorded here; the
+        // spec's own `status` describes the repo workflow this game never went through.
+        if (entry) entries.push({ ...entry, status: 'published' });
+      }
+      storeCatalogCache = { value: entries, expiresAt: now() + storeCatalogTtlMs };
+      return entries;
+    } catch (error) {
+      // The repo catalog is already in hand and is most of the site. Failing the whole
+      // list because the store half could not be read would take down games that have
+      // nothing to do with this path.
+      app.log.error({ err: error }, 'could not read store-published games for the catalog');
+      return cached?.value ?? [];
+    }
+  }
+
   // The public game catalog, derived from SPEC.md frontmatter on the games repo's
   // default branch via the authenticated API. This (not public GitHub Pages) is
   // what the web app lists, so the games repo itself can be private — the app's
@@ -2548,7 +2671,8 @@ export async function registerSubmissionRoutes(
 
     try {
       const entries = await getCatalogEntries(githubClient);
-      return reply.send(entries.filter((entry) => entry.status === 'published'));
+      const published = entries.filter((entry) => entry.status === 'published');
+      return reply.send([...published, ...(await storeCatalogEntries(published.map((entry) => entry.slug)))]);
     } catch (error) {
       if (error instanceof SnapshotUnavailableError) {
         request.log.error({ err: error }, 'snapshot catalog unavailable');
@@ -2664,6 +2788,17 @@ export async function registerSubmissionRoutes(
     }
 
     try {
+      // Store-published first: a delivered game is never committed, so the repo catalog
+      // does not know it exists and would 404 a game the operator published. Its document
+      // is the one the gate assembled — same assembler, same CSP, provenance and
+      // credential scan as the bake applies to a repo game — so this serves an artifact
+      // rather than building one.
+      const stored = await storePublishedGame(slug);
+      if (stored) {
+        gameCache.set(slug, { value: stored, expiresAt: currentTime + gameTtlMs });
+        return reply.send(stored);
+      }
+
       if (!(await isSlugPublished(githubClient, slug))) {
         return reply.status(404).send({ error: 'game not found' });
       }

--- a/apps/web/src/AdminJobsPanel.test.tsx
+++ b/apps/web/src/AdminJobsPanel.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AdminJobsPanel } from './AdminJobsPanel.js';
+import type { JobQueueEntry, JobQueueResponse } from './adminJobsApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchJobQueue: vi.fn(),
+  publishJob: vi.fn(),
+}));
+
+vi.mock('./adminJobsApi.js', () => mocked);
+
+function job(overrides: Partial<JobQueueEntry> = {}): JobQueueEntry {
+  return {
+    issueNumber: 1_000_001,
+    title: 'Comet Courier',
+    ownerUid: 'g:1',
+    slug: 'comet-courier',
+    state: 'ready_for_review',
+    creatorStatus: 'in_review',
+    ageMs: 90 * 60_000,
+    timeInStateMs: 5 * 60_000,
+    stall: null,
+    recentTransitions: [{ to: 'ready_for_review', at: '2026-07-30T12:00:00Z', by: 'gate', reason: 'gate_green' }],
+    ...overrides,
+  };
+}
+
+function queue(jobs: JobQueueEntry[]): JobQueueResponse {
+  return { jobs, byState: {}, stalled: jobs.filter((entry) => entry.stall).length };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AdminJobsPanel));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('AdminJobsPanel', () => {
+  it('offers publish only for a build the gate has passed', async () => {
+    // Any earlier state means the API would refuse, and a button that invites a click
+    // whose answer is already known is worse than no button.
+    mocked.fetchJobQueue.mockResolvedValue(
+      queue([job({ issueNumber: 1, state: 'building' }), job({ issueNumber: 2, state: 'ready_for_review' })]),
+    );
+
+    const { container, root } = await render();
+
+    expect(container.querySelectorAll('.admin-job-publish')).toHaveLength(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('publishes and says which game went live', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job()]));
+    mocked.publishJob.mockResolvedValue({
+      ok: true,
+      slug: 'comet-courier',
+      version: 'v1',
+      publishedAt: '2026-07-30T12:00:00Z',
+    });
+
+    const { container, root } = await render();
+    const button = container.querySelector('.admin-job-publish') as HTMLButtonElement;
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(mocked.publishJob).toHaveBeenCalledWith(1_000_001);
+    expect(container.querySelector('.admin-job-message')?.textContent).toContain('published comet-courier');
+    // Re-read after publishing: the row has left the queue and the view should say so
+    // rather than keep showing a job that is no longer active.
+    expect(mocked.fetchJobQueue).toHaveBeenCalledTimes(2);
+
+    await act(async () => root.unmount());
+  });
+
+  it('names the next step when a publish is refused', async () => {
+    // "Could not publish" collapses three different next steps into one shrug.
+    mocked.fetchJobQueue.mockResolvedValue(queue([job()]));
+    mocked.publishJob.mockResolvedValue({ refused: 'gate_red' });
+
+    const { container, root } = await render();
+
+    await act(async () => {
+      (container.querySelector('.admin-job-publish') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.admin-job-message')?.textContent).toContain('gate failed');
+
+    await act(async () => root.unmount());
+  });
+
+  it('says why a job looks stuck instead of leaving silence to say it', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job({ state: 'building', stall: 'quiet' })]));
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.admin-job-stall')?.textContent).toContain('silent');
+    expect(container.querySelector('.admin-job-row')?.className).toContain('is-stalled');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders nothing but "not found" for a non-admin', async () => {
+    // Same answer the API gives: the operator surface does not confirm it exists.
+    mocked.fetchJobQueue.mockResolvedValue(null);
+
+    const { container, root } = await render();
+
+    expect(container.textContent).toContain('Not found');
+    expect(container.querySelector('.admin-jobs-table')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchJobQueue,
+  publishJob,
+  type JobQueueEntry,
+  type JobQueueResponse,
+  type PublishRefusal,
+} from './adminJobsApi.js';
+
+/**
+ * The build queue an operator actually works from.
+ *
+ * Everything here was already answerable and unanswered: the queue endpoint has existed
+ * with nothing rendering it, and publishing has been a curl command. The creator-
+ * experience review's oldest finding is watching a build for three hours with no way to
+ * tell a stuck agent from a slow one — this is the surface where that becomes visible,
+ * and where the one thing an operator can do about a finished build is a button.
+ *
+ * Deliberately dense and unstyled-by-default: it is a working view for one person, not a
+ * product surface, and a table that fits twenty jobs on a laptop beats cards that fit six.
+ */
+
+const REFUSAL_COPY: Record<PublishRefusal, string> = {
+  // Each names the next step, because that is the difference between a refusal an
+  // operator can act on and one that just says no.
+  gate_red: 'the gate failed this version — read its report before publishing',
+  not_gated: 'the gate has not run against this version yet',
+  nothing_delivered: 'this build has never delivered a version',
+  store_unavailable: 'the games store is not configured on this deployment',
+  unknown: 'refused, and the reason was not one this console knows',
+};
+
+const STALL_COPY: Record<NonNullable<JobQueueEntry['stall']>, string> = {
+  awaiting_input: 'waiting on the creator',
+  not_dispatched: 'never picked up by an agent',
+  quiet: 'agent silent',
+  gate_not_started: 'delivered, gate never started',
+};
+
+/** Short, sortable duration: an operator reads "2h 5m", not 7_500_000. */
+function duration(ms: number | undefined): string {
+  if (ms === undefined || !Number.isFinite(ms)) return '—';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+function JobRow({ job, onPublished }: { job: JobQueueEntry; onPublished: () => void }) {
+  const [publishing, setPublishing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Only a gate-green build can publish, and `ready_for_review` is precisely the state
+  // that means so. Offering the button earlier would be offering an action the API will
+  // refuse — the console should not invite a click it knows the answer to.
+  const publishable = job.state === 'ready_for_review';
+
+  const onPublish = useCallback(async () => {
+    setPublishing(true);
+    setMessage(null);
+    try {
+      const result = await publishJob(job.issueNumber);
+      if ('refused' in result) {
+        setMessage(REFUSAL_COPY[result.refused]);
+      } else {
+        setMessage(`published ${result.slug}`);
+        onPublished();
+      }
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setPublishing(false);
+    }
+  }, [job.issueNumber, onPublished]);
+
+  const latest = job.recentTransitions[0];
+
+  return (
+    <tr className={job.stall ? 'admin-job-row is-stalled' : 'admin-job-row'}>
+      <td>
+        <div className="admin-job-title">{job.title}</div>
+        <div className="admin-job-sub">
+          #{job.issueNumber}
+          {job.slug ? ` · ${job.slug}` : ''}
+        </div>
+      </td>
+      <td>
+        <span className="admin-job-state">{job.state}</span>
+        {job.stall ? <div className="admin-job-stall">{STALL_COPY[job.stall]}</div> : null}
+        {/* The reason the job is where it is — `gate_red`, `task_failed`, `approved`.
+            Without it the state alone cannot distinguish a build that failed from one
+            that is merely waiting. */}
+        {latest?.reason ? <div className="admin-job-sub">{latest.reason}</div> : null}
+      </td>
+      <td>{duration(job.timeInStateMs)}</td>
+      <td>{duration(job.ageMs)}</td>
+      <td>
+        {publishable ? (
+          <button className="admin-job-publish" onClick={onPublish} disabled={publishing}>
+            {publishing ? 'Publishing…' : 'Publish'}
+          </button>
+        ) : null}
+        {message ? <div className="admin-job-message">{message}</div> : null}
+      </td>
+    </tr>
+  );
+}
+
+export function AdminJobsPanel() {
+  const [queue, setQueue] = useState<JobQueueResponse | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetchJobQueue();
+      if (response === null) {
+        setState('forbidden');
+        return;
+      }
+      setQueue(response);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    // A build queue is only useful while it is current, and an operator watching a job
+    // move is the whole reason to have this open. Cheap: the endpoint reads the store
+    // and costs no GitHub calls, which is why it can be polled at all.
+    const timer = setInterval(() => void load(), 30_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+  if (state === 'loading') return <p className="health-empty">Reading the queue…</p>;
+  if (state === 'error') return <p className="health-empty">Could not read the queue.</p>;
+
+  const jobs = queue?.jobs ?? [];
+
+  return (
+    <section className="admin-jobs">
+      <h2 className="health-section-title">Build queue</h2>
+      <p className="health-summary">
+        {jobs.length} active {jobs.length === 1 ? 'job' : 'jobs'}
+        {queue?.stalled ? ` · ${queue.stalled} stalled` : ''}
+      </p>
+
+      {jobs.length === 0 ? (
+        <p className="health-empty">Nothing building.</p>
+      ) : (
+        <div className="health-table-scroll">
+          <table className="health-table admin-jobs-table">
+            <thead>
+              <tr>
+                <th>Game</th>
+                <th>State</th>
+                <th>In state</th>
+                <th>Age</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <JobRow key={job.issueNumber} job={job} onPublished={() => void load()} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/GameHealthView.tsx
+++ b/apps/web/src/GameHealthView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { AdminJobsPanel } from './AdminJobsPanel.js';
 import {
   fetchGameHealth,
   fetchVisitFunnel,
@@ -122,8 +123,9 @@ export function GameHealthView() {
   return (
     <section className="health">
       <header className="health-header">
-        {/* The page now carries both streams, so the title names neither. */}
-        <h1>Telemetry</h1>
+        {/* The page carries the queue and both telemetry streams, so the title names
+            what it is rather than any one of them. */}
+        <h1>Operator</h1>
         <div className="health-windows">
           {WINDOWS.map((window) => (
             <button
@@ -137,6 +139,12 @@ export function GameHealthView() {
           ))}
         </div>
       </header>
+
+      {/* First, because it is the only part of this page with something to *do*: a
+          build waiting on approval is the one thing here that goes stale by being
+          unread. Its own loading and permission states are handled inside, so a slow
+          telemetry read never delays the queue. */}
+      <AdminJobsPanel />
 
       {state === 'loading' && <p className="health-empty">Reading telemetry…</p>}
       {state === 'error' && <p className="health-empty">Could not read telemetry.</p>}

--- a/apps/web/src/adminJobsApi.ts
+++ b/apps/web/src/adminJobsApi.ts
@@ -1,0 +1,85 @@
+/**
+ * The operator's build queue, and the one action taken against it.
+ *
+ * Every admin surface until now has been read-only telemetry. This one changes something:
+ * publishing is the moderation boundary being exercised, and until it had a button it was
+ * a curl command nobody could run from a phone at the moment a game needed approving.
+ *
+ * Same posture as `healthApi`: 404 means "not an admin" and is reported as such rather
+ * than as an error, because the operator surface does not confirm its own existence.
+ */
+
+/** Internal job vocabulary — richer than what a creator is shown. Mirrors job-state.ts. */
+export type JobState =
+  | 'queued'
+  | 'dispatched'
+  | 'building'
+  | 'submitted'
+  | 'gating'
+  | 'ready_for_review'
+  | 'publishing'
+  | 'published'
+  | 'needs_changes'
+  | 'failed'
+  | 'canceled'
+  | 'abandoned';
+
+export type JobStall = 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started';
+
+export interface JobQueueEntry {
+  issueNumber: number;
+  title: string;
+  ownerUid: string;
+  slug?: string;
+  state: JobState;
+  creatorStatus: string;
+  stateSince?: string;
+  timeInStateMs?: number;
+  ageMs: number;
+  stall: JobStall | null;
+  agentState?: string;
+  recentTransitions: Array<{ to: JobState; at: string; by: string; reason?: string }>;
+}
+
+export interface JobQueueResponse {
+  jobs: JobQueueEntry[];
+  byState: Partial<Record<JobState, number>>;
+  stalled: number;
+}
+
+/** Null means "not an admin" (or no session): the route answers 404 to everyone else. */
+export async function fetchJobQueue(): Promise<JobQueueResponse | null> {
+  const response = await fetch('/api/admin/jobs', { credentials: 'include' });
+  if (response.status === 404 || response.status === 401) return null;
+  if (!response.ok) throw new Error(`job queue failed: ${response.status}`);
+  return (await response.json()) as JobQueueResponse;
+}
+
+export interface PublishResult {
+  ok: true;
+  slug: string;
+  version: string;
+  publishedAt: string;
+}
+
+/**
+ * Why a publish was refused, in the API's own vocabulary.
+ *
+ * Kept as codes rather than sentences because each one means something an operator can
+ * act on: `gate_red` is "look at the report", `not_gated` is "the gate has not run yet",
+ * `nothing_delivered` is "this build never uploaded anything". A single "could not
+ * publish" would collapse three different next steps into one shrug.
+ */
+export type PublishRefusal = 'gate_red' | 'not_gated' | 'nothing_delivered' | 'store_unavailable' | 'unknown';
+
+export async function publishJob(issueNumber: number): Promise<PublishResult | { refused: PublishRefusal }> {
+  const response = await fetch(`/api/admin/jobs/${issueNumber}/publish`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (response.ok) return (await response.json()) as PublishResult;
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  const known: PublishRefusal[] = ['gate_red', 'not_gated', 'nothing_delivered', 'store_unavailable'];
+  const refusal = known.find((code) => code === body.error) ?? 'unknown';
+  return { refused: refusal };
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7182,3 +7182,61 @@ body.player-open {
     animation: none;
   }
 }
+
+/* Operator build queue. Reuses the telemetry table styles above — this is the same
+   kind of surface, and a second table idiom would be a second thing to maintain for
+   one reader. Only what the queue adds is defined here. */
+.admin-jobs {
+  margin-bottom: 2rem;
+}
+
+.admin-job-title {
+  font-weight: 600;
+}
+
+.admin-job-sub {
+  font-size: 0.78rem;
+  opacity: 0.65;
+}
+
+.admin-job-state {
+  font-variant-numeric: tabular-nums;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+/* A stalled job is the only row demanding action, so it is the only one that carries
+   colour. Paired with the text in the cell rather than replacing it: colour alone is
+   not a signal for every reader. */
+.admin-job-row.is-stalled {
+  background: color-mix(in srgb, var(--danger, #c0392b) 10%, transparent);
+}
+
+.admin-job-stall {
+  font-size: 0.78rem;
+  color: var(--danger, #c0392b);
+}
+
+.admin-job-publish {
+  cursor: pointer;
+  padding: 0.3rem 0.7rem;
+  font: inherit;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+}
+
+.admin-job-publish:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.admin-job-message {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  opacity: 0.8;
+  max-width: 22rem;
+}


### PR DESCRIPTION
Three commits, each closing a gap the live test exposed. Reviewable in order; the middle one depends on the first.

---

## 1. Carry a game from a green gate to the page it was built for (`a789f8f`)

Delivery worked and publication did not exist. A delivered game was stored, checked, and then sat there: nothing told the job what the gate had said, nothing called `setPublication`, and neither the catalog nor the play route could see a game that was never committed to the games repo.

**The gate now assembles what it stores.** It was keeping the games repo's own `dist/` build as `bundle.html` — the repo's idea of a playable page, not ours. The difference is the whole of serve-time policy: the restrictive CSP that stops a game calling home, the AI Act art. 50(2) provenance marking, the credential scan, the byte budget. All four live in `assembleGameHtml`; none are in `tools/build.ts`.

`gate-runner.ts`'s header claimed this was "applied by the side that owns it". It described an intention nobody had implemented — and **I repeated the claim in #353** when I made that bundle the creator's draft preview, so that path has been serving policy-free documents since it deployed. Containment was never affected (`GameFrame` sandboxes with no `allow-same-origin`), but network egress was unrestricted. Fixed here, before publishing could widen it from drafts to every player.

A game the assembler refuses is now a red verdict with a reason rather than a crash: `check:game` accepts things we will not serve, and a run that dies leaves the version with no verdict at all — which reads as a gate that never ran rather than one that said no.

**Delivery moves the job to `submitted`.** Without it the job stayed `building`, the agent's session then reported `completed` with a candidate present, and the reconciler read that as ready-for-review — promoting a game on the agent's say-so, ahead of the gate.

**The verdict reaches the job by being read, not pushed.** The gate writes it to the version manifest and exits; a poll reads it. A callback would need its own credential and retry to deliver a fact the manifest already holds, and could then disagree with it.

**Publishing is an operator action** — `POST /api/admin/jobs/:issueNumber/publish`, re-reading green off the manifest rather than trusting the job's derived state. Not automatic on green: the gate answers "does this run", a human answers "may this be on the site".

**Catalog and play can see store games**, described by the same `catalogEntryFromSpec` the repo path uses. Play serves the gate's bundle, so the bytes played are the bytes checked — no bake needed, since the gate already produced what a bake would compute.

## 2. Give the operator a queue they can act on (`8b1c24d`)

Nine admin endpoints exist and none had ever had a screen. The build queue in particular was shipped, tested, and reachable only by curl — answering "which build is stuck, and for how long" to nobody. Publishing made that worse: a human action reachable only by curl is one that does not happen at the moment it should.

Publish is offered only for `ready_for_review`; every other state is one the API would refuse. Refusals keep their codes rather than collapsing into "could not publish" — `gate_red` means read the report, `not_gated` means wait, `nothing_delivered` means this build never uploaded. Three different next steps.

Lives on `/health`, already the operator surface, already unlisted, already 404 to everyone else through the same check the API uses.

## 3. Check that a session delivered, and send it back when it did not (`15aa52c`)

A live session did the whole job — read the game, revised it, ran every check — pushed its branch, and stopped. It never uploaded. Both the brief and the `game-builder` agent definition tell it to; the instruction lost to a tool that felt like finishing.

**The check already existed.** `reconcileAgentObservation` returns `task_completed_without_delivery` for a session that ran to completion with nothing stored, and `hasCandidate` comes from our own record rather than anything the session claims. What was wrong was the response: it marked the build failed and told the creator their round was gone, when the work was almost certainly finished and sitting on a branch with only the upload missing.

That case is now answered instead of recorded — and it is the only observation worth answering. Crashed, timed out, killed-for-quota are all "could not continue", and asking again buys the same ending twice.

**Once.** A session that forgot the last step takes the reminder; a setup that cannot deliver fails identically however many times it is asked, and each attempt is a real session against a real quota. Counted before the dispatch, so a dispatch that throws still spends the budget.

**The branch survives this round.** Every other round deletes the previous workspace because the store holds the truth. Undelivered work is exactly where that is false — nothing was uploaded, so that branch is the only copy, and deleting it would destroy what the new round was sent to recover.

**The steer rides on every channel call.** `control` now carries whether anything has been delivered, and while nothing has, a line saying pushing is not delivering. The brief is read once at the start of a session; the omission happens at the end of one.

---

## Verification

Type-check, lint, 1293 API tests, 591 web tests, build — all green locally, and all 7 checks green on `15aa52c`.

New coverage across the three: the gate storing the assembler's document rather than the repo's build; a red verdict when a checked game cannot be assembled; a green gate publishing with both transitions recorded; publish refused on a red gate, on an ungated version, and for non-admins; a store game listed and served with its provenance marking intact; no double-listing when a slug exists on both sides; fallthrough to the repo when a publication has no bundle; the console offering publish only when the gate has passed, naming the next step on refusal, and showing stall reasons; an undelivered session being sent back with its branch named and preserved; the nudge capped at one; and the channel reminder appearing only while undelivered.

## Trying it

With a green delivered build, open `/health` as an admin and press **Publish**. The game then appears in `/api/catalog` and plays at `/play/<slug>`.