### PR TITLE
Fix notification panel position on mobile

### DIFF
--- a/apps/web/src/NotificationBell.css
+++ b/apps/web/src/NotificationBell.css
@@ -43,8 +43,7 @@
   top: calc(100% + 8px);
   right: 0;
   z-index: 1000;
-  width: 320px;
-  max-width: 84vw;
+  width: min(320px, calc(100vw - 24px));
   max-height: 70vh;
   overflow-y: auto;
   background: #14161c;

--- a/apps/web/src/NotificationBell.test.tsx
+++ b/apps/web/src/NotificationBell.test.tsx
@@ -4,6 +4,7 @@ import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
+import { notificationPanelShiftX } from './notificationPanelPosition.js';
 
 /**
  * The weekly digest is the only notification nobody asked for on the day it arrives, so
@@ -156,5 +157,19 @@ describe('NotificationBell — weekly digest switch', () => {
     // The digest itself renders — the bell is the surface that shows it regardless.
     expect(container.textContent).toContain('Your games this week');
     root.unmount();
+  });
+});
+
+describe('notificationPanelShiftX', () => {
+  it('shifts a panel right when it overflows the left edge', () => {
+    expect(notificationPanelShiftX({ left: -9, right: 311 }, 375)).toBe(21);
+  });
+
+  it('shifts a panel left when it overflows the right edge', () => {
+    expect(notificationPanelShiftX({ left: 100, right: 420 }, 400)).toBe(-32);
+  });
+
+  it('leaves a panel in place when it fits within the viewport gutters', () => {
+    expect(notificationPanelShiftX({ left: 40, right: 360 }, 400)).toBe(0);
   });
 });

--- a/apps/web/src/NotificationBell.tsx
+++ b/apps/web/src/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import {
@@ -12,6 +12,7 @@ import {
   type NotificationType,
 } from './notificationsApi.js';
 import { pushUiState, subscribeToPush, unsubscribeFromPush, type PushUiState } from './pushApi.js';
+import { notificationPanelShiftX } from './notificationPanelPosition.js';
 import './NotificationBell.css';
 
 const POLL_MS = 60_000;
@@ -39,6 +40,7 @@ export function NotificationBell() {
   const [prefsBusy, setPrefsBusy] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
 
   const unread = items.filter((n) => n.readAt === null).length;
 
@@ -163,6 +165,26 @@ export function NotificationBell() {
     };
   }, [open]);
 
+  // The bell sits left of the mobile menu, so a panel anchored to it can extend beyond
+  // the viewport even when the panel itself is narrower than the viewport.
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (!open || !panel) return;
+
+    const place = () => {
+      panel.style.transform = '';
+      const shift = notificationPanelShiftX(panel.getBoundingClientRect(), window.innerWidth);
+      panel.style.transform = shift === 0 ? '' : `translateX(${shift}px)`;
+    };
+
+    place();
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('resize', place);
+      panel.style.transform = '';
+    };
+  }, [open, items]);
+
   if (!user) return null;
 
   const toggle = () => {
@@ -194,7 +216,7 @@ export function NotificationBell() {
       </button>
 
       {open && (
-        <div className="notif-panel" role="menu">
+        <div className="notif-panel" role="menu" ref={panelRef}>
           <div className="notif-panel-head">
             <span>{t('notifications.title', { defaultValue: 'Notifications' })}</span>
             {items.length > 0 && (

--- a/apps/web/src/notificationPanelPosition.ts
+++ b/apps/web/src/notificationPanelPosition.ts
@@ -1,0 +1,12 @@
+/** How far to translate a right-anchored panel so it stays inside the viewport. */
+export function notificationPanelShiftX(
+  rect: { left: number; right: number },
+  viewportWidth: number,
+  margin = 12,
+): number {
+  const leftOverflow = margin - rect.left;
+  const rightOverflow = rect.right - (viewportWidth - margin);
+  if (leftOverflow > 0) return leftOverflow;
+  if (rightOverflow > 0) return -rightOverflow;
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- The notifications panel was right-anchored to the bell with a near-full width, which caused the sheet to clip off the left edge on narrow (mobile) viewports.
- The goal is to ensure the panel always fits inside the viewport gutters on phones while keeping the bell anchor behaviour on larger viewports.

### Description

- Constrain the panel width to `min(320px, calc(100vw - 24px))` instead of the previous `84vw` so it respects 12px side gutters on small screens (`apps/web/src/NotificationBell.css`).
- Add a small layout helper `notificationPanelShiftX` (extracted to `apps/web/src/notificationPanelPosition.ts`) that computes a horizontal `translateX` to keep a right-anchored panel inside the viewport.
- Measure and apply the shift with a `ref` + `useLayoutEffect` on the rendered panel so the clamp is applied after layout and recalculated on `resize` and when notification `items` change (`apps/web/src/NotificationBell.tsx`).
- Add unit coverage exercising left-overflow, right-overflow and non-overflow cases in `apps/web/src/NotificationBell.test.tsx`.

### Testing

- Ran the component unit tests with `npm exec --workspace @gamedevpl/web vitest -- run src/NotificationBell.test.tsx` and the test file passed.
- Ran the repository green-gate `npm run type-check && npm run lint && npm run test && npm run build` and the steps completed successfully.
- Ran formatting checks with `prettier --check` on the touched files and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c97fd008c832385bd17fedf0e1ba9)