### PR TITLE
Creator Studio: name the game first, give it an address, and make the studio a thread

### DIFF
--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -642,6 +642,15 @@ export async function registerAgentChannelRoutes(
 
       // The job's own slug wins whenever it has one. A build that has already been
       // associated with a game cannot deliver into a different one, whatever it sends.
+      //
+      // A job now carries its slug from the moment it is created — minted from the
+      // creator's confirmed title and named in the agent's brief — so this check bites
+      // on the *first* delivery rather than only on later ones. That is deliberate and
+      // it is not a tightening for its own sake: the creator has been given
+      // `/studio/<slug>` since they pressed create, and may already have shared a link
+      // to the game, so a delivery that renamed it would break an address that was
+      // handed out in good faith. The error names the slug the agent was briefed with,
+      // which is the one piece of information it needs to deliver again correctly.
       const slug = record.slug ?? parsed.data.slug;
       if (record.slug && record.slug !== parsed.data.slug) {
         return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -40,6 +40,8 @@ export interface CreatorStudioGame {
   lastKnownStatus: string | null;
   slug?: string;
   publishedAt?: string;
+  /** Whether the creator has turned on the shared link for this game's draft. */
+  draftShared?: boolean;
 }
 
 export interface CreatorHealthResponse {
@@ -168,6 +170,7 @@ export async function registerCreatorStudioRoutes(
         lastKnownStatus: record.lastNotifiedStatus ?? null,
         ...(record.slug ? { slug: record.slug } : {}),
         ...(record.publishedAt ? { publishedAt: record.publishedAt } : {}),
+        ...(record.draftSharedAt ? { draftShared: true } : {}),
       }));
 
     return reply.send({ games });

--- a/apps/api/src/refine.test.ts
+++ b/apps/api/src/refine.test.ts
@@ -298,4 +298,55 @@ describe('VertexSpecRefiner over a genaicode client', () => {
       expect(await refiner.refine({ title: 'Game', concept: 'Concept' })).toEqual({ questions: [] });
     }
   });
+
+  it('names the game, and asks for the name without being given one', async () => {
+    // The concept arrives with no title now: the creator has not been asked for one,
+    // which is exactly why the model is asked to propose it.
+    let seen: GenerationRequest | undefined;
+    const refiner = new VertexSpecRefiner({
+      client: stubClient(JSON.stringify({ suggestedTitle: 'TV Tycoon', questions: [] }), (req) => (seen = req)),
+    });
+
+    const result = await refiner.refine({ concept: 'Run a television studio and chase ratings' });
+
+    expect(result.suggestedTitle).toBe('TV Tycoon');
+    expect(seen?.prompt[0]?.text).toContain('suggestedTitle');
+    // Nothing pretending to be a working title when there is none.
+    expect(seen?.prompt[0]?.text).not.toContain('working title');
+  });
+
+  it('tidies a title the model wrapped in quotes or ended with a full stop', async () => {
+    const refiner = new VertexSpecRefiner({
+      client: stubClient(JSON.stringify({ suggestedTitle: '  "TV Tycoon."  ', questions: [] })),
+    });
+
+    expect((await refiner.refine({ concept: 'Run a television studio' })).suggestedTitle).toBe('TV Tycoon');
+  });
+
+  it('offers no title rather than one the submission route would reject', async () => {
+    // A suggestion the creator could not submit unedited is worse than none: they
+    // would meet a validation error on a name they never wrote.
+    for (const suggested of ['', 'ab', '   ']) {
+      const refiner = new VertexSpecRefiner({
+        client: stubClient(JSON.stringify({ suggestedTitle: suggested, questions: [] })),
+      });
+      expect((await refiner.refine({ concept: 'Run a television studio' })).suggestedTitle).toBeUndefined();
+    }
+
+    const long = new VertexSpecRefiner({
+      client: stubClient(JSON.stringify({ suggestedTitle: 'A'.repeat(200), questions: [] })),
+    });
+    expect((await long.refine({ concept: 'Run a television studio' })).suggestedTitle).toHaveLength(80);
+  });
+
+  it('passes a working title through when the creator did supply one', async () => {
+    let seen: GenerationRequest | undefined;
+    const refiner = new VertexSpecRefiner({
+      client: stubClient(JSON.stringify({ questions: [] }), (req) => (seen = req)),
+    });
+
+    await refiner.refine({ title: 'Carrot Farm', concept: 'Grow carrots' });
+
+    expect(seen?.prompt[0]?.text).toContain('Carrot Farm');
+  });
 });

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { checkUserAccess } from './auth.js';
 import { createVertexClient, type VertexGenerationConfig } from './genai.js';
 import type { ContentChecker } from './moderation.js';
+import { sanitizeCreatorText } from './submission-status.js';
 import type { Store } from './store.js';
 import { logModerationRejection } from './moderation-metrics.js';
 
@@ -24,10 +25,25 @@ export interface RefineQuestion {
 
 export interface RefineResponse {
   questions: RefineQuestion[];
+  /**
+   * A name for the game, in the creator's language.
+   *
+   * Games used to be named by truncation — the first 40 characters of the prompt, cut
+   * mid-word — and that string became the title everywhere: the studio, the catalog, the
+   * agent's brief. The model is already reading the concept to write its questions, so
+   * naming it costs nothing extra; the creator confirms or replaces it before anything
+   * is built. Absent when the model declines or the call fails open.
+   */
+  suggestedTitle?: string;
 }
 
 export interface RefineParams {
-  title: string;
+  /**
+   * A name the creator already has in mind. Optional: the flow that calls this has not
+   * asked for one yet — that is what `suggestedTitle` is for — and seeding the model
+   * with a truncated fragment of the concept only anchored it on the truncation.
+   */
+  title?: string;
   concept: string;
   locale?: string;
 }
@@ -61,7 +77,35 @@ export const DEFAULT_REFINE_TIMEOUT_MS = 20_000;
 const REFINE_CACHE_TTL_MS = 10 * 60_000;
 const REFINE_CACHE_MAX_ENTRIES = 200;
 
+/**
+ * The submission route's own title bounds. A suggestion that could not be submitted
+ * unedited is worse than no suggestion: the creator would meet the validation error on
+ * a name they never wrote.
+ */
+const MIN_TITLE_LENGTH = 3;
+const MAX_TITLE_LENGTH = 80;
+
+/**
+ * A model-proposed title, or undefined when there is nothing usable.
+ *
+ * The model is asked for a bare name and mostly gives one, but it also sometimes wraps
+ * it in quotes or ends it with a full stop, and a title is about to be shown in a text
+ * input and then carried by the game forever. Single-lined here rather than at the
+ * route because every caller of a refiner wants the same thing, stubs included.
+ */
+function cleanSuggestedTitle(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = sanitizeCreatorText(raw, { singleLine: true })
+    .replace(/^["'“”„«»]+|["'“”„«»]+$/g, '')
+    .replace(/[.!?,;:]+$/, '')
+    .trim()
+    .slice(0, MAX_TITLE_LENGTH)
+    .trim();
+  return cleaned.length >= MIN_TITLE_LENGTH ? cleaned : undefined;
+}
+
 const RefineResultSchema = z.object({
+  suggestedTitle: z.string().optional(),
   questions: z
     .array(
       z.object({
@@ -120,13 +164,17 @@ export class VertexSpecRefiner implements SpecRefiner {
 
     try {
       const promptText = `You are a helpful game design assistant for gamedev.pl.
-Analyze the following game title and concept specification.
-Identify up to 4 underspecified or missing gameplay/design dimensions (such as visual style, controls, difficulty/pacing, or win/lose conditions) that would help a coding agent build a better game.
+Analyze the following game concept specification.
 
-Language requirement: Formulate questions and options in the language specified (${params.locale ?? 'en'}).
+Do two things:
+1. Propose "suggestedTitle": a short, catchy name for this game — at most 6 words, no quotes, no trailing punctuation. Name the game, do not describe it, and never echo the concept text back as a sentence.
+2. Identify up to 4 underspecified or missing gameplay/design dimensions (such as visual style, controls, difficulty/pacing, or win/lose conditions) that would help a coding agent build a better game.
+
+Language requirement: Write the title, questions and options in the language specified (${params.locale ?? 'en'}).
 
 Respond STRICTLY with a JSON object following this schema:
 {
+  "suggestedTitle": "Short Game Name",
   "questions": [
     {
       "id": "short_unique_id",
@@ -142,9 +190,8 @@ Respond STRICTLY with a JSON object following this schema:
 
 Set "multiple": true only when the options genuinely combine rather than compete — "which mechanics should be in?" can take several, "which visual style?" cannot. Default to false.
 
-If the concept is already fully specified, return {"questions": []}.
-
-Game Title: "${params.title}"
+If the concept is already fully specified, return an empty "questions" array — but always propose a title.
+${params.title ? `\nThe creator's working title, to improve on or keep: "${params.title}"\n` : ''}
 Game Concept:
 """
 ${params.concept}
@@ -155,7 +202,10 @@ ${params.concept}
         .signal(AbortSignal.timeout(this.timeoutMs))
         .json((value) => RefineResultSchema.parse(value));
 
+      const suggestedTitle = cleanSuggestedTitle(parsed.suggestedTitle);
+
       return {
+        ...(suggestedTitle ? { suggestedTitle } : {}),
         questions: (parsed.questions ?? []).slice(0, 4).map((q, idx) => ({
           id: q.id ?? `q_${idx}`,
           question: q.question ?? '',
@@ -188,7 +238,14 @@ export class StubSpecRefiner implements SpecRefiner {
 }
 
 const RefineRequestSchema = z.object({
-  title: z.string().trim().min(3, 'title must be at least 3 characters').max(80, 'title must be at most 80 characters'),
+  // Optional since the naming step moved *after* this call: the app no longer has a
+  // title to send, and the one it used to send was the prompt's first 40 characters.
+  title: z
+    .string()
+    .trim()
+    .min(3, 'title must be at least 3 characters')
+    .max(80, 'title must be at most 80 characters')
+    .optional(),
   concept: z
     .string()
     .trim()
@@ -244,9 +301,9 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
    */
   const refineCache = new Map<string, { expiresAt: number; result: RefineResponse }>();
 
-  const cacheKey = (data: { title: string; concept: string; locale?: string }) =>
+  const cacheKey = (data: { title?: string; concept: string; locale?: string }) =>
     createHash('sha256')
-      .update(`${data.locale ?? 'en'}\x00${data.title}\x00${data.concept}`)
+      .update(`${data.locale ?? 'en'}\x00${data.title ?? ''}\x00${data.concept}`)
       .digest('hex');
 
   const readCache = (key: string, now: number): RefineResponse | null => {
@@ -262,7 +319,9 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
   const writeCache = (key: string, result: RefineResponse, now: number) => {
     // Never cache a fail-open: an empty answer is exactly what a timeout produces,
     // and pinning that for ten minutes would turn one slow call into a dead panel.
-    if (result.questions.length === 0) return;
+    // A title with no questions is not that — it is a fully-specified concept that the
+    // model still named — so emptiness is only disqualifying when it is total.
+    if (result.questions.length === 0 && !result.suggestedTitle) return;
     if (refineCache.size >= REFINE_CACHE_MAX_ENTRIES) {
       const oldest = refineCache.keys().next().value;
       if (oldest !== undefined) refineCache.delete(oldest);
@@ -296,7 +355,10 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
     }
 
     // 2. Content moderation (422 on reject, spends no quota / vertex calls)
-    const moderation = await contentChecker.checkFields([parseResult.data.title, parseResult.data.concept]);
+    const moderatedFields = [parseResult.data.title, parseResult.data.concept].filter((field): field is string =>
+      Boolean(field),
+    );
+    const moderation = await contentChecker.checkFields(moderatedFields);
     if (!moderation.allowed) {
       logModerationRejection(request.log, {
         surface: 'refine',
@@ -322,7 +384,7 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
     const startedAt = Date.now();
     try {
       const result = await specRefiner.refine({
-        title: parseResult.data.title,
+        ...(parseResult.data.title ? { title: parseResult.data.title } : {}),
         concept: parseResult.data.concept,
         locale: parseResult.data.locale,
       });

--- a/apps/api/src/slug.test.ts
+++ b/apps/api/src/slug.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mintGameSlug, slugifyTitle } from './slug.js';
+
+describe('slugifyTitle', () => {
+  it('produces a readable address from an ordinary title', () => {
+    expect(slugifyTitle('TV Tycoon')).toBe('tv-tycoon');
+    expect(slugifyTitle('  Dodge   the Falling Rocks!  ')).toBe('dodge-the-falling-rocks');
+  });
+
+  it('keeps Polish titles recognisable as their creator wrote them', () => {
+    // "ł" is one indivisible codepoint, so decomposition alone drops it: "Łódź" would
+    // slug to "d". Polish is the site's second language, so this is not an edge case.
+    expect(slugifyTitle('Łódź Nocą')).toBe('lodz-noca');
+    expect(slugifyTitle('Zażółć gęślą jaźń')).toBe('zazolc-gesla-jazn');
+  });
+
+  it('always emits something valid, whatever it is handed', () => {
+    const shapes = ['🎮🎮🎮', '???', '---', '', '   '];
+    for (const title of shapes) {
+      const slug = slugifyTitle(title);
+      expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it('cuts a long title at a word boundary and never trails a dash', () => {
+    const slug = slugifyTitle('A game tycoon simulator where I run a television business with presenters and ratings');
+    expect(slug.length).toBeLessThanOrEqual(48);
+    expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    // Whole words only: the point of the whole change is that names stop being cut
+    // mid-word, and a slug is the most visible place that would show.
+    expect('a-game-tycoon-simulator-where-i-run-a-television-business'.startsWith(slug)).toBe(true);
+  });
+
+  it('steps around path segments the app uses', () => {
+    // Suffixed rather than replaced: the creator called it "Play", and "play-2" still
+    // reads as theirs where a generic fallback would not.
+    expect(slugifyTitle('Play')).toBe('play-2');
+    expect(slugifyTitle('admin')).toBe('admin-2');
+    // Only the exact word is reserved — a game genuinely called this is unaffected.
+    expect(slugifyTitle('Play Together')).toBe('play-together');
+  });
+});
+
+describe('mintGameSlug', () => {
+  it('takes the plain name when nothing holds it', async () => {
+    expect(await mintGameSlug('TV Tycoon', async () => false)).toBe('tv-tycoon');
+  });
+
+  it('numbers collisions so the second one is still recognisable', async () => {
+    const taken = new Set(['space-miner', 'space-miner-2']);
+    expect(await mintGameSlug('Space Miner', async (slug) => taken.has(slug))).toBe('space-miner-3');
+  });
+
+  it('never refuses a build over its address, however hostile the probe', async () => {
+    // A probe that answers "taken" to everything is either a very popular title or a
+    // broken lookup. Neither is a reason to fail a submission the creator has paid a
+    // quota slot for, so the loop has a floor it can always land on.
+    const isTaken = vi.fn(async () => true);
+    const slug = await mintGameSlug('Space Miner', isTaken, { maxAttempts: 3 });
+
+    expect(isTaken).toHaveBeenCalledTimes(3);
+    expect(slug).toMatch(/^space-miner-[a-z0-9]+$/);
+    expect(slug).not.toBe('space-miner-2');
+  });
+});

--- a/apps/api/src/slug.ts
+++ b/apps/api/src/slug.ts
@@ -1,0 +1,133 @@
+/**
+ * Turning a creator's title into the name a game is addressed by, for its whole life.
+ *
+ * A slug used to be the agent's to choose, learned the first time it delivered or the
+ * first time a pull request touched `games/<something>/`. That left every build with a
+ * stretch — minutes at best, an hour at worst — during which the game we were building
+ * had no name we could put in a URL, which is why the creator's own studio addressed it
+ * by an HMAC capability token instead. Minting it here, at submission, from the title
+ * the creator just confirmed, is what lets the slug be the address from the first second.
+ *
+ * Pure except for the caller-supplied `isTaken` probe, so the shape of a slug can be
+ * tested without a store, a catalog, or a network.
+ */
+
+/**
+ * Long enough to stay recognisable as the creator's title, short enough to be a URL a
+ * person can read out. The delivery contract's own ceiling is 64, and a collision
+ * suffix has to fit under it.
+ */
+const MAX_SLUG_LENGTH = 48;
+
+/** What a title reduces to when it has no ASCII-able characters at all. */
+const FALLBACK_SLUG = 'game';
+
+/**
+ * Path segments the app itself uses. None of them can currently collide — a game slug
+ * is always addressed under `/play/`, `/draft/` or `/studio/` — but a game called
+ * "admin" is a trap laid for the next person who adds a route, and the cost of not
+ * laying it is this list.
+ */
+const RESERVED_SLUGS = new Set([
+  'admin',
+  'api',
+  'contact',
+  'draft',
+  'health',
+  'join',
+  'new',
+  'play',
+  'privacy',
+  'studio',
+  'status',
+  'terms',
+]);
+
+/**
+ * Letters that survive Unicode decomposition unchanged and would otherwise be dropped.
+ *
+ * `NFD` splits "ó" into an o and a combining accent, so stripping the accents leaves the
+ * letter — but Polish "ł" is a single indivisible codepoint, and so are these others.
+ * Without the map, "Łódź" slugs to "d", which is not a name anybody would recognise as
+ * theirs. Polish is the second language this site is written in, so this is not an edge
+ * case here.
+ */
+const INDIVISIBLE_LETTERS: Array<[RegExp, string]> = [
+  [/ł/g, 'l'],
+  [/đ/g, 'd'],
+  [/ð/g, 'd'],
+  [/ø/g, 'o'],
+  [/þ/g, 'th'],
+  [/ß/g, 'ss'],
+  [/æ/g, 'ae'],
+  [/œ/g, 'oe'],
+];
+
+/**
+ * The slug a title wants, before uniqueness is considered.
+ *
+ * Always a valid slug: lowercase, `[a-z0-9-]`, no leading, trailing or doubled dashes,
+ * never empty, never a reserved word. A title of pure emoji or pure punctuation is a
+ * real thing a creator can type, and it lands on the fallback rather than on ''.
+ */
+export function slugifyTitle(title: string): string {
+  let working = title.toLowerCase();
+  for (const [pattern, replacement] of INDIVISIBLE_LETTERS) {
+    working = working.replace(pattern, replacement);
+  }
+
+  const base = working
+    .normalize('NFD')
+    // Combining marks left behind by the decomposition above.
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!base) return FALLBACK_SLUG;
+
+  // Cut at a dash rather than mid-word, the same courtesy the title suggestion gets.
+  let clipped = base.slice(0, MAX_SLUG_LENGTH);
+  if (base.length > MAX_SLUG_LENGTH) {
+    const lastDash = clipped.lastIndexOf('-');
+    if (lastDash > 0) clipped = clipped.slice(0, lastDash);
+  }
+  clipped = clipped.replace(/^-+|-+$/g, '');
+
+  if (!clipped) return FALLBACK_SLUG;
+  // A reserved word is suffixed rather than replaced: the creator called it "Play",
+  // and "play-2" still reads as theirs where "game" would not.
+  return RESERVED_SLUGS.has(clipped) ? `${clipped}-2` : clipped;
+}
+
+/**
+ * A slug for this title that nothing else is using.
+ *
+ * `isTaken` is asked about each candidate in turn; the caller decides what taken means
+ * (another build, a published game, a name that has been taken down and should not be
+ * reused). Numbered rather than randomised because the numbers are for humans: the
+ * second "space miner" being `space-miner-2` is a fact a creator can hold in their head.
+ *
+ * **Not atomic**, and it cannot be: the probe is a read and the write happens later, so
+ * two submissions racing on the same title can both be told a name is free. The window
+ * is small and the consequence is bounded — two jobs pointing at one slug, where the
+ * newest wins on lookup — but a hard guarantee would need a claim document keyed by the
+ * slug itself, and that is worth building only if it ever actually bites.
+ */
+export async function mintGameSlug(
+  title: string,
+  isTaken: (slug: string) => Promise<boolean>,
+  options: { maxAttempts?: number } = {},
+): Promise<string> {
+  const base = slugifyTitle(title);
+  const maxAttempts = options.maxAttempts ?? 20;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const candidate = attempt === 1 ? base : `${base}-${attempt}`;
+    if (!(await isTaken(candidate))) return candidate;
+  }
+
+  // Twenty games of one name is not a collision pattern, it is either a very popular
+  // title or a probe that answers "taken" to everything. Either way the build must not
+  // be refused over its address, so it gets one that cannot collide.
+  return `${base}-${Date.now().toString(36)}`;
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { Firestore, type DocumentData } from '@google-cloud/firestore';
+import { FieldValue, Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-tasks.js';
 import type { PublicationHealthCheck, PublicationRecord } from './games-store.js';
 import type { JobState, JobTransition } from './job-state.js';
@@ -108,6 +108,19 @@ export interface SubmissionRecord {
    * GitHub entirely (an abandoned build must not read as "needs a tweak").
    */
   abandonedAt?: string;
+  /**
+   * When the creator turned on the shared link for this game's draft, if they have.
+   *
+   * A game is addressable at `/play/<slug>` from the moment it is submitted, but until
+   * this is set only its creator may open it there. Absent means off, which is the
+   * default: before it existed, any signed-in visitor who knew a slug could read any
+   * unpublished game, which made every in-progress game unlisted rather than private and
+   * gave the person making it no say in the matter.
+   *
+   * A timestamp rather than a flag because "when did this become shareable" is the
+   * question worth being able to answer later; clearing it turns sharing back off.
+   */
+  draftSharedAt?: string;
   /**
    * How many clarifying questions the creator actually answered before this was
    * submitted — 0 when they skipped the QA panel or it had nothing to ask.
@@ -1001,6 +1014,8 @@ export interface Store {
   setSubmissionPublishedAt(issueNumber: number, at: string): Promise<void>;
   /** Marks a submission abandoned by its creator. */
   setSubmissionAbandoned(issueNumber: number, at: string): Promise<void>;
+  /** Turns the creator's shared draft link on (a timestamp) or off (null). */
+  setDraftShared(issueNumber: number, at: string | null): Promise<void>;
   /**
    * Reads what is currently published for a slug, or null when nothing ever was.
    *
@@ -1664,6 +1679,15 @@ export class InMemoryStore implements Store {
   async setSubmissionAbandoned(issueNumber: number, at: string): Promise<void> {
     const sub = this.submissions.get(issueNumber);
     if (sub) this.submissions.set(issueNumber, { ...sub, abandonedAt: at });
+  }
+
+  async setDraftShared(issueNumber: number, at: string | null): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    const next = { ...sub };
+    if (at) next.draftSharedAt = at;
+    else delete next.draftSharedAt;
+    this.submissions.set(issueNumber, next);
   }
 
   async setSubmissionLocale(issueNumber: number, locale: string): Promise<void> {
@@ -2679,6 +2703,15 @@ export class FirestoreStore implements Store {
 
   async setSubmissionAbandoned(issueNumber: number, at: string): Promise<void> {
     await this.db.collection('submissions').doc(String(issueNumber)).set({ abandonedAt: at }, { merge: true });
+  }
+
+  async setDraftShared(issueNumber: number, at: string | null): Promise<void> {
+    // Deleted rather than set false, so "shared" is one shape everywhere: a timestamp
+    // is present or it is not, and no reader has to know about a legacy falsy value.
+    await this.db
+      .collection('submissions')
+      .doc(String(issueNumber))
+      .set({ draftSharedAt: at ?? FieldValue.delete() }, { merge: true });
   }
 
   async setSubmissionLocale(issueNumber: number, locale: string): Promise<void> {

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -5,7 +5,7 @@
 // its own; callers pass an `isSlugPublished` probe.
 
 import type { LinkedPullRequest } from './github-client.js';
-import type { JobStall } from './job-state.js';
+import type { JobStall, JobState } from './job-state.js';
 
 export type SubmissionStatus =
   | 'queued'
@@ -129,6 +129,23 @@ export function parseProgressNote(raw: string | null): string | undefined {
 
 export interface SubmissionStatusResponseBase {
   status: SubmissionStatus;
+  /**
+   * The job's own state, when we own one — a finer reading of the same moment than
+   * `status`, which several distinct situations collapse into.
+   *
+   * `status` exists to place the build on a five-step timeline and cannot grow without
+   * changing what every client draws, so `gating` and `building` arrive as one word and
+   * the page says "writing code" while the checks are what is actually running. Worse at
+   * the other end: `ready_for_review` is a delivered game waiting on us, and it renders
+   * as "automated checks are making sure your game runs clean" for however long the wait
+   * takes — a sentence that is not true when it is read, under a checklist saying every
+   * task is done.
+   *
+   * So the coarse word keeps drawing the timeline, and this one lets the copy underneath
+   * it describe the state the build is actually in. Absent for GitHub-derived
+   * submissions, which have no job state to report; clients fall back to `status`.
+   */
+  phase?: JobState;
   slug?: string;
   /**
    * Present while an unmerged PR is open (building/in_review): the creator can

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -528,18 +528,50 @@ describe('submission routes', () => {
     expect(jobs[0].issueNumber).toBeGreaterThanOrEqual(JOB_ID_FLOOR);
     expect(response.json()).toEqual({
       token: mintToken(jobs[0].issueNumber, secret),
+      // Minted here, from the sanitized title, and returned so the app can open the
+      // studio on a readable address instead of on a capability token.
+      slug: 'my-cool-title',
       statusUrl: `/api/submissions/${response.json().token}`,
     });
+    expect(jobs[0].slug).toBe('my-cool-title');
 
     // Creator text is still sanitized and still fenced as data — it just reaches the
     // agent directly now instead of by way of an issue body.
     expect(briefs).toHaveLength(1);
     expect(briefs[0].spec).toContain('My cool title');
+    // The agent is told where to build. Its brief used to name the game directory as
+    // "(the slug named in your first progress report)", which is a sentence, not a path.
+    expect(briefs[0].slug).toBe('my-cool-title');
     expect(briefs[0].spec).toContain('This is a sufficiently long concept with markup and details.');
     expect(briefs[0].spec).not.toContain('<script>');
     expect(briefs[0].spec).not.toContain('<i>');
     expect(briefs[0].channelToken).toBe(mintAgentToken(jobs[0].issueNumber, secret));
   });
+  it('gives two games of the same name addresses of their own', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 93 });
+    const store = new InMemoryStore();
+    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
+
+    const submit = () =>
+      app.inject({
+        method: 'POST',
+        url: '/api/submissions',
+        headers: authHeaders,
+        payload: {
+          title: 'Space Miner',
+          concept: 'Dig asteroids for ore and sell it at the station before your fuel runs out.',
+        },
+      });
+
+    const first = await submit();
+    const second = await submit();
+
+    expect(first.json().slug).toBe('space-miner');
+    // Numbered rather than randomised: the second "space miner" being space-miner-2 is
+    // a fact a creator can hold in their head.
+    expect(second.json().slug).toBe('space-miner-2');
+  });
+
   it('records how many QA answers came with the concept', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 92 });
     const store = new InMemoryStore();

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1065,6 +1065,122 @@ const sampleSources: GameSources = {
   title: 'Bubble Pop Rush',
 };
 
+describe('playing an unpublished game at its permalink', () => {
+  /**
+   * A game answers at `/play/<slug>` from the moment it is submitted. Who that includes
+   * before it is published is the creator's decision, and off is the default — the whole
+   * point of the switch. These pin both halves, because the failure modes are opposite:
+   * a leak on one side, and a creator locked out of their own game on the other.
+   */
+  async function draftApp() {
+    const store = new InMemoryStore();
+    const jobId = 1_000_077;
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.upsertUser({ uid: 'g:someone-else' });
+    await store.createSubmission(jobId, 'g:test-user', 'TV Tycoon');
+    await store.setSubmissionSlug(jobId, 'tv-tycoon');
+    await store.setSubmissionDeliveredVersion(jobId, 'v1');
+
+    const gamesStore = {
+      getDerivedArtifact: async (_s: string, _v: string, name: string) =>
+        name === 'bundle.html' ? Buffer.from('<!doctype html><title>TV Tycoon</title><canvas></canvas>') : null,
+    } as unknown as GamesStore;
+
+    // The catalog knows nothing about it: an unpublished game is in no catalog and no
+    // rail, so the link is the only way in — which is what makes one switch enough.
+    const { githubClient } = createGithubClientStub({ catalog: [] });
+    const { app, authHeaders } = await createApp({
+      store,
+      githubClient,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+    return { app, authHeaders, store, jobId };
+  }
+
+  it('lets the creator play their own game before anyone else can', async () => {
+    const { app, authHeaders } = await draftApp();
+
+    const mine = await app.inject({ method: 'GET', url: '/api/games/tv-tycoon', headers: authHeaders });
+    expect(mine.statusCode).toBe(200);
+    expect(mine.json()).toMatchObject({ slug: 'tv-tycoon', title: 'TV Tycoon' });
+
+    // Sharing is off, so it does not exist for anybody else — including signed-in
+    // visitors, who used to be able to read any draft whose slug they knew.
+    const stranger = await app.inject({
+      method: 'GET',
+      url: '/api/games/tv-tycoon',
+      headers: getAuthHeaders('g:someone-else'),
+    });
+    expect(stranger.statusCode).toBe(404);
+
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/tv-tycoon' });
+    expect(anonymous.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('opens the same permalink to everyone once the creator shares it, and closes it again', async () => {
+    const { app, authHeaders, jobId } = await draftApp();
+
+    const on = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(jobId, secret)}/share`,
+      headers: authHeaders,
+      payload: { shared: true },
+    });
+    expect(on.statusCode).toBe(200);
+    expect(on.json()).toEqual({ shared: true, slug: 'tv-tycoon' });
+
+    // Anyone with the link, signed in or not: it is the game's ordinary permalink, the
+    // same one it keeps once published, so there is nothing to re-send later.
+    expect((await app.inject({ method: 'GET', url: '/api/games/tv-tycoon' })).statusCode).toBe(200);
+
+    const off = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(jobId, secret)}/share`,
+      headers: authHeaders,
+      payload: { shared: false },
+    });
+    expect(off.statusCode).toBe(200);
+    expect((await app.inject({ method: 'GET', url: '/api/games/tv-tycoon' })).statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('will not let a link-holder decide who else can see the game', async () => {
+    // The token is a bearer capability that gets shared around by design. Changing who
+    // may see the game is the creator's alone, checked against the store — the same rule
+    // abandoning follows, and for the same reason.
+    const { app, jobId } = await draftApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(jobId, secret)}/share`,
+      headers: getAuthHeaders('g:someone-else'),
+      payload: { shared: true },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect((await app.inject({ method: 'GET', url: '/api/games/tv-tycoon' })).statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('stops serving a build its creator abandoned, to them as well', async () => {
+    const { app, authHeaders, store, jobId } = await draftApp();
+    await store.setDraftShared(jobId, new Date().toISOString());
+    await store.setSubmissionAbandoned(jobId, new Date().toISOString());
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/tv-tycoon' })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/api/games/tv-tycoon', headers: authHeaders })).statusCode).toBe(
+      404,
+    );
+
+    await app.close();
+  });
+});
+
 describe('submission preview route', () => {
   it('returns 503 when submissions are not configured', async () => {
     const app = await buildApp({ submissionRoutes: { githubToken: undefined, submissionTokenSecret: undefined } });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -572,6 +572,86 @@ describe('submission routes', () => {
     expect(second.json().slug).toBe('space-miner-2');
   });
 
+  it('gives the loser of a slug race a different name rather than a shared one', async () => {
+    // Minting reads then writes, so two submissions of one title can both be told a name
+    // is free. Nothing about that shows until much later and then it is severe: both
+    // agents deliver into the same games-store slug, and whichever job loses the by-slug
+    // lookup becomes unplayable to its own creator. The claim is read back, so the loser
+    // finds out while a different name still costs nothing.
+    const { githubClient } = createGithubClientStub({ issueNumber: 94 });
+    const store = new InMemoryStore();
+    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
+
+    // Somebody else took the name in the window between our probe and our write.
+    const realProbe = store.getSubmissionBySlug.bind(store);
+    let raced = false;
+    store.getSubmissionBySlug = async (slug: string) => {
+      if (slug === 'space-miner' && !raced) {
+        raced = true;
+        return { issueNumber: 999_999, ownerUid: 'g:someone-else', createdAt: '', title: 'Space Miner', slug };
+      }
+      return realProbe(slug);
+    };
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: {
+        title: 'Space Miner',
+        concept: 'Dig asteroids for ore and sell it at the station before your fuel runs out.',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // A different address, not a shared one — and not a failure either, because the
+    // creator has nothing to fix and nothing has been dispatched yet.
+    expect(res.json().slug).toBe('space-miner-2');
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    expect(job.slug).toBe('space-miner-2');
+
+    await app.close();
+  });
+
+  it('refuses the submission outright when it cannot claim any name', async () => {
+    // Losing twice means something is racing us persistently rather than by coincidence.
+    // Better a creator who is told to rename than a game that cannot be addressed.
+    const { githubClient } = createGithubClientStub({ issueNumber: 95 });
+    const { backend, briefs } = createBackendStub();
+    const store = new InMemoryStore();
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      store,
+    });
+
+    store.getSubmissionBySlug = async (slug: string) => ({
+      issueNumber: 999_999,
+      ownerUid: 'g:someone-else',
+      createdAt: '',
+      title: 'Space Miner',
+      slug,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: {
+        title: 'Space Miner',
+        concept: 'Dig asteroids for ore and sell it at the station before your fuel runs out.',
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe('name_unavailable');
+    // And no agent was sent to build a game that has nowhere to live.
+    expect(briefs).toHaveLength(0);
+
+    await app.close();
+  });
+
   it('records how many QA answers came with the concept', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 92 });
     const store = new InMemoryStore();

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -776,6 +776,46 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('reports the job phase alongside the status, so the page can say which wait this is', async () => {
+    // `toSubmissionStatus` is lossy on purpose — `gating` and `building` arrive as one
+    // word, and `ready_for_review` (delivered, checked, waiting on us) arrives as the
+    // same "in_review" the page described as "checks are running". The finer state rides
+    // along so the sentence under the timeline can be true for hours at a time.
+    const { githubClient } = createGithubClientStub({ issueNumber: 91 });
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'system',
+      reason: 'gate_green',
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    expect(status.statusCode).toBe(200);
+    expect(status.json().status).toBe('in_review');
+    expect(status.json().phase).toBe('ready_for_review');
+
+    await app.close();
+  });
+
   it('learns the branch a dispatch is working on, so a revision resumes it', async () => {
     // The task API answers `startTask` before the agent has a branch, so this is the
     // only moment it can be learned. Without it `resume` degrades to a fresh dispatch

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1048,6 +1048,28 @@ export async function registerSubmissionRoutes(
   }
 
   /**
+   * Whether this request may play the unpublished game at `slug`.
+   *
+   * Two ways in, and no third: you made it, or its creator turned sharing on. There is
+   * no separate draft surface to share — a game keeps one permalink for its whole life
+   * — so this is what stands between "my friend can watch it take shape" and "anyone who
+   * guesses a name can read an unreviewed game".
+   *
+   * Sharing is off until the creator says otherwise. Before this existed, any signed-in
+   * visitor who knew a slug could read any draft, which made every in-progress game
+   * unlisted rather than private and gave its creator no say in it.
+   */
+  async function canPlayDraft(request: FastifyRequest, slug: string): Promise<boolean> {
+    if (!store) return false;
+    const record = await store.getSubmissionBySlug(slug);
+    // An abandoned build is nobody's to play, including its creator's: they stopped it.
+    if (!record || record.abandonedAt) return false;
+    if (record.draftSharedAt) return true;
+    const uid = request.user?.uid;
+    return Boolean(uid && uid === record.ownerUid);
+  }
+
+  /**
    * Whether anything already answers to this name.
    *
    * Three namespaces, because a game can exist in three places and a new build must not
@@ -1497,6 +1519,60 @@ export async function registerSubmissionRoutes(
       },
     });
   });
+
+  /**
+   * The creator decides whether anyone else may play their game before it is published.
+   *
+   * There is no separate draft link to hand out: the game answers at `/play/<slug>` for
+   * its whole life, and this decides who that includes. Off by default, and off is
+   * genuinely off — the game is not in the catalog, not in any rail, and 404s for
+   * everyone but its creator, so the link is the only way in and the creator controls
+   * whether it works.
+   *
+   * Ownership is checked against the store rather than against the token, for the same
+   * reason abandoning is: holding a link somebody shared with you must not be enough to
+   * change who else can see the game.
+   */
+  app.post(
+    '/api/submissions/:token/share',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const parsedBody = z.object({ shared: z.boolean() }).safeParse(request.body ?? {});
+      if (!parsedBody.success) {
+        return reply.status(400).send({ error: 'shared must be true or false' });
+      }
+
+      const token = z.string().parse((request.params as { token?: string }).token);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can share this game' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'this game has no address yet' });
+      }
+
+      await store.setDraftShared(issueNumber, parsedBody.data.shared ? new Date(now()).toISOString() : null);
+      return reply.send({ shared: parsedBody.data.shared, slug: record.slug });
+    },
+  );
 
   /**
    * The creator gives up on a build. Closes the issue and the agent's open PR, so
@@ -2660,7 +2736,12 @@ export async function registerSubmissionRoutes(
     }
 
     const record = await store.getSubmissionBySlug(parsedParams.data.slug);
-    if (!record) {
+    // Same rule as `/play/<slug>`, which is now where a draft is shared from: the
+    // creator, or anyone at all once they have turned sharing on. This route used to
+    // serve any draft to any signed-in visitor who knew a slug, which made every
+    // in-progress game unlisted rather than private. Kept working because `/draft/`
+    // links exist in the wild; the app emits `/play/` now.
+    if (!record || !(await canPlayDraft(request, parsedParams.data.slug))) {
       return reply.status(404).send({ error: 'draft not found' });
     }
 
@@ -2881,6 +2962,17 @@ export async function registerSubmissionRoutes(
       }
 
       if (!(await isSlugPublished(githubClient, slug))) {
+        // Not published — but a game has this address from the moment it is submitted,
+        // and its creator can play it, as can anyone they have chosen to share the link
+        // with. One permalink for a game's whole life, before and after it goes live.
+        //
+        // Deliberately after both published paths and outside `gameCache`: that cache is
+        // keyed by slug alone and read before any gate, so a draft written into it would
+        // be served to whoever asked next, share toggle or not.
+        if (await canPlayDraft(request, slug)) {
+          const record = await store?.getSubmissionBySlug(slug);
+          if (record) return replyWithDraft(request, reply, record.issueNumber);
+        }
         return reply.status(404).send({ error: 'game not found' });
       }
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -458,17 +458,16 @@ export async function registerSubmissionRoutes(
 
   async function dispatchBuild(input: {
     issueNumber: number;
-    /** The game directory the agent is to build into. Assigned before dispatch. */
-    slug?: string;
     spec: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
     /**
-     * The existing game this job improves, when it is not building a new one.
+     * The game this job is for: the directory a new build is told to build into, and —
+     * set together with `feedback` — the existing game an improvement continues rather
+     * than rebuilds, which is what makes `buildPrompt` restore its delivered sources.
      *
-     * Set together with `feedback` — that pair is what makes `buildPrompt` say "continue
-     * that game, revise it, do not rebuild it" and restore the delivered sources from the
-     * games store, instead of telling the agent to build something from nothing.
+     * A new build now carries it from the moment it is created, so the brief names a real
+     * path instead of "(the slug named in your first progress report)".
      */
     slug?: string;
     /** What to change about the existing game. Untrusted text: data, never instructions. */

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1057,6 +1057,9 @@ export async function registerSubmissionRoutes(
     const state = record.state ?? 'queued';
     const status: SubmissionStatusResponse = {
       status: record.abandonedAt ? 'abandoned' : toSubmissionStatus(state),
+      // The unprojected state travels alongside the projection: `toSubmissionStatus` is
+      // lossy by design, and the page needs the loss back to describe the wait honestly.
+      ...(record.abandonedAt ? {} : { phase: state }),
       ...(record.slug ? { slug: record.slug } : {}),
     };
     // `failed` projects onto `needs_changes`, which the page renders as "waiting for

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1048,6 +1048,37 @@ export async function registerSubmissionRoutes(
   }
 
   /**
+   * Reads back a slug this job just wrote, and settles who actually holds it.
+   *
+   * `getSubmissionBySlug` is the same oracle every later lookup uses — the draft route,
+   * the play route, the delivery check — so asking it "who owns this name" is exactly the
+   * question that matters, and it answers deterministically even when two records share
+   * a slug. Whoever it does not name has lost the race and takes a different name; the
+   * winner is undisturbed and never learns any of this happened.
+   *
+   * Returns the slug this job ended up with, or null when even the second attempt lost.
+   */
+  async function confirmSlugClaim(issueNumber: number, slug: string, title: string): Promise<string | null> {
+    if (!store) return slug;
+    const holds = async (candidate: string): Promise<boolean> => {
+      const holder = await store.getSubmissionBySlug(candidate);
+      return holder?.issueNumber === issueNumber;
+    };
+
+    if (await holds(slug)) return slug;
+
+    // Lost. Mint again, this time treating anything we do not ourselves hold as taken,
+    // and write it before re-reading — the second write is what makes the second read
+    // meaningful.
+    const retry = await mintGameSlug(title, async (candidate) => {
+      if (candidate === slug) return true;
+      return isSlugClaimed(candidate, issueNumber);
+    });
+    await store.setSubmissionSlug(issueNumber, retry);
+    return (await holds(retry)) ? retry : null;
+  }
+
+  /**
    * Whether this request may play the unpublished game at `slug`.
    *
    * Two ways in, and no third: you made it, or its creator turned sharing on. There is
@@ -1427,11 +1458,30 @@ export async function registerSubmissionRoutes(
       // only on its first delivery, which left every build with a stretch — minutes at
       // best — where the thing being built had no name a URL could use. That is why the
       // creator's own studio addressed their game by a capability token.
-      const slug = await mintGameSlug(sanitizedTitle, (candidate) => isSlugClaimed(candidate));
+      const wanted = await mintGameSlug(sanitizedTitle, (candidate) => isSlugClaimed(candidate));
 
       const jobId = await store.allocateJobId();
       await store.createSubmission(jobId, request.user!.uid, sanitizedTitle);
-      await store.setSubmissionSlug(jobId, slug);
+      await store.setSubmissionSlug(jobId, wanted);
+
+      // Minting is a read then a write, so two submissions of the same title can both be
+      // told a name is free. Nothing about that is visible until much later and then it
+      // is severe: both agents deliver into one games-store slug, interleaving two
+      // different games' sources under it, and whichever job loses the by-slug lookup
+      // becomes unplayable to its own creator. So the claim is read back and the loser
+      // finds out here — before an agent has been dispatched, before the creator has been
+      // given an address, while a different name still costs nothing.
+      const slug = await confirmSlugClaim(jobId, wanted, sanitizedTitle);
+      if (!slug) {
+        // Both attempts lost, which means something is racing us persistently rather
+        // than by coincidence. Fail loudly instead of building a game that cannot be
+        // addressed: the creator can try again, and their quota is the price of the
+        // agent time this never spent.
+        await store.setSubmissionAbandoned(jobId, new Date(now()).toISOString());
+        request.log.error({ issueNumber: jobId, slug: wanted }, 'could not claim a slug for a new submission');
+        return reply.status(409).send({ error: 'name_unavailable' });
+      }
+
       await store.setSubmissionLocale(jobId, creatorLocale);
       // Raw, not sanitized: the sanitizer strips the '##' that marks the block.
       await store.setSubmissionClarificationCount(jobId, countCreatorClarifications(parsed.data.concept));

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -34,6 +34,7 @@ import { emitOperatorAlert, emitSubmissionNotification, notifyOnTransition, type
 import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
 import { isAdminSession } from './admin.js';
 import { peekQuota } from './quota-gate.js';
+import { mintGameSlug } from './slug.js';
 import { type BuildPreviewSummary, type BuildShotSummary, type Store, type SubmissionRecord } from './store.js';
 import {
   CREATOR_FEEDBACK_MARKER,
@@ -457,6 +458,8 @@ export async function registerSubmissionRoutes(
 
   async function dispatchBuild(input: {
     issueNumber: number;
+    /** The game directory the agent is to build into. Assigned before dispatch. */
+    slug?: string;
     spec: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
@@ -477,6 +480,7 @@ export async function registerSubmissionRoutes(
     try {
       const result = await agentBackend.dispatch({
         issueNumber: input.issueNumber,
+        ...(input.slug ? { slug: input.slug } : {}),
         spec: input.spec,
         locale: input.locale,
         channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret),
@@ -1043,6 +1047,40 @@ export async function registerSubmissionRoutes(
     return entries.find((entry) => entry.slug === slug && entry.status === 'published') ?? null;
   }
 
+  /**
+   * Whether anything already answers to this name.
+   *
+   * Three namespaces, because a game can exist in three places and a new build must not
+   * be given an address that already means something else: another submission (building
+   * or built), a game published through the store, and a game published in the games
+   * repo's catalog. `except` lets a job ask about a name it may already hold itself.
+   *
+   * Deliberately forgiving of its own failures. This runs inside submission creation, and
+   * a GitHub outage that made every name look taken would refuse builds the creator has
+   * already paid a quota slot for; a name that is wrongly *available* costs far less than
+   * a submission that will not start, and the delivery path checks again before writing.
+   */
+  async function isSlugClaimed(slug: string, except?: number): Promise<boolean> {
+    if (store) {
+      try {
+        const existing = await store.getSubmissionBySlug(slug);
+        if (existing && existing.issueNumber !== except) return true;
+        const publication = await store.getPublication(slug);
+        if (publication) return true;
+      } catch {
+        // Fall through: see above — an unavailable store must not block creation.
+      }
+    }
+    if (githubClient) {
+      try {
+        if (await isSlugPublished(githubClient, slug)) return true;
+      } catch {
+        // Same reasoning, and this one is the likeliest to fail: it reads GitHub.
+      }
+    }
+    return false;
+  }
+
   // Single source of GitHub-state → status derivation, shared by the on-demand
   // status route and the notification sweep so they never diverge.
   /**
@@ -1362,8 +1400,16 @@ export async function registerSubmissionRoutes(
       if (!store) {
         return reply.status(503).send({ error: 'submissions are unavailable' });
       }
+      // The game's address, minted from the title the creator just confirmed and fixed
+      // for the game's whole life. It used to be the agent's to choose and was learned
+      // only on its first delivery, which left every build with a stretch — minutes at
+      // best — where the thing being built had no name a URL could use. That is why the
+      // creator's own studio addressed their game by a capability token.
+      const slug = await mintGameSlug(sanitizedTitle, (candidate) => isSlugClaimed(candidate));
+
       const jobId = await store.allocateJobId();
       await store.createSubmission(jobId, request.user!.uid, sanitizedTitle);
+      await store.setSubmissionSlug(jobId, slug);
       await store.setSubmissionLocale(jobId, creatorLocale);
       // Raw, not sanitized: the sanitizer strips the '##' that marks the block.
       await store.setSubmissionClarificationCount(jobId, countCreatorClarifications(parsed.data.concept));
@@ -1376,13 +1422,19 @@ export async function registerSubmissionRoutes(
 
       await dispatchBuild({
         issueNumber: jobId,
+        // The agent is told where to build rather than left to name the place itself.
+        // Its brief previously read "games/(the slug named in your first progress
+        // report)/", which is a sentence, not a path.
+        slug,
         spec: issueBody,
         locale: creatorLocale,
         log: request.log,
       });
 
       const token = mintToken(jobId, submissionTokenSecret);
-      return reply.send({ token, statusUrl: `/api/submissions/${token}` });
+      // The slug travels back so the app can go straight to `/studio/<slug>` instead of
+      // putting a capability token in the URL bar and in the creator's history.
+      return reply.send({ token, slug, statusUrl: `/api/submissions/${token}` });
     } catch (error) {
       request.log.error({ err: error }, 'failed to create submission');
       return reply.status(502).send({ error: 'failed to submit game spec' });

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -122,6 +122,7 @@ describe('summarizeVisitFunnel', () => {
       { step: 'spec_submitted', visits: 1 },
       { step: 'signin_required', visits: 1 },
       { step: 'qa_shown', visits: 0 },
+      { step: 'title_confirmed', visits: 0 },
       { step: 'submission_created', visits: 0 },
     ]);
   });

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -70,6 +70,7 @@ export const CREATE_STEPS = [
   'spec_submitted',
   'signin_required',
   'qa_shown',
+  'title_confirmed',
   'submission_created',
 ] as const;
 

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -50,6 +50,7 @@ const CreateStepSchema = z.enum([
   'spec_submitted',
   'signin_required',
   'qa_shown',
+  'title_confirmed',
   'submission_created',
 ]);
 /**

--- a/apps/web/src/App.overlayExit.test.ts
+++ b/apps/web/src/App.overlayExit.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
+
+/**
+ * Closing a game returns you to where you opened it from.
+ *
+ * The exit used to be an unconditional trip home, which quietly threw away context
+ * every time: a creator who opened their build from Creator Studio and closed it landed
+ * on the catalog, several clicks away from the game they were in the middle of making.
+ * Back is only safe when this tab has an in-app entry to go back to, so both halves are
+ * guarded here — the deep link that must not walk off the site is as much the point as
+ * the in-app open that must not lose its place.
+ */
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function mockApi() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/api/auth/me')) {
+      return new Response(JSON.stringify({ user: { uid: 'creator-1', tier: 'beta' } }));
+    }
+    if (url.endsWith('/api/health')) {
+      return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+    }
+    if (url.endsWith('/api/catalog')) {
+      return new Response(
+        JSON.stringify([
+          {
+            slug: 'sky-dodge',
+            title: 'Sky Dodge',
+            genre: 'Arcade',
+            controls: 'Arrow keys',
+            status: 'published',
+            media: null,
+          },
+        ]),
+      );
+    }
+    if (url.includes('/api/games/')) {
+      return new Response(JSON.stringify({ slug: 'sky-dodge', title: 'Sky Dodge', html: '<!doctype html><canvas>' }));
+    }
+    return new Response(JSON.stringify({}), { status: 404 });
+  });
+}
+
+async function renderApp() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AuthProvider, null, createElement(App)));
+    await flushEffects();
+  });
+  await act(async () => {
+    await flushEffects();
+  });
+  return { container, root };
+}
+
+describe('closing a full-viewport game', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+    localStorage.clear();
+    window.history.pushState(null, '', '/');
+    vi.restoreAllMocks();
+  });
+
+  it('goes back to whatever opened it, rather than home', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/');
+    const { container, root } = await renderApp();
+
+    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+
+    const play = container.querySelector<HTMLButtonElement>('.card-actions .primary-btn');
+    expect(play).not.toBeNull();
+    await act(async () => {
+      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(window.location.pathname).toBe('/play/sky-dodge');
+
+    const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
+    expect(exit).not.toBeNull();
+    await act(async () => {
+      exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(back).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('goes home from a cold deep link, where Back would leave the site', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/play/sky-dodge');
+    const { container, root } = await renderApp();
+
+    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+
+    const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
+    expect(exit).not.toBeNull();
+    await act(async () => {
+      exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(back).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -47,9 +47,23 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function mockApi(options: { onRefine?: () => void; gate?: Promise<void> } = {}) {
-  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+function mockApi(
+  options: {
+    onRefine?: () => void;
+    gate?: Promise<void>;
+    /** Empty models a fully-specified concept: nothing to clarify, still to be named. */
+    questions?: typeof QUESTIONS;
+    suggestedTitle?: string;
+    refineFails?: boolean;
+    onSubmit?: (body: { title: string; concept: string }) => void;
+  } = {},
+) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
     const url = String(input);
+    if (url.endsWith('/api/submissions') && init?.method === 'POST') {
+      options.onSubmit?.(JSON.parse(String(init.body)) as { title: string; concept: string });
+      return new Response(JSON.stringify({ token: 'tok-1', statusUrl: '/api/submissions/tok-1' }));
+    }
     if (url.endsWith('/api/auth/me')) {
       return new Response(JSON.stringify({ user: { uid: 'g:test', tier: 'standard' } }));
     }
@@ -65,7 +79,13 @@ function mockApi(options: { onRefine?: () => void; gate?: Promise<void> } = {}) 
     if (url.endsWith('/api/submissions/refine')) {
       options.onRefine?.();
       if (options.gate) await options.gate;
-      return new Response(JSON.stringify({ questions: QUESTIONS }));
+      if (options.refineFails) return new Response(JSON.stringify({ error: 'boom' }), { status: 500 });
+      return new Response(
+        JSON.stringify({
+          questions: options.questions ?? QUESTIONS,
+          ...(options.suggestedTitle ? { suggestedTitle: options.suggestedTitle } : {}),
+        }),
+      );
     }
     return new Response(JSON.stringify({}), { status: 404 });
   });
@@ -201,6 +221,52 @@ describe('the QA gate in App', () => {
     expect(container.querySelector('.qa-container')).toBeNull();
     // Left behind, it would resurrect the abandoned idea on the next visit.
     expect(localStorage.getItem('gamedev_pending_qa')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('stops to have the game named even when there is nothing to clarify', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const submitted: Array<{ title: string; concept: string }> = [];
+    mockApi({ questions: [], suggestedTitle: 'Castaway Craft', onSubmit: (body) => submitted.push(body) });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    // A clean concept used to go straight to the agent, and the name it was built
+    // under was the prompt's first 40 characters. Now it waits here.
+    expect(submitted).toHaveLength(0);
+    expect(container.querySelector('.qa-container')).not.toBeNull();
+    expect(container.querySelector<HTMLInputElement>('.qa-name-input')?.value).toBe('Castaway Craft');
+
+    await act(async () => {
+      container.querySelector('.btn-create-now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]!.title).toBe('Castaway Craft');
+
+    await act(async () => root.unmount());
+  });
+
+  it('still asks for a name when the refiner is down, falling back to one from the prompt', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const submitted: Array<{ title: string; concept: string }> = [];
+    mockApi({ refineFails: true, onSubmit: (body) => submitted.push(body) });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    // Failing open must not mean skipping the step — that is how truncated prompts
+    // became titles in the first place. The suggestion degrades; the gate does not.
+    expect(submitted).toHaveLength(0);
+    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
+    expect(name?.value).toBe('A survival game on a desert island with');
+    expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -509,6 +509,10 @@ export function App() {
     [pendingSpec, qaQuestions],
   );
 
+  // Whether this tab has pushed a history entry of its own — i.e. whether going Back
+  // lands somewhere in the app rather than wherever the visitor came from.
+  const pushedHistoryRef = useRef(false);
+
   const navigate = useCallback((path: string, options?: { replace?: boolean }) => {
     // Update the URL (the source of truth) and the route synchronously so
     // navigation is immediate (and testable) without waiting for popstate.
@@ -516,6 +520,7 @@ export function App() {
       window.history.replaceState(null, '', path);
     } else {
       window.history.pushState(null, '', path);
+      pushedHistoryRef.current = true;
     }
     // pushState/replaceState are silent, so announce the navigation for anything
     // living outside this component (see NAVIGATE_EVENT). Dispatched before the
@@ -523,6 +528,23 @@ export function App() {
     window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT, { detail: { path } }));
     setRoute(readLocationRoute());
   }, []);
+
+  /**
+   * Closing a full-viewport overlay that owns the URL — a game, a draft.
+   *
+   * Home was the unconditional answer, and it threw away context every time: a creator
+   * who opened their build from Creator Studio and closed it landed on the catalog,
+   * several clicks from the game they were in the middle of making. Back returns them
+   * to whatever opened the overlay. A cold visit to a shared link has no in-app entry
+   * behind it — Back there would leave the site entirely — so that case still goes home.
+   */
+  const exitOverlay = useCallback(() => {
+    if (pushedHistoryRef.current) {
+      window.history.back();
+      return;
+    }
+    navigate('/');
+  }, [navigate]);
 
   // Header Up chevron — Android-style parent path, never history.back(). Hidden
   // while App owns a theater (`stageContent`) and on routes whose child owns one
@@ -674,7 +696,7 @@ export function App() {
             }}
           />
         ) : route.view === 'draft' ? (
-          <DraftView slug={route.slug} onExit={() => navigate('/')} onDraftTitle={setDraftTitle} />
+          <DraftView slug={route.slug} onExit={exitOverlay} onDraftTitle={setDraftTitle} />
         ) : (
           <>
             <div id="hero-prompt">
@@ -747,7 +769,7 @@ export function App() {
                 // it short so the title stays the hero of the bar.
                 badge={{ icon: 'sparkle', label: t('ai.generatedShort') }}
                 source={{ slug: stageContent.game.slug }}
-                onExit={() => navigate('/')}
+                onExit={exitOverlay}
                 orientation={stageContent.game.orientation}
                 reportSlug={stageContent.game.slug}
                 submittedBy={stageContent.game.submittedBy}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -134,9 +134,11 @@ export function App() {
         ? (catalogEntries.find((game) => game.slug === route.slug)?.title ??
           (stageContent?.type === 'catalog' && stageContent.game.slug === route.slug ? stageContent.game.title : null))
         : null;
+    // Matched on either address the URL can carry: a slug now, a capability token on
+    // links minted before games had one.
     const studioTitle =
-      route.view === 'studio' && route.token
-        ? (savedSpecs.find((spec) => spec.token === route.token)?.title ?? null)
+      route.view === 'studio' && route.game
+        ? (savedSpecs.find((spec) => spec.token === route.game || spec.slug === route.game)?.title ?? null)
         : null;
 
     return resolveDocumentTitle(route, {
@@ -452,6 +454,7 @@ export function App() {
         title,
         concept,
         createdAt: Date.now(),
+        ...(response.slug ? { slug: response.slug } : {}),
       });
       setSavedSpecs(updatedSpecs);
       setMyGamesRefreshKey((key) => key + 1);
@@ -465,7 +468,9 @@ export function App() {
       setPendingSpec(null);
       clearPendingQa();
 
-      navigate(statusPath(response.token));
+      // Straight to the game's own address. Older API builds answer without a slug, in
+      // which case the token still addresses the studio and gets rewritten there.
+      navigate(studioPath(response.slug ?? response.token));
     } catch (err) {
       const message = err instanceof Error ? err.message : t('errors.generic');
       const category = err instanceof Error ? (err as SubmissionApiError).category : undefined;
@@ -709,7 +714,7 @@ export function App() {
           <AdminConsole section={route.section} onNavigate={navigate} />
         ) : route.view === 'studio' ? (
           <CreatorStudioView
-            selectedToken={route.token}
+            selectedGame={route.game}
             selectedTab={route.tab}
             onNavigate={navigate}
             onPlay={(slug) => navigate(playPath(slug))}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -483,6 +483,11 @@ export function App() {
         // creator can see their remaining count on the hero to check it.
       } else if (message === 'creation_over_capacity') {
         setSubmissionError(t('errors.creationOverCapacity'));
+        // Two submissions of the same title raced for its address and this one lost
+        // twice. Rare, and recoverable by renaming — which is a thing the creator can
+        // now actually do, because they picked the name in the first place.
+      } else if (message === 'name_unavailable') {
+        setSubmissionError(t('errors.nameUnavailable'));
       } else if (message.includes('quota')) {
         setSubmissionError(t('auth.quotaExceeded'));
       } else if (message.includes('blocked')) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { DraftView } from './DraftView.js';
 import { AdminConsole } from './AdminConsole.js';
 import { PixelIcon } from './PixelIcon.js';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
+import { deriveTitleFromConcept } from './gameTitle.js';
 import {
   adminPath,
   canonicalPath,
@@ -314,12 +315,13 @@ export function App() {
     });
   }, []);
 
-  // Bring the clarifying-questions panel into view when the refiner returns some.
+  // Bring the confirm panel into view when it opens. Keyed on the spec rather than on
+  // the questions: the panel now appears for a clean concept too, to be named.
   useEffect(() => {
-    if (qaQuestions.length > 0) {
+    if (pendingSpec) {
       qaRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
     }
-  }, [qaQuestions]);
+  }, [pendingSpec]);
 
   // Menu navigation is scroll-to-section, but the sections only exist on the home
   // route — from a status page we have to go home first and scroll once the target
@@ -387,7 +389,7 @@ export function App() {
   // The generation gate: before spending a submission we run the spec refiner. If it
   // returns clarifying questions, generation pauses on the QA panel until they're
   // answered; a clean spec (or a refiner error — fail-open) submits straight through.
-  async function handleSubmitSpec(title: string, concept: string, displayName: string = '') {
+  async function handleSubmitSpec(concept: string, displayName: string = '') {
     if (!user) {
       // The wall between "wrote an idea" and "made an account". Everything before this
       // is anonymous, so this is the only place that drop-off is visible at all.
@@ -396,33 +398,37 @@ export function App() {
       return;
     }
 
-    const trimmedTitle = title.trim();
     const trimmedConcept = concept.trim();
-    if (!trimmedTitle || !trimmedConcept) return;
+    if (!trimmedConcept) return;
 
     setSubmissionStatus('refining');
     setSubmissionError(null);
 
+    let questions: QAQuestion[] = [];
+    let suggestedTitle: string | undefined;
     try {
-      const { questions } = await refineSpec({
-        title: trimmedTitle,
-        concept: trimmedConcept,
-        locale: i18n.language,
-      });
-      if (questions.length > 0) {
-        recordCreateStep('qa_shown');
-        const spec = { title: trimmedTitle, concept: trimmedConcept, displayName: displayName.trim() };
-        setPendingSpec(spec);
-        setQaQuestions(questions);
-        savePendingQa({ spec, questions, answers: { selected: {}, custom: {} } });
-        setSubmissionStatus('idle');
-        return;
-      }
+      const refined = await refineSpec({ concept: trimmedConcept, locale: i18n.language });
+      questions = refined.questions;
+      suggestedTitle = refined.suggestedTitle;
     } catch {
-      // Fail-open: a refiner outage must never block creation — submit as-is.
+      // Fail-open: a refiner outage must never block creation. It does not skip the
+      // naming step either — that would put us back to games named by truncation —
+      // so the confirm panel opens on a title derived from the prompt instead.
     }
 
-    await submitRefinedSpec(trimmedTitle, trimmedConcept, displayName.trim());
+    if (questions.length > 0) recordCreateStep('qa_shown');
+
+    // The confirm step always happens now, questions or not: it is where the game gets
+    // its name, and a build must not start without one the creator has seen.
+    const spec = {
+      title: suggestedTitle ?? deriveTitleFromConcept(trimmedConcept),
+      concept: trimmedConcept,
+      displayName: displayName.trim(),
+    };
+    setPendingSpec(spec);
+    setQaQuestions(questions);
+    savePendingQa({ spec, questions, answers: { selected: {}, custom: {} } });
+    setSubmissionStatus('idle');
   }
 
   // Actually creates the submission (after the QA gate) and jumps to its status page.
@@ -487,10 +493,12 @@ export function App() {
   // dropped the creator into blank space for however long the API took to create the
   // issue — they had just clicked a button and the page answered by deleting itself.
   // On failure it stays up with the error, so the answers survive a retry.
-  const handleQaComplete = async (finalConcept: string) => {
+  const handleQaComplete = async (finalConcept: string, title: string) => {
     const spec = pendingSpec;
     if (!spec) return;
-    await submitRefinedSpec(spec.title, finalConcept, spec.displayName);
+    // The name the creator settled on, which is the step that gates the build.
+    recordCreateStep('title_confirmed');
+    await submitRefinedSpec(title, finalConcept, spec.displayName);
   };
 
   const handleQaCancel = () => {
@@ -501,10 +509,25 @@ export function App() {
 
   // Every keystroke and chip lands in storage, so the round survives a reload at any
   // point rather than only between questions.
+  const latestAnswersRef = useRef<PendingQaAnswers>({ selected: {}, custom: {} });
   const handleQaAnswersChange = useCallback(
     (answers: PendingQaAnswers) => {
+      latestAnswersRef.current = answers;
       if (!pendingSpec) return;
       savePendingQa({ spec: pendingSpec, questions: qaQuestions, answers });
+    },
+    [pendingSpec, qaQuestions],
+  );
+
+  // The name is parked with the answers, for the same reason: an edited title is work,
+  // and a reload that kept the answers but silently restored the model's suggestion
+  // would be the one part of the panel that lies about having been saved.
+  const handleQaTitleChange = useCallback(
+    (title: string) => {
+      if (!pendingSpec) return;
+      const spec = { ...pendingSpec, title };
+      setPendingSpec(spec);
+      savePendingQa({ spec, questions: qaQuestions, answers: latestAnswersRef.current });
     },
     [pendingSpec, qaQuestions],
   );
@@ -708,19 +731,23 @@ export function App() {
                 onPlayGame={handlePlayGame}
                 submissionStatus={submissionStatus}
                 submissionError={submissionError}
-                onSubmitSpec={(title, concept) => void handleSubmitSpec(title, concept)}
+                onSubmitSpec={(concept) => void handleSubmitSpec(concept)}
                 mockStatus={mockStatus}
                 mockError={mockError}
                 onGenerateMock={(prompt) => void handleGenerateMock(prompt)}
               />
             </div>
 
-            {qaQuestions.length > 0 && pendingSpec && (
+            {/* Gated on the pending spec alone: the panel is the naming step, which
+                always happens, and the questions are the part that is sometimes empty. */}
+            {pendingSpec && (
               <div ref={qaRef}>
                 <CreatorQA
                   questions={qaQuestions}
                   initialConcept={pendingSpec.concept}
+                  initialTitle={pendingSpec.title}
                   onSubmitWithConcept={handleQaComplete}
+                  onTitleChange={handleQaTitleChange}
                   onCancel={handleQaCancel}
                   submitting={submissionStatus === 'loading'}
                   error={submissionError}

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -43,6 +43,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: mockQuestions,
           initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: (concept) => {
             submittedConcept = concept;
           },
@@ -93,6 +94,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: mockQuestions,
           initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: (concept) => {
             submittedConcept = concept;
           },
@@ -156,6 +158,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: multiQuestion,
           initialConcept: 'A trading game',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: (concept) => {
             submittedConcept = concept;
           },
@@ -214,6 +217,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: mockQuestions,
           initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: vi.fn(),
           onCancel: vi.fn(),
           submitting: true,
@@ -255,6 +259,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: mockQuestions,
           initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: () => {
             submitted = true;
           },
@@ -294,6 +299,7 @@ describe('CreatorQA', () => {
         createElement(CreatorQA, {
           questions: mockQuestions,
           initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
           onSubmitWithConcept: (concept) => {
             submittedConcept = concept;
           },
@@ -310,6 +316,130 @@ describe('CreatorQA', () => {
 
     expect(submittedConcept).toBe('Dodge the falling rocks and survive as long as possible');
     expect(submittedConcept).not.toContain('## Creator clarifications');
+
+    await act(async () => root.unmount());
+  });
+
+  it('carries the name the creator settled on, not the one that was suggested', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    let submittedTitle = '';
+    const onTitleChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(CreatorQA, {
+          questions: mockQuestions,
+          initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
+          onTitleChange,
+          onSubmitWithConcept: (_concept, title) => {
+            submittedTitle = title;
+          },
+        }),
+      );
+      await flushEffects();
+    });
+
+    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
+    expect(name?.value).toBe('Rock Dodger');
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(name, '  Boulder Panic  ');
+      name?.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+
+    // Reported as it is typed, so the caller can park it with the rest of the session.
+    expect(onTitleChange).toHaveBeenLastCalledWith('  Boulder Panic  ');
+
+    await act(async () => {
+      container.querySelector('.btn-create-now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(submittedTitle).toBe('Boulder Panic');
+
+    await act(async () => root.unmount());
+  });
+
+  it('will not start a build on a name too short to submit', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const onSubmit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // The refiner had nothing to suggest and the concept yielded nothing either, so
+    // the box starts empty and the creator has to name the thing themselves.
+    await act(async () => {
+      root.render(
+        createElement(CreatorQA, {
+          questions: [],
+          initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: '',
+          onSubmitWithConcept: onSubmit,
+        }),
+      );
+      await flushEffects();
+    });
+
+    const createBtn = container.querySelector<HTMLButtonElement>('.btn-create-now');
+    expect(createBtn?.disabled).toBe(true);
+
+    await act(async () => {
+      createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(name, 'Rock Dodger');
+      name?.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('.btn-create-now')?.disabled).toBe(false);
+
+    await act(async () => root.unmount());
+  });
+
+  it('is still the naming step when the refiner asked nothing', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(CreatorQA, {
+          questions: [],
+          initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
+          onSubmitWithConcept: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // A heading about clarifying questions, over no questions, is a panel that looks
+    // broken. With nothing to clarify it says what it is actually for.
+    expect(container.querySelector('.qa-title')?.textContent).toContain('Name your game');
+    expect(container.querySelector('.qa-name-input')).not.toBeNull();
+    expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
+    // One button, not two: the second exists to be reachable after a long list.
+    expect(container.querySelectorAll('.btn-create-now')).toHaveLength(1);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isSubmittableTitle, MAX_TITLE_LENGTH } from './gameTitle.js';
 import { PixelIcon } from './PixelIcon.js';
 import type { PendingQaAnswers } from './pendingQa.js';
 
@@ -20,7 +21,14 @@ export interface QAQuestion {
 interface CreatorQAProps {
   questions: QAQuestion[];
   initialConcept: string;
-  onSubmitWithConcept: (finalConcept: string) => void;
+  /**
+   * The name to start from — the refiner's proposal, or one derived from the prompt
+   * when it had none. Editable here, and confirming it is what starts the build.
+   */
+  initialTitle: string;
+  onSubmitWithConcept: (finalConcept: string, title: string) => void;
+  /** Fires on every edit so the caller can park the name with the rest of the session. */
+  onTitleChange?: (title: string) => void;
   onCancel?: () => void;
   /** The submission is in flight; the panel stays up rather than vanishing into a gap. */
   submitting?: boolean;
@@ -35,7 +43,9 @@ interface CreatorQAProps {
 export function CreatorQA({
   questions,
   initialConcept,
+  initialTitle,
   onSubmitWithConcept,
+  onTitleChange,
   onCancel,
   submitting = false,
   error = null,
@@ -43,8 +53,10 @@ export function CreatorQA({
   onAnswersChange,
 }: CreatorQAProps) {
   const { t } = useTranslation();
+  const [title, setTitle] = useState(initialTitle);
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string[]>>(initialAnswers?.selected ?? {});
   const [customText, setCustomText] = useState<Record<string, string>>(initialAnswers?.custom ?? {});
+  const titleReady = isSubmittableTitle(title);
 
   const report = (selected: Record<string, string[]>, custom: Record<string, string>) => {
     onAnswersChange?.({ selected, custom });
@@ -109,19 +121,52 @@ export function CreatorQA({
     return `${initialConcept.trim()}\n\n## Creator clarifications\n${clarifications.join('\n')}`;
   };
 
+  const handleTitleChange = (next: string) => {
+    setTitle(next);
+    onTitleChange?.(next);
+  };
+
   const handleSubmit = () => {
-    onSubmitWithConcept(buildMergedConcept());
+    if (!titleReady) return;
+    onSubmitWithConcept(buildMergedConcept(), title.trim());
   };
 
   return (
     <div className="qa-container panel">
       <div className="qa-header">
-        <h3 className="qa-title">{t('qa.title')}</h3>
-        <p className="qa-subtitle">{t('qa.subtitle')}</p>
+        {/* Two jobs, two headings: naming the game is the one that always happens, and
+            the questions only exist when the refiner found something underspecified. */}
+        <h3 className="qa-title">{t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}</h3>
+        <p className="qa-subtitle">{t(questions.length > 0 ? 'qa.subtitle' : 'qa.subtitleNameOnly')}</p>
+      </div>
+
+      {/* The name goes first because it is the prerequisite, not a detail: nothing is
+          built until the creator has confirmed one, which is what stops a game being
+          named after the first 40 characters of the prompt that asked for it. */}
+      <div className="qa-name">
+        <label className="qa-name-label" htmlFor="qa-game-title">
+          {t('qa.nameLabel')}
+        </label>
+        <input
+          id="qa-game-title"
+          type="text"
+          className="input-text qa-name-input"
+          value={title}
+          maxLength={MAX_TITLE_LENGTH}
+          placeholder={t('qa.namePlaceholder')}
+          onChange={(e) => handleTitleChange(e.target.value)}
+          disabled={submitting}
+        />
+        <p className="qa-name-hint">{t('qa.nameHint')}</p>
       </div>
 
       <div className="qa-actions qa-actions--top">
-        <button type="button" className="btn btn-primary btn-create-now" onClick={handleSubmit} disabled={submitting}>
+        <button
+          type="button"
+          className="btn btn-primary btn-create-now"
+          onClick={handleSubmit}
+          disabled={submitting || !titleReady}
+        >
           <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
         </button>
         {/* This dismisses the panel and drops the pending spec — it does *not* submit.
@@ -195,11 +240,19 @@ export function CreatorQA({
 
       {error && <p className="error qa-error">{error}</p>}
 
-      <div className="qa-actions qa-actions--bottom">
-        <button type="button" className="btn btn-primary btn-create-now" onClick={handleSubmit} disabled={submitting}>
-          <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
-        </button>
-      </div>
+      {/* Only worth a second button when there is a list to have scrolled past. */}
+      {questions.length > 0 ? (
+        <div className="qa-actions qa-actions--bottom">
+          <button
+            type="button"
+            className="btn btn-primary btn-create-now"
+            onClick={handleSubmit}
+            disabled={submitting || !titleReady}
+          >
+            <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -181,16 +181,20 @@ describe('CreatorStudioView', () => {
 
     const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0' });
 
-    const detailsTab = Array.from(container.querySelectorAll('[role="tab"]')).find((button) =>
+    const detailsAction = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
       button.textContent?.includes('Details'),
     );
-    expect(detailsTab).toBeTruthy();
+    expect(detailsAction).toBeTruthy();
 
     await act(async () => {
-      detailsTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      detailsAction!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/details');
+    // Beside the thread, not instead of it: opening the facts about a game must not
+    // take the game off the screen.
+    expect(container.querySelector('.studio-rail')).not.toBeNull();
+    expect(container.querySelector('.studio-build')).not.toBeNull();
 
     root.unmount();
   });
@@ -206,13 +210,16 @@ describe('CreatorStudioView', () => {
 
     const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'details' });
 
-    const activeTab = container.querySelector('[role="tab"][aria-selected="true"]');
-    expect(activeTab?.textContent).toContain('Details');
+    expect(container.querySelector('.studio-rail')).not.toBeNull();
     // In place, so the old address does not become a history entry to go Back through.
     expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/details', { replace: true });
-    // Every surface in the URL has a button to leave it by.
-    const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((button) => button.textContent);
-    expect(tabLabels).toEqual(['Thread', 'Details', 'Playtest']);
+    // The surface it landed on has a control showing it is open, and one to close it by.
+    const details = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Details'),
+    );
+    expect(details?.getAttribute('aria-pressed')).toBe('true');
+    // And the tab strip is gone for good.
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(0);
 
     root.unmount();
   });
@@ -413,12 +420,12 @@ describe('CreatorStudioView — what players think', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     const { container, root } = await renderStudio();
-    const statsTab = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.trim().startsWith('Details'),
+    const detailsAction = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Details'),
     );
-    if (statsTab) {
+    if (detailsAction) {
       await act(async () => {
-        statsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        detailsAction.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       });
     }
     return { container, root };

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -176,7 +176,7 @@ describe('CreatorStudioView', () => {
     fetchStudioGames.mockResolvedValue(manyGames(2));
     window.history.replaceState(null, '', '/studio/token-0');
 
-    const { container, root, onNavigate } = await renderStudio({ selectedToken: 'token-0' });
+    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0' });
 
     const improveTab = Array.from(container.querySelectorAll('[role="tab"]')).find((button) =>
       button.textContent?.includes('Improve'),
@@ -200,7 +200,7 @@ describe('CreatorStudioView', () => {
     fetchStudioGames.mockResolvedValue(manyGames(2));
     window.history.replaceState(null, '', '/studio/token-0/stats');
 
-    const { container, root, onNavigate } = await renderStudio({ selectedToken: 'token-0', selectedTab: 'stats' });
+    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'stats' });
 
     // Landed on Build, and the URL was corrected in place rather than pushed.
     const activeTab = container.querySelector('[role="tab"][aria-selected="true"]');
@@ -209,6 +209,58 @@ describe('CreatorStudioView', () => {
     // No tab may exist in the URL that has no button to leave it by.
     const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((button) => button.textContent);
     expect(tabLabels.some((label) => label?.includes('Player feedback'))).toBe(false);
+
+    root.unmount();
+  });
+
+  it('opens a game addressed by its slug', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(3));
+    window.history.replaceState(null, '', '/studio/game-2');
+
+    const { container, root } = await renderStudio({ selectedGame: 'game-2' });
+
+    expect(container.querySelector('.studio-detail-title-block h2')?.textContent).toContain('Game 2');
+
+    root.unmount();
+  });
+
+  it('rewrites an old capability-token link onto the game’s slug', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(3));
+    window.history.replaceState(null, '', '/studio/token-1');
+
+    // The shape of a link from a months-old notification email, minted before games
+    // were given a slug at submission.
+    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-1' });
+
+    // It still opens the right game…
+    expect(container.querySelector('.studio-detail-title-block h2')?.textContent).toContain('Game 2');
+    // …and leaves a readable URL behind it, taking the capability out of history. In
+    // place, so the old address does not become an entry to go Back through.
+    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/overview', { replace: true });
+
+    root.unmount();
+  });
+
+  it('shows nothing for a game the creator does not own', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(3));
+    window.history.replaceState(null, '', '/studio/somebody-elses-game');
+
+    // Slugs are public — they are in every /play/ link — so the guard cannot be that
+    // the address is secret. It is that the shelf holds only this creator's games, and
+    // nothing on this screen is fetched by the URL's value.
+    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'somebody-elses-game' });
+
+    expect(container.querySelector('.studio-detail')).toBeNull();
+    expect(onNavigate).not.toHaveBeenCalled();
 
     root.unmount();
   });
@@ -224,7 +276,7 @@ describe('CreatorStudioView', () => {
 
     // First game is selected in the UI for convenience…
     expect(container.querySelector('.studio-shelf-item.is-active')?.textContent).toContain('Game 1');
-    // …but the address bar stays token-free until an explicit pick.
+    // …but nothing is written to the address bar until an explicit pick.
     expect(onNavigate).not.toHaveBeenCalled();
 
     const second = Array.from(container.querySelectorAll('.studio-shelf-item')).find((item) =>
@@ -234,7 +286,9 @@ describe('CreatorStudioView', () => {
     await act(async () => {
       second!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(onNavigate).toHaveBeenCalledWith('/studio/token-1/overview');
+    // And when it is written, it names the game — not the capability token that used
+    // to sit in the URL bar, in history, and in every screenshot of this screen.
+    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/overview');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -15,6 +15,7 @@ const approveSuggestion = vi.fn();
 const dismissSuggestion = vi.fn();
 const fetchGameAutonomy = vi.fn();
 const setGameAutonomy = vi.fn();
+const setDraftShared = vi.fn();
 let authUser: { uid: string; name: string } | null = null;
 
 vi.mock('./AuthContext', () => ({
@@ -33,6 +34,7 @@ vi.mock('./studioApi', async () => {
     dismissSuggestion: (...args: unknown[]) => dismissSuggestion(...args),
     fetchGameAutonomy: (...args: unknown[]) => fetchGameAutonomy(...args),
     setGameAutonomy: (...args: unknown[]) => setGameAutonomy(...args),
+    setDraftShared: (...args: unknown[]) => setDraftShared(...args),
     submitImprovement: vi.fn(),
   };
 });
@@ -87,6 +89,7 @@ describe('CreatorStudioView', () => {
     fetchGameAutonomy.mockReset();
     fetchGameAutonomy.mockRejectedValue(new Error('not owned'));
     setGameAutonomy.mockReset();
+    setDraftShared.mockReset();
   });
 
   afterEach(() => {
@@ -209,6 +212,71 @@ describe('CreatorStudioView', () => {
     // No tab may exist in the URL that has no button to leave it by.
     const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((button) => button.textContent);
     expect(tabLabels.some((label) => label?.includes('Player feedback'))).toBe(false);
+
+    root.unmount();
+  });
+
+  it('keeps an unpublished game to its creator until they share it', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    setDraftShared.mockResolvedValue({ shared: true, slug: 'tv-tycoon' });
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'token-draft',
+        title: 'TV Tycoon',
+        createdAt: '2026-07-30T09:00:00.000Z',
+        lastKnownStatus: 'building',
+        slug: 'tv-tycoon',
+      },
+    ] satisfies StudioGame[]);
+    window.history.replaceState(null, '', '/studio/tv-tycoon/overview');
+
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'overview' });
+
+    const toggle = container.querySelector<HTMLButtonElement>('.studio-share-toggle');
+    expect(toggle?.getAttribute('aria-checked')).toBe('false');
+    // Off means off: no link on screen to copy, because there is nothing that works.
+    expect(container.querySelector('.studio-share .status-share')).toBeNull();
+
+    await act(async () => {
+      toggle!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(setDraftShared).toHaveBeenCalledWith('token-draft', true);
+    expect(container.querySelector('.studio-share-toggle')?.getAttribute('aria-checked')).toBe('true');
+    // The game's ordinary permalink — the same one it keeps once it is published, so
+    // there is nothing to re-send when that happens. Never a separate draft address.
+    expect(container.querySelector('.studio-share .inline-link')?.textContent).toContain('/play/tv-tycoon');
+
+    root.unmount();
+  });
+
+  it('puts the switch back when the change did not take', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    setDraftShared.mockRejectedValue(new Error('nope'));
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'token-draft',
+        title: 'TV Tycoon',
+        createdAt: '2026-07-30T09:00:00.000Z',
+        lastKnownStatus: 'building',
+        slug: 'tv-tycoon',
+      },
+    ] satisfies StudioGame[]);
+
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'overview' });
+
+    await act(async () => {
+      container.querySelector('.studio-share-toggle')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // A switch left showing "on" after a failed write is the worst outcome here: the
+    // creator believes they shared a game that nobody else can open.
+    expect(container.querySelector('.studio-share-toggle')?.getAttribute('aria-checked')).toBe('false');
+    expect(container.querySelector('.studio-share .error')).not.toBeNull();
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -71,7 +71,15 @@ async function renderStudio(props: Partial<Parameters<typeof CreatorStudioView>[
     await fetchStudioScorecards.mock.results[0]?.value;
     await fetchStudioSuggestions.mock.results[0]?.value;
   });
-  return { container, root, onNavigate };
+  const rerender = async (next: Partial<Parameters<typeof CreatorStudioView>[0]>) => {
+    await act(async () => {
+      root.render(createElement(CreatorStudioView, { onNavigate, onPlay: vi.fn(), ...props, ...next }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+  return { container, root, onNavigate, rerender };
 }
 
 describe('CreatorStudioView', () => {
@@ -334,6 +342,45 @@ describe('CreatorStudioView', () => {
     expect(document.body.style.overflow).not.toBe('hidden');
 
     Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+    root.unmount();
+  });
+
+  it('does not carry one game’s details state onto another', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'token-shared',
+        title: 'TV Tycoon',
+        createdAt: '2026-07-30T09:00:00.000Z',
+        lastKnownStatus: 'building',
+        slug: 'tv-tycoon',
+        draftShared: true,
+      },
+      {
+        token: 'token-private',
+        title: 'Space Miner',
+        createdAt: '2026-07-30T09:30:00.000Z',
+        lastKnownStatus: 'building',
+        slug: 'space-miner',
+      },
+    ] satisfies StudioGame[]);
+
+    // Two `/details` URLs in a row — a browser Back, or a link. The panel stays mounted
+    // across that, so anything it seeded from the first game would still be on screen.
+    const { container, root, rerender } = await renderStudio({
+      selectedGame: 'tv-tycoon',
+      selectedTab: 'details',
+    });
+    expect(container.querySelector('.studio-share-toggle')?.getAttribute('aria-checked')).toBe('true');
+
+    await rerender({ selectedGame: 'space-miner', selectedTab: 'details' });
+
+    // The second game has never been shared, and the switch must say so.
+    expect(container.querySelector('.studio-share-toggle')?.getAttribute('aria-checked')).toBe('false');
+    expect(setDraftShared).not.toHaveBeenCalled();
+
     root.unmount();
   });
 

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -181,37 +181,38 @@ describe('CreatorStudioView', () => {
 
     const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0' });
 
-    const improveTab = Array.from(container.querySelectorAll('[role="tab"]')).find((button) =>
-      button.textContent?.includes('Improve'),
+    const detailsTab = Array.from(container.querySelectorAll('[role="tab"]')).find((button) =>
+      button.textContent?.includes('Details'),
     );
-    expect(improveTab).toBeTruthy();
+    expect(detailsTab).toBeTruthy();
 
     await act(async () => {
-      improveTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      detailsTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/improve');
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/details');
 
     root.unmount();
   });
 
-  it('falls back to the default tab when the deep-linked one does not exist for the game', async () => {
+  it('lands an old tab name on the surface that absorbed it, and corrects the URL', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    // token-0 is still building, so Stats has nothing to show for it.
     fetchStudioGames.mockResolvedValue(manyGames(2));
+    // The shape of a link from before there were three surfaces. The router resolves
+    // `stats` onto Details; what is asserted here is that the address follows.
     window.history.replaceState(null, '', '/studio/token-0/stats');
 
-    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'stats' });
+    const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'details' });
 
-    // Landed on Build, and the URL was corrected in place rather than pushed.
     const activeTab = container.querySelector('[role="tab"][aria-selected="true"]');
-    expect(activeTab?.textContent).toContain('Build');
-    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/build', { replace: true });
-    // No tab may exist in the URL that has no button to leave it by.
+    expect(activeTab?.textContent).toContain('Details');
+    // In place, so the old address does not become a history entry to go Back through.
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/details', { replace: true });
+    // Every surface in the URL has a button to leave it by.
     const tabLabels = Array.from(container.querySelectorAll('[role="tab"]')).map((button) => button.textContent);
-    expect(tabLabels.some((label) => label?.includes('Player feedback'))).toBe(false);
+    expect(tabLabels).toEqual(['Thread', 'Details', 'Playtest']);
 
     root.unmount();
   });
@@ -232,7 +233,7 @@ describe('CreatorStudioView', () => {
     ] satisfies StudioGame[]);
     window.history.replaceState(null, '', '/studio/tv-tycoon/overview');
 
-    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'overview' });
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
 
     const toggle = container.querySelector<HTMLButtonElement>('.studio-share-toggle');
     expect(toggle?.getAttribute('aria-checked')).toBe('false');
@@ -267,7 +268,7 @@ describe('CreatorStudioView', () => {
       },
     ] satisfies StudioGame[]);
 
-    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'overview' });
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
 
     await act(async () => {
       container.querySelector('.studio-share-toggle')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -310,7 +311,7 @@ describe('CreatorStudioView', () => {
     expect(container.querySelector('.studio-detail-title-block h2')?.textContent).toContain('Game 2');
     // …and leaves a readable URL behind it, taking the capability out of history. In
     // place, so the old address does not become an entry to go Back through.
-    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/overview', { replace: true });
+    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/thread', { replace: true });
 
     root.unmount();
   });
@@ -356,7 +357,7 @@ describe('CreatorStudioView', () => {
     });
     // And when it is written, it names the game — not the capability token that used
     // to sit in the URL bar, in history, and in every screenshot of this screen.
-    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/overview');
+    expect(onNavigate).toHaveBeenCalledWith('/studio/game-2/thread');
 
     root.unmount();
   });
@@ -413,7 +414,7 @@ describe('CreatorStudioView — what players think', () => {
     await i18n.changeLanguage('en');
     const { container, root } = await renderStudio();
     const statsTab = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.trim().startsWith('Stats'),
+      button.textContent?.trim().startsWith('Details'),
     );
     if (statsTab) {
       await act(async () => {

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -289,6 +289,54 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('makes the details panel behave like a sheet on a narrow screen', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    // jsdom has no matchMedia, which is also the fallback path in real embedded
+    // webviews — the width is what decides when the query is unavailable.
+    const width = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { value: 420, configurable: true });
+
+    const { container, root } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'details' });
+
+    // Over the thread, so: something to tap beside it, and a page that does not scroll
+    // away behind it. Without these it is a fixed panel the page slides underneath.
+    expect(container.querySelector('.studio-rail-backdrop')).not.toBeNull();
+    expect(container.querySelector('.studio-rail')?.getAttribute('aria-modal')).toBe('true');
+    expect(document.body.style.overflow).toBe('hidden');
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(container.querySelector('.studio-rail')).toBeNull();
+    expect(document.body.style.overflow).not.toBe('hidden');
+
+    Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+    root.unmount();
+  });
+
+  it('leaves the details panel a plain rail when there is room beside the thread', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    const width = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true });
+
+    const { container, root } = await renderStudio({ selectedGame: 'token-0', selectedTab: 'details' });
+
+    // Beside the thread it is not modal, and must not lock the page — the reader can
+    // see straight past it to the conversation it is about.
+    expect(container.querySelector('.studio-rail')).not.toBeNull();
+    expect(container.querySelector('.studio-rail-backdrop')).toBeNull();
+    expect(document.body.style.overflow).not.toBe('hidden');
+
+    Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+    root.unmount();
+  });
+
   it('opens a game addressed by its slug', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -573,6 +573,14 @@ export function CreatorStudioView({
                         </button>
                       </div>
                       <DetailsPanel
+                        // Keyed on the game, so switching to another one gives a fresh
+                        // panel rather than reusing this one's state. Without it every
+                        // `useState(game.…)` initialiser inside keeps the previous game's
+                        // value — the share switch reading the wrong game's setting, and,
+                        // worse, an armed Stop-build carrying across to a game the creator
+                        // never armed it on. Reachable by any move between two `/details`
+                        // URLs, browser Back included.
+                        key={activeGame.token}
                         game={activeGame}
                         health={selectedHealth}
                         days={days}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -73,8 +73,12 @@ const TAB_LABELS: Record<StudioTab, string> = {
 type NavigateOptions = { replace?: boolean };
 
 type CreatorStudioViewProps = {
-  /** Deep-link into a specific game when present. */
-  selectedToken?: string;
+  /**
+   * Deep-link into a specific game when present: its slug, or — for links minted
+   * before games had one — its capability token. Resolved against the creator's own
+   * shelf, so it addresses nothing they do not own.
+   */
+  selectedGame?: string;
   /** Deep-link into a work-surface tab when present. */
   selectedTab?: StudioTab;
   onNavigate: (path: string, options?: NavigateOptions) => void;
@@ -104,6 +108,18 @@ function resolveTab(game: StudioGame, requested?: StudioTab): StudioTab {
   return defaultTabFor(game);
 }
 
+/**
+ * How this game is addressed in the URL.
+ *
+ * The slug once it has one, which is now from the moment the game was submitted. The
+ * capability token is the fallback for games created before slugs were assigned up
+ * front — and it is a fallback rather than the rule because a token in the URL bar is a
+ * grant sitting in browser history, in screenshots, and in anything the creator pastes.
+ */
+function studioAddress(game: StudioGame): string {
+  return game.slug ?? game.token;
+}
+
 function formatSeconds(seconds: number): string {
   if (seconds < 60) return `${Math.round(seconds)}s`;
   const minutes = Math.floor(seconds / 60);
@@ -121,7 +137,7 @@ function healthFor(game: StudioGame, rows: GameHealth[]): GameHealth | null {
 }
 
 export function CreatorStudioView({
-  selectedToken,
+  selectedGame,
   selectedTab,
   onNavigate,
   onPlay,
@@ -138,7 +154,9 @@ export function CreatorStudioView({
   const [days, setDays] = useState(7);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(selectedToken ?? null);
+  // Internally a game is its token — that is what every API call on this screen takes.
+  // The URL says slug; the shelf is what translates between them.
+  const [selected, setSelected] = useState<string | null>(null);
   const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'overview');
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
@@ -147,9 +165,24 @@ export function CreatorStudioView({
   const pickerSearchId = useId();
   const pickerSearchRef = useRef<HTMLInputElement>(null!);
 
+  // What the URL is asking for, readable from inside the shelf fetch below without
+  // making that fetch re-run every time the address changes. Seeded rather than
+  // assigned in an effect because the case that matters is the first render: a deep
+  // link arrives with the shelf request already in flight.
+  const requestedGameRef = useRef(selectedGame);
   useEffect(() => {
-    if (selectedToken) setSelected(selectedToken);
-  }, [selectedToken]);
+    requestedGameRef.current = selectedGame;
+  }, [selectedGame]);
+
+  // Resolve the URL's game segment against the shelf — by slug, or by capability token
+  // for links minted before games were given slugs at submission. A value matching
+  // neither selects nothing: the shelf holds only this creator's games, so a slug
+  // belonging to someone else is indistinguishable from one that does not exist.
+  useEffect(() => {
+    if (!selectedGame) return;
+    const match = games.find((game) => game.slug === selectedGame || game.token === selectedGame);
+    if (match) setSelected(match.token);
+  }, [selectedGame, games]);
 
   useEffect(() => {
     if (!user) {
@@ -174,6 +207,13 @@ export function CreatorStudioView({
         setLoading(false);
         setSelected((current) => {
           if (current && shelf.some((game) => game.token === current)) return current;
+          // A URL naming a game picks that one, or none at all. Falling through to the
+          // newest would answer "show me this game" with a different game, silently —
+          // and since slugs are public, the request may well be for somebody else's.
+          const requested = requestedGameRef.current;
+          if (requested) {
+            return shelf.find((game) => game.slug === requested || game.token === requested)?.token ?? null;
+          }
           return shelf[0]?.token ?? null;
         });
       })
@@ -216,39 +256,49 @@ export function CreatorStudioView({
     };
   }, [user]);
 
-  const selectedGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
-  const selectedHealth = selectedGame ? healthFor(selectedGame, healthRows) : null;
-  const selectedScorecard = selectedGame?.slug
-    ? (scorecards.find((card) => card.slug === selectedGame.slug) ?? null)
+  const activeGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
+  const selectedHealth = activeGame ? healthFor(activeGame, healthRows) : null;
+  const selectedScorecard = activeGame?.slug
+    ? (scorecards.find((card) => card.slug === activeGame.slug) ?? null)
     : null;
   const visibleGames = useMemo(
     () => filterStudioGames(games, { filter: shelfFilter, query: shelfQuery }),
     [games, shelfFilter, shelfQuery],
   );
   const showShelfTools = games.length >= STUDIO_SHELF_TOOLS_AT;
+  // The URL named a game and the shelf does not have it: a typo, a game since abandoned,
+  // or somebody else's slug. Said plainly, because an unexplained shelf looks like the
+  // link worked and the game vanished.
+  const missingGame = Boolean(selectedGame) && !loading && !error && games.length > 0 && !activeGame;
   const buildingCount = useMemo(
     () => games.filter((game) => game.lastKnownStatus && STUDIO_LIVE_STATUSES.has(game.lastKnownStatus)).length,
     [games],
   );
   const liveCount = useMemo(() => games.filter((game) => isStudioGamePublished(game)).length, [games]);
 
-  // Keep the visible tab aligned with the selected game. Only write the
-  // capability token into the URL when the route already carried one (a deep
-  // link, or an earlier explicit pick via selectGame/openTab). Bare `/studio`
-  // keeps shelf selection local so a screenshot or history entry doesn't mint a
-  // token the creator never asked for.
+  // Keep the visible tab aligned with the selected game, and the URL on the game's
+  // current address. Only writes an address when the route already carried one (a deep
+  // link, or an earlier explicit pick via selectGame/openTab); bare `/studio` keeps
+  // shelf selection local so a screenshot or history entry doesn't name a game the
+  // creator never asked to put there.
+  //
+  // This is also where an old `/studio/<token>` link upgrades itself: the address it
+  // rewrites to is the slug, so following a link out of a months-old notification email
+  // leaves a readable URL behind and takes the capability token out of history.
   useEffect(() => {
     if (!selected) return;
     const game = games.find((entry) => entry.token === selected);
     if (!game) return;
     const next = resolveTab(game, selectedTab);
     setTab(next);
-    if (!selectedToken) return;
-    const canonical = studioPath(game.token, next);
+    // The route carried no game, so nothing is written back: this is bare `/studio`,
+    // where the shelf's convenience selection is the view's business and not the URL's.
+    if (!selectedGame) return;
+    const canonical = studioPath(studioAddress(game), next);
     if (window.location.pathname !== canonical) {
       onNavigate(canonical, { replace: true });
     }
-  }, [selected, selectedTab, selectedToken, games, onNavigate]);
+  }, [selected, selectedTab, selectedGame, games, onNavigate]);
 
   useEffect(() => {
     if (!pickerOpen) return;
@@ -272,13 +322,13 @@ export function CreatorStudioView({
     setSelected(token);
     setTab(nextTab);
     setPickerOpen(false);
-    onNavigate(studioPath(token, nextTab));
+    if (next) onNavigate(studioPath(studioAddress(next), nextTab));
   }
 
   function openTab(next: StudioTab) {
-    if (!selectedGame || !tabAvailable(selectedGame, next)) return;
+    if (!activeGame || !tabAvailable(activeGame, next)) return;
     setTab(next);
-    onNavigate(studioPath(selectedGame.token, next));
+    onNavigate(studioPath(studioAddress(activeGame), next));
   }
 
   if (!user) {
@@ -311,7 +361,7 @@ export function CreatorStudioView({
 
   // Derived from the same predicate the router uses, so a deep-linked tab can never
   // resolve to a surface with no button to leave it by.
-  const tabItems = selectedGame ? TAB_ORDER.filter((id) => tabAvailable(selectedGame, id)) : [];
+  const tabItems = activeGame ? TAB_ORDER.filter((id) => tabAvailable(activeGame, id)) : [];
 
   return (
     <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}`}>
@@ -342,10 +392,10 @@ export function CreatorStudioView({
         <div
           className={[
             'studio-layout',
-            selectedGame ? 'is-game-open' : '',
+            activeGame ? 'is-game-open' : '',
             // Once the shelf is no longer a glanceable handful, collapse it after
             // selection so the work surface owns the viewport (desktop + mobile).
-            selectedGame && showShelfTools ? 'is-focus' : '',
+            activeGame && showShelfTools ? 'is-focus' : '',
           ]
             .filter(Boolean)
             .join(' ')}
@@ -369,7 +419,9 @@ export function CreatorStudioView({
             {shelfList}
           </aside>
 
-          {selectedGame ? (
+          {missingGame ? <p className="studio-empty studio-error">{t('studioPanel.gameNotFound')}</p> : null}
+
+          {activeGame ? (
             <div className="studio-detail">
               <div className="studio-detail-head">
                 <button
@@ -385,16 +437,16 @@ export function CreatorStudioView({
                       {t('studioPanel.shelf.count', { count: games.length })}
                     </span>
                   </span>
-                  <span className="studio-game-switcher-title">{selectedGame.title}</span>
-                  {selectedGame.slug ? <code className="studio-slug">{selectedGame.slug}</code> : null}
+                  <span className="studio-game-switcher-title">{activeGame.title}</span>
+                  {activeGame.slug ? <code className="studio-slug">{activeGame.slug}</code> : null}
                   <PixelIcon name="expand" size={12} />
                 </button>
                 <div className="studio-detail-title-row">
                   <div className="studio-detail-title-block">
-                    <h2>{selectedGame.title}</h2>
-                    {selectedGame.slug ? <code className="studio-slug">{selectedGame.slug}</code> : null}
+                    <h2>{activeGame.title}</h2>
+                    {activeGame.slug ? <code className="studio-slug">{activeGame.slug}</code> : null}
                   </div>
-                  <StudioStatusPill game={selectedGame} />
+                  <StudioStatusPill game={activeGame} />
                 </div>
               </div>
 
@@ -416,11 +468,11 @@ export function CreatorStudioView({
               <div className="studio-tab-panel">
                 {tab === 'overview' ? (
                   <OverviewTab
-                    game={selectedGame}
+                    game={activeGame}
                     health={selectedHealth}
                     onOpenBuild={() => openTab('build')}
                     onOpenPlaytest={() => openTab('playtest')}
-                    onPlay={() => selectedGame.slug && onPlay(selectedGame.slug)}
+                    onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
                     onRemoved={(token) => {
                       setGames((prev) => prev.filter((game) => game.token !== token));
                       setSelected((current) => (current === token ? null : current));
@@ -429,10 +481,10 @@ export function CreatorStudioView({
                   />
                 ) : null}
 
-                {tab === 'build' && !isStudioGamePublished(selectedGame) ? (
+                {tab === 'build' && !isStudioGamePublished(activeGame) ? (
                   <div className="studio-build">
                     <SubmissionStatusView
-                      token={selectedGame.token}
+                      token={activeGame.token}
                       embedded
                       onPlaytest={() => openTab('playtest')}
                       onRetry={
@@ -449,15 +501,15 @@ export function CreatorStudioView({
 
                 {tab === 'playtest' ? (
                   <StudioPlaytestPanel
-                    game={selectedGame}
-                    published={isStudioGamePublished(selectedGame)}
+                    game={activeGame}
+                    published={isStudioGamePublished(activeGame)}
                     onExit={() => openTab('overview')}
                   />
                 ) : null}
 
                 {tab === 'stats' ? (
                   <StatsTab
-                    game={selectedGame}
+                    game={activeGame}
                     health={selectedHealth}
                     days={days}
                     healthDays={healthDays}
@@ -467,7 +519,7 @@ export function CreatorStudioView({
                   />
                 ) : null}
 
-                {tab === 'improve' ? <ImproveTab game={selectedGame} /> : null}
+                {tab === 'improve' ? <ImproveTab game={activeGame} /> : null}
               </div>
             </div>
           ) : null}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -6,7 +6,7 @@ import type { GameHealth } from './healthApi.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { playPath, studioPath, type StudioTab } from './router.js';
-import { abandonSubmission, submitFeedback, type SubmissionApiError, type SubmissionState } from './submissionApi.js';
+import { abandonSubmission, type SubmissionState } from './submissionApi.js';
 import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import {
   filterStudioGames,
@@ -26,8 +26,6 @@ import {
   fetchGameAutonomy,
   setGameAutonomy,
   setDraftShared,
-  submitImprovement,
-  type StudioApiError,
   type StudioGame,
   type StudioScorecard,
   type StudioSuggestion,
@@ -37,16 +35,24 @@ import {
 /**
  * Creator control panel (docs/improvement-loop-plan.md IL-2 creator surface).
  *
- * One place for the whole creator loop: shelf of owned games, the draft Build
- * (former status / "dev studio" page), playtest-with-pause prompting, play
- * health, and post-publish improve.
+ * One game is one thread, and the thread is the studio.
  *
- * Shelf scales past a handful of games: compact rows, search/filter once the
- * list grows, and on narrow viewports a game switcher (picker sheet) so the
- * work surface is not buried under ten cards.
+ * Making a game here is a conversation with an agent, and this screen used to be five
+ * tabs laid across the top of it — with the same act, "say what to change", living in
+ * three of them, so which box a creator was allowed depended on a lifecycle state they
+ * had to know in order to find it. There are three surfaces now: the thread, the things
+ * beside the thread (facts, sharing, play health, stopping it), and playtest, which
+ * genuinely takes the screen. The composer at the foot of the thread is the only one,
+ * and it always targets the game's current state — published or not, there is only ever
+ * the tip to work on.
  *
- * Selection + active tab live in the URL (`/studio/:token/:tab`) so a refresh
- * or shared link reopens the same work surface.
+ * Shelf scales past a handful of games: compact rows, search/filter once the list grows,
+ * and on narrow viewports a game switcher (picker sheet) so the thread is not buried
+ * under ten cards.
+ *
+ * Selection + surface live in the URL (`/studio/<slug>/<surface>`) so a refresh or a
+ * shared link reopens the same place. The five old tab names still resolve, onto
+ * whichever surface absorbed them.
  */
 
 const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
@@ -61,14 +67,12 @@ const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
 
 const WINDOWS = [1, 7, 30];
 
-/** Tab strip order, and the label each tab carries. */
-const TAB_ORDER: readonly StudioTab[] = ['overview', 'build', 'playtest', 'stats', 'improve'];
+/** Surface strip order, and the label each one carries. */
+const TAB_ORDER: readonly StudioTab[] = ['thread', 'details', 'playtest'];
 const TAB_LABELS: Record<StudioTab, string> = {
-  overview: 'studioPanel.tabs.overview',
-  build: 'studioPanel.tabs.build',
+  thread: 'studioPanel.tabs.thread',
+  details: 'studioPanel.tabs.details',
   playtest: 'studioPanel.tabs.playtest',
-  stats: 'studioPanel.tabs.stats',
-  improve: 'studioPanel.tabs.improve',
 };
 
 type NavigateOptions = { replace?: boolean };
@@ -88,25 +92,30 @@ type CreatorStudioViewProps = {
   onRetryConcept?: (concept: string) => void;
 };
 
-function defaultTabFor(game: StudioGame | null): StudioTab {
-  if (!game) return 'overview';
-  return isStudioGamePublished(game) ? 'overview' : 'build';
+/**
+ * The thread, always — for a game being built and for one that is live.
+ *
+ * Both used to land somewhere else: a build opened on its status page, a published game
+ * on a facts panel. But the question a creator arrives with is the same either way —
+ * what has happened, and how do I ask for the next thing — and that is one surface.
+ */
+function defaultTabFor(): StudioTab {
+  return 'thread';
 }
 
 /**
- * Which surfaces exist for this game. Must stay in step with the rendered tab list
- * below: a tab that resolves but has no button and no panel is a blank work surface.
+ * Which surfaces exist for this game. All three, for every game: the thread reads the
+ * build's history and takes the next message whatever state it is in, the details panel
+ * always has facts to show, and playtest always has something to play or a reason it
+ * does not yet.
  */
-function tabAvailable(game: StudioGame, tab: StudioTab): boolean {
-  const published = isStudioGamePublished(game);
-  if (tab === 'build') return !published;
-  if (tab === 'stats') return published;
+function tabAvailable(_game: StudioGame, _tab: StudioTab): boolean {
   return true;
 }
 
 function resolveTab(game: StudioGame, requested?: StudioTab): StudioTab {
   if (requested && tabAvailable(game, requested)) return requested;
-  return defaultTabFor(game);
+  return defaultTabFor();
 }
 
 /**
@@ -158,7 +167,7 @@ export function CreatorStudioView({
   // Internally a game is its token — that is what every API call on this screen takes.
   // The URL says slug; the shelf is what translates between them.
   const [selected, setSelected] = useState<string | null>(null);
-  const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'overview');
+  const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'thread');
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -319,7 +328,7 @@ export function CreatorStudioView({
 
   function selectGame(token: string) {
     const next = games.find((game) => game.token === token) ?? null;
-    const nextTab = defaultTabFor(next);
+    const nextTab = defaultTabFor();
     setSelected(token);
     setTab(nextTab);
     setPickerOpen(false);
@@ -467,24 +476,13 @@ export function CreatorStudioView({
               </div>
 
               <div className="studio-tab-panel">
-                {tab === 'overview' ? (
-                  <OverviewTab
-                    game={activeGame}
-                    health={selectedHealth}
-                    onOpenBuild={() => openTab('build')}
-                    onOpenPlaytest={() => openTab('playtest')}
-                    onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
-                    onRemoved={(token) => {
-                      setGames((prev) => prev.filter((game) => game.token !== token));
-                      setSelected((current) => (current === token ? null : current));
-                      onNavigate(studioPath());
-                    }}
-                  />
-                ) : null}
-
-                {tab === 'build' && !isStudioGamePublished(activeGame) ? (
+                {/* The thread is the game. Keyed on the token so switching games starts a
+                    new conversation rather than showing the previous one's tail while the
+                    first poll of the new one is in flight. */}
+                {tab === 'thread' ? (
                   <div className="studio-build">
                     <SubmissionStatusView
+                      key={activeGame.token}
                       token={activeGame.token}
                       embedded
                       onPlaytest={() => openTab('playtest')}
@@ -504,12 +502,14 @@ export function CreatorStudioView({
                   <StudioPlaytestPanel
                     game={activeGame}
                     published={isStudioGamePublished(activeGame)}
-                    onExit={() => openTab('overview')}
+                    onExit={() => openTab('thread')}
                   />
                 ) : null}
 
-                {tab === 'stats' ? (
-                  <StatsTab
+                {/* Everything that is about the game rather than said to it: when it was
+                    made, who can play it, how it is doing, and how to stop it. */}
+                {tab === 'details' ? (
+                  <DetailsPanel
                     game={activeGame}
                     health={selectedHealth}
                     days={days}
@@ -517,10 +517,16 @@ export function CreatorStudioView({
                     truncated={truncated}
                     scorecard={selectedScorecard}
                     onDaysChange={setDays}
+                    onOpenThread={() => openTab('thread')}
+                    onOpenPlaytest={() => openTab('playtest')}
+                    onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
+                    onRemoved={(token) => {
+                      setGames((prev) => prev.filter((game) => game.token !== token));
+                      setSelected((current) => (current === token ? null : current));
+                      onNavigate(studioPath());
+                    }}
                   />
                 ) : null}
-
-                {tab === 'improve' ? <ImproveTab game={activeGame} /> : null}
               </div>
             </div>
           ) : null}
@@ -709,17 +715,32 @@ function StudioShelfList({
   );
 }
 
-function OverviewTab({
+/**
+ * The things beside the thread: when the game was made, how it is doing, who can play
+ * it, and how to stop it. Everything here is *about* the game; the thread is where it
+ * is talked to.
+ */
+function DetailsPanel({
   game,
   health,
-  onOpenBuild,
+  days,
+  healthDays,
+  truncated,
+  scorecard,
+  onDaysChange,
+  onOpenThread,
   onOpenPlaytest,
   onPlay,
   onRemoved,
 }: {
   game: StudioGame;
   health: GameHealth | null;
-  onOpenBuild: () => void;
+  days: number;
+  healthDays: string[];
+  truncated: boolean;
+  scorecard: StudioScorecard | null;
+  onDaysChange: (days: number) => void;
+  onOpenThread: () => void;
   onOpenPlaytest: () => void;
   onPlay: () => void;
   onRemoved: (token: string) => void;
@@ -776,7 +797,7 @@ function OverviewTab({
             <PixelIcon name="play" size={12} /> {t('myGames.play')}
           </button>
         ) : (
-          <button type="button" className="primary-btn" onClick={onOpenBuild}>
+          <button type="button" className="primary-btn" onClick={onOpenThread}>
             <PixelIcon name="wrench" size={12} /> {t('studioPanel.overview.openBuild')}
           </button>
         )}
@@ -796,6 +817,21 @@ function OverviewTab({
       </div>
 
       {!published && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+
+      {/* Only once there is play to report on. Before a game is live every one of these
+          numbers is zero, and a wall of zeroes reads as a verdict rather than as
+          "nobody has played it yet, because nobody can". */}
+      {published ? (
+        <StatsSection
+          game={game}
+          health={health}
+          days={days}
+          healthDays={healthDays}
+          truncated={truncated}
+          scorecard={scorecard}
+          onDaysChange={onDaysChange}
+        />
+      ) : null}
     </div>
   );
 }
@@ -878,7 +914,7 @@ function DraftShareControl({ game }: { game: StudioGame }) {
   );
 }
 
-function StatsTab({
+function StatsSection({
   game,
   health,
   days,
@@ -1303,78 +1339,3 @@ const AUTONOMY_CHOICES: Array<[AutonomyMode, string, string]> = [
   ['auto-fix-defects', 'studioPanel.autonomy.autoFixDefects', 'studioPanel.autonomy.autoFixDefectsHint'],
   ['auto-tune', 'studioPanel.autonomy.autoTune', 'studioPanel.autonomy.autoTuneHint'],
 ];
-
-function ImproveTab({ game }: { game: StudioGame }) {
-  const { t } = useTranslation();
-  const published = isStudioGamePublished(game);
-  const [text, setText] = useState('');
-  const [state, setState] = useState<'idle' | 'sending' | 'sent'>('idle');
-  const [error, setError] = useState<string | null>(null);
-
-  async function handleSubmit() {
-    const trimmed = text.trim();
-    if (trimmed.length < 10 || state === 'sending') return;
-    setState('sending');
-    setError(null);
-    try {
-      if (published) {
-        await submitImprovement(game.token, trimmed);
-      } else {
-        await submitFeedback(game.token, trimmed);
-      }
-      setText('');
-      setState('sent');
-    } catch (err) {
-      const apiErr = err as StudioApiError | SubmissionApiError;
-      const message = apiErr.message ?? '';
-      if (message.includes('quota')) {
-        setError(t('studioPanel.improve.quota'));
-      } else if (apiErr.status === 429 || message.includes('too many')) {
-        setError(t('studioPanel.improve.rateLimit'));
-      } else if (apiErr.status === 422) {
-        setError(t('studioPanel.improve.rejected'));
-      } else {
-        setError(t('studioPanel.improve.error'));
-      }
-      setState('idle');
-    }
-  }
-
-  return (
-    <div className="status-feedback studio-improve">
-      <h3 className="status-feedback-title">
-        {published ? t('studioPanel.improve.titlePublished') : t('studioPanel.improve.titleDraft')}
-      </h3>
-      <p className="status-feedback-hint">
-        {published ? t('studioPanel.improve.hintPublished') : t('studioPanel.improve.hintDraft')}
-      </p>
-      <textarea
-        className="status-feedback-input"
-        rows={5}
-        value={text}
-        onChange={(event) => {
-          setText(event.target.value);
-          if (state === 'sent') setState('idle');
-        }}
-        placeholder={t('studioPanel.improve.placeholder')}
-        disabled={state === 'sending'}
-      />
-      <div className="status-feedback-actions">
-        <button
-          type="button"
-          className="primary-btn"
-          disabled={text.trim().length < 10 || state === 'sending'}
-          onClick={() => void handleSubmit()}
-        >
-          {state === 'sending' ? t('studioPanel.improve.sending') : t('studioPanel.improve.submit')}
-        </button>
-        {state === 'sent' ? (
-          <span className="status-feedback-sent">
-            <PixelIcon name="check" size={13} /> {t('studioPanel.improve.sent')}
-          </span>
-        ) : null}
-      </div>
-      {error ? <p className="error">{error}</p> : null}
-    </div>
-  );
-}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -5,7 +5,7 @@ import { AuthModal } from './AuthModal.js';
 import type { GameHealth } from './healthApi.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
-import { studioPath, type StudioTab } from './router.js';
+import { playPath, studioPath, type StudioTab } from './router.js';
 import { abandonSubmission, submitFeedback, type SubmissionApiError, type SubmissionState } from './submissionApi.js';
 import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import {
@@ -25,6 +25,7 @@ import {
   fetchStudioSuggestions,
   fetchGameAutonomy,
   setGameAutonomy,
+  setDraftShared,
   submitImprovement,
   type StudioApiError,
   type StudioGame,
@@ -793,6 +794,86 @@ function OverviewTab({
           </button>
         ) : null}
       </div>
+
+      {!published && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+    </div>
+  );
+}
+
+/**
+ * Whether anyone else can play this game before it is published.
+ *
+ * Off until the creator turns it on, and the game is in no catalog and no rail either
+ * way — the link is the only way in, which is what makes one switch enough. The link
+ * shown is the game's ordinary permalink, the same one it will keep once it is live,
+ * so there is nothing to re-share when that happens.
+ */
+function DraftShareControl({ game }: { game: StudioGame }) {
+  const { t } = useTranslation();
+  const [shared, setShared] = useState(Boolean(game.draftShared));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const url = game.slug ? new URL(playPath(game.slug), window.location.href).toString() : '';
+
+  async function toggle() {
+    const next = !shared;
+    setBusy(true);
+    setError(null);
+    // Optimistic, and reverted on failure: the switch is the whole control, so leaving
+    // it in the old position while the request runs reads as a dead button.
+    setShared(next);
+    try {
+      await setDraftShared(game.token, next);
+    } catch {
+      setShared(!next);
+      setError(t('studioPanel.share.error'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // No clipboard permission or no clipboard API — the link is on screen to select
+      // by hand, so this needs no error state.
+    }
+  }
+
+  return (
+    <div className="studio-share">
+      <div className="studio-share-head">
+        <h3 className="studio-share-title">{t('studioPanel.share.title')}</h3>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={shared}
+          className={`studio-share-toggle${shared ? ' is-on' : ''}`}
+          onClick={() => void toggle()}
+          disabled={busy}
+        >
+          <span className="studio-share-toggle-track" aria-hidden="true" />
+          {shared ? t('studioPanel.share.on') : t('studioPanel.share.off')}
+        </button>
+      </div>
+      <p className="studio-share-hint">{t(shared ? 'studioPanel.share.hintOn' : 'studioPanel.share.hintOff')}</p>
+      {shared ? (
+        <p className="status-note status-share">
+          <a className="inline-link" href={url}>
+            {url}
+          </a>
+          <button type="button" className="status-share-copy" onClick={() => void copy()}>
+            <PixelIcon name={copied ? 'check' : 'globe'} size={12} />{' '}
+            {copied ? t('statusView.shareCopied') : t('statusView.shareCopy')}
+          </button>
+        </p>
+      ) : null}
+      {error ? <p className="error">{error}</p> : null}
     </div>
   );
 }

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -434,11 +434,7 @@ export function CreatorStudioView({
                     <SubmissionStatusView
                       token={selectedGame.token}
                       embedded
-                      // Feeds the live pill's elapsed timer. With the numeric ETA gone, "Live · 12m"
-                      // is the only thing on this tab saying the build is still moving — a bare
-                      // "Live" next to the header's status pill reads like a second, contradictory
-                      // status instead of a heartbeat.
-                      submittedAt={Date.parse(selectedGame.createdAt)}
+                      onPlaytest={() => openTab('playtest')}
                       onRetry={
                         onRetryConcept
                           ? (concept) => {

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -57,6 +57,15 @@ import {
 
 const WINDOWS = [1, 7, 30];
 
+/**
+ * Where the details panel stops being a rail beside the thread and becomes a sheet over
+ * it. Kept in step with the same breakpoint in styles.css by hand — the two describe one
+ * decision, and a panel that behaves like a sheet while it is drawn as a rail (or the
+ * reverse) locks the page scroll for something the reader can see straight past.
+ */
+const SHEET_MAX_WIDTH = 1099;
+const SHEET_QUERY = `(max-width: ${SHEET_MAX_WIDTH}px)`;
+
 type NavigateOptions = { replace?: boolean };
 
 type CreatorStudioViewProps = {
@@ -292,6 +301,47 @@ export function CreatorStudioView({
     }
   }, [selected, selectedTab, selectedGame, games, onNavigate]);
 
+  /**
+   * Below the rail breakpoint the details panel is a sheet over the thread, and a sheet
+   * has obligations a side panel does not: the page behind it must not scroll, Escape
+   * must close it, and there must be something to tap beside it to dismiss. The game
+   * picker already does all three; this arrived without any of them.
+   */
+  const detailsOpen = tab === 'details';
+  const [detailsIsSheet, setDetailsIsSheet] = useState(false);
+  useEffect(() => {
+    if (!detailsOpen) {
+      setDetailsIsSheet(false);
+      return;
+    }
+    // Width, not `matchMedia` alone: the query is the precise instrument but it is not
+    // universally present (jsdom has none, and neither do some embedded webviews), and a
+    // panel that throws where it is missing is worse than one measured a cruder way.
+    const query = typeof window.matchMedia === 'function' ? window.matchMedia(SHEET_QUERY) : null;
+    const sync = () => setDetailsIsSheet(query ? query.matches : window.innerWidth <= SHEET_MAX_WIDTH);
+    sync();
+    query?.addEventListener('change', sync);
+    window.addEventListener('resize', sync);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') openTabRef.current('thread');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      query?.removeEventListener('change', sync);
+      window.removeEventListener('resize', sync);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [detailsOpen]);
+
+  useEffect(() => {
+    if (!detailsIsSheet) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [detailsIsSheet]);
+
   useEffect(() => {
     if (!pickerOpen) return;
     const previous = document.body.style.overflow;
@@ -317,11 +367,18 @@ export function CreatorStudioView({
     if (next) onNavigate(studioPath(studioAddress(next), nextTab));
   }
 
+  // Read by the Escape handler above, which is registered once per open rather than
+  // re-registered on every render that changes what `openTab` closes over.
+  const openTabRef = useRef((next: StudioTab) => {
+    void next;
+  });
+
   function openTab(next: StudioTab) {
     if (!activeGame || !tabAvailable(activeGame, next)) return;
     setTab(next);
     onNavigate(studioPath(studioAddress(activeGame), next));
   }
+  openTabRef.current = openTab;
 
   if (!user) {
     return (
@@ -491,35 +548,48 @@ export function CreatorStudioView({
                 {/* Everything that is about the game rather than said to it: when it was
                     made, who can play it, how it is doing, and how to stop it. */}
                 {tab === 'details' ? (
-                  <aside className="studio-rail" aria-label={t('studioPanel.tabs.details')}>
-                    <div className="studio-rail-head">
-                      <h3>{t('studioPanel.tabs.details')}</h3>
-                      <button
-                        type="button"
-                        className="modal-close-btn"
+                  <>
+                    {detailsIsSheet ? (
+                      <div
+                        className="modal-backdrop studio-rail-backdrop"
+                        role="presentation"
                         onClick={() => openTab('thread')}
-                        aria-label={t('studioPanel.shelf.closePicker')}
-                      >
-                        <PixelIcon name="close" size={14} />
-                      </button>
-                    </div>
-                    <DetailsPanel
-                      game={activeGame}
-                      health={selectedHealth}
-                      days={days}
-                      healthDays={healthDays}
-                      truncated={truncated}
-                      scorecard={selectedScorecard}
-                      onDaysChange={setDays}
-                      onOpenPlaytest={() => openTab('playtest')}
-                      onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
-                      onRemoved={(token) => {
-                        setGames((prev) => prev.filter((game) => game.token !== token));
-                        setSelected((current) => (current === token ? null : current));
-                        onNavigate(studioPath());
-                      }}
-                    />
-                  </aside>
+                      />
+                    ) : null}
+                    <aside
+                      className="studio-rail"
+                      aria-label={t('studioPanel.tabs.details')}
+                      {...(detailsIsSheet ? { role: 'dialog', 'aria-modal': true } : {})}
+                    >
+                      <div className="studio-rail-head">
+                        <h3>{t('studioPanel.tabs.details')}</h3>
+                        <button
+                          type="button"
+                          className="modal-close-btn"
+                          onClick={() => openTab('thread')}
+                          aria-label={t('studioPanel.shelf.closePicker')}
+                        >
+                          <PixelIcon name="close" size={14} />
+                        </button>
+                      </div>
+                      <DetailsPanel
+                        game={activeGame}
+                        health={selectedHealth}
+                        days={days}
+                        healthDays={healthDays}
+                        truncated={truncated}
+                        scorecard={selectedScorecard}
+                        onDaysChange={setDays}
+                        onOpenPlaytest={() => openTab('playtest')}
+                        onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
+                        onRemoved={(token) => {
+                          setGames((prev) => prev.filter((game) => game.token !== token));
+                          setSelected((current) => (current === token ? null : current));
+                          onNavigate(studioPath());
+                        }}
+                      />
+                    </aside>
+                  </>
                 ) : null}
               </div>
             </div>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
 import type { GameHealth } from './healthApi.js';
-import { PixelIcon, type PixelIconName } from './PixelIcon.js';
+import { PixelIcon } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { playPath, studioPath, type StudioTab } from './router.js';
-import { abandonSubmission, type SubmissionState } from './submissionApi.js';
+import { abandonSubmission } from './submissionApi.js';
 import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import {
   filterStudioGames,
@@ -55,25 +55,7 @@ import {
  * whichever surface absorbed them.
  */
 
-const STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
-  queued: 'clock',
-  building: 'wrench',
-  in_review: 'eye',
-  publishing: 'rocket',
-  published: 'star',
-  needs_changes: 'pencil',
-  abandoned: 'trash',
-};
-
 const WINDOWS = [1, 7, 30];
-
-/** Surface strip order, and the label each one carries. */
-const TAB_ORDER: readonly StudioTab[] = ['thread', 'details', 'playtest'];
-const TAB_LABELS: Record<StudioTab, string> = {
-  thread: 'studioPanel.tabs.thread',
-  details: 'studioPanel.tabs.details',
-  playtest: 'studioPanel.tabs.playtest',
-};
 
 type NavigateOptions = { replace?: boolean };
 
@@ -369,12 +351,8 @@ export function CreatorStudioView({
     />
   );
 
-  // Derived from the same predicate the router uses, so a deep-linked tab can never
-  // resolve to a surface with no button to leave it by.
-  const tabItems = activeGame ? TAB_ORDER.filter((id) => tabAvailable(activeGame, id)) : [];
-
   return (
-    <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}`}>
+    <section className={`studio-panel${tab === 'playtest' ? ' is-playtesting' : ''}${activeGame ? ' is-focused' : ''}`}>
       <header className="studio-panel-header">
         <div>
           <p className="studio-kicker">{t('studioPanel.kicker')}</p>
@@ -415,6 +393,9 @@ export function CreatorStudioView({
               <h2 className="studio-shelf-heading">{t('studioPanel.shelf.heading')}</h2>
               <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: games.length })}</span>
             </div>
+            <button type="button" className="studio-shelf-new" onClick={() => onNavigate('/')}>
+              <PixelIcon name="sparkle" size={12} /> {t('studioPanel.shelf.newGame')}
+            </button>
             <StudioShelfControls
               searchInputId={shelfSearchId}
               query={shelfQuery}
@@ -456,30 +437,31 @@ export function CreatorStudioView({
                     <h2>{activeGame.title}</h2>
                     {activeGame.slug ? <code className="studio-slug">{activeGame.slug}</code> : null}
                   </div>
-                  <StudioStatusPill game={activeGame} />
+                  {/* Actions, not tabs. A tab strip across the work surface says the
+                      surfaces are peers; the thread is not a peer of the panel listing
+                      when the game was made. These open things beside it and leave it
+                      where it is. */}
+                  <div className="studio-head-actions">
+                    <button type="button" className="studio-head-action" onClick={() => openTab('playtest')}>
+                      <PixelIcon name="play" size={12} /> {t('studioPanel.tabs.playtest')}
+                    </button>
+                    <button
+                      type="button"
+                      className={`studio-head-action${tab === 'details' ? ' is-active' : ''}`}
+                      aria-pressed={tab === 'details'}
+                      onClick={() => openTab(tab === 'details' ? 'thread' : 'details')}
+                    >
+                      <PixelIcon name="expand" size={12} /> {t('studioPanel.tabs.details')}
+                    </button>
+                  </div>
                 </div>
               </div>
 
-              <div className="studio-tabs" role="tablist" aria-label={t('studioPanel.title')}>
-                {tabItems.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === id}
-                    className={`studio-tab${tab === id ? ' is-active' : ''}`}
-                    onClick={() => openTab(id)}
-                  >
-                    {t(TAB_LABELS[id])}
-                  </button>
-                ))}
-              </div>
-
-              <div className="studio-tab-panel">
-                {/* The thread is the game. Keyed on the token so switching games starts a
-                    new conversation rather than showing the previous one's tail while the
-                    first poll of the new one is in flight. */}
-                {tab === 'thread' ? (
+              {/* The thread stays put. Details opens beside it on a wide screen and over
+                  it on a narrow one; only playtest, which needs the whole viewport to be
+                  a game, replaces it. */}
+              <div className={`studio-workspace${tab === 'details' ? ' is-details-open' : ''}`}>
+                {tab !== 'playtest' ? (
                   <div className="studio-build">
                     <SubmissionStatusView
                       key={activeGame.token}
@@ -509,23 +491,35 @@ export function CreatorStudioView({
                 {/* Everything that is about the game rather than said to it: when it was
                     made, who can play it, how it is doing, and how to stop it. */}
                 {tab === 'details' ? (
-                  <DetailsPanel
-                    game={activeGame}
-                    health={selectedHealth}
-                    days={days}
-                    healthDays={healthDays}
-                    truncated={truncated}
-                    scorecard={selectedScorecard}
-                    onDaysChange={setDays}
-                    onOpenThread={() => openTab('thread')}
-                    onOpenPlaytest={() => openTab('playtest')}
-                    onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
-                    onRemoved={(token) => {
-                      setGames((prev) => prev.filter((game) => game.token !== token));
-                      setSelected((current) => (current === token ? null : current));
-                      onNavigate(studioPath());
-                    }}
-                  />
+                  <aside className="studio-rail" aria-label={t('studioPanel.tabs.details')}>
+                    <div className="studio-rail-head">
+                      <h3>{t('studioPanel.tabs.details')}</h3>
+                      <button
+                        type="button"
+                        className="modal-close-btn"
+                        onClick={() => openTab('thread')}
+                        aria-label={t('studioPanel.shelf.closePicker')}
+                      >
+                        <PixelIcon name="close" size={14} />
+                      </button>
+                    </div>
+                    <DetailsPanel
+                      game={activeGame}
+                      health={selectedHealth}
+                      days={days}
+                      healthDays={healthDays}
+                      truncated={truncated}
+                      scorecard={selectedScorecard}
+                      onDaysChange={setDays}
+                      onOpenPlaytest={() => openTab('playtest')}
+                      onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
+                      onRemoved={(token) => {
+                        setGames((prev) => prev.filter((game) => game.token !== token));
+                        setSelected((current) => (current === token ? null : current));
+                        onNavigate(studioPath());
+                      }}
+                    />
+                  </aside>
                 ) : null}
               </div>
             </div>
@@ -578,22 +572,6 @@ export function CreatorStudioView({
         </div>
       ) : null}
     </section>
-  );
-}
-
-function StudioStatusPill({ game }: { game: StudioGame }) {
-  const { t } = useTranslation();
-  const published = isStudioGamePublished(game);
-  const statusLabel = game.lastKnownStatus
-    ? t(`statusView.states.${game.lastKnownStatus}.label`)
-    : t('myGames.checking');
-  const live = game.lastKnownStatus ? STUDIO_LIVE_STATUSES.has(game.lastKnownStatus) : false;
-
-  return (
-    <span className={`status-play-badge studio-status-pill${published || live ? ' is-live' : ''}`}>
-      {(published || live) && <span className="live-dot" aria-hidden="true" />}
-      {statusLabel}
-    </span>
   );
 }
 
@@ -696,17 +674,20 @@ function StudioShelfList({
               onClick={() => onSelect(game.token)}
               aria-current={active ? 'true' : undefined}
             >
-              <span className={`studio-shelf-status${building ? ' is-live' : ''}${published ? ' is-published' : ''}`}>
-                {status ? (
-                  <>
-                    <PixelIcon name={STATUS_ICONS[status]} size={11} /> {t(`statusView.states.${status}.label`)}
-                  </>
-                ) : (
-                  t('myGames.checking')
-                )}
-              </span>
+              {/* A dot, not a label. Every row used to carry its status in words and its
+                  age beside it, which made a list of five games a wall of small text with
+                  the titles — the only thing being chosen between — third in the reading
+                  order. The state that matters at a glance is "is this one moving", and a
+                  dot says that without spending a line on it. */}
+              <span
+                className={`studio-shelf-dot${building ? ' is-live' : ''}${published ? ' is-published' : ''}`}
+                aria-hidden="true"
+              />
               <span className="studio-shelf-title">{game.title}</span>
-              <span className="studio-shelf-meta">{formatRelativeTime(Date.parse(game.createdAt), locale)}</span>
+              <span className="studio-sr-only">
+                {status ? t(`statusView.states.${status}.label`) : t('myGames.checking')} ·{' '}
+                {formatRelativeTime(Date.parse(game.createdAt), locale)}
+              </span>
             </button>
           </li>
         );
@@ -728,7 +709,6 @@ function DetailsPanel({
   truncated,
   scorecard,
   onDaysChange,
-  onOpenThread,
   onOpenPlaytest,
   onPlay,
   onRemoved,
@@ -740,7 +720,6 @@ function DetailsPanel({
   truncated: boolean;
   scorecard: StudioScorecard | null;
   onDaysChange: (days: number) => void;
-  onOpenThread: () => void;
   onOpenPlaytest: () => void;
   onPlay: () => void;
   onRemoved: (token: string) => void;
@@ -792,15 +771,14 @@ function DetailsPanel({
       </ul>
 
       <div className="studio-actions">
+        {/* Nothing here to reopen the build with: the thread is on the screen already,
+            beside this panel. Playing a published game is the one action that is not
+            simply "look left". */}
         {published && game.slug ? (
           <button type="button" className="primary-btn" onClick={onPlay}>
             <PixelIcon name="play" size={12} /> {t('myGames.play')}
           </button>
-        ) : (
-          <button type="button" className="primary-btn" onClick={onOpenThread}>
-            <PixelIcon name="wrench" size={12} /> {t('studioPanel.overview.openBuild')}
-          </button>
-        )}
+        ) : null}
         <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
           <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
         </button>

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -13,7 +13,7 @@ type HeroPromptSectionProps = {
   /** 'refining' is the pre-submission spec-refiner call; nothing has been sent yet. */
   submissionStatus: 'idle' | 'refining' | 'loading';
   submissionError: string | null;
-  onSubmitSpec: (title: string, concept: string) => void;
+  onSubmitSpec: (concept: string) => void;
   mockStatus: 'idle' | 'loading' | 'error';
   mockError: string | null;
   // Kept for the demo generator; the primary Build action no longer auto-fires a
@@ -278,11 +278,14 @@ export function HeroPromptSection({
         : `Game idea with attached visuals: ${attachSummary}`;
     }
 
-    const autoTitle = trimmed.slice(0, 40).trim() || 'My Visual AI Game';
     // Recorded here rather than in the handler: this is the visitor asking for a game,
     // which happens whether or not they turn out to be signed in.
     recordCreateStep('spec_submitted');
-    onSubmitSpec(autoTitle, finalPrompt);
+    // No title is invented here any more. This used to send the prompt's first 40
+    // characters as the game's name, and that string went on to be the name — in the
+    // studio, in the catalog, in the agent's brief. Naming happens in the confirm step,
+    // where the creator can see it and change it.
+    onSubmitSpec(finalPrompt);
   };
 
   return (

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -491,7 +491,9 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    expect(fetchSpy).toHaveBeenCalledWith('/api/games/sky-dodge');
+    // Credentialed: this address serves a game before it is published too, and the
+    // creator's own session is what makes that theirs to open.
+    expect(fetchSpy).toHaveBeenCalledWith('/api/games/sky-dodge', { credentials: 'include' });
     const iframe = container.querySelector('iframe[title="Sky Dodge"]');
     expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-pointer-lock');
     // Runs via srcDoc (no external origin), wrapped with the embed bridge in the

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -12,6 +12,12 @@ import {
   getSubmissionStatus,
   submitFeedback,
 } from './submissionApi.js';
+import { submitImprovement } from './studioApi.js';
+
+vi.mock('./studioApi', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi')>('./studioApi');
+  return { ...actual, submitImprovement: vi.fn() };
+});
 
 vi.mock('./submissionApi', async () => {
   const actual = await vi.importActual<typeof import('./submissionApi')>('./submissionApi');
@@ -30,6 +36,7 @@ const mockedGetSubmissionPreview = vi.mocked(getSubmissionPreview);
 const mockedGetChannelPlayable = vi.mocked(getChannelPlayable);
 const mockedSubmitFeedback = vi.mocked(submitFeedback);
 const mockedAbandonSubmission = vi.mocked(abandonSubmission);
+const mockedSubmitImprovement = vi.mocked(submitImprovement);
 
 async function flushEffects() {
   await Promise.resolve();
@@ -425,6 +432,52 @@ describe('SubmissionStatusView', () => {
     const description = container.querySelector('.status-description')?.textContent ?? '';
     expect(description).toContain('An agent is coding your game right now');
     expect(description).not.toContain('statusView.');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('offers the same one box on a published game, and sends it somewhere else', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'published', slug: 'tv-tycoon' });
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, issueNumber: 5, slug: 'tv-tycoon' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/live-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'live-token', embedded: true }));
+      await flushEffects();
+    });
+
+    // A published game used to have no composer here at all — asking for a change meant
+    // knowing to go to a different tab, which meant knowing the game's lifecycle state.
+    const box = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    expect(box).not.toBeNull();
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(box, 'The second level is far too hard, please add a checkpoint.');
+      box!.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+    await act(async () => {
+      container
+        .querySelector('.status-feedback .primary-btn')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    // Routed from the state the server reported, not from a mode the creator picked.
+    expect(mockedSubmitImprovement).toHaveBeenCalledWith(
+      'live-token',
+      'The second level is far too hard, please add a checkpoint.',
+    );
+    expect(mockedSubmitFeedback).not.toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();
@@ -829,9 +882,10 @@ describe('SubmissionStatusView', () => {
 
     const entries = [...container.querySelectorAll('.build-activity-item')].map((node) => node.textContent ?? '');
     expect(entries).toHaveLength(2);
-    // Newest first: the commit that answered the request sits above the request.
-    expect(entries[0]).toContain('Speed up the car');
-    expect(entries[1]).toContain('Make the car faster please.');
+    // A conversation's order: the creator's request, then the commit that answered it,
+    // with the newest at the bottom next to the box they reply in.
+    expect(entries[0]).toContain('Make the car faster please.');
+    expect(entries[1]).toContain('Speed up the car');
     expect(container.querySelectorAll('.build-activity-revision')).toHaveLength(1);
 
     await act(async () => {
@@ -1073,7 +1127,7 @@ describe('SubmissionStatusView stop & retry', () => {
     });
   });
 
-  it('shows pictures of the build, newest first, before any commit exists', async () => {
+  it('shows pictures of the build on the thread, before any commit exists', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // Still queued: no PR, no preview, nothing committed. The only pictures that can
     // exist at this point are ones the agent pushed straight down the channel.
@@ -1099,7 +1153,10 @@ describe('SubmissionStatusView stop & retry', () => {
     // Thumbnails live on the timeline, not as a banner above it.
     const shots = container.querySelectorAll('.build-activity-shot img');
     expect(shots).toHaveLength(2);
-    expect(shots[0]!.getAttribute('src')).toContain('/api/submissions/media-token/shot/shot-2');
+    // Oldest first, like the rest of the thread: the newest picture is the one nearest
+    // the composer, which is where the eye already is.
+    expect(shots[0]!.getAttribute('src')).toContain('/api/submissions/media-token/shot/shot-1');
+    expect(shots[1]!.getAttribute('src')).toContain('/api/submissions/media-token/shot/shot-2');
     // The agent's own caption is what the creator reads, not a generic placeholder.
     expect(container.textContent).toContain('The bridge holds');
     expect(container.querySelector('.status-lightbox')).toBeNull();
@@ -1110,7 +1167,7 @@ describe('SubmissionStatusView stop & retry', () => {
     });
     const lightbox = container.querySelector('.status-lightbox-image') as HTMLImageElement | null;
     expect(lightbox).not.toBeNull();
-    expect(lightbox!.getAttribute('src')).toContain('/api/submissions/media-token/shot/shot-2');
+    expect(lightbox!.getAttribute('src')).toContain('/api/submissions/media-token/shot/shot-1');
 
     await act(async () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -126,6 +126,74 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('offers playtesting next to playing, once there is something to play', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      playable: [{ ref: 'newest', slug: 'puppy-stroll', createdAt: new Date().toISOString() }],
+    });
+    mockedGetChannelPlayable.mockResolvedValue('<!doctype html><canvas></canvas>');
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/playtest-token');
+
+    const onPlaytest = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'playtest-token', embedded: true, onPlaytest }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    // The delivered moment used to have exactly one call to action — Play — and the
+    // surface that turns playing into a message to the agent was a tab you had to
+    // think of. It now sits on the card, next to the game it is about.
+    const playtest = container.querySelector<HTMLButtonElement>('.status-playtest-cta');
+    expect(playtest?.textContent).toContain('Playtest');
+
+    await act(async () => {
+      playtest?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(onPlaytest).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('leaves the playtest call to action out when there is no playtest surface to open', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      playable: [{ ref: 'newest', slug: 'puppy-stroll', createdAt: new Date().toISOString() }],
+    });
+    mockedGetChannelPlayable.mockResolvedValue('<!doctype html><canvas></canvas>');
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/standalone-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // Standalone (a legacy /status link), where the studio's playtest surface is not
+    // on screen to switch to.
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'standalone-token' }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.status-play-cta')).not.toBeNull();
+    expect(container.querySelector('.status-playtest-cta')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('does not show a preview error when a channel draft loaded but the PR preview failed', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // The Studio screenshot case: open PR (so we try the branch assemble) + a
@@ -246,11 +314,21 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('shows the submitted prompt and a ticking elapsed timer while the build is running', async () => {
+  it('shows the submitted prompt, and beats from the agent’s last update rather than from submission', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    mockedGetSubmissionStatus.mockResolvedValue({ status: 'building' });
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      events: [
+        {
+          id: 'evt-1',
+          kind: 'step',
+          text: 'Blocking out the arena',
+          createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+        },
+      ],
+    });
     await i18n.changeLanguage('en');
-    window.history.pushState(null, '', '/status/elapsed-token');
+    window.history.pushState(null, '', '/status/heartbeat-token');
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -259,10 +337,9 @@ describe('SubmissionStatusView', () => {
     await act(async () => {
       root.render(
         createElement(SubmissionStatusView, {
-          token: 'elapsed-token',
+          token: 'heartbeat-token',
           submittedTitle: 'Circus Cat',
           submittedConcept: 'A black cat dodging hula hoops',
-          submittedAt: Date.now() - 134_000,
         }),
       );
       await flushEffects();
@@ -270,8 +347,84 @@ describe('SubmissionStatusView', () => {
 
     // The prompt the player typed is echoed back, so they can see what they asked for.
     expect(container.textContent).toContain('A black cat dodging hula hoops');
-    // 134s -> "2m 14s", proving the duration formatting and that the timer is mounted.
-    expect(container.textContent).toContain('2m 14s');
+    // The pill measures the build's pulse, not its age: a stopwatch from submission
+    // said "in progress for 8h" on a build that had finished and was waiting on us.
+    expect(container.querySelector('.status-heartbeat')?.textContent).toContain('4 minutes ago');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('has no heartbeat to show before the agent has done anything', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'queued' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/silent-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'silent-token' }));
+      await flushEffects();
+    });
+
+    // "Live" alone, with nothing after it — better than inventing a duration for a
+    // build that has not reported anything yet.
+    expect(container.querySelector('.status-live')).not.toBeNull();
+    expect(container.querySelector('.status-heartbeat')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('describes a delivered build waiting to go live, instead of claiming checks are running', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'in_review', phase: 'ready_for_review' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/delivered-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'delivered-token' }));
+      await flushEffects();
+    });
+
+    const description = container.querySelector('.status-description')?.textContent ?? '';
+    expect(description).toContain('waiting for the last look');
+    expect(description).not.toContain('Automated checks are making sure');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('falls back to the coarse status copy for a phase with nothing of its own to say', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'building', phase: 'building' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/building-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'building-token' }));
+      await flushEffects();
+    });
+
+    // No `phases.building` key exists — the status sentence must show through rather
+    // than the raw key leaking onto the page.
+    const description = container.querySelector('.status-description')?.textContent ?? '';
+    expect(description).toContain('An agent is coding your game right now');
+    expect(description).not.toContain('statusView.');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -18,8 +18,9 @@ import {
   type SubmissionPreview,
   type SubmissionStatus,
 } from './submissionApi.js';
-import { draftPath, playPath, statusPath, studioPath } from './router.js';
+import { statusPath, studioPath } from './router.js';
 import { formatRelativeTime } from './relativeTime.js';
+import { submitImprovement } from './studioApi.js';
 
 const TERMINAL_STATUSES = new Set<SubmissionStatus['status']>(['published', 'needs_changes', 'abandoned']);
 /** Statuses that halt the linear timeline rather than sitting on a step of it. */
@@ -298,15 +299,11 @@ export function SubmissionStatusView({
       t(`statusView.states.${status.status}.description`)
     : '';
 
-  // The link to hand to someone else. Deliberately *not* the tracking URL: that one
-  // carries the status token, which grants change requests and spends the creator's
-  // quota. A slug link is watch-only, and survives the game being published.
-  const shareUrl = useMemo(() => {
-    const slug = status?.slug ?? status?.preview?.slug;
-    if (!slug) return null;
-    const path = status?.status === 'published' ? playPath(slug) : draftPath(slug);
-    return new URL(path, window.location.href).toString();
-  }, [status?.slug, status?.preview?.slug, status?.status]);
+  // No share link here any more. It used to be shown unconditionally and pointed at
+  // `/draft/<slug>`, which was readable by any signed-in visitor who knew the slug.
+  // Sharing an unpublished game is now the creator's decision, made on one switch in
+  // Creator Studio; advertising a link that 404s until that switch is on would be worse
+  // than not offering one. A published game shares from the theater, as it always has.
 
   // Auto-load the live preview as soon as one is available, and silently refresh it
   // whenever the agent pushes a new commit (headSha changes) — no click required.
@@ -456,8 +453,6 @@ export function SubmissionStatusView({
             </span>
           </div>
         ) : null}
-        {shareUrl ? <ShareLink url={shareUrl} /> : null}
-
         {loading ? (
           <p className="catalog-state">{t('statusView.loading')}</p>
         ) : errorMessage ? (
@@ -549,23 +544,6 @@ export function SubmissionStatusView({
               </p>
             ) : null}
 
-            {/* Order matters: "played it — want changes?" follows straight on from the
-                play card, so the ask lands while the game is still in mind. The build
-                log is reference material and sits underneath.
-
-                This used to wait for a preview, which waits for a pull request — so the
-                first stretch of the build, when redirecting the agent is cheapest and the
-                creator is most likely to spot a misreading of their idea, was the one
-                stretch they could not say anything. The agent picks messages up off the
-                channel on its next report, so a note left now lands in a minute or two. */}
-            {status.status !== 'published' && status.status !== 'abandoned' ? (
-              <FeedbackPanel
-                token={token}
-                building={!preview && !channelHtml}
-                onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
-              />
-            ) : null}
-
             <BuildProgressPanel
               token={token}
               progress={status.progress}
@@ -573,6 +551,24 @@ export function SubmissionStatusView({
               media={status.media ?? []}
               pendingRevisions={pendingRevisions}
             />
+
+            {/* One box, at the bottom, where a conversation keeps its reply — and it is
+                the only one. There used to be three, all of them the same act: steer the
+                build, request a change on the draft, improve the published game. Which
+                one a creator was allowed depended on the game's lifecycle state, so they
+                had to know it to find the right box. The server knows it; the placeholder
+                says where the message lands, and the creator just writes.
+
+                No mode to pick, either: a game is either published or it is not, and
+                there is only ever the current version to work on. */}
+            {status.status !== 'abandoned' ? (
+              <FeedbackPanel
+                token={token}
+                published={status.status === 'published'}
+                building={!preview && !channelHtml}
+                onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+              />
+            ) : null}
 
             {/* Only alarm when nothing is playable. A channel draft can succeed while
                 the PR-branch assemble 502s (GitHub rate limits); showing both a Play
@@ -669,36 +665,6 @@ function AbandonControl({ token }: { token: string }) {
         {t('statusView.abandon.no')}
       </button>
     </span>
-  );
-}
-
-/** Watch-only link to the game, with one-tap copy (the point is to send it to someone). */
-function ShareLink({ url }: { url: string }) {
-  const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // No clipboard permission (or no clipboard API) — the link is right there to
-      // select by hand, so this needs no error state.
-    }
-  };
-
-  return (
-    <p className="status-note status-share">
-      {t('statusView.shareLink')}{' '}
-      <a className="inline-link" href={url}>
-        {url}
-      </a>
-      <button type="button" className="status-share-copy" onClick={() => void copy()}>
-        <PixelIcon name={copied ? 'check' : 'globe'} size={12} />{' '}
-        {copied ? t('statusView.shareCopied') : t('statusView.shareCopy')}
-      </button>
-    </p>
   );
 }
 
@@ -805,10 +771,13 @@ function ShotLightbox({ token, item, onClose }: { token: string; item: BuildMedi
  */
 function FeedbackPanel({
   token,
+  published,
   building,
   onSent,
 }: {
   token: string;
+  /** Routes the message: an improvement on the live game, or a change on the build. */
+  published: boolean;
   building: boolean;
   onSent: (text: string) => void;
 }) {
@@ -824,7 +793,10 @@ function FeedbackPanel({
     setState('sending');
     setError(null);
     try {
-      await submitFeedback(token, trimmed);
+      // Same box, same act, different destination — decided here from the state the
+      // server reported rather than by asking the creator which one they meant.
+      if (published) await submitImprovement(token, trimmed);
+      else await submitFeedback(token, trimmed);
       setState('sent');
       setText('');
       // Echo it into the activity feed straight away: the API only sees it once the
@@ -845,14 +817,26 @@ function FeedbackPanel({
     }
   };
 
+  // Three states, one box. The copy is the only thing that changes, and it changes so
+  // the creator can see where their message is about to go without having chosen.
+  const hintKey = published
+    ? 'statusView.feedback.hintPublished'
+    : building
+      ? 'statusView.feedback.hintBuilding'
+      : 'statusView.feedback.hint';
+
   return (
-    <div className="status-feedback">
+    <div className="status-feedback status-composer">
       <h3 className="status-feedback-title">
-        {t(building ? 'statusView.feedback.titleBuilding' : 'statusView.feedback.title')}
+        {t(
+          published
+            ? 'statusView.feedback.titlePublished'
+            : building
+              ? 'statusView.feedback.titleBuilding'
+              : 'statusView.feedback.title',
+        )}
       </h3>
-      <p className="status-feedback-hint">
-        {t(building ? 'statusView.feedback.hintBuilding' : 'statusView.feedback.hint')}
-      </p>
+      <p className="status-feedback-hint">{t(hintKey)}</p>
       <textarea
         className="status-feedback-input"
         value={text}
@@ -981,8 +965,12 @@ function buildActivityFeed(
     }
   }
 
-  // Newest first — that's what makes the build feel live.
-  return entries.filter((entry) => Number.isFinite(entry.at)).sort((a, b) => b.at - a.at);
+  // Oldest first, because this is a conversation and that is the order conversations
+  // are read in: the newest thing sits at the bottom, next to the box you reply in.
+  // It used to be newest-first, which put the creator's own last message at the top,
+  // furthest from the composer, and made the thread read backwards once it had more
+  // than a couple of entries in it.
+  return entries.filter((entry) => Number.isFinite(entry.at)).sort((a, b) => a.at - b.at);
 }
 
 function BuildProgressPanel({
@@ -1024,7 +1012,7 @@ function BuildProgressPanel({
   // What the agent says it is doing beats what we infer from its checklist — fall
   // back to the first unfinished task only when it has written nothing.
   const currentStep = headline ? undefined : checklist.find((item) => !item.checked);
-  const lastUpdate = activity[0];
+  const lastUpdate = activity[activity.length - 1];
   // A long gap between pushes is normal, but silence with no explanation reads as
   // "it's broken" — say so plainly instead of letting the creator guess.
   const isQuiet = lastUpdate !== undefined && Date.now() - lastUpdate.at > QUIET_BUILD_MS;
@@ -1095,7 +1083,17 @@ function BuildProgressPanel({
             {activity.map((entry, index) => (
               <li
                 key={`${entry.kind}-${entry.at}-${index}`}
-                className={`build-activity-item build-activity-${entry.kind}${index === 0 ? ' build-progress-commit-latest' : ''}`}
+                className={[
+                  'build-activity-item',
+                  `build-activity-${entry.kind}`,
+                  // The creator's own messages sit on the other side of the thread, the
+                  // way they do in any conversation — without it, a request they sent and
+                  // the agent's reply to it are two identical grey rows.
+                  entry.kind === 'revision' ? 'is-mine' : '',
+                  index === activity.length - 1 ? 'build-progress-commit-latest' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
               >
                 <span className="build-activity-icon" aria-hidden="true">
                   <PixelIcon

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -411,10 +411,141 @@ export function SubmissionStatusView({
   // surface; Studio's own playtest already learned inset frames are unplayable on
   // phones, so everything playable here opens the theater.
 
+  const theaters = (
+    <>
+      {playing === 'published' && status?.status === 'published' && status.slug ? (
+        <GameTheater
+          title={publishedGameTitle}
+          badge={{ icon: 'gamepad', label: t('catalog.playingBadge', { defaultValue: 'Playing' }) }}
+          source={{ slug: status.slug }}
+          onExit={closeTheater}
+        />
+      ) : null}
+
+      {playing === 'draft' && launchedHtml != null ? (
+        <GameTheater
+          title={
+            preview ? previewTitle : (submittedTitle ?? latestChannelBuild?.slug ?? t('statusView.previewGameTitle'))
+          }
+          badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
+          source={{ html: launchedHtml }}
+          onExit={closeTheater}
+        />
+      ) : null}
+    </>
+  );
+
+  /**
+   * Inside Creator Studio this is a thread, not a page.
+   *
+   * The standalone `/status/<token>` view below keeps its page shape — it is a link
+   * somebody was sent, read once, top to bottom. This one is a place the creator comes
+   * back to, so it is built the way every other place you talk to something is: the
+   * conversation scrolls, and the box you answer in does not move.
+   */
+  if (embedded) {
+    const activity = status
+      ? buildActivityFeed(
+          status.progress,
+          status.events ?? [],
+          pendingRevisions,
+          status.media ?? [],
+          t('statusView.gallery.caption'),
+        )
+      : [];
+    const reported = status?.events?.find((event) => event.progress)?.progress;
+    const checklist = status?.progress?.checklist ?? [];
+    const done = reported?.done ?? checklist.filter((item) => item.checked).length;
+    const total = reported?.total ?? checklist.length;
+
+    const playable =
+      status?.status === 'published' && status.slug
+        ? { label: t('statusView.play'), onClick: () => setPlaying('published') }
+        : preview
+          ? { label: t('statusView.playDraft'), onClick: openDraft }
+          : channelHtml
+            ? { label: t('statusView.playDraft'), onClick: openChannel }
+            : undefined;
+
+    return (
+      <>
+        <div className="studio-thread">
+          {loading ? (
+            <p className="catalog-state studio-thread-empty">{t('statusView.loading')}</p>
+          ) : errorMessage ? (
+            <div className="studio-thread-empty">
+              <p className="error">{errorMessage}</p>
+              <p className="status-description">
+                {isInvalidToken ? t('statusView.invalidTokenHelp') : t('statusView.fetchErrorHelp')}
+              </p>
+            </div>
+          ) : status ? (
+            <>
+              <ThreadStream token={token} entries={activity} emptyLabel={stateDescription} />
+
+              <div className="studio-thread-foot">
+                {/* Trouble is said once, immediately above the box the creator would use
+                    to do something about it. A dead round outranks a slow one: when both
+                    are set the failure is the explanation and the stall is its symptom. */}
+                {status.failure ? (
+                  <p className="status-warning">
+                    <PixelIcon name="signal" size={13} />{' '}
+                    {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
+                  </p>
+                ) : status.stall ? (
+                  <p className="status-warning">
+                    <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
+                  </p>
+                ) : status.progress?.checks === 'FAILURE' ? (
+                  <p className="status-warning">
+                    <PixelIcon name="signal" size={13} /> {t('statusView.checksFailed')}
+                  </p>
+                ) : null}
+
+                {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}
+
+                {TERMINAL_STATUSES.has(status.status) &&
+                status.status !== 'published' &&
+                submittedConcept &&
+                onRetry ? (
+                  <button className="primary-btn status-retry" onClick={() => onRetry(submittedConcept)}>
+                    <PixelIcon name="undo" size={13} /> {t('statusView.tryAgain')}
+                  </button>
+                ) : null}
+
+                <ThreadContextBar
+                  {...(status.slug ? { slug: status.slug } : {})}
+                  phase={t(`statusView.states.${status.status}.label`)}
+                  heartbeatAt={heartbeatAt}
+                  {...(total > 0 ? { progress: { done, total } } : {})}
+                  {...(playable ? { primary: playable } : {})}
+                  {...(onPlaytest && playable
+                    ? { secondary: { label: t('statusView.playtestCta'), onClick: onPlaytest } }
+                    : {})}
+                />
+
+                {status.status !== 'abandoned' ? (
+                  <FeedbackPanel
+                    token={token}
+                    published={status.status === 'published'}
+                    building={!preview && !channelHtml}
+                    compact
+                    onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+                  />
+                ) : null}
+              </div>
+            </>
+          ) : null}
+        </div>
+        {theaters}
+      </>
+    );
+  }
+
   return (
     <>
-      <section className={`panel status-panel${embedded ? ' is-embedded' : ''}`}>
-        {!embedded ? (
+      <section className="panel status-panel">
+        {
           <>
             <div className="status-heading">
               <h2 className="section-title">{submittedTitle ?? t('statusView.title')}</h2>
@@ -439,20 +570,7 @@ export function SubmissionStatusView({
               </a>
             </p>
           </>
-        ) : status && !TERMINAL_STATUSES.has(status.status) ? (
-          <div className="status-heading status-heading-embedded">
-            <span className="status-live">
-              <span className="live-dot" aria-hidden="true" />
-              {t('statusView.live')}
-              {heartbeatAt !== null ? (
-                <>
-                  {' · '}
-                  <BuildHeartbeat at={heartbeatAt} />
-                </>
-              ) : null}
-            </span>
-          </div>
-        ) : null}
+        }
         {loading ? (
           <p className="catalog-state">{t('statusView.loading')}</p>
         ) : errorMessage ? (
@@ -461,11 +579,9 @@ export function SubmissionStatusView({
             <p className="status-description">
               {isInvalidToken ? t('statusView.invalidTokenHelp') : t('statusView.fetchErrorHelp')}
             </p>
-            {!embedded ? (
-              <a className="inline-link" href="/">
-                {t('statusView.backHome')}
-              </a>
-            ) : null}
+            <a className="inline-link" href="/">
+              {t('statusView.backHome')}
+            </a>
           </>
         ) : status ? (
           <>
@@ -575,41 +691,16 @@ export function SubmissionStatusView({
                 card and this error was the Studio bug creators hit mid-build. */}
             {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}
 
-            {/* Embedded in Creator Studio the panel is a tab, not a page: the header
-                already carries "Back to home", and a second escape hatch a screen
-                below it just reads as two different ways out. Stopping the build has
-                no such duplicate, so it stays either way. */}
-            <div className={`status-footer-actions${embedded ? ' is-embedded' : ''}`}>
-              {!embedded ? (
-                <a className="inline-link" href="/">
-                  {t('statusView.backHome')}
-                </a>
-              ) : null}
+            <div className="status-footer-actions">
+              <a className="inline-link" href="/">
+                {t('statusView.backHome')}
+              </a>
               {!TERMINAL_STATUSES.has(status.status) ? <AbandonControl token={token} /> : null}
             </div>
           </>
         ) : null}
       </section>
-
-      {playing === 'published' && status?.status === 'published' && status.slug ? (
-        <GameTheater
-          title={publishedGameTitle}
-          badge={{ icon: 'gamepad', label: t('catalog.playingBadge', { defaultValue: 'Playing' }) }}
-          source={{ slug: status.slug }}
-          onExit={closeTheater}
-        />
-      ) : null}
-
-      {playing === 'draft' && launchedHtml != null ? (
-        <GameTheater
-          title={
-            preview ? previewTitle : (submittedTitle ?? latestChannelBuild?.slug ?? t('statusView.previewGameTitle'))
-          }
-          badge={{ icon: 'wrench', label: t('statusView.draftBadge') }}
-          source={{ html: launchedHtml }}
-          onExit={closeTheater}
-        />
-      ) : null}
+      {theaters}
     </>
   );
 }
@@ -773,12 +864,15 @@ function FeedbackPanel({
   token,
   published,
   building,
+  compact = false,
   onSent,
 }: {
   token: string;
   /** Routes the message: an improvement on the live game, or a change on the build. */
   published: boolean;
   building: boolean;
+  /** The thread's reply box rather than a page section — field and send, nothing else. */
+  compact?: boolean;
   onSent: (text: string) => void;
 }) {
   const { t } = useTranslation();
@@ -824,18 +918,54 @@ function FeedbackPanel({
     : building
       ? 'statusView.feedback.hintBuilding'
       : 'statusView.feedback.hint';
+  const titleKey = published
+    ? 'statusView.feedback.titlePublished'
+    : building
+      ? 'statusView.feedback.titleBuilding'
+      : 'statusView.feedback.title';
+
+  // Compact is the thread's composer: a field and a send, the way a reply box looks
+  // everywhere else. The heading and the standing hint paragraph were page furniture —
+  // fine on a page read once, noise under a conversation you come back to. What the hint
+  // said still matters, so it becomes the placeholder: it is on screen exactly while the
+  // box is empty, which is when "where does this go?" is the open question.
+  if (compact) {
+    return (
+      <div className="status-feedback status-composer is-compact">
+        <textarea
+          className="status-feedback-input"
+          value={text}
+          onChange={(event) => {
+            setText(event.target.value);
+            if (state === 'sent') setState('idle');
+          }}
+          placeholder={t(hintKey)}
+          aria-label={t(titleKey)}
+          rows={2}
+          maxLength={2000}
+        />
+        <div className="status-feedback-actions">
+          {error ? <p className="error">{error}</p> : null}
+          {state === 'sent' && !error ? (
+            <span className="status-feedback-sent">
+              <PixelIcon name="check" size={13} /> {t('statusView.feedback.sent')}
+            </span>
+          ) : null}
+          <button
+            className="primary-btn"
+            onClick={() => void send()}
+            disabled={state === 'sending' || trimmed.length < 10}
+          >
+            {state === 'sending' ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="status-feedback status-composer">
-      <h3 className="status-feedback-title">
-        {t(
-          published
-            ? 'statusView.feedback.titlePublished'
-            : building
-              ? 'statusView.feedback.titleBuilding'
-              : 'statusView.feedback.title',
-        )}
-      </h3>
+      <h3 className="status-feedback-title">{t(titleKey)}</h3>
       <p className="status-feedback-hint">{t(hintKey)}</p>
       <textarea
         className="status-feedback-input"
@@ -863,6 +993,153 @@ function FeedbackPanel({
         ) : null}
       </div>
       {error ? <p className="error">{error}</p> : null}
+    </div>
+  );
+}
+
+/**
+ * The thread, in the shape a conversation actually has.
+ *
+ * The build's story used to be a log: a bordered box titled BUILD ACTIVITY, rows of
+ * 12px text behind an icon column, timestamps hard right. Everything in it was true and
+ * none of it read as somebody talking. Here the agent's turns are ordinary prose at full
+ * width with nothing drawn around them, and the creator's are quiet bubbles on the other
+ * side — the asymmetry every chat client uses, and deliberately the way round where the
+ * agent's words are the ones with room to breathe.
+ *
+ * Scrolls in its own pane so the composer beneath it never moves, and sticks to the
+ * bottom as the agent talks — unless the reader has scrolled up, which is them saying
+ * they are reading something and would like it to stay put.
+ */
+function ThreadStream({ token, entries, emptyLabel }: { token: string; entries: ActivityEntry[]; emptyLabel: string }) {
+  const { t, i18n } = useTranslation();
+  const [zoomed, setZoomed] = useState<BuildMediaItem | null>(null);
+  const [broken, setBroken] = useState<string[]>([]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  const onScroll = () => {
+    const pane = scrollRef.current;
+    if (!pane) return;
+    // A small slack, because "at the bottom" is never exact once fonts and images have
+    // settled, and a reader one pixel short of it still means to be following along.
+    stickToBottomRef.current = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 48;
+  };
+
+  useEffect(() => {
+    const pane = scrollRef.current;
+    if (!pane || !stickToBottomRef.current) return;
+    pane.scrollTop = pane.scrollHeight;
+  }, [entries.length]);
+
+  return (
+    <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
+      {entries.length === 0 ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
+      <ol className="studio-thread-turns">
+        {entries.map((entry, index) => {
+          const mine = entry.kind === 'revision';
+          const media = entry.media?.filter((item) => !broken.includes(item.ref)) ?? [];
+          return (
+            <li
+              key={`${entry.kind}-${entry.at}-${index}`}
+              className={`studio-turn${mine ? ' is-mine' : ''}${entry.pending ? ' is-pending' : ''}`}
+            >
+              <div className="studio-turn-body">
+                {/* The step is a closed set, so it is our own translated copy rather than
+                    a machine translation of whatever the agent happened to write. */}
+                {!mine && entry.step ? (
+                  <span className="studio-turn-kicker">{t(`statusView.progress.steps.${entry.step}`)}</span>
+                ) : null}
+                <p className="studio-turn-text">{entry.text}</p>
+                {media.length > 0 ? (
+                  <span className="studio-turn-shots">
+                    {media.map((item) => (
+                      <button
+                        key={item.ref}
+                        type="button"
+                        className="build-activity-shot"
+                        onClick={() => setZoomed(item)}
+                        title={t('statusView.gallery.expand')}
+                      >
+                        <img
+                          src={buildMediaUrl(token, item)}
+                          alt={item.label || t('statusView.gallery.alt')}
+                          loading="lazy"
+                          onError={() => setBroken((refs) => [...refs, item.ref])}
+                        />
+                      </button>
+                    ))}
+                  </span>
+                ) : null}
+              </div>
+              <time className="studio-turn-time" dateTime={new Date(entry.at).toISOString()}>
+                {entry.pending
+                  ? t('statusView.progress.yourRequestSending')
+                  : formatRelativeTime(entry.at, i18n.language)}
+              </time>
+            </li>
+          );
+        })}
+      </ol>
+      {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}
+    </div>
+  );
+}
+
+/**
+ * The bar between the thread and the composer: where the work is, and the one thing to
+ * do about it.
+ *
+ * Replaces a five-step timeline, a progress bar, a status pill and a sentence — four
+ * things saying where the build was, stacked above the conversation and pushing it down
+ * the page. This says it once, in the place the eye already is because the composer is
+ * directly underneath.
+ */
+function ThreadContextBar({
+  slug,
+  phase,
+  heartbeatAt,
+  progress,
+  primary,
+  secondary,
+}: {
+  slug?: string;
+  phase: string;
+  heartbeatAt: number | null;
+  progress?: { done: number; total: number };
+  primary?: { label: string; onClick: () => void };
+  secondary?: { label: string; onClick: () => void };
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="studio-thread-context">
+      <span className="studio-context-state">
+        {slug ? <code className="studio-slug">{slug}</code> : null}
+        <span className="studio-context-phase">{phase}</span>
+        {heartbeatAt !== null ? (
+          <span className="studio-context-beat">
+            <BuildHeartbeat at={heartbeatAt} />
+          </span>
+        ) : null}
+      </span>
+      <span className="studio-context-actions">
+        {progress && progress.total > 0 ? (
+          <span className="studio-context-progress">
+            {t('statusView.progress.checklistCount', { done: progress.done, total: progress.total })}
+          </span>
+        ) : null}
+        {secondary ? (
+          <button type="button" className="secondary-btn status-playtest-cta" onClick={secondary.onClick}>
+            <PixelIcon name="wrench" size={13} /> {secondary.label}
+          </button>
+        ) : null}
+        {primary ? (
+          <button type="button" className="primary-btn status-play-cta" onClick={primary.onClick}>
+            <PixelIcon name="play" size={13} /> {primary.label}
+          </button>
+        ) : null}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -19,7 +19,7 @@ import {
   type SubmissionStatus,
 } from './submissionApi.js';
 import { draftPath, playPath, statusPath, studioPath } from './router.js';
-import { formatDuration, formatRelativeTime } from './relativeTime.js';
+import { formatRelativeTime } from './relativeTime.js';
 
 const TERMINAL_STATUSES = new Set<SubmissionStatus['status']>(['published', 'needs_changes', 'abandoned']);
 /** Statuses that halt the linear timeline rather than sitting on a step of it. */
@@ -51,21 +51,51 @@ const STATUS_ICONS: Record<SubmissionStatus['status'], PixelIconName> = {
 const TIMELINE_STEPS: SubmissionStatus['status'][] = ['queued', 'building', 'in_review', 'publishing', 'published'];
 
 /**
- * Ticking "in progress for 2m 14s" readout. The submission time only exists in
- * localStorage (the API doesn't return it), so this is hidden when the link is
- * opened on a device that didn't submit it.
+ * When the build last did something worth seeing, or null before it has.
+ *
+ * Deliberately the *agent's* moments only — its events, its pictures, its playable
+ * builds, its commits — and not the creator's own change requests. A creator who has
+ * just sent a message would otherwise reset the heartbeat with it and be told the
+ * build is fresh, which is the one moment they are actually waiting on a reply.
  */
-function ElapsedTimer({ since, running }: { since: number; running: boolean }) {
-  const { t } = useTranslation();
-  const [now, setNow] = useState(() => Date.now());
+function latestAgentActivityAt(status: SubmissionStatus | null): number | null {
+  if (!status) return null;
+  const times = [
+    ...(status.events ?? []).map((event) => Date.parse(event.createdAt)),
+    ...(status.media ?? []).map((item) => (item.createdAt ? Date.parse(item.createdAt) : Number.NaN)),
+    ...(status.playable ?? []).map((item) => (item.createdAt ? Date.parse(item.createdAt) : Number.NaN)),
+    ...(status.progress?.commits ?? []).map((commit) => Date.parse(commit.committedDate)),
+  ].filter((time) => Number.isFinite(time));
+  return times.length > 0 ? Math.max(...times) : null;
+}
+
+/**
+ * "Live · updated 3 minutes ago" — the build's pulse.
+ *
+ * This replaced a stopwatch counting from submission, which was the page's most
+ * prominent number and its least informative: on a build that had delivered, passed
+ * its checks and been waiting to go live for hours, it read "In progress for 8h 00m"
+ * directly above a checklist saying every task was done. Time since the last sign of
+ * life answers the question the stopwatch was being read for — is this thing moving? —
+ * and keeps answering it correctly once the agent has finished.
+ *
+ * Re-renders on a slow timer because the text is a relative time that goes stale on
+ * its own; the minute granularity is why 30s is often enough and 1s would be waste.
+ */
+function BuildHeartbeat({ at }: { at: number }) {
+  const { t, i18n } = useTranslation();
+  const [, setTick] = useState(0);
 
   useEffect(() => {
-    if (!running) return;
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    const id = window.setInterval(() => setTick((n) => n + 1), 30_000);
     return () => window.clearInterval(id);
-  }, [running]);
+  }, []);
 
-  return <span className="status-elapsed">{t('statusView.elapsed', { duration: formatDuration(now - since) })}</span>;
+  return (
+    <span className="status-heartbeat">
+      {t('statusView.updatedAgo', { time: formatRelativeTime(at, i18n.language) })}
+    </span>
+  );
 }
 
 function StatusTimeline({ current }: { current: SubmissionStatus['status'] }) {
@@ -119,10 +149,14 @@ type SubmissionStatusViewProps = {
   token: string;
   submittedTitle?: string;
   submittedConcept?: string;
-  submittedAt?: number;
   trackingUrl?: string;
   /** Sends the creator home with this idea loaded, ready to edit and resubmit. */
   onRetry?: (concept: string) => void;
+  /**
+   * Opens the studio's playtest surface on this game. Present only when this view is
+   * embedded in Creator Studio, which is the only place that surface exists.
+   */
+  onPlaytest?: () => void;
   /**
    * When true, this view is nested inside Creator Studio (the Build tab). The
    * outer studio chrome already names the game — skip the page-level heading /
@@ -135,9 +169,9 @@ export function SubmissionStatusView({
   token,
   submittedTitle,
   submittedConcept,
-  submittedAt,
   trackingUrl,
   onRetry,
+  onPlaytest,
   embedded = false,
 }: SubmissionStatusViewProps) {
   const { t, i18n } = useTranslation();
@@ -250,6 +284,19 @@ export function SubmissionStatusView({
   }, [i18n.language, t, token]);
 
   const publishedGameTitle = submittedTitle ?? status?.slug ?? t('statusView.publishedGameTitle');
+  const heartbeatAt = latestAgentActivityAt(status);
+
+  /**
+   * What is happening, in the creator's words.
+   *
+   * Only the phases that mean something the coarse status cannot say carry their own
+   * sentence (see `statusView.phases`); everything else falls through to the status
+   * copy rather than being written twice and drifting.
+   */
+  const stateDescription = status
+    ? (status.phase ? t(`statusView.phases.${status.phase}`, { defaultValue: '' }) : '') ||
+      t(`statusView.states.${status.status}.description`)
+    : '';
 
   // The link to hand to someone else. Deliberately *not* the tracking URL: that one
   // carries the status token, which grants change requests and spends the creator's
@@ -378,10 +425,10 @@ export function SubmissionStatusView({
                 <span className="status-live">
                   <span className="live-dot" aria-hidden="true" />
                   {t('statusView.live')}
-                  {submittedAt ? (
+                  {heartbeatAt !== null ? (
                     <>
                       {' · '}
-                      <ElapsedTimer since={submittedAt} running />
+                      <BuildHeartbeat at={heartbeatAt} />
                     </>
                   ) : null}
                 </span>
@@ -400,10 +447,10 @@ export function SubmissionStatusView({
             <span className="status-live">
               <span className="live-dot" aria-hidden="true" />
               {t('statusView.live')}
-              {submittedAt ? (
+              {heartbeatAt !== null ? (
                 <>
                   {' · '}
-                  <ElapsedTimer since={submittedAt} running />
+                  <BuildHeartbeat at={heartbeatAt} />
                 </>
               ) : null}
             </span>
@@ -429,7 +476,7 @@ export function SubmissionStatusView({
           <>
             <StatusTimeline current={status.status} />
             <p className="status-description" aria-live="polite">
-              {t(`statusView.states.${status.status}.description`)}
+              {stateDescription}
             </p>
 
             {status.progress?.checks === 'FAILURE' ? (
@@ -481,6 +528,7 @@ export function SubmissionStatusView({
                 subtitle={t('statusView.draftHint')}
                 cta={t('statusView.playDraft')}
                 onPlay={openDraft}
+                {...(onPlaytest ? { secondary: { label: t('statusView.playtestCta'), onClick: onPlaytest } } : {})}
               />
             ) : channelHtml && latestChannelBuild ? (
               <PlayCard
@@ -493,6 +541,7 @@ export function SubmissionStatusView({
                 subtitle={latestChannelBuild.label ?? t('statusView.playableHint')}
                 cta={t('statusView.playDraft')}
                 onPlay={openChannel}
+                {...(onPlaytest ? { secondary: { label: t('statusView.playtestCta'), onClick: onPlaytest } } : {})}
               />
             ) : previewLoading || channelLoading ? (
               <p className="status-preview-pending">
@@ -666,6 +715,7 @@ function PlayCard({
   subtitle,
   cta,
   onPlay,
+  secondary,
 }: {
   badge: ReactNode;
   badgeClass?: string;
@@ -673,6 +723,12 @@ function PlayCard({
   subtitle?: string;
   cta: string;
   onPlay: () => void;
+  /**
+   * The other thing to do with a playable build. Playtesting is the studio's own
+   * surface — pause the game, point at what is wrong, send the frame with the note —
+   * and until this button existed the only route to it was noticing a tab.
+   */
+  secondary?: { label: string; onClick: () => void };
 }) {
   return (
     <div className="status-play-card">
@@ -681,9 +737,16 @@ function PlayCard({
         <h3 className="status-play-card-title">{title}</h3>
         {subtitle ? <p className="status-play-card-sub">{subtitle}</p> : null}
       </div>
-      <button className="primary-btn status-play-cta" onClick={onPlay}>
-        <PixelIcon name="play" size={13} /> {cta}
-      </button>
+      <div className="status-play-card-actions">
+        <button className="primary-btn status-play-cta" onClick={onPlay}>
+          <PixelIcon name="play" size={13} /> {cta}
+        </button>
+        {secondary ? (
+          <button className="secondary-btn status-playtest-cta" onClick={secondary.onClick}>
+            <PixelIcon name="wrench" size={13} /> {secondary.label}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -204,7 +204,10 @@ function parseCatalogSubmittedBy(value: unknown): string | null {
 }
 
 export async function fetchPublishedGame(slug: string): Promise<PublishedGame> {
-  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}`);
+  // Credentialed because a game is playable at this address before it is published —
+  // by its creator always, by anyone else once the creator shares it. Without the
+  // session cookie a creator opening their own unpublished game gets a 404.
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}`, { credentials: 'include' });
 
   if (!response.ok) {
     throw new Error(await readApiErrorMessage(response, `Game request failed (${response.status})`));

--- a/apps/web/src/gameTitle.test.ts
+++ b/apps/web/src/gameTitle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTitleFromConcept, isSubmittableTitle } from './gameTitle.js';
+
+/**
+ * The fallback namer, which only runs when the refiner had nothing to offer.
+ *
+ * Its predecessor was `concept.slice(0, 40)`, and its output became the game's real
+ * name everywhere — "A game tycoon like where I run a tv busi" is a production example.
+ * These pin the two things that made that bad: cutting mid-word, and reading as a
+ * sentence fragment rather than a name.
+ */
+describe('deriveTitleFromConcept', () => {
+  it('keeps the opening clause and stops at the first sentence end', () => {
+    expect(deriveTitleFromConcept('A tower defence game. You place turrets on a grid.')).toBe('A tower defence game');
+  });
+
+  it('cuts at a word boundary rather than mid-word', () => {
+    const title = deriveTitleFromConcept('A game tycoon like where I run a tv business with presenters and ratings');
+    expect(title.endsWith('busi')).toBe(false);
+    // Whatever the budget is, the result has to be whole words.
+    expect(title.split(' ').every((word) => word.length > 0)).toBe(true);
+    expect('A game tycoon like where I run a tv business with presenters and ratings').toContain(title);
+  });
+
+  it('collapses newlines and runs of whitespace', () => {
+    expect(deriveTitleFromConcept('  Space   miner\n\nwith upgrades  ')).toBe('Space miner');
+  });
+
+  it('has nothing to offer for an empty concept, and says so', () => {
+    // Empty rather than invented: an empty box the creator must fill beats a name
+    // they never chose, and the create button is disabled until they do.
+    expect(deriveTitleFromConcept('   ')).toBe('');
+    expect(deriveTitleFromConcept('...')).toBe('');
+  });
+});
+
+describe('isSubmittableTitle', () => {
+  it('matches the API bounds, so a suggestion is never rejected on arrival', () => {
+    expect(isSubmittableTitle('ab')).toBe(false);
+    expect(isSubmittableTitle('   ')).toBe(false);
+    expect(isSubmittableTitle('TV Tycoon')).toBe(true);
+    expect(isSubmittableTitle('x'.repeat(80))).toBe(true);
+    expect(isSubmittableTitle('x'.repeat(81))).toBe(false);
+  });
+});

--- a/apps/web/src/gameTitle.ts
+++ b/apps/web/src/gameTitle.ts
@@ -1,0 +1,53 @@
+/**
+ * Naming a game when the refiner could not.
+ *
+ * The suggestion normally comes from the model that already read the concept. This is
+ * the fallback for the cases where it did not answer — a timeout, an outage, a reply
+ * with nothing usable in it — and it exists because the naming step is not optional:
+ * a build that starts without a confirmed name is how games ended up called
+ * "A game tycoon like where I run a tv busi", the prompt's first 40 characters cut
+ * mid-word and then carried by the game everywhere, forever.
+ *
+ * What it produces is a starting point in a text box the creator is looking at, not a
+ * final answer, so it aims to be tidy rather than clever: the opening clause, cut at a
+ * word boundary.
+ */
+
+/** Matches the submission route's own bounds, so a suggestion is always submittable. */
+export const MIN_TITLE_LENGTH = 3;
+export const MAX_TITLE_LENGTH = 80;
+
+/** How much of the opening clause to keep. Long enough to be recognisable as theirs. */
+const FALLBACK_TITLE_LENGTH = 48;
+
+/**
+ * A title derived from the concept, or '' when there is nothing to derive one from.
+ *
+ * Empty is a real answer: an empty box the creator must fill is better than a name
+ * they did not choose and might not notice, and the create button stays disabled
+ * until it holds something either way.
+ */
+export function deriveTitleFromConcept(concept: string): string {
+  const firstClause = concept
+    .trim()
+    // Stop at the first sentence or line break — later sentences are elaboration, and
+    // the opening one is almost always "a game where you …".
+    .split(/[\n.!?]/)[0]
+    ?.trim();
+  if (!firstClause) return '';
+
+  const collapsed = firstClause.replace(/\s+/g, ' ');
+  if (collapsed.length <= FALLBACK_TITLE_LENGTH) return collapsed;
+
+  // Cut at the last word boundary that fits rather than mid-word. A word longer than
+  // the whole budget has no boundary to find, so it is cut where it lands.
+  const clipped = collapsed.slice(0, FALLBACK_TITLE_LENGTH);
+  const lastSpace = clipped.lastIndexOf(' ');
+  return (lastSpace > MIN_TITLE_LENGTH ? clipped.slice(0, lastSpace) : clipped).trim();
+}
+
+/** Whether this title can be submitted as-is — the same bounds the API enforces. */
+export function isSubmittableTitle(title: string): boolean {
+  const trimmed = title.trim();
+  return trimmed.length >= MIN_TITLE_LENGTH && trimmed.length <= MAX_TITLE_LENGTH;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -244,11 +244,9 @@
       "closePicker": "Close game list"
     },
     "tabs": {
-      "overview": "Overview",
-      "build": "Build",
-      "playtest": "Playtest",
-      "stats": "Stats",
-      "improve": "Improve"
+      "thread": "Thread",
+      "details": "Details",
+      "playtest": "Playtest"
     },
     "overview": {
       "status": "Status",
@@ -454,6 +452,8 @@
       "hint": "Played it and something's off? Tell the agent what to change and it'll revise your game.",
       "titleBuilding": "Want to steer it?",
       "hintBuilding": "It's still being made — you don't have to wait. Say what to change and the agent picks it up on its next update.",
+      "titlePublished": "Ask for a change",
+      "hintPublished": "Your game is live. Describe what to change and an agent picks it up as an improvement to it.",
       "placeholder": "e.g. make the car faster, add a second track, use brighter colours…",
       "submit": "Send feedback",
       "sending": "Sending…",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -229,6 +229,7 @@
     "shelfAria": "Your games",
     "shelf": {
       "heading": "Your games",
+      "newGame": "New game",
       "count": "{{count}} games",
       "searchLabel": "Search your games",
       "searchPlaceholder": "Search by title or slug…",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -479,8 +479,8 @@
         "description": "An agent is coding your game right now. Watch it take shape below — no need to refresh."
       },
       "in_review": {
-        "label": "Play-testing",
-        "description": "Automated checks are making sure your game actually runs clean."
+        "label": "Final check",
+        "description": "Your game is built and has passed its checks. It's waiting for the last look before going live."
       },
       "publishing": {
         "label": "Going live",
@@ -499,7 +499,14 @@
         "description": "You stopped this build. The agent is no longer working on it — start a new idea whenever you like."
       }
     },
-    "elapsed": "In progress for {{duration}}",
+    "phases": {
+      "dispatched": "An agent has picked up your idea and is getting started.",
+      "submitted": "The agent delivered your game. We're checking it over now.",
+      "gating": "Automated checks are making sure your game actually runs clean.",
+      "ready_for_review": "Your game passed every check. It's waiting for the last look before going live."
+    },
+    "updatedAgo": "updated {{time}}",
+    "playtestCta": "Playtest & prompt",
     "live": "Live",
     "shareLink": "Share this game (watch only):",
     "shareCopy": "Copy",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -261,6 +261,14 @@
       "abandon": "Stop build",
       "abandonConfirm": "Confirm stop"
     },
+    "share": {
+      "title": "Share the draft",
+      "on": "On",
+      "off": "Off",
+      "hintOff": "Only you can play this game right now. Turn this on to give anyone with the link a go — it stays out of the arcade either way.",
+      "hintOn": "Anyone with this link can play the latest build. It's the same link the game keeps once it's published, so there's nothing to re-send.",
+      "error": "We couldn't change that just now. Please try again in a moment."
+    },
     "playtest": {
       "hint": "Play the game, pause on a moment worth changing, and send a request with that viewport and live instrumentation attached.",
       "loading": "Loading the playable build…",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -375,6 +375,11 @@
   "qa": {
     "title": "Refine Your Game Idea (Optional)",
     "subtitle": "Click any proposed options to clarify your spec, or hit 'Create Now' to submit immediately.",
+    "titleNameOnly": "Name your game",
+    "subtitleNameOnly": "Your idea is clear enough to build. Give it a name and we'll get started.",
+    "nameLabel": "Game name",
+    "namePlaceholder": "e.g. TV Tycoon",
+    "nameHint": "This is what your game will be called everywhere. You can change it now — not later.",
     "createNow": "Create Now",
     "analyzing": "Analyzing your idea…",
     "otherPlaceholder": "Other / Custom answer…",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -583,6 +583,7 @@
     "generic": "Something went wrong",
     "creationPaused": "New games are paused for a moment while we look at something on our side. Your daily allowance hasn't been touched — please try again shortly.",
     "creationOverCapacity": "We've hit today's ceiling on new games across the whole site, so we can't start another one right now. Your own allowance is untouched and still there tomorrow.",
+    "nameUnavailable": "That name was taken while we were setting your game up. Give it a different one and try again.",
     "contentRejected": {
       "profanity": "That includes language we can't publish. Please rephrase and try again.",
       "adult": "That describes adult content, which we can't generate. Please rephrase and try again.",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -224,6 +224,7 @@
     "loading": "Loading your games…",
     "loadError": "Could not load your studio right now. Try again in a moment.",
     "empty": "You have not commissioned a game yet.",
+    "gameNotFound": "We couldn't find that game on your shelf. It may have been stopped, or the link may belong to someone else.",
     "createFirst": "Create your first game",
     "shelfAria": "Your games",
     "shelf": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -261,6 +261,14 @@
       "abandon": "Zatrzymaj build",
       "abandonConfirm": "Potwierdź zatrzymanie"
     },
+    "share": {
+      "title": "Udostępnij wersję roboczą",
+      "on": "Wł.",
+      "off": "Wył.",
+      "hintOff": "Na razie tylko Ty możesz zagrać w tę grę. Włącz, aby każdy z linkiem mógł spróbować — i tak nie trafi do arcade.",
+      "hintOn": "Każdy z tym linkiem może zagrać w najnowszą wersję. To ten sam link, który gra zachowa po publikacji, więc nie trzeba wysyłać go ponownie.",
+      "error": "Nie udało się tego teraz zmienić. Spróbuj ponownie za chwilę."
+    },
     "playtest": {
       "hint": "Zagraj, wstrzymaj w momencie wartym zmiany i wyślij prośbę z tym widokiem oraz sygnałami z sesji.",
       "loading": "Ładujemy grywalny build…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -244,11 +244,9 @@
       "closePicker": "Zamknij listę gier"
     },
     "tabs": {
-      "overview": "Przegląd",
-      "build": "Build",
-      "playtest": "Playtest",
-      "stats": "Statystyki",
-      "improve": "Ulepsz"
+      "thread": "Wątek",
+      "details": "Szczegóły",
+      "playtest": "Testuj"
     },
     "overview": {
       "status": "Status",
@@ -454,6 +452,8 @@
       "hint": "Zagrałeś i coś jest nie tak? Napisz agentowi, co zmienić, a poprawi Twoją grę.",
       "titleBuilding": "Chcesz coś podpowiedzieć?",
       "hintBuilding": "Gra wciąż powstaje — nie musisz czekać. Napisz, co zmienić, a agent odbierze wiadomość przy najbliższej aktualizacji.",
+      "titlePublished": "Poproś o zmianę",
+      "hintPublished": "Twoja gra jest opublikowana. Opisz, co zmienić — agent podejmie to jako ulepszenie.",
       "placeholder": "np. przyspiesz samochód, dodaj drugą trasę, użyj jaśniejszych kolorów…",
       "submit": "Wyślij uwagi",
       "sending": "Wysyłanie…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -229,6 +229,7 @@
     "shelfAria": "Twoje gry",
     "shelf": {
       "heading": "Twoje gry",
+      "newGame": "Nowa gra",
       "count": "{{count}} gier",
       "searchLabel": "Szukaj wśród swoich gier",
       "searchPlaceholder": "Szukaj po tytule lub slugu…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -224,6 +224,7 @@
     "loading": "Ładujemy Twoje gry…",
     "loadError": "Nie udało się wczytać studia. Spróbuj za chwilę.",
     "empty": "Nie zleciłeś jeszcze żadnej gry.",
+    "gameNotFound": "Nie znaleźliśmy tej gry na Twojej półce. Mogła zostać zatrzymana albo link należy do kogoś innego.",
     "createFirst": "Stwórz pierwszą grę",
     "shelfAria": "Twoje gry",
     "shelf": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -583,6 +583,7 @@
     "generic": "Coś poszło nie tak",
     "creationPaused": "Tworzenie nowych gier jest na chwilę wstrzymane — sprawdzamy coś u nas. Twój dzienny limit pozostaje nietknięty, spróbuj ponownie za moment.",
     "creationOverCapacity": "Osiągnęliśmy dzisiejszy limit nowych gier w całym serwisie, więc nie możemy teraz zacząć kolejnej. Twój własny limit jest nietknięty i będzie czekał jutro.",
+    "nameUnavailable": "Ta nazwa została zajęta, gdy przygotowywaliśmy Twoją grę. Nadaj inną i spróbuj ponownie.",
     "contentRejected": {
       "profanity": "To zawiera słownictwo, którego nie możemy opublikować. Popraw treść i spróbuj ponownie.",
       "adult": "To opisuje treści dla dorosłych, których nie możemy wygenerować. Popraw treść i spróbuj ponownie.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -375,6 +375,11 @@
   "qa": {
     "title": "Doprecyzuj swój pomysł (Opcjonalnie)",
     "subtitle": "Kliknij sugerowane opcje, aby doprecyzować specyfikację, lub naciśnij 'Stwórz teraz', aby natychmiast wysłać.",
+    "titleNameOnly": "Nazwij swoją grę",
+    "subtitleNameOnly": "Twój pomysł jest wystarczająco jasny. Nadaj mu nazwę, a zaczynamy.",
+    "nameLabel": "Nazwa gry",
+    "namePlaceholder": "np. Telewizyjny Potentat",
+    "nameHint": "Tak Twoja gra będzie się nazywać wszędzie. Możesz to zmienić teraz — później już nie.",
     "createNow": "Stwórz teraz",
     "analyzing": "Analizuję Twój pomysł…",
     "otherPlaceholder": "Inna / Własna odpowiedź…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -479,8 +479,8 @@
         "description": "Agent właśnie pisze Twoją grę. Obserwuj poniżej, jak powstaje — nie musisz odświeżać."
       },
       "in_review": {
-        "label": "Testujemy",
-        "description": "Automatyczne testy sprawdzają, czy gra działa bez zarzutu."
+        "label": "Ostatni sprawdzian",
+        "description": "Twoja gra jest gotowa i przeszła testy. Czeka na ostatnie spojrzenie przed publikacją."
       },
       "publishing": {
         "label": "Publikujemy",
@@ -499,7 +499,14 @@
         "description": "Zatrzymałeś tę grę. Agent już nad nią nie pracuje — możesz zacząć nowy pomysł, kiedy zechcesz."
       }
     },
-    "elapsed": "Trwa od {{duration}}",
+    "phases": {
+      "dispatched": "Agent podjął Twój pomysł i właśnie zaczyna pracę.",
+      "submitted": "Agent dostarczył Twoją grę. Właśnie ją sprawdzamy.",
+      "gating": "Automatyczne testy sprawdzają, czy gra działa bez zarzutu.",
+      "ready_for_review": "Twoja gra przeszła wszystkie testy. Czeka na ostatnie spojrzenie przed publikacją."
+    },
+    "updatedAgo": "aktualizacja {{time}}",
+    "playtestCta": "Zagraj i podpowiedz",
     "live": "Na żywo",
     "shareLink": "Podziel się tą grą (tylko do oglądania):",
     "shareCopy": "Kopiuj",

--- a/apps/web/src/mp/protocol.test.ts
+++ b/apps/web/src/mp/protocol.test.ts
@@ -82,7 +82,7 @@ describe('join route', () => {
 
   it('still parses the existing routes', () => {
     expect(parsePathRoute('/')).toEqual({ view: 'home' });
-    expect(parsePathRoute('/status/abc')).toEqual({ view: 'studio', token: 'abc' });
+    expect(parsePathRoute('/status/abc')).toEqual({ view: 'studio', game: 'abc' });
   });
 });
 

--- a/apps/web/src/mySpecs.ts
+++ b/apps/web/src/mySpecs.ts
@@ -3,6 +3,11 @@ export type SavedSpec = {
   title: string;
   concept?: string;
   createdAt: number;
+  /**
+   * The game's address, known from submission now. Optional because entries saved
+   * before slugs were assigned up front have none, and those still resolve by token.
+   */
+  slug?: string;
 };
 
 const STORAGE_KEY = 'gamedev_saved_specs';

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -77,7 +77,7 @@ describe('resolveDocumentTitle', () => {
       'Draft Space Runner — Gamedev.pl',
     );
     expect(resolveDocumentTitle({ view: 'studio' }, { copy })).toBe('Creator Studio — Gamedev.pl');
-    expect(resolveDocumentTitle({ view: 'studio', token: 'tok' }, { copy, studioTitle: 'Coin Catcher' })).toBe(
+    expect(resolveDocumentTitle({ view: 'studio', game: 'tok' }, { copy, studioTitle: 'Coin Catcher' })).toBe(
       'Studio · Coin Catcher — Gamedev.pl',
     );
     expect(resolveDocumentTitle({ view: 'join', code: 'K7M3QP', token: 't' }, { copy })).toBe(

--- a/apps/web/src/pendingQa.ts
+++ b/apps/web/src/pendingQa.ts
@@ -38,11 +38,13 @@ export function loadPendingQa(): PendingQaSession | null {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as PendingQaSession;
+    // An empty question list is a real session now, not a corrupt one: the confirm
+    // panel opens for every concept so the game can be named, and a clean concept
+    // reaches it with nothing to clarify. The concept is what makes a session
+    // meaningful; the title may legitimately be blank while the creator picks one.
     if (
-      !parsed?.spec?.title ||
-      !parsed.spec.concept ||
+      !parsed?.spec?.concept ||
       !Array.isArray(parsed.questions) ||
-      parsed.questions.length === 0 ||
       typeof parsed.savedAt !== 'number' ||
       Date.now() - parsed.savedAt > MAX_AGE_MS
     ) {
@@ -52,7 +54,7 @@ export function loadPendingQa(): PendingQaSession | null {
     return {
       ...parsed,
       // displayName is optional to the creator, so tolerate its absence in older blobs.
-      spec: { ...parsed.spec, displayName: parsed.spec.displayName ?? '' },
+      spec: { ...parsed.spec, title: parsed.spec.title ?? '', displayName: parsed.spec.displayName ?? '' },
       answers: { selected: parsed.answers?.selected ?? {}, custom: parsed.answers?.custom ?? {} },
     };
   } catch {

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -96,10 +96,12 @@ describe('parsePathRoute', () => {
   it('parses the creator studio route', () => {
     expect(parsePathRoute('/studio')).toEqual({ view: 'studio' });
     expect(parsePathRoute('/studio/abc%2Ftoken')).toEqual({ view: 'studio', game: 'abc/token' });
+    // 'build' is one of the five names the three surfaces absorbed; it resolves to
+    // the surface rather than being carried around as itself.
     expect(parsePathRoute('/studio/abc%2Ftoken/build')).toEqual({
       view: 'studio',
       game: 'abc/token',
-      tab: 'build',
+      tab: 'thread',
     });
     expect(parsePathRoute('/studio/tok/playtest')).toEqual({ view: 'studio', game: 'tok', tab: 'playtest' });
     expect(parsePathRoute('/studio/tok/nope')).toEqual({ view: 'notFound' });
@@ -164,6 +166,9 @@ describe('path builders', () => {
     expect(canonicalPath('/status/tok-abc')).toBe('/studio/tok-abc');
     // A bare /admin names no section; the queue is what it shows, so that is what it says.
     expect(canonicalPath('/admin')).toBe('/admin/queue');
+    // An old tab name is not the current address for the surface that absorbed it.
+    expect(canonicalPath('/studio/tv-tycoon/build')).toBe('/studio/tv-tycoon/thread');
+    expect(canonicalPath('/studio/tv-tycoon/stats')).toBe('/studio/tv-tycoon/details');
   });
 
   it('leaves an address that is already current alone', () => {
@@ -171,7 +176,7 @@ describe('path builders', () => {
     expect(canonicalPath('/play/sky-dodge')).toBeNull();
     expect(canonicalPath('/admin/telemetry')).toBeNull();
     expect(canonicalPath('/studio/tok-abc')).toBeNull();
-    expect(canonicalPath('/studio/tok-abc/build')).toBeNull();
+    expect(canonicalPath('/studio/tok-abc/thread')).toBeNull();
     expect(canonicalPath('/studio')).toBeNull();
     expect(canonicalPath('/draft/sky-dodge')).toBeNull();
     expect(canonicalPath('/')).toBeNull();
@@ -190,18 +195,37 @@ describe('path builders', () => {
   it('builds a studio path that round-trips', () => {
     expect(studioPath()).toBe('/studio');
     expect(studioPath('tok')).toBe('/studio/tok');
-    expect(studioPath('a b', 'stats')).toBe('/studio/a%20b/stats');
+    expect(studioPath('a b', 'details')).toBe('/studio/a%20b/details');
     expect(parsePathRoute(studioPath('a b'))).toEqual({ view: 'studio', game: 'a b' });
-    expect(parsePathRoute(studioPath('tok', 'improve'))).toEqual({
+    expect(parsePathRoute(studioPath('tok', 'thread'))).toEqual({
       view: 'studio',
       game: 'tok',
-      tab: 'improve',
+      tab: 'thread',
     });
+    // The five-tab vocabulary that came before, resolved onto the surface that
+    // absorbed each one. Old bookmarks and notification links have to land somewhere
+    // real, and they land on the thread or beside it rather than on a 404.
+    for (const [old, surface] of [
+      ['build', 'thread'],
+      ['improve', 'thread'],
+      ['overview', 'details'],
+      ['stats', 'details'],
+      ['playtest', 'playtest'],
+    ] as const) {
+      expect(parsePathRoute(`/studio/tv-tycoon/${old}`)).toEqual({
+        view: 'studio',
+        game: 'tv-tycoon',
+        tab: surface,
+      });
+    }
+    // Still a 404 for a segment that never named anything.
+    expect(parsePathRoute('/studio/tv-tycoon/nonsense')).toEqual({ view: 'notFound' });
+
     // The address games actually carry now.
-    expect(parsePathRoute(studioPath('tv-tycoon', 'build'))).toEqual({
+    expect(parsePathRoute(studioPath('tv-tycoon', 'thread'))).toEqual({
       view: 'studio',
       game: 'tv-tycoon',
-      tab: 'build',
+      tab: 'thread',
     });
   });
 
@@ -236,9 +260,9 @@ describe('navUpTarget', () => {
   });
 
   it('walks studio game work surfaces to the shelf, then home', () => {
-    // Tab → shelf (not `/studio/:token`): a bare token URL is rewritten back onto
-    // the default tab, which would cancel the Up for in-progress Build views.
-    expect(navUpTarget({ view: 'studio', game: 'tok', tab: 'build' })).toEqual({
+    // Surface → shelf (not `/studio/:game`): a bare game URL is rewritten back onto
+    // the default surface, which would cancel the Up for a thread view.
+    expect(navUpTarget({ view: 'studio', game: 'tok', tab: 'thread' })).toEqual({
       path: '/studio',
       labelKey: 'upStudio',
     });

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -20,7 +20,7 @@ describe('parsePathRoute', () => {
   });
 
   it('parses a status token into Creator Studio (legacy alias)', () => {
-    expect(parsePathRoute('/status/abc123')).toEqual({ view: 'studio', token: 'abc123' });
+    expect(parsePathRoute('/status/abc123')).toEqual({ view: 'studio', game: 'abc123' });
   });
 
   it('parses a published-game permalink', () => {
@@ -95,13 +95,13 @@ describe('parsePathRoute', () => {
 
   it('parses the creator studio route', () => {
     expect(parsePathRoute('/studio')).toEqual({ view: 'studio' });
-    expect(parsePathRoute('/studio/abc%2Ftoken')).toEqual({ view: 'studio', token: 'abc/token' });
+    expect(parsePathRoute('/studio/abc%2Ftoken')).toEqual({ view: 'studio', game: 'abc/token' });
     expect(parsePathRoute('/studio/abc%2Ftoken/build')).toEqual({
       view: 'studio',
-      token: 'abc/token',
+      game: 'abc/token',
       tab: 'build',
     });
-    expect(parsePathRoute('/studio/tok/playtest')).toEqual({ view: 'studio', token: 'tok', tab: 'playtest' });
+    expect(parsePathRoute('/studio/tok/playtest')).toEqual({ view: 'studio', game: 'tok', tab: 'playtest' });
     expect(parsePathRoute('/studio/tok/nope')).toEqual({ view: 'notFound' });
     // The stubbed feedback surface is gone from the UI, so its path is gone too —
     // otherwise a deep link resolves to a tab with nothing to render.
@@ -191,11 +191,17 @@ describe('path builders', () => {
     expect(studioPath()).toBe('/studio');
     expect(studioPath('tok')).toBe('/studio/tok');
     expect(studioPath('a b', 'stats')).toBe('/studio/a%20b/stats');
-    expect(parsePathRoute(studioPath('a b'))).toEqual({ view: 'studio', token: 'a b' });
+    expect(parsePathRoute(studioPath('a b'))).toEqual({ view: 'studio', game: 'a b' });
     expect(parsePathRoute(studioPath('tok', 'improve'))).toEqual({
       view: 'studio',
-      token: 'tok',
+      game: 'tok',
       tab: 'improve',
+    });
+    // The address games actually carry now.
+    expect(parsePathRoute(studioPath('tv-tycoon', 'build'))).toEqual({
+      view: 'studio',
+      game: 'tv-tycoon',
+      tab: 'build',
     });
   });
 
@@ -226,17 +232,17 @@ describe('navUpTarget', () => {
     expect(navUpTarget({ view: 'join', code: 'ABC123', token: 'tok' })).toBeNull();
     expect(navUpTarget({ view: 'play', slug: 'sky-dodge' })).toBeNull();
     expect(navUpTarget({ view: 'draft', slug: 'space-runner' })).toBeNull();
-    expect(navUpTarget({ view: 'studio', token: 'tok', tab: 'playtest' })).toBeNull();
+    expect(navUpTarget({ view: 'studio', game: 'tok', tab: 'playtest' })).toBeNull();
   });
 
   it('walks studio game work surfaces to the shelf, then home', () => {
     // Tab → shelf (not `/studio/:token`): a bare token URL is rewritten back onto
     // the default tab, which would cancel the Up for in-progress Build views.
-    expect(navUpTarget({ view: 'studio', token: 'tok', tab: 'build' })).toEqual({
+    expect(navUpTarget({ view: 'studio', game: 'tok', tab: 'build' })).toEqual({
       path: '/studio',
       labelKey: 'upStudio',
     });
-    expect(navUpTarget({ view: 'studio', token: 'tok' })).toEqual({
+    expect(navUpTarget({ view: 'studio', game: 'tok' })).toEqual({
       path: '/studio',
       labelKey: 'upStudio',
     });

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,13 +1,40 @@
 import type { LegalDocId } from './legal/types.js';
 
-/** Creator Studio work surface. Persisted in the URL so a refresh or shared link
- * reopens the same tab on the same game. */
-export type StudioTab = 'overview' | 'build' | 'playtest' | 'stats' | 'improve';
+/**
+ * Creator Studio work surface. Persisted in the URL so a refresh or shared link
+ * reopens the same surface on the same game.
+ *
+ * Three, where there were five. Making a game is a conversation with an agent, and the
+ * studio was five tabs across the top of it — with the same act (say what to change)
+ * living in three of them, so which box a creator was allowed depended on a lifecycle
+ * state they had to know to find it. Now: the thread, the things beside the thread, and
+ * the one surface that genuinely takes over the screen.
+ */
+export type StudioTab = 'thread' | 'details' | 'playtest';
 
-const STUDIO_TABS = new Set<StudioTab>(['overview', 'build', 'playtest', 'stats', 'improve']);
+/**
+ * Every name a surface has answered to, including the five-tab vocabulary that came
+ * before. Old names resolve to the surface that absorbed them and the studio rewrites
+ * the URL, so a bookmark or a notification link from months ago lands somewhere real
+ * and quietly becomes current.
+ */
+const STUDIO_TAB_ALIASES: Record<string, StudioTab> = {
+  thread: 'thread',
+  build: 'thread',
+  improve: 'thread',
+  details: 'details',
+  overview: 'details',
+  stats: 'details',
+  playtest: 'playtest',
+};
+
+/** The surface this URL segment names, or null when it names nothing. */
+export function parseStudioTab(value: string): StudioTab | null {
+  return STUDIO_TAB_ALIASES[value] ?? null;
+}
 
 export function isStudioTab(value: string): value is StudioTab {
-  return STUDIO_TABS.has(value as StudioTab);
+  return parseStudioTab(value) !== null;
 }
 
 /**
@@ -182,10 +209,13 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     if (!tabSegment) {
       return { view: 'studio', game };
     }
-    if (!isStudioTab(tabSegment)) {
+    // Resolved, not passed through: the route carries the surface, and an old name for
+    // it stops existing the moment it is parsed.
+    const tab = parseStudioTab(tabSegment);
+    if (!tab) {
       return { view: 'notFound' };
     }
-    return { view: 'studio', game, tab: tabSegment };
+    return { view: 'studio', game, tab };
   }
 
   // Hybrid join: /join/<code>#<token> — credential stays out of the request line.

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -45,9 +45,20 @@ export type AppRoute =
   // surface before there was a console, and links to it are in people's bookmarks.
   | { view: 'admin'; section: AdminSection }
   // Creator control panel: own games, draft build (ex-status), playtest, improve.
-  // `/status/:token` is accepted as an alias and resolves here too.
-  // Optional `tab` deep-links into a work surface (`/studio/:token/build`).
-  | { view: 'studio'; token?: string; tab?: StudioTab }
+  //
+  // `game` addresses one game on the creator's shelf. It is a **slug** — games are
+  // given one at submission now, so there is no window where a build has no readable
+  // address — but it is deliberately left opaque here, because the same segment used to
+  // carry a capability token and those URLs are in notification emails and browser
+  // histories. The studio resolves it against the shelf by either, then rewrites the
+  // URL to the slug, which is how an old token link upgrades itself on first use.
+  //
+  // Nothing is fetched by this value: the shelf comes from the signed-in creator's own
+  // games, so a slug belonging to somebody else resolves to nothing at all.
+  //
+  // `/status/:token` is accepted as an alias and resolves here too. Optional `tab`
+  // deep-links into a work surface (`/studio/tv-tycoon/build`).
+  | { view: 'studio'; game?: string; tab?: StudioTab }
   // Privacy policy and terms. Reachable without a session — someone deciding whether
   // to sign in has to be able to read what signing in would mean first.
   | { view: 'legal'; doc: LegalDocId }
@@ -113,7 +124,7 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     // Legacy status URLs land in Creator Studio — the draft Build tab is the
     // former status / "dev studio" page, now unified with playtest + improve.
     const token = decodeSegment(statusMatch[1]);
-    if (token) return { view: 'studio', token };
+    if (token) return { view: 'studio', game: token };
   }
 
   const playMatch = normalizedPath.match(PLAY_PREFIX_PATTERN);
@@ -158,23 +169,23 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     return { view: 'studio' };
   }
 
-  // `/studio/:token` or `/studio/:token/:tab`. A third segment that is not a known
-  // tab is a 404 rather than a silent fallback to the token-only view: it keeps the
+  // `/studio/:game` or `/studio/:game/:tab`. A third segment that is not a known
+  // tab is a 404 rather than a silent fallback to the game-only view: it keeps the
   // client in step with the API's shell allowlist, which serves those paths a real 404.
   const studioMatch = normalizedPath.match(/^\/studio\/([^/]+)(?:\/([^/]+))?$/);
   if (studioMatch?.[1]) {
-    const token = decodeSegment(studioMatch[1]);
+    const game = decodeSegment(studioMatch[1]);
     const tabSegment = studioMatch[2] ? decodeSegment(studioMatch[2]) : undefined;
-    if (token === null || tabSegment === null) {
+    if (game === null || tabSegment === null) {
       return { view: 'notFound' };
     }
     if (!tabSegment) {
-      return { view: 'studio', token };
+      return { view: 'studio', game };
     }
     if (!isStudioTab(tabSegment)) {
       return { view: 'notFound' };
     }
-    return { view: 'studio', token, tab: tabSegment };
+    return { view: 'studio', game, tab: tabSegment };
   }
 
   // Hybrid join: /join/<code>#<token> — credential stays out of the request line.
@@ -189,6 +200,17 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
 /** @deprecated Prefer {@link studioPath}. Kept so old `/status/` links and call sites still resolve. */
 export function statusPath(token: string): string {
   return studioPath(token);
+}
+
+/**
+ * Whether a studio path segment names a game the way we now write them.
+ *
+ * Used to decide when a URL is already canonical. A capability token is base64url and
+ * can, rarely, be all-lowercase and dash-free — so this is a test of shape, not proof
+ * of which kind of address it is; the studio resolves it against the shelf either way.
+ */
+export function looksLikeSlug(segment: string): boolean {
+  return SLUG_PATTERN.test(segment);
 }
 
 /** Canonical play URL. Emit this; `/ay/<slug>` and `/ai/<slug>` only as inbound aliases. */
@@ -222,10 +244,11 @@ export function canonicalPath(pathname: string): string | null {
       // showing belongs in the URL, or a refresh is a different page than a reload.
       case 'admin':
         return adminPath(route.section);
-      // Only the token form. `/studio` itself is canonical, and a tab is added by the
-      // view once it knows which game it is showing rather than here.
+      // Only the addressed form. `/studio` itself is canonical, and a tab is added by
+      // the view once it knows which game it is showing rather than here. Rewriting a
+      // token to its slug also happens there, for the same reason: it takes the shelf.
       case 'studio':
-        return route.token ? studioPath(route.token, route.tab) : null;
+        return route.game ? studioPath(route.game, route.tab) : null;
       default:
         return null;
     }
@@ -250,12 +273,13 @@ export function draftPath(slug: string): string {
 }
 
 /**
- * Creator control panel. Optional token deep-links into one game on the shelf;
- * optional tab deep-links into a work surface on that game.
+ * Creator control panel. Optional `game` (a slug, or a legacy capability token)
+ * deep-links into one game on the shelf; optional tab deep-links into a work surface
+ * on that game.
  */
-export function studioPath(token?: string, tab?: StudioTab): string {
-  if (!token) return '/studio';
-  const base = `/studio/${encodeURIComponent(token)}`;
+export function studioPath(game?: string, tab?: StudioTab): string {
+  if (!game) return '/studio';
+  const base = `/studio/${encodeURIComponent(game)}`;
   return tab ? `${base}/${tab}` : base;
 }
 
@@ -286,10 +310,10 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
       // Playtest is a full-viewport theater with its own Close back to overview.
       if (route.tab === 'playtest') return null;
       // Any selected-game URL (with or without a tab) goes to the shelf — not to
-      // `/studio/:token`. CreatorStudioView canonicalizes a bare token URL onto the
+      // `/studio/:game`. CreatorStudioView canonicalizes a bare game URL onto the
       // default tab (Build for in-progress games), which would immediately undo an
       // Up that only stripped the tab and make the chevron look broken.
-      if (route.token) {
+      if (route.game) {
         return { path: studioPath(), labelKey: 'upStudio' };
       }
       return { path: '/', labelKey: 'upHome' };

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -10,6 +10,12 @@ export type StudioGame = {
   lastKnownStatus: SubmissionState | null;
   slug?: string;
   publishedAt?: string;
+  /**
+   * Whether anyone holding the link may play this game before it is published. Off
+   * until the creator says otherwise; irrelevant once the game is live, when the
+   * catalog is the answer instead.
+   */
+  draftShared?: boolean;
 };
 
 export type StudioHealthResponse = {
@@ -79,6 +85,26 @@ export async function fetchStudioScorecards(): Promise<StudioScorecard[]> {
   }
   const body = (await response.json()) as { scorecards?: StudioScorecard[] };
   return body.scorecards ?? [];
+}
+
+/**
+ * Turns the shared link for an unpublished game on or off.
+ *
+ * There is no separate draft address to hand out — the game answers at `/play/<slug>`
+ * for its whole life — so this is the switch that decides whether that link works for
+ * anyone but its creator.
+ */
+export async function setDraftShared(token: string, shared: boolean): Promise<{ shared: boolean; slug: string }> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/share`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ shared }),
+  });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as { shared: boolean; slug: string };
 }
 
 /**

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2274,8 +2274,9 @@ body.player-open {
   gap: 10px;
 }
 
-/* "Live · 2m 14s" — the page polls on its own, so say so rather than leaving
-   the reader wondering whether they need to refresh. */
+/* "Live · updated 3 minutes ago" — the page polls on its own, so say so rather than
+   leaving the reader wondering whether they need to refresh. The trailing half is the
+   build's pulse, not a stopwatch: what matters is when the agent last moved. */
 .status-live {
   display: inline-flex;
   align-items: center;
@@ -2290,7 +2291,7 @@ body.player-open {
   white-space: nowrap;
 }
 
-.status-elapsed {
+.status-heartbeat {
   font-variant-numeric: tabular-nums;
 }
 
@@ -2514,6 +2515,15 @@ body.player-open {
 .status-play-card-info {
   min-width: 0;
   flex: 1 1 260px;
+}
+
+/* Play and Playtest travel together: one opens the game, the other opens the surface
+   where pausing it and pointing at the problem turns into a message to the agent. */
+.status-play-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .status-play-badge {
@@ -4391,7 +4401,14 @@ body.player-open {
     align-items: stretch;
   }
 
-  .status-play-cta {
+  .status-play-card-actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .status-play-cta,
+  .status-playtest-cta {
     width: 100%;
     justify-content: center;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3917,6 +3917,12 @@ body.player-open {
   color: var(--muted);
 }
 
+/* The sheet's backdrop: something to tap beside it, and a dimmed page behind so the
+   thread underneath reads as out of reach rather than merely covered. */
+.studio-rail-backdrop {
+  z-index: 1090;
+}
+
 /* Below the rail breakpoint the details arrive over the thread as a sheet, anchored to
    the bottom where a thumb is — the same shape the game picker already uses. */
 @media (max-width: 1099px) {
@@ -4160,6 +4166,9 @@ body.player-open {
   width: 100%;
   border-radius: 12px;
   resize: vertical;
+  /* The placeholder says where the message will land, which is two lines of text on a
+     phone; at two rows it was cut off mid-sentence. */
+  min-height: 5.25rem;
 }
 
 .status-composer.is-compact .status-feedback-actions {
@@ -4175,12 +4184,31 @@ body.player-open {
   margin-right: auto;
 }
 
-@media (max-width: 640px) {
+/* On a narrow screen the thread does not get a scroller of its own.
+   It had one, and the page had one too: scrolling the transcript moved the page instead,
+   or the other way about, and the composer sat 477px below the fold behind whichever of
+   the two you guessed wrong. One scroller — the page — and the composer rides at the
+   bottom of the viewport until the thread ends. */
+@media (max-width: 900px) {
   .studio-thread {
-    height: calc(100dvh - 18rem);
-    min-height: 20rem;
+    height: auto;
+    min-height: 0;
   }
 
+  .studio-thread-scroll {
+    overflow: visible;
+  }
+
+  .studio-thread-foot {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    padding-bottom: 10px;
+    background: var(--panel);
+  }
+}
+
+@media (max-width: 640px) {
   /* Too little width left for two sides of a conversation; the bubble carries it. */
   .studio-turn.is-mine .studio-turn-body {
     max-width: 100%;
@@ -6821,50 +6849,6 @@ body.player-open {
   padding: 2px 10px;
 }
 
-/* Underline tabs — clearer hierarchy than chip pills for a primary work surface. */
-.studio-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px;
-  margin: 0 0 20px;
-  padding: 0;
-  border-bottom: 1px solid var(--panel-border);
-}
-
-.studio-tab {
-  position: relative;
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  color: var(--muted);
-  border-radius: 0;
-  padding: 10px 14px;
-  margin-bottom: -1px;
-  font-size: 13px;
-  font-weight: 600;
-  white-space: nowrap;
-  cursor: pointer;
-  transition:
-    color 0.15s,
-    border-color 0.15s;
-}
-
-.studio-tab:hover {
-  color: #fff;
-}
-
-.studio-tab.is-active {
-  color: var(--turquoise);
-  background: transparent;
-  border-bottom-color: var(--turquoise);
-  box-shadow: none;
-}
-
-.studio-tab.is-active:hover {
-  color: var(--turquoise);
-  filter: none;
-}
-
 .studio-tab-panel {
   min-width: 0;
 }
@@ -7275,8 +7259,14 @@ body.player-open {
     display: flex;
   }
 
-  .studio-layout.is-game-open .studio-detail-title-row {
+  /* The switcher above already names the game, so the title block goes — but the
+     actions beside it must not, or Playtest and Details become unreachable on a phone. */
+  .studio-layout.is-game-open .studio-detail-title-block {
     display: none;
+  }
+
+  .studio-layout.is-game-open .studio-detail-title-row {
+    justify-content: flex-end;
   }
 
   .studio-layout.is-game-open .studio-detail {
@@ -7299,18 +7289,6 @@ body.player-open {
 
   .studio-detail {
     padding: 18px 16px;
-  }
-
-  .studio-tabs {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    mask-image: linear-gradient(90deg, #000 85%, transparent);
-  }
-
-  .studio-tabs::-webkit-scrollbar {
-    display: none;
   }
 
   .studio-picker {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3834,6 +3834,45 @@ body.player-open {
   margin: 0;
 }
 
+/* The thread's reply box. Pinned to the foot of the conversation, and visibly the place
+   the thread is heading rather than one more panel stacked under it. */
+.status-composer {
+  margin-top: 20px;
+  border: 1px solid rgba(0, 228, 172, 0.28);
+  background: linear-gradient(180deg, rgba(0, 228, 172, 0.05), transparent 60%);
+}
+
+/* The creator's own messages, set across from the agent's — without this a request
+   they sent and the reply to it are two identical grey rows. */
+.build-activity-item.is-mine {
+  flex-direction: row-reverse;
+  text-align: right;
+}
+
+.build-activity-item.is-mine .build-activity-body {
+  align-items: flex-end;
+  border-radius: 10px;
+  background: rgba(0, 228, 172, 0.08);
+  border: 1px solid rgba(0, 228, 172, 0.2);
+  padding: 8px 12px;
+}
+
+.build-activity-item.is-mine .build-activity-label {
+  color: var(--turquoise);
+}
+
+@media (max-width: 640px) {
+  /* Too little width left for two sides of a conversation; the label carries it. */
+  .build-activity-item.is-mine {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .build-activity-item.is-mine .build-activity-body {
+    align-items: flex-start;
+  }
+}
+
 /* Naming the game — the step the build waits on, so it leads the panel and is sized
    like a decision rather than like one more field among the clarifying questions. */
 .qa-name {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6349,6 +6349,107 @@ body.player-open {
   flex: 1;
 }
 
+/* Whether anyone else may play an unpublished game. One switch, because the link is
+   the only way in: the game is in no catalog and no rail either way. */
+.studio-share {
+  margin-top: 20px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: var(--panel-card);
+}
+
+.studio-share-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.studio-share-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.studio-share-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px 5px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.studio-share-toggle:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.studio-share-toggle.is-on {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.4);
+  background: rgba(0, 228, 172, 0.1);
+}
+
+/* The switch itself: a track with a knob that slides when it is on. */
+.studio-share-toggle-track {
+  position: relative;
+  width: 30px;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  transition: background 0.15s ease;
+}
+
+.studio-share-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.studio-share-toggle.is-on .studio-share-toggle-track {
+  background: rgba(0, 228, 172, 0.35);
+}
+
+.studio-share-toggle.is-on .studio-share-toggle-track::after {
+  transform: translateX(14px);
+  background: var(--turquoise);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .studio-share-toggle-track,
+  .studio-share-toggle-track::after {
+    transition: none;
+  }
+}
+
+.studio-share-hint {
+  margin: 8px 0 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.studio-share .status-share {
+  margin: 12px 0 0;
+}
+
 .studio-sr-only {
   position: absolute;
   width: 1px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3834,6 +3834,34 @@ body.player-open {
   margin: 0;
 }
 
+/* Naming the game — the step the build waits on, so it leads the panel and is sized
+   like a decision rather than like one more field among the clarifying questions. */
+.qa-name {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.qa-name-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-heading, #fff);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.qa-name-input {
+  font-size: 1.15rem;
+  font-weight: 600;
+  padding: 12px 14px;
+}
+
+.qa-name-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted, #94a3b8);
+}
+
 .qa-actions {
   display: flex;
   align-items: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3834,42 +3834,356 @@ body.player-open {
   margin: 0;
 }
 
-/* The thread's reply box. Pinned to the foot of the conversation, and visibly the place
-   the thread is heading rather than one more panel stacked under it. */
-.status-composer {
-  margin-top: 20px;
-  border: 1px solid rgba(0, 228, 172, 0.28);
-  background: linear-gradient(180deg, rgba(0, 228, 172, 0.05), transparent 60%);
+/* With a game open the page title steps out of the way. A masthead and a strapline are
+   right for the shelf, which is a page you arrive at; they are 200px of nothing above a
+   conversation you came back to read. */
+.studio-panel.is-focused .studio-panel-header {
+  margin-bottom: 10px;
 }
 
-/* The creator's own messages, set across from the agent's — without this a request
-   they sent and the reply to it are two identical grey rows. */
-.build-activity-item.is-mine {
-  flex-direction: row-reverse;
-  text-align: right;
+.studio-panel.is-focused .studio-kicker,
+.studio-panel.is-focused .studio-panel-header .panel-copy {
+  display: none;
 }
 
-.build-activity-item.is-mine .build-activity-body {
-  align-items: flex-end;
+.studio-panel.is-focused .studio-panel-header .section-title {
+  font-size: 1.05rem;
+  margin: 0;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+/* Starting a new game belongs at the top of the list of games, not behind a trip home. */
+.studio-shelf-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 8px 11px;
   border-radius: 10px;
-  background: rgba(0, 228, 172, 0.08);
-  border: 1px solid rgba(0, 228, 172, 0.2);
-  padding: 8px 12px;
+  border: 1px dashed var(--panel-border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
-.build-activity-item.is-mine .build-activity-label {
+.studio-shelf-new:hover {
   color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.4);
+}
+
+/* Thread on the left, details beside it when asked for. A grid rather than a tab swap,
+   because opening the facts about a game should not take the game off the screen. */
+.studio-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+@media (min-width: 1100px) {
+  .studio-workspace.is-details-open {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  }
+}
+
+.studio-rail {
+  min-width: 0;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-card);
+  padding: 14px 16px 18px;
+}
+
+.studio-rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.studio-rail-head h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Below the rail breakpoint the details arrive over the thread as a sheet, anchored to
+   the bottom where a thumb is — the same shape the game picker already uses. */
+@media (max-width: 1099px) {
+  .studio-workspace.is-details-open .studio-rail {
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: 1100;
+    max-height: min(80vh, 40rem);
+    overflow-y: auto;
+    border-radius: 16px 16px 0 0;
+    border-bottom: 0;
+    background: var(--panel);
+    box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
+    animation: fadeIn 0.2s ease;
+  }
+}
+
+/* Header actions, in place of the tab strip that used to sit across the work surface. */
+.studio-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.studio-head-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.studio-head-action:hover {
+  color: var(--text);
+  border-color: rgba(0, 228, 172, 0.35);
+}
+
+.studio-head-action.is-active {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.4);
+  background: rgba(0, 228, 172, 0.1);
+}
+
+/* A shelf row is a title. The state that matters at a glance rides on a dot. */
+.studio-shelf-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--panel-border);
+  flex: none;
+}
+
+.studio-shelf-dot.is-live {
+  background: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+}
+
+.studio-shelf-dot.is-published {
+  background: var(--turquoise);
+}
+
+/* ── THE THREAD ──────────────────────────────────────────────────────────────────
+   One game is one conversation, so this is built like every other place you talk to
+   something: the transcript scrolls in its own pane and the box you answer in never
+   moves. What it replaced was a bordered box titled BUILD ACTIVITY containing rows of
+   12px text behind an icon column — all of it true, none of it reading as a dialogue.
+
+   The height is viewport-relative rather than full-screen because the studio still
+   lives inside an ordinary scrolling page with a header above it; what matters is that
+   the transcript, not the document, is the thing that scrolls. */
+.studio-thread {
+  display: flex;
+  flex-direction: column;
+  height: min(70vh, 780px);
+  min-height: 24rem;
+}
+
+.studio-thread-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 4px 2px 8px;
+}
+
+.studio-thread-empty {
+  color: var(--muted);
+  margin: 0;
+  padding: 8px 2px;
+}
+
+.studio-thread-turns {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* An agent turn is prose with nothing drawn around it — the widest, quietest thing on
+   the screen, which is what makes it read as the voice rather than as a log line. */
+.studio-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.studio-turn-body {
+  max-width: 68ch;
+  min-width: 0;
+}
+
+.studio-turn-kicker {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--turquoise);
+  margin-bottom: 3px;
+}
+
+.studio-turn-text {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.97rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.studio-turn-time {
+  font-size: 0.72rem;
+  color: var(--muted);
+  opacity: 0.75;
+}
+
+/* The creator's own turn: a bubble on the other side, and deliberately the quieter of
+   the two. It is there to be recognised as theirs while scrolling past, not to compete
+   with the answer it asked for. */
+.studio-turn.is-mine {
+  align-items: flex-end;
+}
+
+.studio-turn.is-mine .studio-turn-body {
+  background: var(--panel-card);
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  padding: 10px 14px;
+  max-width: min(62ch, 78%);
+}
+
+.studio-turn.is-mine .studio-turn-text {
+  color: var(--text);
+}
+
+.studio-turn.is-pending .studio-turn-body {
+  opacity: 0.7;
+}
+
+.studio-turn-shots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* Nothing below this line moves when the thread grows. */
+.studio-thread-foot {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--panel-border);
+}
+
+/* Where the work is, and the one thing to do about it — the bar directly above the
+   composer, in place of a timeline, a progress bar, a pill and a sentence stacked over
+   the conversation and pushing it down the page. */
+.studio-thread-context {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: var(--panel-card);
+  border: 1px solid var(--panel-border);
+  font-size: 0.82rem;
+}
+
+.studio-context-state,
+.studio-context-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.studio-context-phase {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.studio-context-beat,
+.studio-context-progress {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.studio-thread-context .primary-btn,
+.studio-thread-context .secondary-btn {
+  padding: 6px 14px;
+  font-size: 0.82rem;
+}
+
+.status-composer.is-compact {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.status-composer.is-compact .status-feedback-input {
+  width: 100%;
+  border-radius: 12px;
+  resize: vertical;
+}
+
+.status-composer.is-compact .status-feedback-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.status-composer.is-compact .status-feedback-actions .error {
+  margin: 0;
+  margin-right: auto;
 }
 
 @media (max-width: 640px) {
-  /* Too little width left for two sides of a conversation; the label carries it. */
-  .build-activity-item.is-mine {
-    flex-direction: row;
-    text-align: left;
+  .studio-thread {
+    height: calc(100dvh - 18rem);
+    min-height: 20rem;
   }
 
-  .build-activity-item.is-mine .build-activity-body {
-    align-items: flex-start;
+  /* Too little width left for two sides of a conversation; the bubble carries it. */
+  .studio-turn.is-mine .studio-turn-body {
+    max-width: 100%;
   }
 }
 
@@ -6137,15 +6451,11 @@ body.player-open {
 /* Compact rows — denser than home-rail cards so 10+ games stay scannable. */
 .studio-shelf-item {
   width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    'status meta'
-    'title title';
-  column-gap: 8px;
-  row-gap: 2px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
   text-align: left;
-  padding: 10px 12px;
+  padding: 8px 11px;
   border-radius: 10px;
   background: var(--panel-card);
   border: 1px solid var(--panel-border);
@@ -6194,10 +6504,11 @@ body.player-open {
 }
 
 .studio-shelf-title {
-  grid-area: title;
+  flex: 1;
+  min-width: 0;
   display: block;
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: 0.92rem;
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -66,8 +66,31 @@ export type BuildEvent = {
   createdAt: string;
 };
 
+/**
+ * The build job's own state, finer than {@link SubmissionState}.
+ *
+ * `status` drives the five-step timeline and cannot grow without changing what the
+ * timeline draws; this says which of the several situations behind one step the build
+ * is actually in, so the sentence under the timeline can be true. Absent on builds we
+ * derive from GitHub rather than run ourselves.
+ */
+export type BuildPhase =
+  | 'queued'
+  | 'dispatched'
+  | 'building'
+  | 'submitted'
+  | 'gating'
+  | 'ready_for_review'
+  | 'publishing'
+  | 'published'
+  | 'needs_changes'
+  | 'failed'
+  | 'canceled'
+  | 'abandoned';
+
 export type SubmissionStatus = {
   status: SubmissionState;
+  phase?: BuildPhase;
   slug?: string;
   /** Present while an unmerged PR is open: the game can be previewed from its branch. */
   preview?: { slug: string };

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -335,7 +335,8 @@ export async function submitFeedback(
   return (await response.json()) as { ok: boolean; target: string; shotId?: string };
 }
 
-export async function refineSpec(input: { title: string; concept: string; locale?: string }): Promise<{
+/** What the pre-submission refiner has to say about a concept. */
+export type RefinedSpec = {
   questions: Array<{
     id: string;
     question: string;
@@ -343,7 +344,21 @@ export async function refineSpec(input: { title: string; concept: string; locale
     allowFreeText?: boolean;
     multiple?: boolean;
   }>;
-}> {
+  /**
+   * A name for the game, proposed from the concept. The creator confirms or replaces
+   * it before anything is built; absent when the model had nothing usable to offer,
+   * which is the caller's cue to fall back to a name derived from the prompt.
+   */
+  suggestedTitle?: string;
+};
+
+/**
+ * Asks the refiner to read a concept: name it, and say what it still needs to know.
+ *
+ * `title` is optional and normally omitted — the creator has not been asked for one at
+ * this point in the flow, which is the whole reason `suggestedTitle` comes back.
+ */
+export async function refineSpec(input: { title?: string; concept: string; locale?: string }): Promise<RefinedSpec> {
   const response = await fetch(`${API_BASE}/api/submissions/refine`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -355,13 +370,5 @@ export async function refineSpec(input: { title: string; concept: string; locale
     await throwResponseError(response);
   }
 
-  return (await response.json()) as {
-    questions: Array<{
-      id: string;
-      question: string;
-      options: Array<{ label: string; detail?: string }>;
-      allowFreeText?: boolean;
-      multiple?: boolean;
-    }>;
-  };
+  return (await response.json()) as RefinedSpec;
 }

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -206,7 +206,7 @@ export async function submitSpec(input: {
   displayName?: string;
   /** Told to the agent, so it writes its progress updates in this language. */
   locale?: string;
-}): Promise<{ token: string; statusUrl: string }> {
+}): Promise<{ token: string; slug?: string; statusUrl: string }> {
   const response = await fetch(`${API_BASE}/api/submissions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -217,7 +217,9 @@ export async function submitSpec(input: {
     await throwResponseError(response);
   }
 
-  return (await response.json()) as { token: string; statusUrl: string };
+  // `slug` is the game's address, minted server-side from the confirmed title. Optional
+  // only because an older API deploy answers without one.
+  return (await response.json()) as { token: string; slug?: string; statusUrl: string };
 }
 
 /**

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -62,6 +62,12 @@ export type CreateStep =
   | 'signin_required'
   /** The QA gate returned clarifying questions instead of building immediately. */
   | 'qa_shown'
+  /**
+   * The creator settled on a name and pressed create. The last step they control, and
+   * the one the build waits on — a drop here is someone who wrote an idea, was shown
+   * what it would be called, and walked away.
+   */
+  | 'title_confirmed'
   /** A submission actually reached the games repo. */
   | 'submission_created';
 


### PR DESCRIPTION
Nine points of owner feedback on the creation flow, taken in order. The design and the
decisions behind it are in the ops repo (`docs/creator-studio-ux-proposal.md`); this is
what got built.

Seven commits, each self-contained and green on its own.

## Name the game before building it (`f54187c`)

Games were named by truncation: the hero sent `prompt.slice(0, 40)` as the title and that
string became the name everywhere — the studio, the catalog, the agent's brief. *"A game
tycoon like where I run a tv busi"* is a production example, cut mid-word.

The refiner already reads the concept to write its clarifying questions, so it names it in
the same call at no extra cost. An editable confirm step gates generation — including for a
clean concept, which previously went straight to an agent under a name nobody had seen. When
the refiner fails open the step still happens, on a title cut at a word boundary: the
suggestion degrades, the gate does not.

## Give a game its address when it is created (`d87df09`)

A slug used to be the agent's to choose, learned on its first delivery. Every build had a
stretch where the thing being built had no name a URL could use, which is why the studio
addressed a creator's own game by an HMAC capability token — a grant sitting in the URL bar,
in history, and in every screenshot.

Slugs are now minted at submission from the confirmed title, stored before dispatch, and
named in the agent's brief, whose game directory previously read `games/(the slug named in
your first progress report)/`. Polish titles keep their letters: NFD alone drops `ł`, turning
Łódź into `d`. The studio is `/studio/<slug>/<surface>`; old `/studio/<token>` and
`/status/<token>` links resolve and rewrite themselves onto the slug in place.

## Let creators decide who can play a draft (`629629e`)

`GET /api/drafts/:slug` served any draft to any signed-in visitor who knew a slug, which made
every in-progress game unlisted rather than private. Per the owner's decision there is no
separate draft surface: a game answers at `/play/<slug>` for its whole life, and a switch
decides whether that link works for anyone but its creator. Off by default. Draft responses
stay out of `gameCache` deliberately — it is keyed by slug alone and read before any gate.

## One game, one thread (`d2405fa`, `1667345`)

Three composers were the same act — steer the build, request a change, improve the published
game — and which one a creator was allowed depended on a lifecycle state they had to know in
order to find the right box. There is one now, always aimed at the tip, routed by the state
the server already reports.

The first of these two commits got the semantics right and left the shape wrong; the second
fixed the shape against a reference the owner supplied. Agent turns are prose at full width
with nothing drawn around them; the creator's are quiet bubbles on the other side. The
transcript scrolls in its own pane and sticks to the bottom unless the reader has scrolled
up. Beneath it, fixed: a context bar carrying slug, phase, heartbeat and progress, replacing
a five-step timeline, a progress bar, a pill and a sentence that each said where the build
was while pushing the conversation down the page. The tab strip is gone — details open
beside the thread on a wide screen and over it on a narrow one.

## Honest phase copy and a heartbeat (`17c3746`)

The build pill counted from submission, so a build that had delivered, passed its checks and
been waiting hours read *"In progress for 8h 00m"* above a checklist saying every task was
done. It now shows time since the agent last did something. The job's own state rides on the
status response, so the sentence under the timeline stopped claiming checks were running on
a finished build.

## Tell the loser of a slug race (`44f3206`)

Minting is a read then a write, so two submissions of one title could both be told a name was
free — surfacing much later as two agents delivering into one games-store slug. The claim is
now read back immediately; the loser quietly takes a different name, and losing twice fails
the submission with no dispatch. Deliberately not a lock.

## Verification

`npm run type-check && lint && test && build` green: **1337** API tests, **655** web tests.
New coverage for slug generation and races, draft access, the naming step and its fallback,
the composer's routing, phase copy, and the token→slug URL upgrade.

Also driven by hand against a local dev server — a game created through the real flow, agent
events pushed over the build channel, the share toggle flipped, and an old token URL followed
and watched rewrite itself.

## Worth a reviewer's attention

- **Drafts stop being readable by any signed-in visitor.** Deliberate, and a behaviour change.
- **A first delivery under an unbriefed slug now 409s** where it previously bound. The creator
  has had the address since they pressed create and may have shared it, so renaming on
  delivery would break a link handed out in good faith.
- **Existing games keep agent-chosen slugs.** No migration; the studio falls back to the token
  for any game without one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD3KJLV3broyoVUnu26GDm)_