### PR TITLE
Ask the session who is an operator, instead of asking a 404

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -172,6 +172,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     privateBeta,
     betaAllowedUids,
     betaAllowedEmails,
+    // So the session can tell the client whether to offer the operator console. Not
+    // authorization — every operator route still checks this same set itself.
+    adminUids,
   });
 
   await registerSubmissionRoutes(app, {

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -65,6 +65,7 @@ describe('Auth API Routes', () => {
 
   const setupTestServer = async (
     mockUsers: Record<string, { sub: string; email?: string; name?: string; picture?: string }> = {},
+    adminUids?: Set<string>,
   ) => {
     const store = new InMemoryStore();
     const verifier = new MockGoogleVerifier(mockUsers);
@@ -74,6 +75,7 @@ describe('Auth API Routes', () => {
       store,
       sessionSecret: 'test-secret-key',
       googleAuthVerifier: verifier,
+      ...(adminUids ? { adminUids } : {}),
     });
 
     return { app, store };
@@ -174,6 +176,41 @@ describe('Auth API Routes', () => {
 
     expect(meRes.statusCode).toBe(200);
     expect(JSON.parse(meRes.body).user.uid).toBe('g:10002');
+  });
+
+  it('tells an operator’s session that it is one, and says nothing to anyone else', async () => {
+    // The client draws the console link from this rather than from probing an operator
+    // endpoint and reading its 404 as "no" — that probe put an error in every
+    // non-operator's console on every page load.
+    const { app } = await setupTestServer({ 'boss-token': { sub: '10003' } }, new Set(['g:10003']));
+
+    const bossLogin = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'boss-token' },
+    });
+    expect(JSON.parse(bossLogin.body).user.admin).toBe(true);
+
+    const meRes = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { cookie: (bossLogin.headers['set-cookie'] as string).split(';')[0]! },
+    });
+    expect(JSON.parse(meRes.body).user.admin).toBe(true);
+  });
+
+  it('leaves the flag off a session that is not an operator’s', async () => {
+    // Absent rather than false: a client that has never heard of the flag is
+    // unaffected, and nothing can read `admin: false` as a claim about anything else.
+    const { app } = await setupTestServer({ 'player-token': { sub: '10004' } }, new Set(['g:10003']));
+
+    const login = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'player-token' },
+    });
+
+    expect(JSON.parse(login.body).user).not.toHaveProperty('admin');
   });
 
   it('POST /api/auth/logout clears session cookie', async () => {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
 import { isAccessTokenExpired, looksLikeAccessToken, parseAccessToken, verifyTokenSecret } from './access-token.js';
+import { isAdmin, isAdminSession } from './admin.js';
 import { resolveAppleAccount } from './apple-account.js';
 import { createAppleAuthVerifierFromEnv, parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
 import { readBearerToken } from './bearer.js';
@@ -199,6 +200,16 @@ export interface AuthPluginOptions {
   privateBeta?: boolean;
   betaAllowedUids?: Set<string>;
   betaAllowedEmails?: Set<string>;
+  /**
+   * Operators, so the session can say so.
+   *
+   * Nothing here is authorization — every operator route re-checks the same allowlist
+   * itself. This is only how the *client* learns whether to draw a door it is allowed
+   * through, and it exists because the alternative was probing an operator endpoint on
+   * every page load and reading its 404 as "no": one console error per visit for
+   * everybody who is not an operator, which is most people.
+   */
+  adminUids?: Set<string>;
 }
 
 const GoogleAuthSchema = z.object({
@@ -254,6 +265,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
   const isAuthConfigured = Boolean(sessionSecret && (googleClientId || options.googleAuthVerifier)) || !isProd;
 
   const effectiveSessionSecret = sessionSecret ?? 'dev-session-secret-change-me';
+  const adminUids = options.adminUids;
   const sessionSecretPrev = options.sessionSecretPrev ?? process.env.SESSION_SECRET_PREV;
 
   const verifier = options.googleAuthVerifier ?? new DefaultGoogleAuthVerifier(googleClientId);
@@ -475,7 +487,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
           maxAge: DEFAULT_SESSION_DURATION_SECONDS,
         });
 
-        return { user };
+        return sessionPayload(user, isAdmin(user.uid, adminUids));
       } catch (err) {
         const message = err instanceof Error ? err.message : 'google token verification failed';
         return reply.status(401).send({ error: message });
@@ -570,7 +582,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
           maxAge: DEFAULT_SESSION_DURATION_SECONDS,
         });
 
-        return { user };
+        return sessionPayload(user, isAdmin(user.uid, adminUids));
       } catch (err) {
         const message = err instanceof Error ? err.message : 'apple token verification failed';
         return reply.status(401).send({ error: message });
@@ -757,7 +769,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
       maxAge: DEFAULT_SESSION_DURATION_SECONDS,
     });
 
-    return { user };
+    return sessionPayload(user, isAdmin(user.uid, adminUids));
   });
 
   app.post('/api/auth/logout', async (_request, reply) => {
@@ -775,8 +787,22 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     if (request.user.tier === 'blocked') {
       return reply.status(403).send({ error: 'account is blocked' });
     }
-    return { user: request.user };
+    // `isAdminSession`, not `isAdmin`: a request authenticated with a personal access
+    // token acts as its user but is never treated as an operator, and the flag the client
+    // draws its door from must not disagree with the routes behind that door.
+    return sessionPayload(request.user, isAdminSession(request, adminUids));
   });
+}
+
+/**
+ * The session as the client is told it. Adds one derived flag to the stored user.
+ *
+ * `admin` is present only when true, so a client that has never heard of it is
+ * unaffected, and a reader cannot mistake `admin: false` for a claim about anything
+ * other than this request.
+ */
+function sessionPayload(user: User, isOperator: boolean): { user: User & { admin?: true } } {
+  return { user: isOperator ? { ...user, admin: true } : user };
 }
 
 export function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {

--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -83,14 +83,15 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
     expect(describeProblems(watcher.drain())).toBe('');
   });
 
-  it('lands legacy /status links in Creator Studio instead of a dead page', async () => {
+  it('lands legacy /status links in Creator Studio, at the address it lives at now', async () => {
     // `/status/:token` resolves as Creator Studio (same view as `/studio/:token`).
     // An unknown token no longer renders the old "invalid tracking link" panel —
     // Studio loads the creator's shelf (empty for this bot identity) and stays usable.
-    // The path is left as `/status/...` so old bookmarks keep working without a redirect.
+    // The old link keeps working, and the bar is put back on the current address, so a
+    // URL copied out of it is the one that will still mean something next year.
     await visit(page, '/status/deadbeefdeadbeef', 3_000);
 
-    expect(new URL(page.url()).pathname).toBe('/status/deadbeefdeadbeef');
+    expect(new URL(page.url()).pathname).toBe('/studio/deadbeefdeadbeef');
     expect(await bodyText()).toMatch(/creator studio|studio twórcy/i);
     expect(describeProblems(watcher.drain())).toBe('');
   });

--- a/apps/web/src/AuthContext.tsx
+++ b/apps/web/src/AuthContext.tsx
@@ -6,6 +6,16 @@ export interface User {
   name?: string;
   picture?: string;
   tier: 'standard' | 'trusted' | 'blocked';
+  /**
+   * Present, and true, only for an operator on a browser session.
+   *
+   * Not authorization — every operator route re-checks the allowlist itself, and a
+   * client that set this by hand would gain nothing but a link to a page that answers
+   * "not found". It exists so the app can decide whether to *offer* the console without
+   * asking an operator-only endpoint and reading its 404 as "no", which cost everybody
+   * else a console error on every page load.
+   */
+  admin?: boolean;
 }
 
 export type WaitlistStatus = 'unknown' | 'not_on_list' | 'pending' | 'approved' | 'rejected';

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -112,11 +112,15 @@ describe('NavHeader operator link', () => {
     vi.restoreAllMocks();
   });
 
-  async function renderWith(summary: { status: number; body: unknown }) {
+  async function renderWith(summary: { status: number; body: unknown }, admin = true) {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
       if (url.endsWith('/api/auth/me')) {
-        return new Response(JSON.stringify({ user: { uid: 'g:boss', tier: 'free' } }));
+        // The session says whether this account is an operator; the nav never asks an
+        // operator endpoint to find out.
+        return new Response(
+          JSON.stringify({ user: { uid: 'g:boss', tier: 'free', ...(admin ? { admin: true } : {}) } }),
+        );
       }
       if (url.endsWith('/api/health')) {
         return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
@@ -191,29 +195,29 @@ describe('NavHeader operator link', () => {
     await act(async () => root.unmount());
   });
 
-  it('stops asking once it knows the answer is no', async () => {
-    // Whether someone is an operator does not change while they browse, and almost
-    // nobody is one. Left polling, every signed-in visitor would ask a question with a
-    // known answer every two minutes, forever, at one 404 apiece.
-    const { root } = await renderWith({ status: 404, body: { error: 'not found' } });
+  it('never asks an operator endpoint on behalf of someone who is not one', async () => {
+    // The 404 probe this replaced put an error in every non-operator's console on every
+    // page load — which is most people, on most page loads, and is what failed the
+    // deploy gate. A non-operator now makes no operator request at all.
+    const { root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
     const summaryCalls = () =>
       vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith('/api/admin/summary')).length;
 
-    expect(summaryCalls()).toBe(1);
+    expect(summaryCalls()).toBe(0);
     await act(async () => {
       vi.advanceTimersByTime(10 * 60_000);
       await Promise.resolve();
     });
 
-    expect(summaryCalls()).toBe(1);
+    expect(summaryCalls()).toBe(0);
 
     await act(async () => root.unmount());
   });
 
   it('shows nobody else that there is a console at all', async () => {
-    // 404 is the API's answer to a signed-in non-admin, and the nav treats it as the
-    // whole answer: no link, no badge, nothing to notice.
-    const { container, root } = await renderWith({ status: 404, body: { error: 'not found' } });
+    // A session with no `admin` flag is the API's answer for a signed-in non-admin, and
+    // the nav treats it as the whole answer: no link, no badge, nothing to notice.
+    const { container, root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
 
     const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
       element.textContent?.includes('Operator'),

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -45,17 +45,20 @@ export function NavHeader({
   // Header mark mimes the visitor: pull a phone and scroll a tiny feed while the page moves.
   const pageScrolling = usePageScrolling();
   /**
-   * How many jobs are waiting on this person, or null when they are not an operator —
-   * which is everyone. The console has been reachable only by knowing its URL, so the
-   * one surface with something to *do* on it was the one nothing linked to.
+   * How many jobs are waiting on this person. Only ever read for an operator.
    *
-   * The summary endpoint is the admission test: it answers 404 to everybody else, so a
-   * non-operator gets `null` and no link, and nothing here has to know why.
+   * Whether someone *is* one comes from the session (`user.admin`) rather than from
+   * probing an operator endpoint and reading its 404 as "no". That probe was the
+   * obvious implementation and the wrong one: it asked a settled question on every page
+   * load, and for everybody who is not an operator — which is everybody — it answered
+   * with an error in the browser console. The deploy gate that fails on console errors
+   * caught it, correctly.
    */
   const [alertCount, setAlertCount] = useState<number | null>(null);
+  const isOperator = user?.admin === true;
 
   useEffect(() => {
-    if (!user) {
+    if (!isOperator) {
       setAlertCount(null);
       return;
     }
@@ -63,28 +66,20 @@ export function NavHeader({
     const read = () =>
       fetchAdminSummary()
         .then((summary) => {
-          if (cancelled) return;
-          setAlertCount(summary ? summary.alerts.length : null);
-          // Whether someone is an operator does not change while they browse, and
-          // almost nobody is one. Polling on regardless would have every signed-in
-          // visitor asking a question with a known answer, forever, at 404 apiece.
-          if (!summary) clearInterval(timer);
+          if (!cancelled) setAlertCount(summary ? summary.alerts.length : 0);
         })
         .catch(() => {
-          // A failed read is not evidence of anything; leave the link as it was and
-          // keep the timer, since the next read may well succeed.
+          // A failed read is not evidence of anything; leave the badge as it was.
         });
-    // Slower than the console's own poll: this is a badge somebody glances at, not a
-    // queue they are working, and it rides along on every page of the site. Started
-    // before the first read so that read can stop it — it only ever runs on a later
-    // microtask, so the binding is always initialized by then.
-    const timer = setInterval(read, 120_000);
     void read();
+    // Slower than the console's own poll: this is a badge somebody glances at, not a
+    // queue they are working, and it rides along on every page of the site.
+    const timer = setInterval(read, 120_000);
     return () => {
       cancelled = true;
       clearInterval(timer);
     };
-  }, [user]);
+  }, [isOperator]);
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -203,7 +198,7 @@ export function NavHeader({
 
               {/* Operators only — everyone else never learns this exists, which is the
                   same posture the API takes when asked. */}
-              {alertCount !== null && (
+              {isOperator && (
                 <button
                   className="nav-link"
                   onClick={() => {
@@ -212,7 +207,7 @@ export function NavHeader({
                   }}
                 >
                   <PixelIcon name="wrench" size={14} /> Operator
-                  {alertCount > 0 && (
+                  {alertCount !== null && alertCount > 0 && (
                     <span className="specs-count-badge" aria-label={`${alertCount} waiting on you`}>
                       {alertCount}
                     </span>


### PR DESCRIPTION
Fixes the rollout that #360 blocked. The candidate revision was built, deployed and smoke-tested fine; the **browser gate** refused to promote it, and it was right to.

## What broke

The nav learned whether to offer the operator console by calling `/api/admin/summary` and reading its 404 as "no". So every signed-in visitor who is not an operator — which is everybody — logged a failed request in their browser console, on every page load:

```
[http.404] GET https://candidate---…/api/admin/summary
[console.error] Failed to load resource: the server responded with a status of 404
```

`walkthrough.test.ts` asserts a clean console on ordinary pages, with no tolerated statuses. It failed twice and the promote step was skipped, so production stayed on the old revision the whole time.

## The fix

The probe was the obvious implementation and the wrong one. Whether an account is an operator does not change while somebody browses, and the app already fetches the session on boot — so the session carries the answer:

- `/api/auth/me` and both sign-in responses now include `admin: true` for an operator.
- The nav renders the link from `user.admin`, and fetches the summary for its badge **only** when that is true.

A non-operator now makes no operator request at all — not one, ever, rather than one every two minutes that quietly fails.

Three things worth stating about the flag:

- **Present only when true.** A client that has never heard of it is unaffected, and nothing can read `admin: false` as a claim about something else.
- **Not authorization.** Every operator route re-checks the same allowlist itself. A client that set the flag by hand would win a link to a page that answers "not found".
- **`isAdminSession`, not `isAdmin`.** A request authenticated with a personal access token acts as its user but is never an operator, so the door the client draws cannot disagree with the routes behind it.

## The other failure

`resilience.test.ts` pinned `/status/<token>` to its old address, with a comment recording that leaving it alone was deliberate. The canonical redirect is the newer decision and the one just asked for: the old link still resolves, it just does not stay in the bar. Expectation and comment updated.

## Tests

1344 API (+2 on the new flag), 632 web (the nav test now asserts a non-operator makes **zero** operator requests, and fails without the fix). Lint, both suites, e2e type-check and the build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9)_