### PR TITLE
Notify operators when someone joins the beta waitlist

### DIFF
--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -248,6 +248,7 @@ describe('POST /api/waitlist', () => {
       string,
       { sub: string; email?: string; emailVerified?: boolean; name?: string; picture?: string }
     > = {},
+    adminUids?: Set<string>,
   ) => {
     const store = new InMemoryStore();
     const verifier = new MockGoogleVerifier(mockUsers);
@@ -257,6 +258,7 @@ describe('POST /api/waitlist', () => {
       store,
       sessionSecret: 'test-secret-key',
       googleAuthVerifier: verifier,
+      ...(adminUids ? { adminUids } : {}),
     });
 
     return { app, store };
@@ -287,6 +289,54 @@ describe('POST /api/waitlist', () => {
 
     // Never wrote a users/ doc — the caller was never signed in.
     expect(await store.getUser('g:20001')).toBeNull();
+  });
+
+  it('notifies operators when someone joins, once per applicant', async () => {
+    const { app, store } = await setupTestServer(
+      {
+        'rejected-token': { sub: '20010', email: 'newbie@example.com', emailVerified: true, name: 'Newbie' },
+      },
+      new Set(['g:boss']),
+    );
+    await store.upsertUser({ uid: 'g:boss', email: 'boss@example.com', tier: 'trusted' });
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/waitlist',
+      payload: { idToken: 'rejected-token' },
+    });
+    expect(first.statusCode).toBe(200);
+
+    const notes = await store.listNotifications('g:boss');
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatchObject({
+      id: 'op-waitlist-g:20010',
+      type: 'operator.waitlist_joined',
+      link: '/admin/telemetry',
+      params: { title: 'Newbie', email: 'newbie@example.com' },
+    });
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/waitlist',
+      payload: { idToken: 'rejected-token' },
+    });
+    expect(second.statusCode).toBe(200);
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
+  });
+
+  it('still joins when no operators are configured', async () => {
+    const { app, store } = await setupTestServer({
+      'rejected-token': { sub: '20011', email: 'solo@example.com', emailVerified: true },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/waitlist',
+      payload: { idToken: 'rejected-token' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(store.waitlistEntries()).toHaveLength(1);
   });
 
   it('is idempotent — joining twice keeps a single entry and only bumps requestedAt', async () => {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -8,6 +8,9 @@ import { isAdmin, isAdminSession } from './admin.js';
 import { resolveAppleAccount } from './apple-account.js';
 import { createAppleAuthVerifierFromEnv, parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
 import { readBearerToken } from './bearer.js';
+import { createMailerFromEnv } from './mailer.js';
+import { emitWaitlistJoined } from './notify.js';
+import { createPusherFromEnv } from './pusher.js';
 import { withActiveDay, type Store, type User } from './store.js';
 
 export const SESSION_COOKIE_NAME = 'gamedev_session';
@@ -645,6 +648,28 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
           name,
           locale: parseResult.data.locale,
         });
+
+        // Operators need to know a person is waiting — otherwise the waitlist is a
+        // Firestore collection nobody opens. Best-effort: a notification failure must
+        // not turn a successful join into a 500. Idempotent per applicant uid.
+        const adminUids = options.adminUids;
+        if (adminUids && adminUids.size > 0) {
+          const title = (name && name.trim()) || email || 'Someone';
+          try {
+            await emitWaitlistJoined(
+              {
+                store,
+                mailer: process.env.RESEND_API_KEY ? createMailerFromEnv() : undefined,
+                pusher: createPusherFromEnv(),
+                adminUids,
+                logError: (err, msg) => request.log.error({ err }, msg),
+              },
+              { uid, title, ...(email ? { email } : {}) },
+            );
+          } catch (err) {
+            request.log.error({ err }, 'waitlist operator notify failed');
+          }
+        }
 
         return { status: 'ok', waitlistStatus: entry.status };
       } catch (err) {

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -306,13 +306,16 @@ export function digestPushContent(locale: Locale, params: DigestEmailParams): { 
 // also the way to stop being the person these are about.
 
 export interface OperatorEmailParams {
-  /** Sanitized game title. */
+  /** Sanitized game title, or a waitlist applicant's display label. */
   title: string;
-  issueNumber: number;
+  /** Present for job alerts; absent for waitlist joins (no issue). */
+  issueNumber?: number;
   /** Absolute URL to the console. */
   actionUrl: string;
   /** Machine-readable extra, e.g. which kind of stall. Rendered verbatim, so keep it ours. */
   detail?: string;
+  /** Waitlist joins: the applicant's email when the token carried a verified one. */
+  email?: string;
 }
 
 const operatorCopy: Record<OperatorNotificationType, { subject: string; lead: string; cta: string }> = {
@@ -341,6 +344,11 @@ const operatorCopy: Record<OperatorNotificationType, { subject: string; lead: st
     lead: 'no longer passes the check on the current engine. It still serves — the creator has been nudged to refresh it.',
     cta: 'Open the queue',
   },
+  'operator.waitlist_joined': {
+    subject: 'Someone joined the beta waitlist',
+    lead: 'asked to join the closed beta.',
+    cta: 'Open telemetry',
+  },
 };
 
 export function operatorPushContent(type: OperatorNotificationType, title: string): { title: string; body: string } {
@@ -356,18 +364,21 @@ export function operatorNotificationMessage(
   const copy = operatorCopy[type];
   const actionUrl = escapeHtml(params.actionUrl);
   const detail = params.detail ? ` (${params.detail})` : '';
+  const emailLine = params.email;
+  const jobLine = params.issueNumber !== undefined ? `Job #${params.issueNumber}` : undefined;
 
   const text = [
     `“${params.title}” ${copy.lead}${detail}`,
-    '',
-    `Job #${params.issueNumber}`,
+    ...(emailLine ? ['', emailLine] : []),
+    ...(jobLine ? ['', jobLine] : []),
     '',
     `${copy.cta}: ${params.actionUrl}`,
   ].join('\n');
 
   const html = [
     `<p>“${escapeHtml(params.title)}” ${escapeHtml(copy.lead)}${escapeHtml(detail)}</p>`,
-    `<p style="color:#888;font-size:12px">Job #${params.issueNumber}</p>`,
+    ...(emailLine ? [`<p style="color:#888;font-size:12px">${escapeHtml(emailLine)}</p>`] : []),
+    ...(jobLine ? [`<p style="color:#888;font-size:12px">${escapeHtml(jobLine)}</p>`] : []),
     `<p><a href="${actionUrl}">${escapeHtml(copy.cta)}</a></p>`,
   ].join('\n');
 

--- a/apps/api/src/notify.test.ts
+++ b/apps/api/src/notify.test.ts
@@ -6,6 +6,7 @@ import {
   emitDigestNotification,
   emitOperatorAlert,
   emitSubmissionNotification,
+  emitWaitlistJoined,
   notifyOnTransition,
   statusToEvent,
   type EmitDeps,
@@ -533,5 +534,65 @@ describe('emitOperatorAlert', () => {
 
     expect(created).toBe(1);
     expect(await store.listNotifications('g:boss')).toHaveLength(1);
+  });
+});
+
+describe('emitWaitlistJoined', () => {
+  let store: InMemoryStore;
+  let mailer: ConsoleMailer;
+
+  const deps = () => ({
+    store,
+    mailer,
+    appBaseUrl: 'https://www.gamedev.pl',
+    adminUids: ['g:boss'],
+  });
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    mailer = new ConsoleMailer(() => {});
+    await store.upsertUser({ uid: 'g:boss', email: 'boss@example.com' });
+  });
+
+  it('notifies every operator and links them to telemetry', async () => {
+    await store.upsertUser({ uid: 'g:second', email: 'second@example.com' });
+
+    const { created } = await emitWaitlistJoined(
+      { ...deps(), adminUids: ['g:boss', 'g:second'] },
+      { uid: 'g:waiter', title: 'Waiter', email: 'waiter@example.com' },
+    );
+
+    expect(created).toBe(2);
+    const [notification] = await store.listNotifications('g:boss');
+    expect(notification).toMatchObject({
+      id: 'op-waitlist-g:waiter',
+      type: 'operator.waitlist_joined',
+      titleKey: 'notifications.operator.waitlist_joined.title',
+      link: '/admin/telemetry',
+      params: { title: 'Waiter', email: 'waiter@example.com' },
+    });
+    expect(mailer.sent).toHaveLength(2);
+    expect(mailer.sent[0].subject).toContain('waitlist');
+    expect(mailer.sent[0].text).toContain('waiter@example.com');
+    expect(mailer.sent[0].text).toContain('/admin/telemetry');
+    expect(mailer.sent[0].text).not.toContain('Job #');
+  });
+
+  it('says nothing the second time the same applicant joins', async () => {
+    await emitWaitlistJoined(deps(), { uid: 'g:waiter', title: 'Waiter' });
+    const second = await emitWaitlistJoined(deps(), { uid: 'g:waiter', title: 'Waiter' });
+
+    expect(second.created).toBe(0);
+    expect(mailer.sent).toHaveLength(1);
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
+  });
+
+  it('reaches an operator who unsubscribed from creator mail', async () => {
+    await store.setEmailUnsubscribed('g:boss', new Date().toISOString());
+
+    await emitWaitlistJoined(deps(), { uid: 'g:waiter', title: 'Waiter', email: 'waiter@example.com' });
+
+    expect(mailer.sent).toHaveLength(1);
+    expect(mailer.sent[0].headers?.['List-Unsubscribe']).toBeUndefined();
   });
 });

--- a/apps/api/src/notify.test.ts
+++ b/apps/api/src/notify.test.ts
@@ -595,4 +595,28 @@ describe('emitWaitlistJoined', () => {
     expect(mailer.sent).toHaveLength(1);
     expect(mailer.sent[0].headers?.['List-Unsubscribe']).toBeUndefined();
   });
+
+  it('keeps in-app fan-out going when the mail action URL cannot be built', async () => {
+    await store.upsertUser({ uid: 'g:second', email: 'second@example.com' });
+    const errors: string[] = [];
+
+    const { created } = await emitWaitlistJoined(
+      {
+        store,
+        mailer,
+        // Not an absolute origin — absoluteAppUrl throws. Email must swallow that and
+        // the second operator must still get their in-app notification.
+        appBaseUrl: 'not-a-url',
+        adminUids: ['g:boss', 'g:second'],
+        logError: (_err, msg) => errors.push(msg),
+      },
+      { uid: 'g:waiter', title: 'Waiter' },
+    );
+
+    expect(created).toBe(2);
+    expect(await store.listNotifications('g:boss')).toHaveLength(1);
+    expect(await store.listNotifications('g:second')).toHaveLength(1);
+    expect(mailer.sent).toHaveLength(0);
+    expect(errors).toContain('operator alert email send failed');
+  });
 });

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -14,6 +14,7 @@ import {
   submissionNotificationMessage,
   submissionPushContent,
   type DigestEmailParams,
+  type OperatorEmailParams,
 } from './email-templates.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import type { OperatorAlert } from './operator-alerts.js';
@@ -247,7 +248,59 @@ export async function emitOperatorAlert(
     });
     if (!result.created) continue;
     created += 1;
-    await sendOperatorEmail(deps, uid, alert, type);
+    await sendOperatorEmail(deps, uid, alert.id, type, {
+      title: alert.title,
+      issueNumber: alert.issueNumber,
+      actionUrl: absoluteAppUrl(
+        deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl',
+        OPERATOR_ALERT_LINK,
+      ),
+      ...(alert.stall ? { detail: alert.stall } : {}),
+    });
+    await maybePush(deps, uid, result.notification);
+  }
+
+  return { created };
+}
+
+/**
+ * Tell every operator someone asked to join the closed beta.
+ *
+ * Same fan-out as `emitOperatorAlert` (in-app + email + push, no unsubscribe), but not
+ * shaped like a job: there is no issue number, and the deep link is the telemetry panel
+ * where the waitlist funnel lives rather than the build queue. Idempotent per applicant
+ * uid (`op-waitlist-{uid}`), so a visitor who clicks Join twice is one notification.
+ */
+export async function emitWaitlistJoined(
+  deps: EmitDeps & { adminUids: Iterable<string> },
+  event: { uid: string; title: string; email?: string },
+): Promise<{ created: number }> {
+  const createdAt = deps.now ? new Date(deps.now()).toISOString() : new Date().toISOString();
+  const type: OperatorNotificationType = 'operator.waitlist_joined';
+  const id = `op-waitlist-${event.uid}`;
+  const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
+  let created = 0;
+
+  for (const uid of deps.adminUids) {
+    const result = await deps.store.createNotification(uid, {
+      id,
+      type,
+      createdAt,
+      titleKey: `notifications.${type}.title`,
+      bodyKey: `notifications.${type}.body`,
+      params: {
+        title: event.title,
+        ...(event.email ? { email: event.email } : {}),
+      },
+      link: WAITLIST_ALERT_LINK,
+    });
+    if (!result.created) continue;
+    created += 1;
+    await sendOperatorEmail(deps, uid, id, type, {
+      title: event.title,
+      actionUrl: absoluteAppUrl(appBaseUrl, WAITLIST_ALERT_LINK),
+      ...(event.email ? { email: event.email } : {}),
+    });
     await maybePush(deps, uid, result.notification);
   }
 
@@ -257,12 +310,16 @@ export async function emitOperatorAlert(
 /** Where an operator notification lands: the queue, which is where the action is. */
 const OPERATOR_ALERT_LINK = '/admin/queue';
 
-/** Best-effort, like every other send here: a failed alert email must not fail the sweep. */
+/** Waitlist joins land on telemetry — that is where the waitlist funnel is measured. */
+const WAITLIST_ALERT_LINK = '/admin/telemetry';
+
+/** Best-effort, like every other send here: a failed alert email must not fail the caller. */
 async function sendOperatorEmail(
   deps: EmitDeps,
   uid: string,
-  alert: OperatorAlert,
+  notificationId: string,
   type: OperatorNotificationType,
+  params: OperatorEmailParams,
 ): Promise<void> {
   const mailer = deps.mailer ?? (process.env.RESEND_API_KEY ? createMailerFromEnv() : undefined);
   if (!mailer) return;
@@ -270,16 +327,8 @@ async function sendOperatorEmail(
   try {
     const user = await deps.store.getUser(uid);
     if (!user?.email) return;
-    const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
-    await mailer.send(
-      operatorNotificationMessage(user.email, type, {
-        title: alert.title,
-        issueNumber: alert.issueNumber,
-        actionUrl: absoluteAppUrl(appBaseUrl, OPERATOR_ALERT_LINK),
-        ...(alert.stall ? { detail: alert.stall } : {}),
-      }),
-    );
-    await deps.store.markNotificationEmailed(uid, alert.id);
+    await mailer.send(operatorNotificationMessage(user.email, type, params));
+    await deps.store.markNotificationEmailed(uid, notificationId);
   } catch (err) {
     deps.logError?.(err, 'operator alert email send failed');
   }

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -248,13 +248,9 @@ export async function emitOperatorAlert(
     });
     if (!result.created) continue;
     created += 1;
-    await sendOperatorEmail(deps, uid, alert.id, type, {
+    await sendOperatorEmail(deps, uid, alert.id, type, OPERATOR_ALERT_LINK, {
       title: alert.title,
       issueNumber: alert.issueNumber,
-      actionUrl: absoluteAppUrl(
-        deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl',
-        OPERATOR_ALERT_LINK,
-      ),
       ...(alert.stall ? { detail: alert.stall } : {}),
     });
     await maybePush(deps, uid, result.notification);
@@ -278,7 +274,6 @@ export async function emitWaitlistJoined(
   const createdAt = deps.now ? new Date(deps.now()).toISOString() : new Date().toISOString();
   const type: OperatorNotificationType = 'operator.waitlist_joined';
   const id = `op-waitlist-${event.uid}`;
-  const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
   let created = 0;
 
   for (const uid of deps.adminUids) {
@@ -296,9 +291,8 @@ export async function emitWaitlistJoined(
     });
     if (!result.created) continue;
     created += 1;
-    await sendOperatorEmail(deps, uid, id, type, {
+    await sendOperatorEmail(deps, uid, id, type, WAITLIST_ALERT_LINK, {
       title: event.title,
-      actionUrl: absoluteAppUrl(appBaseUrl, WAITLIST_ALERT_LINK),
       ...(event.email ? { email: event.email } : {}),
     });
     await maybePush(deps, uid, result.notification);
@@ -313,13 +307,19 @@ const OPERATOR_ALERT_LINK = '/admin/queue';
 /** Waitlist joins land on telemetry — that is where the waitlist funnel is measured. */
 const WAITLIST_ALERT_LINK = '/admin/telemetry';
 
-/** Best-effort, like every other send here: a failed alert email must not fail the caller. */
+/**
+ * Best-effort, like every other send here: a failed alert email must not fail the caller.
+ *
+ * `actionUrl` is built here — after the mailer early-return — so a bad `APP_BASE_URL`
+ * cannot abort the operator fan-out loop before in-app + push land for everyone else.
+ */
 async function sendOperatorEmail(
   deps: EmitDeps,
   uid: string,
   notificationId: string,
   type: OperatorNotificationType,
-  params: OperatorEmailParams,
+  link: string,
+  params: Omit<OperatorEmailParams, 'actionUrl'>,
 ): Promise<void> {
   const mailer = deps.mailer ?? (process.env.RESEND_API_KEY ? createMailerFromEnv() : undefined);
   if (!mailer) return;
@@ -327,7 +327,9 @@ async function sendOperatorEmail(
   try {
     const user = await deps.store.getUser(uid);
     if (!user?.email) return;
-    await mailer.send(operatorNotificationMessage(user.email, type, params));
+    const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
+    const actionUrl = absoluteAppUrl(appBaseUrl, link);
+    await mailer.send(operatorNotificationMessage(user.email, type, { ...params, actionUrl }));
     await deps.store.markNotificationEmailed(uid, notificationId);
   } catch (err) {
     deps.logError?.(err, 'operator alert email send failed');

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -560,7 +560,12 @@ export type NotificationType =
   | 'operator.build_stalled'
   | 'operator.feedback_undelivered'
   /** A health re-gate came back red: a live game no longer passes on the current engine. */
-  | 'operator.game_unhealthy';
+  | 'operator.game_unhealthy'
+  /**
+   * Someone asked to join the closed beta. Not a job alert — there is no issue number —
+   * but it is still an operator action: approve (or not) via the waitlist tooling.
+   */
+  | 'operator.waitlist_joined';
 
 /**
  * The types that are about one submission, and so can render "«game title» happened".

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -58,6 +58,10 @@
       "game_unhealthy": {
         "title": "A live game failed its health check",
         "body": "“{{title}}” no longer passes on the current engine. The creator has been nudged."
+      },
+      "waitlist_joined": {
+        "title": "Someone joined the beta waitlist",
+        "body": "“{{title}}” asked to join the closed beta."
       }
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -58,6 +58,10 @@
       "game_unhealthy": {
         "title": "Opublikowana gra nie przeszła kontroli",
         "body": "„{{title}}” nie przechodzi już testów na aktualnym silniku. Twórca dostał zachętę do odświeżenia."
+      },
+      "waitlist_joined": {
+        "title": "Ktoś dołączył do listy oczekujących",
+        "body": "„{{title}}” chce dołączyć do zamkniętej bety."
       }
     }
   },

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -51,6 +51,9 @@ explicit click.
 - **Telemetry:** `waitlist_step` on the visit stream (`cta_clicked` → `joined`),
   aggregated in `summarizeVisitFunnel` and rendered as a Waitlist block on the
   operator telemetry panel beside Creating.
+- **Operator notify:** each new applicant fans out `operator.waitlist_joined` to
+  every `ADMIN_UIDS` account (in-app bell + email + push, same posture as queue
+  alerts — no unsubscribe). Idempotent per uid. Deep link: `/admin/telemetry`.
 ## Store
 
 `Store` interface gains `upsertWaitlistEntry(entry)` (+ `InMemoryStore` and

--- a/docs/notifications-plan.md
+++ b/docs/notifications-plan.md
@@ -95,6 +95,7 @@ and **delivery** (in-app, push, email).
 | `game.updated`              | players following the game | new merge touches a game's directory            | M3             |
 | `catalog.new_game`          | opted-in players           | new slug appears in catalog                     | M3             |
 | `quota.reset` / system      | any                        | server-side                                     | later, if ever |
+| `operator.waitlist_joined`  | operators (`ADMIN_UIDS`)   | `POST /api/waitlist` creates a new applicant    | closed beta    |
 
 `submission.queued` and `in_review` are deliberately **not** notified — the creator just
 performed the action or is mid-flow; notifying every micro-transition trains people to


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When someone joins the closed-beta waitlist, every `ADMIN_UIDS` operator gets `operator.waitlist_joined` via the same path as queue alerts: in-app bell, email (when Resend is configured), and Web Push (when VAPID is configured). Unsubscribe does not silence these.

## Details

- Idempotent per applicant (`op-waitlist-{uid}`) so a double-click is one notification
- Deep link: `/admin/telemetry` (waitlist funnel)
- Email includes the applicant’s display name and verified email when present
- Join still succeeds if notify fails or no operators are configured
- Copilot feedback addressed: `actionUrl` is built inside the email send path so a bad `APP_BASE_URL` cannot abort in-app fan-out

## Test plan

- [x] Unit: `emitWaitlistJoined` fans out, is idempotent, ignores creator unsubscribe
- [x] Unit: bad mail base URL still delivers in-app notifications to every operator
- [x] Unit: `POST /api/waitlist` creates the operator notification once per applicant
- [x] Green gate
- [x] CI green on latest commit
- [x] Copilot review: 1 comment fixed and resolved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb751-942b-727e-a3d9-baa12d535c59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb751-942b-727e-a3d9-baa12d535c59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

