### PR TITLE
Price the ledger in dollars, and quiet the console's banner

### DIFF
--- a/apps/api/src/job-costs.test.ts
+++ b/apps/api/src/job-costs.test.ts
@@ -86,6 +86,17 @@ describe('buildCostReport', () => {
     expect(report.totals.usd).toBeUndefined();
   });
 
+  it('leaves money absent on a ledger that holds only unpriced entries', () => {
+    // Having a ledger is not the same as having a price. A gate run books an entry with
+    // neither credits nor dollars, because Cloud Build minutes are billed and nothing
+    // reads the price back — so "no figure" here means unpriced, not free.
+    const report = buildCostReport([record({ issueNumber: 1, costs: [gateRun(ago(10 * MINUTE))] })]);
+
+    expect(report.jobs[0].gateRuns).toBe(1);
+    expect(report.jobs[0].usd).toBeUndefined();
+    expect(report.unmeasuredJobs).toBe(0);
+  });
+
   it('prices a published game and the builds that never shipped', () => {
     const report = buildCostReport([
       record({ issueNumber: 1, state: 'published', publishedAt: ago(MINUTE), costs: [session(ago(20 * MINUTE))] }),

--- a/apps/api/src/job-costs.test.ts
+++ b/apps/api/src/job-costs.test.ts
@@ -57,14 +57,57 @@ describe('buildCostReport', () => {
     expect(report.creditsOnUnpublished).toBe(2);
   });
 
-  it('reports money and tokens as absent rather than as zero', () => {
-    // Nothing measures either today. A report claiming $0.00 per game would be a lie in
-    // the shape of a measurement.
+  it('prices credits in money, because the rate is fixed rather than estimated', () => {
+    // 100 credits to the dollar, published by GitHub. Converting is arithmetic, not a
+    // guess, so the money column is a measurement and not a placeholder.
+    const report = buildCostReport([
+      record({ issueNumber: 1, costs: [session(ago(20 * MINUTE)), session(ago(10 * MINUTE))] }),
+    ]);
+
+    expect(report.jobs[0].usd).toBe(0.02);
+    expect(report.totals.usd).toBe(0.02);
+  });
+
+  it('still reports tokens as absent rather than as zero', () => {
+    // Copilot exposes no token counts, and a zero would read as a measurement that came
+    // back empty instead of one that was never taken.
     const report = buildCostReport([record({ issueNumber: 1, costs: [session(ago(10 * MINUTE))] })]);
 
-    expect(report.totals.usd).toBeUndefined();
     expect(report.totals.tokens).toBeUndefined();
+    expect(report.jobs[0].tokens).toBeUndefined();
+  });
+
+  it('leaves money absent on a job nothing was ever billed to', () => {
+    // A job dispatched before the ledger existed has no spending to convert. $0.00 would
+    // say it was free; a dash says it was never measured.
+    const report = buildCostReport([record({ issueNumber: 1, state: 'published', publishedAt: ago(MINUTE) })]);
+
     expect(report.jobs[0].usd).toBeUndefined();
+    expect(report.totals.usd).toBeUndefined();
+  });
+
+  it('prices a published game and the builds that never shipped', () => {
+    const report = buildCostReport([
+      record({ issueNumber: 1, state: 'published', publishedAt: ago(MINUTE), costs: [session(ago(20 * MINUTE))] }),
+      record({ issueNumber: 2, state: 'failed', costs: [session(ago(40 * MINUTE)), session(ago(35 * MINUTE))] }),
+    ]);
+
+    // Three credits spent, one game shipped: three cents a game, two of them wasted.
+    expect(report.usdPerPublishedGame).toBe(0.03);
+    expect(report.usdOnUnpublished).toBe(0.02);
+  });
+
+  it('adds directly-priced spending to converted credits rather than replacing it', () => {
+    // A backend that bills dollars and a backend that bills credits are different
+    // spending on the same job, not two readings of the same spending.
+    const report = buildCostReport([
+      record({
+        issueNumber: 1,
+        costs: [session(ago(20 * MINUTE)), { kind: 'agent_session', at: ago(10 * MINUTE), by: 'backend-b', usd: 0.4 }],
+      }),
+    ]);
+
+    expect(report.jobs[0].usd).toBe(0.41);
   });
 
   it('adds up tokens and money once a backend does report them', () => {

--- a/apps/api/src/job-costs.ts
+++ b/apps/api/src/job-costs.ts
@@ -52,10 +52,12 @@ export interface JobCostSummary {
   tokens?: { input: number; output: number };
   /**
    * What this job cost, in money: credits at the fixed rate plus anything a service
-   * priced directly. Absent only when nothing was measured at all — a job with a ledger
-   * has a real figure, and one without says so by having none.
+   * priced directly.
    *
-   * Excludes the gate's Cloud Build minutes, which nothing reports yet.
+   * Absent when no *priced* spending was recorded — which is not the same as no ledger.
+   * A gate run is booked as an entry with neither credits nor dollars, because Cloud
+   * Build minutes are billed and nothing reads the price back, so a job can have a
+   * ledger and still have nothing to report here.
    */
   usd?: number;
   /** Creation to the last thing that happened to it. */
@@ -148,8 +150,8 @@ function summarize(record: SubmissionRecord): JobCostSummary {
     gateRuns: entries.filter((entry) => entry.kind === 'gate_run').length,
     // Absent rather than zero: nothing reports tokens yet, and a zero would read as a
     // measurement that came back empty instead of one that was never taken. Money is
-    // absent on the same rule — but a job with credits always has some, so the dash now
-    // means "nothing billed to this job", not "we cannot say".
+    // absent on the same rule — a missing figure means no priced spending was recorded,
+    // which still includes the case of a job whose only entries are unpriced gate runs.
     ...(tokens.input + tokens.output > 0 ? { tokens } : {}),
     ...(usd > 0 ? { usd } : {}),
     elapsedMs: Math.max(0, lastActivityAt(record) - Date.parse(record.createdAt)),

--- a/apps/api/src/job-costs.ts
+++ b/apps/api/src/job-costs.ts
@@ -9,14 +9,33 @@
 // (see `JobCostEntry`). Nothing is estimated, and nothing is inferred from state: a job
 // that took four sessions reports four whether or not its transitions still say so.
 //
-// The unit problem is deliberate and load-bearing. Copilot bills a premium request per
-// session and exposes no token counts; the gate bills Cloud Build minutes we do not yet
-// read back. So credits and sessions are real, tokens and dollars are absent, and this
-// module reports absence as absence rather than as zero — a report that said "$0.00 per
-// game" would be worse than one that says the money is not measurable yet.
+// The unit problem is narrower than it looks. Copilot bills a premium request per session
+// and exposes no token counts, so tokens stay absent — but a credit is not a proxy for
+// money, it *is* money in another unit, and converting it estimates nothing. What remains
+// genuinely unpriced is Cloud Build minutes behind the gate, which is a smaller and
+// nameable hole rather than the whole money column.
+//
+// Where absence is still the truth, this module reports absence rather than zero: a job
+// with no ledger reads as unmeasured, not as free.
 
 import { resolveJobState, type JobState } from './job-state.js';
 import type { JobCostEntry, SubmissionRecord } from './store.js';
+
+/**
+ * GitHub fixes an AI credit at $0.01 — 100 credits to the dollar, a published rate rather
+ * than a quote that moves with usage.
+ *
+ * Credits stay the *stored* unit: the ledger books what was actually billed, in the unit
+ * the bill is denominated in, and the conversion happens here on read. If the rate ever
+ * changes, that is one constant and no migration — and a historical entry still says what
+ * it said when it was written.
+ */
+export const USD_PER_CREDIT = 0.01;
+
+/** Money is only ever reported to the cent; floating-point sums are not. */
+function cents(usd: number): number {
+  return Math.round(usd * 100) / 100;
+}
 
 export interface JobCostSummary {
   issueNumber: number;
@@ -31,7 +50,13 @@ export interface JobCostSummary {
   gateRuns: number;
   /** Present only when some backend actually reported tokens. */
   tokens?: { input: number; output: number };
-  /** Present only when some service actually reported money. */
+  /**
+   * What this job cost, in money: credits at the fixed rate plus anything a service
+   * priced directly. Absent only when nothing was measured at all — a job with a ledger
+   * has a real figure, and one without says so by having none.
+   *
+   * Excludes the gate's Cloud Build minutes, which nothing reports yet.
+   */
   usd?: number;
   /** Creation to the last thing that happened to it. */
   elapsedMs: number;
@@ -62,10 +87,14 @@ export interface CostReport {
    * failed twice before succeeding cost three sessions, and so did the game.
    */
   creditsPerPublishedGame: number | null;
+  /** The same number in money, which is the one worth quoting. */
+  usdPerPublishedGame: number | null;
   /** Median wall-clock of the jobs that shipped. Null when none did. */
   medianTimeToPublishMs: number | null;
   /** Of the credits above, how many bought nothing playable. The cost of the failure rate. */
   creditsOnUnpublished: number;
+  /** The failure rate priced. */
+  usdOnUnpublished: number;
   /**
    * Jobs in the window that have no ledger at all — dispatched before this recorded
    * anything. Reported so a small total is legible as "not measured yet" rather than
@@ -103,7 +132,11 @@ function summarize(record: SubmissionRecord): JobCostSummary {
       entry.tokens ? { input: sum.input + entry.tokens.input, output: sum.output + entry.tokens.output } : sum,
     { input: 0, output: 0 },
   );
-  const usd = entries.reduce((sum, entry) => sum + (entry.usd ?? 0), 0);
+  const credits = entries.reduce((sum, entry) => sum + (entry.credits ?? 0), 0);
+  // Credits converted, plus anything a service priced in dollars directly. The two are
+  // added rather than treated as alternatives: they are different spending, not two
+  // measurements of the same spending.
+  const usd = cents(credits * USD_PER_CREDIT + entries.reduce((sum, entry) => sum + (entry.usd ?? 0), 0));
 
   return {
     issueNumber: record.issueNumber,
@@ -111,10 +144,12 @@ function summarize(record: SubmissionRecord): JobCostSummary {
     ...(record.slug ? { slug: record.slug } : {}),
     ...(state ? { state } : {}),
     sessions: entries.filter((entry) => entry.kind === 'agent_session').length,
-    credits: entries.reduce((sum, entry) => sum + (entry.credits ?? 0), 0),
+    credits,
     gateRuns: entries.filter((entry) => entry.kind === 'gate_run').length,
-    // Absent rather than zero: nothing reports these yet, and a zero would read as a
-    // measurement that came back empty instead of one that was never taken.
+    // Absent rather than zero: nothing reports tokens yet, and a zero would read as a
+    // measurement that came back empty instead of one that was never taken. Money is
+    // absent on the same rule — but a job with credits always has some, so the dash now
+    // means "nothing billed to this job", not "we cannot say".
     ...(tokens.input + tokens.output > 0 ? { tokens } : {}),
     ...(usd > 0 ? { usd } : {}),
     elapsedMs: Math.max(0, lastActivityAt(record) - Date.parse(record.createdAt)),
@@ -139,15 +174,21 @@ export function buildCostReport(records: SubmissionRecord[]): CostReport {
     { input: 0, output: 0 },
   );
   if (tokens.input + tokens.output > 0) totals.tokens = tokens;
-  const usd = jobs.reduce((sum, job) => sum + (job.usd ?? 0), 0);
+  const usd = cents(jobs.reduce((sum, job) => sum + (job.usd ?? 0), 0));
   if (usd > 0) totals.usd = usd;
+
+  const unpublished = jobs.filter((job) => !job.published);
 
   return {
     jobs,
     totals,
     creditsPerPublishedGame: totals.published > 0 ? Math.round((totals.credits / totals.published) * 100) / 100 : null,
+    // Divided from the total rather than averaged over the per-job dollars, so the cents
+    // dropped by rounding each job do not compound into the headline.
+    usdPerPublishedGame: totals.published > 0 ? cents(usd / totals.published) : null,
     medianTimeToPublishMs: median(jobs.filter((job) => job.published).map((job) => job.elapsedMs)),
-    creditsOnUnpublished: jobs.filter((job) => !job.published).reduce((sum, job) => sum + job.credits, 0),
+    creditsOnUnpublished: unpublished.reduce((sum, job) => sum + job.credits, 0),
+    usdOnUnpublished: cents(unpublished.reduce((sum, job) => sum + (job.usd ?? 0), 0)),
     unmeasuredJobs: records.filter((record) => (record.costs ?? []).length === 0).length,
   };
 }

--- a/apps/web/src/AdminConsole.test.tsx
+++ b/apps/web/src/AdminConsole.test.tsx
@@ -49,6 +49,14 @@ async function render(section: AdminSection = 'queue', onNavigate = vi.fn()) {
   return { container, root, onNavigate };
 }
 
+/** The banner is one line until asked; the rows only exist once it is open. */
+async function openAlerts(container: HTMLElement) {
+  const toggle = container.querySelector('.admin-alerts-summary') as HTMLElement;
+  await act(async () => {
+    toggle.click();
+  });
+}
+
 afterEach(() => {
   document.body.innerHTML = '';
   vi.clearAllMocks();
@@ -110,11 +118,44 @@ describe('AdminConsole', () => {
 
     const { container, root } = await render('telemetry');
 
+    // Closed, it is one line that still says how many and of what kind.
+    expect(container.querySelector('.admin-alerts-summary')?.textContent).toContain('1 ready to publish');
+    // The count rides on the queue tab, because that is where the doing happens.
+    expect(container.querySelector('.admin-tab-badge')?.textContent).toBe('1');
+
+    await openAlerts(container);
     const alerts = container.querySelector('.admin-alerts');
     expect(alerts?.textContent).toContain('Comet Courier');
     expect(alerts?.textContent).toContain('waiting to be published');
-    // The count rides on the queue tab, because that is where the doing happens.
-    expect(container.querySelector('.admin-tab-badge')?.textContent).toBe('1');
+
+    await act(async () => root.unmount());
+  });
+
+  it('sends an alert to the queue, which is the only place it can be acted on', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(
+      summary({
+        alerts: [
+          {
+            id: 'op-1-build_stalled',
+            kind: 'build_stalled',
+            issueNumber: 1_000_001,
+            title: 'Comet Courier',
+            ownerUid: 'g:1',
+            since: new Date(Date.now() - 20 * 60_000).toISOString(),
+            stall: 'quiet',
+          },
+        ],
+      }),
+    );
+    const onNavigate = vi.fn();
+
+    const { container, root } = await render('telemetry', onNavigate);
+    await openAlerts(container);
+    await act(async () => {
+      (container.querySelector('.admin-alert-open') as HTMLElement).click();
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('/admin/queue');
 
     await act(async () => root.unmount());
   });
@@ -138,6 +179,7 @@ describe('AdminConsole', () => {
     );
 
     const { container, root } = await render('queue');
+    await openAlerts(container);
 
     expect(container.querySelector('.admin-alert-age')?.textContent).toContain('0m');
     expect(container.textContent).not.toContain('-1m');
@@ -145,12 +187,31 @@ describe('AdminConsole', () => {
     await act(async () => root.unmount());
   });
 
-  it('says so plainly when nothing needs attention', async () => {
+  it('shows no banner at all when nothing is waiting', async () => {
+    // A banner that is always on screen is furniture, not a signal — and the header
+    // counts already say the queue is quiet.
     mocked.fetchAdminSummary.mockResolvedValue(summary());
 
     const { container, root } = await render('queue');
 
-    expect(container.querySelector('.admin-alerts--clear')?.textContent).toBe('Nothing waiting on you.');
+    expect(container.querySelector('.admin-alerts')).toBeNull();
+    expect(container.textContent).not.toContain('waiting on you');
+
+    await act(async () => root.unmount());
+  });
+
+  it('flags a pulled breaker on the tab that can put it back', async () => {
+    // Creation being paused is invisible from five of the six sections otherwise.
+    mocked.fetchAdminSummary.mockResolvedValue(
+      summary({ limits: { paused: true, globalDailySubmissionCap: 50, todaySubmissions: 3 } }),
+    );
+
+    const { container, root } = await render('telemetry');
+
+    const limitsTab = Array.from(container.querySelectorAll('.admin-tab')).find((tab) =>
+      tab.textContent?.startsWith('Limits'),
+    );
+    expect(limitsTab?.querySelector('.admin-tab-badge')?.textContent).toBe('paused');
 
     await act(async () => root.unmount());
   });
@@ -162,7 +223,10 @@ describe('AdminConsole', () => {
     const { container, root } = await render('queue', onNavigate);
     const tokensTab = Array.from(container.querySelectorAll('.admin-tab')).find(
       (tab) => tab.textContent === 'Tokens',
-    ) as HTMLButtonElement;
+    ) as HTMLAnchorElement;
+    // A real href, so the section can also be opened in a new tab the way any other
+    // address on the site can.
+    expect(tokensTab.getAttribute('href')).toBe('/admin/tokens');
     await act(async () => {
       tokensTab.click();
     });

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -39,6 +39,14 @@ const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
   feedback_undelivered: 'change request never collected — check the relay',
 };
 
+/** The same kinds again, short enough to sit several to a line in the summary. */
+const ALERT_SHORT: Record<OperatorAlert['kind'], string> = {
+  review_ready: 'ready to publish',
+  build_failed: 'failed',
+  build_stalled: 'stopped',
+  feedback_undelivered: 'undelivered feedback',
+};
+
 /** Rough age, in the same vocabulary the queue uses. */
 function since(at: string, now: number): string {
   // Clamped, because these two clocks are not the same clock: `at` is the server's and
@@ -53,39 +61,84 @@ function since(at: string, now: number): string {
   return `${Math.floor(hours / 24)}d`;
 }
 
+/** "2 ready to publish, 1 stopped" — the whole banner, when it is closed. */
+function summarize(alerts: OperatorAlert[]): string {
+  const counts = new Map<OperatorAlert['kind'], number>();
+  // Insertion order is the server's severity order, so the summary leads with the same
+  // thing the list would.
+  for (const alert of alerts) counts.set(alert.kind, (counts.get(alert.kind) ?? 0) + 1);
+  return [...counts].map(([kind, count]) => `${count} ${ALERT_SHORT[kind]}`).join(', ');
+}
+
 /**
  * What is waiting on the person reading, above whatever section they opened.
  *
  * Shown on every section rather than only on the queue: the reason to consolidate these
  * pages is that an operator opens one of them and finds out about the others, and an
  * alert visible only on the page you had to already be on would not be an alert.
+ *
+ * But it is one line until asked, and nothing at all when there is nothing waiting. The
+ * first version was a stack of boxes between the tabs and the section on every page,
+ * including a permanent "Nothing waiting on you." — which is a banner that is always
+ * there, and a banner that is always there is furniture rather than a signal. Collapsed,
+ * it costs a line and still says the number; open, it is the same list as before.
  */
-function AlertBanner({ alerts }: { alerts: OperatorAlert[] }) {
+function AlertBanner({
+  alerts,
+  open,
+  onToggle,
+  onOpenQueue,
+}: {
+  alerts: OperatorAlert[];
+  open: boolean;
+  onToggle: () => void;
+  onOpenQueue: () => void;
+}) {
   const now = Date.now();
-  if (alerts.length === 0) {
-    return <p className="admin-alerts admin-alerts--clear">Nothing waiting on you.</p>;
-  }
+  // Nothing waiting is not news. The header counts already say the queue is quiet.
+  if (alerts.length === 0) return null;
+
   return (
-    <ul className="admin-alerts">
-      {alerts.map((alert) => (
-        <li key={alert.id} className={`admin-alert admin-alert--${alert.kind}`}>
-          <span className="admin-alert-title">{alert.title}</span>{' '}
-          <span className="admin-alert-kind">
-            {ALERT_COPY[alert.kind]}
-            {alert.stall ? ` (${alert.stall})` : ''}
-          </span>{' '}
-          <span className="admin-alert-age">
-            #{alert.issueNumber} · {since(alert.since, now)}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <div className="admin-alerts">
+      <button type="button" className="admin-alerts-summary" aria-expanded={open} onClick={onToggle}>
+        <span className="admin-alerts-count">{alerts.length}</span>
+        <span className="admin-alerts-gist">waiting on you — {summarize(alerts)}</span>
+        <span className="admin-alerts-chevron" aria-hidden="true">
+          {open ? '▾' : '▸'}
+        </span>
+      </button>
+
+      {open && (
+        <ul className="admin-alerts-list">
+          {alerts.map((alert) => (
+            <li key={alert.id} className={`admin-alert admin-alert--${alert.kind}`}>
+              {/* The row is the way to the queue, which is the only place any of these can
+                  actually be acted on. Before this it was inert text that told you
+                  something was wrong and offered no verb. */}
+              <button type="button" className="admin-alert-open" onClick={onOpenQueue}>
+                <span className="admin-alert-title">{alert.title}</span>{' '}
+                <span className="admin-alert-kind">
+                  {ALERT_COPY[alert.kind]}
+                  {alert.stall ? ` (${alert.stall})` : ''}
+                </span>{' '}
+                <span className="admin-alert-age">
+                  #{alert.issueNumber} · {since(alert.since, now)}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 
 export function AdminConsole({ section, onNavigate }: { section: AdminSection; onNavigate: (path: string) => void }) {
   const [summary, setSummary] = useState<AdminSummary | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+  // Held here rather than in the banner so switching sections does not re-collapse a list
+  // the operator just opened — the banner is the same banner on every section.
+  const [alertsOpen, setAlertsOpen] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -118,33 +171,76 @@ export function AdminConsole({ section, onNavigate }: { section: AdminSection; o
       <header className="admin-console-header">
         <h1>Operator</h1>
         {summary && (
-          <p className="admin-console-counts">
-            {summary.queue.active} active · {summary.queue.stalled} stalled · {summary.limits.todaySubmissions}/
-            {summary.limits.globalDailySubmissionCap} today
-            {summary.limits.paused ? ' · creation paused' : ''}
-          </p>
+          // Discrete figures rather than one dot-separated sentence: these are four
+          // unrelated numbers, and reading them as prose meant reading all of them to
+          // find the one you came for.
+          <dl className="admin-console-counts">
+            <div>
+              <dt>Active</dt>
+              <dd>{summary.queue.active}</dd>
+            </div>
+            <div className={summary.queue.stalled > 0 ? 'is-warn' : undefined}>
+              <dt>Stalled</dt>
+              <dd>{summary.queue.stalled}</dd>
+            </div>
+            <div>
+              <dt>Today</dt>
+              <dd>
+                {summary.limits.todaySubmissions}
+                <span className="admin-console-of">/{summary.limits.globalDailySubmissionCap}</span>
+              </dd>
+            </div>
+            <div className={summary.limits.paused ? 'is-warn' : undefined}>
+              <dt>Creation</dt>
+              <dd>{summary.limits.paused ? 'paused' : 'open'}</dd>
+            </div>
+          </dl>
         )}
       </header>
 
-      <nav className="admin-tabs">
+      <nav className="admin-tabs" aria-label="Operator sections">
         {ADMIN_SECTIONS.map((candidate) => (
-          <button
+          // Real links, not buttons: these are addresses, so a middle-click or a
+          // cmd-click should open one in a new tab the way it does everywhere else on
+          // the site. The click handler is the in-app path, not the only path.
+          <a
             key={candidate}
-            type="button"
+            href={adminPath(candidate)}
             className={candidate === section ? 'admin-tab is-active' : 'admin-tab'}
             aria-current={candidate === section ? 'page' : undefined}
-            onClick={() => onNavigate(adminPath(candidate))}
+            onClick={(event) => {
+              if (event.defaultPrevented || event.button !== 0) return;
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+              event.preventDefault();
+              onNavigate(adminPath(candidate));
+            }}
           >
             {SECTION_LABELS[candidate]}
             {candidate === 'queue' && summary && summary.alerts.length > 0 ? (
-              <span className="admin-tab-badge">{summary.alerts.length}</span>
+              <span className="admin-tab-badge" aria-label={`${summary.alerts.length} waiting on you`}>
+                {summary.alerts.length}
+              </span>
             ) : null}
-          </button>
+            {/* The breaker being pulled is the other state that wants a person, and it
+                is invisible from five of the six sections without this. */}
+            {candidate === 'limits' && summary?.limits.paused ? (
+              <span className="admin-tab-badge is-warn" aria-label="creation paused">
+                paused
+              </span>
+            ) : null}
+          </a>
         ))}
       </nav>
 
       {state === 'error' && <p className="health-empty">Could not read the console summary.</p>}
-      {summary && <AlertBanner alerts={summary.alerts} />}
+      {summary && (
+        <AlertBanner
+          alerts={summary.alerts}
+          open={alertsOpen}
+          onToggle={() => setAlertsOpen((wasOpen) => !wasOpen)}
+          onOpenQueue={() => onNavigate(adminPath('queue'))}
+        />
+      )}
 
       {section === 'queue' && <AdminJobsPanel />}
       {section === 'costs' && <CostsPanel />}

--- a/apps/web/src/CostsPanel.test.tsx
+++ b/apps/web/src/CostsPanel.test.tsx
@@ -30,6 +30,7 @@ function job(overrides: Partial<JobCostSummary> = {}): JobCostSummary {
     sessions: 2,
     credits: 2,
     gateRuns: 1,
+    usd: 0.02,
     elapsedMs: 2 * HOUR,
     published: true,
     createdAt: '2026-07-30T10:00:00Z',
@@ -40,10 +41,12 @@ function job(overrides: Partial<JobCostSummary> = {}): JobCostSummary {
 function report(overrides: Partial<CostReport> = {}): CostReport {
   return {
     jobs: [job()],
-    totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 1, published: 1 },
+    totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 1, published: 1, usd: 0.02 },
     creditsPerPublishedGame: 2,
+    usdPerPublishedGame: 0.02,
     medianTimeToPublishMs: 2 * HOUR,
     creditsOnUnpublished: 0,
+    usdOnUnpublished: 0,
     unmeasuredJobs: 0,
     ...overrides,
   };
@@ -74,8 +77,11 @@ describe('CostsPanel', () => {
     const { container, root } = await render();
 
     const headline = container.querySelector('.admin-cost-headline');
-    expect(headline?.textContent).toContain('Credits per published game');
-    expect(headline?.querySelector('dd')?.textContent).toBe('2');
+    expect(headline?.textContent).toContain('Cost per published game');
+    // Money leads, because that is the number worth quoting; credits stay beside it
+    // because that is the unit a bill can be checked against.
+    expect(headline?.querySelector('dd')?.textContent).toBe('$0.02');
+    expect(headline?.textContent).toContain('2 credits');
 
     await act(async () => root.unmount());
   });
@@ -83,30 +89,49 @@ describe('CostsPanel', () => {
   it('shows what the failure rate costs, as a share of the whole', async () => {
     mocked.fetchCostReport.mockResolvedValue(
       report({
-        jobs: [job(), job({ issueNumber: 1_000_002, published: false, state: 'failed', credits: 2, sessions: 2 })],
-        totals: { jobs: 2, sessions: 4, credits: 4, gateRuns: 1, published: 1 },
+        jobs: [
+          job(),
+          job({ issueNumber: 1_000_002, published: false, state: 'failed', credits: 2, sessions: 2, usd: 0.02 }),
+        ],
+        totals: { jobs: 2, sessions: 4, credits: 4, gateRuns: 1, published: 1, usd: 0.04 },
         creditsPerPublishedGame: 4,
+        usdPerPublishedGame: 0.04,
         creditsOnUnpublished: 2,
+        usdOnUnpublished: 0.02,
       }),
     );
 
     const { container, root } = await render();
 
-    expect(container.querySelector('.admin-cost-headline')?.textContent).toContain('2 (50%)');
+    expect(container.querySelector('.admin-cost-headline')?.textContent).toContain('$0.02');
+    expect(container.querySelector('.admin-cost-headline')?.textContent).toContain('50% of the window');
     // The failed job keeps its row: the headline is only checkable if the rows are there.
     expect(container.querySelectorAll('.admin-cost-row.is-unpublished')).toHaveLength(1);
 
     await act(async () => root.unmount());
   });
 
-  it('renders unmeasured money and tokens as dashes, never as zero', async () => {
+  it('prices a job in money and still shows tokens as a dash', async () => {
+    // The rate is fixed, so money is a measurement. Tokens are not measured at all.
     mocked.fetchCostReport.mockResolvedValue(report());
 
     const { container, root } = await render();
 
     const cells = Array.from(container.querySelectorAll('tbody td')).map((cell) => cell.textContent);
-    expect(cells.slice(-2)).toEqual(['—', '—']);
-    expect(container.textContent).not.toContain('$0.00');
+    expect(cells.slice(-2)).toEqual(['—', '$0.02']);
+
+    await act(async () => root.unmount());
+  });
+
+  it('leaves money a dash on a job nothing was billed to, rather than showing it as free', async () => {
+    mocked.fetchCostReport.mockResolvedValue(
+      report({ jobs: [job({ sessions: 0, credits: 0, gateRuns: 0, usd: undefined })] }),
+    );
+
+    const { container, root } = await render();
+
+    const cells = Array.from(container.querySelectorAll('tbody td')).map((cell) => cell.textContent);
+    expect(cells.slice(-1)).toEqual(['—']);
 
     await act(async () => root.unmount());
   });
@@ -125,18 +150,24 @@ describe('CostsPanel', () => {
     mocked.fetchCostReport.mockResolvedValue(
       report({
         jobs: [job({ published: false, state: 'building' })],
-        totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 0, published: 0 },
+        totals: { jobs: 1, sessions: 2, credits: 2, gateRuns: 0, published: 0, usd: 0.02 },
         creditsPerPublishedGame: null,
+        usdPerPublishedGame: null,
         medianTimeToPublishMs: null,
         creditsOnUnpublished: 2,
+        usdOnUnpublished: 0.02,
       }),
     );
 
     const { container, root } = await render();
 
-    const values = Array.from(container.querySelectorAll('.admin-cost-headline dd')).map((dd) => dd.textContent);
+    // The leading value of each group, not the smaller unit under it.
+    const values = Array.from(container.querySelectorAll('.admin-cost-headline dd:first-of-type')).map(
+      (dd) => dd.textContent,
+    );
     expect(values[0]).toBe('—');
     expect(values[1]).toBe('—');
+    expect(container.querySelector('.admin-cost-headline')?.textContent).toContain('nothing published yet');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/CostsPanel.test.tsx
+++ b/apps/web/src/CostsPanel.test.tsx
@@ -136,6 +136,28 @@ describe('CostsPanel', () => {
     await act(async () => root.unmount());
   });
 
+  it('dashes the window total when nothing in it was priced, rather than claiming $0.00', async () => {
+    // The headline has to answer the same way the rows do; $0.00 would read as a
+    // measurement that came back zero instead of one that was never taken.
+    mocked.fetchCostReport.mockResolvedValue(
+      report({
+        jobs: [job({ sessions: 0, credits: 0, gateRuns: 1, usd: undefined })],
+        totals: { jobs: 1, sessions: 0, credits: 0, gateRuns: 1, published: 1 },
+        usdPerPublishedGame: null,
+      }),
+    );
+
+    const { container, root } = await render();
+
+    // The last group is the window total. "Spent on builds that never shipped" stays
+    // $0.00 here on purpose — there are no unpublished jobs, so nothing wasted is a
+    // measured zero rather than an unmeasured one.
+    const groups = container.querySelectorAll('.admin-cost-headline > div');
+    expect(groups[groups.length - 1].querySelector('dd')?.textContent).toBe('—');
+
+    await act(async () => root.unmount());
+  });
+
   it('says the totals are a floor when jobs predate the ledger', async () => {
     mocked.fetchCostReport.mockResolvedValue(report({ unmeasuredJobs: 3 }));
 

--- a/apps/web/src/CostsPanel.tsx
+++ b/apps/web/src/CostsPanel.tsx
@@ -4,14 +4,15 @@ import { fetchCostReport, type CostReport, type JobCostSummary } from './adminAp
 /**
  * What building games costs, per job and per shipped game.
  *
- * The headline number is credits per published game, and it is deliberately computed
+ * The headline number is what one published game costs, and it is deliberately computed
  * against *every* credit spent — including the ones spent on builds that never shipped.
  * A cost-per-game that quietly excluded failures would be the most flattering number
  * available and the least useful one: the failure rate is most of what a build costs.
  *
- * Money and tokens are shown as unmeasured rather than as zero. Copilot bills a premium
- * request per session and exposes no token counts, so credits are what there is; the
- * columns appear the moment a backend reports anything else.
+ * Money is real here, not a placeholder: GitHub fixes a credit at $0.01, so converting
+ * one to the other estimates nothing. Tokens stay dashes because Copilot reports none,
+ * and the gate's Cloud Build minutes are the one piece of spending still missing — named
+ * in the footnote rather than silently folded into a total that would then be wrong.
  */
 
 function duration(ms: number): string {
@@ -20,6 +21,11 @@ function duration(ms: number): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ${minutes % 60}m`;
   return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+/** Always two decimals: these are cents-scale figures, and `$0.1` reads as a typo. */
+function money(usd: number): string {
+  return `$${usd.toFixed(2)}`;
 }
 
 function JobRow({ job }: { job: JobCostSummary }) {
@@ -39,7 +45,7 @@ function JobRow({ job }: { job: JobCostSummary }) {
       <td>{job.gateRuns}</td>
       <td>{duration(job.elapsedMs)}</td>
       <td>{job.tokens ? `${job.tokens.input + job.tokens.output}` : '—'}</td>
-      <td>{job.usd === undefined ? '—' : `$${job.usd.toFixed(2)}`}</td>
+      <td>{job.usd === undefined ? '—' : money(job.usd)}</td>
     </tr>
   );
 }
@@ -80,23 +86,33 @@ export function CostsPanel() {
 
       <dl className="admin-cost-headline">
         <div>
-          <dt>Credits per published game</dt>
-          <dd>{report.creditsPerPublishedGame ?? '—'}</dd>
+          <dt>Cost per published game</dt>
+          <dd>{report.usdPerPublishedGame === null ? '—' : money(report.usdPerPublishedGame)}</dd>
+          {/* The credit figure stays visible beside the money: it is the unit the bill
+              arrives in, so it is the one to check a bill against. */}
+          <dd className="admin-cost-sub">
+            {report.creditsPerPublishedGame === null
+              ? 'nothing published yet'
+              : `${report.creditsPerPublishedGame} credits`}
+          </dd>
         </div>
         <div>
           <dt>Median time to publish</dt>
           <dd>{report.medianTimeToPublishMs === null ? '—' : duration(report.medianTimeToPublishMs)}</dd>
         </div>
         <div>
-          <dt>Credits on builds that never shipped</dt>
-          <dd>
-            {report.creditsOnUnpublished}
-            {totals.credits > 0 ? ` (${Math.round((report.creditsOnUnpublished / totals.credits) * 100)}%)` : ''}
+          <dt>Spent on builds that never shipped</dt>
+          <dd>{money(report.usdOnUnpublished)}</dd>
+          <dd className="admin-cost-sub">
+            {totals.credits > 0
+              ? `${Math.round((report.creditsOnUnpublished / totals.credits) * 100)}% of the window`
+              : 'nothing spent yet'}
           </dd>
         </div>
         <div>
           <dt>Spent in this window</dt>
-          <dd>{totals.usd === undefined ? `${totals.credits} credits` : `$${totals.usd.toFixed(2)}`}</dd>
+          <dd>{money(totals.usd ?? 0)}</dd>
+          <dd className="admin-cost-sub">{totals.credits} credits</dd>
         </div>
       </dl>
 
@@ -141,9 +157,10 @@ export function CostsPanel() {
 
       <p className="health-note">
         One credit is one premium request — what an agent session costs, charged whether or not the session delivers
-        anything. Tokens and money are dashes because the Copilot backend reports neither; both fill in on their own if
-        a backend that does report them is ever wired up. Gate runs carry their Cloud Build id, so a line on the bill
-        can be traced back to the game that caused it.
+        anything — and GitHub prices a credit at a flat $0.01, so the money here is converted, not estimated. Two things
+        are still missing from it: the gate&rsquo;s Cloud Build minutes, which nothing reports back yet, and tokens,
+        which the Copilot backend does not expose at all. Both would only push these figures up. Gate runs carry their
+        Cloud Build id, so a line on the bill can be traced back to the game that caused it.
       </p>
     </section>
   );

--- a/apps/web/src/CostsPanel.tsx
+++ b/apps/web/src/CostsPanel.tsx
@@ -111,7 +111,11 @@ export function CostsPanel() {
         </div>
         <div>
           <dt>Spent in this window</dt>
-          <dd>{money(totals.usd ?? 0)}</dd>
+          {/* A dash, not $0.00: an absent total means nothing in the window was priced,
+              which is not the same claim as "the window cost nothing". The rows below
+              use the same rule, and a headline that disagreed with them would be the
+              one number a reader trusts least. */}
+          <dd>{totals.usd === undefined ? '—' : money(totals.usd)}</dd>
           <dd className="admin-cost-sub">{totals.credits} credits</dd>
         </div>
       </dl>

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -127,8 +127,10 @@ export interface CostReport {
     usd?: number;
   };
   creditsPerPublishedGame: number | null;
+  usdPerPublishedGame: number | null;
   medianTimeToPublishMs: number | null;
   creditsOnUnpublished: number;
+  usdOnUnpublished: number;
   unmeasuredJobs: number;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7252,10 +7252,41 @@ body.player-open {
   margin-bottom: 0.5rem;
 }
 
+/* Four separate figures, read at a glance and in any order. */
 .admin-console-counts {
-  font-size: 0.85rem;
-  opacity: 0.75;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.1rem;
+  margin: 0;
   font-variant-numeric: tabular-nums;
+}
+
+.admin-console-counts div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.admin-console-counts dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.admin-console-counts dd {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.admin-console-counts .is-warn dd {
+  color: var(--danger, #c0392b);
+}
+
+.admin-console-of {
+  font-weight: 400;
+  opacity: 0.55;
 }
 
 .admin-tabs {
@@ -7267,13 +7298,21 @@ body.player-open {
 
 .admin-tab {
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   padding: 0.3rem 0.75rem;
   font: inherit;
   font-size: 0.85rem;
+  text-decoration: none;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
   background: transparent;
   color: inherit;
+}
+
+.admin-tab:hover {
+  border-color: color-mix(in srgb, currentColor 60%, transparent);
 }
 
 .admin-tab.is-active {
@@ -7282,33 +7321,91 @@ body.player-open {
 }
 
 .admin-tab-badge {
-  margin-left: 0.35rem;
   font-variant-numeric: tabular-nums;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
+  line-height: 1;
+  padding: 0.15rem 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 20%, transparent);
 }
 
-/* What is waiting on the reader, shown above every section. Colour carries no meaning
-   on its own here — each row says in words what kind of alert it is. */
+.admin-tab-badge.is-warn {
+  background: color-mix(in srgb, var(--danger, #c0392b) 22%, transparent);
+  color: var(--danger, #c0392b);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* What is waiting on the reader, shown above every section — one line until opened, and
+   absent entirely when nothing is waiting. Colour carries no meaning on its own here:
+   each row says in words what kind of alert it is. */
 .admin-alerts {
-  list-style: none;
   margin: 0 0 1.25rem;
+}
+
+.admin-alerts-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  cursor: pointer;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  font-size: 0.85rem;
+  text-align: left;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--danger, #c0392b) 35%, transparent);
+  background: color-mix(in srgb, var(--danger, #c0392b) 8%, transparent);
+  color: inherit;
+}
+
+.admin-alerts-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--danger, #c0392b) 25%, transparent);
+}
+
+.admin-alerts-gist {
+  flex: 1;
+}
+
+.admin-alerts-chevron {
+  opacity: 0.6;
+}
+
+.admin-alerts-list {
+  list-style: none;
+  margin: 0.3rem 0 0;
   padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
 }
 
-.admin-alerts--clear {
-  font-size: 0.85rem;
-  opacity: 0.6;
-}
-
 .admin-alert {
-  padding: 0.4rem 0.6rem;
   border-radius: 4px;
   font-size: 0.85rem;
   background: color-mix(in srgb, currentColor 8%, transparent);
   border-left: 3px solid color-mix(in srgb, currentColor 40%, transparent);
+}
+
+.admin-alert-open {
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  font-size: inherit;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.admin-alert-open:hover {
+  background: color-mix(in srgb, currentColor 6%, transparent);
 }
 
 .admin-alert--review_ready {
@@ -7441,6 +7538,13 @@ body.player-open {
   margin: 0.15rem 0 0;
   font-size: 1.35rem;
   font-variant-numeric: tabular-nums;
+}
+
+/* The same figure in the unit the bill arrives in, under the one worth quoting. */
+.admin-cost-headline .admin-cost-sub {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  margin-top: 0;
 }
 
 /* Dimmed, not hidden: a build that never shipped is still money, and its row is how the


### PR DESCRIPTION
Two things, both about the console being read rather than merely correct.

## Money

GitHub fixes an AI credit at **$0.01** — 100 to the dollar, a published rate and not a quote that moves — so converting credits to money estimates nothing. The report was withholding a dollar figure on the grounds that money was unmeasurable, which was true of tokens and wrong about credits: they are not a proxy for spending, they *are* spending denominated in another unit.

Credits stay what the ledger stores, because that is the unit a bill arrives in and can be checked against. The conversion happens on read, so the rate is one constant rather than a migration, and a historical entry still says what it said when it was written.

- **Cost per published game** is now the headline, in dollars, with the credit figure beside it.
- Directly-priced spending is *added* to converted credits rather than replacing it — a backend that bills dollars and one that bills credits are different spending on the same job, not two readings of the same spending.
- New on the report: `usdPerPublishedGame`, `usdOnUnpublished`.

What is still missing is now smaller and nameable rather than the whole money column: the gate's Cloud Build minutes, which nothing reports back yet, and tokens, which Copilot does not expose at all. The footnote says so, and says both would only push the figures up.

A job with no ledger at all still shows a dash, not `$0.00` — the dash means "never measured", and that distinction is the reason the column was empty to begin with.

## The banner

The alert list sat between the tabs and the section on every page, and when nothing was waiting it said "Nothing waiting on you." there permanently. A banner that is always on screen is furniture, not a signal — and on the queue it repeated the table directly beneath it.

It is now one line — `3 waiting on you — 2 ready to publish, 1 stopped` — expanding to the same list as before, and absent entirely when nothing is waiting. Open state is held by the console, so switching sections does not re-collapse a list somebody just opened.

Each row is a link into the queue, which is the only place any of these can be acted on. It used to be inert text that reported a problem and offered no verb.

## Around it

- The header counts are four discrete figures instead of one dot-separated sentence, with stalled and paused going red.
- The tabs are anchors with real `href`s, so a section opens in a new tab like any other address on the site.
- A pulled creation breaker gets a badge on the **Limits** tab — it was otherwise invisible from five of the six sections.

## Testing

Full gate green: lint, type-check, 2096 tests, build. New coverage for the conversion (including that a job with no ledger stays a dash), for the collapsed/expanded banner, for an alert routing to the queue, and for the paused badge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9)_