### PR TITLE
Fix update banner missing on iPhone Home Screen reopen

### DIFF
--- a/apps/web/src/AppUpdateBanner.test.tsx
+++ b/apps/web/src/AppUpdateBanner.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppUpdateBanner } from './AppUpdateBanner.js';
 import i18n from './i18n/index.js';
+import { clearPendingShellUpdate } from './shellUpdate.js';
 
 let container: HTMLDivElement;
 let root: Root;
@@ -25,6 +26,7 @@ function postFromWorker(data: unknown) {
 beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   await i18n.changeLanguage('en');
+  clearPendingShellUpdate();
 
   serviceWorker = new EventTarget();
   Object.defineProperty(navigator, 'serviceWorker', { value: serviceWorker, configurable: true });
@@ -40,6 +42,7 @@ beforeEach(async () => {
 afterEach(async () => {
   await act(async () => root.unmount());
   document.body.innerHTML = '';
+  clearPendingShellUpdate();
   Reflect.deleteProperty(navigator, 'serviceWorker');
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -97,6 +100,18 @@ describe('AppUpdateBanner', () => {
     });
 
     expect(banner()).toBeNull();
+  });
+
+  it('appears on mount when an earlier boot listener already parked the update', async () => {
+    await act(async () => root.unmount());
+    sessionStorage.setItem('gamedev_shell_update_pending', 'parked-rev');
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(AppUpdateBanner));
+    });
+
+    expect(banner()).not.toBeNull();
   });
 
   it('renders nothing where there is no service worker at all', async () => {

--- a/apps/web/src/AppUpdateBanner.tsx
+++ b/apps/web/src/AppUpdateBanner.tsx
@@ -1,7 +1,3 @@
-import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { PixelIcon } from './PixelIcon.js';
-
 /**
  * "A new version is ready" — the visible half of the shell cache's honesty contract.
  *
@@ -15,22 +11,46 @@ import { PixelIcon } from './PixelIcon.js';
  * this offers the one action that resolves it. A stale shell now lasts exactly as long as
  * someone ignores a banner, which is a different and much more defensible thing than
  * lasting until they happen to navigate.
+ *
+ * The announce can beat this component to the punch (auth splash, beta gate). Boot-time
+ * {@link watchShellUpdates} parks it in sessionStorage so a late mount still sees it.
  */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
+import { clearPendingShellUpdate, pendingShellUpdate, SHELL_UPDATED_EVENT } from './shellUpdate.js';
+
 export function AppUpdateBanner() {
   const { t } = useTranslation();
-  const [updated, setUpdated] = useState(false);
+  const [updated, setUpdated] = useState(() => pendingShellUpdate() != null);
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
 
+    function show() {
+      setUpdated(true);
+    }
+
     function onMessage(event: MessageEvent) {
       if ((event.data as { type?: string } | null)?.type === 'shell-updated') {
-        setUpdated(true);
+        show();
       }
     }
 
+    function onParked() {
+      if (pendingShellUpdate()) show();
+    }
+
     navigator.serviceWorker.addEventListener('message', onMessage);
-    return () => navigator.serviceWorker.removeEventListener('message', onMessage);
+    window.addEventListener(SHELL_UPDATED_EVENT, onParked);
+    // Re-read in case the early listener won the race between first render and effect.
+    onParked();
+
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', onMessage);
+      window.removeEventListener(SHELL_UPDATED_EVENT, onParked);
+    };
   }, []);
 
   if (!updated) return null;
@@ -42,13 +62,23 @@ export function AppUpdateBanner() {
       <div className="app-update__actions">
         {/* A plain reload is enough: the new worker has already claimed this page, so the
             very next document request is answered from the new build's cache. */}
-        <button type="button" className="primary-btn app-update__reload" onClick={() => window.location.reload()}>
+        <button
+          type="button"
+          className="primary-btn app-update__reload"
+          onClick={() => {
+            clearPendingShellUpdate();
+            window.location.reload();
+          }}
+        >
           {t('pwa.updateAction')}
         </button>
         <button
           type="button"
           className="app-update__close"
-          onClick={() => setUpdated(false)}
+          onClick={() => {
+            clearPendingShellUpdate();
+            setUpdated(false);
+          }}
           aria-label={t('pwa.updateDismiss')}
           title={t('pwa.updateDismiss')}
         >

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { App } from './App.js';
 import { AuthProvider } from './AuthContext.js';
 import { recordVisit, watchInstallPrompt } from './pwa.js';
+import { watchShellUpdates } from './shellUpdate.js';
 import { startVisitTracking } from './visitTelemetry.js';
 import './i18n/index.js';
 import './styles.css';
@@ -20,9 +21,15 @@ startVisitTracking();
  * `recordVisit` because "has this person been here before" must count every session,
  * including the ones spent on the beta splash or a controller page — routes where the
  * install banner deliberately never renders and so could never do the counting itself.
+ *
+ * `watchShellUpdates` for the same timing reason as the install prompt: the worker can
+ * activate and post `shell-updated` while the auth splash is still up, long before
+ * `AppUpdateBanner` mounts. Without an early listener the message is gone and an
+ * iPhone Home Screen reopen stays on a stale shell with no Reload offer.
  */
 watchInstallPrompt();
 recordVisit();
+watchShellUpdates();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/web/src/shellUpdate.test.ts
+++ b/apps/web/src/shellUpdate.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearPendingShellUpdate, pendingShellUpdate, SHELL_UPDATED_EVENT, watchShellUpdates } from './shellUpdate.js';
+
+describe('shellUpdate', () => {
+  let serviceWorker: EventTarget & {
+    getRegistration: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    serviceWorker = Object.assign(new EventTarget(), {
+      getRegistration: vi.fn(async () => null),
+    });
+    Object.defineProperty(navigator, 'serviceWorker', { value: serviceWorker, configurable: true });
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+    vi.restoreAllMocks();
+  });
+
+  it('parks a shell-updated message so a late banner mount can still see it', () => {
+    const onParked = vi.fn();
+    window.addEventListener(SHELL_UPDATED_EVENT, onParked);
+    watchShellUpdates();
+
+    const event = new Event('message') as MessageEvent;
+    Object.defineProperty(event, 'data', { value: { type: 'shell-updated', revision: 'abc123' } });
+    serviceWorker.dispatchEvent(event);
+
+    expect(pendingShellUpdate()).toBe('abc123');
+    expect(onParked).toHaveBeenCalledOnce();
+    window.removeEventListener(SHELL_UPDATED_EVENT, onParked);
+  });
+
+  it('ignores unrelated worker messages', () => {
+    watchShellUpdates();
+    const event = new Event('message') as MessageEvent;
+    Object.defineProperty(event, 'data', { value: { type: 'push-received' } });
+    serviceWorker.dispatchEvent(event);
+    expect(pendingShellUpdate()).toBeNull();
+  });
+
+  it('clears the pending flag when the banner is dismissed or reloaded', () => {
+    watchShellUpdates();
+    const event = new Event('message') as MessageEvent;
+    Object.defineProperty(event, 'data', { value: { type: 'shell-updated', revision: 'abc123' } });
+    serviceWorker.dispatchEvent(event);
+    clearPendingShellUpdate();
+    expect(pendingShellUpdate()).toBeNull();
+  });
+
+  it('asks the registration to update when the app returns to the foreground', async () => {
+    const update = vi.fn(async () => undefined);
+    serviceWorker.getRegistration.mockResolvedValue({ update });
+
+    Object.defineProperty(document, 'readyState', { configurable: true, value: 'complete' });
+    watchShellUpdates();
+    await vi.waitFor(() => expect(update).toHaveBeenCalled());
+    const afterBoot = update.mock.calls.length;
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.waitFor(() => expect(update.mock.calls.length).toBeGreaterThan(afterBoot));
+  });
+});

--- a/apps/web/src/shellUpdate.ts
+++ b/apps/web/src/shellUpdate.ts
@@ -1,0 +1,89 @@
+/**
+ * Catch "a new shell is ready" before React has mounted the banner.
+ *
+ * The worker posts `{ type: 'shell-updated' }` from `activate` the moment it replaces
+ * an earlier build. `AppUpdateBanner` only mounts after auth + the beta gate, so on a
+ * phone Home Screen reopen the message can land while the loading splash is still up
+ * and vanish — no banner, stale shell, no way to reload. Listening here (same pattern
+ * as `watchInstallPrompt`) parks the revision in sessionStorage until the banner can
+ * show it, and `registration.update()` on foreground is what makes iOS actually check
+ * for a new worker when the user comes back.
+ */
+
+const PENDING_KEY = 'gamedev_shell_update_pending';
+export const SHELL_UPDATED_EVENT = 'gamedev:shell-updated';
+
+function readSession(key: string): string | null {
+  try {
+    return window.sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(key: string, value: string): void {
+  try {
+    window.sessionStorage.setItem(key, value);
+  } catch {
+    /* private mode — banner simply will not resurface after a race */
+  }
+}
+
+function clearSession(key: string): void {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+function notePending(revision: string): void {
+  writeSession(PENDING_KEY, revision);
+  window.dispatchEvent(new CustomEvent(SHELL_UPDATED_EVENT, { detail: { revision } }));
+}
+
+/** Pending build revision, if the worker announced a replacement this session. */
+export function pendingShellUpdate(): string | null {
+  const value = readSession(PENDING_KEY);
+  return value && value.length > 0 ? value : null;
+}
+
+/** Call when the user reloads or dismisses so a fresh session does not re-nag. */
+export function clearPendingShellUpdate(): void {
+  clearSession(PENDING_KEY);
+}
+
+/**
+ * Attach the early listener and ask the browser to look for a newer worker.
+ * Safe to call once at boot; no-ops where service workers do not exist.
+ */
+export function watchShellUpdates(): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data as { type?: string; revision?: string } | null;
+    if (data?.type !== 'shell-updated') return;
+    notePending(typeof data.revision === 'string' && data.revision ? data.revision : 'updated');
+  });
+
+  const requestUpdate = () => {
+    void navigator.serviceWorker
+      .getRegistration('/sw.js')
+      .then((registration) => registration?.update())
+      .catch(() => {
+        /* offline / blocked — the next foreground will try again */
+      });
+  };
+
+  // `load` is when main.tsx registers the worker; updating immediately after that is
+  // what catches a deploy that landed while the installed app was closed.
+  if (document.readyState === 'complete') {
+    requestUpdate();
+  } else {
+    window.addEventListener('load', requestUpdate, { once: true });
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') requestUpdate();
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On iPhone Home Screen, the “new version / Reload” banner often never appeared after a deploy.

**Cause:** the service worker posts `shell-updated` as soon as it activates. `AppUpdateBanner` only mounts after auth + the beta gate, so the message could fire during the loading splash and be lost — leaving a stale shell with no Reload offer.

**Fix:**
- Listen for `shell-updated` at boot (`watchShellUpdates`), park the revision in `sessionStorage`
- Banner reads that on mount (and still listens live)
- Call `registration.update()` on load and whenever the app returns to the foreground (helps iOS actually fetch the new worker)

## Test plan

- [ ] Install / open Home Screen PWA on an older build, deploy a new one, fully quit and reopen — bottom banner with **Reload** should appear
- [ ] Tap Reload — new shell loads; banner gone
- [ ] Dismiss — banner gone for that session
- [ ] `npm run type-check && npm run lint && npm run test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc89351-8f6c-4256-8756-163dd93e6a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

