### PR TITLE
Fix Google sign-in flash that jumps Apple login on the beta splash

### DIFF
--- a/apps/web/src/GoogleSignInButton.test.tsx
+++ b/apps/web/src/GoogleSignInButton.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The GIS widget must paint once and stay put. Inline onError from ClosedBetaSplash
+ * (and a fresh signInWithGoogleToken from AuthProvider after a rejected One Tap) used
+ * to re-run the init effect, wipe the container, and shove the Apple button below it.
+ */
+
+const auth = vi.hoisted(() => ({
+  signInWithGoogleToken: vi.fn(async () => {
+    throw new Error('private beta — sign-ups are closed');
+  }),
+}));
+
+vi.mock('./AuthContext.js', () => ({ useAuth: () => auth }));
+
+type GisApi = {
+  initialize: ReturnType<typeof vi.fn>;
+  renderButton: ReturnType<typeof vi.fn>;
+  prompt: ReturnType<typeof vi.fn>;
+  disableAutoSelect: ReturnType<typeof vi.fn>;
+  callback: ((res: { credential: string }) => void) | null;
+};
+
+let gis: GisApi;
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  gis = {
+    initialize: vi.fn((config: { callback: (res: { credential: string }) => void }) => {
+      gis.callback = config.callback;
+    }),
+    renderButton: vi.fn((parent: HTMLElement) => {
+      const marker = document.createElement('span');
+      marker.dataset.gis = 'btn';
+      parent.appendChild(marker);
+    }),
+    prompt: vi.fn(),
+    disableAutoSelect: vi.fn(),
+    callback: null,
+  };
+
+  (globalThis as unknown as { google: unknown }).google = {
+    accounts: { id: gis },
+  };
+
+  auth.signInWithGoogleToken = vi.fn(async () => {
+    throw new Error('private beta — sign-ups are closed');
+  });
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  delete (globalThis as { google?: unknown }).google;
+  vi.restoreAllMocks();
+});
+
+describe('GoogleSignInButton', () => {
+  it('reserves a fixed slot so the Apple button below does not jump before GIS paints', async () => {
+    const { GoogleSignInButton } = await import('./GoogleSignInButton.js');
+
+    await act(async () => {
+      root.render(createElement(GoogleSignInButton));
+    });
+
+    const slot = container.querySelector('.google-sign-in-container');
+    expect(slot).not.toBeNull();
+    // Dimensions live in CSS; the class is the contract the stylesheet sizes.
+    expect(slot?.className).toBe('google-sign-in-container');
+  });
+
+  it('does not wipe and re-render the GIS button when the parent passes a new onError', async () => {
+    const { GoogleSignInButton } = await import('./GoogleSignInButton.js');
+
+    function Host() {
+      const [tick, setTick] = useState(0);
+      return createElement(
+        'div',
+        null,
+        createElement(GoogleSignInButton, {
+          // New function identity every render — the bug that cleared the widget.
+          onError: () => {
+            void tick;
+          },
+        }),
+        createElement('button', { type: 'button', id: 'rerender', onClick: () => setTick((n) => n + 1) }, 'x'),
+      );
+    }
+
+    await act(async () => {
+      root.render(createElement(Host));
+    });
+
+    expect(gis.renderButton).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-gis="btn"]')).not.toBeNull();
+
+    await act(async () => {
+      container.querySelector('#rerender')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(gis.renderButton).toHaveBeenCalledTimes(1);
+    expect(gis.initialize).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-gis="btn"]')).not.toBeNull();
+  });
+
+  it('keeps the painted button after a rejected One Tap updates parent state', async () => {
+    const { GoogleSignInButton } = await import('./GoogleSignInButton.js');
+
+    function Host() {
+      const [, setErr] = useState<string | null>(null);
+      return createElement(GoogleSignInButton, {
+        onError: (msg) => setErr(msg),
+      });
+    }
+
+    await act(async () => {
+      root.render(createElement(Host));
+    });
+
+    expect(gis.callback).not.toBeNull();
+    expect(gis.renderButton).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await gis.callback!({ credential: 'tok' });
+    });
+
+    expect(gis.disableAutoSelect).toHaveBeenCalled();
+    // Parent setState from onError must not trigger a second renderButton / blank flash.
+    expect(gis.renderButton).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-gis="btn"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/GoogleSignInButton.tsx
+++ b/apps/web/src/GoogleSignInButton.tsx
@@ -31,7 +31,20 @@ interface GoogleSignInButtonProps {
 export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonProps) {
   const { signInWithGoogleToken } = useAuth();
   const buttonRef = useRef<HTMLDivElement>(null);
+  const rendered = useRef(false);
   const [scriptLoaded, setScriptLoaded] = useState(false);
+
+  // Callers pass inline lambdas (ClosedBetaSplash, AuthModal). Putting those in the
+  // GIS effect deps cleared the button on every parent re-render — empty flash, then
+  // paint again — which shoved the Apple button below it. Same for the auth context
+  // function, which is recreated whenever AuthProvider updates (e.g. waitlist status
+  // after a rejected One Tap). Hold the latest values in refs and init GIS once.
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+  const signInRef = useRef(signInWithGoogleToken);
+  onSuccessRef.current = onSuccess;
+  onErrorRef.current = onError;
+  signInRef.current = signInWithGoogleToken;
 
   useEffect(() => {
     if (window.google?.accounts?.id) {
@@ -44,14 +57,15 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
     script.async = true;
     script.defer = true;
     script.onload = () => setScriptLoaded(true);
-    script.onerror = () => onError?.('Failed to load Google Identity Services');
+    script.onerror = () => onErrorRef.current?.('Failed to load Google Identity Services');
     document.body.appendChild(script);
-  }, [onError]);
+  }, []);
 
   useEffect(() => {
-    if (!scriptLoaded || !buttonRef.current || !window.google?.accounts?.id) {
+    if (!scriptLoaded || !buttonRef.current || !window.google?.accounts?.id || rendered.current) {
       return;
     }
+    rendered.current = true;
 
     const clientId = (import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID as string) || undefined;
 
@@ -60,12 +74,12 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
       auto_select: true,
       callback: async (response) => {
         try {
-          await signInWithGoogleToken(response.credential);
-          onSuccess?.();
+          await signInRef.current(response.credential);
+          onSuccessRef.current?.();
         } catch (err) {
           window.google?.accounts?.id?.disableAutoSelect?.();
           const message = err instanceof Error ? err.message : 'Sign in failed';
-          onError?.(message, response.credential);
+          onErrorRef.current?.(message, response.credential);
         }
       },
     });
@@ -85,7 +99,8 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
       width: 240,
     });
     window.google.accounts.id.prompt();
-  }, [scriptLoaded, signInWithGoogleToken, onSuccess, onError]);
+  }, [scriptLoaded]);
 
+  // Width/height reserved in CSS before GIS paints — see `.google-sign-in-container`.
   return <div ref={buttonRef} className="google-sign-in-container" />;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3516,6 +3516,16 @@ body.player-open {
   margin-top: 16px;
 }
 
+/* GIS paints asynchronously into this node. Without a reserved slot the Apple button
+   below starts at the top of the stack and jumps down when the iframe arrives — and
+   jumped again whenever a parent re-render used to wipe and re-render the widget. */
+.google-sign-in-container {
+  width: 240px;
+  height: 40px;
+  /* GIS's iframe is display:inline-block; keep the slot from collapsing while empty. */
+  line-height: 0;
+}
+
 .auth-error-banner {
   background: rgba(255, 107, 107, 0.15);
   border: 1px solid var(--error);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the closed-beta splash, the Google sign-in control flashed empty and the Apple button jumped.

Two causes:

1. **Unstable GIS init** — `GoogleSignInButton` re-ran `initialize` / wiped `innerHTML` / `renderButton` whenever the parent re-rendered. `ClosedBetaSplash` passes an inline `onError`, and `AuthProvider` recreates `signInWithGoogleToken` on updates (e.g. waitlist status after a rejected One Tap). That cleared the widget and painted it again.
2. **No reserved slot** — the Google container started at zero height, so Apple sat at the top of the stack until GIS painted, then jumped down.

## Fix

- Hold callbacks / `signInWithGoogleToken` in refs and initialize GIS once.
- Reserve a fixed `240×40` `.google-sign-in-container` so the Apple button never shifts on first paint.

## Screenshot

Local beta splash after the fix — Google slot is reserved at 240×40; Apple sits stably below it (no jump on paint / re-render):

[Beta splash sign-in buttons](https://cursor.com/agents/bc-019fb751-322f-7a21-9575-eff5ff837639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbeta-splash-signin.png)

## Tests

- New `GoogleSignInButton.test.tsx`: parent re-render and rejected One Tap must not call `renderButton` again.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb751-322f-7a21-9575-eff5ff837639?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb751-322f-7a21-9575-eff5ff837639&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

