### PR TITLE
Make Studio Playtest button more prominent

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -207,6 +207,27 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('makes Playtest the primary head action, not a peer of Details', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    window.history.replaceState(null, '', '/studio/token-0');
+
+    const { container, root } = await renderStudio({ selectedGame: 'token-0' });
+
+    const playtest = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Playtest'),
+    );
+    const details = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Details'),
+    );
+    expect(playtest?.classList.contains('is-primary')).toBe(true);
+    expect(details?.classList.contains('is-primary')).toBe(false);
+
+    root.unmount();
+  });
+
   it('lands an old tab name on the surface that absorbed it, and corrects the URL', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -499,7 +499,13 @@ export function CreatorStudioView({
                       when the game was made. These open things beside it and leave it
                       where it is. */}
                   <div className="studio-head-actions">
-                    <button type="button" className="studio-head-action" onClick={() => openTab('playtest')}>
+                    {/* Playtest is the next action after a build — same weight as Send
+                        feedback, not a peer of the Details toggle beside it. */}
+                    <button
+                      type="button"
+                      className="studio-head-action is-primary"
+                      onClick={() => openTab('playtest')}
+                    >
                       <PixelIcon name="play" size={12} /> {t('studioPanel.tabs.playtest')}
                     </button>
                     <button

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4056,7 +4056,9 @@ body.player-open {
   transition:
     color 0.15s,
     border-color 0.15s,
-    background 0.15s;
+    background 0.15s,
+    filter 0.15s,
+    box-shadow 0.15s;
 }
 
 .studio-head-action:hover {
@@ -4068,6 +4070,21 @@ body.player-open {
   color: var(--turquoise);
   border-color: rgba(0, 228, 172, 0.4);
   background: rgba(0, 228, 172, 0.1);
+}
+
+/* Solid turquoise CTA — Playtest must read louder than the outlined Details toggle. */
+.studio-head-action.is-primary {
+  background: var(--turquoise);
+  border-color: var(--turquoise);
+  color: #08241d;
+  font-weight: 700;
+}
+
+.studio-head-action.is-primary:hover {
+  color: #08241d;
+  border-color: var(--turquoise);
+  filter: brightness(1.1);
+  box-shadow: 0 0 16px var(--turquoise-glow);
 }
 
 /* A shelf row is a title. The state that matters at a glance rides on a dot. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Studio header **Playtest** control sat next to **Details** with the same outlined pill style, so it read as a secondary toggle rather than the next action after a build.

## Changes

- Give Playtest the solid turquoise primary CTA treatment (`studio-head-action is-primary`)
- Leave Details as the outlined secondary toggle
- Add a regression test that Playtest carries `is-primary` while Details does not

## Screenshot

[Studio header with solid turquoise Playtest button next to outlined Details](https://cursor.com/agents/bc-719b2c20-f825-4d8c-8acf-e52e66e999f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplaytest-button-primary.png)

## Test plan

- [x] Unit test for primary Playtest head action (`CreatorStudioView.test.tsx` — 31 passed)
- [x] `type-check` and `lint` clean
- [x] Visual screenshot of the primary Playtest CTA
- [ ] Click Playtest still opens the playtest theater

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719b2c20-f825-4d8c-8acf-e52e66e999f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719b2c20-f825-4d8c-8acf-e52e66e999f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

