### PR TITLE
Make the studio thread an app screen on a phone, and take the furniture out of it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,34 @@ will be; exchange it at `POST /api/auth/session` for the cookie the SPA sends if
 driving a browser. Tokens are issued by the repo owner and must never be committed. See
 [`docs/agent-access-tokens.md`](docs/agent-access-tokens.md).
 
+## Layout changes: check the states that coexist with the one you built
+
+A green suite says nothing about layout. jsdom runs no media queries and does no layout, so
+every CSS decision in this repo is held by someone looking at it in a browser — which means
+looking at the _right_ screen, not just the one you were working on.
+
+The trap is that you verify the state you built and miss the states that share the screen
+with it. A studio thread was checked at six widths and looked right at all of them; it was
+still broken, because a bottom-anchored install/update banner sat on the composer, and the
+shell that pinned the composer to the bottom edge had also removed the page scroll that used
+to let a reader escape from under it. Nothing about that is visible on a screen with no
+banner.
+
+So when you change layout, before you call it done, put the other states on screen:
+
+- **Bottom-anchored overlays** — `.install-prompt`, `.app-update`. Both are `position: fixed`
+  at `z-index: 900` and appear on conditions you will not hit by accident.
+- **The on-screen keyboard**, which halves the viewport on a phone and is what `100dvh`
+  behaves differently under.
+- **Sheets, modals, and the details rail**, which change what "the bottom of the screen"
+  means.
+- **The longest real string you have**, in Polish as well as English — Polish runs longer,
+  and a box sized to English clips it.
+
+Forcing a state that needs an event you cannot trigger (an install prompt, a waiting service
+worker) is legitimate: inject an element with the same class and measure against it. That is
+what the CSS contract actually promises.
+
 ## Current architecture
 
 Production games will live in a **dedicated games repo maintained by coding agents**; this app
@@ -58,7 +86,7 @@ reasons** and is not a future phase. Read
 The steel thread is **built and deployed** — all milestones M0–M5 merged. The app (web + API,
 one same-origin service) is **live on Cloud Run in `europe-west1`** (GCP project `gamedevpl`)
 and serves **`https://www.gamedev.pl`** through a native domain mapping. It is no longer a
-GitHub Pages site — the domain *is* the app.
+GitHub Pages site — the domain _is_ the app.
 
 Firestore lives in `europe-central2`, which is why backup and scheduler commands use a
 different region from deploy commands. That split is deliberate, not a typo.

--- a/apps/e2e/src/studio-mobile.test.ts
+++ b/apps/e2e/src/studio-mobile.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { APIRequestContext, Browser, Page } from 'playwright-core';
+import {
+  collectProblems,
+  describeProblems,
+  e2ePrerequisites,
+  launchSiteBrowser,
+  signedInApiContext,
+  signedInContext,
+  visit,
+} from './browser.js';
+
+/**
+ * The studio thread on a phone, with the things that share the screen with it.
+ *
+ * Separate from anonymous-and-mobile.test.ts, which is deliberately gated on a browser
+ * alone so it runs anywhere Chromium exists; the studio is behind sign-in and needs a
+ * token.
+ *
+ * What this is for: on a narrow screen the studio owns the viewport — the page does not
+ * scroll, and the composer is pinned to the bottom edge. That is a good shape and it has
+ * one failure mode, which shipped once already: anything else anchored to the bottom of
+ * the viewport lands on top of the composer, and removing the page scroll removed the
+ * only way a reader had to get out from under it. A screen with no banner on it looks
+ * perfect, which is exactly why this needs a test rather than another look.
+ */
+const prereq = e2ePrerequisites();
+if (!prereq.ok) {
+  console.warn(`[e2e] SKIPPED studio mobile: ${prereq.reason}`);
+}
+
+/** Everything the app anchors to the bottom of the viewport, by class. */
+const BOTTOM_BARS = ['app-update', 'install-prompt'];
+
+describe.skipIf(!prereq.ok)('the studio thread on a phone', () => {
+  let browser: Browser;
+  let api: APIRequestContext;
+  let page: Page;
+
+  beforeAll(async () => {
+    api = await signedInApiContext();
+    browser = await launchSiteBrowser();
+    const context = await signedInContext(browser, api);
+    page = await context.newPage();
+    await page.setViewportSize({ width: 390, height: 844 });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await api?.dispose();
+  });
+
+  /**
+   * Puts a bar on screen with the class the real one carries and reports whether it
+   * covers the composer.
+   *
+   * Injected rather than provoked: the install nudge needs a `beforeinstallprompt` the
+   * browser fires on its own terms, and the update bar needs a service worker waiting to
+   * take over. Neither is summonable from a test. The class is what the stylesheet keys
+   * on, so an element carrying it is exactly the contract being checked — "an element
+   * with this class does not cover the composer" is the promise, and this is the promise.
+   */
+  async function coverageBy(bar: string): Promise<{ overlapsComposer: boolean; sendIsHittable: boolean }> {
+    return page.evaluate((className) => {
+      const app = document.querySelector('.app');
+      const injected = document.createElement('div');
+      injected.className = className;
+      injected.dataset.e2eInjected = 'true';
+      injected.innerHTML = '<span>A new version is ready.</span><button type="button">Reload</button>';
+      app?.appendChild(injected);
+
+      return new Promise<{ overlapsComposer: boolean; sendIsHittable: boolean }>((resolve) => {
+        // Two frames: one for the append, one for the layout it causes.
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            const composer = document.querySelector('.status-composer.is-compact')?.getBoundingClientRect();
+            const send = document.querySelector('.status-composer.is-compact .primary-btn');
+            const bar = injected.getBoundingClientRect();
+
+            let overlapsComposer = false;
+            let sendIsHittable = false;
+
+            if (composer) {
+              overlapsComposer = bar.top < composer.bottom && bar.bottom > composer.top;
+            }
+            if (send) {
+              // The question a finger asks: at the middle of the send button, what would
+              // actually receive the tap? Catches any covering element, not just this one.
+              const box = send.getBoundingClientRect();
+              const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+              sendIsHittable = hit === send || send.contains(hit);
+            }
+
+            injected.remove();
+            resolve({ overlapsComposer, sendIsHittable });
+          }),
+        );
+      });
+    }, bar);
+  }
+
+  it('keeps the composer clear of everything anchored to the bottom of the screen', async () => {
+    const watcher = collectProblems(page);
+
+    await visit(page, '/studio', 4_000);
+
+    // The bot identity's shelf is whatever previous runs left behind. With no games there
+    // is no thread and nothing to assert — say so rather than passing quietly, because a
+    // guard that silently stops guarding is worse than no guard.
+    const hasComposer = await page.locator('.status-composer.is-compact').count();
+    if (hasComposer === 0) {
+      console.warn('[e2e] studio mobile: the e2e account has no games open in the studio; composer check skipped');
+      expect(describeProblems(watcher.drain())).toBe('');
+      return;
+    }
+
+    // The page owning the viewport is the precondition for the rest: it is what removes
+    // the scroll a reader would otherwise use to escape a bar sitting on the composer.
+    const pageScroll = await page.evaluate(
+      () => document.documentElement.scrollHeight - document.documentElement.clientHeight,
+    );
+    expect(pageScroll, 'the studio thread should own the viewport on a phone').toBeLessThanOrEqual(2);
+
+    for (const bar of BOTTOM_BARS) {
+      const { overlapsComposer, sendIsHittable } = await coverageBy(bar);
+      expect(overlapsComposer, `.${bar} covers the composer on a phone`).toBe(false);
+      expect(sendIsHittable, `.${bar} covers the composer's send button on a phone`).toBe(true);
+    }
+
+    expect(describeProblems(watcher.drain())).toBe('');
+  });
+});

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -487,7 +487,10 @@ export function CreatorStudioView({
                   </span>
                   <span className="studio-game-switcher-title">{activeGame.title}</span>
                   {activeGame.slug ? <code className="studio-slug">{activeGame.slug}</code> : null}
-                  <PixelIcon name="expand" size={12} />
+                  {/* Not `expand`: once a phone puts this button and the Details button on
+                      one row, the same icon appeared twice on that row meaning two
+                      different things. A folder is the other games. */}
+                  <PixelIcon name="folder" size={12} />
                 </button>
                 <div className="studio-detail-title-row">
                   <div className="studio-detail-title-block">
@@ -501,12 +504,12 @@ export function CreatorStudioView({
                   <div className="studio-head-actions">
                     {/* Playtest is the next action after a build — same weight as Send
                         feedback, not a peer of the Details toggle beside it. */}
-                    <button
-                      type="button"
-                      className="studio-head-action is-primary"
-                      onClick={() => openTab('playtest')}
-                    >
-                      <PixelIcon name="play" size={12} /> {t('studioPanel.tabs.playtest')}
+                    {/* Labels are wrapped rather than left as bare text so a phone can
+                        hide the word and keep the icon — and hide it the way that leaves
+                        the button still named for a screen reader, not display: none. */}
+                    <button type="button" className="studio-head-action is-primary" onClick={() => openTab('playtest')}>
+                      <PixelIcon name="play" size={12} />{' '}
+                      <span className="studio-head-action-label">{t('studioPanel.tabs.playtest')}</span>
                     </button>
                     <button
                       type="button"
@@ -514,7 +517,8 @@ export function CreatorStudioView({
                       aria-pressed={tab === 'details'}
                       onClick={() => openTab(tab === 'details' ? 'thread' : 'details')}
                     >
-                      <PixelIcon name="expand" size={12} /> {t('studioPanel.tabs.details')}
+                      <PixelIcon name="expand" size={12} />{' '}
+                      <span className="studio-head-action-label">{t('studioPanel.tabs.details')}</span>
                     </button>
                   </div>
                 </div>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -938,6 +938,15 @@ function FeedbackPanel({
     : building
       ? 'statusView.feedback.titleBuilding'
       : 'statusView.feedback.title';
+  // The composer gets its own, much shorter version of the same three hints. The
+  // paragraph reads fine above a page; as placeholder text on a phone it ran to four
+  // lines and the box clipped the last of them mid-word — worse in Polish, where the
+  // same sentence is longer. The placeholder now says where the message goes and stops.
+  const composerHintKey = published
+    ? 'statusView.feedback.composerHintPublished'
+    : building
+      ? 'statusView.feedback.composerHintBuilding'
+      : 'statusView.feedback.composerHint';
 
   // Compact is the thread's composer: a field and a send, the way a reply box looks
   // everywhere else. The heading and the standing hint paragraph were page furniture —
@@ -956,7 +965,7 @@ function FeedbackPanel({
             autoGrow();
             if (state === 'sent') setState('idle');
           }}
-          placeholder={t(hintKey)}
+          placeholder={t(composerHintKey)}
           aria-label={t(titleKey)}
           rows={2}
           maxLength={2000}

--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -62,6 +62,30 @@ describe('locale resources', () => {
     }
   });
 
+  // The composer's placeholder is one line of a phone screen, in every language.
+  // It started as the same paragraph the status page shows above its feedback box; at
+  // 390px that ran to four lines and the box clipped the last one mid-word, which is
+  // worse in Polish, where the sentence is longer than the English it came from. The
+  // limit is what stops a future edit from quietly putting the paragraph back.
+  it('keeps the composer placeholders short enough for a phone', () => {
+    const MAX = 60;
+    for (const [lang, resource] of [
+      ['en', en],
+      ['pl', pl],
+    ] as const) {
+      const feedback = (resource as unknown as { statusView: { feedback: Record<string, string> } }).statusView
+        .feedback;
+      const composerHints = Object.entries(feedback).filter(([key]) => key.startsWith('composerHint'));
+      expect(composerHints.length, `${lang} has no composer placeholders`).toBe(3);
+      for (const [key, value] of composerHints) {
+        expect(
+          value.length,
+          `${lang}.statusView.feedback.${key} is ${value.length} chars: "${value}"`,
+        ).toBeLessThanOrEqual(MAX);
+      }
+    }
+  });
+
   it('has no empty translation values', () => {
     for (const [lang, resource] of [
       ['en', en],

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -457,10 +457,13 @@
     "feedback": {
       "title": "Want changes?",
       "hint": "Played it and something's off? Tell the agent what to change and it'll revise your game.",
+      "composerHint": "Say what to change",
       "titleBuilding": "Want to steer it?",
       "hintBuilding": "It's still being made — you don't have to wait. Say what to change and the agent picks it up on its next update.",
+      "composerHintBuilding": "Say what to change as it builds",
       "titlePublished": "Ask for a change",
       "hintPublished": "Your game is live. Describe what to change and an agent picks it up as an improvement to it.",
+      "composerHintPublished": "Describe an improvement",
       "placeholder": "e.g. make the car faster, add a second track, use brighter colours…",
       "submit": "Send feedback",
       "sending": "Sending…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -461,10 +461,13 @@
     "feedback": {
       "title": "Chcesz zmian?",
       "hint": "Zagrałeś i coś jest nie tak? Napisz agentowi, co zmienić, a poprawi Twoją grę.",
+      "composerHint": "Napisz, co zmienić",
       "titleBuilding": "Chcesz coś podpowiedzieć?",
       "hintBuilding": "Gra wciąż powstaje — nie musisz czekać. Napisz, co zmienić, a agent odbierze wiadomość przy najbliższej aktualizacji.",
+      "composerHintBuilding": "Napisz, co zmienić w trakcie budowy",
       "titlePublished": "Poproś o zmianę",
       "hintPublished": "Twoja gra jest opublikowana. Opisz, co zmienić — agent podejmie to jako ulepszenie.",
+      "composerHintPublished": "Opisz ulepszenie",
       "placeholder": "np. przyspiesz samochód, dodaj drugą trasę, użyj jaśniejszych kolorów…",
       "submit": "Wyślij uwagi",
       "sending": "Wysyłanie…",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4363,8 +4363,14 @@ body.player-open {
    in the URL, so a URL-driven class left exactly that case on the old broken shape. What
    matters is whether a game is open on screen, which is what this asks. Browsers without
    `:has()` drop the block and get today's layout — the degradation is the old page, not a
-   broken one. */
-@media (max-width: 900px) {
+   broken one.
+
+   800px, not 900, because that is where the studio itself changes shape: below it the
+   shelf collapses into the switcher and the detail's own title row is hidden. Between
+   801 and 900 the shelf is still stacked above the thread and the title row is the only
+   place the game is named — an earlier draft of this ran to 900 and left that band with
+   no title on screen at all. */
+@media (max-width: 800px) {
   .app:has(.studio-layout.is-game-open) {
     height: 100dvh;
     display: flex;
@@ -4445,6 +4451,68 @@ body.player-open {
      is what pushed that line onto two rows. */
   .app:has(.studio-layout.is-game-open) .studio-thread-context .studio-slug {
     display: none;
+  }
+
+  /* Two rows of chrome above the conversation — a switcher row and an actions row —
+     was about 150px of a phone screen spent on furniture. One row: which game, and the
+     two things you can do to it. `display: contents` is what lets the actions join that
+     row without moving them in the markup, where their place beside the title is right
+     on every wider screen. */
+  .app:has(.studio-layout.is-game-open) .studio-detail-head {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-row {
+    display: contents;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher {
+    flex: 1;
+  }
+
+  /* "Switch game / 1 game" spells out what the chevron already says, and the slug is
+     repeated in the address bar and again on the details sheet. The title is the thing
+     you actually need to see, and it was the one item the row had no width for. */
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher-meta,
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher .studio-slug,
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-block {
+    display: none;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher-title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-head-actions {
+    flex: none;
+  }
+
+  /* Details keeps its icon and loses its word. Clipped rather than display: none, so the
+     button is still called "Details" by a screen reader. Playtest keeps both — it is the
+     thing most people came to do. */
+  .app:has(.studio-layout.is-game-open) .studio-head-action:not(.is-primary) .studio-head-action-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* A bordered card around two words of status, directly above a bordered composer, read
+     as two controls stacked. It is a caption; it can look like one. */
+  .app:has(.studio-layout.is-game-open) .studio-thread-context {
+    border: 0;
+    background: none;
+    padding: 0 2px;
   }
 
   /* The tall empty box existed to fit a placeholder that ran to four lines. The

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4515,6 +4515,25 @@ body.player-open {
     padding: 0 2px;
   }
 
+  /* The install nudge and the update bar are fixed to the bottom of the viewport at
+     z-index 900, which is exactly where this shell now pins the composer. On the old
+     scrolling page a reader could push the composer up past them; here there is nothing
+     to scroll, so a banner would sit on the textarea until it was dismissed.
+
+     They join the column instead of floating over it. Both are already the last children
+     of `.app`, so as ordinary flex items they land under the composer and the transcript
+     gives up the height — a bar at the foot of the screen rather than a lid on the one
+     control that matters. Suppressing them was the other option and a worse one: the
+     update bar is how a phone finds out there is a new shell, and the studio is a screen
+     people sit on for a long time. */
+  .app:has(.studio-layout.is-game-open) .install-prompt,
+  .app:has(.studio-layout.is-game-open) .app-update {
+    position: static;
+    flex: none;
+    margin: 0 12px max(12px, env(safe-area-inset-bottom, 0px));
+    animation: none;
+  }
+
   /* The tall empty box existed to fit a placeholder that ran to four lines. The
      placeholder is one line now, so the box can start at the size of a reply and grow
      into the message — which is a third of a phone screen handed back to the thread. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4352,6 +4352,189 @@ body.player-open {
   }
 }
 
+/* The studio thread as an app screen rather than a section of a scrolling page.
+   Measured on a phone, the old shape put the composer mid-document with ~350px of empty
+   panel under it and the marketing footer below that — so the one thing a scroll down
+   from the composer could reach was the privacy policy. The shell owns the viewport now:
+   header, transcript, composer, nothing else.
+
+   Keyed off `:has()` rather than a class on the route, because the route is not the
+   question. Bare /studio picks a game for you and shows its thread without ever naming it
+   in the URL, so a URL-driven class left exactly that case on the old broken shape. What
+   matters is whether a game is open on screen, which is what this asks. Browsers without
+   `:has()` drop the block and get today's layout — the degradation is the old page, not a
+   broken one. */
+@media (max-width: 900px) {
+  .app:has(.studio-layout.is-game-open) {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .app:has(.studio-layout.is-game-open) > .content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    /* The page centres its sections, which sizes them to their content — fine for a
+       column of cards, wrong for a screen that has to be exactly as wide as the phone.
+       Without this the panel took its width from the longest slug in it. */
+    align-items: stretch;
+    overflow: hidden;
+  }
+
+  /* Legal links and a strapline do not belong under a live conversation. */
+  .app:has(.studio-layout.is-game-open) .site-footer {
+    display: none;
+  }
+
+  /* Every wrapper between the shell and the transcript has to give up its height, or the
+     scroller at the bottom of the chain has nothing to measure itself against. */
+  .app:has(.studio-layout.is-game-open) .studio-panel,
+  .app:has(.studio-layout.is-game-open) .studio-layout,
+  .app:has(.studio-layout.is-game-open) .studio-detail,
+  .app:has(.studio-layout.is-game-open) .studio-workspace,
+  .app:has(.studio-layout.is-game-open) .studio-build {
+    flex: 1;
+    min-height: 0;
+    /* Without this a flex item refuses to shrink below its content, and one long slug
+       chip is enough to push the whole column wider than the phone. */
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    /* Two things quietly opt an element out of being stretched to its parent's width, and
+       this chain had both: an `auto` cross-axis margin (which disables stretch outright)
+       and an `align-items` that is not `stretch` (which sizes children to their content).
+       Either one lets the widest thing inside decide how wide the screen is. */
+    align-items: stretch;
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  /* A masthead and a trip home above a conversation, on the screen where the header
+     already offers both. */
+  .app:has(.studio-layout.is-game-open) .studio-panel-header {
+    display: none;
+  }
+
+  /* The switcher holds a slug, and a slug can be longer than a phone. It never showed
+     because the grid used to cap the column; once the shell became a flex chain the row
+     sized to its content and pushed everything past the right edge. Truncate it here
+     rather than letting one long name decide the width of the screen. */
+  .app:has(.studio-layout.is-game-open) .studio-detail-head,
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-game-switcher .studio-slug {
+    /* Overrides the flex-shrink: 0 the chip carries everywhere else. A slug that refuses
+       to shrink is a slug that decides how wide the screen is. */
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The switcher directly above already names the game; repeating it in the status line
+     is what pushed that line onto two rows. */
+  .app:has(.studio-layout.is-game-open) .studio-thread-context .studio-slug {
+    display: none;
+  }
+
+  /* The tall empty box existed to fit a placeholder that ran to four lines. The
+     placeholder is one line now, so the box can start at the size of a reply and grow
+     into the message — which is a third of a phone screen handed back to the thread. */
+  .app:has(.studio-layout.is-game-open) .status-composer.is-compact .status-feedback-input {
+    min-height: 2.75rem;
+  }
+
+  /* Undoes the one-scroller compromise above. That rule existed because the transcript's
+     scroller and the page's fought each other; with the page no longer scrolling there is
+     only one again, and it can be the transcript's. */
+  .app:has(.studio-layout.is-game-open) .studio-thread {
+    flex: 1;
+    min-height: 0;
+    height: auto;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-thread-scroll {
+    overflow-y: auto;
+  }
+
+  /* 126px of page padding — 60 on the content, 48 on the panel, 18 on the detail — was
+     what put the composer that far above the bottom of the screen with nothing under it.
+     Right for a section of a document, wrong for the bottom edge of an app. */
+  .app:has(.studio-layout.is-game-open) > .content,
+  .app:has(.studio-layout.is-game-open) .studio-panel,
+  .app:has(.studio-layout.is-game-open) .studio-detail {
+    padding-bottom: 0;
+  }
+
+  /* Edge to edge. A card with a rounded border floating inside a screen reads as one
+     panel on a page; the screen itself is the panel here. */
+  .app:has(.studio-layout.is-game-open) > .content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-panel {
+    border: 0;
+    border-radius: 0;
+    background: none;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+  }
+
+  /* The detail card is the screen now. Its rounded border used to enclose a section;
+     full height, it just ran off the bottom edge with nothing to enclose. */
+  .app:has(.studio-layout.is-game-open) .studio-detail {
+    border: 0;
+    border-radius: 0;
+    padding-left: 14px;
+    padding-right: 14px;
+    padding-top: 12px;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-thread-foot {
+    position: static;
+    /* Clear of the iOS home indicator, and of nothing at all where there isn't one. */
+    padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+  }
+
+  /* Four stacked rows of status above the composer is most of a phone screen spent on
+     metadata. One line: which game, and what it is doing. */
+  .studio-thread-context {
+    gap: 8px;
+    font-size: 0.78rem;
+  }
+
+  /* Left to wrap rather than forced onto one line: nowrap here just moves the overflow
+     somewhere it cannot be seen. It fits on one line because there is less in it. */
+  .studio-thread-context .studio-context-state {
+    min-width: 0;
+    gap: 8px;
+  }
+
+  .studio-thread-context .studio-slug {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The heartbeat is the first thing to go: "updated 10 minutes ago" is reassurance, and
+     the phase beside it already carries the fact. */
+  .studio-thread-context .studio-context-beat {
+    display: none;
+  }
+}
+
 @media (max-width: 640px) {
   /* Too little width left for two sides of a conversation; the bubble carries it. */
   .studio-turn.is-mine .studio-turn-body {


### PR DESCRIPTION
From a real phone screenshot of the merged studio, reproduced at 390×844 in Polish and
measured rather than eyeballed. Three commits.

## The composer placeholder was clipped mid-word (`bf852c2`)

A regression from #369, where the composer lost its resize handle. The placeholder is a
full sentence sized for a two-line box; at 390px it ran to four lines and the last one was
cut off mid-word — worse in Polish, where the sentence is longer than the English it was
translated from.

It is a short string of its own now, with a test holding every language's version under 60
characters so the paragraph cannot quietly come back. The long version stays where it still
reads well: above the feedback box on the standalone status page.

## The thread was a section of a scrolling page (`bf852c2`)

The composer sat mid-document with about 350px of empty panel beneath it and the site
footer under that — so the only thing a scroll down from a live conversation could reach
was the privacy policy. 126px of that was page padding: 60 on the content, 48 on the panel,
18 on the detail. Right for a section of a document, wrong for the bottom edge of an app.

On a narrow screen the shell owns the viewport now: header, transcript, composer, nothing
else. The page stops scrolling, which means the transcript can have its own scroller back —
the earlier one-scroller compromise existed because the two fought each other, and with the
page no longer scrolling there is only one again. Footer out, panel edge to edge, composer
on the bottom edge clear of the iOS home indicator.

Three things had to be undone before that could hold, and they are the reason the first two
attempts made the overflow worse rather than better:

- An `auto` cross-axis margin silently opts an element out of being stretched to its
  parent's width.
- An `align-items` that is not `stretch` sizes children to their content instead.
- The slug chip carries `flex-shrink: 0`, so it could not give width back once it had taken
  it.

This chain had all three, so the longest slug in the thread was deciding how wide the screen
was.

**Keyed off `:has(.studio-layout.is-game-open)` rather than a class on the route.** The
route is not the question: bare `/studio` picks a game for you and shows its thread without
ever naming it in the URL, and a URL-driven class left exactly that case on the old broken
shape. A browser without `:has()` drops the block and gets the previous layout — the
degradation is the old page, not a broken one.

## Two rows of chrome above the conversation (`00c3261`)

A switcher row carrying "Switch game", a count, the slug and an icon, then a row of two
buttons: about 150px of a phone screen spent on furniture, and the one thing it had no room
for was the game's own title.

One row now, 42px: the title, tappable to switch, and the two things you can do to the game.
The actions join that row through `display: contents` rather than by moving in the markup,
where their place beside the title is right on every wider screen. Out go "Switch game / 1
game" (the icon says it, and a count of your own games is not news) and the slug (it is in
the address bar and on the details sheet). Details keeps its icon and loses its word,
clipped rather than `display: none` so a screen reader still calls the button Details;
Playtest keeps both, being what most people opened the studio to do. The status line loses
its border and background — a bordered card holding two words directly above a bordered
composer read as two controls stacked, and it is a caption.

The switcher's icon changed from `expand` to `folder`. It only mattered once these two
buttons shared a row: the same icon appeared twice on it, meaning "other games" in one place
and "open details" in the other.

## A bug this introduced and then fixed

The first draft hung all of the above at 900px. The studio changes shape at **800** — that
is where the shelf collapses into the switcher and the detail's own title row is hidden. So
between 801 and 900 the rules hid the title row while no switcher had appeared to replace
it, and those widths had the game's name nowhere on screen. Everything is on the 800px
breakpoint now.

## Verification

`npm run type-check && lint && test && build` green: **1527** API tests, **708** web tests
(one new, the placeholder length guard).

Measured in a real browser at 390, 780, 820, 850, 1180 and 1440, across the thread, details
and playtest surfaces and the shelf: game title present at every width, no horizontal
overflow anywhere, no page scroll on a phone, desktop unchanged.

## Worth a reviewer's attention

- **The layout work is CSS, and jsdom does no media queries or layout**, so none of it is
  covered by a unit test. It is held by measurement in a browser, not by anything that will
  fail in CI if someone breaks it. The placeholder length is the one piece that has a test.
- **`:has()` and `display: contents`** are both load-bearing here. Both are supported in
  current Safari and Chrome; the `:has()` failure mode is documented above, and
  `display: contents` degrading would put the actions back on their own row, which is the
  old layout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD3KJLV3broyoVUnu26GDm)_