### PR TITLE
Show Join waitlist before sign-in, with telemetry on the operator funnel

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -128,13 +128,20 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
   `GET /api/admin/telemetry/visits`, rendered by `VisitFunnelPanel` beside game health
   on the operator page. Both admin reads share one partition-scan budget, so the two
   views cannot drift in how they report truncation.
-- ~~Creator funnel starts too late~~ — **closed 2026-07-26**: `create_step` on the visit
+  - ~~Creator funnel starts too late~~ — **closed 2026-07-26**: `create_step` on the visit
   stream records `prompt_started` → `spec_submitted` → `signin_required` → `qa_shown` →
   `submission_created`. Steps dedupe per visit (a rung means "this visit got this far"),
   and the aggregate dedupes again so a replayed flush cannot inflate one. Adding a rung
   means touching the enum in `visitTelemetry.ts`, the zod enum in `visit-telemetry.ts`,
   and `CREATE_STEPS` in `visit-funnel.ts` — the order in `CREATE_STEPS` _is_ the funnel's
   meaning.
+- ~~Closed-beta waitlist funnel unmeasured~~ — **closed 2026-07-31**: `waitlist_step` on
+  the visit stream records `cta_clicked` → `joined`. Same three-place enum contract as
+  `create_step` (`visitTelemetry.ts`, `visit-telemetry.ts`, `WAITLIST_STEPS` in
+  `visit-funnel.ts`); rendered as a Waitlist block on `VisitFunnelPanel` beside Creating.
+  The Join CTA is visible before sign-in; the drop between click and join *is* the
+  sign-in wall, so there is no separate `signin_required` rung (that name already means
+  the creation wall).
 - ~~Creator return is under-measured~~ — **closed 2026-07-26**: `User.activeDays` (a
   capped list of `yyyy-mm-dd`, touched once per account per day from the auth hook)
   plus `summarizeCreatorMetrics` behind `GET /api/admin/telemetry/creators`. Use a list

--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -134,7 +134,8 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
   and the aggregate dedupes again so a replayed flush cannot inflate one. Adding a rung
   means touching the enum in `visitTelemetry.ts`, the zod enum in `visit-telemetry.ts`,
   and `CREATE_STEPS` in `visit-funnel.ts` — the order in `CREATE_STEPS` _is_ the funnel's
-  meaning.
+  meaning. The waitlist funnel (`waitlist_step` / `WAITLIST_STEPS`) follows the same
+  three-place contract beside it.
 - ~~Closed-beta waitlist funnel unmeasured~~ — **closed 2026-07-31**: `waitlist_step` on
   the visit stream records `cta_clicked` → `joined`. Same three-place enum contract as
   `create_step` (`visitTelemetry.ts`, `visit-telemetry.ts`, `WAITLIST_STEPS` in

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -454,7 +454,7 @@ export interface TelemetryEvent {
 export interface VisitEvent {
   /** Per-tab uuid from `sessionStorage`. Dies with the tab; never a uid. */
   visitId: string;
-  type: 'visit_started' | 'route_viewed' | 'play_started' | 'create_step';
+  type: 'visit_started' | 'route_viewed' | 'play_started' | 'create_step' | 'waitlist_step';
   /** Server-anchored instant, derived like `TelemetryEvent.at`. */
   at: string;
   /** Milliseconds from visit start — the trustworthy measure of within-visit timing. */
@@ -463,7 +463,7 @@ export interface VisitEvent {
   entry?: string;
   /** `route_viewed`: the route kind now shown. Never its parameters. */
   route?: string;
-  /** `create_step`: which step of the creation funnel this visit reached. */
+  /** `create_step` / `waitlist_step`: which funnel step this visit reached. */
   step?: string;
   /** `visit_started`: bare hostname of an external referrer. Never a full URL. */
   referrer?: string;

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -136,10 +136,46 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.creating[0]).toEqual({ step: 'prompt_started', visits: 1 });
   });
 
+  it('reports the waitlist funnel in step order, zeroes included', () => {
+    const step = (visitId: string, step: string): VisitEvent =>
+      ({ visitId, type: 'waitlist_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step }) as VisitEvent;
+
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      step('a', 'cta_clicked'),
+      step('a', 'joined'),
+      started('b'),
+      step('b', 'cta_clicked'),
+      started('c'),
+    ]);
+
+    expect(funnel.waitlist).toEqual([
+      { step: 'cta_clicked', visits: 2 },
+      { step: 'joined', visits: 1 },
+    ]);
+  });
+
+  it('keeps waitlist and create steps from colliding', () => {
+    // Both event types share the `step` field on the wire; a shared Set would make a
+    // waitlist click look like a create step if the names ever overlapped.
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      { visitId: 'a', type: 'waitlist_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step: 'cta_clicked' },
+      { visitId: 'a', type: 'create_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 1, step: 'prompt_started' },
+    ]);
+    expect(funnel.waitlist[0]).toEqual({ step: 'cta_clicked', visits: 1 });
+    expect(funnel.creating[0]).toEqual({ step: 'prompt_started', visits: 1 });
+    expect(funnel.waitlist.find((row) => row.step === 'joined')?.visits).toBe(0);
+  });
+
   it('survives a window with no events at all', () => {
     const funnel = summarizeVisitFunnel([]);
     expect(funnel).toMatchObject({ visits: 0, bounces: 0, plays: 0, medianPlaysPerPlayingVisit: 0 });
     expect(funnel.entries).toEqual([]);
+    expect(funnel.waitlist).toEqual([
+      { step: 'cta_clicked', visits: 0 },
+      { step: 'joined', visits: 0 },
+    ]);
   });
 
   it('counts a visit whose landing event fell outside the window', () => {

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -62,6 +62,11 @@ export interface VisitFunnel {
    * step where everyone stopped.
    */
   creating: Array<{ step: CreateStep; visits: number }>;
+  /**
+   * The closed-beta waitlist funnel, always in step order and always with every step
+   * present — including zeroes. Same posture as `creating`.
+   */
+  waitlist: Array<{ step: WaitlistStep; visits: number }>;
 }
 
 /** Step order is the funnel's meaning, so it is declared once and reused. */
@@ -76,10 +81,16 @@ export const CREATE_STEPS = [
 
 export type CreateStep = (typeof CREATE_STEPS)[number];
 
+export const WAITLIST_STEPS = ['cta_clicked', 'joined'] as const;
+
+export type WaitlistStep = (typeof WAITLIST_STEPS)[number];
+
 interface VisitRollup {
   started: boolean;
   /** Creation steps this visit reached. A Set, so a repeated step counts once. */
   steps: Set<string>;
+  /** Waitlist steps this visit reached. Separate from create so the two funnels cannot collide. */
+  waitlistSteps: Set<string>;
   entry?: string;
   referrer?: string;
   utmSource?: string;
@@ -108,7 +119,12 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
   const visits = new Map<string, VisitRollup>();
 
   for (const event of events) {
-    const rollup = visits.get(event.visitId) ?? { started: false, plays: 0, steps: new Set<string>() };
+    const rollup = visits.get(event.visitId) ?? {
+      started: false,
+      plays: 0,
+      steps: new Set<string>(),
+      waitlistSteps: new Set<string>(),
+    };
 
     if (event.type === 'visit_started') {
       rollup.started = true;
@@ -121,6 +137,8 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       // The client already dedupes, but a Set here means a replayed or duplicated
       // flush cannot inflate a funnel rung either.
       if (event.step) rollup.steps.add(event.step);
+    } else if (event.type === 'waitlist_step') {
+      if (event.step) rollup.waitlistSteps.add(event.step);
     } else if (event.type === 'play_started') {
       rollup.plays += 1;
       // Earliest wins: a flush can deliver events out of order, and "time to first
@@ -204,6 +222,10 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     creating: CREATE_STEPS.map((step) => ({
       step,
       visits: rollups.filter((rollup) => rollup.steps.has(step)).length,
+    })),
+    waitlist: WAITLIST_STEPS.map((step) => ({
+      step,
+      visits: rollups.filter((rollup) => rollup.waitlistSteps.has(step)).length,
     })),
   };
 }

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -169,6 +169,26 @@ describe('POST /api/telemetry/visit', () => {
     expect(bad.statusCode).toBe(400);
   });
 
+  it('records a waitlist step and rejects one outside the enum', async () => {
+    const ok = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'waitlist_step', step: 'cta_clicked', msSinceStart: 0 }],
+    });
+    expect(ok.statusCode).toBe(202);
+    expect((await store.listVisitEvents(today()))[0]).toMatchObject({
+      type: 'waitlist_step',
+      step: 'cta_clicked',
+    });
+
+    const bad = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'waitlist_step', step: 'emailed_us', msSinceStart: 0 }],
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
   it('rejects an oversized batch', async () => {
     const response = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -54,6 +54,11 @@ const CreateStepSchema = z.enum([
   'submission_created',
 ]);
 /**
+ * Closed-beta waitlist funnel. Same closed-enum posture as create steps: the value
+ * reaches a grouping key on an open endpoint.
+ */
+const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
+/**
  * Acquisition strings are re-validated here rather than trusted from the client. The
  * browser filters them for cleanliness; this filters them because a value that reaches a
  * grouping key must not be able to carry punctuation, markup, or an address.
@@ -84,6 +89,7 @@ const EventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('route_viewed'), route: RouteKindSchema, ...offsetField }),
   z.object({ type: z.literal('play_started'), ...offsetField }),
   z.object({ type: z.literal('create_step'), step: CreateStepSchema, ...offsetField }),
+  z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
 ]);
 
 const RequestSchema = z.object({
@@ -174,6 +180,7 @@ export async function registerVisitTelemetryRoutes(
         case 'route_viewed':
           return { ...base, type: event.type, route: event.route };
         case 'create_step':
+        case 'waitlist_step':
           return { ...base, type: event.type, step: event.step };
         default:
           return { ...base, type: 'play_started' };

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider } from './AuthContext.js';
 import { ClosedBetaSplash } from './ClosedBetaSplash.js';
 import i18n from './i18n/index.js';
+import { setVisitSessionForTesting, VisitSession } from './visitTelemetry.js';
 
 import { AppLoadingScreen } from './AppLoadingScreen.js';
 
@@ -19,6 +20,7 @@ describe('ClosedBetaSplash', () => {
     document.body.innerHTML = '';
     vi.restoreAllMocks();
     delete (globalThis as { google?: unknown }).google;
+    setVisitSessionForTesting(null);
   });
 
   it('renders the full screen AppLoadingScreen component', async () => {
@@ -39,7 +41,7 @@ describe('ClosedBetaSplash', () => {
     await act(async () => root.unmount());
   });
 
-  it('signed-out visitor sees the Google sign-in button', async () => {
+  it('signed-out visitor sees Join waitlist before sign-in', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
@@ -60,8 +62,14 @@ describe('ClosedBetaSplash', () => {
       await flushEffects();
     });
 
+    const joinButton = container.querySelector<HTMLButtonElement>('#btn-join-waitlist');
+    expect(joinButton).not.toBeNull();
+    expect(joinButton?.textContent).toMatch(/waitlist/i);
     expect(container.querySelector('.google-sign-in-container')).not.toBeNull();
-    expect(container.querySelector('#btn-join-waitlist')).toBeNull();
+    // Join sits above the sign-in buttons in the DOM.
+    const waitlist = container.querySelector('.beta-splash__waitlist');
+    const signin = container.querySelector('.beta-splash__signin');
+    expect(waitlist?.compareDocumentPosition(signin!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
     expect(mascot).not.toBeNull();
     expect(mascot?.getAttribute('aria-label')).toMatch(/poke|szturchnij/i);
@@ -69,7 +77,130 @@ describe('ClosedBetaSplash', () => {
     await act(async () => root.unmount());
   });
 
-  it('a rejected sign-in shows the waitlist CTA, and joining shows confirmation', async () => {
+  it('Join without a token asks for sign-in and does not POST yet', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const sent: unknown[] = [];
+    const session = new VisitSession('11111111-1111-4111-8111-111111111111', 0, (body) => sent.push(body));
+    setVisitSessionForTesting(session);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) return new Response(JSON.stringify({}), { status: 401 });
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: true }));
+      }
+      if (url.endsWith('/api/waitlist')) {
+        throw new Error('waitlist must not be called before sign-in');
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(ClosedBetaSplash)));
+      await flushEffects();
+    });
+
+    const joinButton = container.querySelector<HTMLButtonElement>('#btn-join-waitlist');
+    await act(async () => {
+      joinButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.beta-splash__signin-hint')?.textContent).toMatch(/Sign in/i);
+    session.flush();
+    const flush = sent[0] as { events: Array<{ type: string; step?: string }> };
+    expect(flush.events).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'waitlist_step', step: 'cta_clicked' })]),
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it('Join then rejected sign-in auto-joins and records both funnel steps', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    let capturedCallback: ((res: { credential: string }) => void) | null = null;
+    const sent: unknown[] = [];
+    const session = new VisitSession('22222222-2222-4222-8222-222222222222', 0, (body) => sent.push(body));
+    setVisitSessionForTesting(session);
+
+    (globalThis as unknown as { google: unknown }).google = {
+      accounts: {
+        id: {
+          initialize: (config: { callback: (res: { credential: string }) => void }) => {
+            capturedCallback = config.callback;
+          },
+          renderButton: () => {},
+          prompt: () => {},
+        },
+      },
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) return new Response(JSON.stringify({}), { status: 401 });
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: true }));
+      }
+      if (url.endsWith('/api/auth/google')) {
+        return new Response(JSON.stringify({ error: 'private beta — sign-ups are closed', waitlistStatus: null }), {
+          status: 403,
+        });
+      }
+      if (url.endsWith('/api/waitlist')) {
+        const body = JSON.parse(String(init?.body)) as { idToken: string };
+        expect(body.idToken).toBe('test-credential');
+        return new Response(JSON.stringify({ status: 'ok', waitlistStatus: 'pending' }));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(ClosedBetaSplash)));
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('#btn-join-waitlist')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+      await flushEffects();
+    });
+
+    expect(capturedCallback).not.toBeNull();
+
+    await act(async () => {
+      capturedCallback!({ credential: 'test-credential' });
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('#btn-join-waitlist')).toBeNull();
+    expect(container.querySelector('.beta-splash__waitlist-confirm')).not.toBeNull();
+
+    session.flush();
+    const steps = sent.flatMap((body) => (body as { events: Array<{ type: string; step?: string }> }).events);
+    expect(steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'waitlist_step', step: 'cta_clicked' }),
+        expect.objectContaining({ type: 'waitlist_step', step: 'joined' }),
+      ]),
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it('a rejected sign-in without prior Join still shows the waitlist CTA with a token', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     let capturedCallback: ((res: { credential: string }) => void) | null = null;
 
@@ -92,7 +223,6 @@ describe('ClosedBetaSplash', () => {
         return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: true }));
       }
       if (url.endsWith('/api/auth/google')) {
-        // 403 with no waitlistStatus — user is not yet on the waitlist
         return new Response(JSON.stringify({ error: 'private beta — sign-ups are closed', waitlistStatus: null }), {
           status: 403,
         });
@@ -162,7 +292,6 @@ describe('ClosedBetaSplash', () => {
         return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: true }));
       }
       if (url.endsWith('/api/auth/google')) {
-        // 403 with pending status — user is already on the waitlist
         return new Response(
           JSON.stringify({ error: 'private beta — sign-ups are closed', waitlistStatus: 'pending' }),
           { status: 403 },
@@ -189,7 +318,6 @@ describe('ClosedBetaSplash', () => {
       await flushEffects();
     });
 
-    // Should show the pending status directly, NOT the join button
     expect(container.querySelector('#btn-join-waitlist')).toBeNull();
     expect(container.querySelector('.beta-splash__waitlist-confirm')).not.toBeNull();
 

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -69,7 +69,9 @@ describe('ClosedBetaSplash', () => {
     // Join sits above the sign-in buttons in the DOM.
     const waitlist = container.querySelector('.beta-splash__waitlist');
     const signin = container.querySelector('.beta-splash__signin');
-    expect(waitlist?.compareDocumentPosition(signin!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(waitlist).not.toBeNull();
+    expect(signin).not.toBeNull();
+    expect(waitlist!.compareDocumentPosition(signin!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
     expect(mascot).not.toBeNull();
     expect(mascot?.getAttribute('aria-label')).toMatch(/poke|szturchnij/i);

--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppleSignInButton } from './AppleSignInButton.js';
 import { useAuth } from './AuthContext.js';
 import { GoogleSignInButton } from './GoogleSignInButton.js';
 import { InteractiveMascot } from './Mascot.js';
+import { recordWaitlistStep } from './visitTelemetry.js';
 
 type WaitlistState = 'idle' | 'joining' | 'joined' | 'error';
 
@@ -17,21 +18,51 @@ export function ClosedBetaSplash() {
   // verifier would reject the very person the waitlist exists to catch.
   const [idTokenProvider, setIdTokenProvider] = useState<'google' | 'apple'>('google');
   const [waitlistState, setWaitlistState] = useState<WaitlistState>('idle');
+  // Clicked Join before signing in — after a rejected sign-in we auto-join with that token
+  // so the visitor is not asked to press Join a second time.
+  const [awaitingSignIn, setAwaitingSignIn] = useState(false);
+  const joinIntentRef = useRef(false);
   const isBlocked = error != null;
 
-  const handleJoinWaitlist = async () => {
-    if (!idToken || waitlistState === 'joining' || waitlistState === 'joined') return;
+  const doJoin = async (token: string, provider: 'google' | 'apple') => {
+    if (waitlistState === 'joining' || waitlistState === 'joined') return;
     setWaitlistState('joining');
+    setAwaitingSignIn(false);
+    joinIntentRef.current = false;
     try {
-      await joinWaitlist(idToken, i18n.language, idTokenProvider);
+      await joinWaitlist(token, i18n.language, provider);
       setWaitlistState('joined');
+      recordWaitlistStep('joined');
     } catch {
       setWaitlistState('error');
     }
   };
 
+  const handleJoinWaitlist = () => {
+    if (waitlistState === 'joining' || waitlistState === 'joined') return;
+    recordWaitlistStep('cta_clicked');
+    if (!idToken) {
+      // Still requires login: the CTA is visible up front, but the write only happens
+      // after an ID token arrives from Google or Apple.
+      joinIntentRef.current = true;
+      setAwaitingSignIn(true);
+      return;
+    }
+    void doJoin(idToken, idTokenProvider);
+  };
+
+  const handleSignInError = (msg: string, token: string | undefined, provider: 'google' | 'apple') => {
+    setError(msg);
+    setIdToken(token ?? null);
+    setIdTokenProvider(provider);
+    if (token && joinIntentRef.current) {
+      void doJoin(token, provider);
+    }
+  };
+
   // Determine if we should show a known waitlist status (from the API 403 or a previous join)
   const hasKnownStatus = waitlistStatus === 'pending' || waitlistStatus === 'approved' || waitlistStatus === 'rejected';
+  const showStatus = waitlistState === 'joined' || (hasKnownStatus && waitlistState !== 'error');
 
   return (
     <div className="beta-splash">
@@ -54,22 +85,22 @@ export function ClosedBetaSplash() {
 
         <div className="beta-splash__badge">{t('betaSplash.badge')}</div>
 
-        {isBlocked && (
-          <div className="beta-splash__blocked">
-            <p className="beta-splash__blocked-msg">{t('betaSplash.blockedMsg')}</p>
-            {waitlistState === 'joined' || (hasKnownStatus && waitlistState !== 'error') ? (
-              <div className="beta-splash__status">
-                {(waitlistStatus === 'pending' || waitlistState === 'joined') && (
-                  <p className="beta-splash__waitlist-confirm">{t('betaSplash.waitlistPending')}</p>
-                )}
-                {waitlistStatus === 'approved' && (
-                  <p className="beta-splash__waitlist-confirm">{t('betaSplash.waitlistApproved')}</p>
-                )}
-                {waitlistStatus === 'rejected' && (
-                  <p className="beta-splash__waitlist-rejected">{t('betaSplash.waitlistRejected')}</p>
-                )}
-              </div>
-            ) : (
+        <div className="beta-splash__waitlist">
+          {showStatus ? (
+            <div className="beta-splash__status">
+              {(waitlistStatus === 'pending' || waitlistState === 'joined') && (
+                <p className="beta-splash__waitlist-confirm">{t('betaSplash.waitlistPending')}</p>
+              )}
+              {waitlistStatus === 'approved' && (
+                <p className="beta-splash__waitlist-confirm">{t('betaSplash.waitlistApproved')}</p>
+              )}
+              {waitlistStatus === 'rejected' && (
+                <p className="beta-splash__waitlist-rejected">{t('betaSplash.waitlistRejected')}</p>
+              )}
+            </div>
+          ) : (
+            <>
+              {isBlocked && <p className="beta-splash__blocked-msg">{t('betaSplash.blockedMsg')}</p>}
               <button
                 id="btn-join-waitlist"
                 className="beta-splash__waitlist-btn"
@@ -78,26 +109,25 @@ export function ClosedBetaSplash() {
               >
                 {waitlistState === 'joining' ? t('betaSplash.joiningWaitlist') : t('betaSplash.joinWaitlist')}
               </button>
-            )}
-            {waitlistState === 'error' && (
-              <p className="beta-splash__waitlist-error">{t('betaSplash.waitlistError')}</p>
-            )}
-          </div>
-        )}
+              {awaitingSignIn && !idToken && (
+                <p className="beta-splash__signin-hint">{t('betaSplash.signInToJoin')}</p>
+              )}
+            </>
+          )}
+          {waitlistState === 'error' && (
+            <p className="beta-splash__waitlist-error">{t('betaSplash.waitlistError')}</p>
+          )}
+        </div>
 
         <div className="beta-splash__signin">
           <GoogleSignInButton
             onError={(msg, token) => {
-              setError(msg);
-              setIdToken(token ?? null);
-              setIdTokenProvider('google');
+              handleSignInError(msg, token, 'google');
             }}
           />
           <AppleSignInButton
             onError={(msg, token) => {
-              setError(msg);
-              setIdToken(token ?? null);
-              setIdTokenProvider('apple');
+              handleSignInError(msg, token, 'apple');
             }}
           />
         </div>

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -48,6 +48,7 @@ function game(partial: Partial<GameHealth> & { slug: string }): GameHealth {
 
 const EMPTY_FUNNEL: VisitFunnel = {
   creating: [],
+  waitlist: [],
   visits: 0,
   bounces: 0,
   visitsWithPlay: 0,

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -28,6 +28,7 @@ function funnel(overrides: Partial<VisitFunnel> = {}): VisitFunnel {
     referrers: [],
     campaigns: [],
     creating: [],
+    waitlist: [],
     ...overrides,
   };
 }
@@ -144,5 +145,35 @@ describe('VisitFunnelPanel', () => {
     );
     expect(text).toContain('Games per visit');
     expect(text).toContain('median games / playing visit');
+  });
+
+  it('renders the waitlist funnel as a share of clicks, not of all visits', () => {
+    const text = render(
+      response({
+        visits: 10,
+        waitlist: [
+          { step: 'cta_clicked', visits: 4 },
+          { step: 'joined', visits: 2 },
+        ],
+      }),
+    );
+    expect(text).toContain('Waitlist');
+    expect(text).toContain('clicked Join waitlist');
+    expect(text).toContain('joined waitlist');
+    // 2 of 4 clicks joined — 50%, not 20% of all visits.
+    expect(text).toContain('50%');
+  });
+
+  it('says so when nobody touched the waitlist', () => {
+    const text = render(
+      response({
+        visits: 3,
+        waitlist: [
+          { step: 'cta_clicked', visits: 0 },
+          { step: 'joined', visits: 0 },
+        ],
+      }),
+    );
+    expect(text).toContain('Nobody clicked Join waitlist');
   });
 });

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -25,6 +25,11 @@ const STEP_LABELS: Record<string, string> = {
   submission_created: 'game submitted',
 };
 
+const WAITLIST_LABELS: Record<string, string> = {
+  cta_clicked: 'clicked Join waitlist',
+  joined: 'joined waitlist',
+};
+
 function bucketLabel(upToSeconds: number | null): string {
   if (upToSeconds === null) return 'slower';
   if (upToSeconds < 60) return `≤ ${upToSeconds}s`;
@@ -177,6 +182,36 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                      * and most visitors never try.
                      */}
                     <td className="num">{percent(row.visits, funnel.creating[0]?.visits ?? 0)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="funnel-block">
+          <h3>Waitlist</h3>
+          {funnel.waitlist.every((row) => row.visits === 0) ? (
+            <p className="health-empty">Nobody clicked Join waitlist in this window.</p>
+          ) : (
+            <table className="health-table">
+              <thead>
+                <tr>
+                  <th scope="col">Step</th>
+                  <th scope="col" className="num">
+                    Visits
+                  </th>
+                  <th scope="col" className="num">
+                    Of clicks
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {funnel.waitlist.map((row) => (
+                  <tr key={row.step}>
+                    <td>{WAITLIST_LABELS[row.step] ?? row.step}</td>
+                    <td className="num">{row.visits}</td>
+                    <td className="num">{percent(row.visits, funnel.waitlist[0]?.visits ?? 0)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -66,6 +66,8 @@ export interface VisitFunnel {
   campaigns: Array<{ source?: string; medium?: string; campaign?: string; visits: number; plays: number }>;
   /** Creation funnel in step order, every step present even at zero. */
   creating: Array<{ step: string; visits: number }>;
+  /** Closed-beta waitlist funnel in step order, every step present even at zero. */
+  waitlist: Array<{ step: string; visits: number }>;
 }
 
 export interface VisitsResponse {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -572,6 +572,7 @@
     "blockedMsg": "The beta is closed right now — access is invite-only.",
     "joinWaitlist": "Join the waitlist",
     "joiningWaitlist": "Joining…",
+    "signInToJoin": "Sign in with Google or Apple below to join.",
     "waitlistJoined": "You're on the list — we'll email you when a spot opens up.",
     "waitlistPending": "✓ You're on the waitlist — we'll email you when a spot opens up.",
     "waitlistApproved": "🎉 You've been approved! Please sign in again to access the beta.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -572,6 +572,7 @@
     "blockedMsg": "Beta jest obecnie zamknięta — dostęp tylko na zaproszenie.",
     "joinWaitlist": "Dołącz do listy oczekujących",
     "joiningWaitlist": "Dołączanie…",
+    "signInToJoin": "Zaloguj się przez Google lub Apple poniżej, aby dołączyć.",
     "waitlistJoined": "Jesteś na liście — napiszemy, gdy zwolni się miejsce.",
     "waitlistPending": "✓ Jesteś na liście oczekujących — napiszemy, gdy zwolni się miejsce.",
     "waitlistApproved": "🎉 Twoja aplikacja została zaakceptowana! Zaloguj się ponownie, aby uzyskać dostęp.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3634,6 +3634,14 @@ body.player-open {
   margin-bottom: 28px;
 }
 
+.beta-splash__waitlist {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
 .beta-splash__signin {
   display: flex;
   flex-direction: column;
@@ -3645,7 +3653,14 @@ body.player-open {
 .beta-splash__blocked-msg {
   color: var(--text);
   font-size: 0.95rem;
-  margin-bottom: 16px;
+  margin: 0;
+}
+
+.beta-splash__signin-hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0;
+  max-width: 28ch;
 }
 
 .beta-splash__waitlist-btn {
@@ -3776,6 +3791,11 @@ body.player-open {
     margin-bottom: 16px;
   }
 
+  .beta-splash__waitlist {
+    margin-bottom: 16px;
+    gap: 8px;
+  }
+
   .beta-splash__signin {
     margin-bottom: 14px;
   }
@@ -3788,18 +3808,20 @@ body.player-open {
      margin 0 and must stay there, or the blocked state grows instead of shrinking. */
   .beta-splash__blocked-msg {
     font-size: 0.92rem;
-    margin-bottom: 12px;
+  }
+
+  .beta-splash__signin-hint {
+    font-size: 0.8rem;
   }
 
   .beta-splash__legal {
     margin-top: 0.7rem;
   }
 
-  /* The invite-only panel adds a message and a button, and it only ever appears after
-     the visitor has read the pitch and tried to sign in — so on a short screen the
-     pitch is what gives way, rather than the legal links dropping off the bottom
-     again. Progressive enhancement: without :has() the card scrolls, as it does now. */
-  .beta-splash__card:has(.beta-splash__blocked) .beta-splash__sub {
+  /* The waitlist CTA is always on the splash, and on a short screen the pitch is what
+     gives way rather than the legal links dropping off the bottom again. Progressive
+     enhancement: without :has() the card scrolls, as it does now. */
+  .beta-splash__card:has(.beta-splash__waitlist) .beta-splash__sub {
     display: none;
   }
 }

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -11,6 +11,7 @@ import {
   readVisitIdentity,
   recordCreateStep,
   recordVisitEvent,
+  recordWaitlistStep,
   referrerDomain,
   routeKind,
   sanitizeUtm,
@@ -292,6 +293,30 @@ describe('recordCreateStep', () => {
 
     // The second visit must record its own start; dedupe is per visit, not global.
     expect(second.batches[0].events).toHaveLength(1);
+  });
+});
+
+describe('recordWaitlistStep', () => {
+  it('records each waitlist step once per visit', () => {
+    const { batches, send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    setVisitSessionForTesting(session);
+
+    recordWaitlistStep('cta_clicked');
+    recordWaitlistStep('cta_clicked');
+    recordWaitlistStep('joined');
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    expect(batches[0].events).toEqual([
+      expect.objectContaining({ type: 'waitlist_step', step: 'cta_clicked' }),
+      expect.objectContaining({ type: 'waitlist_step', step: 'joined' }),
+    ]);
+  });
+
+  it('is a silent no-op when tracking was never started', () => {
+    setVisitSessionForTesting(null);
+    expect(() => recordWaitlistStep('cta_clicked')).not.toThrow();
   });
 });
 

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -42,7 +42,9 @@ export type VisitEvent =
   /** A published game began playing. Intentionally carries no slug. */
   | { type: 'play_started' }
   /** A step of the creation funnel was reached. Carries no prompt text, ever. */
-  | { type: 'create_step'; step: CreateStep };
+  | { type: 'create_step'; step: CreateStep }
+  /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */
+  | { type: 'waitlist_step'; step: WaitlistStep };
 
 /**
  * The creation funnel, in the order a creator meets it.
@@ -70,6 +72,20 @@ export type CreateStep =
   | 'title_confirmed'
   /** A submission actually reached the games repo. */
   | 'submission_created';
+
+/**
+ * The closed-beta waitlist funnel, in the order a visitor meets it.
+ *
+ * The Join CTA is visible before sign-in; `cta_clicked` is intent, and `joined` is the
+ * successful write after an ID token arrives. Sign-in itself is not a rung here — the
+ * drop between click and join *is* the sign-in wall, and inventing a middle step would
+ * double-count it against the creation funnel's `signin_required`.
+ */
+export type WaitlistStep =
+  /** Pressed Join the waitlist on the splash. */
+  | 'cta_clicked'
+  /** `POST /api/waitlist` succeeded for this visit. */
+  | 'joined';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;
@@ -320,11 +336,20 @@ export function recordCreateStep(step: CreateStep): void {
   currentSession.record({ type: 'create_step', step });
 }
 
+let recordedWaitlistSteps = new Set<WaitlistStep>();
+
+export function recordWaitlistStep(step: WaitlistStep): void {
+  if (!currentSession || recordedWaitlistSteps.has(step)) return;
+  recordedWaitlistSteps.add(step);
+  currentSession.record({ type: 'waitlist_step', step });
+}
+
 /** Test seam: installs a session without touching the DOM. */
 export function setVisitSessionForTesting(session: VisitSession | null): void {
   currentSession = session;
   // Otherwise one test's steps would silence the next test's identical steps.
   recordedSteps = new Set();
+  recordedWaitlistSteps = new Set();
 }
 
 export interface StartVisitTrackingOptions {
@@ -357,6 +382,7 @@ export function startVisitTracking(options: StartVisitTrackingOptions = {}): () 
   // A reload continues the visit but re-runs this module, so the funnel would silently
   // stop deduping across it if these were not cleared with the session that owns them.
   recordedSteps = new Set();
+  recordedWaitlistSteps = new Set();
 
   if (identity.isNew) {
     const referrer = referrerDomain(document.referrer ?? '', window.location.hostname);

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -16,34 +16,41 @@ render a branded closed-beta landing instead of the app UI:
   accent, gamedev.pl wordmark (`.pl` in turquoise), Proxima Nova.
 - Copy (i18n en/pl): what this is ("create games with AI, play what others
   made") + "closed beta — access is invite-only for now".
-- Primary action: **Sign in with Google** (existing GIS button).
+- Primary action: **Join the waitlist** (visible before sign-in; still requires
+  Google/Apple login to complete) plus **Sign in with Google** / Apple.
 - No data fetches beyond `/api/auth/me` — the catalog is walled anyway;
   don't fire requests that will 401 and log noise.
 
 ## Waitlist — sign-in based, consent-explicit
 
-Mechanic: non-allowlisted user signs in with Google → `/api/auth/google`
-returns 403 (existing behavior, still writes NOTHING) → UI shows
-"The beta is closed — want to join the waitlist?" with a join button.
+Mechanic: the splash always shows **Join the waitlist** above the sign-in buttons.
+Clicking it without an ID token asks the visitor to sign in (Google or Apple); joining
+still requires a verified token. After a rejected allowlist sign-in with join intent,
+the splash auto-joins so the visitor is not asked to press Join twice. A rejected
+sign-in without prior intent still leaves the CTA visible and keeps the token for an
+explicit click.
 
-- Clicking join calls **`POST /api/waitlist`** with the same Google ID token
-  (re-verified server-side — never trust the client's claim of who they are).
+- Clicking join (with a token) calls **`POST /api/waitlist`** with the same Google/Apple
+  ID token (re-verified server-side — never trust the client's claim of who they are).
   The endpoint:
-  - verifies the token (same `GoogleAuthVerifier`, same audience pinning);
+  - verifies the token (same verifier, same audience pinning);
   - upserts `waitlist/{uid}`: `{ uid, email, name, requestedAt, locale }`
     (idempotent — joining twice updates `requestedAt` at most);
   - is rate-limited by the existing per-IP auth limiter;
   - works WITHOUT a session (the caller is by definition not allowed in).
 - Privacy invariants:
   - A rejected sign-in alone still leaves no Firestore trace; only the
-    explicit join click writes data (that click is the consent moment).
+    explicit join click (or auto-join after an explicit Join → sign-in) writes data
+    (that click is the consent moment).
   - Deletion = delete one doc. No marketing use implied; the doc exists so
     the owner can invite people.
   - `email_verified` must be true on the token to store the email (same
     rule as the beta email allowlist).
 - UI after joining: "You're on the list" confirmation; joining again is a
   no-op visually ("already on the list").
-
+- **Telemetry:** `waitlist_step` on the visit stream (`cta_clicked` → `joined`),
+  aggregated in `summarizeVisitFunnel` and rendered as a Waitlist block on the
+  operator telemetry panel beside Creating.
 ## Store
 
 `Store` interface gains `upsertWaitlistEntry(entry)` (+ `InMemoryStore` and
@@ -67,8 +74,10 @@ v2 (only if the list grows): store-backed allowlist — `waitlist/{uid}.status
 - Invalid/forged token → 401, nothing written.
 - Unverified email on token → entry stored WITHOUT email (or rejected —
   either is fine, but never store an unverified email).
-- Web: signed-out state renders splash; 403 sign-in shows waitlist CTA;
-  joined state renders confirmation.
+- Web: signed-out state renders splash with Join waitlist above sign-in; Join without
+  a token prompts sign-in and does not POST; Join → rejected sign-in auto-joins;
+  rejected sign-in without prior Join still shows the CTA; joined state renders
+  confirmation; `waitlist_step` events reach the visit funnel panel.
 
 ## Smoke (deploy.yml)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The closed-beta splash always shows **Join the waitlist** above Google/Apple sign-in (instead of only after a rejected allowlist attempt). Completing still requires login: clicking Join without a token prompts sign-in; after a rejected sign-in with join intent, the splash auto-joins.

## Telemetry

Visit stream gains `waitlist_step` with rungs `cta_clicked` → `joined` (same three-place enum contract as `create_step`). `summarizeVisitFunnel` aggregates them; the operator telemetry panel renders a **Waitlist** block beside Creating.

**Questions this answers:** of splash visitors who click Join, how many complete sign-in and land on the waitlist?

## Test plan

- [x] Unit: splash shows Join before sign-in; Join without token does not POST; Join → 403 auto-joins and records both steps
- [x] Unit: visit intake accepts/rejects waitlist steps; funnel aggregates waitlist separately from create
- [x] Unit: VisitFunnelPanel renders Waitlist shares of clicks
- [x] Green gate: `npm run type-check && npm run lint && npm run test && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb751-942b-727e-a3d9-baa12d535c59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb751-942b-727e-a3d9-baa12d535c59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

