### PR TITLE
Show why a build needs changes in Creator Studio

### DIFF
--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -190,12 +190,13 @@ export interface SubmissionStatusResponseBase {
    */
   stall?: JobStall;
   /**
-   * The build's last round ended in an error rather than a delivery. Set alongside
-   * `status` because the public vocabulary projects `failed` onto `needs_changes` —
-   * without this the page says "waiting for your input" about a session that died,
-   * which reads as the creator's fault instead of ours. `reason` is the transition's
-   * machine-readable cause (`task_failed`, `task_timed_out`, …), a closed vocabulary
-   * like `stall`: the UI renders its own translated copy, not this string.
+   * Why this build is asking the creator to act, when it is. Set alongside `status`
+   * because the public vocabulary projects both `failed` and a gate bounce onto
+   * `needs_changes` — without this the page only shows the label, and a creator who
+   * clicked "needs changes" never learns what happened or that feedback below starts
+   * the next round. `reason` is the transition's machine-readable cause
+   * (`task_failed`, `task_timed_out`, `gate_red`, …), a closed vocabulary like
+   * `stall`: the UI renders its own translated copy, not this string.
    */
   failure?: { reason: string };
 }

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -891,6 +891,46 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('names a gate bounce so Studio can say why the build needs another round', async () => {
+    // Public status collapses `needs_changes` into a label; without `failure` the
+    // creator who clicked the notification sees planning notes and an empty foot.
+    const { githubClient } = createGithubClientStub({ issueNumber: 88 });
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'needs_changes',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_red',
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    expect(status.statusCode).toBe(200);
+    expect(status.json().status).toBe('needs_changes');
+    expect(status.json().phase).toBe('needs_changes');
+    expect(status.json().failure).toEqual({ reason: 'gate_red' });
+
+    await app.close();
+  });
+
   it('reports the job phase alongside the status, so the page can say which wait this is', async () => {
     // `toSubmissionStatus` is lossy on purpose — `gating` and `building` arrive as one
     // word, and `ready_for_review` (delivered, checked, waiting on us) arrives as the

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1302,13 +1302,16 @@ export async function registerSubmissionRoutes(
       ...(record.abandonedAt ? {} : { phase: state }),
       ...(record.slug ? { slug: record.slug } : {}),
     };
-    // `failed` projects onto `needs_changes`, which the page renders as "waiting for
-    // your input" — true about what to do next, a lie about what happened. Name the
-    // error, with the transition's own reason, so the creator is asked to retry a
-    // build that died rather than left waiting on one that looks alive.
-    if (state === 'failed' && !record.abandonedAt) {
-      const lastFailure = [...(record.transitions ?? [])].reverse().find((transition) => transition.to === 'failed');
-      status.failure = { reason: lastFailure?.reason ?? 'unknown' };
+    // `failed` and a gate bounce both project onto public `needs_changes`. Without a
+    // reason the Studio page only says the label — creators click the notification,
+    // land on a thread of old planning notes, and never learn *why* the build stopped
+    // or that sending feedback below is what starts the next round. Name the
+    // transition's own cause so the page can render translated copy for it.
+    if ((state === 'failed' || state === 'needs_changes') && !record.abandonedAt) {
+      const lastBounce = [...(record.transitions ?? [])].reverse().find((transition) => transition.to === state);
+      status.failure = {
+        reason: lastBounce?.reason ?? (state === 'failed' ? 'unknown' : 'gate_red'),
+      };
     }
     // Echo the creator's change requests from the store. On jobs without a pull
     // request the store copy is the only durable record — the page used to render

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -500,6 +500,44 @@ describe('SubmissionStatusView', () => {
     });
 
     expect(container.textContent).toContain('Needs a tweak');
+    expect(container.textContent).toContain('Send a short note below to continue');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('names a gate bounce in Studio even when the thread already has turns', async () => {
+    // The bounce reason used to live only in emptyLabel — once the agent had posted
+    // planning notes, "Needs a tweak" was a label with no explanation above the box.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'needs_changes',
+      failure: { reason: 'gate_red' },
+      events: [
+        {
+          id: 'e1',
+          kind: 'step',
+          step: 'planning',
+          text: 'Sketching the board.',
+          createdAt: '2026-07-30T12:00:00.000Z',
+        },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'gate-red-token', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.status-warning')?.textContent).toContain("didn't pass our automatic checks");
+    expect(container.textContent).toContain('Needs a tweak');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -140,7 +140,7 @@ function StatusTimeline({ current }: { current: SubmissionStatus['status'] }) {
 type PendingRevision = { text: string; at: number };
 
 /** Failure reasons with their own copy; anything newer gets the generic sentence. */
-const FAILURE_COPY_KEYS = new Set(['task_failed', 'task_timed_out', 'task_completed_without_delivery']);
+const FAILURE_COPY_KEYS = new Set(['task_failed', 'task_timed_out', 'task_completed_without_delivery', 'gate_red']);
 
 function failureCopyKey(reason: string): string {
   return FAILURE_COPY_KEYS.has(reason) ? reason : 'generic';
@@ -486,11 +486,19 @@ export function SubmissionStatusView({
               <div className="studio-thread-foot">
                 {/* Trouble is said once, immediately above the box the creator would use
                     to do something about it. A dead round outranks a slow one: when both
-                    are set the failure is the explanation and the stall is its symptom. */}
+                    are set the failure is the explanation and the stall is its symptom.
+                    `needs_changes` without a typed failure (legacy GitHub path) still
+                    needs a sentence here — the thread's emptyLabel only shows when there
+                    are no turns, which is exactly when a bounced build still has planning
+                    notes and used to look like nothing was wrong. */}
                 {status.failure ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} />{' '}
                     {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
+                  </p>
+                ) : status.status === 'needs_changes' ? (
+                  <p className="status-warning">
+                    <PixelIcon name="signal" size={13} /> {t('statusView.states.needs_changes.description')}
                   </p>
                 ) : status.stall ? (
                   <p className="status-warning">

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -513,7 +513,7 @@
       },
       "needs_changes": {
         "label": "Needs a tweak",
-        "description": "This one didn't make it through. Tweak the idea and submit it again."
+        "description": "This build needs another round before it can go live. Send a short note below to continue — even \"please fix the checks\" is enough."
       },
       "abandoned": {
         "label": "Stopped",
@@ -537,6 +537,7 @@
       "task_failed": "The build agent stopped unexpectedly before finishing. Your game and everything built so far are safe — send feedback below to start another round.",
       "task_timed_out": "The build ran out of time before finishing. Your progress is safe — send feedback below to start another round.",
       "task_completed_without_delivery": "The agent finished without delivering the game. Send feedback below to start another round.",
+      "gate_red": "This build didn't pass our automatic checks, so it can't go live yet. Send feedback below to start another round — the agent will see what failed and fix it.",
       "generic": "This build round ended with an error. Your progress is safe — send feedback below to start another round."
     },
     "stall": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -517,7 +517,7 @@
       },
       "needs_changes": {
         "label": "Wymaga poprawki",
-        "description": "Ta wersja nie przeszła. Popraw pomysł i zgłoś go ponownie."
+        "description": "Ta wersja potrzebuje jeszcze jednej rundy, zanim będzie mogła trafić do arcade. Wyślij poniżej krótką uwagę, aby kontynuować — nawet „popraw testy” wystarczy."
       },
       "abandoned": {
         "label": "Zatrzymana",
@@ -541,6 +541,7 @@
       "task_failed": "Agent budujący niespodziewanie przerwał pracę. Twoja gra i dotychczasowe postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "task_timed_out": "Budowanie nie zdążyło się skończyć w wyznaczonym czasie. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "task_completed_without_delivery": "Agent zakończył pracę, ale nie dostarczył gry. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
+      "gate_red": "Ta wersja nie przeszła naszych automatycznych testów, więc jeszcze nie może trafić do arcade. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę — agent zobaczy, co nie przeszło, i to poprawi.",
       "generic": "Ta runda budowania zakończyła się błędem. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę."
     },
     "stall": {

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -119,10 +119,10 @@ export type SubmissionStatus = {
    */
   stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started';
   /**
-   * The last build round ended in an error rather than a delivery. `reason` is a
-   * machine-readable cause (`task_failed`, `task_timed_out`, …) — render translated
-   * copy keyed on it, never the string itself. Sending feedback starts a new round,
-   * so the message to pair with this is "retry", not "give up".
+   * Why this build is asking the creator to act. Covers a dead agent round
+   * (`task_failed`, …) and a gate bounce (`gate_red`) — both arrive as public
+   * `needs_changes`. Render translated copy keyed on `reason`, never the string
+   * itself. Sending feedback starts a new round.
    */
   failure?: { reason: string };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a build lands in **Needs a tweak** / **Wymaga poprawki** (especially after automatic checks refuse a delivery), Creator Studio only showed the status label. Clicking the notification opened a thread of earlier planning notes and a feedback box, with no explanation of *what* failed or that sending a note starts the next round.

## Fix

- Status API now returns `failure.reason` for both dead agent rounds (`task_failed`, …) and gate bounces (`gate_red`).
- Studio always renders that explanation above the feedback composer, even when the activity thread already has turns.
- Copy updated so creators are pointed at the feedback box instead of “submit the idea again.”

## Test plan

- [x] API: gate_red job reports `failure: { reason: 'gate_red' }`
- [x] UI: embedded Studio shows gate-bounce copy when events exist
- [x] Full green gate (`type-check`, `lint`, `test`, `build`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6776a40-409d-4fe9-8bb9-4b8ee561bb5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6776a40-409d-4fe9-8bb9-4b8ee561bb5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

