### PR TITLE
Operator cancel/retry, and re-gate live games against today's engine

### DIFF
--- a/apps/api/scripts/run-gate.ts
+++ b/apps/api/scripts/run-gate.ts
@@ -26,6 +26,13 @@
  * Usage:
  *   npm run gate:run -w @gamedevpl/api -- --slug <slug> --version <version>
  *   npm run gate:run -w @gamedevpl/api -- --slug <slug> --version <version> --keep-harness
+ *   npm run gate:run -w @gamedevpl/api -- --slug <slug> --version <version> --health
+ *
+ * `--health` re-runs the same check against the *current* engine (`main`, not the
+ * manifest's pin) and records the verdict as `manifest.health` instead of
+ * `manifest.gate`. The acceptance verdict is provenance and must survive a red re-run;
+ * health is expected to change as the engine moves. A red health run still exits
+ * non-zero so the Cloud Build history shows it red.
  */
 
 import { spawn } from 'node:child_process';
@@ -86,35 +93,58 @@ async function main(): Promise<void> {
   const repo = process.env.GAMES_REPO?.trim() ?? 'gamedevpl/www.gamedev.pl-games';
   const store = createGcsGamesStore({ bucket });
   const harnesses: string[] = [];
+  const health = process.argv.includes('--health');
 
-  const outcome = await runGate(slug, version, {
-    store,
-    run,
-    async prepareHarness(engineRef) {
-      // A real clone rather than the tarball reader the bake uses: the gate has to *run*
-      // the repo's toolchain, which means node_modules, the browser and ffmpeg — a
-      // read-only file source cannot be npm-installed or executed.
-      const dir = await mkdtemp(path.join(tmpdir(), 'gate-harness-'));
-      harnesses.push(dir);
-      const url = `https://x-access-token:${token}@github.com/${repo}.git`;
-      // Shallow and single-branch: the gate needs the tree at one ref, and the history
-      // it would otherwise pull is ~200 MB of capture media it will never read.
-      const clone = await run('git', ['clone', '--depth', '1', '--branch', engineRef, url, dir], process.cwd());
-      if (clone.code !== 0) throw new Error(`could not fetch harness at ${engineRef}`);
-      const install = await run('npm', ['ci', '--no-audit', '--no-fund'], dir);
-      if (install.code !== 0) throw new Error('harness install failed');
-      return dir;
+  const outcome = await runGate(
+    slug,
+    version,
+    {
+      store,
+      run,
+      async prepareHarness(engineRef) {
+        // A real clone rather than the tarball reader the bake uses: the gate has to *run*
+        // the repo's toolchain, which means node_modules, the browser and ffmpeg — a
+        // read-only file source cannot be npm-installed or executed.
+        const dir = await mkdtemp(path.join(tmpdir(), 'gate-harness-'));
+        harnesses.push(dir);
+        const url = `https://x-access-token:${token}@github.com/${repo}.git`;
+        // Shallow and single-branch: the gate needs the tree at one ref, and the history
+        // it would otherwise pull is ~200 MB of capture media it will never read.
+        const clone = await run('git', ['clone', '--depth', '1', '--branch', engineRef, url, dir], process.cwd());
+        if (clone.code !== 0) throw new Error(`could not fetch harness at ${engineRef}`);
+        const install = await run('npm', ['ci', '--no-audit', '--no-fund'], dir);
+        if (install.code !== 0) throw new Error('harness install failed');
+        return dir;
+      },
     },
-  });
+    // Health asks about today's engine, so the manifest's pin is exactly the thing to
+    // ignore. An acceptance run passes nothing and lets the pin (or `main`) decide.
+    health ? { engineRef: 'main' } : {},
+  );
 
-  await store.putGateResult(slug, version, { green: outcome.green, report: outcome.report });
+  if (health) {
+    await store.putHealthResult(slug, version, {
+      green: outcome.green,
+      report: outcome.report,
+      engineRef: outcome.engineCommit,
+    });
+  } else {
+    // The resolved sha rides along so the manifest ends up pinned to what was actually
+    // checked — the first run stamps it, later runs leave the pin alone.
+    await store.putGateResult(slug, version, {
+      green: outcome.green,
+      report: outcome.report,
+      engineRef: outcome.engineCommit,
+    });
+  }
 
   if (!process.argv.includes('--keep-harness')) {
     await Promise.all(harnesses.map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})));
   }
 
   console.log(
-    `\ngate ${outcome.green ? 'PASSED' : 'FAILED'} for ${slug}@${version} in ${Math.round(outcome.durationMs / 1000)}s`,
+    `\n${health ? 'health check' : 'gate'} ${outcome.green ? 'PASSED' : 'FAILED'} for ${slug}@${version} ` +
+      `in ${Math.round(outcome.durationMs / 1000)}s`,
   );
   if (outcome.artifacts.length) console.log(`stored: ${outcome.artifacts.join(', ')}`);
   if (!outcome.green) console.error(outcome.report);

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -239,6 +239,36 @@ describe('agent build channel', () => {
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
   });
 
+  it('tells an agent to stop when the operator canceled the job', async () => {
+    // This is the whole mechanism behind `agentBackend.cancel` on the Copilot backend:
+    // there is no kill endpoint, so cancellation is the job being terminal here — the
+    // live session learns on its next report, and its writes stop landing.
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.recordJobTransition(ISSUE, {
+      to: 'canceled',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'operator_canceled',
+    });
+    app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(),
+      payload: { text: 'Still building away.' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      accepted: false,
+      rejected: 'stopped',
+      control: { stop: true, reason: 'canceled' },
+    });
+    expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
+  });
+
   it('rejects a missing, malformed, or wrongly scoped token', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -197,6 +197,12 @@ export interface AgentChannelOptions {
     issueNumber: number;
     slug: string;
     version: string;
+    /**
+     * The delivery path never sets this; it exists so the operator's health re-gate can
+     * reuse the same configured trigger (see gate-trigger.ts) instead of a second one
+     * that would drift.
+     */
+    mode?: 'health';
   }) => Promise<{ buildId?: string } | void> | void;
 }
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { InvalidAgentTokenError, readBearerToken, verifyAgentToken } from './agent-token.js';
 import { InvalidUploadError, type GamesStore } from './games-store.js';
-import { canTransition } from './job-state.js';
+import { canTransition, resolveJobState } from './job-state.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 
@@ -281,9 +281,16 @@ export async function registerAgentChannelRoutes(
     return { issueNumber, record };
   }
 
-  function stopReason(record: SubmissionRecord): 'abandoned' | 'published' | null {
+  function stopReason(record: SubmissionRecord): 'abandoned' | 'published' | 'canceled' | null {
     if (record.abandonedAt) return 'abandoned';
     if (record.publishedAt) return 'published';
+    // The operator's cancel. This check is what makes cancellation *mean* something on
+    // the Copilot backend: its tasks API has no cancel endpoint, so the whole mechanism
+    // is the job being terminal here — a live session reads `control.stop` on its next
+    // report and winds down, and anything it sends anyway is rejected below. Before this
+    // line, `copilot-backend.cancel` described that behaviour without anything
+    // implementing it.
+    if (resolveJobState(record) === 'canceled') return 'canceled';
     return null;
   }
 

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -141,6 +141,22 @@ const notificationCopy: Record<
     en: { subject: 'Your gamedev.pl submission needs changes', lead: 'needs another look.', cta: 'See details' },
     pl: { subject: 'Twoje zgłoszenie na gamedev.pl wymaga zmian', lead: 'wymaga poprawek.', cta: 'Zobacz szczegóły' },
   },
+  // A nudge, not an alarm: the live game keeps working — its published bundle froze the
+  // engine it shipped with — but the platform underneath has moved on, and an
+  // improvement round is what brings the game along. Framed as an invitation because
+  // it is one: the creator touching their game again is the good outcome here.
+  'submission.game_health': {
+    en: {
+      subject: 'Your game could use a refresh',
+      lead: 'no longer passes our checks on the latest engine. It still plays fine — but a quick improvement round would bring it up to date.',
+      cta: 'Improve it',
+    },
+    pl: {
+      subject: 'Twoja gra przydałaby się odświeżyć',
+      lead: 'nie przechodzi już naszych testów na najnowszym silniku. Nadal działa — ale krótka runda ulepszeń przywróci ją do formy.',
+      cta: 'Ulepsz ją',
+    },
+  },
 };
 
 const unsubscribeLine: Record<Locale, string> = {
@@ -318,6 +334,11 @@ const operatorCopy: Record<OperatorNotificationType, { subject: string; lead: st
   'operator.feedback_undelivered': {
     subject: 'A change request is not reaching the agent',
     lead: 'has a creator’s change request that no agent has collected — the relay may be down.',
+    cta: 'Open the queue',
+  },
+  'operator.game_unhealthy': {
+    subject: 'A live game failed its health check',
+    lead: 'no longer passes the check on the current engine. It still serves — the creator has been nudged to refresh it.',
     cta: 'Open the queue',
   },
 };

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -152,7 +152,7 @@ const notificationCopy: Record<
       cta: 'Improve it',
     },
     pl: {
-      subject: 'Twoja gra przydałaby się odświeżyć',
+      subject: 'Twojej grze przydałoby się odświeżenie',
       lead: 'nie przechodzi już naszych testów na najnowszym silniku. Nadal działa — ale krótka runda ulepszeń przywróci ją do formy.',
       cta: 'Ulepsz ją',
     },

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -209,6 +209,35 @@ describe('GCS games store', () => {
     expect((await store.getManifest('g', version))?.gate).toMatchObject({ green: false, report: '3 checks failed' });
   });
 
+  it('pins the engine the first gate run checked against, and never repins', async () => {
+    const { impl } = stubGcs();
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+    const { version } = await store.putCandidateSources({ slug: 'g', issueNumber: 1, files: MINIMAL });
+
+    await store.putGateResult('g', version, { green: true, engineRef: 'aaa111' });
+    // A later re-run against a moved engine must not rewrite what the verdict was
+    // rendered against — the pin is provenance, and provenance is append-only.
+    await store.putGateResult('g', version, { green: true, engineRef: 'bbb222' });
+
+    expect((await store.getManifest('g', version))?.engineRef).toBe('aaa111');
+  });
+
+  it('records a health verdict beside the gate verdict, never over it', async () => {
+    const { impl } = stubGcs();
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+    const { version } = await store.putCandidateSources({ slug: 'g', issueNumber: 1, files: MINIMAL });
+    await store.putGateResult('g', version, { green: true, report: 'accepted' });
+
+    // The engine moved on and the same game now fails. The acceptance verdict is the
+    // record of why this version was allowed to publish; a red health run erasing it
+    // would erase the justification along with it.
+    await store.putHealthResult('g', version, { green: false, report: 'trace diverged', engineRef: 'ccc333' });
+
+    const manifest = await store.getManifest('g', version);
+    expect(manifest?.gate).toMatchObject({ green: true, report: 'accepted' });
+    expect(manifest?.health).toMatchObject({ green: false, report: 'trace diverged', engineRef: 'ccc333' });
+  });
+
   it('round-trips derived artifacts the gate produces', async () => {
     const { impl } = stubGcs();
     const store = createGcsGamesStore({ ...base, fetchImpl: impl });

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -200,10 +200,42 @@ export interface VersionManifest {
   engineRef?: string;
   /** Verdict of our own gate. A version without a green one is never publishable. */
   gate?: { green: boolean; ranAt: string; report?: string };
+  /**
+   * The most recent *health* verdict: the same check re-run later against the current
+   * engine, asking "does this game still work on today's GameKit".
+   *
+   * A separate field from `gate` on purpose. The gate verdict is provenance — "it worked
+   * when we accepted it" — and a red health run overwriting it would erase the one fact
+   * that justified the publication. Health is the opposite kind of record: always the
+   * latest run, expected to change as the engine moves, and never consulted by
+   * publishing.
+   */
+  health?: { green: boolean; ranAt: string; engineRef?: string; report?: string };
   sourceFiles: string[];
 }
 
 export type PublicationState = 'published' | 'archived' | 'disabled';
+
+/**
+ * One health re-gate of a published game, requested by the operator and resolved by the
+ * sweep (the gate runs remotely, writes to the manifest and exits — same read-back
+ * pattern as the acceptance verdict, for the same reason).
+ *
+ * Kept on the publication rather than the job: the job that built this game is terminal
+ * and its state machine must stay finished. Health is a property of what is *live*.
+ */
+export interface PublicationHealthCheck {
+  /** The stored version the check ran against — current at request time. */
+  version: string;
+  requestedAt: string;
+  /** Cloud Build's id for the run, when the trigger reported one. */
+  buildId?: string;
+  /** Set once the sweep reads the verdict off the manifest. */
+  green?: boolean;
+  verdictAt?: string;
+  /** Set once a red verdict has nudged the creator, so sweep re-runs stay quiet. */
+  notifiedAt?: string;
+}
 
 /**
  * What is live, decided here rather than by what exists in the bucket.
@@ -219,6 +251,8 @@ export interface PublicationRecord {
   publishedAt: string;
   takedownAt?: string;
   takedownReason?: string;
+  /** The latest health re-gate, when one has been requested. See the type's own doc. */
+  healthCheck?: PublicationHealthCheck;
 }
 
 export interface GamesStore {
@@ -233,8 +267,29 @@ export interface GamesStore {
   }): Promise<{ version: string; manifest: VersionManifest }>;
   getManifest(slug: string, version: string): Promise<VersionManifest | null>;
   getSourceFile(slug: string, version: string, path: string): Promise<string | null>;
-  /** Records our gate's verdict against a version. Only a green one may publish. */
-  putGateResult(slug: string, version: string, result: { green: boolean; report?: string }): Promise<void>;
+  /**
+   * Records our gate's verdict against a version. Only a green one may publish.
+   *
+   * `engineRef` is the commit the run actually checked against, resolved from the
+   * harness itself. Stamped only when the manifest carries none: deliveries do not pin
+   * an engine yet, and the gate run is the first moment anything knows the concrete sha
+   * a green verdict is reproducible against.
+   */
+  putGateResult(
+    slug: string,
+    version: string,
+    result: { green: boolean; report?: string; engineRef?: string },
+  ): Promise<void>;
+  /**
+   * Records a *health* verdict — the check re-run against the current engine, long
+   * after acceptance. Never touches `gate` or `engineRef`: health answers "does it
+   * still work", and must not rewrite the record of what was accepted.
+   */
+  putHealthResult(
+    slug: string,
+    version: string,
+    result: { green: boolean; report?: string; engineRef?: string },
+  ): Promise<void>;
   /** Stores an artifact the gate produced — bundle or media. Agents never write these. */
   putDerivedArtifact(slug: string, version: string, name: string, body: Buffer, contentType: string): Promise<void>;
   getDerivedArtifact(slug: string, version: string, name: string): Promise<Buffer | null>;
@@ -365,6 +420,23 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       if (!existing) throw new Error(`no manifest for ${slug}@${version}`);
       const manifest = JSON.parse(existing.toString('utf8')) as VersionManifest;
       manifest.gate = { green: result.green, ranAt: new Date(now()).toISOString(), report: result.report };
+      // First writer wins: the ref the *first* gate run checked against is the one the
+      // verdict is reproducible against, and a re-run must not quietly repin it.
+      if (result.engineRef && !manifest.engineRef) manifest.engineRef = result.engineRef;
+      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
+    },
+
+    async putHealthResult(slug, version, result) {
+      const prefix = versionPrefix(slug, version);
+      const existing = await readObject(`${prefix}/manifest.json`);
+      if (!existing) throw new Error(`no manifest for ${slug}@${version}`);
+      const manifest = JSON.parse(existing.toString('utf8')) as VersionManifest;
+      manifest.health = {
+        green: result.green,
+        ranAt: new Date(now()).toISOString(),
+        ...(result.engineRef ? { engineRef: result.engineRef } : {}),
+        ...(result.report ? { report: result.report } : {}),
+      };
       await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
     },
 

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -75,7 +75,72 @@ describe('runGate', () => {
 
     await runGate('comet-courier', 'v1', { store, prepareHarness: harnessDir, run, assembleBundle: stubAssemble });
 
-    expect(run.mock.calls[0]![1]).not.toContain('--accept');
+    // Addressed by content, not by index: the runner also shells out for bookkeeping
+    // (`git rev-parse`), and the check invocation is the one this is about.
+    const check = run.mock.calls.find(([command]) => command === 'npm');
+    expect(check?.[1]).not.toContain('--accept');
+  });
+
+  it('reports the engine commit it actually checked against, from the harness itself', async () => {
+    const { store } = stubStore();
+    const run = vi.fn(async (command: string) =>
+      command === 'git' ? { code: 0, output: 'deadbeefcafe\n' } : { code: 0, output: 'ok' },
+    );
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run,
+      assembleBundle: stubAssemble,
+    });
+
+    expect(outcome.engineCommit).toBe('deadbeefcafe');
+    // The sha is in the report too, so a verdict read by a human names the target.
+    expect(outcome.report).toContain('deadbeefcafe');
+  });
+
+  it('checks against the manifest pin by default, and the override when asked', async () => {
+    const { store } = stubStore();
+    const seen: string[] = [];
+    const prepareHarness = async (engineRef: string) => {
+      seen.push(engineRef);
+      return harnessDir();
+    };
+    const run = vi.fn(async () => ({ code: 0, output: 'ok' }));
+
+    await runGate('comet-courier', 'v1', { store, prepareHarness, run, assembleBundle: stubAssemble });
+    // A health run's whole question is "does it work on *today's* engine", so the pin —
+    // which exists to keep the acceptance verdict reproducible — is exactly what it
+    // must ignore.
+    await runGate(
+      'comet-courier',
+      'v1',
+      { store, prepareHarness, run, assembleBundle: stubAssemble },
+      {
+        engineRef: 'main',
+      },
+    );
+
+    expect(seen).toEqual(['abc123', 'main']);
+  });
+
+  it('still renders a verdict when the sha cannot be resolved', async () => {
+    // The commit is bookkeeping; the check is the verdict. Failing the run because
+    // `git rev-parse` failed would discard an answer we already paid for.
+    const { store } = stubStore();
+    const run = vi.fn(async (command: string) =>
+      command === 'git' ? { code: 128, output: 'not a repository' } : { code: 0, output: 'ok' },
+    );
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run,
+      assembleBundle: stubAssemble,
+    });
+
+    expect(outcome.green).toBe(true);
+    expect(outcome.engineCommit).toBeUndefined();
   });
 
   it('runs against the engine the version was built for, not whatever is current', async () => {

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -34,6 +34,22 @@ export interface GateOutcome {
   artifacts: string[];
   /** How long the check took — the number that tells us if this is affordable. */
   durationMs: number;
+  /**
+   * The engine commit the run actually checked against, read from the harness itself
+   * (`git rev-parse HEAD`) rather than trusted from the ref that requested it. A ref
+   * like `main` names a moving target; this is where it was standing when the verdict
+   * was rendered — the sha that makes "it worked when we checked" checkable later.
+   */
+  engineCommit?: string;
+}
+
+export interface GateRunOptions {
+  /**
+   * Check against this engine ref instead of the manifest's pin. Health runs use it to
+   * ask the question the pin exists to avoid: "does this game work on *today's* engine,
+   * not the one it was accepted against".
+   */
+  engineRef?: string;
 }
 
 export interface GateRunnerDeps {
@@ -110,7 +126,12 @@ const MEDIA_EXTENSIONS = ['.png', '.mp4', '.json'];
  * one worth reporting. Telling an agent about six failures when five are consequences of
  * the first is how a fix round gets spent on the wrong thing.
  */
-export async function runGate(slug: string, version: string, deps: GateRunnerDeps): Promise<GateOutcome> {
+export async function runGate(
+  slug: string,
+  version: string,
+  deps: GateRunnerDeps,
+  options: GateRunOptions = {},
+): Promise<GateOutcome> {
   const now = deps.now ?? Date.now;
   const roots = deps.artifactRoots ?? DEFAULT_ARTIFACT_ROOTS;
   const startedAt = now();
@@ -120,16 +141,20 @@ export async function runGate(slug: string, version: string, deps: GateRunnerDep
     return { green: false, report: `no such version: ${slug}@${version}`, artifacts: [], durationMs: 0 };
   }
 
-  // Ideally every version pins the engine *commit* it was built against, so a green
-  // verdict stays reproducible after the engine moves on. Deliveries do not record one
-  // yet — dispatch targets `main`, a moving branch, and pinning would mean resolving it
-  // to a sha at dispatch and carrying that through to the upload. Until that exists this
-  // falls back to the default branch, which means a re-run of an old version is checked
-  // against a newer engine than it was written for. That is a real limitation, not a
-  // detail: it is why `engineRef` is on the manifest at all, and closing it is the next
-  // change to this file.
-  const engineRef = manifest.engineRef ?? 'main';
+  // Deliveries do not pin an engine commit yet — dispatch targets `main`, a moving
+  // branch — so a first gate run checks against wherever `main` stands and stamps the
+  // resolved sha back onto the manifest (see the caller). A *re*-run of a stamped
+  // version checks against that pin, which is what keeps a green verdict reproducible
+  // after the engine moves on. Health runs override the pin on purpose: their whole
+  // question is whether the game survives the engine having moved.
+  const engineRef = options.engineRef ?? manifest.engineRef ?? 'main';
   const harness = await deps.prepareHarness(engineRef);
+  // Best effort: an outcome without the sha is poorer, not wrong, and a verdict must
+  // not be discarded because a bookkeeping read failed.
+  const engineCommit = await deps
+    .run('git', ['rev-parse', 'HEAD'], harness)
+    .then((head) => (head.code === 0 ? head.output.trim().split('\n').pop()?.trim() : undefined))
+    .catch(() => undefined);
   const gameDir = path.join(harness, 'games', slug);
 
   try {
@@ -157,6 +182,7 @@ export async function runGate(slug: string, version: string, deps: GateRunnerDep
         // unverified document has no path to a player either way.
         artifacts: await storePreview(deps, slug, version, harness),
         durationMs: now() - startedAt,
+        ...(engineCommit ? { engineCommit } : {}),
       };
     }
 
@@ -174,14 +200,16 @@ export async function runGate(slug: string, version: string, deps: GateRunnerDep
         report: error instanceof Error ? error.message : String(error),
         artifacts: [],
         durationMs: now() - startedAt,
+        ...(engineCommit ? { engineCommit } : {}),
       };
     }
 
     return {
       green: true,
-      report: `check:game passed against engine ${engineRef}; ${artifacts.length} artifacts stored`,
+      report: `check:game passed against engine ${engineCommit ?? engineRef}; ${artifacts.length} artifacts stored`,
       artifacts,
       durationMs: now() - startedAt,
+      ...(engineCommit ? { engineCommit } : {}),
     };
   } finally {
     // The harness is disposable and can be large. Leaving it behind is how a long-lived
@@ -220,12 +248,7 @@ async function materializeCandidate(store: GamesStore, manifest: VersionManifest
  * verdict already says everything there is to say. Throwing here would turn a reported
  * failure into a crashed gate, which is strictly less information.
  */
-async function storePreview(
-  deps: GateRunnerDeps,
-  slug: string,
-  version: string,
-  harness: string,
-): Promise<string[]> {
+async function storePreview(deps: GateRunnerDeps, slug: string, version: string, harness: string): Promise<string[]> {
   try {
     const preview = await (deps.assembleBundle ?? assembleFromHarness)(harness, slug);
     if (preview === null) return [];

--- a/apps/api/src/gate-trigger.test.ts
+++ b/apps/api/src/gate-trigger.test.ts
@@ -29,6 +29,21 @@ describe('createCloudBuildGateTrigger', () => {
     expect(calls[0]!.url).toContain('/projects/gamedevpl/builds');
     const steps = calls[0]!.body.steps as Array<{ args: string[] }>;
     expect(steps[1]!.args[1]).toContain("--slug 'comet-courier' --version 'v1'");
+    // An acceptance run, so no --health: the verdict lands as `manifest.gate`.
+    expect(steps[1]!.args[1]).not.toContain('--health');
+  });
+
+  it('runs a health re-gate as the same build with the health flag and its own tag', async () => {
+    const { impl, calls } = stubFetch();
+    const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
+
+    await trigger!({ slug: 'comet-courier', version: 'v1', mode: 'health' });
+
+    const script = (calls[0]!.body.steps as Array<{ args: string[] }>)[1]!.args[1]!;
+    expect(script).toContain("--slug 'comet-courier' --version 'v1' --health");
+    // Tagged so a fleet re-check reads as one in the Cloud Build history, not as a
+    // wave of failing acceptance gates.
+    expect(calls[0]!.body.tags).toEqual(['gate', 'health', 'slug-comet-courier']);
   });
 
   it('points the capture harness at the browser it actually installed', async () => {

--- a/apps/api/src/gate-trigger.ts
+++ b/apps/api/src/gate-trigger.ts
@@ -41,6 +41,12 @@ export interface GateTriggerOptions {
 export interface GateTriggerInput {
   slug: string;
   version: string;
+  /**
+   * `health` re-runs the check against the current engine and records the verdict as
+   * `manifest.health`, leaving the acceptance verdict alone. Omitted means the
+   * acceptance gate, exactly as before.
+   */
+  mode?: 'health';
 }
 
 const DEFAULTS = {
@@ -103,7 +109,10 @@ function buildSpec(
             // Single-quoted so a slug or version can never break out of the command.
             // Both are already validated upstream — the slug against SLUG_PATTERN, the
             // version because we generated it — and this is the belt to that braces.
-            `npm run gate:run -w @gamedevpl/api -- --slug '${input.slug}' --version '${input.version}'`,
+            // `--health` is our own constant, appended from a two-value union, never
+            // from input text.
+            `npm run gate:run -w @gamedevpl/api -- --slug '${input.slug}' --version '${input.version}'` +
+              (input.mode === 'health' ? ' --health' : ''),
           ].join('\n'),
         ],
       },
@@ -118,8 +127,10 @@ function buildSpec(
     },
     options: { logging: 'CLOUD_LOGGING_ONLY', machineType: 'E2_HIGHCPU_8' },
     timeout: '3600s',
-    // Searchable in the Cloud Build history: "show me every gate run for this game".
-    tags: ['gate', `slug-${input.slug}`],
+    // Searchable in the Cloud Build history: "show me every gate run for this game" —
+    // and health runs carry their own tag so a fleet re-check reads as one, not as a
+    // wave of failing acceptance gates.
+    tags: ['gate', ...(input.mode === 'health' ? ['health'] : []), `slug-${input.slug}`],
   };
 }
 

--- a/apps/api/src/notify-sweep.test.ts
+++ b/apps/api/src/notify-sweep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
+import type { GamesStore } from './games-store.js';
 import type { CatalogGameEntry, GitHubClient, LinkedPullRequest } from './github-client.js';
 import type { InternalAuthVerifier } from './internal-auth.js';
 import { InMemoryStore } from './store.js';
@@ -112,7 +113,15 @@ describe('POST /api/internal/notify-sweep', () => {
       headers: { authorization: 'Bearer scheduler-token' },
     });
     expect(first.statusCode).toBe(200);
-    expect(first.json()).toEqual({ scanned: 1, emitted: 1, alerts: 0, alerted: 0, stalled: 0 });
+    expect(first.json()).toEqual({
+      scanned: 1,
+      emitted: 1,
+      alerts: 0,
+      alerted: 0,
+      stalled: 0,
+      healthResolved: 0,
+      unhealthy: 0,
+    });
 
     const list = await store.listNotifications('g:owner');
     expect(list).toHaveLength(1);
@@ -126,7 +135,15 @@ describe('POST /api/internal/notify-sweep', () => {
       url: '/api/internal/notify-sweep',
       headers: { authorization: 'Bearer scheduler-token' },
     });
-    expect(second.json()).toEqual({ scanned: 0, emitted: 0, alerts: 0, alerted: 0, stalled: 0 });
+    expect(second.json()).toEqual({
+      scanned: 0,
+      emitted: 0,
+      alerts: 0,
+      alerted: 0,
+      stalled: 0,
+      healthResolved: 0,
+      unhealthy: 0,
+    });
     await app.close();
   });
 
@@ -345,6 +362,124 @@ describe('undelivered feedback reaches the operator, not just the log', () => {
     expect(res.json()).toMatchObject({ stalled: 1, alerts: 1, alerted: 1 });
     const [notification] = await store.listNotifications('g:boss');
     expect(notification.type).toBe('operator.feedback_undelivered');
+    await app.close();
+  });
+});
+
+/**
+ * The health half of the sweep: verdicts of re-gates in flight, read back off the
+ * manifest exactly the way the acceptance verdict is.
+ */
+describe('health re-gate verdicts on the notify sweep', () => {
+  const REQUESTED_AT = '2026-07-30T12:00:00.000Z';
+  const RAN_AT = '2026-07-30T12:20:00.000Z';
+
+  async function sweep(app: Awaited<ReturnType<typeof buildApp>>) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer scheduler-token' },
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  async function appWithPendingCheck(health: { green: boolean; ranAt: string } | null) {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.createSubmission(1_000_042, 'g:creator', 'Sky Dodge');
+    await store.setSubmissionPublishedAt(1_000_042, '2026-07-01T00:00:00.000Z');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    await store.setPublicationHealthCheck('sky-dodge', { version: 'v1', requestedAt: REQUESTED_AT });
+
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'sky-dodge',
+        version: 'v1',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        issueNumber: 1_000_042,
+        sourceFiles: [],
+        ...(health ? { health: { ...health, report: 'trace diverged' } } : {}),
+      }),
+    } as unknown as GamesStore;
+
+    const app = await buildApp({
+      store,
+      sessionSecret: 'dev-session-secret-change-me',
+      adminUids: 'g:boss',
+      submissionRoutes: {
+        githubToken: 'token',
+        submissionTokenSecret: secret,
+        gamesRepo: 'gamedevpl/www.gamedev.pl-games',
+        githubClient: publishedGithubClient(),
+        internalAuthVerifier: acceptAll,
+        agentChannel: { gamesStore },
+      },
+    });
+    return { app, store };
+  }
+
+  it('nudges the creator and copies the operator when a live game goes red', async () => {
+    const { app, store } = await appWithPendingCheck({ green: false, ranAt: RAN_AT });
+
+    expect(await sweep(app)).toMatchObject({ healthResolved: 1, unhealthy: 1 });
+
+    // The creator's nudge deep-links to the studio, where the improvement round it is
+    // asking for actually starts.
+    const creator = (await store.listNotifications('g:creator')).find(
+      (notification) => notification.type === 'submission.game_health',
+    );
+    expect(creator).toMatchObject({ link: '/studio', params: { title: 'Sky Dodge' } });
+
+    const operator = (await store.listNotifications('g:boss')).find(
+      (notification) => notification.type === 'operator.game_unhealthy',
+    );
+    expect(operator).toBeDefined();
+
+    const publication = await store.getPublication('sky-dodge');
+    expect(publication?.healthCheck).toMatchObject({ green: false, verdictAt: RAN_AT });
+    expect(publication?.healthCheck?.notifiedAt).toBeDefined();
+
+    // The situation has not changed, so a second sweep says nothing new.
+    expect(await sweep(app)).toMatchObject({ healthResolved: 0, unhealthy: 0 });
+    expect(
+      (await store.listNotifications('g:creator')).filter(
+        (notification) => notification.type === 'submission.game_health',
+      ),
+    ).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it('records a green verdict quietly — nothing is waiting on anybody', async () => {
+    const { app, store } = await appWithPendingCheck({ green: true, ranAt: RAN_AT });
+
+    expect(await sweep(app)).toMatchObject({ healthResolved: 1, unhealthy: 0 });
+
+    const publication = await store.getPublication('sky-dodge');
+    expect(publication?.healthCheck).toMatchObject({ green: true, verdictAt: RAN_AT });
+    expect(
+      (await store.listNotifications('g:creator')).filter(
+        (notification) => notification.type === 'submission.game_health',
+      ),
+    ).toHaveLength(0);
+
+    await app.close();
+  });
+
+  it('keeps waiting when the manifest only holds an older run’s verdict', async () => {
+    // A verdict older than the request answers the previous question, not this one.
+    const { app, store } = await appWithPendingCheck({ green: false, ranAt: '2026-07-30T11:00:00.000Z' });
+
+    expect(await sweep(app)).toMatchObject({ healthResolved: 0, unhealthy: 0 });
+    expect((await store.getPublication('sky-dodge'))?.healthCheck?.verdictAt).toBeUndefined();
+
     await app.close();
   });
 });

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -33,6 +33,7 @@ const SHORT_TYPE: Record<SubmissionNotificationType, string> = {
   'submission.building': 'building',
   'submission.published': 'published',
   'submission.needs_changes': 'needs-changes',
+  'submission.game_health': 'game-health',
 };
 
 // Which derived statuses are worth a notification, and as which event. queued,
@@ -347,9 +348,15 @@ export async function emitSubmissionNotification(
   const id = `sub-${event.issueNumber}-${SHORT_TYPE[event.type]}`;
   const now = deps.now ? new Date(deps.now()).toISOString() : new Date().toISOString();
 
-  // Published games deep-link to play; everything else to the status page.
+  // Published games deep-link to play; the health nudge to the studio, where the
+  // improvement round it is asking for actually starts; everything else to the
+  // status page.
   const link =
-    event.type === 'submission.published' && event.slug ? `/play/${event.slug}` : `/status/${event.statusToken}`;
+    event.type === 'submission.published' && event.slug
+      ? `/play/${event.slug}`
+      : event.type === 'submission.game_health'
+        ? '/studio'
+        : `/status/${event.statusToken}`;
 
   const { created, notification } = await deps.store.createNotification(event.uid, {
     id,

--- a/apps/api/src/operator-alerts.ts
+++ b/apps/api/src/operator-alerts.ts
@@ -29,7 +29,15 @@ export type OperatorAlertKind =
    * comment lands, no session starts, and the creator waits on an answer that is not
    * coming. This is the only symptom.
    */
-  | 'feedback_undelivered';
+  | 'feedback_undelivered'
+  /**
+   * A *published* game's health re-gate came back red: it no longer passes the check on
+   * the current engine. Not produced by `detectOperatorAlerts` — that walks active
+   * jobs, and this is about a finished one — the sweep raises it directly when it reads
+   * the verdict off the manifest. The game keeps serving either way; the creator has
+   * been nudged, and this is the operator's copy of that fact.
+   */
+  | 'game_unhealthy';
 
 export interface OperatorAlert {
   /**
@@ -73,6 +81,9 @@ const KIND_ORDER: Record<OperatorAlertKind, number> = {
   feedback_undelivered: 1,
   build_stalled: 2,
   build_failed: 3,
+  // Last because it is the least urgent thing here: the game still serves, and the
+  // creator — not the operator — holds the fix.
+  game_unhealthy: 4,
 };
 
 /**

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-tasks.js';
-import type { PublicationRecord } from './games-store.js';
+import type { PublicationHealthCheck, PublicationRecord } from './games-store.js';
 import type { JobState, JobTransition } from './job-state.js';
 import type { BuildEvent, SubmissionStatus } from './submission-status.js';
 
@@ -518,6 +518,13 @@ export type NotificationType =
   | 'submission.published'
   | 'submission.needs_changes'
   /**
+   * The engine moved and this creator's *published* game no longer passes the check it
+   * was accepted under (the health re-gate). Deliberately a nudge, not a takedown
+   * notice: the game keeps serving — its baked bundle froze the engine it shipped with —
+   * and the ask is an improvement round, which rebuilds it against the current engine.
+   */
+  | 'submission.game_health'
+  /**
    * Weekly summary of how a creator's published games are doing
    * (docs/improvement-loop-plan.md IL-2). Unlike the three above it is not tied to one
    * submission, which is why its id is keyed by week rather than by issue number.
@@ -533,7 +540,9 @@ export type NotificationType =
   | 'operator.review_ready'
   | 'operator.build_failed'
   | 'operator.build_stalled'
-  | 'operator.feedback_undelivered';
+  | 'operator.feedback_undelivered'
+  /** A health re-gate came back red: a live game no longer passes on the current engine. */
+  | 'operator.game_unhealthy';
 
 /**
  * The types that are about one submission, and so can render "«game title» happened".
@@ -1011,6 +1020,12 @@ export interface Store {
    * version pointer.
    */
   takedownPublication(slug: string, reason: string, at: string): Promise<boolean>;
+  /**
+   * Records or updates the publication's health re-gate (request, verdict, and
+   * notified-at are all patches of the same record — see PublicationHealthCheck).
+   * False when the slug has no publication to attach it to.
+   */
+  setPublicationHealthCheck(slug: string, check: PublicationHealthCheck): Promise<boolean>;
   /** Every slug currently live — the input the snapshot bake reads. */
   listPublications(): Promise<PublicationRecord[]>;
   /** Records the creator's language, so the agent can report progress in it. */
@@ -1586,6 +1601,13 @@ export class InMemoryStore implements Store {
 
   async setPublication(record: PublicationRecord): Promise<void> {
     this.publications.set(record.slug, { ...record });
+  }
+
+  async setPublicationHealthCheck(slug: string, check: PublicationHealthCheck): Promise<boolean> {
+    const record = this.publications.get(slug);
+    if (!record) return false;
+    this.publications.set(slug, { ...record, healthCheck: { ...check } });
+    return true;
   }
 
   async takedownPublication(slug: string, reason: string, at: string): Promise<boolean> {
@@ -2584,6 +2606,20 @@ export class FirestoreStore implements Store {
     // player feedback and scorecards already live at games/{slug}, and a takedown that
     // has to remember to visit a second place is a takedown that eventually misses one.
     await this.db.collection('games').doc(record.slug).set({ publication: record }, { merge: true });
+  }
+
+  async setPublicationHealthCheck(slug: string, check: PublicationHealthCheck): Promise<boolean> {
+    const ref = this.db.collection('games').doc(slug);
+    // Transactional for the same reason takedown is: the sweep writing a verdict can
+    // race an operator re-requesting, and a merge from a stale read would resurrect
+    // whichever check the other side just replaced.
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const current = (snap.data() as { publication?: PublicationRecord } | undefined)?.publication;
+      if (!current) return false;
+      tx.set(ref, { publication: { ...current, healthCheck: check } }, { merge: true });
+      return true;
+    });
   }
 
   async takedownPublication(slug: string, reason: string, at: string): Promise<boolean> {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -119,7 +119,15 @@ async function createApp(params: {
   contentChecker?: ContentChecker;
   maxCachedDraftPreviews?: number;
   agentBackend?: AgentBackend;
-  agentChannel?: { gamesStore?: GamesStore };
+  agentChannel?: {
+    gamesStore?: GamesStore;
+    onSourcesDelivered?: (input: {
+      issueNumber: number;
+      slug: string;
+      version: string;
+      mode?: 'health';
+    }) => Promise<{ buildId?: string } | void>;
+  };
   adminUids?: string;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
@@ -2602,5 +2610,135 @@ describe('operator cancel and retry', () => {
     expect(response.json()).toMatchObject({ error: 'dispatch_failed' });
 
     await second.app.close();
+  });
+});
+
+/**
+ * The operator's health re-gate: the manual trigger of the break-and-nudge loop. The
+ * verdict's read-back and the nudge itself are covered with the sweep
+ * (notify-sweep.test.ts); this is the request side.
+ */
+describe('operator health re-gate', () => {
+  const bossHeaders = () => getAuthHeaders('g:boss');
+
+  async function appWithPublishedGame(publicationState: 'published' | 'disabled' = 'published') {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.createSubmission(1_000_042, 'g:creator', 'Sky Dodge');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: publicationState,
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    const triggered: Array<{ issueNumber: number; slug: string; version: string; mode?: 'health' }> = [];
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'sky-dodge',
+        version: 'v1',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        issueNumber: 1_000_042,
+        sourceFiles: [],
+      }),
+    } as unknown as GamesStore;
+
+    const { app } = await createApp({
+      githubClient: createGithubClientStub({}).githubClient,
+      store,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+      agentChannel: {
+        gamesStore,
+        onSourcesDelivered: async (input) => {
+          triggered.push(input);
+          return { buildId: 'health-build-1' };
+        },
+      },
+    });
+    return { app, store, triggered };
+  }
+
+  it('answers 404 to a non-operator', async () => {
+    const { app } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/regate',
+      headers: getAuthHeaders('g:someone-else'),
+    });
+    expect(response.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('starts a health run against the current engine and records what it asked', async () => {
+    const { app, store, triggered } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/regate',
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, slug: 'sky-dodge', version: 'v1', buildId: 'health-build-1' });
+    // Same configured trigger the delivery path uses, in health mode — a second
+    // trigger would be a second definition of the gate.
+    expect(triggered).toEqual([{ issueNumber: 1_000_042, slug: 'sky-dodge', version: 'v1', mode: 'health' }]);
+
+    // The pending check is what the sweep will resolve.
+    const publication = await store.getPublication('sky-dodge');
+    expect(publication?.healthCheck).toMatchObject({ version: 'v1', buildId: 'health-build-1' });
+    expect(publication?.healthCheck?.verdictAt).toBeUndefined();
+
+    // A health run is a gate run on the bill, booked to the job that built the game.
+    const record = await store.getSubmission(1_000_042);
+    expect(record?.costs).toEqual([
+      expect.objectContaining({ kind: 'gate_run', by: 'cloud-build', ref: 'health-build-1' }),
+    ]);
+
+    await app.close();
+  });
+
+  it('refuses a game that is not currently published', async () => {
+    // Nothing is live, so there is nothing whose health could mean anything.
+    const { app, triggered } = await appWithPublishedGame('disabled');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/regate',
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'not_published', state: 'disabled' });
+    expect(triggered).toHaveLength(0);
+
+    await app.close();
+  });
+
+  it('lists the published shelf with its health for the console', async () => {
+    const { app, store } = await appWithPublishedGame();
+    await store.setPublicationHealthCheck('sky-dodge', {
+      version: 'v1',
+      requestedAt: '2026-07-29T10:00:00.000Z',
+      green: false,
+      verdictAt: '2026-07-29T10:20:00.000Z',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/admin/games', headers: bossHeaders() });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().games).toEqual([
+      expect.objectContaining({
+        slug: 'sky-dodge',
+        currentVersion: 'v1',
+        healthCheck: expect.objectContaining({ green: false }),
+      }),
+    ]);
+
+    await app.close();
   });
 });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -120,12 +120,14 @@ async function createApp(params: {
   maxCachedDraftPreviews?: number;
   agentBackend?: AgentBackend;
   agentChannel?: { gamesStore?: GamesStore };
+  adminUids?: string;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
   await store.upsertUser({ uid: 'g:test-user' });
   const app = await buildApp({
     store,
     sessionSecret,
+    ...(params.adminUids ? { adminUids: params.adminUids } : {}),
     ...(params.contentChecker ? { contentChecker: params.contentChecker } : {}),
     submissionRoutes: {
       githubToken: params.githubClient ? 'token' : undefined,
@@ -2305,5 +2307,300 @@ describe('POST /api/submissions/:token/improve', () => {
     expect(source?.state).toBe('published');
     expect(source?.dispatch).toBeUndefined();
     await app.close();
+  });
+});
+
+/**
+ * The operator's cancel and retry. Both live behind the same 404-to-strangers posture
+ * as every other operator surface, and both act through the state machine rather than
+ * around it.
+ */
+describe('operator cancel and retry', () => {
+  const body = { title: 'Game idea', concept: 'A concept long enough to pass validation rules.' };
+  const bossHeaders = () => getAuthHeaders('g:boss');
+
+  /** A dispatched job owned by g:test-user, with an operator allowlisted. */
+  async function appWithJob(overrides: { backend?: AgentBackend } = {}) {
+    const stub = createGithubClientStub({});
+    const { backend, briefs } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: overrides.backend ?? backend,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+    });
+    // The auth hook resolves the session's user from the store, so the operator has to
+    // exist there like anyone else.
+    await store.upsertUser({ uid: 'g:boss' });
+    await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    return { app, store, job, briefs };
+  }
+
+  it('answers 404 to a non-operator, the same as every operator surface', async () => {
+    const { app, job } = await appWithJob();
+
+    for (const verb of ['cancel', 'retry']) {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/admin/jobs/${job.issueNumber}/${verb}`,
+        headers: getAuthHeaders('g:someone-else'),
+      });
+      expect(response.statusCode).toBe(404);
+    }
+
+    await app.close();
+  });
+
+  it('cancels a running job, and is honest that the stop is cooperative', async () => {
+    const { app, store, job } = await appWithJob();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/cancel`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    // `stopEnforced: false` is the Copilot backend telling the truth: there is no kill
+    // endpoint, the session winds down when it next reads the channel.
+    expect(response.json()).toEqual({ ok: true, state: 'canceled', stopEnforced: false });
+
+    const record = await store.getSubmission(job.issueNumber);
+    expect(record?.state).toBe('canceled');
+    const last = record?.transitions?.at(-1);
+    expect(last).toMatchObject({ to: 'canceled', by: 'operator', reason: 'operator_canceled' });
+
+    await app.close();
+  });
+
+  it('refuses to cancel a finished job rather than rewriting its ending', async () => {
+    const { app, store, job } = await appWithJob();
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'published',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'published',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/cancel`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'already_finished', state: 'published' });
+
+    await app.close();
+  });
+
+  it('refuses to cancel mid-publish, where a half-killed bake could lie', async () => {
+    const { app, store, job } = await appWithJob();
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'publishing',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'approved',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/cancel`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'mid_publish' });
+
+    await app.close();
+  });
+
+  it('retries a failed round that never delivered, preserving its branch', async () => {
+    const { app, store, job, briefs } = await appWithJob();
+    await store.setDispatchWorkspace(job.issueNumber, 'copilot/has-the-work');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'failed',
+      at: new Date().toISOString(),
+      by: 'reconciler',
+      reason: 'task_failed',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, state: 'building', creditsSpent: 1 });
+
+    // The branch is the only copy of undelivered work; the new round is told where it is.
+    const brief = briefs.at(-1);
+    expect(brief?.undelivered).toBe(true);
+    expect(brief?.previousWorkspace).toBe('copilot/has-the-work');
+
+    const record = await store.getSubmission(job.issueNumber);
+    expect(record?.state).toBe('building');
+    // The history says who restarted it, not `derived_from_github`.
+    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'building', by: 'operator', reason: 'operator_retry' });
+    // The retry is an agent session like any other, so the ledger books it.
+    expect(record?.costs?.filter((entry) => entry.kind === 'agent_session')).toHaveLength(2);
+
+    await app.close();
+  });
+
+  it('briefs a delivered-but-refused retry from the channel, not from a second copy', async () => {
+    const { app, store, job, briefs } = await appWithJob();
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'needs_changes',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_red',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const brief = briefs.at(-1);
+    // Delivered work restores from the store; nothing to salvage from a branch.
+    expect(brief?.undelivered).toBeUndefined();
+    // The brief points at the channel rather than repeating the gate report, which the
+    // channel already carries on every call.
+    expect(brief?.feedback).toContain('build channel');
+
+    await app.close();
+  });
+
+  it('kicks a quiet building job with a fresh session, and says so in the history', async () => {
+    const { app, store, job } = await appWithJob();
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'reconciler',
+      reason: 'task_in_progress',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const record = await store.getSubmission(job.issueNumber);
+    // Same state, new session — without the explicit transition the retry would leave
+    // no trace in the job's history at all.
+    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'building', by: 'operator', reason: 'operator_retry' });
+    expect(record?.dispatch?.refs).toHaveLength(2);
+
+    await app.close();
+  });
+
+  it('refuses to retry a job that was never dispatched, where a round would brief nothing', async () => {
+    const stub = createGithubClientStub({});
+    // No agent backend on create: the job stays queued with no dispatch and no spec on
+    // record. Retry must refuse rather than start an empty session — but the route
+    // needs *a* backend to exist, so one is present and never called.
+    const { backend, briefs } = createBackendStub();
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.upsertUser({ uid: 'g:boss' });
+    const first = await createApp({ githubClient: stub.githubClient, submissionTokenSecret: secret, store });
+    await first.app.inject({ method: 'POST', url: '/api/submissions', headers: first.authHeaders, payload: body });
+    await first.app.close();
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'failed',
+      at: new Date().toISOString(),
+      by: 'system',
+      reason: 'dispatch_failed',
+    });
+
+    const { app } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+      store,
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'never_dispatched' });
+    expect(briefs).toHaveLength(0);
+
+    await app.close();
+  });
+
+  it('refuses states where a retry has nothing to redo', async () => {
+    const { app, store, job } = await appWithJob();
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'not_retryable', state: 'ready_for_review' });
+
+    await app.close();
+  });
+
+  it('reports a dispatch that failed instead of pretending the retry took', async () => {
+    const { backend } = createBackendStub();
+    const failing: AgentBackend = {
+      ...backend,
+      dispatch: async () => {
+        throw new Error('backend down');
+      },
+      resume: async () => {
+        throw new Error('backend down');
+      },
+    };
+    const { app, store, job } = await appWithJob();
+    await app.close();
+
+    const second = await createApp({
+      githubClient: createGithubClientStub({}).githubClient,
+      agentBackend: failing,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+      store,
+    });
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'failed',
+      at: new Date().toISOString(),
+      by: 'reconciler',
+      reason: 'task_failed',
+    });
+
+    const response = await second.app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.json()).toMatchObject({ error: 'dispatch_failed' });
+
+    await second.app.close();
   });
 });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -18,9 +18,12 @@ import type { AgentBackend } from './agent-backend.js';
 import {
   canTransition,
   detectStall,
+  isTerminal,
   planObservedStatusTransition,
   reconcileAgentObservation,
+  resolveJobState,
   toSubmissionStatus,
+  type JobState,
   type JobTransition,
 } from './job-state.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
@@ -28,6 +31,7 @@ import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { emitOperatorAlert, notifyOnTransition, type EmitDeps } from './notify.js';
 import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
+import { isAdminSession } from './admin.js';
 import { peekQuota } from './quota-gate.js';
 import { type BuildPreviewSummary, type BuildShotSummary, type Store, type SubmissionRecord } from './store.js';
 import {
@@ -515,6 +519,13 @@ export async function registerSubmissionRoutes(
     log: { error: (context: object, message: string) => void };
     /** Set when this round exists only because the last one never uploaded. */
     undelivered?: boolean;
+    /**
+     * Who asked for this round and why, when it was not the creator. The transition an
+     * operator's retry writes has to say so — a history reading `derived_from_github`
+     * for a round a person explicitly started would be the history lying about the one
+     * fact an audit of that job would want.
+     */
+    transition?: { by: JobTransition['by']; reason: string };
   }): Promise<void> {
     if (!agentBackend || !submissionTokenSecret || !store) return;
     const record = await store.getSubmission(input.issueNumber);
@@ -556,9 +567,19 @@ export async function registerSubmissionRoutes(
         await releaseWorkspace(input.issueNumber, previous.workspace, input.log);
       }
       const transition = record?.state
-        ? planObservedStatusTransition(record.state, 'building', new Date(now()).toISOString(), 'creator')
+        ? planObservedStatusTransition(
+            record.state,
+            'building',
+            new Date(now()).toISOString(),
+            input.transition?.by ?? 'creator',
+          )
         : null;
-      if (transition) await store.recordJobTransition(input.issueNumber, transition);
+      if (transition) {
+        await store.recordJobTransition(input.issueNumber, {
+          ...transition,
+          ...(input.transition ? { reason: input.transition.reason } : {}),
+        });
+      }
     } catch (error) {
       // The creator's request is already queued on the build channel, so a failed
       // resume costs the round its head start, not the request itself.
@@ -1878,6 +1899,139 @@ export async function registerSubmissionRoutes(
       return reply.send({ ok: true, jobId: started.jobId, slug: record.slug, ...(shotId ? { shotId } : {}) });
     },
   );
+
+  /**
+   * The operator's two verbs on a build beyond publish: stop it, and run it again.
+   *
+   * Registered here rather than in job-admin-routes because they are made of this
+   * module's machinery — the dispatcher, the channel token mint, the cost ledger — and
+   * the queue module deliberately owns none of that. Same admission rule as every other
+   * operator surface: a non-operator gets 404, not 403.
+   */
+  app.post<{ Params: { issueNumber: string } }>('/api/admin/jobs/:issueNumber/cancel', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+    if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+    const issueNumber = Number(request.params.issueNumber);
+    if (!Number.isInteger(issueNumber)) return reply.status(400).send({ error: 'invalid_job' });
+
+    const record = await store.getSubmission(issueNumber);
+    if (!record) return reply.status(404).send({ error: 'not_found' });
+
+    const state = resolveJobState(record);
+    if (state && isTerminal(state)) return reply.status(409).send({ error: 'already_finished', state });
+    // The transition table forbids exactly one non-terminal exit to canceled: a bake in
+    // flight. Killing a job mid-publish could leave a publication pointing at a version
+    // whose job says it never happened — let it land or fail, then act on that.
+    if (state && !canTransition(state, 'canceled')) return reply.status(409).send({ error: 'mid_publish', state });
+
+    const at = new Date(now()).toISOString();
+    // A record the job model never adopted has no state to transition from; recording
+    // the cancel adopts it directly as canceled, which is the fact the operator just
+    // established about it.
+    await store.recordJobTransition(issueNumber, { to: 'canceled', at, by: 'operator', reason: 'operator_canceled' });
+
+    // Best effort, and honest about what it did. The Copilot backend has no kill switch —
+    // cancellation there is the job being terminal: the channel's control block now says
+    // stop, a live session reads it on its next report, and anything it sends anyway is
+    // rejected. `stopEnforced: false` is the console's cue to say "told to stop" rather
+    // than "stopped".
+    let stopEnforced = false;
+    const refs = record.dispatch?.refs;
+    if (agentBackend && refs?.length) {
+      try {
+        stopEnforced = (await agentBackend.cancel(refs[refs.length - 1])).enforced;
+      } catch (cancelError) {
+        request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed; job is canceled regardless');
+      }
+    }
+
+    return reply.send({ ok: true, state: 'canceled', stopEnforced });
+  });
+
+  /**
+   * What the operator's retry tells the agent. Deliberately thin: the channel already
+   * carries the substantive brief — the gate verdict with its report, pending creator
+   * messages, the must-deliver reminder — on every call, derived from what we stored.
+   * Repeating any of it here would be a second copy that drifts.
+   */
+  const OPERATOR_RETRY_BRIEF =
+    'The operator restarted this build after it stopped making progress. Read the gate verdict and any ' +
+    'pending creator messages on the build channel, fix what ended the last round, and deliver again.';
+
+  /** States a retry makes sense from. */
+  const OPERATOR_RETRY_STATES: ReadonlySet<JobState> = new Set<JobState>([
+    // The round is dead and feedback-as-retry is the creator's move; this is the
+    // operator making it for them.
+    'failed',
+    'needs_changes',
+    // Not dead, just stuck — a quiet session or a wedged dispatch. A retry supersedes
+    // the old session with a fresh one on the same job.
+    'building',
+    'dispatched',
+  ]);
+
+  app.post<{ Params: { issueNumber: string } }>('/api/admin/jobs/:issueNumber/retry', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+    if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+    if (!agentBackend || !submissionTokenSecret) {
+      return reply.status(503).send({ error: 'agent_backend_unavailable' });
+    }
+    const issueNumber = Number(request.params.issueNumber);
+    if (!Number.isInteger(issueNumber)) return reply.status(400).send({ error: 'invalid_job' });
+
+    const record = await store.getSubmission(issueNumber);
+    if (!record) return reply.status(404).send({ error: 'not_found' });
+
+    const state = resolveJobState(record);
+    if (!state || !OPERATOR_RETRY_STATES.has(state)) {
+      return reply.status(409).send({ error: 'not_retryable', ...(state ? { state } : {}) });
+    }
+    // Nothing delivered and nothing dispatched: there is no branch to recover, no stored
+    // version to restore, and the spec is not on the record — a round started from here
+    // would brief the agent with nothing. `queued` jobs land here, which is deliberate:
+    // their fix is dispatch coming back, not an empty session.
+    const undelivered = !record.deliveredVersion;
+    if (undelivered && !record.dispatch?.refs?.length) {
+      return reply.status(409).send({ error: 'never_dispatched' });
+    }
+
+    const refsBefore = record.dispatch?.refs?.length ?? 0;
+    await resumeBuild({
+      issueNumber,
+      feedback: undelivered ? '' : OPERATOR_RETRY_BRIEF,
+      locale: record.locale ?? 'en',
+      log: request.log,
+      // An undelivered job's work only exists on its branch; the flag is what stops the
+      // resume path deleting it and what hands the new session the old workspace.
+      ...(undelivered ? { undelivered: true } : {}),
+      transition: { by: 'operator', reason: 'operator_retry' },
+    });
+
+    // `resumeBuild` reports dispatch failure by logging, not throwing — right for the
+    // feedback route, where the request is queued on the channel either way, but an
+    // operator clicking retry needs the truth now. A new session always appends a ref,
+    // so no new ref means no new session.
+    const after = await store.getSubmission(issueNumber);
+    if ((after?.dispatch?.refs?.length ?? 0) <= refsBefore) {
+      return reply.status(502).send({ error: 'dispatch_failed' });
+    }
+
+    // A same-state retry (kicking a quiet build) records no transition on the resume
+    // path — building to building is not a move the table knows — so without this the
+    // retry would be invisible in the job's own history. The quiet-stall flag may keep
+    // showing until the new session first reports, which is accurate: it hasn't yet.
+    if (state === 'building') {
+      await store.recordJobTransition(issueNumber, {
+        to: 'building',
+        at: new Date(now()).toISOString(),
+        by: 'operator',
+        reason: 'operator_retry',
+      });
+    }
+
+    // One credit: the retry is an agent session like any other, booked by resumeBuild.
+    return reply.send({ ok: true, state: 'building', creditsSpent: 1 });
+  });
 
   // The notification sweep (docs/notifications-plan.md N1): the closed-tab backstop
   // for the opportunistic poll-path detection above. Cloud Scheduler POSTs here with

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -29,7 +29,7 @@ import {
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
-import { emitOperatorAlert, notifyOnTransition, type EmitDeps } from './notify.js';
+import { emitOperatorAlert, emitSubmissionNotification, notifyOnTransition, type EmitDeps } from './notify.js';
 import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
 import { isAdminSession } from './admin.js';
 import { peekQuota } from './quota-gate.js';
@@ -2033,6 +2033,79 @@ export async function registerSubmissionRoutes(
     return reply.send({ ok: true, state: 'building', creditsSpent: 1 });
   });
 
+  /**
+   * The published shelf, as the operator sees it: what is live, at which version, and
+   * what the last health re-gate said. Slugs only — a publication's identity is its
+   * slug, and joining titles back through manifests would cost a read per game on a
+   * list that exists to be glanced at.
+   */
+  app.get('/api/admin/games', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+    if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+    const publications = await store.listPublications();
+    return reply.send({
+      games: publications.sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt)),
+    });
+  });
+
+  /**
+   * Re-gates a published game against the *current* engine — the manual trigger of the
+   * break-and-nudge loop.
+   *
+   * The published bundle froze the engine it shipped with, so serving is immune to
+   * engine changes; what drifts is whether the game would still pass a rebuild. This
+   * runs the same gate on the game's current version with the engine pin overridden,
+   * records the verdict as `manifest.health` (never touching the acceptance verdict,
+   * which is provenance), and leaves the read-back to the sweep — the same pattern the
+   * acceptance gate uses, for the same reason: the verdict is durable in the store, and
+   * a callback would be a second source of a fact the manifest already holds.
+   *
+   * A red verdict nudges the creator rather than pulling the game: an improvement round
+   * rebuilds it against the current engine, and inviting one is the point.
+   */
+  app.post<{ Params: { slug: string } }>('/api/admin/games/:slug/regate', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+    if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+    const gamesStore = options.agentChannel?.gamesStore;
+    const gateTrigger = options.agentChannel?.onSourcesDelivered;
+    if (!gamesStore || !gateTrigger) return reply.status(503).send({ error: 'gate_unavailable' });
+
+    const slug = request.params.slug;
+    const publication = await store.getPublication(slug);
+    if (!publication) return reply.status(404).send({ error: 'not_found' });
+    if (publication.state !== 'published') {
+      return reply.status(409).send({ error: 'not_published', state: publication.state });
+    }
+
+    const version = publication.currentVersion;
+    const manifest = await gamesStore.getManifest(slug, version);
+    if (!manifest) return reply.status(409).send({ error: 'version_missing' });
+
+    const requestedAt = new Date(now()).toISOString();
+    const triggered = await gateTrigger({ issueNumber: manifest.issueNumber, slug, version, mode: 'health' });
+    const buildId = triggered && typeof triggered === 'object' ? triggered.buildId : undefined;
+
+    // Replaces any previous check wholesale: the question is always about the latest
+    // run, and a stale verdict left beside a fresh request would read as an answer.
+    await store.setPublicationHealthCheck(slug, {
+      version,
+      requestedAt,
+      ...(buildId ? { buildId } : {}),
+    });
+    // Booked to the job that built the game — a health run is a gate run on the bill,
+    // and this is the one place the issue number is known.
+    if (buildId) {
+      await store.recordJobCost(manifest.issueNumber, {
+        kind: 'gate_run',
+        at: requestedAt,
+        by: 'cloud-build',
+        ref: buildId,
+      });
+    }
+
+    return reply.send({ ok: true, slug, version, ...(buildId ? { buildId } : {}) });
+  });
+
   // The notification sweep (docs/notifications-plan.md N1): the closed-tab backstop
   // for the opportunistic poll-path detection above. Cloud Scheduler POSTs here with
   // an OIDC token; we derive the current status of every still-active submission and
@@ -2127,6 +2200,73 @@ export async function registerSubmissionRoutes(
         }
       }
 
+      // The health half of the sweep: read back verdicts of re-gates in flight. The
+      // gate ran remotely, wrote to the manifest and exited — same read-back pattern as
+      // the acceptance verdict. Bounded: one manifest read per *pending* check, and a
+      // publication with no check (or a resolved one) costs nothing.
+      let healthResolved = 0;
+      let unhealthy = 0;
+      const healthGamesStore = options.agentChannel?.gamesStore;
+      if (healthGamesStore) {
+        const publications = await store.listPublications().catch(() => []);
+        for (const publication of publications) {
+          const check = publication.healthCheck;
+          if (!check || check.verdictAt) continue;
+          try {
+            const manifest = await healthGamesStore.getManifest(publication.slug, check.version);
+            const health = manifest?.health;
+            // A verdict older than the request is the previous run's answer, not this
+            // one's — the run we are waiting for has not written yet.
+            if (!health || Date.parse(health.ranAt) < Date.parse(check.requestedAt)) continue;
+
+            healthResolved += 1;
+            const resolved = { ...check, green: health.green, verdictAt: health.ranAt };
+            if (health.green) {
+              await store.setPublicationHealthCheck(publication.slug, resolved);
+              continue;
+            }
+
+            unhealthy += 1;
+            // Red: the game still serves — its baked bundle froze the engine it shipped
+            // with — but a rebuild would fail. Nudge the creator, whose improvement
+            // round is the fix, and copy the operator. Notified-at is written only
+            // after both, so an emit that dies retries next sweep; the emits themselves
+            // are idempotent by id.
+            const submission = manifest ? await store.getSubmission(manifest.issueNumber) : null;
+            if (submission) {
+              await emitSubmissionNotification(buildNotifyDeps(), {
+                uid: submission.ownerUid,
+                type: 'submission.game_health',
+                issueNumber: submission.issueNumber,
+                gameTitle: submission.title,
+                statusToken: mintToken(submission.issueNumber, submissionTokenSecret),
+              });
+            }
+            if (adminUids && adminUids.size > 0) {
+              await emitOperatorAlert(
+                { ...buildNotifyDeps(), adminUids },
+                {
+                  id: `op-health-${publication.slug}-${check.version}`,
+                  kind: 'game_unhealthy',
+                  issueNumber: manifest?.issueNumber ?? 0,
+                  title: submission?.title ?? publication.slug,
+                  ownerUid: submission?.ownerUid ?? '',
+                  slug: publication.slug,
+                  since: health.ranAt,
+                },
+              );
+            }
+            await store.setPublicationHealthCheck(publication.slug, {
+              ...resolved,
+              notifiedAt: new Date(now()).toISOString(),
+            });
+          } catch (healthError) {
+            // One unreadable manifest must not abort the sweep — same rule as above.
+            request.log.error({ err: healthError, slug: publication.slug }, 'health check read failed');
+          }
+        }
+      }
+
       // Logged at error level so it surfaces without new infrastructure, the same way
       // the scorecard sweep reports its failures — a nightly job nobody watches is
       // exactly the kind that fails quietly for weeks.
@@ -2140,6 +2280,8 @@ export async function registerSubmissionRoutes(
           alerted,
           stalled: stalledIssues.length,
           stalledIssues,
+          healthResolved,
+          unhealthy,
         },
         stalledIssues.length > 0
           ? 'creator feedback undelivered past the stall threshold — the games-repo @copilot relay may be down'
@@ -2151,6 +2293,8 @@ export async function registerSubmissionRoutes(
         alerts: alerts.length,
         alerted,
         stalled: stalledIssues.length,
+        healthResolved,
+        unhealthy,
       });
     },
   );

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -37,6 +37,7 @@ const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
   // Names the suspect, because this one is never about the game: the request landed
   // and the relay that wakes an agent for it did not fire.
   feedback_undelivered: 'change request never collected — check the relay',
+  game_unhealthy: 'live game failing on the current engine — creator nudged',
 };
 
 /** The same kinds again, short enough to sit several to a line in the summary. */
@@ -45,6 +46,7 @@ const ALERT_SHORT: Record<OperatorAlert['kind'], string> = {
   build_failed: 'failed',
   build_stalled: 'stopped',
   feedback_undelivered: 'undelivered feedback',
+  game_unhealthy: 'unhealthy live game',
 };
 
 /** Rough age, in the same vocabulary the queue uses. */

--- a/apps/web/src/AdminJobsPanel.test.tsx
+++ b/apps/web/src/AdminJobsPanel.test.tsx
@@ -11,6 +11,8 @@ const mocked = vi.hoisted(() => ({
   publishJob: vi.fn(),
   cancelJob: vi.fn(),
   retryJob: vi.fn(),
+  fetchPublishedGames: vi.fn(),
+  regateGame: vi.fn(),
 }));
 
 vi.mock('./adminJobsApi.js', () => mocked);
@@ -36,6 +38,11 @@ function queue(jobs: JobQueueEntry[]): JobQueueResponse {
 }
 
 async function render() {
+  // The published shelf loads alongside the queue in every test; individual tests
+  // override with real data when the shelf is what they are about.
+  if (mocked.fetchPublishedGames.getMockImplementation() === undefined) {
+    mocked.fetchPublishedGames.mockResolvedValue([]);
+  }
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -220,6 +227,59 @@ describe('AdminJobsPanel', () => {
     });
 
     expect(container.querySelector('.admin-job-message')?.textContent).toContain('cancel it instead');
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows the published shelf with its health, and re-gates in one click', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([]));
+    mocked.fetchPublishedGames.mockResolvedValue([
+      {
+        slug: 'comet-courier',
+        state: 'published',
+        currentVersion: 'v1',
+        publishedAt: '2026-07-01T10:00:00Z',
+        healthCheck: {
+          version: 'v1',
+          requestedAt: '2026-07-29T10:00:00Z',
+          green: false,
+          verdictAt: '2026-07-29T10:20:00Z',
+        },
+      },
+      { slug: 'apex-sprint', state: 'published', currentVersion: 'v2', publishedAt: '2026-07-02T10:00:00Z' },
+    ]);
+    mocked.regateGame.mockResolvedValue({ ok: true, buildId: 'b1' });
+
+    const { container, root } = await render();
+
+    const shelf = container.querySelector('.admin-published');
+    expect(shelf?.textContent).toContain('comet-courier');
+    // A red verdict is loud, and says the creator already knows.
+    expect(shelf?.textContent).toContain('FAILING');
+    expect(shelf?.textContent).toContain('creator nudged');
+    // A game never checked says so rather than implying an answer.
+    expect(shelf?.textContent).toContain('never checked');
+
+    const regate = Array.from(shelf?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Re-gate',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      regate.click();
+      await Promise.resolve();
+    });
+    expect(mocked.regateGame).toHaveBeenCalledWith('comet-courier');
+    expect(shelf?.textContent).toContain('health check started');
+
+    await act(async () => root.unmount());
+  });
+
+  it('hides the shelf entirely when nothing is published', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job()]));
+    mocked.fetchPublishedGames.mockResolvedValue([]);
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.admin-published')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/AdminJobsPanel.test.tsx
+++ b/apps/web/src/AdminJobsPanel.test.tsx
@@ -9,6 +9,8 @@ import type { JobQueueEntry, JobQueueResponse } from './adminJobsApi.js';
 const mocked = vi.hoisted(() => ({
   fetchJobQueue: vi.fn(),
   publishJob: vi.fn(),
+  cancelJob: vi.fn(),
+  retryJob: vi.fn(),
 }));
 
 vi.mock('./adminJobsApi.js', () => mocked);
@@ -117,6 +119,107 @@ describe('AdminJobsPanel', () => {
 
     expect(container.querySelector('.admin-job-stall')?.textContent).toContain('silent');
     expect(container.querySelector('.admin-job-row')?.className).toContain('is-stalled');
+
+    await act(async () => root.unmount());
+  });
+
+  it('takes two clicks to cancel, because canceled has no undo', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job({ state: 'building' })]));
+    mocked.cancelJob.mockResolvedValue({ ok: true, state: 'canceled', stopEnforced: false });
+
+    const { container, root } = await render();
+    const button = container.querySelector('.admin-job-cancel') as HTMLButtonElement;
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    // Armed, not fired: the first click is the question, not the answer.
+    expect(mocked.cancelJob).not.toHaveBeenCalled();
+    expect(button.textContent).toContain('Sure?');
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    expect(mocked.cancelJob).toHaveBeenCalledWith(1_000_001);
+    // "Told to stop", not "stopped" — the backend has no kill switch and the panel
+    // must not promise one.
+    expect(container.querySelector('.admin-job-message')?.textContent).toContain('next report');
+
+    await act(async () => root.unmount());
+  });
+
+  it('never offers cancel mid-publish', async () => {
+    // The one non-terminal state the API refuses to cancel from; the console should not
+    // invite the click it knows the answer to.
+    mocked.fetchJobQueue.mockResolvedValue(queue([job({ state: 'publishing' })]));
+
+    const { container, root } = await render();
+
+    expect(container.querySelector('.admin-job-cancel')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('offers retry on dead rounds and stalled builds, not on every healthy one', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(
+      queue([
+        job({ issueNumber: 1, state: 'failed' }),
+        job({ issueNumber: 2, state: 'needs_changes' }),
+        job({ issueNumber: 3, state: 'building', stall: 'quiet' }),
+        // Healthy and working: a retry button here is an invitation to spend a credit
+        // on nothing.
+        job({ issueNumber: 4, state: 'building' }),
+        job({ issueNumber: 5, state: 'ready_for_review' }),
+      ]),
+    );
+
+    const { container, root } = await render();
+
+    const retryButtons = Array.from(container.querySelectorAll('button')).filter(
+      (button) => button.textContent === 'Retry',
+    );
+    expect(retryButtons).toHaveLength(3);
+
+    await act(async () => root.unmount());
+  });
+
+  it('retries in one click and says what it cost', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job({ state: 'failed' })]));
+    mocked.retryJob.mockResolvedValue({ ok: true, state: 'building', creditsSpent: 1 });
+
+    const { container, root } = await render();
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'Retry',
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(mocked.retryJob).toHaveBeenCalledWith(1_000_001);
+    expect(container.querySelector('.admin-job-message')?.textContent).toContain('1 credit');
+
+    await act(async () => root.unmount());
+  });
+
+  it('names the next step when a retry is refused', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([job({ state: 'failed' })]));
+    mocked.retryJob.mockResolvedValue({ refused: 'never_dispatched' });
+
+    const { container, root } = await render();
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'Retry',
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.admin-job-message')?.textContent).toContain('cancel it instead');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -87,7 +87,12 @@ function healthLabel(game: PublishedGame, now: number): string {
     const minutes = Math.max(0, Math.floor((now - Date.parse(check.requestedAt)) / 60_000));
     return `checking… (${minutes < 60 ? `${minutes}m` : `${Math.floor(minutes / 60)}h`} ago)`;
   }
-  return check.green ? `healthy (${check.verdictAt.slice(0, 10)})` : `FAILING (${check.verdictAt.slice(0, 10)})`;
+  // Explicit on both branches: `green` is optional on the record, and a resolved check
+  // that somehow lacks it must read as "unreadable", not as failing — the loud label
+  // has to agree with the row highlight, which only fires on `green === false`.
+  if (check.green === true) return `healthy (${check.verdictAt.slice(0, 10)})`;
+  if (check.green === false) return `FAILING (${check.verdictAt.slice(0, 10)})`;
+  return `verdict unreadable (${check.verdictAt.slice(0, 10)})`;
 }
 
 function PublishedRow({ game, onChanged }: { game: PublishedGame; onChanged: () => void }) {

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -2,12 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   cancelJob,
   fetchJobQueue,
+  fetchPublishedGames,
   publishJob,
+  regateGame,
   retryJob,
   type CancelRefusal,
   type JobQueueEntry,
   type JobQueueResponse,
+  type PublishedGame,
   type PublishRefusal,
+  type RegateRefusal,
   type RetryRefusal,
 } from './adminJobsApi.js';
 
@@ -61,6 +65,140 @@ const RETRY_COPY: Record<RetryRefusal, string> = {
 function retryable(job: JobQueueEntry): boolean {
   if (job.state === 'failed' || job.state === 'needs_changes') return true;
   return (job.state === 'building' || job.state === 'dispatched') && job.stall !== null;
+}
+
+const REGATE_COPY: Record<RegateRefusal, string> = {
+  not_published: 'not currently published — nothing live to check',
+  version_missing: 'the published version is missing from the store',
+  gate_unavailable: 'the gate is not configured on this deployment',
+  store_unavailable: 'the store is not configured on this deployment',
+  unknown: 'refused, and the reason was not one this console knows',
+};
+
+/**
+ * The health column in words. Three honest states: never asked, asked and waiting
+ * (with the age, because a request the gate never picked up looks exactly like a slow
+ * one until someone reads the date), and answered.
+ */
+function healthLabel(game: PublishedGame, now: number): string {
+  const check = game.healthCheck;
+  if (!check) return 'never checked';
+  if (!check.verdictAt) {
+    const minutes = Math.max(0, Math.floor((now - Date.parse(check.requestedAt)) / 60_000));
+    return `checking… (${minutes < 60 ? `${minutes}m` : `${Math.floor(minutes / 60)}h`} ago)`;
+  }
+  return check.green ? `healthy (${check.verdictAt.slice(0, 10)})` : `FAILING (${check.verdictAt.slice(0, 10)})`;
+}
+
+function PublishedRow({ game, onChanged }: { game: PublishedGame; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const onRegate = useCallback(async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await regateGame(game.slug);
+      if ('refused' in result) {
+        setMessage(REGATE_COPY[result.refused]);
+      } else {
+        setMessage('health check started — the verdict lands within a few sweeps');
+        onChanged();
+      }
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(false);
+    }
+  }, [game.slug, onChanged]);
+
+  const failing = game.healthCheck?.verdictAt && game.healthCheck.green === false;
+
+  return (
+    <tr className={failing ? 'admin-job-row is-stalled' : 'admin-job-row'}>
+      <td>
+        <div className="admin-job-title">{game.slug}</div>
+        <div className="admin-job-sub">{game.currentVersion}</div>
+      </td>
+      <td>{game.publishedAt.slice(0, 10)}</td>
+      <td>
+        <span className="admin-job-state">{healthLabel(game, Date.now())}</span>
+        {failing ? <div className="admin-job-stall">creator nudged to refresh</div> : null}
+      </td>
+      <td>
+        <button className="admin-job-publish" onClick={onRegate} disabled={busy}>
+          {busy ? 'Starting…' : 'Re-gate'}
+        </button>
+        {message ? <div className="admin-job-message">{message}</div> : null}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * What is live, and whether it still passes on today's engine.
+ *
+ * The queue above answers for builds in flight; published games are terminal jobs and
+ * would never appear there — yet they are the only thing players actually see. This is
+ * where the break-and-nudge loop starts: re-gate a game, and a red verdict nudges its
+ * creator to run an improvement round. The game keeps serving either way — its baked
+ * bundle froze the engine it shipped with.
+ */
+function PublishedGames() {
+  const [games, setGames] = useState<PublishedGame[] | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetchPublishedGames();
+      if (response === null) {
+        setState('forbidden');
+        return;
+      }
+      setGames(response);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    // Half the queue's cadence: health verdicts arrive on the sweep's schedule, not in
+    // seconds, and this table changes far less often than the queue above it.
+    const timer = setInterval(() => void load(), 60_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  // Forbidden renders nothing at all: the queue above has already said "Not found" to
+  // a stranger, and a second copy would only say it twice.
+  if (state === 'forbidden') return null;
+  if (state === 'loading') return null;
+  if (state === 'error') return <p className="health-empty">Could not read the published shelf.</p>;
+  if (!games || games.length === 0) return null;
+
+  return (
+    <section className="admin-published">
+      <h2 className="health-section-title">Published</h2>
+      <div className="health-table-scroll">
+        <table className="health-table">
+          <thead>
+            <tr>
+              <th>Game</th>
+              <th>Published</th>
+              <th>Health</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {games.map((game) => (
+              <PublishedRow key={game.slug} game={game} onChanged={() => void load()} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
 }
 
 /** Short, sortable duration: an operator reads "2h 5m", not 7_500_000. */
@@ -264,6 +402,8 @@ export function AdminJobsPanel() {
           </table>
         </div>
       )}
+
+      <PublishedGames />
     </section>
   );
 }

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
+  cancelJob,
   fetchJobQueue,
   publishJob,
+  retryJob,
+  type CancelRefusal,
   type JobQueueEntry,
   type JobQueueResponse,
   type PublishRefusal,
+  type RetryRefusal,
 } from './adminJobsApi.js';
 
 /**
@@ -37,6 +41,28 @@ const STALL_COPY: Record<NonNullable<JobQueueEntry['stall']>, string> = {
   gate_not_started: 'delivered, gate never started',
 };
 
+const CANCEL_COPY: Record<CancelRefusal, string> = {
+  already_finished: 'already finished — the queue is behind, refresh',
+  mid_publish: 'mid-publish — let the bake land or fail, then act on that',
+  store_unavailable: 'the store is not configured on this deployment',
+  unknown: 'refused, and the reason was not one this console knows',
+};
+
+const RETRY_COPY: Record<RetryRefusal, string> = {
+  not_retryable: 'nothing to retry from this state',
+  never_dispatched: 'never reached an agent, so there is nothing to resume — cancel it instead',
+  dispatch_failed: 'the agent backend refused to start a session — check it, then try again',
+  agent_backend_unavailable: 'no agent backend is configured on this deployment',
+  store_unavailable: 'the store is not configured on this deployment',
+  unknown: 'refused, and the reason was not one this console knows',
+};
+
+/** Where a retry makes sense: the round is dead, or alive and visibly stuck. */
+function retryable(job: JobQueueEntry): boolean {
+  if (job.state === 'failed' || job.state === 'needs_changes') return true;
+  return (job.state === 'building' || job.state === 'dispatched') && job.stall !== null;
+}
+
 /** Short, sortable duration: an operator reads "2h 5m", not 7_500_000. */
 function duration(ms: number | undefined): string {
   if (ms === undefined || !Number.isFinite(ms)) return '—';
@@ -48,8 +74,11 @@ function duration(ms: number | undefined): string {
 }
 
 function JobRow({ job, onPublished }: { job: JobQueueEntry; onPublished: () => void }) {
-  const [publishing, setPublishing] = useState(false);
+  const [busy, setBusy] = useState<'publish' | 'cancel' | 'retry' | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  // Cancel is irreversible — canceled has no exit in the state machine — so it takes two
+  // clicks: the first arms, the second fires. Anything else on the row disarms it.
+  const [cancelArmed, setCancelArmed] = useState(false);
 
   // Only a gate-green build can publish, and `ready_for_review` is precisely the state
   // that means so. Offering the button earlier would be offering an action the API will
@@ -57,8 +86,9 @@ function JobRow({ job, onPublished }: { job: JobQueueEntry; onPublished: () => v
   const publishable = job.state === 'ready_for_review';
 
   const onPublish = useCallback(async () => {
-    setPublishing(true);
+    setBusy('publish');
     setMessage(null);
+    setCancelArmed(false);
     try {
       const result = await publishJob(job.issueNumber);
       if ('refused' in result) {
@@ -70,7 +100,52 @@ function JobRow({ job, onPublished }: { job: JobQueueEntry; onPublished: () => v
     } catch {
       setMessage('could not reach the API');
     } finally {
-      setPublishing(false);
+      setBusy(null);
+    }
+  }, [job.issueNumber, onPublished]);
+
+  const onCancel = useCallback(async () => {
+    if (!cancelArmed) {
+      setCancelArmed(true);
+      return;
+    }
+    setBusy('cancel');
+    setMessage(null);
+    setCancelArmed(false);
+    try {
+      const result = await cancelJob(job.issueNumber);
+      if ('refused' in result) {
+        setMessage(CANCEL_COPY[result.refused]);
+      } else {
+        // "Told to stop", not "stopped": the Copilot backend has no kill switch, so a
+        // live session winds down when it next reads the channel. Saying more than
+        // that would be promising something we cannot do.
+        setMessage(result.stopEnforced ? 'canceled and stopped' : 'canceled — the session stops at its next report');
+        onPublished();
+      }
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(null);
+    }
+  }, [cancelArmed, job.issueNumber, onPublished]);
+
+  const onRetry = useCallback(async () => {
+    setBusy('retry');
+    setMessage(null);
+    setCancelArmed(false);
+    try {
+      const result = await retryJob(job.issueNumber);
+      if ('refused' in result) {
+        setMessage(RETRY_COPY[result.refused]);
+      } else {
+        setMessage(`new session started (${result.creditsSpent} credit${result.creditsSpent === 1 ? '' : 's'})`);
+        onPublished();
+      }
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(null);
     }
   }, [job.issueNumber, onPublished]);
 
@@ -96,11 +171,30 @@ function JobRow({ job, onPublished }: { job: JobQueueEntry; onPublished: () => v
       <td>{duration(job.timeInStateMs)}</td>
       <td>{duration(job.ageMs)}</td>
       <td>
-        {publishable ? (
-          <button className="admin-job-publish" onClick={onPublish} disabled={publishing}>
-            {publishing ? 'Publishing…' : 'Publish'}
-          </button>
-        ) : null}
+        <div className="admin-job-actions">
+          {publishable ? (
+            <button className="admin-job-publish" onClick={onPublish} disabled={busy !== null}>
+              {busy === 'publish' ? 'Publishing…' : 'Publish'}
+            </button>
+          ) : null}
+          {retryable(job) ? (
+            // Offered where a round is dead or visibly stuck — not on every healthy
+            // build, where the button would be an invitation to spend a credit on
+            // nothing. One credit per click, and the copy says so afterwards.
+            <button className="admin-job-publish" onClick={onRetry} disabled={busy !== null}>
+              {busy === 'retry' ? 'Retrying…' : 'Retry'}
+            </button>
+          ) : null}
+          {job.state !== 'publishing' ? (
+            <button
+              className={cancelArmed ? 'admin-job-cancel is-armed' : 'admin-job-cancel'}
+              onClick={onCancel}
+              disabled={busy !== null}
+            >
+              {busy === 'cancel' ? 'Canceling…' : cancelArmed ? 'Sure? This is final' : 'Cancel'}
+            </button>
+          ) : null}
+        </div>
         {message ? <div className="admin-job-message">{message}</div> : null}
       </td>
     </tr>

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -7,7 +7,8 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type OperatorAlertKind = 'review_ready' | 'build_failed' | 'build_stalled' | 'feedback_undelivered';
+export type OperatorAlertKind =
+  'review_ready' | 'build_failed' | 'build_stalled' | 'feedback_undelivered' | 'game_unhealthy';
 
 export interface OperatorAlert {
   id: string;

--- a/apps/web/src/adminJobsApi.ts
+++ b/apps/web/src/adminJobsApi.ts
@@ -108,6 +108,44 @@ export async function cancelJob(issueNumber: number): Promise<CancelResult | { r
   return { refused: known.find((code) => code === body.error) ?? 'unknown' };
 }
 
+export interface PublicationHealthCheck {
+  version: string;
+  requestedAt: string;
+  buildId?: string;
+  green?: boolean;
+  verdictAt?: string;
+  notifiedAt?: string;
+}
+
+export interface PublishedGame {
+  slug: string;
+  state: 'published' | 'archived' | 'disabled';
+  currentVersion: string;
+  publishedAt: string;
+  healthCheck?: PublicationHealthCheck;
+}
+
+export async function fetchPublishedGames(): Promise<PublishedGame[] | null> {
+  const response = await fetch('/api/admin/games', { credentials: 'include' });
+  if (response.status === 404 || response.status === 401) return null;
+  if (!response.ok) throw new Error(`published games failed: ${response.status}`);
+  return ((await response.json()) as { games: PublishedGame[] }).games;
+}
+
+export type RegateRefusal = 'not_published' | 'version_missing' | 'gate_unavailable' | 'store_unavailable' | 'unknown';
+
+/** Starts a health re-gate of a published game against the current engine. */
+export async function regateGame(slug: string): Promise<{ ok: true; buildId?: string } | { refused: RegateRefusal }> {
+  const response = await fetch(`/api/admin/games/${encodeURIComponent(slug)}/regate`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (response.ok) return (await response.json()) as { ok: true; buildId?: string };
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  const known: RegateRefusal[] = ['not_published', 'version_missing', 'gate_unavailable', 'store_unavailable'];
+  return { refused: known.find((code) => code === body.error) ?? 'unknown' };
+}
+
 export interface RetryResult {
   ok: true;
   state: 'building';

--- a/apps/web/src/adminJobsApi.ts
+++ b/apps/web/src/adminJobsApi.ts
@@ -83,3 +83,59 @@ export async function publishJob(issueNumber: number): Promise<PublishResult | {
   const refusal = known.find((code) => code === body.error) ?? 'unknown';
   return { refused: refusal };
 }
+
+export interface CancelResult {
+  ok: true;
+  state: 'canceled';
+  /**
+   * Whether the agent session was actually killed, or only told to stop. The Copilot
+   * backend has no kill switch — false there is the honest answer, and the panel says
+   * "told to stop" rather than "stopped" because of it.
+   */
+  stopEnforced: boolean;
+}
+
+export type CancelRefusal = 'already_finished' | 'mid_publish' | 'store_unavailable' | 'unknown';
+
+export async function cancelJob(issueNumber: number): Promise<CancelResult | { refused: CancelRefusal }> {
+  const response = await fetch(`/api/admin/jobs/${issueNumber}/cancel`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (response.ok) return (await response.json()) as CancelResult;
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  const known: CancelRefusal[] = ['already_finished', 'mid_publish', 'store_unavailable'];
+  return { refused: known.find((code) => code === body.error) ?? 'unknown' };
+}
+
+export interface RetryResult {
+  ok: true;
+  state: 'building';
+  /** A retry is a real agent session; the ledger books it whether or not it delivers. */
+  creditsSpent: number;
+}
+
+export type RetryRefusal =
+  | 'not_retryable'
+  | 'never_dispatched'
+  | 'dispatch_failed'
+  | 'agent_backend_unavailable'
+  | 'store_unavailable'
+  | 'unknown';
+
+export async function retryJob(issueNumber: number): Promise<RetryResult | { refused: RetryRefusal }> {
+  const response = await fetch(`/api/admin/jobs/${issueNumber}/retry`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (response.ok) return (await response.json()) as RetryResult;
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  const known: RetryRefusal[] = [
+    'not_retryable',
+    'never_dispatched',
+    'dispatch_failed',
+    'agent_backend_unavailable',
+    'store_unavailable',
+  ];
+  return { refused: known.find((code) => code === body.error) ?? 'unknown' };
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -22,6 +22,10 @@
       "needs_changes": {
         "title": "Your submission needs changes",
         "body": "“{{title}}” needs another look."
+      },
+      "game_health": {
+        "title": "Your game could use a refresh",
+        "body": "“{{title}}” no longer passes our checks on the latest engine. It still plays — an improvement round would bring it up to date."
       }
     },
     "creator": {
@@ -50,6 +54,10 @@
       "feedback_undelivered": {
         "title": "A change request is not reaching the agent",
         "body": "“{{title}}” has a change request nobody has collected."
+      },
+      "game_unhealthy": {
+        "title": "A live game failed its health check",
+        "body": "“{{title}}” no longer passes on the current engine. The creator has been nudged."
       }
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -22,6 +22,10 @@
       "needs_changes": {
         "title": "Twoje zgłoszenie wymaga zmian",
         "body": "„{{title}}” wymaga poprawek."
+      },
+      "game_health": {
+        "title": "Twoja gra przydałaby się odświeżyć",
+        "body": "„{{title}}” nie przechodzi już naszych testów na najnowszym silniku. Nadal działa — runda ulepszeń przywróci ją do formy."
       }
     },
     "creator": {
@@ -50,6 +54,10 @@
       "feedback_undelivered": {
         "title": "Prośba o zmianę nie dociera do agenta",
         "body": "„{{title}}” ma prośbę o zmianę, której nikt nie odebrał."
+      },
+      "game_unhealthy": {
+        "title": "Opublikowana gra nie przeszła kontroli",
+        "body": "„{{title}}” nie przechodzi już testów na aktualnym silniku. Twórca dostał zachętę do odświeżenia."
       }
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -24,7 +24,7 @@
         "body": "„{{title}}” wymaga poprawek."
       },
       "game_health": {
-        "title": "Twoja gra przydałaby się odświeżyć",
+        "title": "Twojej grze przydałoby się odświeżenie",
         "body": "„{{title}}” nie przechodzi już naszych testów na najnowszym silniku. Nadal działa — runda ulepszeń przywróci ją do formy."
       }
     },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7265,6 +7265,11 @@ body.player-open {
   cursor: default;
 }
 
+/* The published shelf sits under the queue, clearly a second thing. */
+.admin-published {
+  margin-top: 2rem;
+}
+
 .admin-job-message {
   margin-top: 0.35rem;
   font-size: 0.78rem;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7234,6 +7234,37 @@ body.player-open {
   cursor: default;
 }
 
+.admin-job-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+/* Same shape as the publish button; the colour only arrives once it is armed, because
+   the danger is in the second click, not the first. */
+.admin-job-cancel {
+  cursor: pointer;
+  padding: 0.3rem 0.7rem;
+  font: inherit;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, currentColor 45%, transparent);
+  background: transparent;
+  color: inherit;
+  opacity: 0.8;
+}
+
+.admin-job-cancel.is-armed {
+  border-color: var(--danger, #c0392b);
+  color: var(--danger, #c0392b);
+  opacity: 1;
+}
+
+.admin-job-cancel:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .admin-job-message {
   margin-top: 0.35rem;
   font-size: 0.78rem;


### PR DESCRIPTION
Two features, built in parallel as requested: the console's missing verbs, and the break-and-nudge loop that replaces engine pinning.

## Cancel and retry

The console could watch a stuck build and publish a finished one, but the most common alert — a stalled job — had no verb: killing or restarting still meant curl.

**Cancel** transitions the job to `canceled` and is honest about what that does. The Copilot tasks API has no kill endpoint, so cancellation is cooperative: the job being terminal *is* the mechanism — the build channel's stop check now includes the canceled state (`copilot-backend.cancel` has described that behaviour since it was written; nothing implemented it until now), so a live session reads `control.stop` on its next report and winds down, and its writes stop landing. The response says `stopEnforced: false` and the panel renders "canceled — the session stops at its next report" rather than "stopped". Two named refusals: a finished job stays finished, and a job mid-publish is left to land or fail. The button takes two clicks, because canceled has no exit in the transition table.

**Retry** starts a fresh session through the same resume path creator feedback uses — restoring delivered work from the store, or handing an undelivered round its old branch, the only copy of its work. Offered from dead rounds (`failed`, `needs_changes`) and visibly stuck ones (stalled `building`/`dispatched`), not from every healthy build. Honest edges: a job that never reached an agent is refused (`never_dispatched` — no spec on record, no branch to resume, an empty session would spend a credit briefing an agent with nothing); a resume the backend refused answers **502** rather than pretending it took; a same-state retry writes its own `operator_retry` transition so the round a person explicitly started is visible in the history. The ledger books the credit, and the response says so.

## Break-and-nudge (phase 1)

The engine question, answered by regeneration rather than pinning: detect breakage, nudge the creator, make the fix an improvement round.

The premise that makes this safe: **serving is already immune** — a published game is a baked, self-contained bundle. What drifts is whether the game would still *pass* a rebuild, and nothing measured that.

- **Health is a second verdict, never a rewrite of the first.** A re-gate runs the same check on the same stored sources with the engine pin overridden to `main`, recorded as `manifest.health`. The acceptance verdict is provenance — a red re-run erasing it would erase the justification for publishing.
- **Verdicts now name their target.** The gate resolves the commit it actually checked against (`git rev-parse HEAD` in the harness) and the first run stamps it onto the manifest — closing the runner's "closing it is the next change to this file" note from the validation side.
- **The loop:** operator hits *Re-gate* on the console's new published shelf → the same configured Cloud Build trigger runs in `--health` mode (tagged `health`, cost booked to the job that built the game) → the verdict lands on the manifest → the sweep reads it back. Green resolves quietly. **Red nudges the creator** (in-app + email, deep-linked to the studio where the improvement round starts, written as an invitation: "it still plays fine — a quick improvement round would bring it up to date") **and copies the operator**, idempotently.

Deliberately out of this slice, named so it stays visible: nothing auto-re-gates on an engine push yet — the trigger is the operator's button; wiring the games repo's push webhook to sweep the shelf is the follow-up.

## Testing

Full gate green: lint, type-check, 2129 tests, build. New coverage: channel stop on canceled, both routes' refusals and edge cases, two-click cancel, retry offer rules, engine-commit resolution and override, health-verdict-beside-gate-verdict, first-run-pins/never-repins, `--health` flag and tag, regate route, sweep resolution (red/green/stale), nudge idempotency, the published shelf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1rDAP357447cbEmwhCXY9)_