### PR TITLE
Fix QA questions staying English after switching to Polish

### DIFF
--- a/apps/api/src/refine.test.ts
+++ b/apps/api/src/refine.test.ts
@@ -256,7 +256,21 @@ describe('VertexSpecRefiner over a genaicode client', () => {
     });
     expect(seen?.temperature).toBe(0.2);
     expect(seen?.prompt[0]?.text).toContain('Carrot Farm');
-    expect(seen?.prompt[0]?.text).toContain('(pl)');
+    // Full language name, not a bare `pl` tag — models ignore the tag when the
+    // concept itself is English.
+    expect(seen?.prompt[0]?.text).toContain('Polish');
+    expect(seen?.prompt[0]?.text).toContain('entirely in Polish');
+  });
+
+  it('asks for English by name when locale is missing or unknown', async () => {
+    let seen: GenerationRequest | undefined;
+    const refiner = new VertexSpecRefiner({
+      client: stubClient(JSON.stringify({ questions: [] }), (req) => (seen = req)),
+    });
+
+    await refiner.refine({ concept: 'A concept long enough to refine without a title yet' });
+
+    expect(seen?.prompt[0]?.text).toContain('entirely in English');
   });
 
   it('fills defaults for partial question objects', async () => {

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -8,6 +8,13 @@ import type { ContentChecker } from './moderation.js';
 import { sanitizeCreatorText } from './submission-status.js';
 import type { Store } from './store.js';
 import { logModerationRejection } from './moderation-metrics.js';
+import { normalizeLocale } from './translate.js';
+
+/** Full names the model is asked to write in — a bare `pl` tag is easy to ignore. */
+const LANGUAGE_NAMES: Record<string, string> = {
+  pl: 'Polish',
+  en: 'English',
+};
 
 export interface RefineOption {
   label: string;
@@ -163,6 +170,12 @@ export class VertexSpecRefiner implements SpecRefiner {
     }
 
     try {
+      // Resolve to a language *name*: models routinely echo English when the concept
+      // is English and the instruction only says `(pl)`. The UI language wins even
+      // when the creator typed their idea in another language.
+      const locale = normalizeLocale(params.locale);
+      const languageName = LANGUAGE_NAMES[locale] ?? 'English';
+
       const promptText = `You are a helpful game design assistant for gamedev.pl.
 Analyze the following game concept specification.
 
@@ -170,7 +183,7 @@ Do two things:
 1. Propose "suggestedTitle": a short, catchy name for this game — at most 6 words, no quotes, no trailing punctuation. Name the game, do not describe it, and never echo the concept text back as a sentence.
 2. Identify up to 4 underspecified or missing gameplay/design dimensions (such as visual style, controls, difficulty/pacing, or win/lose conditions) that would help a coding agent build a better game.
 
-Language requirement: Write the title, questions and options in the language specified (${params.locale ?? 'en'}).
+Language requirement (mandatory): Write suggestedTitle, every question, every option label, and every option detail entirely in ${languageName}. The game concept below may be written in a different language — ignore that and still write all of your output in ${languageName}. Do not mix languages. Proper nouns from the concept may stay as-is.
 
 Respond STRICTLY with a JSON object following this schema:
 {
@@ -303,7 +316,7 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
 
   const cacheKey = (data: { title?: string; concept: string; locale?: string }) =>
     createHash('sha256')
-      .update(`${data.locale ?? 'en'}\x00${data.title ?? ''}\x00${data.concept}`)
+      .update(`${normalizeLocale(data.locale)}\x00${data.title ?? ''}\x00${data.concept}`)
       .digest('hex');
 
   const readCache = (key: string, now: number): RefineResponse | null => {
@@ -386,7 +399,7 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
       const result = await specRefiner.refine({
         ...(parseResult.data.title ? { title: parseResult.data.title } : {}),
         concept: parseResult.data.concept,
-        locale: parseResult.data.locale,
+        locale: normalizeLocale(parseResult.data.locale),
       });
       // Fail-open makes an outage look exactly like a fully-specified concept: both
       // are zero questions and a 200. Without this line there is no way to tell them

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -49,10 +49,12 @@ function deferred<T>() {
 
 function mockApi(
   options: {
-    onRefine?: () => void;
+    onRefine?: (body: { concept: string; locale?: string }) => void;
     gate?: Promise<void>;
     /** Empty models a fully-specified concept: nothing to clarify, still to be named. */
     questions?: typeof QUESTIONS;
+    /** Per-locale override — used to prove a language switch re-asks. */
+    questionsByLocale?: Record<string, typeof QUESTIONS>;
     suggestedTitle?: string;
     refineFails?: boolean;
     onSubmit?: (body: { title: string; concept: string }) => void;
@@ -77,12 +79,19 @@ function mockApi(
     }
     if (url.includes('/api/submissions/mine')) return new Response(JSON.stringify({ submissions: [] }));
     if (url.endsWith('/api/submissions/refine')) {
-      options.onRefine?.();
+      const body = JSON.parse(String(init?.body ?? '{}')) as { concept: string; locale?: string };
+      options.onRefine?.(body);
       if (options.gate) await options.gate;
       if (options.refineFails) return new Response(JSON.stringify({ error: 'boom' }), { status: 500 });
+      const locale = body.locale ?? 'en';
+      const questions =
+        options.questionsByLocale?.[locale] ??
+        options.questionsByLocale?.[locale.slice(0, 2)] ??
+        options.questions ??
+        QUESTIONS;
       return new Response(
         JSON.stringify({
-          questions: options.questions ?? QUESTIONS,
+          questions,
           ...(options.suggestedTitle ? { suggestedTitle: options.suggestedTitle } : {}),
         }),
       );
@@ -267,6 +276,56 @@ describe('the QA gate in App', () => {
     const name = container.querySelector<HTMLInputElement>('.qa-name-input');
     expect(name?.value).toBe('A survival game on a desert island with');
     expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('re-asks the questions in Polish when the UI language switches mid-round', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const locales: string[] = [];
+    mockApi({
+      onRefine: (body) => locales.push(body.locale ?? 'en'),
+      questionsByLocale: {
+        en: QUESTIONS,
+        pl: [
+          {
+            id: 'visual_style',
+            question: 'Jaki styl wizualny pasuje najlepiej?',
+            options: [{ label: 'Pixel art' }, { label: 'Low-poly 3D' }],
+            allowFreeText: true,
+          },
+        ],
+      },
+    });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    expect(container.querySelector('.qa-card__question')?.textContent).toContain('What visual style');
+    expect(locales).toEqual(['en']);
+
+    // Pick a chip so we can prove the language switch clears English selections —
+    // those labels would no longer match the Polish options.
+    await act(async () => {
+      container.querySelector('.qa-chip')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(container.querySelector('.qa-chip')?.getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => {
+      await i18n.changeLanguage('pl');
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(locales).toEqual(['en', 'pl']);
+    expect(container.querySelector('.qa-card__question')?.textContent).toContain('Jaki styl wizualny');
+    expect(container.querySelectorAll('.qa-card')).toHaveLength(1);
+    // Old English selection must not linger under the new chips.
+    expect(container.querySelector('.qa-chip')?.getAttribute('aria-pressed')).toBe('false');
+    expect(JSON.parse(localStorage.getItem('gamedev_pending_qa')!).locale).toBe('pl');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -80,7 +80,7 @@ function mockApi(
     if (url.includes('/api/submissions/mine')) return new Response(JSON.stringify({ submissions: [] }));
     if (url.endsWith('/api/submissions/refine')) {
       const body = JSON.parse(String(init?.body ?? '{}')) as { concept: string; locale?: string };
-      options.onRefine?.(body);
+      await options.onRefine?.(body);
       if (options.gate) await options.gate;
       if (options.refineFails) return new Response(JSON.stringify({ error: 'boom' }), { status: 500 });
       const locale = body.locale ?? 'en';
@@ -327,6 +327,128 @@ describe('the QA gate in App', () => {
     expect(container.querySelector('.qa-chip')?.getAttribute('aria-pressed')).toBe('false');
     expect(JSON.parse(localStorage.getItem('gamedev_pending_qa')!).locale).toBe('pl');
 
+    await act(async () => root.unmount());
+  });
+
+  it('disables QA controls while relocalizing during a language switch', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const gate = deferred<void>();
+    let refineCalls = 0;
+    mockApi({
+      onRefine: async () => {
+        refineCalls += 1;
+        if (refineCalls === 2) await gate.promise;
+      },
+      questionsByLocale: {
+        en: QUESTIONS,
+        pl: [
+          {
+            id: 'visual_style',
+            question: 'Jaki styl wizualny?',
+            options: [{ label: 'Pixel art' }],
+            allowFreeText: true,
+          },
+        ],
+      },
+    });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    const createBtn = container.querySelector<HTMLButtonElement>('.qa-container .btn-create-now')!;
+    const chipBtn = container.querySelector<HTMLButtonElement>('.qa-chip')!;
+    expect(createBtn).not.toBeNull();
+    expect(createBtn.disabled).toBe(false);
+    expect(chipBtn.disabled).toBe(false);
+
+    // Switch language to trigger relocalization (which is the 2nd refine call, paused on `gate.promise`)
+    await act(async () => {
+      await i18n.changeLanguage('pl');
+      await flushEffects();
+    });
+
+    // While relocalization is in flight, controls in CreatorQA must be disabled
+    expect(container.querySelector<HTMLButtonElement>('.qa-container .btn-create-now')?.disabled).toBe(true);
+    expect(container.querySelector<HTMLButtonElement>('.qa-chip')?.disabled).toBe(true);
+
+    // Resolve relocalization call
+    await act(async () => {
+      gate.resolve();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('.btn-create-now')?.disabled).toBe(false);
+    expect(container.querySelector<HTMLButtonElement>('.qa-chip')?.disabled).toBe(false);
+    await act(async () => root.unmount());
+  });
+
+  it('preserves existing questions when relocalization returns an empty fail-open response', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    mockApi({
+      questionsByLocale: {
+        en: QUESTIONS,
+        pl: [], // Model returns empty array on fail-open/timeout
+      },
+    });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    expect(container.querySelectorAll('.qa-card')).toHaveLength(2);
+
+    await act(async () => {
+      await i18n.changeLanguage('pl');
+      await flushEffects();
+      await flushEffects();
+    });
+
+    // The 2 English questions must be retained, not erased into a name-only panel
+    expect(container.querySelectorAll('.qa-card')).toHaveLength(2);
+    expect(container.querySelector('.qa-card__question')?.textContent).toContain('What visual style');
+    await act(async () => root.unmount());
+  });
+
+  it('preserves user-entered custom text when switching UI language', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    mockApi({
+      questionsByLocale: {
+        en: QUESTIONS,
+        pl: [
+          {
+            id: 'visual_style',
+            question: 'Jaki styl wizualny pasuje najlepiej?',
+            options: [{ label: 'Pixel art' }, { label: 'Low-poly 3D' }],
+            allowFreeText: true,
+          },
+        ],
+      },
+    });
+
+    const { container, root } = await renderApp();
+    await submitIdea(container);
+
+    const customInput = container.querySelector<HTMLInputElement>('.qa-custom-input input')!;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(customInput, 'with Amiga palette');
+      customInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(customInput.value).toBe('with Amiga palette');
+
+    await act(async () => {
+      await i18n.changeLanguage('pl');
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const plCustomInput = container.querySelector<HTMLInputElement>('.qa-custom-input input');
+    expect(plCustomInput?.value).toBe('with Amiga palette');
     await act(async () => root.unmount());
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -102,6 +102,8 @@ export function App() {
   // during which nothing has been submitted yet, so the UI must not claim otherwise.
   const [submissionStatus, setSubmissionStatus] = useState<'idle' | 'refining' | 'loading'>('idle');
   const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const submissionStatusRef = useRef(submissionStatus);
+  submissionStatusRef.current = submissionStatus;
 
   // Clarifying-questions gate: a submission runs the spec refiner first, and when
   // it returns questions the creator must answer them before generation proceeds.
@@ -348,7 +350,7 @@ export function App() {
     const targetLocale = i18n.resolvedLanguage ?? i18n.language;
     if (qaLocale === targetLocale) return;
     // A real submit is in flight — don't yank the questions out from under it.
-    if (submissionStatus === 'loading') return;
+    if (submissionStatusRef.current === 'loading') return;
     if (qaRelocalizingRef.current) return;
 
     let cancelled = false;
@@ -360,19 +362,44 @@ export function App() {
       try {
         const refined = await refineSpec({ concept, locale: targetLocale });
         if (cancelled) return;
+        // A real submit started while refine was in flight — drop the relocalization.
+        if (submissionStatusRef.current === 'loading') return;
+
         const questions = refined.questions;
+        // Fail-open: when Vertex times out or errors, it returns empty questions.
+        // Keep the existing questions and parked session instead of wiping them into a name-only panel.
+        if (questions.length === 0) return;
+
         // Prefer the live parked spec so a title edit mid-flight is not overwritten.
         const liveSpec = pendingSpecRef.current;
         if (!liveSpec) return;
+
+        // Preserve user-entered custom answers across questions matching by ID or index.
+        const oldCustom = latestAnswersRef.current.custom ?? {};
+        const oldQuestions = qaQuestions;
+        const preservedCustom: Record<string, string> = {};
+
+        questions.forEach((newQ, idx) => {
+          const customById = oldCustom[newQ.id];
+          const oldQ = oldQuestions[idx];
+          const customByIndex = oldQ ? oldCustom[oldQ.id] : undefined;
+          const val = customById || customByIndex;
+          if (val && val.trim()) {
+            preservedCustom[newQ.id] = val;
+          }
+        });
+
+        const newAnswers: PendingQaAnswers = { selected: {}, custom: preservedCustom };
+
         setQaQuestions(questions);
         setQaLocale(targetLocale);
-        latestAnswersRef.current = { selected: {}, custom: {} };
+        latestAnswersRef.current = newAnswers;
         // Drop restored answers so a remounted panel doesn't revive English selections.
         if (restoredQa.current) {
           restoredQa.current = {
             ...restoredQa.current,
             questions,
-            answers: { selected: {}, custom: {} },
+            answers: newAnswers,
             locale: targetLocale,
             savedAt: Date.now(),
           };
@@ -380,7 +407,7 @@ export function App() {
         savePendingQa({
           spec: liveSpec,
           questions,
-          answers: { selected: {}, custom: {} },
+          answers: newAnswers,
           locale: targetLocale,
         });
         setQaFormKey((key) => key + 1);
@@ -388,7 +415,9 @@ export function App() {
         // Keep the previous questions rather than blanking the panel on a blip.
       } finally {
         qaRelocalizingRef.current = false;
-        if (!cancelled) setSubmissionStatus('idle');
+        if (!cancelled && submissionStatusRef.current === 'refining') {
+          setSubmissionStatus('idle');
+        }
       }
     }
 
@@ -851,9 +880,9 @@ export function App() {
                   onSubmitWithConcept={handleQaComplete}
                   onTitleChange={handleQaTitleChange}
                   onCancel={handleQaCancel}
-                  submitting={submissionStatus === 'loading'}
+                  submitting={submissionStatus === 'loading' || submissionStatus === 'refining'}
                   error={submissionError}
-                  initialAnswers={qaFormKey === 0 ? restoredQa.current?.answers : undefined}
+                  initialAnswers={latestAnswersRef.current}
                   onAnswersChange={handleQaAnswersChange}
                 />
               </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -113,7 +113,17 @@ export function App() {
   const [pendingSpec, setPendingSpec] = useState<{ title: string; concept: string; displayName: string } | null>(
     restoredQa.current?.spec ?? null,
   );
+  // Language the parked questions were written in. Empty when an older blob never
+  // recorded one — that mismatch with the live UI language is what triggers a
+  // one-shot re-ask so English chips don't stick under a Polish chrome.
+  const [qaLocale, setQaLocale] = useState<string>(restoredQa.current?.locale ?? '');
+  // Bumped when questions are rewritten for a new language so CreatorQA remounts
+  // with empty answers — English chip labels must not survive as "selected" under
+  // Polish options that no longer match.
+  const [qaFormKey, setQaFormKey] = useState(0);
   const qaRef = useRef<HTMLDivElement | null>(null);
+  // Kept next to the QA state so the language-switch effect can clear it too.
+  const latestAnswersRef = useRef<PendingQaAnswers>(restoredQa.current?.answers ?? { selected: {}, custom: {} });
 
   // Demo generator state
   const [mockStatus, setMockStatus] = useState<'idle' | 'loading' | 'error'>('idle');
@@ -325,6 +335,77 @@ export function App() {
     }
   }, [pendingSpec]);
 
+  // The static chrome follows the language switcher instantly; the AI questions do
+  // not — they were authored in whatever language the refine call used. Re-ask when
+  // the UI language changes mid-round (or a restored session was parked under a
+  // different language) so a Polish UI never keeps showing English chips.
+  const qaRelocalizingRef = useRef(false);
+  const pendingSpecRef = useRef(pendingSpec);
+  pendingSpecRef.current = pendingSpec;
+  useEffect(() => {
+    const parked = pendingSpecRef.current;
+    if (!parked) return;
+    const targetLocale = i18n.resolvedLanguage ?? i18n.language;
+    if (qaLocale === targetLocale) return;
+    // A real submit is in flight — don't yank the questions out from under it.
+    if (submissionStatus === 'loading') return;
+    if (qaRelocalizingRef.current) return;
+
+    let cancelled = false;
+    qaRelocalizingRef.current = true;
+    setSubmissionStatus('refining');
+    const concept = parked.concept;
+
+    async function relocalizeQa() {
+      try {
+        const refined = await refineSpec({ concept, locale: targetLocale });
+        if (cancelled) return;
+        const questions = refined.questions;
+        // Prefer the live parked spec so a title edit mid-flight is not overwritten.
+        const liveSpec = pendingSpecRef.current;
+        if (!liveSpec) return;
+        setQaQuestions(questions);
+        setQaLocale(targetLocale);
+        latestAnswersRef.current = { selected: {}, custom: {} };
+        // Drop restored answers so a remounted panel doesn't revive English selections.
+        if (restoredQa.current) {
+          restoredQa.current = {
+            ...restoredQa.current,
+            questions,
+            answers: { selected: {}, custom: {} },
+            locale: targetLocale,
+            savedAt: Date.now(),
+          };
+        }
+        savePendingQa({
+          spec: liveSpec,
+          questions,
+          answers: { selected: {}, custom: {} },
+          locale: targetLocale,
+        });
+        setQaFormKey((key) => key + 1);
+      } catch {
+        // Keep the previous questions rather than blanking the panel on a blip.
+      } finally {
+        qaRelocalizingRef.current = false;
+        if (!cancelled) setSubmissionStatus('idle');
+      }
+    }
+
+    void relocalizeQa();
+    return () => {
+      cancelled = true;
+      // Strict Mode remounts (and a follow-up language flip) must be allowed to start
+      // a new call; leaving the guard latched would park the panel on "analyzing".
+      qaRelocalizingRef.current = false;
+    };
+    // Depend on the concept, not the whole pendingSpec object: title edits must not
+    // cancel and restart a language switch mid-flight. submissionStatus is read to
+    // skip during submit; listing it would cancel the relocalize when we flip to
+    // 'refining' ourselves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
+  }, [i18n.language, i18n.resolvedLanguage, pendingSpec?.concept, qaLocale]);
+
   // Menu navigation is scroll-to-section, but the sections only exist on the home
   // route — from a status page we have to go home first and scroll once the target
   // has mounted (the Games gallery may still be loading).
@@ -427,9 +508,13 @@ export function App() {
       concept: trimmedConcept,
       displayName: displayName.trim(),
     };
+    const locale = i18n.resolvedLanguage ?? i18n.language;
     setPendingSpec(spec);
     setQaQuestions(questions);
-    savePendingQa({ spec, questions, answers: { selected: {}, custom: {} } });
+    setQaLocale(locale);
+    latestAnswersRef.current = { selected: {}, custom: {} };
+    savePendingQa({ spec, questions, answers: { selected: {}, custom: {} }, locale });
+    setQaFormKey((key) => key + 1);
     setSubmissionStatus('idle');
   }
 
@@ -466,6 +551,7 @@ export function App() {
       // whole call. A no-op when the spec never went through the gate.
       setQaQuestions([]);
       setPendingSpec(null);
+      setQaLocale('');
       clearPendingQa();
 
       // Straight to the game's own address. Older API builds answer without a slug, in
@@ -514,19 +600,19 @@ export function App() {
   const handleQaCancel = () => {
     setQaQuestions([]);
     setPendingSpec(null);
+    setQaLocale('');
     clearPendingQa();
   };
 
   // Every keystroke and chip lands in storage, so the round survives a reload at any
   // point rather than only between questions.
-  const latestAnswersRef = useRef<PendingQaAnswers>({ selected: {}, custom: {} });
   const handleQaAnswersChange = useCallback(
     (answers: PendingQaAnswers) => {
       latestAnswersRef.current = answers;
       if (!pendingSpec) return;
-      savePendingQa({ spec: pendingSpec, questions: qaQuestions, answers });
+      savePendingQa({ spec: pendingSpec, questions: qaQuestions, answers, locale: qaLocale });
     },
-    [pendingSpec, qaQuestions],
+    [pendingSpec, qaQuestions, qaLocale],
   );
 
   // The name is parked with the answers, for the same reason: an edited title is work,
@@ -537,9 +623,14 @@ export function App() {
       if (!pendingSpec) return;
       const spec = { ...pendingSpec, title };
       setPendingSpec(spec);
-      savePendingQa({ spec, questions: qaQuestions, answers: latestAnswersRef.current });
+      savePendingQa({
+        spec,
+        questions: qaQuestions,
+        answers: latestAnswersRef.current,
+        locale: qaLocale,
+      });
     },
-    [pendingSpec, qaQuestions],
+    [pendingSpec, qaQuestions, qaLocale],
   );
 
   // Whether this tab has pushed a history entry of its own — i.e. whether going Back
@@ -753,6 +844,7 @@ export function App() {
             {pendingSpec && (
               <div ref={qaRef}>
                 <CreatorQA
+                  key={qaFormKey}
                   questions={qaQuestions}
                   initialConcept={pendingSpec.concept}
                   initialTitle={pendingSpec.title}
@@ -761,7 +853,7 @@ export function App() {
                   onCancel={handleQaCancel}
                   submitting={submissionStatus === 'loading'}
                   error={submissionError}
-                  initialAnswers={restoredQa.current?.answers}
+                  initialAnswers={qaFormKey === 0 ? restoredQa.current?.answers : undefined}
                   onAnswersChange={handleQaAnswersChange}
                 />
               </div>

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -203,6 +203,7 @@ export function CreatorQA({
                       // every chip identically whether or not it was chosen.
                       aria-pressed={isSelected}
                       className={`qa-chip ${isSelected ? 'qa-chip--selected' : ''}`}
+                      disabled={submitting}
                       onClick={() => handleSelectOption(q, opt.label)}
                     >
                       <span className="qa-chip__label">{opt.label}</span>
@@ -222,6 +223,7 @@ export function CreatorQA({
                     // not names — without this the field is announced unlabelled.
                     aria-label={`${q.question} — ${t('qa.otherPlaceholder')}`}
                     value={custom}
+                    disabled={submitting}
                     onChange={(e) => handleCustomTextChange(q.id, e.target.value)}
                   />
                 </div>

--- a/apps/web/src/pendingQa.test.ts
+++ b/apps/web/src/pendingQa.test.ts
@@ -16,12 +16,18 @@ describe('pendingQa', () => {
   });
 
   it('round-trips a session so a reload resumes where the creator left off', () => {
-    savePendingQa(session);
+    savePendingQa({ ...session, locale: 'pl' });
 
     const restored = loadPendingQa();
     expect(restored?.spec).toEqual(session.spec);
     expect(restored?.questions).toEqual(session.questions);
     expect(restored?.answers).toEqual(session.answers);
+    expect(restored?.locale).toBe('pl');
+  });
+
+  it('tolerates older blobs that never recorded a locale', () => {
+    savePendingQa(session);
+    expect(loadPendingQa()?.locale).toBeUndefined();
   });
 
   it('drops a session older than a day instead of resurrecting a forgotten idea', () => {

--- a/apps/web/src/pendingQa.ts
+++ b/apps/web/src/pendingQa.ts
@@ -21,6 +21,12 @@ export interface PendingQaSession {
   spec: { title: string; concept: string; displayName: string };
   questions: QAQuestion[];
   answers: PendingQaAnswers;
+  /**
+   * UI language the questions were authored in. When the creator switches language
+   * mid-round, the app re-asks so chips and free-text stay in the language they are
+   * reading — without this, a Polish UI would keep showing English AI text.
+   */
+  locale?: string;
   savedAt: number;
 }
 
@@ -56,6 +62,7 @@ export function loadPendingQa(): PendingQaSession | null {
       // displayName is optional to the creator, so tolerate its absence in older blobs.
       spec: { ...parsed.spec, title: parsed.spec.title ?? '', displayName: parsed.spec.displayName ?? '' },
       answers: { selected: parsed.answers?.selected ?? {}, custom: parsed.answers?.custom ?? {} },
+      ...(typeof parsed.locale === 'string' && parsed.locale ? { locale: parsed.locale } : {}),
     };
   } catch {
     // Corrupt or unreadable (private mode, disabled storage): start clean rather than


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Switching the UI to Polish left creator QA questions and answer chips in English. Static chrome (placeholders, buttons, section titles) translated correctly; only the AI-authored content did not.

Two causes:

1. The refine prompt asked the model to write in `(pl)` — a bare locale tag that models routinely ignore when the concept itself is English.
2. Questions parked mid-round (including restored sessions) never re-asked after a language switch, so English chips stayed under Polish chrome.

## Fix

- Strengthen the Vertex refine prompt to demand output **entirely in Polish/English by name**, even when the concept is in another language.
- Normalize the refine locale the same way as the rest of the API.
- Record the locale on the pending QA session, and re-call refine when the language switcher flips mid-round (clearing stale chip selections so English labels cannot linger under Polish options).

## Tests

- Refine prompt asserts full language names (`Polish` / `English`).
- App QA test: EN → PL mid-round re-asks and replaces the questions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53aacbc6-6842-4336-b07a-1770d2022715?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53aacbc6-6842-4336-b07a-1770d2022715&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

