### PR TITLE
Fix iPhone voice prompt feedback and interim transcription

### DIFF
--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -181,4 +181,62 @@ describe('HeroPromptSection', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('shows listening immediately and renders interim speech on iPhone-style recognition', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    class FakeSpeechRecognition {
+      continuous = false;
+      interimResults = false;
+      lang = '';
+      onstart: (() => void) | null = null;
+      onresult: ((event: { results: Array<{ 0: { transcript: string } }> }) => void) | null = null;
+      onerror: ((event: { error: string }) => void) | null = null;
+      onend: (() => void) | null = null;
+      start = vi.fn();
+      stop = vi.fn(() => this.onend?.());
+    }
+
+    const recognition = new FakeSpeechRecognition();
+    Object.defineProperty(window, 'webkitSpeechRecognition', {
+      configurable: true,
+      value: vi.fn(() => recognition),
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: '',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+          mockStatus: 'idle',
+          mockError: null,
+        }),
+      );
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.mic-btn')?.click();
+      await flushEffects();
+    });
+    expect(recognition.interimResults).toBe(true);
+    expect(container.querySelector('.mic-notice-text')?.textContent).toContain('Listening');
+    expect(container.querySelector<HTMLButtonElement>('.mic-btn')?.getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => {
+      recognition.onresult?.({ results: [{ 0: { transcript: 'A flying cat game' } }] });
+      await flushEffects();
+    });
+    expect(container.querySelector<HTMLTextAreaElement>('.big-prompt-input')?.value).toBe('A flying cat game');
+
+    await act(async () => root.unmount());
+    delete (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+  });
 });

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -83,7 +83,7 @@ interface SpeechRecognitionResult {
 }
 
 interface SpeechRecognitionEvent {
-  results: SpeechRecognitionResult[];
+  results: ArrayLike<SpeechRecognitionResult>;
 }
 
 interface SpeechRecognitionErrorEvent {
@@ -141,6 +141,11 @@ export function HeroPromptSection({
 
   // Web Speech Recognition
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const speechBasePromptRef = useRef('');
+
+  useEffect(() => {
+    return () => recognitionRef.current?.stop();
+  }, []);
 
   const toggleSpeechRecognition = () => {
     setMicNotice(null);
@@ -164,7 +169,9 @@ export function HeroPromptSection({
     try {
       const recognition = new SpeechClass();
       recognition.continuous = false;
-      recognition.interimResults = false;
+      // Safari on iOS can take a while to produce a final result. Showing its interim
+      // transcription makes the control responsive while the person is still speaking.
+      recognition.interimResults = true;
       recognition.lang = window.navigator.language || 'en-US';
 
       recognition.onstart = () => {
@@ -172,14 +179,18 @@ export function HeroPromptSection({
       };
 
       recognition.onresult = (event: SpeechRecognitionEvent) => {
-        const transcript = event.results?.[0]?.[0]?.transcript;
+        const transcript = Array.from(event.results ?? [])
+          .map((result) => result[0]?.transcript ?? '')
+          .join('')
+          .trim();
         if (transcript) {
-          setPromptText((prev) => (prev ? `${prev} ${transcript}` : transcript));
+          recordCreateStep('prompt_started');
+          setPromptText(speechBasePromptRef.current ? `${speechBasePromptRef.current} ${transcript}` : transcript);
         }
-        setIsListening(false);
       };
 
       recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        recognitionRef.current = null;
         setIsListening(false);
         if (event.error === 'not-allowed') {
           setMicNotice(t('hero.micDenied'));
@@ -189,10 +200,15 @@ export function HeroPromptSection({
       };
 
       recognition.onend = () => {
+        recognitionRef.current = null;
         setIsListening(false);
       };
 
+      speechBasePromptRef.current = promptText.trim();
       recognitionRef.current = recognition;
+      // Do not wait for Safari's onstart callback: it may only arrive after the native
+      // permission sheet closes, which otherwise makes the page appear unresponsive.
+      setIsListening(true);
       recognition.start();
     } catch (err: unknown) {
       setIsListening(false);
@@ -331,7 +347,8 @@ export function HeroPromptSection({
                 className={`prompt-icon-btn mic-btn ${isListening ? 'listening' : ''}`}
                 onClick={toggleSpeechRecognition}
                 title={isListening ? t('hero.micListening') : t('hero.micStart')}
-                aria-label={t('hero.micStart')}
+                aria-label={isListening ? t('hero.micListening') : t('hero.micStart')}
+                aria-pressed={isListening}
               >
                 <PixelIcon name="mic" size={18} />
               </button>
@@ -364,7 +381,11 @@ export function HeroPromptSection({
             </div>
           </div>
 
-          {micNotice && <p className="mic-notice-text">{micNotice}</p>}
+          {(micNotice || isListening) && (
+            <p className="mic-notice-text" role="status" aria-live="polite">
+              {micNotice ?? t('hero.micListening')}
+            </p>
+          )}
 
           {attachments.length > 0 && (
             <div className="attachments-preview-container">


### PR DESCRIPTION
### Motivation

- Repair the voice-prompt UX on iPhone/Safari where granting microphone permission could leave the page appearing frozen and produce no visible transcript.  

### Description

- Start the listening state immediately (do not wait for Safari's delayed `onstart`) so the UI shows responsiveness as the permission sheet closes.  
- Enable `interimResults` and render interim transcripts while the user speaks, merging them with any pre-existing prompt text.  
- Stop recognition on unmount and clear the `recognitionRef` on `error`/`end`, and record the existing `prompt_started` create-step when the first transcript arrives.  
- Add accessible feedback: an ARIA `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c977e32d483239f788027e5691ae6)