### PR TITLE
Give the operator one console, and let it come to them

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,6 +23,14 @@ paths = [
   '''app/css/fontello-embedded\.css''',
 ]
 regexes = [
+  # Two placeholder access-token ids from the operator console's tests: the hex
+  # digits in order, and the hex digits reversed. `generic-api-key` fires on any
+  # 16-char hex string, which is exactly the shape of a token id (`^[0-9a-f]{16}$`),
+  # so a made-up one is indistinguishable from a real one by rule. The fixtures
+  # themselves are zero-entropy now (`aaaa…`), but both strings are permanently in
+  # the history of PR #360 and CI scans every commit.
+  '''0123456789abcdef''',
+  '''fedcba9876543210''',
   # Google AdSense client id from the 2017 site (only in git history now).
   # AdSense client ids ship in public page HTML by design — not a secret.
   '''ca-pub-0288128369759519''',

--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { InMemoryStore, type Scorecard, type TelemetryEvent, type VisitEvent } from './store.js';
-import type { CreationLimitsResponse, HealthResponse, ScorecardsResponse, VisitsResponse } from './admin.js';
+import type {
+  AdminSummaryResponse,
+  CreationLimitsResponse,
+  HealthResponse,
+  ScorecardsResponse,
+  VisitsResponse,
+} from './admin.js';
 import { runScorecardSweep } from './scorecard.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -533,5 +539,55 @@ describe('/api/admin/creation-limits', () => {
     // The refusals are refusals, not silent no-ops.
     expect(await store.getCreationLimits()).toBeNull();
     await app.close();
+  });
+});
+
+describe('GET /api/admin/summary', () => {
+  it('answers 404 to a signed-in non-admin, like every other operator route', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:player' });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:player') });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns what needs doing, the queue behind it, and the breaker', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_001, 'g:boss', 'Comet Courier');
+    await store.recordJobTransition(1_000_001, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:boss') });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as AdminSummaryResponse;
+    expect(body.alerts).toHaveLength(1);
+    expect(body.alerts[0]).toMatchObject({ kind: 'review_ready', issueNumber: 1_000_001, title: 'Comet Courier' });
+    expect(body.queue).toMatchObject({ active: 1, stalled: 0, byState: { ready_for_review: 1 } });
+    expect(body.limits.paused).toBe(false);
+  });
+
+  it('reports the breaker an operator just pulled', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    const app = await appWith(store);
+    await app.inject({
+      method: 'POST',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+      payload: { paused: true },
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:boss') });
+
+    expect((res.json() as AdminSummaryResponse).limits.paused).toBe(true);
   });
 });

--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -9,6 +9,7 @@ import type {
   ScorecardsResponse,
   VisitsResponse,
 } from './admin.js';
+import type { CostReport } from './job-costs.js';
 import { runScorecardSweep } from './scorecard.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -589,5 +590,77 @@ describe('GET /api/admin/summary', () => {
     const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:boss') });
 
     expect((res.json() as AdminSummaryResponse).limits.paused).toBe(true);
+  });
+});
+
+describe('GET /api/admin/costs', () => {
+  it('answers 404 to a signed-in non-admin', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:player' });
+    const app = await appWith(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/admin/costs', headers: authHeaders('g:player') });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('prices a published game against every credit spent getting there', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+
+    await store.createSubmission(1_000_001, 'g:boss', 'Comet Courier');
+    await store.recordJobCost(1_000_001, {
+      kind: 'agent_session',
+      at: '2026-07-30T10:00:00Z',
+      by: 'copilot',
+      credits: 1,
+    });
+    await store.recordJobCost(1_000_001, {
+      kind: 'gate_run',
+      at: '2026-07-30T10:20:00Z',
+      by: 'cloud-build',
+      ref: 'b1',
+    });
+    await store.setSubmissionPublishedAt(1_000_001, '2026-07-30T10:30:00Z');
+
+    // A build that cost a session and shipped nothing. It belongs in the numerator.
+    await store.createSubmission(1_000_002, 'g:boss', 'Lost Cause');
+    await store.recordJobCost(1_000_002, {
+      kind: 'agent_session',
+      at: '2026-07-30T11:00:00Z',
+      by: 'copilot',
+      credits: 1,
+    });
+
+    const app = await appWith(store);
+    const res = await app.inject({ method: 'GET', url: '/api/admin/costs', headers: authHeaders('g:boss') });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CostReport;
+    expect(body.totals).toMatchObject({ jobs: 2, sessions: 2, credits: 2, gateRuns: 1, published: 1 });
+    expect(body.creditsPerPublishedGame).toBe(2);
+    expect(body.creditsOnUnpublished).toBe(1);
+  });
+
+  it('counts a freshly published job once, not once per list it appears in', async () => {
+    // It is both "active" (not yet notified as published) and "recently published", and
+    // double-counting it would inflate the one number this route exists for.
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_003, 'g:boss', 'Comet Courier');
+    await store.recordJobCost(1_000_003, {
+      kind: 'agent_session',
+      at: '2026-07-30T10:00:00Z',
+      by: 'copilot',
+      credits: 1,
+    });
+    await store.setSubmissionPublishedAt(1_000_003, '2026-07-30T10:30:00Z');
+
+    const app = await appWith(store);
+    const body = (
+      await app.inject({ method: 'GET', url: '/api/admin/costs', headers: authHeaders('g:boss') })
+    ).json() as CostReport;
+
+    expect(body.totals).toMatchObject({ jobs: 1, credits: 1 });
   });
 });

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -8,6 +8,9 @@ import {
   type PartitionScanBudget,
 } from './telemetry-health.js';
 import { routeAll, type Suggestion } from './suggestions.js';
+import { buildJobQueue } from './job-admin-routes.js';
+import type { JobState } from './job-state.js';
+import { detectOperatorAlerts, type OperatorAlert } from './operator-alerts.js';
 import { summarizeVisitFunnel, type VisitFunnel } from './visit-funnel.js';
 import { summarizeCreatorMetrics, type CreatorMetrics } from './creator-metrics.js';
 import { DEFAULT_CREATION_LIMITS_TTL_MS, resolveDefaultGlobalDailyCap } from './creation-limits.js';
@@ -149,6 +152,21 @@ export interface CreatorsResponse {
  */
 const MAX_SUBMISSIONS_SAMPLED = 100;
 
+/**
+ * The one read the console header and the nav badge share.
+ *
+ * Everything in it is already answerable from other routes; what it adds is being cheap
+ * enough to call on every page load. The nav needs two things — may this person see the
+ * console at all, and is there anything in it demanding them — and getting those from
+ * `/api/admin/jobs` would mean shipping the whole queue to draw one dot.
+ */
+export interface AdminSummaryResponse {
+  /** Jobs waiting on a person, worst first. Short by construction — see operator-alerts. */
+  alerts: OperatorAlert[];
+  queue: { active: number; stalled: number; byState: Partial<Record<JobState, number>> };
+  limits: { paused: boolean; globalDailySubmissionCap: number; todaySubmissions: number };
+}
+
 export function isAdmin(uid: string | undefined, adminUids: Set<string> | undefined): boolean {
   return uid !== undefined && adminUids !== undefined && adminUids.has(uid);
 }
@@ -197,6 +215,34 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       propagationMs: creationLimitsTtlMs,
     };
   }
+
+  /**
+   * Console header and nav badge in one request.
+   *
+   * Same 404-to-everyone-else contract as the reads below, which is what makes it usable
+   * as the admin test the client has never had: the web app has no idea who is an
+   * operator, so until now the console could only be reached by knowing the URL and the
+   * page could only say "not found" after the fact.
+   */
+  app.get('/api/admin/summary', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const [records, limits] = await Promise.all([store.listActiveSubmissions(), readCreationLimits()]);
+    const at = now();
+    const queue = buildJobQueue(records, at);
+    const body: AdminSummaryResponse = {
+      alerts: detectOperatorAlerts(records, at),
+      queue: { active: queue.jobs.length, stalled: queue.stalled, byState: queue.byState },
+      limits: {
+        paused: limits.effective.paused,
+        globalDailySubmissionCap: limits.effective.globalDailySubmissionCap,
+        todaySubmissions: limits.today.submissions,
+      },
+    };
+    return reply.status(200).send(body);
+  });
 
   app.get('/api/admin/creation-limits', async (request, reply) => {
     if (!isAdminSession(request, adminUids)) {

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -10,6 +10,7 @@ import {
 import { routeAll, type Suggestion } from './suggestions.js';
 import { buildJobQueue } from './job-admin-routes.js';
 import type { JobState } from './job-state.js';
+import { buildCostReport } from './job-costs.js';
 import { detectOperatorAlerts, type OperatorAlert } from './operator-alerts.js';
 import { summarizeVisitFunnel, type VisitFunnel } from './visit-funnel.js';
 import { summarizeCreatorMetrics, type CreatorMetrics } from './creator-metrics.js';
@@ -19,6 +20,7 @@ import {
   type CreationLimits,
   type Scorecard,
   type Store,
+  type SubmissionRecord,
   type TelemetryEvent,
   type User,
   type VisitEvent,
@@ -153,6 +155,15 @@ export interface CreatorsResponse {
 const MAX_SUBMISSIONS_SAMPLED = 100;
 
 /**
+ * How far back the cost report reaches, in published games.
+ *
+ * The window is what makes the answer useful: "what does a game cost" is a question
+ * about the current pipeline, and averaging it against builds from three architectures
+ * ago would produce a number that is true of nothing.
+ */
+const MAX_COST_SUBMISSIONS = 100;
+
+/**
  * The one read the console header and the nav badge share.
  *
  * Everything in it is already answerable from other routes; what it adds is being cheap
@@ -217,6 +228,26 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
   }
 
   /**
+   * When each open job's oldest uncollected change request arrived.
+   *
+   * One query per active job, which is the only read on this route that is not O(1) —
+   * paid because the alternative is a console whose alert list is missing the one kind
+   * the sweep can see, and an operator learning to distrust the number. The active set
+   * is open submissions only, and the sweep walks the same set every two minutes doing
+   * strictly more work per record.
+   */
+  async function pendingFeedbackAges(records: SubmissionRecord[]): Promise<Map<number, string>> {
+    const ages = new Map<number, string>();
+    await Promise.all(
+      records.map(async (record) => {
+        const [oldest] = await store.listPendingCreatorMessages(record.issueNumber, { limit: 1 });
+        if (oldest) ages.set(record.issueNumber, oldest.createdAt);
+      }),
+    );
+    return ages;
+  }
+
+  /**
    * Console header and nav badge in one request.
    *
    * Same 404-to-everyone-else contract as the reads below, which is what makes it usable
@@ -233,7 +264,7 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
     const at = now();
     const queue = buildJobQueue(records, at);
     const body: AdminSummaryResponse = {
-      alerts: detectOperatorAlerts(records, at),
+      alerts: detectOperatorAlerts(records, at, await pendingFeedbackAges(records)),
       queue: { active: queue.jobs.length, stalled: queue.stalled, byState: queue.byState },
       limits: {
         paused: limits.effective.paused,
@@ -242,6 +273,36 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       },
     };
     return reply.status(200).send(body);
+  });
+
+  /**
+   * What building games has cost, per job and in aggregate.
+   *
+   * Reads the jobs in flight plus the last {@link MAX_COST_SUBMISSIONS} that published —
+   * deliberately not "everything ever", because the answer worth having is what a game
+   * costs *now*, and a window that reached back to launch would average today against a
+   * pipeline that no longer exists. It also bounds the read, like every other route here.
+   *
+   * A job appears in the window whether or not it has a ledger. One dispatched before
+   * any of this was recorded contributes nothing and is counted in `unmeasuredJobs`, so
+   * a small total reads as "not measured yet" rather than as "cheap".
+   */
+  app.get('/api/admin/costs', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const [active, published] = await Promise.all([
+      store.listActiveSubmissions(),
+      store.listRecentlyPublished(MAX_COST_SUBMISSIONS),
+    ]);
+    // A job can be in both lists — active is "not abandoned and not yet notified as
+    // published", which a freshly published one still satisfies. Counting it twice would
+    // double its credits in the very total the report exists for.
+    const byIssue = new Map<number, SubmissionRecord>();
+    for (const record of [...active, ...published]) byIssue.set(record.issueNumber, record);
+
+    return reply.status(200).send(buildCostReport([...byIssue.values()]));
   });
 
   app.get('/api/admin/creation-limits', async (request, reply) => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -188,7 +188,16 @@ export interface AgentChannelOptions {
   /** Deliveries one build may make per hour. */
   maxSubmitsPerWindow?: number;
   /** Called when a candidate version lands, so the job can move on to the gate. */
-  onSourcesDelivered?: (input: { issueNumber: number; slug: string; version: string }) => Promise<void> | void;
+  /**
+   * Starts whatever verifies a delivery. May answer with what the run cost — the gate
+   * trigger reports Cloud Build's own build id, which is booked below so a line on the
+   * bill can be traced back to the game that caused it.
+   */
+  onSourcesDelivered?: (input: {
+    issueNumber: number;
+    slug: string;
+    version: string;
+  }) => Promise<{ buildId?: string } | void> | void;
 }
 
 type RejectionReason = 'stopped' | 'rate_limited' | 'too_many_events' | 'too_many_shots';
@@ -604,7 +613,21 @@ export async function registerAgentChannelRoutes(
             });
           }
         }
-        await options.onSourcesDelivered?.({ issueNumber, slug, version });
+        const gate = await options.onSourcesDelivered?.({ issueNumber, slug, version });
+        // Booked here rather than inside the trigger because this is where the job is
+        // known: the trigger takes a slug and a version and has no idea whose ledger to
+        // write to. Best-effort like every other write in this handler — the delivery has
+        // already been accepted, and refusing it now would make the agent upload again.
+        if (store && gate?.buildId) {
+          await store
+            .recordJobCost(issueNumber, {
+              kind: 'gate_run',
+              at: new Date().toISOString(),
+              by: 'cloud-build',
+              ref: gate.buildId,
+            })
+            .catch(() => {});
+        }
         options.onEvent?.(issueNumber);
 
         return reply.send({

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -178,6 +178,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     ...options.submissionRoutes,
     store,
     contentChecker,
+    // Same allowlist the console is gated on: the people who can see the queue are the
+    // people its alerts are addressed to. Two lists would drift, and the failure mode of
+    // drift here is an alert nobody receives.
+    adminUids,
     agentBackend: options.submissionRoutes?.agentBackend ?? createAgentBackendFromEnv(app.log),
     agentChannel: {
       ...options.submissionRoutes?.agentChannel,

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -315,6 +315,11 @@ const operatorCopy: Record<OperatorNotificationType, { subject: string; lead: st
     lead: 'has not moved for longer than its state allows.',
     cta: 'Open the queue',
   },
+  'operator.feedback_undelivered': {
+    subject: 'A change request is not reaching the agent',
+    lead: 'has a creator’s change request that no agent has collected — the relay may be down.',
+    cta: 'Open the queue',
+  },
 };
 
 export function operatorPushContent(type: OperatorNotificationType, title: string): { title: string; body: string } {

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -6,7 +6,7 @@
 // notification mails described in docs/notifications-plan.md.
 
 import type { EmailMessage } from './mailer.js';
-import type { SubmissionNotificationType } from './store.js';
+import type { OperatorNotificationType, SubmissionNotificationType } from './store.js';
 
 export type Locale = 'en' | 'pl';
 
@@ -248,8 +248,13 @@ export function digestNotificationMessage(to: string, locale: Locale, params: Di
   const unsub = escapeHtml(params.unsubscribeUrl);
   const line = copy.line(params);
 
-  const text = [line, '', `${copy.cta}: ${params.actionUrl}`, '', `${unsubscribeLine[locale]} ${params.unsubscribeUrl}`]
-    .join('\n');
+  const text = [
+    line,
+    '',
+    `${copy.cta}: ${params.actionUrl}`,
+    '',
+    `${unsubscribeLine[locale]} ${params.unsubscribeUrl}`,
+  ].join('\n');
 
   const html = [
     `<p>${escapeHtml(line)}</p>`,
@@ -272,6 +277,75 @@ export function digestNotificationMessage(to: string, locale: Locale, params: Di
 export function digestPushContent(locale: Locale, params: DigestEmailParams): { title: string; body: string } {
   const copy = digestCopy[locale];
   return { title: copy.subject, body: copy.line(params) };
+}
+
+// --- Operator alerts (operator-alerts.ts) ---
+//
+// English only, on the same reasoning as the contact mail below and the console itself:
+// the recipient is the operator mailbox rather than a member of the public, and a second
+// language for a surface one person reads costs more than it explains.
+//
+// No unsubscribe link, and deliberately: this is not a subscription, it is the queue
+// telling somebody it needs them. The way to stop it is to leave ADMIN_UIDS, which is
+// also the way to stop being the person these are about.
+
+export interface OperatorEmailParams {
+  /** Sanitized game title. */
+  title: string;
+  issueNumber: number;
+  /** Absolute URL to the console. */
+  actionUrl: string;
+  /** Machine-readable extra, e.g. which kind of stall. Rendered verbatim, so keep it ours. */
+  detail?: string;
+}
+
+const operatorCopy: Record<OperatorNotificationType, { subject: string; lead: string; cta: string }> = {
+  'operator.review_ready': {
+    subject: 'A build is waiting to be published',
+    lead: 'passed the gate and is waiting for the publish decision.',
+    cta: 'Open the queue',
+  },
+  'operator.build_failed': {
+    subject: 'A build failed',
+    lead: 'ended without delivering a game.',
+    cta: 'Open the queue',
+  },
+  'operator.build_stalled': {
+    subject: 'A build has stopped moving',
+    lead: 'has not moved for longer than its state allows.',
+    cta: 'Open the queue',
+  },
+};
+
+export function operatorPushContent(type: OperatorNotificationType, title: string): { title: string; body: string } {
+  const copy = operatorCopy[type];
+  return { title: copy.subject, body: `“${title}” ${copy.lead}` };
+}
+
+export function operatorNotificationMessage(
+  to: string,
+  type: OperatorNotificationType,
+  params: OperatorEmailParams,
+): EmailMessage {
+  const copy = operatorCopy[type];
+  const actionUrl = escapeHtml(params.actionUrl);
+  const detail = params.detail ? ` (${params.detail})` : '';
+
+  const text = [
+    `“${params.title}” ${copy.lead}${detail}`,
+    '',
+    `Job #${params.issueNumber}`,
+    '',
+    `${copy.cta}: ${params.actionUrl}`,
+  ].join('\n');
+
+  const html = [
+    `<p>“${escapeHtml(params.title)}” ${escapeHtml(copy.lead)}${escapeHtml(detail)}</p>`,
+    `<p style="color:#888;font-size:12px">Job #${params.issueNumber}</p>`,
+    `<p><a href="${actionUrl}">${escapeHtml(copy.cta)}</a></p>`,
+  ].join('\n');
+
+  return { to, subject: `${copy.subject}: ${params.title}`.slice(0, 200), text, html };
 }
 
 export interface ContactEmailParams {

--- a/apps/api/src/gate-trigger.test.ts
+++ b/apps/api/src/gate-trigger.test.ts
@@ -5,7 +5,14 @@ function stubFetch(response: Partial<Response> = {}) {
   const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
   const impl = (async (url: string | URL, init: RequestInit = {}) => {
     calls.push({ url: String(url), body: JSON.parse(String(init.body ?? '{}')) });
-    return { ok: true, status: 200, text: async () => '', ...response } as Response;
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '',
+      // Cloud Build answers a create with a long-running operation carrying the build.
+      json: async () => ({ metadata: { build: { id: 'build-abc' } } }),
+      ...response,
+    } as Response;
   }) as unknown as typeof fetch;
   return { impl, calls };
 }
@@ -42,6 +49,24 @@ describe('createCloudBuildGateTrigger', () => {
     expect(script.indexOf('GAME_CAPTURE_CHROME')).toBeLessThan(script.indexOf('gate:run'));
   });
 
+  it('reports the build id, so a line on the bill can be traced back to a game', async () => {
+    // Previously read off the response and dropped, which left cost attribution with no
+    // join at all between a GCP charge and the game that caused it.
+    const { impl } = stubFetch();
+    const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
+
+    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({ buildId: 'build-abc' });
+  });
+
+  it('keeps the gate running when the response is not the shape we expected', async () => {
+    // The build is already queued by the time this is parsed. An unrecognised body costs
+    // us the id, and must not cost us the verification.
+    const { impl } = stubFetch({ json: async () => ({ nothing: 'useful' }) });
+    const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
+
+    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({});
+  });
+
   it('uses the read-only games token, never a credential that can start agent work', async () => {
     // The gate runs agent-authored code. A token that could dispatch work has no
     // business in that container, which is the same reasoning as cloudbuild-gate.yaml.
@@ -63,7 +88,9 @@ describe('createCloudBuildGateTrigger', () => {
     const error = vi.fn();
     const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl }, { error, info: vi.fn() });
 
-    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toBeUndefined();
+    // Resolves with no build id, which is the same statement as "this cost nothing":
+    // the caller books a gate run only when there was one.
+    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({});
     // Loud, because the consequence is silent: nothing will ever verify this candidate
     // unless somebody notices.
     expect(error).toHaveBeenCalled();

--- a/apps/api/src/gate-trigger.ts
+++ b/apps/api/src/gate-trigger.ts
@@ -128,10 +128,22 @@ function buildSpec(
  * configured, so local development and tests get delivery without a build backend
  * rather than an error they cannot act on.
  */
+/**
+ * What starting a gate produced, for the caller that books what it cost.
+ *
+ * `buildId` is Cloud Build's own id for the run. It was previously read off the response
+ * and dropped, which meant a line on the GCP bill could never be traced back to the game
+ * that caused it — the one join a cost report actually needs. Absent when the gate did
+ * not start, which is the same thing as "this cost nothing".
+ */
+export interface GateTriggerResult {
+  buildId?: string;
+}
+
 export function createCloudBuildGateTrigger(
   options: GateTriggerOptions | null,
   log?: { error: (details: unknown, message: string) => void; info: (details: unknown, message: string) => void },
-): ((input: GateTriggerInput) => Promise<void>) | undefined {
+): ((input: GateTriggerInput) => Promise<GateTriggerResult>) | undefined {
   if (!options?.project || !options.bucket) return undefined;
 
   const resolved = {
@@ -154,7 +166,7 @@ export function createCloudBuildGateTrigger(
       return token;
     });
 
-  return async (input: GateTriggerInput) => {
+  return async (input: GateTriggerInput): Promise<GateTriggerResult> => {
     try {
       const response = await fetchImpl(`https://cloudbuild.googleapis.com/v1/projects/${resolved.project}/builds`, {
         method: 'POST',
@@ -166,11 +178,20 @@ export function createCloudBuildGateTrigger(
           `cloud build refused the gate run: ${response.status} ${await response.text().catch(() => '')}`,
         );
       }
-      log?.info({ slug: input.slug, version: input.version }, 'gate started');
+      // The create call answers with a long-running operation whose metadata carries the
+      // build. Parsed defensively: a shape we did not expect costs us the id, not the
+      // gate run — the build is already queued by the time this is read.
+      const buildId = await response
+        .json()
+        .then((body: unknown) => (body as { metadata?: { build?: { id?: string } } })?.metadata?.build?.id)
+        .catch(() => undefined);
+      log?.info({ slug: input.slug, version: input.version, buildId }, 'gate started');
+      return buildId ? { buildId } : {};
     } catch (error) {
       // Loud, because the consequence is silent: the candidate is stored, the agent
       // thinks it is done, and nothing will ever verify it unless someone notices this.
       log?.error({ err: error, slug: input.slug, version: input.version }, 'could not start the gate for a delivery');
+      return {};
     }
   };
 }

--- a/apps/api/src/job-admin-routes.ts
+++ b/apps/api/src/job-admin-routes.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify';
 import { isAdminSession } from './admin.js';
-import { detectStall, isTerminal, toSubmissionStatus, type JobStall, type JobState } from './job-state.js';
+import {
+  detectStall,
+  isTerminal,
+  resolveJobState,
+  toSubmissionStatus,
+  type JobStall,
+  type JobState,
+} from './job-state.js';
 import type { GamesStore } from './games-store.js';
 import type { Store, SubmissionRecord } from './store.js';
 
@@ -67,10 +74,10 @@ export function buildJobQueue(records: SubmissionRecord[], now: number): JobQueu
   const jobs = records
     .map((record): JobQueueEntry | null => {
       // A record adopted into the job model has a state; one that has never been polled
-      // since this shipped does not. Fall back to what the last derivation said so the
-      // queue is complete from the first request rather than filling in gradually.
-      const state: JobState | undefined =
-        record.state ?? (record.lastStatus ? jobStateFromLastStatus(record.lastStatus) : undefined);
+      // since this shipped does not. `resolveJobState` falls back to what the last
+      // derivation said, so the queue is complete from the first request rather than
+      // filling in gradually.
+      const state = resolveJobState(record);
       if (!state || isTerminal(state)) return null;
 
       const stateSince = record.stateSince ?? record.createdAt;
@@ -98,28 +105,6 @@ export function buildJobQueue(records: SubmissionRecord[], now: number): JobQueu
   for (const job of jobs) byState[job.state] = (byState[job.state] ?? 0) + 1;
 
   return { jobs, byState, stalled: jobs.filter((job) => job.stall).length };
-}
-
-/** Narrow bridge for records that predate adoption — same mapping as job-state's. */
-function jobStateFromLastStatus(status: SubmissionRecord['lastStatus']): JobState | undefined {
-  switch (status) {
-    case 'queued':
-      return 'queued';
-    case 'building':
-      return 'building';
-    case 'in_review':
-      return 'ready_for_review';
-    case 'publishing':
-      return 'publishing';
-    case 'published':
-      return 'published';
-    case 'needs_changes':
-      return 'needs_changes';
-    case 'abandoned':
-      return 'abandoned';
-    default:
-      return undefined;
-  }
 }
 
 export async function registerJobAdminRoutes(

--- a/apps/api/src/job-costs.test.ts
+++ b/apps/api/src/job-costs.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { buildCostReport } from './job-costs.js';
+import type { JobCostEntry, SubmissionRecord } from './store.js';
+
+const NOW = Date.parse('2026-07-30T12:00:00Z');
+const MINUTE = 60_000;
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+function session(at: string): JobCostEntry {
+  return { kind: 'agent_session', at, by: 'copilot', ref: 'task-1', credits: 1 };
+}
+
+function gateRun(at: string): JobCostEntry {
+  return { kind: 'gate_run', at, by: 'cloud-build', ref: 'build-1' };
+}
+
+function record(overrides: Partial<SubmissionRecord> & { issueNumber: number }): SubmissionRecord {
+  return {
+    ownerUid: 'g:1',
+    title: 'A game',
+    createdAt: ago(60 * MINUTE),
+    ...overrides,
+  };
+}
+
+describe('buildCostReport', () => {
+  it('counts what was billed, not what succeeded', () => {
+    // Three sessions for one published game is the real cost of that game. A report
+    // that only counted the round that shipped would understate building by two thirds.
+    const report = buildCostReport([
+      record({
+        issueNumber: 1,
+        state: 'published',
+        publishedAt: ago(5 * MINUTE),
+        costs: [
+          session(ago(50 * MINUTE)),
+          session(ago(30 * MINUTE)),
+          session(ago(10 * MINUTE)),
+          gateRun(ago(6 * MINUTE)),
+        ],
+      }),
+    ]);
+
+    expect(report.totals).toMatchObject({ jobs: 1, sessions: 3, credits: 3, gateRuns: 1, published: 1 });
+    expect(report.creditsPerPublishedGame).toBe(3);
+  });
+
+  it('charges failed builds to the price of a published one', () => {
+    // The denominator is games that shipped; the numerator is every credit spent. That
+    // is what "what does a game cost" means when a third of builds produce nothing.
+    const report = buildCostReport([
+      record({ issueNumber: 1, state: 'published', publishedAt: ago(MINUTE), costs: [session(ago(20 * MINUTE))] }),
+      record({ issueNumber: 2, state: 'failed', costs: [session(ago(40 * MINUTE)), session(ago(35 * MINUTE))] }),
+    ]);
+
+    expect(report.creditsPerPublishedGame).toBe(3);
+    expect(report.creditsOnUnpublished).toBe(2);
+  });
+
+  it('reports money and tokens as absent rather than as zero', () => {
+    // Nothing measures either today. A report claiming $0.00 per game would be a lie in
+    // the shape of a measurement.
+    const report = buildCostReport([record({ issueNumber: 1, costs: [session(ago(10 * MINUTE))] })]);
+
+    expect(report.totals.usd).toBeUndefined();
+    expect(report.totals.tokens).toBeUndefined();
+    expect(report.jobs[0].usd).toBeUndefined();
+  });
+
+  it('adds up tokens and money once a backend does report them', () => {
+    const report = buildCostReport([
+      record({
+        issueNumber: 1,
+        costs: [
+          { kind: 'agent_session', at: ago(20 * MINUTE), by: 'backend-b', tokens: { input: 1000, output: 250 } },
+          {
+            kind: 'agent_session',
+            at: ago(10 * MINUTE),
+            by: 'backend-b',
+            tokens: { input: 500, output: 125 },
+            usd: 0.4,
+          },
+        ],
+      }),
+    ]);
+
+    expect(report.totals.tokens).toEqual({ input: 1500, output: 375 });
+    expect(report.totals.usd).toBe(0.4);
+  });
+
+  it('says how many jobs it could not measure, so a small total is not read as cheap', () => {
+    const report = buildCostReport([
+      record({ issueNumber: 1, costs: [session(ago(10 * MINUTE))] }),
+      // Dispatched before any of this recorded anything.
+      record({ issueNumber: 2, state: 'published', publishedAt: ago(MINUTE) }),
+    ]);
+
+    expect(report.unmeasuredJobs).toBe(1);
+    expect(report.totals.credits).toBe(1);
+  });
+
+  it('puts the most expensive job first, which is where a runaway hides', () => {
+    const report = buildCostReport([
+      record({ issueNumber: 1, costs: [session(ago(10 * MINUTE))] }),
+      record({ issueNumber: 2, costs: [session(ago(50 * MINUTE)), session(ago(40 * MINUTE))] }),
+    ]);
+
+    expect(report.jobs.map((job) => job.issueNumber)).toEqual([2, 1]);
+  });
+
+  it('has no answer at all before anything has published', () => {
+    const report = buildCostReport([record({ issueNumber: 1, state: 'building', costs: [session(ago(10 * MINUTE))] })]);
+
+    expect(report.creditsPerPublishedGame).toBeNull();
+    expect(report.medianTimeToPublishMs).toBeNull();
+  });
+
+  it('measures elapsed time to the last thing that happened, not to now', () => {
+    // Otherwise every finished job would keep getting more expensive in wall-clock terms
+    // the longer ago it finished.
+    const report = buildCostReport([
+      record({
+        issueNumber: 1,
+        createdAt: ago(120 * MINUTE),
+        state: 'published',
+        publishedAt: ago(60 * MINUTE),
+        costs: [session(ago(119 * MINUTE))],
+      }),
+    ]);
+
+    expect(report.jobs[0].elapsedMs).toBe(60 * MINUTE);
+    expect(report.medianTimeToPublishMs).toBe(60 * MINUTE);
+  });
+});

--- a/apps/api/src/job-costs.ts
+++ b/apps/api/src/job-costs.ts
@@ -1,0 +1,153 @@
+// What a game costs to build, from what was actually billed.
+//
+// The question this exists to answer is not "what is our cloud spend" — GCP already
+// answers that, badly, for the whole project at once. It is "what does one game cost,
+// and what does the failure rate cost", which nothing could answer because the spending
+// was never attributed to the job that caused it.
+//
+// Every number here is derived from ledger entries written at the moment of spending
+// (see `JobCostEntry`). Nothing is estimated, and nothing is inferred from state: a job
+// that took four sessions reports four whether or not its transitions still say so.
+//
+// The unit problem is deliberate and load-bearing. Copilot bills a premium request per
+// session and exposes no token counts; the gate bills Cloud Build minutes we do not yet
+// read back. So credits and sessions are real, tokens and dollars are absent, and this
+// module reports absence as absence rather than as zero — a report that said "$0.00 per
+// game" would be worse than one that says the money is not measurable yet.
+
+import { resolveJobState, type JobState } from './job-state.js';
+import type { JobCostEntry, SubmissionRecord } from './store.js';
+
+export interface JobCostSummary {
+  issueNumber: number;
+  title: string;
+  slug?: string;
+  state?: JobState;
+  /** Agent sessions started. One premium request each on the Copilot backend. */
+  sessions: number;
+  /** Premium requests booked. Equal to `sessions` today; separate because it need not be. */
+  credits: number;
+  /** Gate runs started for this job — one per delivery that reached the verifier. */
+  gateRuns: number;
+  /** Present only when some backend actually reported tokens. */
+  tokens?: { input: number; output: number };
+  /** Present only when some service actually reported money. */
+  usd?: number;
+  /** Creation to the last thing that happened to it. */
+  elapsedMs: number;
+  /** Whether the spending bought a game anybody can play. */
+  published: boolean;
+  createdAt: string;
+}
+
+export interface CostTotals {
+  jobs: number;
+  sessions: number;
+  credits: number;
+  gateRuns: number;
+  published: number;
+  tokens?: { input: number; output: number };
+  usd?: number;
+}
+
+export interface CostReport {
+  /** Most expensive first — the tail is where a runaway job hides. */
+  jobs: JobCostSummary[];
+  totals: CostTotals;
+  /**
+   * The bizstrat number: what one published game costs, all in.
+   *
+   * Divides *every* credit spent in the window by the games that shipped, including the
+   * credits spent on jobs that never did. That is the honest denominator — a build that
+   * failed twice before succeeding cost three sessions, and so did the game.
+   */
+  creditsPerPublishedGame: number | null;
+  /** Median wall-clock of the jobs that shipped. Null when none did. */
+  medianTimeToPublishMs: number | null;
+  /** Of the credits above, how many bought nothing playable. The cost of the failure rate. */
+  creditsOnUnpublished: number;
+  /**
+   * Jobs in the window that have no ledger at all — dispatched before this recorded
+   * anything. Reported so a small total is legible as "not measured yet" rather than
+   * read as "cheap".
+   */
+  unmeasuredJobs: number;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+/** Newest timestamp on the record, so elapsed time means something for a finished job. */
+function lastActivityAt(record: SubmissionRecord): number {
+  const stamps = [
+    record.createdAt,
+    record.stateSince,
+    record.publishedAt,
+    ...(record.transitions ?? []).map((transition) => transition.at),
+    ...(record.costs ?? []).map((entry) => entry.at),
+  ]
+    .map((value) => (value ? Date.parse(value) : NaN))
+    .filter((value) => Number.isFinite(value));
+  return stamps.length > 0 ? Math.max(...stamps) : Date.parse(record.createdAt);
+}
+
+function summarize(record: SubmissionRecord): JobCostSummary {
+  const entries: JobCostEntry[] = record.costs ?? [];
+  const state = resolveJobState(record);
+  const tokens = entries.reduce(
+    (sum, entry) =>
+      entry.tokens ? { input: sum.input + entry.tokens.input, output: sum.output + entry.tokens.output } : sum,
+    { input: 0, output: 0 },
+  );
+  const usd = entries.reduce((sum, entry) => sum + (entry.usd ?? 0), 0);
+
+  return {
+    issueNumber: record.issueNumber,
+    title: record.title,
+    ...(record.slug ? { slug: record.slug } : {}),
+    ...(state ? { state } : {}),
+    sessions: entries.filter((entry) => entry.kind === 'agent_session').length,
+    credits: entries.reduce((sum, entry) => sum + (entry.credits ?? 0), 0),
+    gateRuns: entries.filter((entry) => entry.kind === 'gate_run').length,
+    // Absent rather than zero: nothing reports these yet, and a zero would read as a
+    // measurement that came back empty instead of one that was never taken.
+    ...(tokens.input + tokens.output > 0 ? { tokens } : {}),
+    ...(usd > 0 ? { usd } : {}),
+    elapsedMs: Math.max(0, lastActivityAt(record) - Date.parse(record.createdAt)),
+    published: state === 'published' || Boolean(record.publishedAt),
+    createdAt: record.createdAt,
+  };
+}
+
+export function buildCostReport(records: SubmissionRecord[]): CostReport {
+  const jobs = records.map(summarize).sort((a, b) => b.credits - a.credits || b.elapsedMs - a.elapsedMs);
+
+  const totals: CostTotals = {
+    jobs: jobs.length,
+    sessions: jobs.reduce((sum, job) => sum + job.sessions, 0),
+    credits: jobs.reduce((sum, job) => sum + job.credits, 0),
+    gateRuns: jobs.reduce((sum, job) => sum + job.gateRuns, 0),
+    published: jobs.filter((job) => job.published).length,
+  };
+
+  const tokens = jobs.reduce(
+    (sum, job) => (job.tokens ? { input: sum.input + job.tokens.input, output: sum.output + job.tokens.output } : sum),
+    { input: 0, output: 0 },
+  );
+  if (tokens.input + tokens.output > 0) totals.tokens = tokens;
+  const usd = jobs.reduce((sum, job) => sum + (job.usd ?? 0), 0);
+  if (usd > 0) totals.usd = usd;
+
+  return {
+    jobs,
+    totals,
+    creditsPerPublishedGame: totals.published > 0 ? Math.round((totals.credits / totals.published) * 100) / 100 : null,
+    medianTimeToPublishMs: median(jobs.filter((job) => job.published).map((job) => job.elapsedMs)),
+    creditsOnUnpublished: jobs.filter((job) => !job.published).reduce((sum, job) => sum + job.credits, 0),
+    unmeasuredJobs: records.filter((record) => (record.costs ?? []).length === 0).length,
+  };
+}

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -181,6 +181,19 @@ export function fromSubmissionStatus(status: SubmissionStatus): JobState {
 }
 
 /**
+ * The state a stored job is in, as far as anything can tell.
+ *
+ * A record adopted into the job model carries its own state; one that has not been
+ * polled since the model shipped carries only the last derived status. Readers that
+ * skipped the second case filled in gradually rather than being complete on the first
+ * request, and every one of them wrote the same three lines — so the fallback lives
+ * here, structurally typed to avoid dragging the store's record type into a pure module.
+ */
+export function resolveJobState(record: { state?: JobState; lastStatus?: SubmissionStatus }): JobState | undefined {
+  return record.state ?? (record.lastStatus ? fromSubmissionStatus(record.lastStatus) : undefined);
+}
+
+/**
  * Decides what to write when a derived status is observed for a job — the bridge that
  * lets the existing GitHub derivation feed the state machine instead of bypassing it.
  *

--- a/apps/api/src/notify-sweep.test.ts
+++ b/apps/api/src/notify-sweep.test.ts
@@ -102,7 +102,7 @@ describe('POST /api/internal/notify-sweep', () => {
       headers: { authorization: 'Bearer scheduler-token' },
     });
     expect(first.statusCode).toBe(200);
-    expect(first.json()).toEqual({ scanned: 1, emitted: 1, stalled: 0 });
+    expect(first.json()).toEqual({ scanned: 1, emitted: 1, alerts: 0, alerted: 0, stalled: 0 });
 
     const list = await store.listNotifications('g:owner');
     expect(list).toHaveLength(1);
@@ -116,7 +116,7 @@ describe('POST /api/internal/notify-sweep', () => {
       url: '/api/internal/notify-sweep',
       headers: { authorization: 'Bearer scheduler-token' },
     });
-    expect(second.json()).toEqual({ scanned: 0, emitted: 0, stalled: 0 });
+    expect(second.json()).toEqual({ scanned: 0, emitted: 0, alerts: 0, alerted: 0, stalled: 0 });
     await app.close();
   });
 
@@ -218,6 +218,89 @@ describe('POST /api/internal/notify-sweep', () => {
     });
     const res = await app.inject({ method: 'POST', url: '/api/internal/notify-sweep' });
     expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});
+
+// The operator half of the same sweep. It runs over the set of jobs already being
+// scanned, so the cost is a pure function and whatever the alerts themselves cost.
+describe('operator alerts on the notify sweep', () => {
+  async function sweep(app: Awaited<ReturnType<typeof buildSweepApp>>) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer scheduler-token' },
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  async function appWithOperator(store: InMemoryStore, adminUids: string | undefined) {
+    return buildApp({
+      store,
+      sessionSecret: 'dev-session-secret-change-me',
+      ...(adminUids ? { adminUids } : {}),
+      submissionRoutes: {
+        githubToken: 'token',
+        submissionTokenSecret: secret,
+        gamesRepo: 'gamedevpl/www.gamedev.pl-games',
+        githubClient: buildingGithubClient(),
+        internalAuthVerifier: acceptAll,
+      },
+    });
+  }
+
+  it('tells the operator about a build waiting on the publish decision', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_001, 'g:creator', 'Comet Courier');
+    await store.recordJobTransition(1_000_001, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    const app = await appWithOperator(store, 'g:boss');
+
+    expect(await sweep(app)).toMatchObject({ alerts: 1, alerted: 1 });
+    const [notification] = await store.listNotifications('g:boss');
+    expect(notification).toMatchObject({ type: 'operator.review_ready', link: '/admin/queue' });
+
+    // Twice through the scheduler is one notification: the situation has not changed.
+    expect(await sweep(app)).toMatchObject({ alerts: 1, alerted: 0 });
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
+    await app.close();
+  });
+
+  it('counts the alert but tells nobody when no operator is configured', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(1_000_002, 'g:creator', 'Comet Courier');
+    await store.recordJobTransition(1_000_002, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    const app = await appWithOperator(store, undefined);
+
+    expect(await sweep(app)).toMatchObject({ alerts: 1, alerted: 0 });
+    await app.close();
+  });
+
+  it('does not alert on a build that is merely slow', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_003, 'g:creator', 'Comet Courier');
+    await store.recordJobTransition(1_000_003, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'reconciler',
+      reason: 'task_in_progress',
+    });
+    const app = await appWithOperator(store, 'g:boss');
+
+    expect(await sweep(app)).toMatchObject({ alerts: 0, alerted: 0 });
+    expect(await store.listNotifications('g:boss')).toEqual([]);
     await app.close();
   });
 });

--- a/apps/api/src/notify-sweep.test.ts
+++ b/apps/api/src/notify-sweep.test.ts
@@ -304,3 +304,37 @@ describe('operator alerts on the notify sweep', () => {
     await app.close();
   });
 });
+
+describe('undelivered feedback reaches the operator, not just the log', () => {
+  it('emits an alert for a change request no agent collected', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(42, 'g:creator', 'Sky Dodge');
+    await store.appendCreatorMessage(42, 'make the ship slower');
+    const app = await buildApp({
+      store,
+      sessionSecret: 'dev-session-secret-change-me',
+      adminUids: 'g:boss',
+      submissionRoutes: {
+        githubToken: 'token',
+        submissionTokenSecret: secret,
+        gamesRepo: 'gamedevpl/www.gamedev.pl-games',
+        githubClient: buildingGithubClient(),
+        internalAuthVerifier: acceptAll,
+        // An hour past the threshold, so the message is stale without waiting for one.
+        now: () => Date.now() + 2 * HOUR_MS,
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer scheduler-token' },
+    });
+
+    expect(res.json()).toMatchObject({ stalled: 1, alerts: 1, alerted: 1 });
+    const [notification] = await store.listNotifications('g:boss');
+    expect(notification.type).toBe('operator.feedback_undelivered');
+    await app.close();
+  });
+});

--- a/apps/api/src/notify.test.ts
+++ b/apps/api/src/notify.test.ts
@@ -4,6 +4,7 @@ import { ConsoleMailer, type EmailMessage, type Mailer } from './mailer.js';
 import {
   absoluteAppUrl,
   emitDigestNotification,
+  emitOperatorAlert,
   emitSubmissionNotification,
   notifyOnTransition,
   statusToEvent,
@@ -446,5 +447,91 @@ describe('digest opt-out', () => {
     );
 
     expect(sent).toHaveLength(1);
+  });
+});
+
+describe('emitOperatorAlert', () => {
+  let store: InMemoryStore;
+  let mailer: ConsoleMailer;
+
+  const alert = {
+    id: 'op-1000001-review_ready',
+    kind: 'review_ready' as const,
+    issueNumber: 1_000_001,
+    title: 'Comet Courier',
+    ownerUid: 'g:creator',
+    slug: 'comet-courier',
+    since: '2026-07-30T11:00:00Z',
+  };
+
+  const deps = () => ({
+    store,
+    mailer,
+    appBaseUrl: 'https://www.gamedev.pl',
+    unsubscribeSecret: 'secret',
+    adminUids: ['g:boss'],
+  });
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    mailer = new ConsoleMailer(() => {});
+    await store.upsertUser({ uid: 'g:boss', email: 'boss@example.com' });
+  });
+
+  it('notifies every operator and links them to the queue', async () => {
+    await store.upsertUser({ uid: 'g:second', email: 'second@example.com' });
+
+    const { created } = await emitOperatorAlert({ ...deps(), adminUids: ['g:boss', 'g:second'] }, alert);
+
+    expect(created).toBe(2);
+    const [notification] = await store.listNotifications('g:boss');
+    expect(notification).toMatchObject({
+      id: 'op-1000001-review_ready',
+      type: 'operator.review_ready',
+      titleKey: 'notifications.operator.review_ready.title',
+      link: '/admin/queue',
+      params: { title: 'Comet Courier', issueNumber: '1000001' },
+    });
+    expect(mailer.sent.map((message) => message.to)).toEqual(['boss@example.com', 'second@example.com']);
+  });
+
+  it('says nothing the second time the sweep sees the same situation', async () => {
+    await emitOperatorAlert(deps(), alert);
+    const second = await emitOperatorAlert(deps(), alert);
+
+    expect(second.created).toBe(0);
+    expect(mailer.sent).toHaveLength(1);
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
+  });
+
+  it('reaches an operator who unsubscribed from creator mail', async () => {
+    // An alert is a pager, not a subscription. Someone who once clicked "unsubscribe" on
+    // a build notification must not thereby have silenced their own queue.
+    await store.setEmailUnsubscribed('g:boss', new Date().toISOString());
+
+    await emitOperatorAlert(deps(), alert);
+
+    expect(mailer.sent).toHaveLength(1);
+    expect(mailer.sent[0].headers?.['List-Unsubscribe']).toBeUndefined();
+  });
+
+  it('carries the stall kind into the notification, so the fix is legible', async () => {
+    await emitOperatorAlert(deps(), {
+      ...alert,
+      id: 'op-1000001-build_stalled',
+      kind: 'build_stalled',
+      stall: 'quiet',
+    });
+
+    const [notification] = await store.listNotifications('g:boss');
+    expect(notification.params.detail).toBe('quiet');
+    expect(mailer.sent[0].text).toContain('(quiet)');
+  });
+
+  it('creates the in-app record even when email is not configured', async () => {
+    const { created } = await emitOperatorAlert({ store, adminUids: ['g:boss'] }, alert);
+
+    expect(created).toBe(1);
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
   });
 });

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -9,13 +9,18 @@ import {
   digestNotificationMessage,
   digestPushContent,
   normalizeLocale,
+  operatorNotificationMessage,
+  operatorPushContent,
   submissionNotificationMessage,
   submissionPushContent,
   type DigestEmailParams,
 } from './email-templates.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
+import type { OperatorAlert } from './operator-alerts.js';
 import { createPusherFromEnv, type Pusher } from './pusher.js';
 import type {
+  NotificationType,
+  OperatorNotificationType,
   StoredNotification,
   SubmissionNotificationType,
   SubmissionRecord,
@@ -42,6 +47,11 @@ const STATUS_TO_EVENT: Partial<Record<SubmissionStatus, SubmissionNotificationTy
 
 export function statusToEvent(status: SubmissionStatus): SubmissionNotificationType | null {
   return STATUS_TO_EVENT[status] ?? null;
+}
+
+/** Narrows a stored notification's type, so the two audiences cannot be crossed by accident. */
+function isOperatorNotification(type: NotificationType): type is OperatorNotificationType {
+  return type.startsWith('operator.');
 }
 
 /**
@@ -84,6 +94,10 @@ export interface EmitDeps {
  */
 async function maybeSendEmail(deps: EmitDeps, uid: string, notification: StoredNotification): Promise<void> {
   if (notification.emailedAt) return;
+  // Operator alerts have their own send (see `emitOperatorAlert`): they carry no
+  // unsubscribe and must not be silenced by one. Guarded here rather than left to the
+  // call sites so a future caller cannot accidentally route one through creator mail.
+  if (isOperatorNotification(notification.type)) return;
 
   // Explicit deps win (tests inject them). Otherwise fall back to env config so
   // the default call sites send email in prod with no extra wiring: a real mailer
@@ -150,7 +164,10 @@ async function maybePush(deps: EmitDeps, uid: string, notification: StoredNotifi
     const { title, body } =
       notification.type === 'creator.digest'
         ? digestPushContent(locale, digestEmailParams(notification, '', ''))
-        : submissionPushContent(locale, notification.type, notification.params.title ?? '');
+        : isOperatorNotification(notification.type)
+          ? // English regardless of the reader's locale — see the operator copy's comment.
+            operatorPushContent(notification.type, notification.params.title ?? '')
+          : submissionPushContent(locale, notification.type, notification.params.title ?? '');
     const payload = { title, body, url: absoluteAppUrl(appBaseUrl, notification.link), tag: notification.id };
 
     await Promise.all(
@@ -191,6 +208,80 @@ function digestEmailParams(
     actionUrl,
     unsubscribeUrl,
   };
+}
+
+/**
+ * Fan an operator alert out to everyone who can act on it.
+ *
+ * Deliberately not routed through `maybeSendEmail`: that path is built for creator mail,
+ * where an unsubscribe is a right and a send is skipped when it was exercised. An alert
+ * is the opposite kind of message — the queue telling its operator it needs them — and a
+ * pager that someone silenced eighteen months ago by clicking "unsubscribe" on a build
+ * notification would fail exactly when it mattered and say nothing about why.
+ *
+ * The in-app notification is still the durable record, and its id is the alert's, so a
+ * sweep running every two minutes emits each situation once.
+ */
+export async function emitOperatorAlert(
+  deps: EmitDeps & { adminUids: Iterable<string> },
+  alert: OperatorAlert,
+): Promise<{ created: number }> {
+  const createdAt = deps.now ? new Date(deps.now()).toISOString() : new Date().toISOString();
+  const type: OperatorNotificationType = `operator.${alert.kind}`;
+  let created = 0;
+
+  for (const uid of deps.adminUids) {
+    const result = await deps.store.createNotification(uid, {
+      id: alert.id,
+      type,
+      createdAt,
+      titleKey: `notifications.${type}.title`,
+      bodyKey: `notifications.${type}.body`,
+      params: {
+        title: alert.title,
+        issueNumber: String(alert.issueNumber),
+        ...(alert.stall ? { detail: alert.stall } : {}),
+      },
+      link: OPERATOR_ALERT_LINK,
+    });
+    if (!result.created) continue;
+    created += 1;
+    await sendOperatorEmail(deps, uid, alert, type);
+    await maybePush(deps, uid, result.notification);
+  }
+
+  return { created };
+}
+
+/** Where an operator notification lands: the queue, which is where the action is. */
+const OPERATOR_ALERT_LINK = '/admin/queue';
+
+/** Best-effort, like every other send here: a failed alert email must not fail the sweep. */
+async function sendOperatorEmail(
+  deps: EmitDeps,
+  uid: string,
+  alert: OperatorAlert,
+  type: OperatorNotificationType,
+): Promise<void> {
+  const mailer = deps.mailer ?? (process.env.RESEND_API_KEY ? createMailerFromEnv() : undefined);
+  if (!mailer) return;
+
+  try {
+    const user = await deps.store.getUser(uid);
+    if (!user?.email) return;
+    const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
+    await mailer.send(
+      operatorNotificationMessage(user.email, type, {
+        title: alert.title,
+        issueNumber: alert.issueNumber,
+        actionUrl: absoluteAppUrl(appBaseUrl, OPERATOR_ALERT_LINK),
+        ...(alert.stall ? { detail: alert.stall } : {}),
+      }),
+    );
+    await deps.store.markNotificationEmailed(uid, alert.id);
+  } catch (err) {
+    deps.logError?.(err, 'operator alert email send failed');
+  }
 }
 
 export interface SubmissionNotificationEvent {

--- a/apps/api/src/operator-alerts.test.ts
+++ b/apps/api/src/operator-alerts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectOperatorAlerts, FAILED_ALERT_WINDOW_MS } from './operator-alerts.js';
+import { detectOperatorAlerts, FAILED_ALERT_WINDOW_MS, FEEDBACK_STALL_MS } from './operator-alerts.js';
 import type { SubmissionRecord } from './store.js';
 
 const NOW = Date.parse('2026-07-30T12:00:00Z');
@@ -110,5 +110,72 @@ describe('detectOperatorAlerts', () => {
     );
 
     expect(alerts.map((alert) => alert.issueNumber)).toEqual([13, 12, 11, 10]);
+  });
+});
+
+describe('detectOperatorAlerts — undelivered change requests', () => {
+  it('flags a request no agent has collected past the threshold', () => {
+    // The job itself looks healthy, and that is the point: the relay that wakes an
+    // agent for a change request can be down while the build it should reach is fine.
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 20, state: 'building', stateSince: ago(MINUTE), lastAgentSignalAt: ago(MINUTE) })],
+      NOW,
+      new Map([[20, ago(FEEDBACK_STALL_MS + MINUTE)]]),
+    );
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({ kind: 'feedback_undelivered', issueNumber: 20 });
+  });
+
+  it('leaves a fresh request alone', () => {
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 21, state: 'building', stateSince: ago(MINUTE), lastAgentSignalAt: ago(MINUTE) })],
+      NOW,
+      new Map([[21, ago(5 * MINUTE)]]),
+    );
+
+    expect(alerts).toEqual([]);
+  });
+
+  it('answers without it when the caller cannot afford the reads', () => {
+    // A smaller answer, never a wrong one: the other three kinds still come back.
+    const alerts = detectOperatorAlerts([record({ issueNumber: 22, state: 'ready_for_review' })], NOW);
+
+    expect(alerts.map((alert) => alert.kind)).toEqual(['review_ready']);
+  });
+
+  it('outranks a stall on the same job — the relay is the thing that is broken', () => {
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 23, state: 'building', stateSince: ago(90 * MINUTE) })],
+      NOW,
+      new Map([[23, ago(FEEDBACK_STALL_MS + MINUTE)]]),
+    );
+
+    expect(alerts.map((alert) => alert.kind)).toEqual(['feedback_undelivered']);
+  });
+});
+
+describe('detectOperatorAlerts — records the state machine cannot read', () => {
+  it('still reports an uncollected change request on a record with no state at all', () => {
+    // The sweep's alert pass reads the records it fetched before deriving anything, so a
+    // job on its first sweep has neither `state` nor `lastStatus`. Skipping it as
+    // unreadable would silently exempt exactly the newest jobs.
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 30 })],
+      NOW,
+      new Map([[30, ago(FEEDBACK_STALL_MS + MINUTE)]]),
+    );
+
+    expect(alerts.map((alert) => alert.kind)).toEqual(['feedback_undelivered']);
+  });
+
+  it('says nothing about a message left on finished work', () => {
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 31, state: 'canceled' })],
+      NOW,
+      new Map([[31, ago(FEEDBACK_STALL_MS + MINUTE)]]),
+    );
+
+    expect(alerts).toEqual([]);
   });
 });

--- a/apps/api/src/operator-alerts.test.ts
+++ b/apps/api/src/operator-alerts.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { detectOperatorAlerts, FAILED_ALERT_WINDOW_MS } from './operator-alerts.js';
+import type { SubmissionRecord } from './store.js';
+
+const NOW = Date.parse('2026-07-30T12:00:00Z');
+const MINUTE = 60_000;
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+function record(overrides: Partial<SubmissionRecord> & { issueNumber: number }): SubmissionRecord {
+  return {
+    ownerUid: 'g:1',
+    title: 'A game',
+    createdAt: ago(30 * MINUTE),
+    ...overrides,
+  };
+}
+
+describe('detectOperatorAlerts', () => {
+  it('says nothing about a build that is simply taking a while', () => {
+    // The property the whole channel depends on: a job reporting progress is not an
+    // alert, however long it has been running. Get this wrong and every alert is noise.
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 1, state: 'building', stateSince: ago(180 * MINUTE), lastAgentSignalAt: ago(MINUTE) })],
+      NOW,
+    );
+
+    expect(alerts).toEqual([]);
+  });
+
+  it('flags a gate-green build waiting on the publish decision', () => {
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 1_000_001, state: 'ready_for_review', stateSince: ago(5 * MINUTE), slug: 'comet' })],
+      NOW,
+    );
+
+    expect(alerts).toEqual([
+      {
+        id: 'op-1000001-review_ready',
+        kind: 'review_ready',
+        issueNumber: 1_000_001,
+        title: 'A game',
+        ownerUid: 'g:1',
+        slug: 'comet',
+        since: ago(5 * MINUTE),
+      },
+    ]);
+  });
+
+  it('flags a stall and says which kind, so the fix is legible', () => {
+    const alerts = detectOperatorAlerts(
+      [
+        record({
+          issueNumber: 2,
+          state: 'building',
+          stateSince: ago(60 * MINUTE),
+          lastAgentSignalAt: ago(40 * MINUTE),
+        }),
+      ],
+      NOW,
+    );
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({ kind: 'build_stalled', stall: 'quiet' });
+  });
+
+  it('forgets a failure once it is old news', () => {
+    const fresh = record({ issueNumber: 3, state: 'failed', stateSince: ago(2 * 60 * MINUTE) });
+    const ancient = record({ issueNumber: 4, state: 'failed', stateSince: ago(FAILED_ALERT_WINDOW_MS + MINUTE) });
+
+    const alerts = detectOperatorAlerts([fresh, ancient], NOW);
+
+    expect(alerts.map((alert) => alert.issueNumber)).toEqual([3]);
+  });
+
+  it('ignores finished and abandoned work', () => {
+    const alerts = detectOperatorAlerts(
+      [
+        record({ issueNumber: 5, state: 'published', stateSince: ago(MINUTE) }),
+        record({ issueNumber: 6, state: 'canceled', stateSince: ago(MINUTE) }),
+        // Abandoned by the creator while it happened to be stalled: their decision ends it.
+        record({ issueNumber: 7, state: 'building', stateSince: ago(90 * MINUTE), abandonedAt: ago(MINUTE) }),
+      ],
+      NOW,
+    );
+
+    expect(alerts).toEqual([]);
+  });
+
+  it('sees a legacy record through its last derived status', () => {
+    // Records that predate the job model carry no state at all. Missing them would make
+    // the console quietly wrong about exactly the builds most likely to be stuck.
+    const alerts = detectOperatorAlerts(
+      [record({ issueNumber: 8, lastStatus: 'in_review', stateSince: ago(MINUTE) })],
+      NOW,
+    );
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].kind).toBe('review_ready');
+  });
+
+  it('puts the publish decision above a stall, and the longest wait first', () => {
+    const alerts = detectOperatorAlerts(
+      [
+        record({ issueNumber: 10, state: 'failed', stateSince: ago(MINUTE) }),
+        record({ issueNumber: 11, state: 'queued', stateSince: ago(30 * MINUTE) }),
+        record({ issueNumber: 12, state: 'ready_for_review', stateSince: ago(2 * MINUTE) }),
+        record({ issueNumber: 13, state: 'ready_for_review', stateSince: ago(20 * MINUTE) }),
+      ],
+      NOW,
+    );
+
+    expect(alerts.map((alert) => alert.issueNumber)).toEqual([13, 12, 11, 10]);
+  });
+});

--- a/apps/api/src/operator-alerts.ts
+++ b/apps/api/src/operator-alerts.ts
@@ -19,7 +19,17 @@ export type OperatorAlertKind =
   /** The round ended with nothing delivered, or the agent gave up. */
   | 'build_failed'
   /** Still open, but nothing has moved for longer than the job's state tolerates. */
-  | 'build_stalled';
+  | 'build_stalled'
+  /**
+   * A creator's change request that no agent has collected.
+   *
+   * Its own kind rather than a flavour of stall, because it is a failure of a
+   * different thing: the request reached us, and the relay that turns it into
+   * something an agent wakes for did not fire. Nothing errors when that breaks — the
+   * comment lands, no session starts, and the creator waits on an answer that is not
+   * coming. This is the only symptom.
+   */
+  | 'feedback_undelivered';
 
 export interface OperatorAlert {
   /**
@@ -48,17 +58,56 @@ export interface OperatorAlert {
  */
 export const FAILED_ALERT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * How long a creator's change request may sit uncollected before it is a stall.
+ *
+ * Generous on purpose: the relay fires in seconds, but the agent it wakes only acks its
+ * inbox once it has a session running, and a queue behind a busy repo can legitimately
+ * take a while. An hour is far past that and far short of the creator giving up.
+ */
+export const FEEDBACK_STALL_MS = 60 * 60 * 1000;
+
 /** Oldest first within a kind: the thing that has been waiting longest is the thing to do. */
 const KIND_ORDER: Record<OperatorAlertKind, number> = {
   review_ready: 0,
-  build_stalled: 1,
-  build_failed: 2,
+  feedback_undelivered: 1,
+  build_stalled: 2,
+  build_failed: 3,
 };
 
-function alertFor(record: SubmissionRecord, now: number): OperatorAlert | null {
+/**
+ * When the oldest uncollected change request for a job arrived, per job.
+ *
+ * Passed in rather than read here because it is a separate query per job and this module
+ * does no I/O. A caller that cannot afford the reads passes nothing and gets the other
+ * three kinds, which is a smaller answer but never a wrong one.
+ */
+export type PendingFeedbackAges = ReadonlyMap<number, string>;
+
+function alertFor(record: SubmissionRecord, now: number, pendingFeedback?: PendingFeedbackAges): OperatorAlert | null {
   if (record.abandonedAt) return null;
 
   const state = resolveJobState(record);
+
+  // Checked before the job's own state, and deliberately — twice over. A job can look
+  // perfectly healthy, building and reporting progress, while the request the creator is
+  // waiting on never reached it; that is the case this kind exists for. And it is the one
+  // alert that needs no state at all, so a record whose state cannot be resolved — a
+  // legacy one, or one whose first derivation has not been written back yet — still
+  // reports it rather than being skipped as unreadable.
+  const pendingSince = pendingFeedback?.get(record.issueNumber);
+  if (pendingSince && (!state || !isTerminal(state)) && now - Date.parse(pendingSince) > FEEDBACK_STALL_MS) {
+    return {
+      id: `op-${record.issueNumber}-feedback_undelivered`,
+      kind: 'feedback_undelivered',
+      issueNumber: record.issueNumber,
+      title: record.title,
+      ownerUid: record.ownerUid,
+      ...(record.slug ? { slug: record.slug } : {}),
+      since: pendingSince,
+    };
+  }
+
   if (!state) return null;
 
   const since = record.stateSince ?? record.createdAt;
@@ -100,9 +149,13 @@ function alertFor(record: SubmissionRecord, now: number): OperatorAlert | null {
  * Pure and clock-injected like the rest of job-state, so the console and the sweep can
  * be tested against the same fixtures and the same instant.
  */
-export function detectOperatorAlerts(records: SubmissionRecord[], now: number): OperatorAlert[] {
+export function detectOperatorAlerts(
+  records: SubmissionRecord[],
+  now: number,
+  pendingFeedback?: PendingFeedbackAges,
+): OperatorAlert[] {
   return records
-    .map((record) => alertFor(record, now))
+    .map((record) => alertFor(record, now, pendingFeedback))
     .filter((alert): alert is OperatorAlert => alert !== null)
     .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || Date.parse(a.since) - Date.parse(b.since));
 }

--- a/apps/api/src/operator-alerts.ts
+++ b/apps/api/src/operator-alerts.ts
@@ -1,0 +1,108 @@
+// What actually wants a person, out of everything the queue can show.
+//
+// The queue (job-admin-routes.ts) answers "what is in flight". This answers the narrower
+// question a notification may be sent about: which jobs are waiting on somebody rather
+// than on time passing. The two are deliberately different — a build that has been
+// running for forty minutes and reporting progress belongs in the queue and nowhere near
+// an inbox.
+//
+// One pure function because two callers need the same answer: the console badge and the
+// sweep that emails. An alert that shows up in one and not the other is worse than no
+// alert, because the number stops meaning anything.
+
+import { detectStall, isTerminal, resolveJobState, type JobStall } from './job-state.js';
+import type { SubmissionRecord } from './store.js';
+
+export type OperatorAlertKind =
+  /** Gate green, waiting for the publish decision — the one thing only a human does. */
+  | 'review_ready'
+  /** The round ended with nothing delivered, or the agent gave up. */
+  | 'build_failed'
+  /** Still open, but nothing has moved for longer than the job's state tolerates. */
+  | 'build_stalled';
+
+export interface OperatorAlert {
+  /**
+   * Stable per job and kind, so re-running the sweep does not re-notify. The cost is
+   * that a job which stalls, recovers and stalls again only alerts once — the right
+   * trade for a channel whose failure mode is being ignored.
+   */
+  id: string;
+  kind: OperatorAlertKind;
+  issueNumber: number;
+  title: string;
+  ownerUid: string;
+  slug?: string;
+  /** When the job entered the situation being alerted about. */
+  since: string;
+  /** Only on `build_stalled`: which flavour of stuck, so the fix is legible. */
+  stall?: JobStall;
+}
+
+/**
+ * How long a failure stays news.
+ *
+ * A failed job is terminal, so it sits in the active set until the creator retries or
+ * walks away — without a window the console would accumulate every failure since launch
+ * and the count would be furniture rather than a signal.
+ */
+export const FAILED_ALERT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Oldest first within a kind: the thing that has been waiting longest is the thing to do. */
+const KIND_ORDER: Record<OperatorAlertKind, number> = {
+  review_ready: 0,
+  build_stalled: 1,
+  build_failed: 2,
+};
+
+function alertFor(record: SubmissionRecord, now: number): OperatorAlert | null {
+  if (record.abandonedAt) return null;
+
+  const state = resolveJobState(record);
+  if (!state) return null;
+
+  const since = record.stateSince ?? record.createdAt;
+  const base = {
+    issueNumber: record.issueNumber,
+    title: record.title,
+    ownerUid: record.ownerUid,
+    ...(record.slug ? { slug: record.slug } : {}),
+    since,
+  };
+
+  if (state === 'ready_for_review') {
+    return { id: `op-${record.issueNumber}-review_ready`, kind: 'review_ready', ...base };
+  }
+
+  if (state === 'failed') {
+    const at = Date.parse(since);
+    if (!Number.isFinite(at) || now - at > FAILED_ALERT_WINDOW_MS) return null;
+    return { id: `op-${record.issueNumber}-build_failed`, kind: 'build_failed', ...base };
+  }
+
+  // Everything else terminal — published, canceled — is somebody's finished business.
+  if (isTerminal(state)) return null;
+
+  const stall = detectStall({
+    state,
+    stateSince: since,
+    lastAgentSignalAt: record.lastAgentSignalAt,
+    agentState: record.agentState,
+    now,
+  });
+  if (!stall) return null;
+  return { id: `op-${record.issueNumber}-build_stalled`, kind: 'build_stalled', ...base, stall };
+}
+
+/**
+ * Every job that wants attention, worst first.
+ *
+ * Pure and clock-injected like the rest of job-state, so the console and the sweep can
+ * be tested against the same fixtures and the same instant.
+ */
+export function detectOperatorAlerts(records: SubmissionRecord[], now: number): OperatorAlert[] {
+  return records
+    .map((record) => alertFor(record, now))
+    .filter((alert): alert is OperatorAlert => alert !== null)
+    .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || Date.parse(a.since) - Date.parse(b.since));
+}

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -42,6 +42,7 @@ describe('isKnownSpaShellPath', () => {
     '/studio/tok-abc/playtest',
     '/admin',
     '/admin/queue',
+    '/admin/costs',
     '/admin/telemetry',
     '/admin/tokens',
     '/join/K7M3QP',

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -40,6 +40,10 @@ describe('isKnownSpaShellPath', () => {
     '/studio/tok-abc',
     '/studio/tok-abc/build',
     '/studio/tok-abc/playtest',
+    '/admin',
+    '/admin/queue',
+    '/admin/telemetry',
+    '/admin/tokens',
     '/join/K7M3QP',
   ])('treats %s as a known shell path (HTTP 200)', (path) => {
     expect(isKnownSpaShellPath(path)).toBe(true);
@@ -54,6 +58,8 @@ describe('isKnownSpaShellPath', () => {
     '/draft/',
     '/draft/..%2Fadmin',
     '/health/brick-storm',
+    '/admin/nope',
+    '/admin/queue/extra',
     '/studio/tok-abc/nope',
     '/studio/tok-abc/feedback',
     '/studio/tok-abc/build/extra',

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -19,7 +19,7 @@ const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats
 // The operator console. Its sections are listed rather than matched loosely, so the
 // shell and the client's router agree about what is a real page and what is a typo —
 // the same contract the studio tabs above keep.
-const ADMIN_PATTERN = /^\/admin(?:\/(?:queue|telemetry|limits|tokens|suggestions))?$/;
+const ADMIN_PATTERN = /^\/admin(?:\/(?:queue|costs|telemetry|limits|tokens|suggestions))?$/;
 /** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
 const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
 

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -16,6 +16,10 @@ const STATUS_PATTERN = /^\/status\/([^/]+)$/;
 const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
 /** `/studio`, `/studio/:token`, `/studio/:token/:tab` — keep aligned with router.ts. */
 const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats|improve))?)?$/;
+// The operator console. Its sections are listed rather than matched loosely, so the
+// shell and the client's router agree about what is a real page and what is a typo —
+// the same contract the studio tabs above keep.
+const ADMIN_PATTERN = /^\/admin(?:\/(?:queue|telemetry|limits|tokens|suggestions))?$/;
 /** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
 const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
 
@@ -51,6 +55,7 @@ export function isKnownSpaShellPath(urlOrPath: string): boolean {
   }
 
   if (STUDIO_PATTERN.test(pathname)) return true;
+  if (ADMIN_PATTERN.test(pathname)) return true;
 
   const statusMatch = pathname.match(STATUS_PATTERN);
   if (statusMatch?.[1]) return true;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -187,7 +187,47 @@ export interface SubmissionRecord {
    * workspace. The newest is the one to observe.
    */
   dispatch?: { backend: string; refs: string[]; workspace?: string };
+  /**
+   * What this job has cost, one entry per thing that was billed.
+   *
+   * Recorded at the moment of spending rather than reconstructed later: a session that
+   * was started is a session that is charged for whatever happens next, and by the time
+   * a job is published the evidence of how many rounds it took has been overwritten by
+   * the rounds themselves.
+   */
+  costs?: JobCostEntry[];
 }
+
+/**
+ * One billed thing, attached to the job that incurred it.
+ *
+ * The units are deliberately plural. Copilot bills a *premium request* per session and
+ * exposes no token counts at all — so credits is the only honest number we can record
+ * for it, and a schema built around tokens would have had to lie or leave them zero.
+ * `tokens` and `usd` exist unpopulated for the backend that would report them
+ * (docs: architecture B), so that arriving is a writer, not a migration.
+ */
+export interface JobCostEntry {
+  kind: 'agent_session' | 'gate_run';
+  at: string;
+  /** Who charged for it: `copilot`, `cloud-build`. */
+  by: string;
+  /** The vendor's own id, so a line on a bill can be traced back to a job. */
+  ref?: string;
+  /** Premium requests. One per agent session, which is how Copilot bills. */
+  credits?: number;
+  /** Model tokens, when a backend reports them. Nothing does today. */
+  tokens?: { input: number; output: number };
+  /** Money, when a service reports it directly rather than in its own unit. */
+  usd?: number;
+}
+
+/**
+ * How many cost entries a job keeps. Higher than the transition cap: transitions are
+ * how a job got somewhere and only the tail matters, while a dropped cost entry is
+ * money that silently stops being counted.
+ */
+export const MAX_JOB_COSTS = 200;
 
 /**
  * How many transitions a submission keeps. Oldest are dropped first; the tail is what
@@ -492,7 +532,8 @@ export type NotificationType =
    */
   | 'operator.review_ready'
   | 'operator.build_failed'
-  | 'operator.build_stalled';
+  | 'operator.build_stalled'
+  | 'operator.feedback_undelivered';
 
 /**
  * The types that are about one submission, and so can render "«game title» happened".
@@ -829,6 +870,12 @@ export interface Store {
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
   recordDispatch(issueNumber: number, dispatch: { backend: string; ref: string; workspace?: string }): Promise<void>;
+  /**
+   * Appends one billed thing to a job's ledger. Best-effort by contract: a cost that
+   * fails to record must never fail the work it was recording, because the alternative
+   * is dropping a build to keep the books.
+   */
+  recordJobCost(issueNumber: number, entry: JobCostEntry): Promise<void>;
   /**
    * Records where a dispatched job's work actually lives, once the backend can say.
    *
@@ -1348,6 +1395,15 @@ export class InMemoryStore implements Store {
         refs: [...(existing?.refs ?? []), dispatch.ref],
         workspace: dispatch.workspace ?? existing?.workspace,
       },
+    });
+  }
+
+  async recordJobCost(issueNumber: number, entry: JobCostEntry): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    this.submissions.set(issueNumber, {
+      ...sub,
+      costs: [...(sub.costs ?? []), entry].slice(-MAX_JOB_COSTS),
     });
   }
 
@@ -2251,6 +2307,19 @@ export class FirestoreStore implements Store {
         },
         { merge: true },
       );
+    });
+  }
+
+  async recordJobCost(issueNumber: number, entry: JobCostEntry): Promise<void> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    // Transactional like every other append here: two rounds of a job can be charged
+    // within the same second, and a read outside a transaction loses one of them —
+    // which is the one failure mode a ledger may not have.
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return;
+      const existing = (snap.data() as SubmissionRecord).costs ?? [];
+      tx.set(ref, { costs: [...existing, entry].slice(-MAX_JOB_COSTS) }, { merge: true });
     });
   }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -482,7 +482,17 @@ export type NotificationType =
    * (docs/improvement-loop-plan.md IL-2). Unlike the three above it is not tied to one
    * submission, which is why its id is keyed by week rather than by issue number.
    */
-  | 'creator.digest';
+  | 'creator.digest'
+  /**
+   * The operator's own queue, delivered instead of waited on
+   * (`operator-alerts.ts`). These do not go to the creator: they go to every uid in
+   * ADMIN_UIDS, because the thing being reported — a build waiting on the publish
+   * decision, one that failed, one that has stopped moving — is nobody else's to act
+   * on, and the creator already has their own status page for their own game.
+   */
+  | 'operator.review_ready'
+  | 'operator.build_failed'
+  | 'operator.build_stalled';
 
 /**
  * The types that are about one submission, and so can render "«game title» happened".
@@ -492,7 +502,10 @@ export type NotificationType =
  * means a fourth submission event joins the email and push copy automatically, while a
  * second non-submission event has to be thought about.
  */
-export type SubmissionNotificationType = Exclude<NotificationType, 'creator.digest'>;
+export type SubmissionNotificationType = Extract<NotificationType, `submission.${string}`>;
+
+/** The operator-facing half, derived the same way and for the same reason. */
+export type OperatorNotificationType = Extract<NotificationType, `operator.${string}`>;
 
 export interface StoredNotification {
   /** Deterministic id (e.g. `sub-142-published`) so emission is idempotent. */

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2902,3 +2902,67 @@ describe('a session that finishes without delivering', () => {
     await app.close();
   });
 });
+
+/**
+ * The cost ledger. The unit here is a session, because that is the unit the backend
+ * bills — see `JobCostEntry`.
+ */
+describe('what a build costs', () => {
+  const body = { title: 'Game idea', concept: 'A concept long enough to pass validation rules.' };
+
+  it('books a session the moment one is started', async () => {
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const created = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    expect(created.statusCode).toBe(200);
+
+    const [record] = await store.listSubmissionsByOwner('g:test-user');
+    expect(record?.costs).toEqual([
+      {
+        kind: 'agent_session',
+        at: expect.any(String),
+        by: 'stub',
+        ref: 'task-1',
+        credits: 1,
+      },
+    ]);
+
+    await app.close();
+  });
+
+  it('books every round, including the ones that produced nothing', async () => {
+    // The whole point of recording at dispatch: a revision round costs a premium request
+    // whether or not it delivers, and a ledger written on success would price a game at
+    // whatever its last attempt cost.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const created = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    const { token } = created.json() as { token: string };
+
+    const feedback = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${token}/feedback`,
+      headers: authHeaders,
+      payload: { feedback: 'Make the ship a little slower, it is hard to control.' },
+    });
+    expect(feedback.statusCode).toBe(200);
+
+    const [record] = await store.listSubmissionsByOwner('g:test-user');
+    expect(record?.costs?.map((entry) => entry.ref)).toEqual(['task-1', 'task-2']);
+    expect(record?.costs?.every((entry) => entry.credits === 1)).toBe(true);
+
+    await app.close();
+  });
+});

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -35,7 +35,7 @@ import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { emitOperatorAlert, notifyOnTransition, type EmitDeps } from './notify.js';
-import { detectOperatorAlerts } from './operator-alerts.js';
+import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
 import { peekQuota } from './quota-gate.js';
 import {
   isNativeJobId,
@@ -105,15 +105,6 @@ const FeedbackRequestSchema = z.object({
     })
     .optional(),
 });
-
-/**
- * How long a creator's change request may sit uncollected before the notify sweep
- * calls it a stall. Generous on purpose: the relay fires in seconds, but the agent
- * it wakes only acks its inbox once it has a session running, and a queue behind a
- * busy repo can legitimately take a while. An hour is far past that and far short
- * of the creator giving up.
- */
-const CREATOR_FEEDBACK_STALL_MS = 60 * 60 * 1000;
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const MAX_CREATOR_SHOT_BYTES = 300 * 1024;
@@ -419,6 +410,40 @@ export async function registerSubmissionRoutes(
    * succeeds and the label workflow remains the path that starts it. A creator must never
    * lose a submission to orchestration that is not wired up yet.
    */
+  /**
+   * Books one agent session against a job.
+   *
+   * A session is the billed unit on the Copilot backend — one premium request each,
+   * charged when the session starts and regardless of what it produces. That last part
+   * is why this is recorded here rather than on delivery: a round that fails, stalls, or
+   * finishes without uploading cost exactly as much as one that shipped a game, and a
+   * ledger that only counted successes would report the cost of building games as a
+   * fraction of what it is.
+   *
+   * Never throws. A ledger is worth having, and it is not worth dropping a build for.
+   */
+  async function recordSessionCost(
+    issueNumber: number,
+    ref: string,
+    log: { error: (context: object, message: string) => void },
+  ): Promise<void> {
+    if (!store || !agentBackend) return;
+    try {
+      await store.recordJobCost(issueNumber, {
+        kind: 'agent_session',
+        at: new Date(now()).toISOString(),
+        by: agentBackend.name,
+        ref,
+        // One premium request per session. Tokens are not exposed by this backend at
+        // all, so recording a zero would be an invented measurement rather than a
+        // missing one — the field is simply absent until something can fill it.
+        credits: 1,
+      });
+    } catch (error) {
+      log.error({ err: error, issueNumber }, 'could not record the cost of an agent session');
+    }
+  }
+
   async function dispatchBuild(input: {
     issueNumber: number;
     spec: string;
@@ -441,6 +466,7 @@ export async function registerSubmissionRoutes(
         ref: result.ref,
         workspace: result.workspace,
       });
+      await recordSessionCost(input.issueNumber, result.ref, input.log);
       await store?.recordJobTransition(input.issueNumber, {
         to: 'dispatched',
         at: new Date(now()).toISOString(),
@@ -497,6 +523,7 @@ export async function registerSubmissionRoutes(
         ref: result.ref,
         workspace: result.workspace,
       });
+      await recordSessionCost(input.issueNumber, result.ref, input.log);
       // The previous workspace is spent the moment a new round has one of its own: the
       // round that follows restores the game from the store rather than from a branch.
       // Deleted after the dispatch succeeds, never before — a round that failed to
@@ -2092,6 +2119,9 @@ export async function registerSubmissionRoutes(
       const active = await store.listActiveSubmissions();
       let emitted = 0;
       const stalledIssues: number[] = [];
+      // When each job's oldest uncollected change request arrived, collected as the
+      // loop goes so the alert pass below can see it without reading anything twice.
+      const pendingFeedback = new Map<number, string>();
       for (const record of active) {
         try {
           // Relay-stall detection. A creator's change request goes out two ways
@@ -2107,8 +2137,11 @@ export async function registerSubmissionRoutes(
           const oldest = pending[0];
           // Checked before the GitHub read below so a transient API failure cannot be
           // what hides a stall — this half needs no network.
-          if (oldest && now() - Date.parse(oldest.createdAt) > CREATOR_FEEDBACK_STALL_MS) {
-            stalledIssues.push(record.issueNumber);
+          if (oldest) {
+            pendingFeedback.set(record.issueNumber, oldest.createdAt);
+            if (now() - Date.parse(oldest.createdAt) > FEEDBACK_STALL_MS) {
+              stalledIssues.push(record.issueNumber);
+            }
           }
 
           const status = await deriveSubmissionStatus(githubClient, record.issueNumber);
@@ -2135,7 +2168,7 @@ export async function registerSubmissionRoutes(
       // of jobs that could be in trouble, so it is the one place all three kinds are
       // observable. Idempotent per job and kind, so re-running it does not re-notify.
       let alerted = 0;
-      const alerts = detectOperatorAlerts(active, now());
+      const alerts = detectOperatorAlerts(active, now(), pendingFeedback);
       if (adminUids && adminUids.size > 0) {
         for (const alert of alerts) {
           try {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -34,7 +34,8 @@ import {
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
-import { notifyOnTransition, type EmitDeps } from './notify.js';
+import { emitOperatorAlert, notifyOnTransition, type EmitDeps } from './notify.js';
+import { detectOperatorAlerts } from './operator-alerts.js';
 import { peekQuota } from './quota-gate.js';
 import {
   isNativeJobId,
@@ -244,6 +245,12 @@ export interface SubmissionRoutesOptions {
   maxCachedDraftPreviews?: number;
   /** How many times a job may be sent back for finishing without delivering. */
   maxDeliveryNudges?: number;
+  /**
+   * Who gets the operator alerts the sweep raises. Empty (the default) means the queue
+   * is still visible in the console and nobody is told about it — which is the honest
+   * default for an environment that has not named an operator.
+   */
+  adminUids?: Set<string>;
 }
 
 function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {
@@ -326,6 +333,7 @@ export async function registerSubmissionRoutes(
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? Date.now;
   const store = options.store;
+  const adminUids = options.adminUids;
   const dailySubmissionQuota = options.dailySubmissionQuota ?? 5;
 
   // Per-user quotas bound one creator; this bounds everyone at once, and can be pulled
@@ -2119,18 +2127,51 @@ export async function registerSubmissionRoutes(
           request.log.error({ err: sweepError, issueNumber: record.issueNumber }, 'sweep item failed');
         }
       }
+      // Then the operator's own half of the sweep.
+      //
+      // Raised here rather than at each transition because the alerts are not all
+      // transitions: a stall is time passing, and there is no moment anybody could have
+      // written it. This loop already runs every couple of minutes over exactly the set
+      // of jobs that could be in trouble, so it is the one place all three kinds are
+      // observable. Idempotent per job and kind, so re-running it does not re-notify.
+      let alerted = 0;
+      const alerts = detectOperatorAlerts(active, now());
+      if (adminUids && adminUids.size > 0) {
+        for (const alert of alerts) {
+          try {
+            const { created } = await emitOperatorAlert({ ...buildNotifyDeps(), adminUids }, alert);
+            alerted += created;
+          } catch (alertError) {
+            request.log.error({ err: alertError, alert: alert.id }, 'operator alert emit failed');
+          }
+        }
+      }
+
       // Logged at error level so it surfaces without new infrastructure, the same way
       // the scorecard sweep reports its failures — a nightly job nobody watches is
       // exactly the kind that fails quietly for weeks.
       const sweepLog =
         stalledIssues.length > 0 ? request.log.error.bind(request.log) : request.log.info.bind(request.log);
       sweepLog(
-        { scanned: active.length, emitted, stalled: stalledIssues.length, stalledIssues },
+        {
+          scanned: active.length,
+          emitted,
+          alerts: alerts.length,
+          alerted,
+          stalled: stalledIssues.length,
+          stalledIssues,
+        },
         stalledIssues.length > 0
           ? 'creator feedback undelivered past the stall threshold — the games-repo @copilot relay may be down'
           : 'notify sweep complete',
       );
-      return reply.send({ scanned: active.length, emitted, stalled: stalledIssues.length });
+      return reply.send({
+        scanned: active.length,
+        emitted,
+        alerts: alerts.length,
+        alerted,
+        stalled: stalledIssues.length,
+      });
     },
   );
 

--- a/apps/web/src/AccessTokensPanel.test.tsx
+++ b/apps/web/src/AccessTokensPanel.test.tsx
@@ -126,6 +126,49 @@ describe('AccessTokensPanel', () => {
     await act(async () => root.unmount());
   });
 
+  it('clears the list when a lookup comes back empty-handed', async () => {
+    // Otherwise the previous account's tokens sit under the new uid, and revoking off a
+    // mislabelled list is a mistake this panel would have invited.
+    mocked.fetchAccessTokens.mockResolvedValueOnce([token()]).mockResolvedValueOnce(null);
+
+    const { container, root } = await render();
+    await type(inputFor(container, 'Account uid'), 'g:agent');
+    await act(async () => {
+      button(container, 'List').click();
+    });
+    expect(container.querySelectorAll('.admin-token-row')).toHaveLength(1);
+
+    await type(inputFor(container, 'Account uid'), 'g:nobody');
+    await act(async () => {
+      button(container, 'List').click();
+    });
+
+    expect(container.querySelectorAll('.admin-token-row')).toHaveLength(0);
+    expect(container.querySelector('.admin-limits-message')?.textContent).toBe('not found');
+
+    await act(async () => root.unmount());
+  });
+
+  it('says so when a revoke never reached the API, rather than going quiet', async () => {
+    // The one failure that must not look like silence: an operator would walk away
+    // believing the credential is dead.
+    mocked.fetchAccessTokens.mockResolvedValue([token()]);
+    mocked.revokeAccessToken.mockRejectedValue(new Error('offline'));
+
+    const { container, root } = await render();
+    await type(inputFor(container, 'Account uid'), 'g:agent');
+    await act(async () => {
+      button(container, 'List').click();
+    });
+    await act(async () => {
+      button(container, 'Revoke').click();
+    });
+
+    expect(container.querySelector('.admin-limits-message')?.textContent).toBe('could not reach the API');
+
+    await act(async () => root.unmount());
+  });
+
   it('refuses to mint without both an account and a label', async () => {
     const { container, root } = await render();
 

--- a/apps/web/src/AccessTokensPanel.test.tsx
+++ b/apps/web/src/AccessTokensPanel.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AccessTokensPanel } from './AccessTokensPanel.js';
+import type { AccessToken } from './adminApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchAdminSummary: vi.fn(),
+  fetchCreationLimits: vi.fn(),
+  setCreationLimits: vi.fn(),
+  fetchSuggestions: vi.fn(),
+  fetchAccessTokens: vi.fn(),
+  mintAccessToken: vi.fn(),
+  revokeAccessToken: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+
+function token(overrides: Partial<AccessToken> = {}): AccessToken {
+  return {
+    tokenId: '0123456789abcdef',
+    uid: 'g:agent',
+    name: 'agent VM',
+    createdAt: '2026-07-01T10:00:00Z',
+    createdByUid: 'g:boss',
+    expiresAt: '2026-08-15T10:00:00Z',
+    lastUsedAt: null,
+    expired: false,
+    ...overrides,
+  };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AccessTokensPanel));
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll('button')).find((element) => element.textContent === label);
+  if (!found) throw new Error(`no button labelled ${label}`);
+  return found as HTMLButtonElement;
+}
+
+/** Types into a controlled input the way React's onChange expects. */
+async function type(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  await act(async () => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function inputFor(container: HTMLElement, label: string): HTMLInputElement {
+  const found = Array.from(container.querySelectorAll('label')).find((element) =>
+    element.textContent?.startsWith(label),
+  );
+  const input = found?.querySelector('input');
+  if (!input) throw new Error(`no input labelled ${label}`);
+  return input;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('AccessTokensPanel', () => {
+  it('lists the tokens an account holds and offers to revoke each one', async () => {
+    mocked.fetchAccessTokens.mockResolvedValue([token(), token({ tokenId: 'fedcba9876543210', expired: true })]);
+
+    const { container, root } = await render();
+    await type(inputFor(container, 'Account uid'), 'g:agent');
+    await act(async () => {
+      button(container, 'List').click();
+    });
+
+    expect(mocked.fetchAccessTokens).toHaveBeenCalledWith('g:agent');
+    expect(container.querySelectorAll('.admin-token-row')).toHaveLength(2);
+    // An expired token is still listed: revoking it is still worth doing, and its
+    // absence would read as "already gone".
+    expect(container.querySelectorAll('.admin-token-row.is-expired')).toHaveLength(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows the minted secret once, and says that is the only time', async () => {
+    mocked.fetchAccessTokens.mockResolvedValue([token()]);
+    mocked.mintAccessToken.mockResolvedValue({ ...token(), token: 'gdpl_pat_secret' });
+
+    const { container, root } = await render();
+    await type(inputFor(container, 'Account uid'), 'g:agent');
+    await type(inputFor(container, 'Label'), 'agent VM');
+    await act(async () => {
+      button(container, 'Mint').click();
+    });
+
+    const secret = container.querySelector('.admin-token-secret');
+    expect(secret?.textContent).toContain('gdpl_pat_secret');
+    expect(secret?.textContent).toContain('cannot be shown again');
+
+    await act(async () => root.unmount());
+  });
+
+  it('explains a refusal in terms of what to do about it', async () => {
+    mocked.mintAccessToken.mockResolvedValue({ error: 'unknown_uid' });
+
+    const { container, root } = await render();
+    await type(inputFor(container, 'Account uid'), 'g:nobody');
+    await type(inputFor(container, 'Label'), 'agent VM');
+    await act(async () => {
+      button(container, 'Mint').click();
+    });
+
+    expect(container.querySelector('.admin-limits-message')?.textContent).toBe('no such account — check the uid');
+    expect(container.querySelector('.admin-token-secret')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('refuses to mint without both an account and a label', async () => {
+    const { container, root } = await render();
+
+    expect(button(container, 'Mint').disabled).toBe(true);
+    await type(inputFor(container, 'Account uid'), 'g:agent');
+    expect(button(container, 'Mint').disabled).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/AccessTokensPanel.test.tsx
+++ b/apps/web/src/AccessTokensPanel.test.tsx
@@ -20,7 +20,7 @@ vi.mock('./adminApi.js', () => mocked);
 
 function token(overrides: Partial<AccessToken> = {}): AccessToken {
   return {
-    tokenId: '0123456789abcdef',
+    tokenId: 'aaaaaaaaaaaaaaaa',
     uid: 'g:agent',
     name: 'agent VM',
     createdAt: '2026-07-01T10:00:00Z',
@@ -75,7 +75,7 @@ afterEach(() => {
 
 describe('AccessTokensPanel', () => {
   it('lists the tokens an account holds and offers to revoke each one', async () => {
-    mocked.fetchAccessTokens.mockResolvedValue([token(), token({ tokenId: 'fedcba9876543210', expired: true })]);
+    mocked.fetchAccessTokens.mockResolvedValue([token(), token({ tokenId: 'bbbbbbbbbbbbbbbb', expired: true })]);
 
     const { container, root } = await render();
     await type(inputFor(container, 'Account uid'), 'g:agent');

--- a/apps/web/src/AccessTokensPanel.tsx
+++ b/apps/web/src/AccessTokensPanel.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useState } from 'react';
+import { fetchAccessTokens, mintAccessToken, revokeAccessToken, type AccessToken } from './adminApi.js';
+
+/**
+ * Personal access tokens (docs/agent-access-tokens.md), minted and revoked from a page.
+ *
+ * Until now this was the `token:mint` CLI or a curl command, which meant the practical
+ * answer to "revoke that token" involved finding a laptop. Revocation is the half that
+ * matters: a credential you cannot cancel quickly is one you have to be lucky with.
+ *
+ * Listing is per account rather than global, because the API has no "every token" read —
+ * deliberately, since that response would be a map of every automation credential on the
+ * site in one request.
+ *
+ * The secret is shown exactly once, on mint. It is stored only as a hash, so there is no
+ * second chance and the panel says so rather than letting someone assume otherwise.
+ */
+
+const MINT_FAILURE_COPY: Record<string, string> = {
+  unknown_uid: 'no such account — check the uid',
+  blocked: 'that account is blocked',
+  too_many_tokens: 'that account already holds the maximum number of tokens',
+  invalid_expiry: 'expiry is outside the allowed range',
+};
+
+export function AccessTokensPanel() {
+  const [uid, setUid] = useState('');
+  const [name, setName] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState('');
+  const [tokens, setTokens] = useState<AccessToken[] | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const list = useCallback(async (forUid: string) => {
+    if (!forUid.trim()) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await fetchAccessTokens(forUid.trim());
+      if (result === null) {
+        setMessage('not found');
+        return;
+      }
+      setTokens(result);
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const mint = useCallback(async () => {
+    setBusy(true);
+    setMessage(null);
+    setSecret(null);
+    try {
+      const days = Number(expiresInDays);
+      const result = await mintAccessToken({
+        uid: uid.trim(),
+        name: name.trim(),
+        ...(Number.isInteger(days) && days > 0 ? { expiresInDays: days } : {}),
+      });
+      if ('error' in result) {
+        setMessage(MINT_FAILURE_COPY[result.error] ?? result.error);
+        return;
+      }
+      setSecret(result.token);
+      setName('');
+      await list(uid);
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(false);
+    }
+  }, [expiresInDays, list, name, uid]);
+
+  const revoke = useCallback(
+    async (tokenId: string) => {
+      setBusy(true);
+      try {
+        const { ok } = await revokeAccessToken(tokenId);
+        setMessage(ok ? 'revoked' : 'could not revoke that token');
+        await list(uid);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [list, uid],
+  );
+
+  return (
+    <section className="admin-tokens">
+      <h2 className="health-section-title">Access tokens</h2>
+
+      <div className="admin-tokens-form">
+        <label>
+          Account uid
+          <input value={uid} onChange={(event) => setUid(event.target.value)} placeholder="g:123…" />
+        </label>
+        <button type="button" disabled={busy || !uid.trim()} onClick={() => void list(uid)}>
+          List
+        </button>
+        <label>
+          Label
+          <input value={name} onChange={(event) => setName(event.target.value)} placeholder="agent VM" />
+        </label>
+        <label>
+          Days
+          <input
+            type="number"
+            min={1}
+            value={expiresInDays}
+            onChange={(event) => setExpiresInDays(event.target.value)}
+            placeholder="default"
+          />
+        </label>
+        <button type="button" disabled={busy || !uid.trim() || !name.trim()} onClick={() => void mint()}>
+          Mint
+        </button>
+      </div>
+
+      {message && <p className="admin-limits-message">{message}</p>}
+
+      {secret && (
+        <p className="admin-token-secret">
+          <strong>Copy this now — it is not stored and cannot be shown again:</strong>
+          <code>{secret}</code>
+        </p>
+      )}
+
+      {tokens && tokens.length === 0 && <p className="health-empty">That account holds no tokens.</p>}
+
+      {tokens && tokens.length > 0 && (
+        <div className="health-table-scroll">
+          <table className="health-table">
+            <thead>
+              <tr>
+                <th>Label</th>
+                <th>Id</th>
+                <th>Expires</th>
+                <th>Last used</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((token) => (
+                <tr key={token.tokenId} className={token.expired ? 'admin-token-row is-expired' : 'admin-token-row'}>
+                  <td>{token.name}</td>
+                  <td>
+                    <code>{token.tokenId}</code>
+                  </td>
+                  <td>
+                    {token.expiresAt}
+                    {token.expired ? ' (expired)' : ''}
+                  </td>
+                  <td>{token.lastUsedAt ?? 'never'}</td>
+                  <td>
+                    <button type="button" disabled={busy} onClick={() => void revoke(token.tokenId)}>
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="health-note">
+        Tokens act as their account and can never mint another — that is what keeps a leaked one inside a single
+        account. Minting is session-only, so this page is the only place it can happen.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/AccessTokensPanel.tsx
+++ b/apps/web/src/AccessTokensPanel.tsx
@@ -39,11 +39,16 @@ export function AccessTokensPanel() {
     try {
       const result = await fetchAccessTokens(forUid.trim());
       if (result === null) {
+        // Cleared, not left standing: a list from the previous uid sitting under the new
+        // one reads as that account's tokens, and revoking off a mislabelled list is a
+        // mistake this panel would have invited.
+        setTokens(null);
         setMessage('not found');
         return;
       }
       setTokens(result);
     } catch {
+      setTokens(null);
       setMessage('could not reach the API');
     } finally {
       setBusy(false);
@@ -82,6 +87,10 @@ export function AccessTokensPanel() {
         const { ok } = await revokeAccessToken(tokenId);
         setMessage(ok ? 'revoked' : 'could not revoke that token');
         await list(uid);
+      } catch {
+        // A revoke whose request never left is the one failure that must not look like
+        // silence: the operator would walk away believing the credential is dead.
+        setMessage('could not reach the API');
       } finally {
         setBusy(false);
       }

--- a/apps/web/src/AdminConsole.test.tsx
+++ b/apps/web/src/AdminConsole.test.tsx
@@ -119,6 +119,32 @@ describe('AdminConsole', () => {
     await act(async () => root.unmount());
   });
 
+  it('never reports a negative age when the browser clock runs behind', async () => {
+    // `since` is the server's clock and `now` is the browser's. A minute of skew used to
+    // render an alert as having waited "-1m".
+    mocked.fetchAdminSummary.mockResolvedValue(
+      summary({
+        alerts: [
+          {
+            id: 'op-1-review_ready',
+            kind: 'review_ready',
+            issueNumber: 1_000_001,
+            title: 'Comet Courier',
+            ownerUid: 'g:1',
+            since: new Date(Date.now() + 90_000).toISOString(),
+          },
+        ],
+      }),
+    );
+
+    const { container, root } = await render('queue');
+
+    expect(container.querySelector('.admin-alert-age')?.textContent).toContain('0m');
+    expect(container.textContent).not.toContain('-1m');
+
+    await act(async () => root.unmount());
+  });
+
   it('says so plainly when nothing needs attention', async () => {
     mocked.fetchAdminSummary.mockResolvedValue(summary());
 

--- a/apps/web/src/AdminConsole.test.tsx
+++ b/apps/web/src/AdminConsole.test.tsx
@@ -22,6 +22,7 @@ vi.mock('./adminApi.js', () => mocked);
 // one is on screen, not what it renders.
 vi.mock('./AdminJobsPanel.js', () => ({ AdminJobsPanel: () => createElement('p', null, 'queue-panel') }));
 vi.mock('./GameHealthView.js', () => ({ GameHealthView: () => createElement('p', null, 'telemetry-panel') }));
+vi.mock('./CostsPanel.js', () => ({ CostsPanel: () => createElement('p', null, 'costs-panel') }));
 vi.mock('./CreationLimitsPanel.js', () => ({ CreationLimitsPanel: () => createElement('p', null, 'limits-panel') }));
 vi.mock('./AccessTokensPanel.js', () => ({ AccessTokensPanel: () => createElement('p', null, 'tokens-panel') }));
 vi.mock('./SuggestionsPanel.js', () => ({ SuggestionsPanel: () => createElement('p', null, 'suggestions-panel') }));
@@ -63,6 +64,17 @@ describe('AdminConsole', () => {
     expect(container.textContent).toContain('limits-panel');
     expect(container.textContent).not.toContain('queue-panel');
     expect(container.querySelector('.admin-tab.is-active')?.textContent).toBe('Limits');
+
+    await act(async () => root.unmount());
+  });
+
+  it('routes to the cost section, which nothing linked to before', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(summary());
+
+    const { container, root } = await render('costs');
+
+    expect(container.textContent).toContain('costs-panel');
+    expect(container.querySelector('.admin-tab.is-active')?.textContent).toBe('Cost');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/AdminConsole.test.tsx
+++ b/apps/web/src/AdminConsole.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AdminConsole } from './AdminConsole.js';
+import type { AdminSummary } from './adminApi.js';
+import type { AdminSection } from './router.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchAdminSummary: vi.fn(),
+  fetchCreationLimits: vi.fn(),
+  setCreationLimits: vi.fn(),
+  fetchSuggestions: vi.fn(),
+  fetchAccessTokens: vi.fn(),
+  mintAccessToken: vi.fn(),
+  revokeAccessToken: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+// The sections themselves are covered by their own tests; the console's job is which
+// one is on screen, not what it renders.
+vi.mock('./AdminJobsPanel.js', () => ({ AdminJobsPanel: () => createElement('p', null, 'queue-panel') }));
+vi.mock('./GameHealthView.js', () => ({ GameHealthView: () => createElement('p', null, 'telemetry-panel') }));
+vi.mock('./CreationLimitsPanel.js', () => ({ CreationLimitsPanel: () => createElement('p', null, 'limits-panel') }));
+vi.mock('./AccessTokensPanel.js', () => ({ AccessTokensPanel: () => createElement('p', null, 'tokens-panel') }));
+vi.mock('./SuggestionsPanel.js', () => ({ SuggestionsPanel: () => createElement('p', null, 'suggestions-panel') }));
+
+function summary(overrides: Partial<AdminSummary> = {}): AdminSummary {
+  return {
+    alerts: [],
+    queue: { active: 2, stalled: 0, byState: { building: 2 } },
+    limits: { paused: false, globalDailySubmissionCap: 50, todaySubmissions: 3 },
+    ...overrides,
+  };
+}
+
+async function render(section: AdminSection = 'queue', onNavigate = vi.fn()) {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AdminConsole, { section, onNavigate }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root, onNavigate };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('AdminConsole', () => {
+  it('renders the section it was routed to, and only that one', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(summary());
+
+    const { container, root } = await render('limits');
+
+    expect(container.textContent).toContain('limits-panel');
+    expect(container.textContent).not.toContain('queue-panel');
+    expect(container.querySelector('.admin-tab.is-active')?.textContent).toBe('Limits');
+
+    await act(async () => root.unmount());
+  });
+
+  it('tells a non-operator nothing, including that there was anything to tell', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(null);
+
+    const { container, root } = await render('queue');
+
+    expect(container.textContent).toBe('Not found.');
+    // No section is rendered at all — not even the one that would have said "not found"
+    // itself a moment later.
+    expect(container.textContent).not.toContain('queue-panel');
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows what is waiting on the operator, whichever section they opened', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(
+      summary({
+        alerts: [
+          {
+            id: 'op-1-review_ready',
+            kind: 'review_ready',
+            issueNumber: 1_000_001,
+            title: 'Comet Courier',
+            ownerUid: 'g:1',
+            since: new Date(Date.now() - 20 * 60_000).toISOString(),
+          },
+        ],
+      }),
+    );
+
+    const { container, root } = await render('telemetry');
+
+    const alerts = container.querySelector('.admin-alerts');
+    expect(alerts?.textContent).toContain('Comet Courier');
+    expect(alerts?.textContent).toContain('waiting to be published');
+    // The count rides on the queue tab, because that is where the doing happens.
+    expect(container.querySelector('.admin-tab-badge')?.textContent).toBe('1');
+
+    await act(async () => root.unmount());
+  });
+
+  it('says so plainly when nothing needs attention', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(summary());
+
+    const { container, root } = await render('queue');
+
+    expect(container.querySelector('.admin-alerts--clear')?.textContent).toBe('Nothing waiting on you.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('navigates by path, so a section survives a refresh', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(summary());
+    const onNavigate = vi.fn();
+
+    const { container, root } = await render('queue', onNavigate);
+    const tokensTab = Array.from(container.querySelectorAll('.admin-tab')).find(
+      (tab) => tab.textContent === 'Tokens',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      tokensTab.click();
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('/admin/tokens');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AccessTokensPanel } from './AccessTokensPanel.js';
 import { AdminJobsPanel } from './AdminJobsPanel.js';
+import { CostsPanel } from './CostsPanel.js';
 import { CreationLimitsPanel } from './CreationLimitsPanel.js';
 import { GameHealthView } from './GameHealthView.js';
 import { SuggestionsPanel } from './SuggestionsPanel.js';
@@ -22,6 +23,7 @@ import { ADMIN_SECTIONS, adminPath, type AdminSection } from './router.js';
 
 const SECTION_LABELS: Record<AdminSection, string> = {
   queue: 'Queue',
+  costs: 'Cost',
   telemetry: 'Telemetry',
   limits: 'Limits',
   tokens: 'Tokens',
@@ -32,6 +34,9 @@ const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
   review_ready: 'waiting to be published',
   build_failed: 'failed',
   build_stalled: 'stopped moving',
+  // Names the suspect, because this one is never about the game: the request landed
+  // and the relay that wakes an agent for it did not fire.
+  feedback_undelivered: 'change request never collected — check the relay',
 };
 
 /** Rough age, in the same vocabulary the queue uses. */
@@ -139,6 +144,7 @@ export function AdminConsole({ section, onNavigate }: { section: AdminSection; o
       {summary && <AlertBanner alerts={summary.alerts} />}
 
       {section === 'queue' && <AdminJobsPanel />}
+      {section === 'costs' && <CostsPanel />}
       {section === 'telemetry' && <GameHealthView />}
       {section === 'limits' && <CreationLimitsPanel onChanged={() => void load()} />}
       {section === 'tokens' && <AccessTokensPanel />}

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AccessTokensPanel } from './AccessTokensPanel.js';
+import { AdminJobsPanel } from './AdminJobsPanel.js';
+import { CreationLimitsPanel } from './CreationLimitsPanel.js';
+import { GameHealthView } from './GameHealthView.js';
+import { SuggestionsPanel } from './SuggestionsPanel.js';
+import { fetchAdminSummary, type AdminSummary, type OperatorAlert } from './adminApi.js';
+import { ADMIN_SECTIONS, adminPath, type AdminSection } from './router.js';
+
+/**
+ * One place for everything an operator can do.
+ *
+ * Before this the operator surfaces were four endpoints and one page: the queue and the
+ * telemetry shared `/health`, the creation breaker and the access tokens had no UI at
+ * all, and the suggestion router — which will eventually file work against people's
+ * games — could only be inspected with curl. Anything without a page was, in practice,
+ * something that did not get used.
+ *
+ * Deliberately untranslated, like the telemetry view it absorbs: one person reads this,
+ * and a dozen locale keys per panel would cost more than they explain.
+ */
+
+const SECTION_LABELS: Record<AdminSection, string> = {
+  queue: 'Queue',
+  telemetry: 'Telemetry',
+  limits: 'Limits',
+  tokens: 'Tokens',
+  suggestions: 'Suggestions',
+};
+
+const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
+  review_ready: 'waiting to be published',
+  build_failed: 'failed',
+  build_stalled: 'stopped moving',
+};
+
+/** Rough age, in the same vocabulary the queue uses. */
+function since(at: string, now: number): string {
+  const ms = now - Date.parse(at);
+  if (!Number.isFinite(ms)) return '';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/**
+ * What is waiting on the person reading, above whatever section they opened.
+ *
+ * Shown on every section rather than only on the queue: the reason to consolidate these
+ * pages is that an operator opens one of them and finds out about the others, and an
+ * alert visible only on the page you had to already be on would not be an alert.
+ */
+function AlertBanner({ alerts }: { alerts: OperatorAlert[] }) {
+  const now = Date.now();
+  if (alerts.length === 0) {
+    return <p className="admin-alerts admin-alerts--clear">Nothing waiting on you.</p>;
+  }
+  return (
+    <ul className="admin-alerts">
+      {alerts.map((alert) => (
+        <li key={alert.id} className={`admin-alert admin-alert--${alert.kind}`}>
+          <span className="admin-alert-title">{alert.title}</span>{' '}
+          <span className="admin-alert-kind">
+            {ALERT_COPY[alert.kind]}
+            {alert.stall ? ` (${alert.stall})` : ''}
+          </span>{' '}
+          <span className="admin-alert-age">
+            #{alert.issueNumber} · {since(alert.since, now)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function AdminConsole({ section, onNavigate }: { section: AdminSection; onNavigate: (path: string) => void }) {
+  const [summary, setSummary] = useState<AdminSummary | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetchAdminSummary();
+      if (response === null) {
+        setState('forbidden');
+        return;
+      }
+      setSummary(response);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    // Same cadence and the same reason as the queue's own poll: this is a page someone
+    // leaves open while a build runs, and it costs one store read.
+    const timer = setInterval(() => void load(), 30_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  // The same answer the API gives a non-operator: nothing here, and no hint that there
+  // could be. Rendered before anything else so no section ever loads for a stranger.
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+
+  return (
+    <section className="admin-console">
+      <header className="admin-console-header">
+        <h1>Operator</h1>
+        {summary && (
+          <p className="admin-console-counts">
+            {summary.queue.active} active · {summary.queue.stalled} stalled · {summary.limits.todaySubmissions}/
+            {summary.limits.globalDailySubmissionCap} today
+            {summary.limits.paused ? ' · creation paused' : ''}
+          </p>
+        )}
+      </header>
+
+      <nav className="admin-tabs">
+        {ADMIN_SECTIONS.map((candidate) => (
+          <button
+            key={candidate}
+            type="button"
+            className={candidate === section ? 'admin-tab is-active' : 'admin-tab'}
+            aria-current={candidate === section ? 'page' : undefined}
+            onClick={() => onNavigate(adminPath(candidate))}
+          >
+            {SECTION_LABELS[candidate]}
+            {candidate === 'queue' && summary && summary.alerts.length > 0 ? (
+              <span className="admin-tab-badge">{summary.alerts.length}</span>
+            ) : null}
+          </button>
+        ))}
+      </nav>
+
+      {state === 'error' && <p className="health-empty">Could not read the console summary.</p>}
+      {summary && <AlertBanner alerts={summary.alerts} />}
+
+      {section === 'queue' && <AdminJobsPanel />}
+      {section === 'telemetry' && <GameHealthView />}
+      {section === 'limits' && <CreationLimitsPanel onChanged={() => void load()} />}
+      {section === 'tokens' && <AccessTokensPanel />}
+      {section === 'suggestions' && <SuggestionsPanel />}
+    </section>
+  );
+}

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -41,7 +41,10 @@ const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
 
 /** Rough age, in the same vocabulary the queue uses. */
 function since(at: string, now: number): string {
-  const ms = now - Date.parse(at);
+  // Clamped, because these two clocks are not the same clock: `at` is the server's and
+  // `now` is the browser's, and a browser running a minute behind would otherwise
+  // report a build as having been waiting "-1m".
+  const ms = Math.max(0, now - Date.parse(at));
   if (!Number.isFinite(ms)) return '';
   const minutes = Math.floor(ms / 60_000);
   if (minutes < 60) return `${minutes}m`;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,10 +8,11 @@ import { HeroPromptSection } from './HeroPromptSection.js';
 import { ArcadeCatalog } from './ArcadeCatalog.js';
 import { CreatorStudioView } from './CreatorStudioView.js';
 import { DraftView } from './DraftView.js';
-import { GameHealthView } from './GameHealthView.js';
+import { AdminConsole } from './AdminConsole.js';
 import { PixelIcon } from './PixelIcon.js';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
 import {
+  adminPath,
   canonicalPlayPath,
   NAVIGATE_EVENT,
   navUpTarget,
@@ -572,6 +573,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -592,6 +594,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -613,6 +616,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -641,6 +645,7 @@ export function App() {
         onNavigate={handleNavigateSection}
         onHome={() => navigate('/')}
         onStudio={() => navigate(studioPath())}
+        onAdmin={() => navigate(adminPath())}
         upTarget={headerUp}
         onUp={navigate}
       />
@@ -650,8 +655,8 @@ export function App() {
       <PullToRefresh enabled={route.view === 'home' && !stageContent} onRefresh={handlePullToRefresh} />
 
       <main className="content">
-        {route.view === 'health' ? (
-          <GameHealthView />
+        {route.view === 'admin' ? (
+          <AdminConsole section={route.section} onNavigate={navigate} />
         ) : route.view === 'studio' ? (
           <CreatorStudioView
             selectedToken={route.token}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,7 @@ import { PixelIcon } from './PixelIcon.js';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
 import {
   adminPath,
-  canonicalPlayPath,
+  canonicalPath,
   NAVIGATE_EVENT,
   navUpTarget,
   parsePathRoute,
@@ -32,9 +32,14 @@ import { SiteFooter } from './SiteFooter.js';
 import { resolveDocumentTitle } from './pageTitle.js';
 import { useDocumentTitle } from './useDocumentTitle.js';
 
-/** Read the current URL into an AppRoute, rewriting `/ay|/ai/<slug>` → `/play/<slug>`. */
+/**
+ * Read the current URL into an AppRoute, putting the browser on the current address
+ * first — `/ay|/ai/<slug>` → `/play/<slug>`, `/status/<token>` → `/studio/<token>`,
+ * `/health` → `/admin/telemetry`. The old address still works; it just does not stay
+ * in the bar to be copied out of.
+ */
 function readLocationRoute(): AppRoute {
-  const canonical = canonicalPlayPath(window.location.pathname);
+  const canonical = canonicalPath(window.location.pathname);
   if (canonical) {
     window.history.replaceState(null, '', canonical);
   }

--- a/apps/web/src/CostsPanel.test.tsx
+++ b/apps/web/src/CostsPanel.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CostsPanel } from './CostsPanel.js';
+import type { CostReport, JobCostSummary } from './adminApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchAdminSummary: vi.fn(),
+  fetchCostReport: vi.fn(),
+  fetchCreationLimits: vi.fn(),
+  setCreationLimits: vi.fn(),
+  fetchSuggestions: vi.fn(),
+  fetchAccessTokens: vi.fn(),
+  mintAccessToken: vi.fn(),
+  revokeAccessToken: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+
+const HOUR = 60 * 60_000;
+
+function job(overrides: Partial<JobCostSummary> = {}): JobCostSummary {
+  return {
+    issueNumber: 1_000_001,
+    title: 'Comet Courier',
+    slug: 'comet-courier',
+    state: 'published',
+    sessions: 2,
+    credits: 2,
+    gateRuns: 1,
+    elapsedMs: 2 * HOUR,
+    published: true,
+    createdAt: '2026-07-30T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function report(overrides: Partial<CostReport> = {}): CostReport {
+  return {
+    jobs: [job()],
+    totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 1, published: 1 },
+    creditsPerPublishedGame: 2,
+    medianTimeToPublishMs: 2 * HOUR,
+    creditsOnUnpublished: 0,
+    unmeasuredJobs: 0,
+    ...overrides,
+  };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(CostsPanel));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('CostsPanel', () => {
+  it('leads with what a published game costs', async () => {
+    mocked.fetchCostReport.mockResolvedValue(report());
+
+    const { container, root } = await render();
+
+    const headline = container.querySelector('.admin-cost-headline');
+    expect(headline?.textContent).toContain('Credits per published game');
+    expect(headline?.querySelector('dd')?.textContent).toBe('2');
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows what the failure rate costs, as a share of the whole', async () => {
+    mocked.fetchCostReport.mockResolvedValue(
+      report({
+        jobs: [job(), job({ issueNumber: 1_000_002, published: false, state: 'failed', credits: 2, sessions: 2 })],
+        totals: { jobs: 2, sessions: 4, credits: 4, gateRuns: 1, published: 1 },
+        creditsPerPublishedGame: 4,
+        creditsOnUnpublished: 2,
+      }),
+    );
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.admin-cost-headline')?.textContent).toContain('2 (50%)');
+    // The failed job keeps its row: the headline is only checkable if the rows are there.
+    expect(container.querySelectorAll('.admin-cost-row.is-unpublished')).toHaveLength(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders unmeasured money and tokens as dashes, never as zero', async () => {
+    mocked.fetchCostReport.mockResolvedValue(report());
+
+    const { container, root } = await render();
+
+    const cells = Array.from(container.querySelectorAll('tbody td')).map((cell) => cell.textContent);
+    expect(cells.slice(-2)).toEqual(['—', '—']);
+    expect(container.textContent).not.toContain('$0.00');
+
+    await act(async () => root.unmount());
+  });
+
+  it('says the totals are a floor when jobs predate the ledger', async () => {
+    mocked.fetchCostReport.mockResolvedValue(report({ unmeasuredJobs: 3 }));
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.health-note')?.textContent).toContain('a floor, not a total');
+
+    await act(async () => root.unmount());
+  });
+
+  it('has no cost-per-game to show before anything published', async () => {
+    mocked.fetchCostReport.mockResolvedValue(
+      report({
+        jobs: [job({ published: false, state: 'building' })],
+        totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 0, published: 0 },
+        creditsPerPublishedGame: null,
+        medianTimeToPublishMs: null,
+        creditsOnUnpublished: 2,
+      }),
+    );
+
+    const { container, root } = await render();
+
+    const values = Array.from(container.querySelectorAll('.admin-cost-headline dd')).map((dd) => dd.textContent);
+    expect(values[0]).toBe('—');
+    expect(values[1]).toBe('—');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/CostsPanel.tsx
+++ b/apps/web/src/CostsPanel.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { fetchCostReport, type CostReport, type JobCostSummary } from './adminApi.js';
+
+/**
+ * What building games costs, per job and per shipped game.
+ *
+ * The headline number is credits per published game, and it is deliberately computed
+ * against *every* credit spent — including the ones spent on builds that never shipped.
+ * A cost-per-game that quietly excluded failures would be the most flattering number
+ * available and the least useful one: the failure rate is most of what a build costs.
+ *
+ * Money and tokens are shown as unmeasured rather than as zero. Copilot bills a premium
+ * request per session and exposes no token counts, so credits are what there is; the
+ * columns appear the moment a backend reports anything else.
+ */
+
+function duration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+function JobRow({ job }: { job: JobCostSummary }) {
+  return (
+    <tr className={job.published ? 'admin-cost-row' : 'admin-cost-row is-unpublished'}>
+      <td>
+        <div className="admin-job-title">{job.title}</div>
+        <div className="admin-job-sub">
+          #{job.issueNumber}
+          {job.slug ? ` · ${job.slug}` : ''}
+        </div>
+      </td>
+      <td>
+        <span className="admin-job-state">{job.state ?? '—'}</span>
+      </td>
+      <td>{job.sessions}</td>
+      <td>{job.gateRuns}</td>
+      <td>{duration(job.elapsedMs)}</td>
+      <td>{job.tokens ? `${job.tokens.input + job.tokens.output}` : '—'}</td>
+      <td>{job.usd === undefined ? '—' : `$${job.usd.toFixed(2)}`}</td>
+    </tr>
+  );
+}
+
+export function CostsPanel() {
+  const [report, setReport] = useState<CostReport | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCostReport()
+      .then((response) => {
+        if (cancelled) return;
+        if (response === null) {
+          setState('forbidden');
+          return;
+        }
+        setReport(response);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+  if (state === 'loading') return <p className="health-empty">Adding it up…</p>;
+  if (state === 'error' || !report) return <p className="health-empty">Could not read the ledger.</p>;
+
+  const { totals } = report;
+
+  return (
+    <section className="admin-costs">
+      <h2 className="health-section-title">Cost</h2>
+
+      <dl className="admin-cost-headline">
+        <div>
+          <dt>Credits per published game</dt>
+          <dd>{report.creditsPerPublishedGame ?? '—'}</dd>
+        </div>
+        <div>
+          <dt>Median time to publish</dt>
+          <dd>{report.medianTimeToPublishMs === null ? '—' : duration(report.medianTimeToPublishMs)}</dd>
+        </div>
+        <div>
+          <dt>Credits on builds that never shipped</dt>
+          <dd>
+            {report.creditsOnUnpublished}
+            {totals.credits > 0 ? ` (${Math.round((report.creditsOnUnpublished / totals.credits) * 100)}%)` : ''}
+          </dd>
+        </div>
+        <div>
+          <dt>Spent in this window</dt>
+          <dd>{totals.usd === undefined ? `${totals.credits} credits` : `$${totals.usd.toFixed(2)}`}</dd>
+        </div>
+      </dl>
+
+      <p className="health-summary">
+        {totals.jobs} job{totals.jobs === 1 ? '' : 's'} · {totals.sessions} agent session
+        {totals.sessions === 1 ? '' : 's'} · {totals.gateRuns} gate run{totals.gateRuns === 1 ? '' : 's'} ·{' '}
+        {totals.published} published
+      </p>
+
+      {report.unmeasuredJobs > 0 && (
+        <p className="health-note">
+          {report.unmeasuredJobs} job{report.unmeasuredJobs === 1 ? '' : 's'} in this window predate{' '}
+          {report.unmeasuredJobs === 1 ? 's' : ''} the ledger and contribute nothing to these totals — the numbers are a
+          floor, not a total.
+        </p>
+      )}
+
+      {report.jobs.length === 0 ? (
+        <p className="health-empty">Nothing has cost anything yet.</p>
+      ) : (
+        <div className="health-table-scroll">
+          <table className="health-table">
+            <thead>
+              <tr>
+                <th>Game</th>
+                <th>State</th>
+                <th>Sessions</th>
+                <th>Gate runs</th>
+                <th>Elapsed</th>
+                <th>Tokens</th>
+                <th>Money</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.jobs.map((job) => (
+                <JobRow key={job.issueNumber} job={job} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="health-note">
+        One credit is one premium request — what an agent session costs, charged whether or not the session delivers
+        anything. Tokens and money are dashes because the Copilot backend reports neither; both fill in on their own if
+        a backend that does report them is ever wired up. Gate runs carry their Cloud Build id, so a line on the bill
+        can be traced back to the game that caused it.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/CreationLimitsPanel.test.tsx
+++ b/apps/web/src/CreationLimitsPanel.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CreationLimitsPanel } from './CreationLimitsPanel.js';
+import type { CreationLimits } from './adminApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchAdminSummary: vi.fn(),
+  fetchCreationLimits: vi.fn(),
+  setCreationLimits: vi.fn(),
+  fetchSuggestions: vi.fn(),
+  fetchAccessTokens: vi.fn(),
+  mintAccessToken: vi.fn(),
+  revokeAccessToken: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+
+function limits(overrides: Partial<CreationLimits> = {}): CreationLimits {
+  return {
+    stored: null,
+    effective: { paused: false, globalDailySubmissionCap: 50 },
+    today: { dateStr: '2026-07-30', submissions: 12 },
+    propagationMs: 60_000,
+    ...overrides,
+  };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(CreationLimitsPanel, {}));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll('button')).find((element) => element.textContent === label);
+  if (!found) throw new Error(`no button labelled ${label}`);
+  return found as HTMLButtonElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('CreationLimitsPanel', () => {
+  it('reports what is in force, not what happens to be stored', async () => {
+    // Nothing stored still means a ceiling: the deployed default. An operator deciding
+    // whether to pause needs the number actually being enforced.
+    mocked.fetchCreationLimits.mockResolvedValue(limits());
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.health-summary')?.textContent).toContain('12 of 50 used today');
+    expect(container.querySelector('.health-note')?.textContent).toContain('Nothing stored');
+
+    await act(async () => root.unmount());
+  });
+
+  it('pauses creation and reports when the change is everywhere', async () => {
+    mocked.fetchCreationLimits.mockResolvedValue(limits());
+    mocked.setCreationLimits.mockResolvedValue(
+      limits({ stored: { paused: true }, effective: { paused: true, globalDailySubmissionCap: 50 } }),
+    );
+
+    const { container, root } = await render();
+    await act(async () => {
+      button(container, 'Pause creation').click();
+    });
+
+    expect(mocked.setCreationLimits).toHaveBeenCalledWith({ paused: true });
+    expect(container.querySelector('.health-summary')?.textContent).toContain('Creation is paused');
+    // The button flips to the way out, so an incident does not end with a paused site
+    // and no visible way to unpause it.
+    expect(button(container, 'Resume creation')).toBeTruthy();
+    expect(container.querySelector('.admin-limits-message')?.textContent).toContain('within 60s');
+
+    await act(async () => root.unmount());
+  });
+
+  it('clears a stored ceiling rather than freezing today’s number into it', async () => {
+    mocked.fetchCreationLimits.mockResolvedValue(limits({ stored: { globalDailySubmissionCap: 20 } }));
+    mocked.setCreationLimits.mockResolvedValue(limits());
+
+    const { container, root } = await render();
+    await act(async () => {
+      button(container, 'Use the deployed default').click();
+    });
+
+    expect(mocked.setCreationLimits).toHaveBeenCalledWith({ globalDailySubmissionCap: null });
+
+    await act(async () => root.unmount());
+  });
+
+  it('surfaces a refusal instead of pretending the change landed', async () => {
+    mocked.fetchCreationLimits.mockResolvedValue(limits());
+    mocked.setCreationLimits.mockResolvedValue({ error: 'nothing to change' });
+
+    const { container, root } = await render();
+    await act(async () => {
+      button(container, 'Pause creation').click();
+    });
+
+    expect(container.querySelector('.admin-limits-message')?.textContent).toBe('nothing to change');
+    expect(container.querySelector('.health-summary')?.textContent).toContain('Creation is open');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/CreationLimitsPanel.tsx
+++ b/apps/web/src/CreationLimitsPanel.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchCreationLimits, setCreationLimits, type CreationLimits } from './adminApi.js';
+
+/**
+ * The creation circuit-breaker, as something an operator can actually pull.
+ *
+ * The endpoint has existed since the breaker did; pulling it meant a curl command or an
+ * edit in the Firestore console. Both work, and neither is reachable from a phone at the
+ * moment somebody notices the site is minting builds it should not be — which is the only
+ * moment this feature is for.
+ *
+ * The panel reports **effective** state rather than what is stored: an unset ceiling is
+ * still a ceiling, and an operator deciding whether to pause needs the number actually in
+ * force, not the absence of a document.
+ */
+
+function relative(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 90) return `${seconds}s`;
+  return `${Math.round(seconds / 60)}m`;
+}
+
+export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
+  const [limits, setLimits] = useState<CreationLimits | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [capDraft, setCapDraft] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetchCreationLimits();
+      if (response === null) {
+        setState('forbidden');
+        return;
+      }
+      setLimits(response);
+      setCapDraft(String(response.effective.globalDailySubmissionCap));
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const apply = useCallback(
+    async (patch: { paused?: boolean; globalDailySubmissionCap?: number | null }) => {
+      setBusy(true);
+      setMessage(null);
+      try {
+        const result = await setCreationLimits(patch);
+        if ('error' in result) {
+          setMessage(result.error);
+          return;
+        }
+        setLimits(result);
+        setCapDraft(String(result.effective.globalDailySubmissionCap));
+        // The change lands in Firestore, and instances read it through a cache — so say
+        // when it will be everywhere rather than implying it already is.
+        setMessage(`in force everywhere within ${relative(result.propagationMs)}`);
+        onChanged?.();
+      } catch {
+        setMessage('could not reach the API');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [onChanged],
+  );
+
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+  if (state === 'loading') return <p className="health-empty">Reading the breaker…</p>;
+  if (state === 'error' || !limits) return <p className="health-empty">Could not read the breaker.</p>;
+
+  const { effective, stored, today } = limits;
+  const parsedCap = Number(capDraft);
+  const capValid = Number.isInteger(parsedCap) && parsedCap >= 0;
+
+  return (
+    <section className="admin-limits">
+      <h2 className="health-section-title">Creation limits</h2>
+      <p className="health-summary">
+        {effective.paused ? 'Creation is paused.' : 'Creation is open.'} {today.submissions} of{' '}
+        {effective.globalDailySubmissionCap} used today ({today.dateStr}).
+      </p>
+
+      <div className="admin-limits-controls">
+        <button
+          type="button"
+          className={effective.paused ? 'admin-limits-resume' : 'admin-limits-pause'}
+          disabled={busy}
+          onClick={() => void apply({ paused: !effective.paused })}
+        >
+          {effective.paused ? 'Resume creation' : 'Pause creation'}
+        </button>
+
+        <label className="admin-limits-cap">
+          Daily cap
+          <input
+            type="number"
+            min={0}
+            value={capDraft}
+            disabled={busy}
+            onChange={(event) => setCapDraft(event.target.value)}
+          />
+        </label>
+        <button
+          type="button"
+          disabled={busy || !capValid || parsedCap === effective.globalDailySubmissionCap}
+          onClick={() => void apply({ globalDailySubmissionCap: parsedCap })}
+        >
+          Set cap
+        </button>
+        {/* Clearing is a different intent from setting a number: it hands the decision
+            back to whatever the deployment's default is, rather than freezing today's
+            number into the config document forever. */}
+        <button
+          type="button"
+          disabled={busy || stored?.globalDailySubmissionCap === undefined || stored?.globalDailySubmissionCap === null}
+          onClick={() => void apply({ globalDailySubmissionCap: null })}
+        >
+          Use the deployed default
+        </button>
+      </div>
+
+      {message && <p className="admin-limits-message">{message}</p>}
+
+      <p className="health-note">
+        {stored
+          ? `Stored by ${stored.updatedBy ?? 'unknown'}${stored.updatedAt ? ` at ${stored.updatedAt}` : ''}.`
+          : 'Nothing stored — the deployed defaults are what is in force.'}{' '}
+        A change needs no redeploy and reaches every instance within {relative(limits.propagationMs)}.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/GameHealthView.tsx
+++ b/apps/web/src/GameHealthView.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AdminJobsPanel } from './AdminJobsPanel.js';
 import {
   fetchGameHealth,
   fetchVisitFunnel,
@@ -17,6 +16,9 @@ import { ScorecardPanel } from './ScorecardPanel.js';
 
 /**
  * Operator view over play telemetry (docs/improvement-loop-plan.md IL-2).
+ *
+ * The telemetry section of the console (see AdminConsole) — it was the whole operator
+ * page before there was a console, which is why `/health` still resolves to it.
  *
  * Deliberately not translated: this is a single-operator surface, not a product one,
  * and adding a dozen keys to every locale for a page no player can reach would cost
@@ -123,9 +125,9 @@ export function GameHealthView() {
   return (
     <section className="health">
       <header className="health-header">
-        {/* The page carries the queue and both telemetry streams, so the title names
-            what it is rather than any one of them. */}
-        <h1>Operator</h1>
+        {/* A section of the console now, not a page: the console owns the title, the
+            alerts and the queue, and this is the telemetry inside it. */}
+        <h2 className="health-section-title">Telemetry</h2>
         <div className="health-windows">
           {WINDOWS.map((window) => (
             <button
@@ -139,12 +141,6 @@ export function GameHealthView() {
           ))}
         </div>
       </header>
-
-      {/* First, because it is the only part of this page with something to *do*: a
-          build waiting on approval is the one thing here that goes stale by being
-          unread. Its own loading and permission states are handled inside, so a slow
-          telemetry read never delays the queue. */}
-      <AdminJobsPanel />
 
       {state === 'loading' && <p className="health-empty">Reading telemetry…</p>}
       {state === 'error' && <p className="health-empty">Could not read telemetry.</p>}

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -44,6 +44,7 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: { path: '/studio', ariaLabel: 'Back to Studio' },
             onUp,
           }),
@@ -81,6 +82,7 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -92,5 +94,110 @@ describe('NavHeader Up chevron', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+});
+
+// The console has been reachable only by typing its URL, which is why the one operator
+// surface with something to do on it was also the one nothing linked to.
+describe('NavHeader operator link', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  async function renderWith(summary: { status: number; body: unknown }) {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:boss', tier: 'free' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/admin/summary')) {
+        return new Response(JSON.stringify(summary.body), { status: summary.status });
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onAdmin = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin,
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The menu holds the link; open it the way a reader would.
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+    await act(async () => {
+      hamburger.click();
+      await Promise.resolve();
+    });
+    return { container, root, onAdmin };
+  }
+
+  it('offers the console, with what is waiting, to an operator', async () => {
+    const { container, root, onAdmin } = await renderWith({
+      status: 200,
+      body: {
+        alerts: [
+          {
+            id: 'op-1-review_ready',
+            kind: 'review_ready',
+            issueNumber: 1,
+            title: 'X',
+            ownerUid: 'g:1',
+            since: '2026-07-30T11:00:00Z',
+          },
+        ],
+        queue: { active: 1, stalled: 0, byState: {} },
+        limits: { paused: false, globalDailySubmissionCap: 50, todaySubmissions: 0 },
+      },
+    });
+
+    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
+      element.textContent?.includes('Operator'),
+    ) as HTMLButtonElement;
+    expect(link).toBeTruthy();
+    expect(link.querySelector('.specs-count-badge')?.textContent).toBe('1');
+
+    await act(async () => link.click());
+    expect(onAdmin).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows nobody else that there is a console at all', async () => {
+    // 404 is the API's answer to a signed-in non-admin, and the nav treats it as the
+    // whole answer: no link, no badge, nothing to notice.
+    const { container, root } = await renderWith({ status: 404, body: { error: 'not found' } });
+
+    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
+      element.textContent?.includes('Operator'),
+    );
+    expect(link).toBeUndefined();
+
+    await act(async () => root.unmount());
   });
 });

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -102,10 +102,13 @@ describe('NavHeader Up chevron', () => {
 describe('NavHeader operator link', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en');
+    // The badge polls; the tests that care about that advance the clock themselves.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
     document.body.innerHTML = '';
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -184,6 +187,25 @@ describe('NavHeader operator link', () => {
 
     await act(async () => link.click());
     expect(onAdmin).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('stops asking once it knows the answer is no', async () => {
+    // Whether someone is an operator does not change while they browse, and almost
+    // nobody is one. Left polling, every signed-in visitor would ask a question with a
+    // known answer every two minutes, forever, at one 404 apiece.
+    const { root } = await renderWith({ status: 404, body: { error: 'not found' } });
+    const summaryCalls = () =>
+      vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith('/api/admin/summary')).length;
+
+    expect(summaryCalls()).toBe(1);
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(summaryCalls()).toBe(1);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -63,15 +63,23 @@ export function NavHeader({
     const read = () =>
       fetchAdminSummary()
         .then((summary) => {
-          if (!cancelled) setAlertCount(summary ? summary.alerts.length : null);
+          if (cancelled) return;
+          setAlertCount(summary ? summary.alerts.length : null);
+          // Whether someone is an operator does not change while they browse, and
+          // almost nobody is one. Polling on regardless would have every signed-in
+          // visitor asking a question with a known answer, forever, at 404 apiece.
+          if (!summary) clearInterval(timer);
         })
         .catch(() => {
-          // A failed read is not evidence of anything; leave the link as it was.
+          // A failed read is not evidence of anything; leave the link as it was and
+          // keep the timer, since the next read may well succeed.
         });
-    void read();
     // Slower than the console's own poll: this is a badge somebody glances at, not a
-    // queue they are working, and it rides along on every page of the site.
+    // queue they are working, and it rides along on every page of the site. Started
+    // before the first read so that read can stop it — it only ever runs on a later
+    // microtask, so the binding is always initialized by then.
     const timer = setInterval(read, 120_000);
+    void read();
     return () => {
       cancelled = true;
       clearInterval(timer);

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
@@ -6,6 +6,7 @@ import { LanguageSwitcher } from './LanguageSwitcher.js';
 import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
+import { fetchAdminSummary } from './adminApi.js';
 import { usePageScrolling } from './usePageScrolling.js';
 import githubIcon from './assets/github-mark-white.svg';
 
@@ -17,6 +18,8 @@ type NavHeaderProps = {
   onHome: () => void;
   /** Opens the creator control panel. */
   onStudio: () => void;
+  /** Opens the operator console. Only ever called from a link only operators are shown. */
+  onAdmin: () => void;
   /**
    * Android-style Up target for non-home surfaces. Null on home, join, play, and
    * while an immersive theater owns escape. Never history.back() — deep links
@@ -26,13 +29,54 @@ type NavHeaderProps = {
   onUp?: (path: string) => void;
 };
 
-export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTarget = null, onUp }: NavHeaderProps) {
+export function NavHeader({
+  activeBuildCount,
+  onNavigate,
+  onHome,
+  onStudio,
+  onAdmin,
+  upTarget = null,
+  onUp,
+}: NavHeaderProps) {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Header mark mimes the visitor: pull a phone and scroll a tiny feed while the page moves.
   const pageScrolling = usePageScrolling();
+  /**
+   * How many jobs are waiting on this person, or null when they are not an operator —
+   * which is everyone. The console has been reachable only by knowing its URL, so the
+   * one surface with something to *do* on it was the one nothing linked to.
+   *
+   * The summary endpoint is the admission test: it answers 404 to everybody else, so a
+   * non-operator gets `null` and no link, and nothing here has to know why.
+   */
+  const [alertCount, setAlertCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setAlertCount(null);
+      return;
+    }
+    let cancelled = false;
+    const read = () =>
+      fetchAdminSummary()
+        .then((summary) => {
+          if (!cancelled) setAlertCount(summary ? summary.alerts.length : null);
+        })
+        .catch(() => {
+          // A failed read is not evidence of anything; leave the link as it was.
+        });
+    void read();
+    // Slower than the console's own poll: this is a badge somebody glances at, not a
+    // queue they are working, and it rides along on every page of the site.
+    const timer = setInterval(read, 120_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [user]);
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -148,6 +192,25 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
                   </span>
                 )}
               </button>
+
+              {/* Operators only — everyone else never learns this exists, which is the
+                  same posture the API takes when asked. */}
+              {alertCount !== null && (
+                <button
+                  className="nav-link"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    onAdmin();
+                  }}
+                >
+                  <PixelIcon name="wrench" size={14} /> Operator
+                  {alertCount > 0 && (
+                    <span className="specs-count-badge" aria-label={`${alertCount} waiting on you`}>
+                      {alertCount}
+                    </span>
+                  )}
+                </button>
+              )}
 
               {/* Controls that live in the header bar on a desktop but cannot fit
                   beside it on a phone. Hidden above the mobile breakpoint, where

--- a/apps/web/src/SuggestionsPanel.test.tsx
+++ b/apps/web/src/SuggestionsPanel.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SuggestionsPanel } from './SuggestionsPanel.js';
+import type { Suggestion } from './adminApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchAdminSummary: vi.fn(),
+  fetchCreationLimits: vi.fn(),
+  setCreationLimits: vi.fn(),
+  fetchSuggestions: vi.fn(),
+  fetchAccessTokens: vi.fn(),
+  mintAccessToken: vi.fn(),
+  revokeAccessToken: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+
+function suggestion(overrides: Partial<Suggestion> = {}): Suggestion {
+  return {
+    slug: 'comet-courier',
+    class: 'defect',
+    priority: 3.5,
+    evidence: [{ finding: 'One in three sessions ends in an uncaught error.', metrics: { errors: 12 } }],
+    untrustedContext: { errorSamples: [], progressLabels: [], feedbackThemes: [] },
+    computedFrom: '2026-07-30T02:00:00Z',
+    ...overrides,
+  };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(SuggestionsPanel));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('SuggestionsPanel', () => {
+  it('counts what is actionable, and shows the rest as context', async () => {
+    // A game the router passed over is still listed: silence has to be legible, or a
+    // router that stopped routing looks exactly like a catalog with no problems.
+    mocked.fetchSuggestions.mockResolvedValue({
+      suggestions: [
+        suggestion(),
+        suggestion({ slug: 'brick-storm', class: 'healthy' }),
+        suggestion({ slug: 'sky-dodge', class: 'insufficient-data' }),
+      ],
+      computedFrom: '2026-07-30T02:00:00Z',
+    });
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.health-summary')?.textContent).toBe('1 of 3 games have something to look at.');
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(3);
+
+    await act(async () => root.unmount());
+  });
+
+  it('carries player- and game-written text as text, beside the numbers', async () => {
+    mocked.fetchSuggestions.mockResolvedValue({
+      suggestions: [
+        suggestion({
+          untrustedContext: {
+            errorSamples: [{ message: 'TypeError: undefined is not a function', count: 4 }],
+            progressLabels: [],
+            feedbackThemes: [{ theme: 'too hard', count: 2 }],
+          },
+        }),
+      ],
+      computedFrom: '2026-07-30T02:00:00Z',
+    });
+
+    const { container, root } = await render();
+
+    const disclosure = container.querySelector('.health-disclosure');
+    expect(disclosure?.querySelector('summary')?.textContent).toBe('2');
+    expect(disclosure?.textContent).toContain('TypeError: undefined is not a function');
+    expect(disclosure?.textContent).toContain('too hard');
+
+    await act(async () => root.unmount());
+  });
+
+  it('says a stale answer is stale rather than letting it read as current', async () => {
+    mocked.fetchSuggestions.mockResolvedValue({ suggestions: [], computedFrom: null });
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.health-note')?.textContent).toContain('which has never run');
+
+    await act(async () => root.unmount());
+  });
+
+  it('tells a non-operator nothing', async () => {
+    mocked.fetchSuggestions.mockResolvedValue(null);
+
+    const { container, root } = await render();
+
+    expect(container.textContent).toBe('Not found.');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/SuggestionsPanel.tsx
+++ b/apps/web/src/SuggestionsPanel.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import { fetchSuggestions, type Suggestion, type SuggestionsResponse } from './adminApi.js';
+
+/**
+ * What the improvement router would say about every game it can see.
+ *
+ * Nothing here files, assigns or notifies — that is the point of looking at it. The
+ * router will eventually open work against people's games, and the honest order is to
+ * let an operator watch what it *would* do for a while first. This is the surface that
+ * makes "for a while" possible; until now the endpoint answered only to curl.
+ *
+ * The `untrustedContext` block is game- and player-written text. It is rendered as text
+ * and never interpolated anywhere else — which is exactly why it is worth showing beside
+ * the numbers rather than hidden: a human reading it is the safe consumer.
+ */
+
+const CLASS_COPY: Record<Suggestion['class'], string> = {
+  defect: 'defect',
+  friction: 'friction',
+  'design-change': 'design change',
+  healthy: 'healthy',
+  'insufficient-data': 'not enough data',
+};
+
+function SuggestionRow({ suggestion }: { suggestion: Suggestion }) {
+  const errors = suggestion.untrustedContext.errorSamples;
+  const themes = suggestion.untrustedContext.feedbackThemes;
+
+  return (
+    <tr>
+      <td className="health-slug">
+        <a href={`/play/${suggestion.slug}`}>{suggestion.slug}</a>
+      </td>
+      <td>
+        <span className={`admin-suggestion-class admin-suggestion-class--${suggestion.class}`}>
+          {CLASS_COPY[suggestion.class]}
+        </span>
+      </td>
+      <td>{Math.round(suggestion.priority * 100) / 100}</td>
+      <td>
+        {suggestion.evidence.length === 0 ? (
+          '—'
+        ) : (
+          <ul className="admin-suggestion-evidence">
+            {suggestion.evidence.map((item) => (
+              <li key={item.finding}>{item.finding}</li>
+            ))}
+          </ul>
+        )}
+      </td>
+      <td>
+        {errors.length === 0 && themes.length === 0 ? (
+          '—'
+        ) : (
+          <details className="health-disclosure">
+            <summary>{errors.length + themes.length}</summary>
+            <ul>
+              {errors.map((sample) => (
+                <li key={`e:${sample.message}`}>
+                  <span className="health-error-count">{sample.count}×</span> {sample.message}
+                </li>
+              ))}
+              {themes.map((theme) => (
+                <li key={`t:${theme.theme}`}>
+                  <span className="health-error-count">{theme.count}×</span> {theme.theme}
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export function SuggestionsPanel() {
+  const [data, setData] = useState<SuggestionsResponse | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSuggestions()
+      .then((response) => {
+        if (cancelled) return;
+        if (response === null) {
+          setState('forbidden');
+          return;
+        }
+        setData(response);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+  if (state === 'loading') return <p className="health-empty">Running the router…</p>;
+  if (state === 'error' || !data) return <p className="health-empty">Could not run the router.</p>;
+
+  const actionable = data.suggestions.filter(
+    (suggestion) => suggestion.class !== 'healthy' && suggestion.class !== 'insufficient-data',
+  );
+
+  return (
+    <section className="admin-suggestions">
+      <h2 className="health-section-title">Suggestions</h2>
+      <p className="health-summary">
+        {actionable.length} of {data.suggestions.length} games have something to look at.
+      </p>
+
+      {data.suggestions.length === 0 ? (
+        <p className="health-empty">The sweep has written nothing for the router to read yet.</p>
+      ) : (
+        <div className="health-table-scroll">
+          <table className="health-table">
+            <thead>
+              <tr>
+                <th>Game</th>
+                <th>Class</th>
+                <th>Priority</th>
+                <th>Evidence</th>
+                <th>From players</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.suggestions.map((suggestion) => (
+                <SuggestionRow key={suggestion.slug} suggestion={suggestion} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="health-note">
+        Computed on read and stored nowhere. Only as current as the nightly scorecard sweep behind it
+        {data.computedFrom ? ` (last computed ${data.computedFrom})` : ' (which has never run)'}. Nothing here has been
+        filed against any game.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -7,7 +7,7 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type OperatorAlertKind = 'review_ready' | 'build_failed' | 'build_stalled';
+export type OperatorAlertKind = 'review_ready' | 'build_failed' | 'build_stalled' | 'feedback_undelivered';
 
 export interface OperatorAlert {
   id: string;
@@ -98,6 +98,45 @@ export async function fetchSuggestions(): Promise<SuggestionsResponse | null> {
   if (res.status === 404 || res.status === 401) return null;
   if (!res.ok) throw new Error(`suggestions failed (${res.status})`);
   return (await res.json()) as SuggestionsResponse;
+}
+
+export interface JobCostSummary {
+  issueNumber: number;
+  title: string;
+  slug?: string;
+  state?: string;
+  sessions: number;
+  credits: number;
+  gateRuns: number;
+  tokens?: { input: number; output: number };
+  usd?: number;
+  elapsedMs: number;
+  published: boolean;
+  createdAt: string;
+}
+
+export interface CostReport {
+  jobs: JobCostSummary[];
+  totals: {
+    jobs: number;
+    sessions: number;
+    credits: number;
+    gateRuns: number;
+    published: number;
+    tokens?: { input: number; output: number };
+    usd?: number;
+  };
+  creditsPerPublishedGame: number | null;
+  medianTimeToPublishMs: number | null;
+  creditsOnUnpublished: number;
+  unmeasuredJobs: number;
+}
+
+export async function fetchCostReport(): Promise<CostReport | null> {
+  const res = await fetch(`${API_BASE}/api/admin/costs`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`cost report failed (${res.status})`);
+  return (await res.json()) as CostReport;
 }
 
 export interface AccessToken {

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -1,0 +1,150 @@
+// Client for the operator console's own reads and writes — the queue lives in
+// adminJobsApi, the telemetry in healthApi, and this covers the rest.
+//
+// Same posture as both of those: 404 means "not an admin" and comes back as `null`
+// rather than as an error, because the operator surface does not confirm its own
+// existence to someone who is not one.
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export type OperatorAlertKind = 'review_ready' | 'build_failed' | 'build_stalled';
+
+export interface OperatorAlert {
+  id: string;
+  kind: OperatorAlertKind;
+  issueNumber: number;
+  title: string;
+  ownerUid: string;
+  slug?: string;
+  since: string;
+  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started';
+}
+
+export interface AdminSummary {
+  alerts: OperatorAlert[];
+  queue: { active: number; stalled: number; byState: Record<string, number> };
+  limits: { paused: boolean; globalDailySubmissionCap: number; todaySubmissions: number };
+}
+
+/**
+ * The console's admission test as well as its header.
+ *
+ * Null is the whole answer for a non-operator: the nav draws no link, the page renders
+ * "not found", and neither has to know why.
+ */
+export async function fetchAdminSummary(): Promise<AdminSummary | null> {
+  const res = await fetch(`${API_BASE}/api/admin/summary`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`admin summary failed (${res.status})`);
+  return (await res.json()) as AdminSummary;
+}
+
+export interface CreationLimits {
+  stored: { paused?: boolean; globalDailySubmissionCap?: number | null; updatedAt?: string; updatedBy?: string } | null;
+  effective: { paused: boolean; globalDailySubmissionCap: number };
+  today: { dateStr: string; submissions: number };
+  propagationMs: number;
+}
+
+export async function fetchCreationLimits(): Promise<CreationLimits | null> {
+  const res = await fetch(`${API_BASE}/api/admin/creation-limits`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`creation limits failed (${res.status})`);
+  return (await res.json()) as CreationLimits;
+}
+
+/**
+ * Pulls or resets the breaker. Returns the state that is now in force, so the panel
+ * renders what the server agreed to rather than what the click asked for.
+ *
+ * `globalDailySubmissionCap: null` clears the stored ceiling — a different intent from
+ * setting a number, and the API distinguishes them.
+ */
+export async function setCreationLimits(patch: {
+  paused?: boolean;
+  globalDailySubmissionCap?: number | null;
+}): Promise<CreationLimits | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/creation-limits`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (res.ok) return (await res.json()) as CreationLimits;
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
+}
+
+export interface Suggestion {
+  slug: string;
+  class: 'defect' | 'friction' | 'design-change' | 'healthy' | 'insufficient-data';
+  priority: number;
+  evidence: Array<{ finding: string; metrics: Record<string, number | null> }>;
+  untrustedContext: {
+    errorSamples: Array<{ message: string; count: number }>;
+    progressLabels: Array<{ label: string; sessions: number }>;
+    feedbackThemes: Array<{ theme: string; count: number }>;
+  };
+  computedFrom: string;
+}
+
+export interface SuggestionsResponse {
+  suggestions: Suggestion[];
+  computedFrom: string | null;
+}
+
+export async function fetchSuggestions(): Promise<SuggestionsResponse | null> {
+  const res = await fetch(`${API_BASE}/api/admin/suggestions`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`suggestions failed (${res.status})`);
+  return (await res.json()) as SuggestionsResponse;
+}
+
+export interface AccessToken {
+  tokenId: string;
+  uid: string;
+  name: string;
+  createdAt: string;
+  createdByUid: string;
+  expiresAt: string;
+  lastUsedAt: string | null;
+  expired: boolean;
+}
+
+/** Tokens are listed per account — there is no "every token on the site" read. */
+export async function fetchAccessTokens(uid: string): Promise<AccessToken[] | null> {
+  const res = await fetch(`${API_BASE}/api/admin/access-tokens?uid=${encodeURIComponent(uid)}`, {
+    credentials: 'include',
+  });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`access tokens failed (${res.status})`);
+  return ((await res.json()) as { tokens: AccessToken[] }).tokens;
+}
+
+/**
+ * Mints a token. The secret comes back exactly once — it is not stored anywhere it
+ * could be read again, which is why the panel makes a point of saying so.
+ */
+export async function mintAccessToken(input: {
+  uid: string;
+  name: string;
+  expiresInDays?: number;
+}): Promise<(AccessToken & { token: string; accountCreated?: boolean }) | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/access-tokens`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (res.ok) return (await res.json()) as AccessToken & { token: string; accountCreated?: boolean };
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
+}
+
+export async function revokeAccessToken(tokenId: string): Promise<{ ok: boolean }> {
+  const res = await fetch(`${API_BASE}/api/admin/access-tokens/${encodeURIComponent(tokenId)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  return { ok: res.ok };
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -46,6 +46,10 @@
       "build_stalled": {
         "title": "A build has stopped moving",
         "body": "“{{title}}” has gone quiet ({{detail}})."
+      },
+      "feedback_undelivered": {
+        "title": "A change request is not reaching the agent",
+        "body": "“{{title}}” has a change request nobody has collected."
       }
     }
   },

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -33,6 +33,20 @@
     "prefs": {
       "digestOn": "Weekly summary on",
       "digestOff": "Weekly summary off"
+    },
+    "operator": {
+      "review_ready": {
+        "title": "A build is waiting to be published",
+        "body": "“{{title}}” passed the gate."
+      },
+      "build_failed": {
+        "title": "A build failed",
+        "body": "“{{title}}” ended without delivering."
+      },
+      "build_stalled": {
+        "title": "A build has stopped moving",
+        "body": "“{{title}}” has gone quiet ({{detail}})."
+      }
     }
   },
   "header": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -33,6 +33,20 @@
     "prefs": {
       "digestOn": "Cotygodniowe podsumowanie włączone",
       "digestOff": "Cotygodniowe podsumowanie wyłączone"
+    },
+    "operator": {
+      "review_ready": {
+        "title": "Build czeka na publikację",
+        "body": "„{{title}}” przeszedł kontrolę."
+      },
+      "build_failed": {
+        "title": "Build się nie powiódł",
+        "body": "„{{title}}” zakończył się bez dostarczenia gry."
+      },
+      "build_stalled": {
+        "title": "Build stanął w miejscu",
+        "body": "„{{title}}” milczy ({{detail}})."
+      }
     }
   },
   "header": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -46,6 +46,10 @@
       "build_stalled": {
         "title": "Build stanął w miejscu",
         "body": "„{{title}}” milczy ({{detail}})."
+      },
+      "feedback_undelivered": {
+        "title": "Prośba o zmianę nie dociera do agenta",
+        "body": "„{{title}}” ma prośbę o zmianę, której nikt nie odebrał."
       }
     }
   },

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -83,7 +83,7 @@ describe('resolveDocumentTitle', () => {
     expect(resolveDocumentTitle({ view: 'join', code: 'K7M3QP', token: 't' }, { copy })).toBe(
       'Join the game — Gamedev.pl',
     );
-    expect(resolveDocumentTitle({ view: 'health' }, { copy })).toBe('Telemetry — Gamedev.pl');
+    expect(resolveDocumentTitle({ view: 'admin', section: 'queue' }, { copy })).toBe('Telemetry — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'legal', doc: 'privacy' }, { copy })).toBe('Privacy Policy — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'legal', doc: 'terms' }, { copy })).toBe('Terms of Service — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'contact' }, { copy })).toBe('Contact — Gamedev.pl');

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -70,7 +70,7 @@ export function resolveDocumentTitle(route: AppRoute, ctx: DocumentTitleContext)
         : brandedPageTitle(ctx.copy.draft);
     case 'join':
       return brandedPageTitle(ctx.copy.join);
-    case 'health':
+    case 'admin':
       return brandedPageTitle(ctx.copy.health);
     case 'studio':
       return ctx.studioTitle?.trim()

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -69,6 +69,15 @@ describe('parsePathRoute', () => {
     expect(parsePathRoute('/join/K7M3QP/abc-DEF_123')).toEqual({ view: 'notFound' });
   });
 
+  it('survives malformed percent-encoding on every segment it decodes', () => {
+    // `decodeURIComponent('%E0')` throws. Each of these used to take the SPA with it.
+    expect(parsePathRoute('/play/%E0')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/draft/%E0')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/status/%E0')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/studio/%E0')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/studio/tok/%E0')).toEqual({ view: 'notFound' });
+  });
+
   it('parses the unlisted operator console, and keeps its old address working', () => {
     expect(parsePathRoute('/admin')).toEqual({ view: 'admin', section: 'queue' });
     expect(parsePathRoute('/admin/telemetry')).toEqual({ view: 'admin', section: 'telemetry' });
@@ -77,6 +86,9 @@ describe('parsePathRoute', () => {
     expect(parsePathRoute('/health')).toEqual({ view: 'admin', section: 'telemetry' });
     // A section that does not exist is a typo, and says so.
     expect(parsePathRoute('/admin/nope')).toEqual({ view: 'notFound' });
+    // Malformed percent-encoding is a 404, not a URIError: route parsing runs on every
+    // navigation, and a throw there takes the whole app down.
+    expect(parsePathRoute('/admin/%E0')).toEqual({ view: 'notFound' });
     expect(parsePathRoute('/health/brick-storm')).toEqual({ view: 'notFound' });
   });
 

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -69,9 +69,14 @@ describe('parsePathRoute', () => {
     expect(parsePathRoute('/join/K7M3QP/abc-DEF_123')).toEqual({ view: 'notFound' });
   });
 
-  it('parses the unlisted health route', () => {
-    expect(parsePathRoute('/health')).toEqual({ view: 'health' });
-    // Trailing segments are not the health view.
+  it('parses the unlisted operator console, and keeps its old address working', () => {
+    expect(parsePathRoute('/admin')).toEqual({ view: 'admin', section: 'queue' });
+    expect(parsePathRoute('/admin/telemetry')).toEqual({ view: 'admin', section: 'telemetry' });
+    // `/health` was the whole operator page before the console existed, and is what is
+    // in the operator's bookmarks — it resolves to the section it used to be.
+    expect(parsePathRoute('/health')).toEqual({ view: 'admin', section: 'telemetry' });
+    // A section that does not exist is a typo, and says so.
+    expect(parsePathRoute('/admin/nope')).toEqual({ view: 'notFound' });
     expect(parsePathRoute('/health/brick-storm')).toEqual({ view: 'notFound' });
   });
 
@@ -206,7 +211,7 @@ describe('navUpTarget', () => {
   });
 
   it('sends browsable non-studio surfaces home', () => {
-    expect(navUpTarget({ view: 'health' })).toEqual({ path: '/', labelKey: 'upHome' });
+    expect(navUpTarget({ view: 'admin', section: 'queue' })).toEqual({ path: '/', labelKey: 'upHome' });
     expect(navUpTarget({ view: 'legal', doc: 'privacy' })).toEqual({ path: '/', labelKey: 'upHome' });
     expect(navUpTarget({ view: 'contact' })).toEqual({ path: '/', labelKey: 'upHome' });
     expect(navUpTarget({ view: 'notFound' })).toEqual({ path: '/', labelKey: 'upHome' });

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canonicalPath,
   canonicalPlayPath,
   draftPath,
   joinPath,
@@ -152,6 +153,29 @@ describe('path builders', () => {
     expect(canonicalPlayPath('/play/sky-dodge')).toBeNull();
     expect(canonicalPlayPath('/draft/sky-dodge')).toBeNull();
     expect(canonicalPlayPath('/')).toBeNull();
+  });
+
+  it('sends every old address to the one that replaced it', () => {
+    // The aliases keep resolving — bookmarks, old emails, notifications sent months
+    // ago — but the bar is put back on the current address so a copied URL survives.
+    expect(canonicalPath('/ay/sky-dodge')).toBe('/play/sky-dodge');
+    expect(canonicalPath('/ai/sky-dodge')).toBe('/play/sky-dodge');
+    expect(canonicalPath('/health')).toBe('/admin/telemetry');
+    expect(canonicalPath('/status/tok-abc')).toBe('/studio/tok-abc');
+    // A bare /admin names no section; the queue is what it shows, so that is what it says.
+    expect(canonicalPath('/admin')).toBe('/admin/queue');
+  });
+
+  it('leaves an address that is already current alone', () => {
+    // Returning a path here would mean a replaceState on every navigation.
+    expect(canonicalPath('/play/sky-dodge')).toBeNull();
+    expect(canonicalPath('/admin/telemetry')).toBeNull();
+    expect(canonicalPath('/studio/tok-abc')).toBeNull();
+    expect(canonicalPath('/studio/tok-abc/build')).toBeNull();
+    expect(canonicalPath('/studio')).toBeNull();
+    expect(canonicalPath('/draft/sky-dodge')).toBeNull();
+    expect(canonicalPath('/')).toBeNull();
+    expect(canonicalPath('/nonsense')).toBeNull();
   });
 
   it('builds a draft path that round-trips', () => {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -67,6 +67,24 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
 
 /**
+ * Percent-decode one path segment, or null when it is not decodable.
+ *
+ * `decodeURIComponent` throws on malformed encoding — `/play/%E0` is a URIError, not a
+ * bad slug — and a throw here takes the whole app down on a route parse, which is the
+ * one function in the client that must never fail. A segment that cannot be decoded is
+ * a segment that cannot match anything, so null flows into the same `notFound` every
+ * other unrecognised path takes. The API's shell allowlist has always guarded these the
+ * same way (see spa-paths.ts); the client simply did not.
+ */
+function decodeSegment(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Parse the SPA route from pathname (+ optional hash for the join credential).
  * Unknown / invalid paths become `notFound` (not home) so the URL stays visible.
  */
@@ -94,21 +112,22 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
   if (statusMatch?.[1]) {
     // Legacy status URLs land in Creator Studio — the draft Build tab is the
     // former status / "dev studio" page, now unified with playtest + improve.
-    return { view: 'studio', token: decodeURIComponent(statusMatch[1]) };
+    const token = decodeSegment(statusMatch[1]);
+    if (token) return { view: 'studio', token };
   }
 
   const playMatch = normalizedPath.match(PLAY_PREFIX_PATTERN);
   if (playMatch?.[2]) {
-    const slug = decodeURIComponent(playMatch[2]);
-    if (SLUG_PATTERN.test(slug)) {
+    const slug = decodeSegment(playMatch[2]);
+    if (slug && SLUG_PATTERN.test(slug)) {
       return { view: 'play', slug };
     }
   }
 
   const draftMatch = normalizedPath.match(/^\/draft\/([^/]+)$/);
   if (draftMatch?.[1]) {
-    const slug = decodeURIComponent(draftMatch[1]);
-    if (SLUG_PATTERN.test(slug)) {
+    const slug = decodeSegment(draftMatch[1]);
+    if (slug && SLUG_PATTERN.test(slug)) {
       return { view: 'draft', slug };
     }
   }
@@ -124,7 +143,9 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
 
   const adminMatch = normalizedPath.match(/^\/admin\/([^/]+)$/);
   if (adminMatch?.[1]) {
-    const section = decodeURIComponent(adminMatch[1]);
+    // Matched raw rather than decoded: every section name is fixed lowercase ASCII, so
+    // an encoded one is not a section by definition and there is nothing to decode.
+    const section = adminMatch[1];
     // An unknown section is a 404 rather than a silent fall back to the queue — same
     // rule as the studio tabs, and for the same reason: a typo should be visible.
     if (isAdminSection(section)) {
@@ -142,8 +163,11 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
   // client in step with the API's shell allowlist, which serves those paths a real 404.
   const studioMatch = normalizedPath.match(/^\/studio\/([^/]+)(?:\/([^/]+))?$/);
   if (studioMatch?.[1]) {
-    const token = decodeURIComponent(studioMatch[1]);
-    const tabSegment = studioMatch[2] ? decodeURIComponent(studioMatch[2]) : undefined;
+    const token = decodeSegment(studioMatch[1]);
+    const tabSegment = studioMatch[2] ? decodeSegment(studioMatch[2]) : undefined;
+    if (token === null || tabSegment === null) {
+      return { view: 'notFound' };
+    }
     if (!tabSegment) {
       return { view: 'studio', token };
     }

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -10,6 +10,20 @@ export function isStudioTab(value: string): value is StudioTab {
   return STUDIO_TABS.has(value as StudioTab);
 }
 
+/**
+ * Operator console sections, in the order they are offered.
+ *
+ * `queue` leads because it is the only one with something to do in it; the rest are
+ * things to look at. In the URL so a refresh, a bookmark, or the link in an alert
+ * notification lands on the section it meant rather than on whichever one is first.
+ */
+export const ADMIN_SECTIONS = ['queue', 'telemetry', 'limits', 'tokens', 'suggestions'] as const;
+export type AdminSection = (typeof ADMIN_SECTIONS)[number];
+
+export function isAdminSection(value: string): value is AdminSection {
+  return (ADMIN_SECTIONS as readonly string[]).includes(value);
+}
+
 export type AppRoute =
   | { view: 'home' }
   // A published game being played. The slug is a stable permalink, so refreshing
@@ -25,10 +39,11 @@ export type AppRoute =
   // token rides in the fragment so it never hits access logs or Referer
   // (see docs/path-routing-plan.md § Join, docs/multiplayer-plan.md §4.3).
   | { view: 'join'; code: string; token: string }
-  // The operator telemetry view. Unlisted rather than secret: reaching the route
-  // renders nothing unless the API recognises the caller as an admin, and the API
-  // answers 404 to everyone else.
-  | { view: 'health' }
+  // The operator console. Unlisted rather than secret: reaching the route renders
+  // nothing unless the API recognises the caller as an admin, and the API answers 404
+  // to everyone else. `/health` still resolves here (telemetry) — it was the whole
+  // surface before there was a console, and links to it are in people's bookmarks.
+  | { view: 'admin'; section: AdminSection }
   // Creator control panel: own games, draft build (ex-status), playtest, improve.
   // `/status/:token` is accepted as an alias and resolves here too.
   // Optional `tab` deep-links into a work surface (`/studio/:token/build`).
@@ -98,8 +113,24 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     }
   }
 
+  // The console's old address, kept working: it is what the operator has bookmarked.
   if (normalizedPath === '/health') {
-    return { view: 'health' };
+    return { view: 'admin', section: 'telemetry' };
+  }
+
+  if (normalizedPath === '/admin') {
+    return { view: 'admin', section: 'queue' };
+  }
+
+  const adminMatch = normalizedPath.match(/^\/admin\/([^/]+)$/);
+  if (adminMatch?.[1]) {
+    const section = decodeURIComponent(adminMatch[1]);
+    // An unknown section is a 404 rather than a silent fall back to the queue — same
+    // rule as the studio tabs, and for the same reason: a typo should be visible.
+    if (isAdminSection(section)) {
+      return { view: 'admin', section };
+    }
+    return { view: 'notFound' };
   }
 
   if (normalizedPath === '/studio') {
@@ -200,12 +231,17 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
         return { path: studioPath(), labelKey: 'upStudio' };
       }
       return { path: '/', labelKey: 'upHome' };
-    case 'health':
+    case 'admin':
     case 'legal':
     case 'contact':
     case 'notFound':
       return { path: '/', labelKey: 'upHome' };
   }
+}
+
+/** Path for an operator console section. Used by the tabs and by alert deep links. */
+export function adminPath(section: AdminSection = 'queue'): string {
+  return `/admin/${section}`;
 }
 
 /** QR / share URL path+fragment for a multiplayer lobby guest. */

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -17,7 +17,7 @@ export function isStudioTab(value: string): value is StudioTab {
  * things to look at. In the URL so a refresh, a bookmark, or the link in an alert
  * notification lands on the section it meant rather than on whichever one is first.
  */
-export const ADMIN_SECTIONS = ['queue', 'telemetry', 'limits', 'tokens', 'suggestions'] as const;
+export const ADMIN_SECTIONS = ['queue', 'costs', 'telemetry', 'limits', 'tokens', 'suggestions'] as const;
 export type AdminSection = (typeof ADMIN_SECTIONS)[number];
 
 export function isAdminSection(value: string): value is AdminSection {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -197,8 +197,46 @@ export function playPath(slug: string): string {
 }
 
 /**
- * If pathname is a play alias (`/ay/…` or `/ai/…`), return the canonical `/play/…`
- * path to rewrite to. Otherwise null (already canonical, or not a play route).
+ * The current address for a path that has more than one, or null when the path given is
+ * already it.
+ *
+ * Aliases accumulate as surfaces move. `/ay` and `/ai` are short forms of `/play`;
+ * `/status/:token` is where the build page lived before Creator Studio absorbed it;
+ * `/health` is where the operator console lived before it had sections. Every one of
+ * them still resolves, and that is not negotiable — links live in bookmarks, in old
+ * emails, in notifications sent months ago, and breaking them to tidy a route table
+ * would be a strange kind of housekeeping.
+ *
+ * What this adds is the second half: the browser is put back on the current address, so
+ * a URL copied out of the bar is one that will still make sense next year, and a page
+ * someone reports as broken names something that still exists. The rewrite is a
+ * `replaceState`, so the alias does not become a history entry to go Back through.
+ */
+export function canonicalPath(pathname: string): string | null {
+  const route = parsePathRoute(pathname);
+  const canonical = ((): string | null => {
+    switch (route.view) {
+      case 'play':
+        return playPath(route.slug);
+      // Including a bare `/admin`, which lands on the queue: the section a page is
+      // showing belongs in the URL, or a refresh is a different page than a reload.
+      case 'admin':
+        return adminPath(route.section);
+      // Only the token form. `/studio` itself is canonical, and a tab is added by the
+      // view once it knows which game it is showing rather than here.
+      case 'studio':
+        return route.token ? studioPath(route.token, route.tab) : null;
+      default:
+        return null;
+    }
+  })();
+  return canonical && canonical !== pathname ? canonical : null;
+}
+
+/**
+ * @deprecated Prefer {@link canonicalPath}, which covers every alias rather than only
+ * the play prefixes. Kept as its own export because the play aliases are the pair most
+ * likely to be reached for by name.
  */
 export function canonicalPlayPath(pathname: string): string | null {
   const route = parsePathRoute(pathname);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7316,7 +7316,8 @@ body.player-open {
 }
 
 .admin-alert--build_failed,
-.admin-alert--build_stalled {
+.admin-alert--build_stalled,
+.admin-alert--feedback_undelivered {
   border-left-color: var(--danger, #c0392b);
 }
 
@@ -7419,4 +7420,31 @@ body.player-open {
   margin: 0;
   padding-left: 1rem;
   font-size: 0.8rem;
+}
+
+/* Cost. The headline numbers read as a row of facts rather than a dashboard: there are
+   four of them, they are the ones that answer "what does a game cost", and a chart would
+   be decoration over a table that is already short. */
+.admin-cost-headline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.admin-cost-headline dt {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.admin-cost-headline dd {
+  margin: 0.15rem 0 0;
+  font-size: 1.35rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Dimmed, not hidden: a build that never shipped is still money, and its row is how the
+   headline "credits on builds that never shipped" is checkable. */
+.admin-cost-row.is-unpublished {
+  opacity: 0.7;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7240,3 +7240,183 @@ body.player-open {
   opacity: 0.8;
   max-width: 22rem;
 }
+
+/* Operator console shell. The panels inside it borrow the telemetry table styles for
+   the same reason the queue does — one table idiom, one reader — so what is defined
+   here is only the chrome that holds them together. */
+.admin-console-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.admin-console-counts {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+
+.admin-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.admin-tab {
+  cursor: pointer;
+  padding: 0.3rem 0.75rem;
+  font: inherit;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  background: transparent;
+  color: inherit;
+}
+
+.admin-tab.is-active {
+  background: color-mix(in srgb, currentColor 15%, transparent);
+  border-color: currentColor;
+}
+
+.admin-tab-badge {
+  margin-left: 0.35rem;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+}
+
+/* What is waiting on the reader, shown above every section. Colour carries no meaning
+   on its own here — each row says in words what kind of alert it is. */
+.admin-alerts {
+  list-style: none;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.admin-alerts--clear {
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+
+.admin-alert {
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  border-left: 3px solid color-mix(in srgb, currentColor 40%, transparent);
+}
+
+.admin-alert--review_ready {
+  border-left-color: var(--success, #2e8b57);
+}
+
+.admin-alert--build_failed,
+.admin-alert--build_stalled {
+  border-left-color: var(--danger, #c0392b);
+}
+
+.admin-alert-title {
+  font-weight: 600;
+}
+
+.admin-alert-age {
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+
+.admin-limits-controls,
+.admin-tokens-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin: 0.75rem 0;
+}
+
+.admin-limits-controls button,
+.admin-tokens-form button,
+.admin-tokens button {
+  cursor: pointer;
+  padding: 0.3rem 0.7rem;
+  font: inherit;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+}
+
+.admin-limits-controls button:disabled,
+.admin-tokens-form button:disabled,
+.admin-tokens button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Pausing creation is the one destructive control on this page; it looks like it. */
+.admin-limits-pause {
+  color: var(--danger, #c0392b);
+}
+
+.admin-limits-cap,
+.admin-tokens-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+  opacity: 0.8;
+}
+
+.admin-limits-cap input,
+.admin-tokens-form input {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.4rem;
+  width: 9rem;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  background: transparent;
+  color: inherit;
+}
+
+.admin-limits-message {
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
+/* Shown once and never again — it wraps rather than truncating, because a token cut
+   off at the edge of the column is a token somebody copies wrong. */
+.admin-token-secret code {
+  display: block;
+  margin-top: 0.3rem;
+  padding: 0.4rem;
+  word-break: break-all;
+  font-size: 0.8rem;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  border-radius: 4px;
+}
+
+.admin-token-row.is-expired {
+  opacity: 0.55;
+}
+
+.admin-suggestion-class {
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.admin-suggestion-class--defect {
+  color: var(--danger, #c0392b);
+}
+
+.admin-suggestion-evidence {
+  margin: 0;
+  padding-left: 1rem;
+  font-size: 0.8rem;
+}

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -163,10 +163,13 @@ export function routeKind(view: string): VisitRouteKind {
     case 'draft':
     case 'join':
     case 'legal':
-    case 'health':
     case 'studio':
     case 'notFound':
       return view;
+    // The console reports as `health`, the name it had when the funnel started
+    // recording it. Renaming the bucket would split one surface's history in two.
+    case 'admin':
+      return 'health';
     // Contact shares the public-chrome posture of legal pages (reachable without a
     // session, outside the creator funnel). Folding it into `legal` keeps the
     // visit vocabulary stable without inventing a new funnel bucket for a form.


### PR DESCRIPTION
Two things, in that order: somewhere to do the work, and a reason to know there is work.

## The console

There were five operator surfaces and one page. The queue and the telemetry shared `/health`; the creation breaker, the access tokens and the suggestion router had no UI at all — they were endpoints reached with curl, which in practice meant they were endpoints nobody reached.

`/admin` is now the door, one section each, addressed in the URL so a refresh or a link lands where it meant:

| Section | What it is | Was |
| --- | --- | --- |
| Queue | build queue + publish | on `/health` |
| Telemetry | play health, funnel, creators, scorecards | on `/health` |
| Limits | pause creation, set or clear the daily cap | curl only |
| Tokens | mint and **revoke** access tokens | CLI / curl only |
| Suggestions | what the improvement router would say | curl only |

`/health` still resolves — to the telemetry section it used to be. It is what is in the bookmarks, and breaking it to tidy a route would be a strange first act for a page about being easier to reach.

Two of the new panels do things rather than show them. The breaker can be pulled from a phone, which is the only situation it exists for, and it reports what is **in force** rather than what is stored — an unset ceiling is still a ceiling. Tokens can be revoked from a page; a credential you can only cancel from a laptop is one you have to be lucky with.

The nav links to it, for operators only: the summary endpoint answers 404 to everyone else, so a non-operator gets no link and never learns there is one.

## The notifications

One definition of "this wants a person" (`operator-alerts.ts`), read by both the console and the notification sweep — a badge and an inbox that disagree teach you to trust neither. Three kinds, deliberately few:

- **waiting to be published** — gate green, the one decision only a human makes
- **failed** — the round ended with nothing delivered
- **stopped moving** — nothing has happened for longer than the state allows

A build that is merely slow is not an alert. That is the property the whole channel depends on.

The sweep raises them rather than each transition writing its own, because a stall is time passing and there is no moment anybody could have written it. Idempotent per job and kind, so running every two minutes notifies once. They land in the bell, in email, and in Web Push if it is enabled — reusing the fan-out that already exists.

Operator mail does **not** go through the creator email path. That path skips a send when someone has unsubscribed, and an alert is not a subscription: a pager silenced eighteen months ago by clicking "unsubscribe" on a build notification would fail exactly when it mattered and say nothing about why. Recipients come from `ADMIN_UIDS` — the same allowlist the console is gated on, so the people who can see the queue are the people its alerts are addressed to.

## New API

- `GET /api/admin/summary` — alerts, queue counts, breaker, in one cheap read. Doubles as the client's admission test, which is why the nav can finally decide whether to draw a link instead of rendering a page that answers "not found".

## Notes

- `resolveJobState` moved into `job-state.ts`; the queue builder's private copy is gone.
- `SubmissionNotificationType` is now `Extract<…, 'submission.…'>` rather than `Exclude<…, 'creator.digest'>`, so adding an operator type does not silently widen it.
- The console is untranslated, like the telemetry view it absorbs. The bell is not — its keys are in both locales.

## Tests

1317 API (+30), 615 web (+19). Both suites, lint and the build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9)_