### PR TITLE
Make party lobby join URL clickable

### DIFF
--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -172,9 +172,12 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
     // The join credential rides in the fragment so it stays out of access logs and
     // Referer headers (docs/multiplayer-plan.md §4.3) — a join URL that put the token
     // in the path would leak it, so assert the shape, not just that a link exists.
-    // `.party-url` renders it scheme-less, hence the optional host prefix.
-    const joinUrl = await page.locator('.party-url').innerText();
+    // `.party-url` is a real <a> (clickable / copy-link); label stays scheme-less.
+    const partyUrl = page.locator('a.party-url');
+    const joinUrl = await partyUrl.innerText();
     expect(joinUrl).toMatch(/\/join\/[A-Z0-9]{6}#[A-Za-z0-9_-]+$/);
+    const href = await partyUrl.getAttribute('href');
+    expect(href).toMatch(/^https?:\/\/.+\/join\/[A-Z0-9]{6}#[A-Za-z0-9_-]+$/);
     expect(await page.locator('.party-code').innerText()).toMatch(/^[A-Z0-9]{6}$/);
 
     watcher.drain();

--- a/apps/web/src/mp/PartyStage.tsx
+++ b/apps/web/src/mp/PartyStage.tsx
@@ -148,7 +148,9 @@ export function PartyStage({ game, session, onExit }: PartyStageProps) {
       <div className="party-qr-block">
         <QrCode value={url} label={t('party.qrLabel', { code: session.code })} />
         <p className="party-code">{session.code}</p>
-        <p className="party-url">{url.replace(/^https?:\/\//, '')}</p>
+        <a className="party-url" href={url} target="_blank" rel="noopener noreferrer">
+          {url.replace(/^https?:\/\//, '')}
+        </a>
       </div>
 
       <div className="party-lobby-side">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4641,11 +4641,18 @@ body.player-open {
 }
 
 .party-url {
+  display: inline-block;
   margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
   word-break: break-all;
   max-width: 34ch;
+}
+
+.party-url:hover,
+.party-url:focus-visible {
+  color: var(--turquoise);
+  text-decoration: underline;
 }
 
 .party-lobby-side {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The join URL under the party-lobby QR looked like a link but was not clickable — it was rendered as plain text in a `<p>`.

## Change

- Render `.party-url` as an `<a href={joinUrl}>` that opens in a new tab
- Keep the scheme-less display text
- Light hover/focus styling so it reads as interactive
- E2E asserts the anchor `href` shape (`/join/<code>#<token>`)

## Test plan

- Open a party lobby, click the URL under the QR → join page opens in a new tab
- Right-click → Copy link address works
- QR still encodes the same absolute join URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-715e7740-ce86-440c-8252-c71e33aed0a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-715e7740-ce86-440c-8252-c71e33aed0a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

