### PR TITLE
Stop the white Google iframe frame on the beta splash

### DIFF
--- a/apps/api/src/zones.test.ts
+++ b/apps/api/src/zones.test.ts
@@ -65,6 +65,10 @@ describe('zone admission', () => {
     // The host is a place where untrusted game code runs. Handing it durable identity
     // would make the sim isolate a privacy boundary as well as a safety one, and one
     // cage should not have two jobs.
+    //
+    // Assert on the full uid (`g:ada`), not a short substring like `ada`: the ticket's
+    // player tag and HMAC are hex, and hex randomly contains `ada` — that flake failed
+    // CI without any product change.
     const app = await appWith();
     const response = await app.inject({
       method: 'POST',
@@ -72,9 +76,15 @@ describe('zone admission', () => {
       headers: authHeaders('g:ada'),
     });
 
-    const decoded = Buffer.from(response.json().ticket, 'base64url').toString('utf8');
-    expect(decoded).not.toContain('ada');
-    expect(JSON.stringify(response.json())).not.toContain('ada');
+    const body = response.json() as { ticket: string };
+    const claims = verifyZoneTicket(body.ticket, sessionSecret);
+    expect(claims.player).not.toBe('g:ada');
+    expect(claims).not.toHaveProperty('uid');
+    expect(claims).not.toHaveProperty('email');
+
+    const decoded = Buffer.from(body.ticket, 'base64url').toString('utf8');
+    expect(decoded).not.toContain('g:ada');
+    expect(JSON.stringify(body)).not.toContain('g:ada');
     await app.close();
   });
 

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -65,7 +65,7 @@ describe('ClosedBetaSplash', () => {
     const joinButton = container.querySelector<HTMLButtonElement>('#btn-join-waitlist');
     expect(joinButton).not.toBeNull();
     expect(joinButton?.textContent).toMatch(/waitlist/i);
-    expect(container.querySelector('.google-sign-in-container')).not.toBeNull();
+    expect(container.querySelector('.google-sign-in')).not.toBeNull();
     // Join sits above the sign-in buttons in the DOM.
     const waitlist = container.querySelector('.beta-splash__waitlist');
     const signin = container.querySelector('.beta-splash__signin');

--- a/apps/web/src/GoogleSignInButton.test.tsx
+++ b/apps/web/src/GoogleSignInButton.test.tsx
@@ -77,7 +77,8 @@ describe('GoogleSignInButton', () => {
 
     const slot = container.querySelector('.google-sign-in-container');
     expect(slot).not.toBeNull();
-    // Dimensions live in CSS; the class is the contract the stylesheet sizes.
+    // Dimensions + color-scheme:light live in CSS; the class is the contract that
+    // keeps Apple from jumping and stops the dark-scheme white iframe frame.
     expect(slot?.className).toBe('google-sign-in-container');
   });
 

--- a/apps/web/src/GoogleSignInButton.test.tsx
+++ b/apps/web/src/GoogleSignInButton.test.tsx
@@ -85,6 +85,25 @@ describe('GoogleSignInButton', () => {
     expect(container.querySelector('.google-sign-in-gis')).not.toBeNull();
     expect(container.querySelector('.google-sign-in-face')?.textContent).toMatch(/Sign in with Google/i);
     expect(container.querySelector('.google-sign-in-mark')).not.toBeNull();
+    expect(gis.renderButton).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ locale: 'en', theme: 'filled_black', width: 240 }),
+    );
+  });
+
+  it('passes a Polish locale to GIS when the UI language is pl', async () => {
+    await i18n.changeLanguage('pl');
+    const { GoogleSignInButton } = await import('./GoogleSignInButton.js');
+
+    await act(async () => {
+      root.render(createElement(GoogleSignInButton));
+    });
+
+    expect(gis.renderButton).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ locale: 'pl' }),
+    );
+    expect(container.querySelector('.google-sign-in-face')?.textContent).toMatch(/Zaloguj się przez Google/i);
   });
 
   it('does not wipe and re-render the GIS button when the parent passes a new onError', async () => {

--- a/apps/web/src/GoogleSignInButton.test.tsx
+++ b/apps/web/src/GoogleSignInButton.test.tsx
@@ -3,11 +3,15 @@
 import { act, createElement, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
 
 /**
  * The GIS widget must paint once and stay put. Inline onError from ClosedBetaSplash
  * (and a fresh signInWithGoogleToken from AuthProvider after a rejected One Tap) used
  * to re-run the init effect, wipe the container, and shove the Apple button below it.
+ *
+ * The visible control is our black face; GIS sits opacity:0 on top so the dark-scheme
+ * white iframe envelope never shows.
  */
 
 const auth = vi.hoisted(() => ({
@@ -30,8 +34,9 @@ let gis: GisApi;
 let container: HTMLDivElement;
 let root: Root;
 
-beforeEach(() => {
+beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
 
   gis = {
     initialize: vi.fn((config: { callback: (res: { credential: string }) => void }) => {
@@ -68,18 +73,18 @@ afterEach(async () => {
 });
 
 describe('GoogleSignInButton', () => {
-  it('reserves a fixed slot so the Apple button below does not jump before GIS paints', async () => {
+  it('draws a black face and hides the GIS iframe so no white envelope shows', async () => {
     const { GoogleSignInButton } = await import('./GoogleSignInButton.js');
 
     await act(async () => {
       root.render(createElement(GoogleSignInButton));
     });
 
-    const slot = container.querySelector('.google-sign-in-container');
-    expect(slot).not.toBeNull();
-    // Dimensions + color-scheme:light live in CSS; the class is the contract that
-    // keeps Apple from jumping and stops the dark-scheme white iframe frame.
-    expect(slot?.className).toBe('google-sign-in-container');
+    expect(container.querySelector('.google-sign-in')).not.toBeNull();
+    expect(container.querySelector('.google-sign-in-face')).not.toBeNull();
+    expect(container.querySelector('.google-sign-in-gis')).not.toBeNull();
+    expect(container.querySelector('.google-sign-in-face')?.textContent).toMatch(/Sign in with Google/i);
+    expect(container.querySelector('.google-sign-in-mark')).not.toBeNull();
   });
 
   it('does not wipe and re-render the GIS button when the parent passes a new onError', async () => {

--- a/apps/web/src/GoogleSignInButton.tsx
+++ b/apps/web/src/GoogleSignInButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 
 declare global {
@@ -28,7 +29,37 @@ interface GoogleSignInButtonProps {
   onError?: (err: string, idToken?: string) => void;
 }
 
+/**
+ * Official four-color Google "G" on a white square — required by the Sign in with
+ * Google branding guidelines for any custom (non-GIS-rendered) button face.
+ */
+function GoogleMark() {
+  return (
+    <span className="google-sign-in-mark" aria-hidden="true">
+      <svg viewBox="0 0 48 48" width="18" height="18" focusable="false">
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+        />
+      </svg>
+    </span>
+  );
+}
+
 export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonProps) {
+  const { t, i18n } = useTranslation();
   const { signInWithGoogleToken } = useAuth();
   const buttonRef = useRef<HTMLDivElement>(null);
   const rendered = useRef(false);
@@ -68,6 +99,8 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
     rendered.current = true;
 
     const clientId = (import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID as string) || undefined;
+    // GIS locale tags are BCP-47 with underscore (en_US); i18n gives "en" / "pl".
+    const locale = i18n.language?.toLowerCase().startsWith('pl') ? 'pl' : 'en';
 
     window.google.accounts.id.initialize({
       client_id: clientId,
@@ -84,23 +117,30 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
       },
     });
 
+    // The real GIS widget stays opacity:0 over our black face. Clicks still hit Google's
+    // iframe (required for FedCM / ITP), but the dark-scheme white "envelope" that GIS
+    // paints around filled_black never shows — that was the flash shoving Apple down.
     buttonRef.current.innerHTML = '';
     window.google.accounts.id.renderButton(buttonRef.current, {
       theme: 'filled_black',
       size: 'large',
       text: 'signin_with',
       shape: 'rectangular',
-      // Pinned so this button and the Sign in with Apple one below it are the same size.
-      // Left to itself the widget sizes to its own label — 223px in Polish, wider in
-      // English — so any width chosen for the Apple button is wrong in some locale.
-      // Sizing the *container* to fit its widest child instead does not work: the widget
-      // measures its parent while laying out, and a `fit-content` parent collapses it to
-      // zero on a cold load (it survives an HMR patch, which is how that nearly shipped).
+      locale,
       width: 240,
     });
     window.google.accounts.id.prompt();
-  }, [scriptLoaded]);
+  }, [scriptLoaded, i18n.language]);
 
-  // Width/height reserved in CSS before GIS paints — see `.google-sign-in-container`.
-  return <div ref={buttonRef} className="google-sign-in-container" />;
+  return (
+    <div className="google-sign-in">
+      {/* Visual twin of the Apple button. aria-hidden: the real control is the GIS
+          iframe layered on top (opacity 0), which carries its own accessible name. */}
+      <div className="google-sign-in-face" aria-hidden="true">
+        <GoogleMark />
+        <span>{t('auth.signInWithGoogle')}</span>
+      </div>
+      <div ref={buttonRef} className="google-sign-in-gis" />
+    </div>
+  );
 }

--- a/apps/web/src/GoogleSignInButton.tsx
+++ b/apps/web/src/GoogleSignInButton.tsx
@@ -99,7 +99,7 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
     rendered.current = true;
 
     const clientId = (import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID as string) || undefined;
-    // GIS locale tags are BCP-47 with underscore (en_US); i18n gives "en" / "pl".
+    // GIS accepts short language codes here (`en`, `pl`); keep them aligned with i18n.
     const locale = i18n.language?.toLowerCase().startsWith('pl') ? 'pl' : 'en';
 
     window.google.accounts.id.initialize({

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3518,12 +3518,20 @@ body.player-open {
 
 /* GIS paints asynchronously into this node. Without a reserved slot the Apple button
    below starts at the top of the stack and jumps down when the iframe arrives — and
-   jumped again whenever a parent re-render used to wipe and re-render the widget. */
+   jumped again whenever a parent re-render used to wipe and re-render the widget.
+   `color-scheme: light` is required even with theme:filled_black: the page sets
+   color-scheme:dark (meta + html), and GIS's iframe inherits it as a white frame
+   around the button — the flash that shoved Apple on the beta splash. */
 .google-sign-in-container {
   width: 240px;
   height: 40px;
+  /* Match filled_black so an empty/loading slot is not a white flash on dark UI. */
+  background: #131314;
+  border-radius: 4px;
+  overflow: hidden;
   /* GIS's iframe is display:inline-block; keep the slot from collapsing while empty. */
   line-height: 0;
+  color-scheme: light;
 }
 
 .auth-error-banner {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3574,6 +3574,13 @@ body.player-open {
   cursor: pointer;
 }
 
+/* The focusable control lives inside the opacity:0 GIS iframe, so the browser's
+   focus ring would be invisible. Mirror it onto the face when the overlay is focused. */
+.google-sign-in:focus-within .google-sign-in-face {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 @media (pointer: coarse) {
   .google-sign-in {
     height: 44px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3516,22 +3516,68 @@ body.player-open {
   margin-top: 16px;
 }
 
-/* GIS paints asynchronously into this node. Without a reserved slot the Apple button
-   below starts at the top of the stack and jumps down when the iframe arrives — and
-   jumped again whenever a parent re-render used to wipe and re-render the widget.
-   `color-scheme: light` is required even with theme:filled_black: the page sets
-   color-scheme:dark (meta + html), and GIS's iframe inherits it as a white frame
-   around the button — the flash that shoved Apple on the beta splash. */
-.google-sign-in-container {
+/* Custom Google face + invisible GIS iframe on top.
+   -----------------------------------------------
+   GIS's renderButton iframe inherits the page's color-scheme:dark and paints a white
+   "envelope" around the widget — even with theme:filled_black. That flash shoved the
+   Apple button on the beta splash. We draw our own black face (same size as Apple)
+   and leave the real GIS control opacity:0 on top so clicks still hit Google's iframe
+   (FedCM / ITP require that). */
+.google-sign-in {
+  position: relative;
   width: 240px;
   height: 40px;
-  /* Match filled_black so an empty/loading slot is not a white flash on dark UI. */
-  background: #131314;
+}
+
+.google-sign-in-face {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 0 12px;
+  border: 1px solid #000;
   border-radius: 4px;
+  background: #000;
+  color: #fff;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+.google-sign-in-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 2px;
+  background: #fff;
+}
+
+.google-sign-in-mark svg {
+  display: block;
+}
+
+.google-sign-in-gis {
+  position: absolute;
+  inset: 0;
   overflow: hidden;
-  /* GIS's iframe is display:inline-block; keep the slot from collapsing while empty. */
-  line-height: 0;
-  color-scheme: light;
+  opacity: 0;
+  /* Keep a hit target even before the iframe paints. */
+  cursor: pointer;
+}
+
+@media (pointer: coarse) {
+  .google-sign-in {
+    height: 44px;
+  }
 }
 
 .auth-error-banner {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production shows a **white box** around the whole Google sign-in control on the beta splash. Apple jumps when that frame appears.

`color-scheme: light` on the GIS container was not enough — the iframe still paints the white envelope on a dark page.

## Fix

Draw our own black Google face (same size/shape as Apple, official four-color G on a white square per Google branding) and leave the real GIS `renderButton` iframe at `opacity: 0` on top so clicks still hit Google’s control (FedCM / ITP).

Also:

- GIS init once via refs (no wipe-on-re-render), fixed 240×40 slot
- `:focus-within` focus ring on the visible face (Copilot)
- Locale `en`/`pl` passed to GIS + covered in tests (Copilot)
- Unflaked unrelated zone ticket privacy assertion that was failing CI (`ada` substring in hex)

## After

[Black Google + Apple buttons, no white envelope](https://cursor.com/agents/bc-019fb751-322f-7a21-9575-eff5ff837639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbeta-signin-no-white-envelope.png)

## Status

- CI: green
- Copilot’s three inline comments: addressed and resolved


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb751-322f-7a21-9575-eff5ff837639?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb751-322f-7a21-9575-eff5ff837639&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

