### PR TITLE
Fix stuck playtest when no build is ready

### DIFF
--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -39,6 +39,8 @@ describe('isKnownSpaShellPath', () => {
     '/studio',
     '/studio/tok-abc',
     '/studio/tok-abc/build',
+    '/studio/tok-abc/thread',
+    '/studio/tok-abc/details',
     '/studio/tok-abc/playtest',
     '/admin',
     '/admin/queue',

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -15,7 +15,8 @@ const DRAFT_PATTERN = /^\/draft\/([^/]+)$/;
 const STATUS_PATTERN = /^\/status\/([^/]+)$/;
 const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
 /** `/studio`, `/studio/:token`, `/studio/:token/:tab` — keep aligned with router.ts. */
-const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:overview|build|playtest|stats|improve))?)?$/;
+/** Keep aligned with `STUDIO_TAB_ALIASES` in apps/web/src/router.ts. */
+const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:thread|details|playtest|overview|build|stats|improve))?)?$/;
 // The operator console. Its sections are listed rather than matched loosely, so the
 // shell and the client's router agree about what is a real page and what is a typo —
 // the same contract the studio tabs above keep.

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -228,6 +228,34 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('lets Playtest toggle back to the thread when already open', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(2));
+    window.history.replaceState(null, '', '/studio/token-0/playtest');
+
+    const { container, root, onNavigate } = await renderStudio({
+      selectedGame: 'token-0',
+      selectedTab: 'playtest',
+    });
+
+    const playtest = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Playtest'),
+    );
+    expect(playtest?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('.studio-playtest')).not.toBeNull();
+    expect(container.querySelector('.studio-build')).toBeNull();
+
+    await act(async () => {
+      playtest!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/thread');
+
+    root.unmount();
+  });
+
   it('lands an old tab name on the surface that absorbed it, and corrects the URL', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -166,6 +166,34 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('closes picker on Escape while in playtest tab without exiting playtest', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(6));
+
+    const { container, root } = await renderStudio({ selectedGame: 'game-2', selectedTab: 'playtest' });
+
+    const switcher = container.querySelector('.studio-game-switcher');
+    expect(switcher).toBeTruthy();
+
+    await act(async () => {
+      switcher!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.studio-picker')).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(container.querySelector('.studio-picker')).toBeFalsy();
+    expect(container.querySelector('.studio-panel')?.classList.contains('is-playtesting')).toBe(true);
+
+    root.unmount();
+    authUser = null;
+  });
+
   it('enters focus mode once the shelf has many games selected', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -503,11 +503,18 @@ export function CreatorStudioView({
                       where it is. */}
                   <div className="studio-head-actions">
                     {/* Playtest is the next action after a build — same weight as Send
-                        feedback, not a peer of the Details toggle beside it. */}
+                        feedback, not a peer of the Details toggle beside it. When already
+                        open (empty/error keeps chrome visible), clicking again returns to
+                        the thread so creators are never stuck without a Build tab. */}
                     {/* Labels are wrapped rather than left as bare text so a phone can
                         hide the word and keep the icon — and hide it the way that leaves
                         the button still named for a screen reader, not display: none. */}
-                    <button type="button" className="studio-head-action is-primary" onClick={() => openTab('playtest')}>
+                    <button
+                      type="button"
+                      className={`studio-head-action is-primary${tab === 'playtest' ? ' is-active' : ''}`}
+                      aria-pressed={tab === 'playtest'}
+                      onClick={() => openTab(tab === 'playtest' ? 'thread' : 'playtest')}
+                    >
                       <PixelIcon name="play" size={12} />{' '}
                       <span className="studio-head-action-label">{t('studioPanel.tabs.playtest')}</span>
                     </button>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -559,6 +559,7 @@ export function CreatorStudioView({
                     game={activeGame}
                     published={isStudioGamePublished(activeGame)}
                     onExit={() => openTab('thread')}
+                    pickerOpen={pickerOpen}
                   />
                 ) : null}
 

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -42,6 +42,7 @@ const game: StudioGame = {
 describe('StudioPlaytestPanel theater', () => {
   beforeEach(() => {
     document.body.className = '';
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -89,5 +90,49 @@ describe('StudioPlaytestPanel theater', () => {
 
     root.unmount();
     expect(document.body.classList.contains('player-open')).toBe(false);
+  });
+
+  it('offers a way back to the thread when no playable build exists', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const { getSubmissionPreview } = await import('./submissionApi.js');
+    vi.mocked(getSubmissionPreview).mockRejectedValueOnce(new Error('no preview'));
+
+    const onExit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const unpublished: StudioGame = { ...game, lastKnownStatus: 'building', slug: undefined, publishedAt: undefined };
+
+    await act(async () => {
+      root.render(createElement(StudioPlaytestPanel, { game: unpublished, published: false, onExit }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.studio-playtest-theater')).toBeNull();
+    expect(container.textContent).toContain('No playable build is ready yet');
+    expect(container.textContent).not.toContain('Build tab');
+
+    const back = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Back to thread'),
+    );
+    expect(back).toBeTruthy();
+
+    await act(async () => {
+      back!.click();
+    });
+    expect(onExit).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onExit).toHaveBeenCalledTimes(2);
+
+    root.unmount();
   });
 });

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -135,4 +135,29 @@ describe('StudioPlaytestPanel theater', () => {
 
     root.unmount();
   });
+
+  it('does not exit on Escape when pickerOpen is true', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const onExit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioPlaytestPanel, { game, published: true, onExit, pickerOpen: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onExit).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
 });

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -148,7 +148,8 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
         if (cancelled) return;
         // Local Studio seed has submissions but no games-repo HTML. Fall back to a
         // tiny canvas toy in Vite so Pause & note can still be exercised offline.
-        if (import.meta.env.DEV) {
+        // Vitest runs with MODE=test — keep the real empty/error surface there.
+        if (import.meta.env.MODE === 'development') {
           setHtml(DEV_PLAYTEST_HTML);
           setLoading(false);
           return;
@@ -162,24 +163,28 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
     };
   }, [game.token, game.slug, published, t, clearSnapshot]);
 
-  // Scroll lock + Escape + focus handoff while the theater owns the viewport.
+  // Escape always returns to the thread — including the empty/error state, where the
+  // theater never mounts and the Close control used to be missing entirely.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') requestExit();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [requestExit]);
+
+  // Scroll lock + focus handoff while the theater owns the viewport.
   useEffect(() => {
     if (!html) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
     document.body.classList.add('player-open');
     exitRef.current?.focus();
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') requestExit();
-    };
-    window.addEventListener('keydown', onKeyDown);
-
     return () => {
-      window.removeEventListener('keydown', onKeyDown);
       document.body.classList.remove('player-open');
       previouslyFocused?.focus?.();
     };
-  }, [html, requestExit]);
+  }, [html]);
 
   const attachedPng = snapshot?.pngBase64 ?? null;
   const trimmed = text.trim();
@@ -219,11 +224,16 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
   return (
     <div className="studio-playtest">
       {!html ? (
-        <>
+        <div className="studio-playtest-empty">
           <p className="panel-copy studio-playtest-hint">{t('studioPanel.playtest.hint')}</p>
           {loading ? <p className="studio-muted">{t('studioPanel.playtest.loading')}</p> : null}
           {loadError ? <p className="error">{loadError}</p> : null}
-        </>
+          {/* Theater Close only exists once HTML loads; empty/error must still offer a
+              labeled way back to the build thread (Testuj replaces that surface). */}
+          <button type="button" className="secondary-btn" onClick={onExit} ref={exitRef}>
+            <PixelIcon name="close" size={12} /> {t('studioPanel.playtest.backToThread')}
+          </button>
+        </div>
       ) : (
         <div
           className={`studio-playtest-theater${paused ? ' is-paused' : ''}${promptOpen ? ' is-prompting' : ''}`}

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -51,6 +51,8 @@ type StudioPlaytestPanelProps = {
   published: boolean;
   /** Leave theater — typically returns to Overview so Studio chrome is usable again. */
   onExit: () => void;
+  /** True when the game switcher picker overlay is open above the playtest surface. */
+  pickerOpen?: boolean;
 };
 
 /**
@@ -102,7 +104,7 @@ function toContext(
   };
 }
 
-export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestPanelProps) {
+export function StudioPlaytestPanel({ game, published, onExit, pickerOpen }: StudioPlaytestPanelProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const exitRef = useRef<HTMLButtonElement | null>(null);
@@ -121,8 +123,9 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
   const requestExit = useCallback(() => {
+    if (pickerOpen) return;
     onExitRef.current();
-  }, []);
+  }, [pickerOpen]);
   // Escape inside the sandboxed game never reaches the parent — the bridge relays it.
   useGamePlayer(frameRef, active, requestExit);
 
@@ -167,11 +170,11 @@ export function StudioPlaytestPanel({ game, published, onExit }: StudioPlaytestP
   // theater never mounts and the Close control used to be missing entirely.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') requestExit();
+      if (event.key === 'Escape' && !pickerOpen) requestExit();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [requestExit]);
+  }, [requestExit, pickerOpen]);
 
   // Scroll lock + focus handoff while the theater owns the viewport.
   useEffect(() => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -276,7 +276,8 @@
     "playtest": {
       "hint": "Play the game, pause on a moment worth changing, and send a request with that viewport and live instrumentation attached.",
       "loading": "Loading the playable build…",
-      "loadError": "No playable build is ready yet. Check the Build tab and try again once a preview exists.",
+      "loadError": "No playable build is ready yet. Go back to the thread and try again once a preview appears.",
+      "backToThread": "Back to thread",
       "theaterAria": "Playtest · {{title}}",
       "pause": "Pause & note",
       "resume": "Resume",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -278,7 +278,8 @@
     "playtest": {
       "hint": "Zagraj, wstrzymaj w momencie wartym zmiany i wyślij prośbę z tym widokiem oraz sygnałami z sesji.",
       "loading": "Ładujemy grywalny build…",
-      "loadError": "Nie ma jeszcze grywalnego buildu. Sprawdź zakładkę Build i spróbuj, gdy pojawi się podgląd.",
+      "loadError": "Nie ma jeszcze grywalnego buildu. Wróć do wątku i spróbuj, gdy pojawi się podgląd.",
+      "backToThread": "Wróć do wątku",
       "theaterAria": "Playtest · {{title}}",
       "pause": "Wstrzymaj i zanotuj",
       "resume": "Wznów",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7427,6 +7427,17 @@ body.player-open {
   margin: 0 0 0.75rem;
 }
 
+.studio-playtest-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.studio-playtest-empty .secondary-btn {
+  margin-top: 0.5rem;
+}
+
 /* Full-viewport playtest theater — same contract as `.stage.is-playing-full-viewport`.
    An inset card inside Studio chrome leaves a postage-stamp iframe on phones
    (iPhone SE especially); the game must own the screen, with controls as layers. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Clicking **Testuj** with no playable build left creators on an empty playtest surface that said “check the Build tab,” but that tab no longer exists after the thread UX rework. There was also no Close control (and Escape only worked once the theater loaded), so returning to the build log felt impossible.

## Fix
- Show a **Back to thread** button on the empty/error playtest state; Escape always exits playtest
- Let the **Testuj** head action toggle back to the thread when already open
- Update EN/PL copy to point at the thread instead of a removed Build tab
- Allow `/studio/:game/thread` and `/details` as known SPA shell paths (aligned with router aliases)

## Test plan
- [ ] Open Studio on a game with no preview, click Testuj → see updated error + Back to thread
- [ ] Click Back to thread / press Escape / click Testuj again → return to build log
- [ ] Successful playtest still exits via theater Close / Escape

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddc30599-687a-4fbb-8c9d-474566712b09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddc30599-687a-4fbb-8c9d-474566712b09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

