### PR TITLE
deploy: thread SEED_DISPATCH from a repo variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,6 +153,18 @@ jobs:
             ENV_VARS="${ENV_VARS}|ZONE_HOST_URL=${ZONE_HOST_URL_VAL}"
           fi
 
+          # Seeded dispatch: a model writes a first draft of the game before the coding
+          # agent starts, and a compiling draft becomes the creator's round-0 preview
+          # (docs/agent-adapters.md). Threaded from a repo variable for the same reason
+          # as the two below — set by hand on the service, the next deploy would wipe it
+          # and builds would quietly stop being seeded with nothing to show why. Absent
+          # or anything other than "true" leaves seeding off, which is how every build
+          # ran before it existed.
+          SEED_DISPATCH_VAL="${{ vars.SEED_DISPATCH }}"
+          if [ -n "$SEED_DISPATCH_VAL" ]; then
+            ENV_VARS="${ENV_VARS}|SEED_DISPATCH=${SEED_DISPATCH_VAL}"
+          fi
+
           # Threaded through the same way as ZONE_HOST_URL, and for the same reason:
           # --set-env-vars replaces the whole map, so a value set by hand on the service
           # would be wiped by the next deploy — here that would silently pull room


### PR DESCRIPTION
## What

Adds `SEED_DISPATCH` to the env map the deploy builds, sourced from `vars.SEED_DISPATCH` and appended only when non-empty — the same pattern as `ZONE_HOST_URL` and `MP_RELAY_URL` directly below it.

## Why this is not just "set it in the console"

`gcloud run deploy --set-env-vars` **replaces the whole env map**. A value set by hand on the service survives exactly until the next deploy, then vanishes — and seeded dispatch failing open means builds would quietly stop being seeded with no error, no alert, and nothing in the job record to explain why. The workflow already carries this warning twice, for the two variables that learned it the hard way.

## Effect

None, until the variable is set. An absent or non-`true` value leaves seeding off, which is how every build ran before #372. Turning it on is a variable change plus a redeploy; turning it off again is the same.

Credentials need nothing new: the seeder reads `GAMES_REPO_TOKEN` and falls back to `GITHUB_TOKEN`, which is already mounted on the service.

## Rollout after this merges

1. Set repo variable `SEED_DISPATCH=true`, redeploy.
2. Watch the first seeded builds: a `seed/job-<id>` branch appearing then being released, `seed` cost entries carrying token counts, and the "First rough draft" preview on the creator's status page. The logs carry `compiles` / `repaired` per seed — the first real read on how often drafts bundle first try.
3. After a dozen jobs each way, compare seeded against unseeded in the cost report (every job is labelled `seeded`), which continues the A/B on production traffic rather than the three specs it was decided on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMJs4GRCznxHQi6pKX5n37

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMJs4GRCznxHQi6pKX5n37)_