### PR TITLE
Bake the games snapshot from the dispatched commit, not the branch label

### DIFF
--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -46,7 +46,11 @@ function readFlag(name: string): string | null {
 const dryRun = process.argv.includes('--dry-run');
 const repo = (process.env.GAMES_REPO ?? 'gamedevpl/www.gamedev.pl-games').trim();
 const requestedRef = (readFlag('ref') ?? process.env.GAMES_PUBLISHED_REF ?? 'main').trim();
-const commitSha = readFlag('commit-sha');
+// Normalized once, then used for both the ref below and the pointer metadata.
+// Keeping an untrimmed copy for the pointer would reintroduce, in miniature,
+// the exact failure this script is being fixed for: a `--commit-sha "  "` that
+// reads from the branch while recording whitespace as the commit it read.
+const commitSha = readFlag('commit-sha')?.trim() || null;
 
 /**
  * What the bake actually reads.
@@ -65,7 +69,7 @@ const commitSha = readFlag('commit-sha');
  * what keeps them consistent — `games-repo-archive` refuses to serve a ref it
  * does not hold, and rightly so.
  */
-const ref = commitSha?.trim() || requestedRef;
+const ref = commitSha || requestedRef;
 const bucket = (process.env.GAMES_SNAPSHOT_BUCKET ?? '').trim();
 const token = (process.env.GAMES_REPO_TOKEN ?? process.env.GITHUB_TOKEN ?? '').trim();
 

--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -26,7 +26,11 @@
  * Usage:
  *   npm run snapshot:publish -w @gamedevpl/api
  *   npm run snapshot:publish -w @gamedevpl/api -- --dry-run
- *   npm run snapshot:publish -w @gamedevpl/api -- --ref <sha> --commit-sha <sha>
+ *   npm run snapshot:publish -w @gamedevpl/api -- --ref main --commit-sha <sha>
+ *
+ * `--commit-sha` is not just metadata: when present it is the ref every read
+ * is pinned to, so a bake is a photograph of one tree rather than of whatever
+ * the branch pointed at during each request. See `ref` below.
  */
 
 import { publishSnapshot } from '../src/game-snapshot-publish.js';
@@ -41,8 +45,27 @@ function readFlag(name: string): string | null {
 
 const dryRun = process.argv.includes('--dry-run');
 const repo = (process.env.GAMES_REPO ?? 'gamedevpl/www.gamedev.pl-games').trim();
-const ref = (readFlag('ref') ?? process.env.GAMES_PUBLISHED_REF ?? 'main').trim();
+const requestedRef = (readFlag('ref') ?? process.env.GAMES_PUBLISHED_REF ?? 'main').trim();
 const commitSha = readFlag('commit-sha');
+
+/**
+ * What the bake actually reads.
+ *
+ * A branch name is a moving target. The games repo pushes its refreshed
+ * `catalog.json` and dispatches this job seconds later, so resolving `main`
+ * here can still land on the pre-push tree — and it did: a merge that added a
+ * game published a snapshot of the previous 92 while recording the newer
+ * commit in the pointer. Green run, correct-looking metadata, missing game,
+ * and nothing else retires that snapshot until the next merge or the nightly
+ * re-bake.
+ *
+ * The dispatch already tells us the exact commit, so bake that. `ref` stays
+ * the fallback for callers that cannot name one (a manual bake, the nightly).
+ * Both the archive download and every read below use this one value, which is
+ * what keeps them consistent — `games-repo-archive` refuses to serve a ref it
+ * does not hold, and rightly so.
+ */
+const ref = commitSha?.trim() || requestedRef;
 const bucket = (process.env.GAMES_SNAPSHOT_BUCKET ?? '').trim();
 const token = (process.env.GAMES_REPO_TOKEN ?? process.env.GITHUB_TOKEN ?? '').trim();
 
@@ -95,7 +118,11 @@ async function main(): Promise<void> {
   const client = createGitHubClient({ token, repo, files });
   const writer = dryRun ? createDryRunWriter() : createGcsSnapshotStore({ bucket });
 
-  console.log(`snapshot publish: ${repo}@${ref} → ${dryRun ? '(dry run, nothing written)' : `gs://${bucket}`}`);
+  console.log(
+    `snapshot publish: ${repo}@${ref}` +
+      (ref === requestedRef ? '' : ` (${requestedRef} pinned at this commit)`) +
+      ` → ${dryRun ? '(dry run, nothing written)' : `gs://${bucket}`}`,
+  );
 
   const result = await publishSnapshot({
     client,


### PR DESCRIPTION
A merge that adds a game can publish a snapshot without it, report success, and record the *correct* commit in the pointer while doing so. That happened today with `carjack-city` (games-repo #268).

## What happens

`validate.yml` in the games repo, on a push to `main`, does three things in order: run the gate, commit and push the refreshed `catalog.json`, then dispatch this job with `client_payload.{ref, sha}`. Those last two are seconds apart — today, **3 seconds** (push 10:09:42, dispatch 10:09:45).

The dispatch faithfully sends the exact SHA it just pushed. `publish-snapshot.ts` then used it only as pointer metadata and resolved content from `--ref` (`main`) instead — both for the tarball download and every subsequent read. Resolving `main` in that window returned the pre-push tree, so the bake published **92 games instead of 93**, exited green, and wrote a pointer whose `commitSha` named the commit that *did* contain the 93rd.

Nothing retires that snapshot: the site kept serving 92 games until a manual re-bake. Absent that, it would have waited for the next merge or the 04:23 UTC nightly. The traceability metadata being wrong in the reassuring direction is what makes this hard to spot.

## The fix

Resolve one ref up front in the CLI — `commitSha || ref` — and use it for both the archive download and `publishSnapshot`. The branch remains the fallback for callers that cannot name a commit (a manual bake, the nightly).

**Why the CLI and not `publishSnapshot`:** I tried it a layer lower first, and it is actively worse. `games-repo-archive` refuses to serve a ref it does not hold (`games-repo archive holds ${ref}, not ${requested}`) — correctly, since the archive is one commit. Pinning reads to the SHA while the CLI had fetched the tarball at `main` makes *every* game fail to bake, and a fully-failed bake leaves the pointer untouched. That trades a silently stale snapshot for no publish at all. The caller owns the archive, so the caller has to own the ref.

## Verification

- `apps/api/src/game-snapshot-publish.test.ts` and `games-repo-archive.test.ts` pass (18 tests).
- Dry run against the real repo shows the pinning: the archive request becomes `gamedevpl/www.gamedev.pl-games@bf2b51a…` (previously `@main`), logged as `…@bf2b51a… (main pinned at this commit)`. It then stops at `401` because this container's token has no games-repo scope — environmental, not behavioural.
- `game-snapshot-serve.test.ts` fails identically before and after on a clean tree (unbuilt `@gamedevpl/game-generator` workspace package here), so it is untouched by this change.

## Note on scope

`publishSnapshot`'s own contract is unchanged: `ref` is still what it reads, `commitSha` still pointer metadata. That keeps it honest with `assertRef`. A follow-up worth considering — not done here — is making a partial bake's failure list mention the ref mismatch explicitly, since that is the shape a future mistake here would take.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKmGFA8Ra9NsfNcRxuvdAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKmGFA8Ra9NsfNcRxuvdAJ)_