### PR TITLE
Studio follow-ups: name the games that still have none, and two fixes the first real screenshot found

### DIFF
--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -73,9 +73,14 @@ export interface SubmissionRecord {
   createdAt: string;
   title: string;
   /**
-   * Game directory on the agent's branch, learned the first time a status poll sees
-   * one. It is what makes an in-progress game addressable by slug (like a published
-   * game) instead of only by its capability-granting status token.
+   * The game's permanent address: its directory on the agent's branch, its `/play/`
+   * link, and how the studio names it instead of the capability-granting status token.
+   *
+   * Minted from the confirmed title when the submission is created, so a game has this
+   * before any agent has seen it. Optional only for records that predate that, and for
+   * the crash window between writing a record and setting its slug — both of which the
+   * operator backfill exists to clear. Treat a missing slug as a straggler to be fixed,
+   * not a state to design around.
    */
   slug?: string;
   /**
@@ -1135,6 +1140,19 @@ export interface Store {
    */
   listActiveSubmissions(): Promise<SubmissionRecord[]>;
   /**
+   * Submissions a creator can still see that have no slug — the backfill's work list.
+   *
+   * Every submission has been given a slug at creation since the studio started
+   * addressing games by name, so this is legacy records plus anything that crashed in
+   * the window between the record being written and its slug being set. Oldest first,
+   * so a bounded run works through the backlog in a stable order.
+   *
+   * Abandoned builds are left out deliberately. The shelf hides them, so they are never
+   * addressed by anyone, and minting names for them would reserve every one against the
+   * games that might want it later.
+   */
+  listSubmissionsMissingSlug(): Promise<SubmissionRecord[]>;
+  /**
    * Every submission a creator owns, newest first. Backs the "my games" rail, so a
    * creator finds their work-in-progress without having saved the tracking link
    * (and on a device that never had it in localStorage).
@@ -1893,6 +1911,13 @@ export class InMemoryStore implements Store {
       .map((s) => ({ ...s }));
   }
 
+  async listSubmissionsMissingSlug(): Promise<SubmissionRecord[]> {
+    return Array.from(this.submissions.values())
+      .filter((s) => !s.slug && !s.abandonedAt)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+      .map((s) => ({ ...s }));
+  }
+
   async listSubmissionsByOwner(ownerUid: string, opts?: { limit?: number }): Promise<SubmissionRecord[]> {
     return Array.from(this.submissions.values())
       .filter((s) => s.ownerUid === ownerUid)
@@ -2334,15 +2359,17 @@ export class InMemoryStore implements Store {
     limit?: number;
   }): Promise<SuggestionRecord[]> {
     const wanted = opts?.status ? new Set(opts.status) : null;
-    return [...this.suggestions.values()]
-      .filter((record) => (wanted ? wanted.has(record.status) : true))
-      .filter((record) => (opts?.ownerUid ? record.ownerUid === opts.ownerUid : true))
-      .map((record) => structuredClone(record))
-      .sort(compareSuggestions)
-      // No limit means every match, matching Firestore's paged read. Defaulting to a
-      // number here would make the in-memory store agree with production only while the
-      // collection stayed small — the divergence that hides until it matters.
-      .slice(0, opts?.limit ?? Number.MAX_SAFE_INTEGER);
+    return (
+      [...this.suggestions.values()]
+        .filter((record) => (wanted ? wanted.has(record.status) : true))
+        .filter((record) => (opts?.ownerUid ? record.ownerUid === opts.ownerUid : true))
+        .map((record) => structuredClone(record))
+        .sort(compareSuggestions)
+        // No limit means every match, matching Firestore's paged read. Defaulting to a
+        // number here would make the in-memory store agree with production only while the
+        // collection stayed small — the divergence that hides until it matters.
+        .slice(0, opts?.limit ?? Number.MAX_SAFE_INTEGER)
+    );
   }
 
   async listGameSlugs(): Promise<string[]> {
@@ -3003,6 +3030,18 @@ export class FirestoreStore implements Store {
       .filter(
         (s) => !s.abandonedAt && s.lastNotifiedStatus !== 'published' && s.lastNotifiedStatus !== 'needs_changes',
       );
+  }
+
+  async listSubmissionsMissingSlug(): Promise<SubmissionRecord[]> {
+    // Firestore cannot ask for documents where a field is absent, so this is the same
+    // full scan and client-side filter as listActiveSubmissions above, for the same
+    // reason: the collection is small and the alternative is a sentinel field written
+    // to every record just so this one query can exist.
+    const snap = await this.db.collection('submissions').get();
+    return snap.docs
+      .map((d) => d.data() as SubmissionRecord)
+      .filter((s) => !s.slug && !s.abandonedAt)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
   async listSubmissionsByOwner(ownerUid: string, opts?: { limit?: number }): Promise<SubmissionRecord[]> {
@@ -3672,7 +3711,6 @@ export class FirestoreStore implements Store {
       .get();
     return snap.docs.map((doc) => doc.data() as Scorecard).sort(compareScorecards);
   }
-
 
   async listGameSlugs(): Promise<string[]> {
     // `listDocuments()` rather than `get()`: it lists references without reading

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -3011,3 +3011,99 @@ describe('operator health re-gate', () => {
     await app.close();
   });
 });
+
+describe('operator slug backfill', () => {
+  const bossHeaders = () => getAuthHeaders('g:boss');
+
+  /** An app with an operator, plus whatever slug-less records a test asks for. */
+  async function appWithLegacyRecords(titles: string[]) {
+    const { app, store } = await createApp({ adminUids: 'g:boss' });
+    await store.upsertUser({ uid: 'g:boss' });
+    // createSubmission is what the flow used to do on its own: a record, no slug. It is
+    // the exact shape of every game that predates minting at submission.
+    let issueNumber = 500;
+    for (const title of titles) await store.createSubmission(issueNumber++, 'g:test-user', title);
+    return { app, store };
+  }
+
+  it('answers 404 to a non-operator, the same as every operator surface', async () => {
+    const { app } = await appWithLegacyRecords(['Space Miner']);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/slug-backfill',
+      headers: getAuthHeaders('g:someone-else'),
+    });
+
+    expect(response.statusCode).toBe(404);
+    await app.close();
+  });
+
+  it('gives every slug-less game an address derived from its title', async () => {
+    const { app, store } = await appWithLegacyRecords(['Space Miner', 'Łódź Nights']);
+
+    const response = await app.inject({ method: 'POST', url: '/api/admin/slug-backfill', headers: bossHeaders() });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ ok: true, dryRun: false, scanned: 2, named: 2, failed: 0 });
+    expect((await store.getSubmission(500))?.slug).toBe('space-miner');
+    // The Polish letter survives: NFD alone would drop it and leave 'dz-nights'.
+    expect((await store.getSubmission(501))?.slug).toBe('lodz-nights');
+
+    await app.close();
+  });
+
+  it('reports what it would do without writing anything, when asked to rehearse', async () => {
+    const { app, store } = await appWithLegacyRecords(['Space Miner']);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/slug-backfill?dryRun=1',
+      headers: bossHeaders(),
+    });
+
+    expect(response.json()).toMatchObject({ dryRun: true, scanned: 1, named: 1 });
+    expect(response.json().games).toEqual([{ issueNumber: 500, title: 'Space Miner', slug: 'space-miner' }]);
+    expect((await store.getSubmission(500))?.slug).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('does not promise one name to two games, even in a rehearsal that writes nothing', async () => {
+    const { app } = await appWithLegacyRecords(['Space Miner', 'Space Miner']);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/slug-backfill?dryRun=1',
+      headers: bossHeaders(),
+    });
+
+    // Without an in-run ledger both would be told 'space-miner', and the rehearsal would
+    // be reporting an outcome the real run could not produce.
+    expect(response.json().games.map((game: { slug: string }) => game.slug)).toEqual(['space-miner', 'space-miner-2']);
+
+    await app.close();
+  });
+
+  it('leaves abandoned builds alone rather than reserving names for them', async () => {
+    const { app, store } = await appWithLegacyRecords(['Space Miner']);
+    await store.setSubmissionAbandoned(500, new Date().toISOString());
+
+    const response = await app.inject({ method: 'POST', url: '/api/admin/slug-backfill', headers: bossHeaders() });
+
+    expect(response.json()).toMatchObject({ scanned: 0, named: 0 });
+    expect((await store.getSubmission(500))?.slug).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('finds nothing to do on a second run', async () => {
+    const { app } = await appWithLegacyRecords(['Space Miner']);
+
+    await app.inject({ method: 'POST', url: '/api/admin/slug-backfill', headers: bossHeaders() });
+    const second = await app.inject({ method: 'POST', url: '/api/admin/slug-backfill', headers: bossHeaders() });
+
+    expect(second.json()).toMatchObject({ scanned: 0, named: 0, failed: 0 });
+    await app.close();
+  });
+});

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2268,6 +2268,63 @@ export async function registerSubmissionRoutes(
     return reply.send({ ok: true, slug, version: start.version, ...(start.buildId ? { buildId: start.buildId } : {}) });
   });
 
+  /**
+   * Gives an address to every game still missing one.
+   *
+   * A slug is minted at submission now, so this exists for the records that predate
+   * that and for anything that died between the record being written and its slug
+   * being set. Those games still work — the studio addresses them by status token —
+   * but a token in the URL bar is the thing slugs were introduced to stop, and a
+   * fallback nobody sweeps up is a fallback that becomes permanent.
+   *
+   * An operator button rather than a scheduled sweep: the backlog is finite and
+   * shrinking, so a nightly job would spend most of its life finding nothing. Run it
+   * with `?dryRun=1` first — that reports exactly what it would name each game and
+   * writes nothing.
+   *
+   * Sequential on purpose. Each mint asks the store what is taken, so the previous
+   * write has to be visible before the next candidate is judged; running these
+   * concurrently would reintroduce the race the claim read-back exists to settle.
+   */
+  app.post<{ Querystring: { dryRun?: string } }>('/api/admin/slug-backfill', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+    if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+
+    const dryRun = request.query.dryRun === '1' || request.query.dryRun === 'true';
+    const pending = await store.listSubmissionsMissingSlug();
+
+    // Names handed out earlier in this run. Redundant on the write path, where the store
+    // already knows, and load-bearing on the dry run, where nothing is written and two
+    // games with the same title would otherwise both be promised the same slug.
+    const mintedHere = new Set<string>();
+    const games: Array<{ issueNumber: number; title: string; slug: string | null }> = [];
+
+    for (const record of pending) {
+      const isTaken = async (candidate: string): Promise<boolean> =>
+        mintedHere.has(candidate) || (await isSlugClaimed(candidate, record.issueNumber));
+      const wanted = await mintGameSlug(record.title, isTaken);
+
+      if (dryRun) {
+        mintedHere.add(wanted);
+        games.push({ issueNumber: record.issueNumber, title: record.title, slug: wanted });
+        continue;
+      }
+
+      await store.setSubmissionSlug(record.issueNumber, wanted);
+      // Same read-back as submission creation: the write is a claim, not a grant.
+      const settled = await confirmSlugClaim(record.issueNumber, wanted, record.title);
+      if (settled) mintedHere.add(settled);
+      games.push({ issueNumber: record.issueNumber, title: record.title, slug: settled });
+    }
+
+    const named = games.filter((game) => game.slug !== null).length;
+    const result = { ok: true, dryRun, scanned: pending.length, named, failed: pending.length - named, games };
+    // Logged as well as returned: this changes permanent addresses, and the response
+    // goes to one browser tab that may not be open the next time anyone asks what ran.
+    request.log.info({ dryRun, scanned: result.scanned, named, failed: result.failed }, 'slug backfill complete');
+    return reply.send(result);
+  });
+
   // The notification sweep (docs/notifications-plan.md N1): the closed-tab backstop
   // for the opportunistic poll-path detection above. Cloud Scheduler POSTs here with
   // an OIDC token; we derive the current status of every still-active submission and

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -879,8 +879,20 @@ function FeedbackPanel({
   const [text, setText] = useState('');
   const [state, setState] = useState<'idle' | 'sending' | 'sent'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const trimmed = text.trim();
+
+  // The composer grows with what is typed, which is what replaced the resize grip: once
+  // the send button moved inside the box, a drag handle in the middle of its right edge
+  // read as a rendering fault. Capped, so a long message scrolls instead of pushing the
+  // conversation off the top of the screen.
+  const autoGrow = () => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 220)}px`;
+  };
 
   const send = async () => {
     if (trimmed.length < 10) return;
@@ -893,6 +905,9 @@ function FeedbackPanel({
       else await submitFeedback(token, trimmed);
       setState('sent');
       setText('');
+      // Back to the CSS height rather than the height the sent message grew it to: an
+      // empty box the size of the last paragraph is a leftover, not a state.
+      if (inputRef.current) inputRef.current.style.height = '';
       // Echo it into the activity feed straight away: the API only sees it once the
       // comment round-trips through GitHub, which is a poll or two away.
       onSent(trimmed);
@@ -933,10 +948,12 @@ function FeedbackPanel({
     return (
       <div className="status-feedback status-composer is-compact">
         <textarea
+          ref={inputRef}
           className="status-feedback-input"
           value={text}
           onChange={(event) => {
             setText(event.target.value);
+            autoGrow();
             if (state === 'sent') setState('idle');
           }}
           placeholder={t(hintKey)}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4155,20 +4155,47 @@ body.player-open {
   font-size: 0.82rem;
 }
 
+/* One control, not a field with a button parked under it.
+   The border used to be on the textarea, which left the send button floating in the gap
+   below with nothing tying the two together. Moving it out here makes the box the thing
+   you focus and the button something inside it — and the focus ring, now on the box,
+   covers both. */
 .status-composer.is-compact {
   margin: 0;
-  padding: 0;
-  border: 0;
-  background: none;
+  padding: 7px 8px 8px 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  background: var(--panel-card);
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.status-composer.is-compact:focus-within {
+  border-color: rgba(0, 228, 172, 0.5);
+  box-shadow: 0 0 0 3px rgba(0, 228, 172, 0.08);
 }
 
 .status-composer.is-compact .status-feedback-input {
   width: 100%;
-  border-radius: 12px;
-  resize: vertical;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  padding: 4px 2px;
+  /* The box grows with the text instead (see autoGrow). A drag handle sitting in the
+     middle of the composer's right edge, now that the border belongs to the box rather
+     than the field, looked like something had gone wrong. */
+  resize: none;
+  overflow-y: auto;
   /* The placeholder says where the message will land, which is two lines of text on a
      phone; at two rows it was cut off mid-sentence. */
   min-height: 5.25rem;
+}
+
+.status-composer.is-compact .status-feedback-input:focus {
+  /* The ring belongs to the box now — two of them nested looked like a bug. */
+  outline: none;
+  box-shadow: none;
 }
 
 .status-composer.is-compact .status-feedback-actions {
@@ -4176,7 +4203,14 @@ body.player-open {
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
-  margin-top: 8px;
+  margin-top: 2px;
+}
+
+/* Sized down to sit inside the composer rather than under it. */
+.status-composer.is-compact .status-feedback-actions .primary-btn {
+  padding: 7px 15px;
+  font-size: 0.84rem;
+  border-radius: 9px;
 }
 
 .status-composer.is-compact .status-feedback-actions .error {
@@ -6501,13 +6535,22 @@ body.player-open {
   background: rgba(0, 228, 172, 0.04);
 }
 
-.studio-shelf-item.is-active {
-  border-color: rgba(0, 228, 172, 0.45);
-  box-shadow: 0 0 14px rgba(0, 228, 172, 0.1);
-}
-
 .studio-shelf-item.is-live {
   border-color: rgba(45, 212, 191, 0.35);
+}
+
+/* Deliberately after .is-live, and deliberately more than a border tint.
+   Almost every game in a shelf is building or just built, so a selected state made of
+   the same turquoise border as the status lost to the rule below it and read as "all of
+   these are the same" — which is what the shelf is for denying. The fill and the left
+   marker are what say *here*, and they hold whatever the game's status is. */
+.studio-shelf-item.is-active,
+.studio-shelf-item.is-active:hover {
+  border-color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.12);
+  box-shadow:
+    inset 3px 0 0 var(--turquoise),
+    0 0 14px rgba(0, 228, 172, 0.1);
 }
 
 .studio-shelf-status {


### PR DESCRIPTION
Follow-up to #368, from watching it run for real. Two commits, each green on its own.

## Give an address to the games that still have none (`4bebc0e`)

A slug has been minted at submission since #368, so a record without one is either older
than that or died in the window between being written and having its slug set. Those games
still work — the studio addresses them by capability token — but that fallback is the exact
thing slugs were introduced to get out of the URL bar, and a fallback nobody ever sweeps up
is one that becomes permanent.

`POST /api/admin/slug-backfill` names every game still missing one, minting from the title
through the same path submission uses, claim read-back included. `?dryRun=1` reports exactly
what it would call each game and writes nothing.

Three things worth knowing about how it runs:

- **Sequential, not fanned out.** Each mint asks the store what is taken, so the previous
  write has to be visible before the next candidate is judged. Concurrency here would
  reintroduce the race the read-back exists to settle.
- **The dry run keeps its own ledger of names promised so far.** Without it, two games
  sharing a title would both be told they get the same slug, and the rehearsal would be
  describing an outcome the real run cannot produce.
- **Abandoned builds are skipped.** The shelf hides them, so nobody ever needs to address
  one, and naming them would reserve each of those names against the games that might want
  them later.

An operator action rather than a scheduled sweep: the backlog is finite and shrinking, so a
nightly job would spend almost all of its life finding nothing.

The `slug` field's doc comment went with it — it still said slugs were learned from the first
status poll, which stopped being true one PR ago.

## Show which game is open, and make the composer one control (`6f2a2cf`)

Both of these were visible in the first screenshot of the merged studio running against real
data, and neither showed up in the ones taken while building it.

**The shelf did not say which game you were reading.** The selected row was marked by tinting
its border turquoise — and the rule for a game that is *building* tints the same border the
same colour, one line further down the stylesheet, so it won every time. Almost every game in
a shelf is building or just built, which made the selected state invisible in exactly the case
it exists for. It is a fill and a left marker now, and it sits after the status rule rather
than before it.

**The send button sat under the composer with a gap between them, belonging to nothing.** The
border was on the textarea, so the button was outside the only box on screen. Moving the
border out to the wrapper makes the field and the button one control, and the focus ring now
lights the box rather than the field inside it.

That left a resize grip floating in the middle of the box's right edge, which read as a
rendering fault, so the composer grows with what is typed instead — capped, so a long message
scrolls rather than pushing the conversation off the top of the screen, and reset on send
rather than leaving an empty box the height of the paragraph that just left it.

## Verification

`npm run type-check && lint && test && build` green: **1454** API tests (6 new, covering the
operator guard, the mint, the rehearsal, the in-run collision, the abandoned skip, and a
second run finding nothing), **695** web tests.

Also driven by hand against a local dev server with a seeded shelf — the selected row checked
against a real two-game shelf, and the composer checked empty, focused and typed-into. The
collision path confirmed itself by accident along the way: re-running the seed produced
`…-tv-business-2`.

## Worth a reviewer's attention

- **The backfill writes permanent addresses.** Idempotent and re-runnable, but the intended
  first call is `?dryRun=1`.
- **The token fallback stays.** The crash window is narrow but real, so this is a safety net
  the backfill sweeps up behind — not dead code to delete yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD3KJLV3broyoVUnu26GDm)_