### PR TITLE
Let the game tell the player how it is played

### DIFF
--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -260,3 +260,70 @@ describe('GameTheater how-to-play', () => {
     expect(onExit).not.toHaveBeenCalled();
   });
 });
+
+describe('GameTheater controls reported by the game', () => {
+  const CATALOG_CONTROLS = 'Left/Right to move; Space to fire; M to mute';
+
+  /** Relay a bridge message the way an opaque-origin frame does. */
+  async function report(payload: Record<string, unknown>) {
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { source: 'gdpl-player', type: 'controls', ...payload },
+          origin: 'null',
+        }),
+      );
+    });
+  }
+
+  it('offers how-to-play on a deep link, where the catalog never arrives', async () => {
+    // The gap this closes: /play/<slug> renders from a placeholder entry whose `controls`
+    // is empty, because the catalog is fetched on the home route only. The game document
+    // is the only source of truth there — and it is always present, because it is the
+    // thing being played.
+    await draw({ controls: '' });
+    expect(container.querySelector('.howto-btn')).toBeNull();
+
+    await report({ rows: [{ keys: 'Z/X', action: 'Rotate' }] });
+
+    const trigger = container.querySelector('.howto-btn');
+    expect(trigger).not.toBeNull();
+    await click(trigger);
+    expect(
+      [...document.querySelectorAll('.howto-row')].map((row) => [
+        row.querySelector('dt')?.textContent,
+        row.querySelector('dd')?.textContent,
+      ]),
+    ).toEqual([['Z/X', 'Rotate']]);
+  });
+
+  it('lets the game overrule the catalog, which is a spec claim about it', async () => {
+    await draw({ controls: CATALOG_CONTROLS });
+    await report({ rows: [{ keys: 'A/D', action: 'Skręt' }] });
+    await click(container.querySelector('.howto-btn'));
+    expect([...document.querySelectorAll('.howto-row dd')].map((cell) => cell.textContent)).toEqual(['Skręt']);
+  });
+
+  it('keeps the catalog rows when a later report says nothing', async () => {
+    // The bridge re-sends after i18n and after GameKit wires input. An empty re-send
+    // must not blank a card that already had content.
+    await draw({ controls: CATALOG_CONTROLS });
+    await report({ rows: [], kit: [], hint: '' });
+    await click(container.querySelector('.howto-btn'));
+    expect(document.querySelectorAll('.howto-row').length).toBe(3);
+  });
+
+  it('ignores a controls report that did not come from this game frame', async () => {
+    await draw({ controls: '' });
+    await act(async () => {
+      // Same shape, wrong origin — another window trying to put text on our card.
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { source: 'gdpl-player', type: 'controls', rows: [{ keys: 'X', action: 'Spoofed' }] },
+          origin: 'https://evil.example',
+        }),
+      );
+    });
+    expect(container.querySelector('.howto-btn')).toBeNull();
+  });
+});

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -327,3 +327,75 @@ describe('GameTheater controls reported by the game', () => {
     expect(container.querySelector('.howto-btn')).toBeNull();
   });
 });
+
+describe('GameTheater how-to-play reachability', () => {
+  /**
+   * jsdom implements no matchMedia, so a breakpoint has to be stated to be tested.
+   * `width` here is the viewport the component should believe it is on.
+   */
+  function stubViewport(width: number) {
+    const listeners = new Set<() => void>();
+    (window as unknown as Record<string, unknown>).matchMedia = (query: string) => {
+      const limit = Number(/max-width:\s*(\d+)px/.exec(query)?.[1] ?? 0);
+      return {
+        matches: width <= limit,
+        addEventListener: (_: string, fn: () => void) => listeners.add(fn),
+        removeEventListener: (_: string, fn: () => void) => listeners.delete(fn),
+      };
+    };
+    return () => delete (window as unknown as Record<string, unknown>).matchMedia;
+  }
+
+  async function drawDraft() {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <GameTheater
+          title="Draft"
+          badge={{ icon: 'rocket', label: 'AI' }}
+          source={{ html: '<canvas></canvas>' }}
+          onExit={() => undefined}
+        />,
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { source: 'gdpl-player', type: 'controls', rows: [{ keys: 'W', action: 'Jump' }] },
+          origin: 'null',
+        }),
+      );
+    });
+  }
+
+  it('renders the More menu for a slug-less game at a width where the bar copy is hidden', async () => {
+    // The bar copy sheds at 900px but the menu only existed below 768px, so between the
+    // two a game with no `reportSlug` — a draft or a generated game, which have no catalog
+    // entry but do report their own controls over the bridge — had the bar copy hidden by
+    // CSS and no menu to fall back to, and the control vanished. Unreachable while the
+    // catalog was the only source; reachable the moment the game itself became one.
+    const restore = stubViewport(820);
+    try {
+      await drawDraft();
+      expect(container.querySelector('.theater-more')).not.toBeNull();
+      const menuItems = [...container.querySelectorAll('.theater-more-panel .theater-menu-item')];
+      expect(menuItems.some((el) => el.textContent?.includes('How to play'))).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not grow a More menu on a wide screen, where the bar copy is the route', async () => {
+    // The menu must not appear just because a game has controls: on a wide screen the bar
+    // copy is visible, and an otherwise-empty overflow menu is the thing `isNarrow` was
+    // introduced to avoid.
+    const restore = stubViewport(1280);
+    try {
+      await drawDraft();
+      expect(container.querySelector('.howto-btn')).not.toBeNull();
+      expect(container.querySelector('.theater-more')).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -5,7 +5,7 @@ import { GameFrame } from './GameFrame.js';
 import { HowToPlayPanel } from './HowToPlayPanel.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
-import { parseControls } from './howToPlay.js';
+import { resolveControlRows } from './howToPlay.js';
 import { PlayerFeedbackWidget } from './PlayerFeedbackWidget.js';
 import { ReportGameButton } from './ReportGameButton.js';
 import { ShareGameButton } from './ShareGameButton.js';
@@ -46,10 +46,10 @@ type GameTheaterProps = {
    */
   submittedBy?: string | null;
   /**
-   * The game's `controls` line from the catalog, which turns on the "How to play"
-   * control. Absent for generated and draft games: they have no catalog entry, and the
-   * frame is sandboxed without `allow-same-origin`, so there is nowhere else to read a
-   * control list from. The control simply does not render for them.
+   * The game's `controls` line from the catalog. A fallback now rather than the only
+   * source: the player bridge reports the game's own control list, which is localized,
+   * already split into key and action, and present on a deep link where the catalog is
+   * never fetched. This still covers a game whose document reports nothing.
    */
   controls?: string;
   /** Catalog touch support; `none` adds the keyboard-only line to the panel. */
@@ -107,12 +107,6 @@ export function GameTheater({
   const [moreOpen, setMoreOpen] = useState(false);
   const [howToOpen, setHowToOpen] = useState(false);
 
-  // A deep-linked /play/<slug> renders before the catalog lands, with a placeholder
-  // entry whose `controls` is empty; the real string arrives on a later render. Deriving
-  // this every render (rather than memoizing the first value) is what lets the control
-  // appear when it does.
-  const hasControls = parseControls(controls ?? '').length > 0;
-
   // Playing is the one thing you do here without touching the screen for minutes at
   // a time, which is exactly when a phone dims and sleeps. Hold the screen awake.
   useScreenWakeLock(true);
@@ -165,6 +159,15 @@ export function GameTheater({
   // own chrome, and this covers the game iframe, which holds focus while playing
   // and swallows its own key events.
   const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore);
+
+  // What the game says about itself, falling back to what the catalog says about it.
+  // Derived every render rather than memoized on first value, because both sources
+  // arrive late and at different times: on a deep-linked /play/<slug> the catalog never
+  // arrives at all (the placeholder entry's `controls` stays empty) and the bridge report
+  // is the only source there, while the bridge itself re-reports once GameKit has wired
+  // its input. Recomputing is what lets the control appear when either one lands.
+  const controlRows = resolveControlRows(player.controls, controls ?? '');
+  const hasControls = controlRows.length > 0;
 
   // Durable progress for games that ask for it (docs/persistent-world-plan.md P1).
   // Keyed on `reportSlug` — the *published* slug — for the same reason the vote and
@@ -449,9 +452,10 @@ export function GameTheater({
       ) : null}
       <HowToPlayPanel
         open={howToOpen}
-        controls={controls ?? ''}
+        rows={controlRows}
         gameTitle={displayTitle}
         touch={touch}
+        padReported={player.controls?.pad ?? false}
         onClose={closeHowTo}
       />
     </section>

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -167,7 +167,11 @@ export function GameTheater({
   // is the only source there, while the bridge itself re-reports once GameKit has wired
   // its input. Recomputing is what lets the control appear when either one lands.
   const controlRows = resolveControlRows(player.controls, controls ?? '');
-  const hasControls = controlRows.length > 0;
+  // A pad counts on its own. A generated game on a phone can mount an on-screen pad while
+  // shipping no legend, no hint and no catalog entry — naming its buttons is the whole
+  // answer to "how do I play this", and gating the control on keyboard rows hid it.
+  const hasControls =
+    controlRows.length > 0 || Boolean(player.controls?.pad) || (player.controls?.padButtons.length ?? 0) > 0;
 
   // Durable progress for games that ask for it (docs/persistent-world-plan.md P1).
   // Keyed on `reportSlug` — the *published* slug — for the same reason the vote and

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -220,6 +220,20 @@ export function GameTheater({
     return () => query.removeEventListener('change', update);
   }, []);
 
+  // Where the how-to-play bar copy is hidden but the rest of the chrome is still on the
+  // bar. Tracked in JS for the same reason `isNarrow` is: the menu must not be rendered
+  // empty, so whether it exists is a render decision, not something CSS can make.
+  const [isMidWidth, setIsMidWidth] = useState(false);
+
+  useEffect(() => {
+    if (typeof matchMedia !== 'function') return;
+    const query = matchMedia('(max-width: 900px)');
+    const update = () => setIsMidWidth(query.matches);
+    update();
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, []);
+
   useEffect(() => {
     const onChange = () => setFullscreen(Boolean(document.fullscreenElement));
     document.addEventListener('fullscreenchange', onChange);
@@ -301,7 +315,12 @@ export function GameTheater({
     };
   }, [moreOpen]);
 
-  const showMoreMenu = Boolean(reportSlug) || isNarrow;
+  // The menu also has to exist wherever a control has shed into it. How-to-play sheds at
+  // 900px while sound and fullscreen shed at 768px, so between those widths a game with
+  // no `reportSlug` (a draft, a generated game — no catalog entry, but the game document
+  // still reports its own controls) would have had the bar copy hidden by CSS and no menu
+  // to fall back to, and the control would have vanished entirely.
+  const showMoreMenu = Boolean(reportSlug) || isNarrow || (hasControls && isMidWidth);
 
   const soundControl = (className: string) => (
     <button

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -475,6 +475,7 @@ export function GameTheater({
         gameTitle={displayTitle}
         touch={touch}
         padReported={player.controls?.pad ?? false}
+        padButtons={player.controls?.padButtons ?? []}
         onClose={closeHowTo}
       />
     </section>

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -94,6 +94,14 @@ describe('HowToPlayPanel', () => {
     expect(document.querySelector('.howto-dismiss')?.textContent).toContain('Escape');
   });
 
+  it('renders a Touch-only card when the pad is all the game reported', async () => {
+    // On a phone this may be the only answer there is, and a card of just this row beats
+    // no control at all.
+    await draw({ rows: [], padReported: true, padButtons: ['Fire', 'Throttle'] });
+    expect(card()).not.toBeNull();
+    expect(rows()).toEqual([['Touch', 'On-screen pad on touch screens — Fire, Throttle']]);
+  });
+
   it('renders nothing when closed, and nothing when the game has no controls', async () => {
     await draw({ open: false });
     expect(card()).toBeNull();

--- a/apps/web/src/HowToPlayPanel.test.tsx
+++ b/apps/web/src/HowToPlayPanel.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { HowToPlayPanel } from './HowToPlayPanel.js';
+import { parseControls } from './howToPlay.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;
@@ -30,7 +31,9 @@ async function draw(props: Partial<Parameters<typeof HowToPlayPanel>[0]> = {}) {
   const onClose = vi.fn();
   root = createRoot(container);
   await act(async () => {
-    root!.render(<HowToPlayPanel open controls={CONTROLS} gameTitle="Apex Sprint" onClose={onClose} {...props} />);
+    root!.render(
+      <HowToPlayPanel open rows={parseControls(CONTROLS)} gameTitle="Apex Sprint" onClose={onClose} {...props} />,
+    );
   });
   return { onClose };
 }
@@ -69,7 +72,7 @@ describe('HowToPlayPanel', () => {
     // beat-teacher, verbatim: the semicolons keep the comma-listed keys in one clause,
     // and that clause has no key/action shape to split on.
     await draw({
-      controls: 'Press A, S, D, F, or Space in sync with scrolling rhythm note prompts; M to mute',
+      rows: parseControls('Press A, S, D, F, or Space in sync with scrolling rhythm note prompts; M to mute'),
     });
     const row = document.querySelector('.howto-row');
     expect(row?.classList.contains('is-wide')).toBe(true);
@@ -95,7 +98,7 @@ describe('HowToPlayPanel', () => {
     await draw({ open: false });
     expect(card()).toBeNull();
 
-    await redraw({ controls: '   ' });
+    await redraw({ rows: parseControls('   ') });
     expect(card()).toBeNull();
   });
 
@@ -173,6 +176,14 @@ describe('HowToPlayPanel', () => {
     outside.remove();
   });
 
+  it('states a touch pad the running game mounted, over what the catalog inferred', async () => {
+    // `touch: 'none'` is a build-time classification of the game's source; `padReported`
+    // is GameKit saying it built a pad in the document being played. The second wins.
+    await draw({ touch: 'none', padReported: true });
+    expect(rows().at(-1)).toEqual(['Touch', 'On-screen pad on touch screens']);
+    expect(document.querySelector('.howto-note')).toBeNull();
+  });
+
   it('states touch support from the catalog, and only what the catalog knows', async () => {
     await draw();
     expect(document.querySelector('.howto-note')).toBeNull();
@@ -188,14 +199,14 @@ describe('HowToPlayPanel', () => {
 
   it('renders repeated clauses without a duplicate-key warning', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    await draw({ controls: 'Space to jump; Space to jump' });
+    await draw({ rows: parseControls('Space to jump; Space to jump') });
     expect(rows()).toHaveLength(2);
     expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key');
     consoleError.mockRestore();
   });
 
   it('renders agent-authored control text as literal text, never as markup', async () => {
-    await draw({ controls: '<img src=x onerror=alert(1)> to jump' });
+    await draw({ rows: parseControls('<img src=x onerror=alert(1)> to jump') });
     expect(document.querySelector('.howto-keys img')).toBeNull();
     expect(rows()).toEqual([['<img src=x onerror=alert(1)>', 'jump']]);
   });

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -98,12 +98,14 @@ export function HowToPlayPanel({
   }, [open]);
 
   if (!open) return null;
-  if (rows.length === 0) return null;
 
   // The pad is stated when the running game actually mounted one, or when the catalog's
   // build-time classifier says the game uses GameKit's. `native` and `controllers` games
   // handle touch their own way and are not described by either line.
-  const showPad = padReported || touch === 'gamekit';
+  const showPad = padReported || padButtons.length > 0 || touch === 'gamekit';
+  // A card of nothing but a Touch row is still an answer — on a phone it may be the only
+  // one there is. A card of nothing at all is not.
+  if (rows.length === 0 && !showPad) return null;
 
   // Portalled to the body: `.game-theater-bar` and `.theater-more-panel` carry a
   // backdrop-filter, which makes an ancestor the containing block for position:fixed

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -32,6 +32,8 @@ type HowToPlayPanelProps = {
    * what a build-time classifier inferred about its source.
    */
   padReported?: boolean;
+  /** On-screen button names read off the built pad, shown alongside the Touch row. */
+  padButtons?: string[];
   onClose: () => void;
 };
 
@@ -51,6 +53,7 @@ export function HowToPlayPanel({
   gameTitle,
   touch = null,
   padReported = false,
+  padButtons = [],
   onClose,
 }: HowToPlayPanelProps) {
   const { t } = useTranslation();
@@ -146,7 +149,11 @@ export function HowToPlayPanel({
           {showPad ? (
             <div className="howto-row">
               <dt>{t('player.howToPlayTouch')}</dt>
-              <dd>{t('player.howToPlayTouchPad')}</dd>
+              <dd>
+                {padButtons.length > 0
+                  ? `${t('player.howToPlayTouchPad')} — ${padButtons.join(', ')}`
+                  : t('player.howToPlayTouchPad')}
+              </dd>
             </div>
           ) : null}
         </dl>

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -3,12 +3,17 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { CatalogTouch } from './catalog.js';
 import { PixelIcon } from './PixelIcon.js';
-import { parseControls } from './howToPlay.js';
+import type { ControlRow } from './howToPlay.js';
 
 type HowToPlayPanelProps = {
   open: boolean;
-  /** The game's `controls` string from the catalog. Free text; rendered as text nodes. */
-  controls: string;
+  /**
+   * The rows to show, already resolved from the best available source (see
+   * `resolveControlRows`). Every string in here is agent-authored — from a SPEC, or
+   * reported by the game itself across the sandbox — so all of it renders as JSX text
+   * nodes and none of it ever reaches an HTML sink.
+   */
+  rows: ControlRow[];
   /**
    * Names the game in the close button's accessible label. It is not shown: the theater
    * bar behind the card already carries the title, and repeating it in a card this small
@@ -21,6 +26,12 @@ type HowToPlayPanelProps = {
    * `none` earns the keyboard-only line.
    */
   touch?: CatalogTouch | null;
+  /**
+   * GameKit reported mounting an on-screen d-pad in *this* game document. Believed over
+   * the catalog's `touch` when set, because it is what the running game did rather than
+   * what a build-time classifier inferred about its source.
+   */
+  padReported?: boolean;
   onClose: () => void;
 };
 
@@ -34,7 +45,14 @@ const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabi
  * game's own in-shell controls popup is hidden on purpose by the player bridge
  * (`gamePlayer.ts` HIDE_CHROME) because the theater surfaces this chrome instead.
  */
-export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClose }: HowToPlayPanelProps) {
+export function HowToPlayPanel({
+  open,
+  rows,
+  gameTitle,
+  touch = null,
+  padReported = false,
+  onClose,
+}: HowToPlayPanelProps) {
   const { t } = useTranslation();
   const cardRef = useRef<HTMLDivElement | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
@@ -77,9 +95,12 @@ export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClos
   }, [open]);
 
   if (!open) return null;
-
-  const rows = parseControls(controls);
   if (rows.length === 0) return null;
+
+  // The pad is stated when the running game actually mounted one, or when the catalog's
+  // build-time classifier says the game uses GameKit's. `native` and `controllers` games
+  // handle touch their own way and are not described by either line.
+  const showPad = padReported || touch === 'gamekit';
 
   // Portalled to the body: `.game-theater-bar` and `.theater-more-panel` carry a
   // backdrop-filter, which makes an ancestor the containing block for position:fixed
@@ -120,16 +141,18 @@ export function HowToPlayPanel({ open, controls, gameTitle, touch = null, onClos
               <dd>{row.action}</dd>
             </div>
           ))}
-          {/* Stated, not guessed: `touch` is derived from the game's own source by the
-              games-repo build, so a pad promised here is a pad that exists. */}
-          {touch === 'gamekit' ? (
+          {/* Stated, not guessed. Either the running game mounted a pad (GameKit said so
+              over the bridge) or the games-repo build read one out of its source. */}
+          {showPad ? (
             <div className="howto-row">
               <dt>{t('player.howToPlayTouch')}</dt>
               <dd>{t('player.howToPlayTouchPad')}</dd>
             </div>
           ) : null}
         </dl>
-        {touch === 'none' ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
+        {/* Only when nothing contradicts it: a game whose document reported a live pad
+            is playable with a thumb whatever the catalog inferred at build time. */}
+        {touch === 'none' && !padReported ? <p className="howto-note">{t('catalog.keyboardOnlyTooltip')}</p> : null}
         <p className="howto-dismiss">{t('player.howToPlayDismiss')}</p>
       </div>
     </div>,

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -76,15 +76,38 @@ const BRIDGE = `(function(){
     var out=[];
     try{
       var kit=window.GameKit;
-      if(!kit||typeof kit.controlsManifest!=='function')return out;
+      if(!kit||typeof kit.controlsManifest!=='function')return padRows();
       var m=kit.controlsManifest();
-      if(!m)return out;
+      if(!m)return padRows();
       var buttons=m.buttons||[];
       for(var i=0;i<buttons.length;i++){
         var keys=(buttons[i].keys||[]).join(' / '),label=String(buttons[i].label||'');
         if(keys&&label)out.push({keys:keys,action:label,touch:true});
       }
       if(m.pad)out.push({keys:'',action:'',pad:String(m.pad)});
+    }catch(err){return padRows();}
+    return out.length>0?out:padRows();
+  }
+  /**
+   * The pad GameKit actually built, read off the page.
+   *
+   * Weaker than the manifest — it names buttons but not the keys behind them, and it
+   * exists only where the pad does (a coarse pointer) — but it needs nothing from the
+   * games repo, so it works on every published snapshot today rather than after a
+   * re-bake. On the devices where it is present, the key behind a button is not the
+   * question anyway: you tap the button.
+   */
+  function padRows(){
+    var out=[],seen={};
+    try{
+      var buttons=document.querySelectorAll('.gamekit-touch-btn');
+      for(var i=0;i<buttons.length;i++){
+        var label=text(buttons[i]);
+        if(!label||seen[label])continue;
+        seen[label]=1;
+        out.push({keys:'',action:label,touch:true});
+      }
+      if(document.querySelector('.gamekit-touch-pad'))out.push({keys:'',action:'',pad:'full'});
     }catch(err){}
     return out;
   }

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -98,13 +98,15 @@ const BRIDGE = `(function(){
    * question anyway: you tap the button.
    */
   function padRows(){
-    var out=[],seen={};
+    // \`seen\` is a list, not a keyed object: these labels are written by the game, and
+    // "__proto__" as a property name would reach Object.prototype.
+    var out=[],seen=[];
     try{
       var buttons=document.querySelectorAll('.gamekit-touch-btn');
       for(var i=0;i<buttons.length;i++){
         var label=text(buttons[i]);
-        if(!label||seen[label])continue;
-        seen[label]=1;
+        if(!label||seen.indexOf(label)!==-1)continue;
+        seen.push(label);
         out.push({keys:'',action:label,touch:true});
       }
       if(document.querySelector('.gamekit-touch-pad'))out.push({keys:'',action:'',pad:'full'});

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -71,6 +71,24 @@ const BRIDGE = `(function(){
     }
     return out;
   }
+  /**
+   * Keycaps, from the names GameKit reads keys by.
+   *
+   * Space arrives as " ", which survives a truthiness check but is whitespace — the host
+   * collapses and trims every reported field, so posting it raw loses the key entirely and
+   * "Space to fire" renders as an actionless row. The rest are lowercase internal names
+   * ("shift", "arrowup") that read as code rather than as something to press.
+   */
+  var KEY_NAMES={' ':'Space',shift:'Shift',control:'Ctrl',alt:'Alt',meta:'Meta',enter:'Enter',
+    escape:'Esc',tab:'Tab',backspace:'Backspace',arrowup:'Up',arrowdown:'Down',
+    arrowleft:'Left',arrowright:'Right'};
+  function keyName(key){
+    var raw=String(key),lower=raw.toLowerCase();
+    // hasOwnProperty, not a bare lookup: these names come from game code, and "constructor"
+    // would otherwise resolve up the prototype chain to a function.
+    if(Object.prototype.hasOwnProperty.call(KEY_NAMES,lower))return KEY_NAMES[lower];
+    return raw.length===1?raw.toUpperCase():raw;
+  }
   /** GameKit's resolved input config — the only source that can name a touch button. */
   function kitRows(){
     var out=[];
@@ -81,7 +99,9 @@ const BRIDGE = `(function(){
       if(!m)return padRows();
       var buttons=m.buttons||[];
       for(var i=0;i<buttons.length;i++){
-        var keys=(buttons[i].keys||[]).join(' / '),label=String(buttons[i].label||'');
+        var names=[],raw=buttons[i].keys||[];
+        for(var k=0;k<raw.length;k++)names.push(keyName(raw[k]));
+        var keys=names.join(' / '),label=String(buttons[i].label||'');
         if(keys&&label)out.push({keys:keys,action:label,touch:true});
       }
       if(m.pad)out.push({keys:'',action:'',pad:String(m.pad)});

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
 import { isPlayTimeAccruing, TelemetrySession } from './telemetry.js';
+import { readReportedControls, type ReportedControls } from './howToPlay.js';
 import { recordVisitEvent } from './visitTelemetry.js';
 
 // Message envelope tags. The host is the app; the player is the bridge script
@@ -30,7 +31,15 @@ const PLAYER = 'gdpl-player';
 //      cannot inspect, and its CSP blocks every way it could report for itself. An
 //      uncaught error is the single most reliable "this published game is broken"
 //      signal we can get, and `frames: 0` while on screen distinguishes a stalled
-//      game from a hard game (docs/improvement-loop-plan.md IL-1).
+//      game from a hard game (docs/improvement-loop-plan.md IL-1);
+//   7. reports the game's own account of its controls, for the player's How-to-play
+//      card. Job 1 is exactly why this is needed: the card is host chrome because the
+//      game's `.game-controls` and `.hint` are hidden here, and an opaque origin means
+//      the host cannot read them for itself. The alternative — the catalog's `controls`
+//      string — is prose an agent wrote in a SPEC, is English-only, cannot name a touch
+//      button, and is absent entirely on a `/play/` deep link (the catalog is fetched on
+//      the home route only). Everything reported here is agent-authored text and is
+//      validated and rendered as text by the host, never as markup.
 const BRIDGE = `(function(){
   function el(id){return document.getElementById(id);}
   function post(m){m.source='${PLAYER}';parent.postMessage(m,'*');}
@@ -40,6 +49,49 @@ const BRIDGE = `(function(){
     post({type:'meta',title:t?(t.textContent||'').trim():'',desc:d?(d.textContent||'').trim():'',muted:isMuted()});
   }
   function sendSound(){post({type:'sound',muted:isMuted()});}
+  // --- controls (job 7) -------------------------------------------------------
+  // Everything below reads the game's *own* account of its controls and hands it to
+  // the host, which has no other way to get one: it hides this document's chrome and
+  // cannot see into an opaque origin. Three sources, best first. All of it is
+  // agent-authored text — the host validates and renders it as text, never as markup.
+  function text(node){return node?String(node.textContent||'').replace(/\\s+/g,' ').trim():'';}
+  /** The shell's how-to-play popup: already a dt/dd key→action table, already localized. */
+  function legendRows(){
+    var out=[],groups=document.querySelectorAll('.legend-keys');
+    for(var g=0;g<groups.length;g++){
+      var kids=groups[g].children;
+      // dt/dd arrive as siblings, not wrapped: pair each dt with the dd that follows.
+      for(var i=0;i<kids.length;i++){
+        if(kids[i].tagName!=='DT')continue;
+        var next=kids[i+1];
+        if(!next||next.tagName!=='DD')continue;
+        var keys=text(kids[i]),action=text(next);
+        if(keys||action)out.push({keys:keys,action:action});
+      }
+    }
+    return out;
+  }
+  /** GameKit's resolved input config — the only source that can name a touch button. */
+  function kitRows(){
+    var out=[];
+    try{
+      var kit=window.GameKit;
+      if(!kit||typeof kit.controlsManifest!=='function')return out;
+      var m=kit.controlsManifest();
+      if(!m)return out;
+      var buttons=m.buttons||[];
+      for(var i=0;i<buttons.length;i++){
+        var keys=(buttons[i].keys||[]).join(' / '),label=String(buttons[i].label||'');
+        if(keys&&label)out.push({keys:keys,action:label,touch:true});
+      }
+      if(m.pad)out.push({keys:'',action:'',pad:String(m.pad)});
+    }catch(err){}
+    return out;
+  }
+  function sendControls(){
+    var rows=legendRows(),kit=kitRows();
+    post({type:'controls',rows:rows,kit:kit,hint:text(document.querySelector('.hint'))});
+  }
   addEventListener('error',function(e){post({type:'error',message:String((e&&e.message)||'error').slice(0,200)});});
   addEventListener('unhandledrejection',function(e){
     var r=e&&e.reason;post({type:'error',message:String((r&&r.message)||r||'unhandled rejection').slice(0,200)});
@@ -208,7 +260,7 @@ const BRIDGE = `(function(){
   addEventListener('message',function(e){
     var m=e.data||{};
     if(m.source!=='${HOST}')return;
-    if(m.type==='hello'){sendMeta();}
+    if(m.type==='hello'){sendMeta();sendControls();}
     else if(m.type==='setSound'){var s=el('sound-toggle');if(s&&isMuted()!==!!m.muted){s.click();}sendSound();}
     else if(m.type==='pause'){setPaused(true);}
     else if(m.type==='resume'){setPaused(false);}
@@ -228,7 +280,11 @@ const BRIDGE = `(function(){
     sendMeta();
     var s=el('sound-toggle');
     if(s&&'MutationObserver'in window){new MutationObserver(sendSound).observe(s,{attributes:true,attributeFilter:['aria-pressed']});}
-    setTimeout(sendMeta,400); // pick up any i18n applied just after load
+    sendControls();
+    // Same 400ms retry as the title/description, for the same reason (i18n applies
+    // just after load) plus one of its own: GameKit resolves its input config when the
+    // game calls createInput, which happens after this script runs.
+    setTimeout(function(){sendMeta();sendControls();},400);
   }
   if(document.readyState==='loading')addEventListener('DOMContentLoaded',init);else init();
 })();`;
@@ -398,8 +454,9 @@ export type GamePlayerMeta = { title: string; desc: string };
 
 /**
  * Subscribes to the player bridge for the currently-embedded game iframe and
- * exposes its title/description and a sound toggle the header can drive. `active`
- * gates the subscription so it only runs while a single-player game is on stage.
+ * exposes its title/description, the controls it reports, and a sound toggle the
+ * header can drive. `active` gates the subscription so it only runs while a
+ * single-player game is on stage.
  */
 export function useGamePlayer(
   frameRef: MutableRefObject<HTMLIFrameElement | null>,
@@ -410,6 +467,7 @@ export function useGamePlayer(
   onPointer?: () => void,
 ) {
   const [meta, setMeta] = useState<GamePlayerMeta | null>(null);
+  const [controls, setControls] = useState<ReportedControls | null>(null);
   const [muted, setMuted] = useState(false);
 
   // Held in refs so a caller's inline closures can't resubscribe the listener below.
@@ -421,6 +479,7 @@ export function useGamePlayer(
   useEffect(() => {
     if (!active) {
       setMeta(null);
+      setControls(null);
       setMuted(false);
       return;
     }
@@ -443,6 +502,13 @@ export function useGamePlayer(
       if (data.type === 'meta') {
         setMeta({ title: String(data.title ?? ''), desc: String(data.desc ?? '') });
         setMuted(Boolean(data.muted));
+      } else if (data.type === 'controls') {
+        // The bridge re-sends this (i18n and GameKit both land after load), so a later
+        // report replaces an earlier one — but a report with nothing in it never clears
+        // one that had something, or a game that swaps its own chrome would blank the
+        // card mid-play.
+        const next = readReportedControls(data);
+        if (next) setControls(next);
       } else if (data.type === 'sound') {
         setMuted(Boolean(data.muted));
       } else if (data.type === 'key' && data.key === 'Escape') {
@@ -473,7 +539,7 @@ export function useGamePlayer(
     });
   }, [frameRef]);
 
-  return { meta, muted, toggleSound };
+  return { meta, controls, muted, toggleSound };
 }
 
 /** Instrumentation gathered while a creator playtests inside Studio. */

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -1,13 +1,24 @@
-// @vitest-environment jsdom
-
 import { afterEach, describe, expect, it } from 'vitest';
 import { embedGameHtml } from './gamePlayer.js';
 
 /*
+ * jsdom is a devDependency here but ships no types, and the surface this file uses is
+ * three members wide — cheaper to state than to take on `@types/jsdom` for one test.
+ */
+type FrameWindow = Record<string, unknown> & {
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  close(): void;
+};
+type JsdomLike = { window: FrameWindow };
+type JsdomOptions = { runScripts: 'dangerously'; pretendToBeVisual: boolean; beforeParse(win: FrameWindow): void };
+// @ts-expect-error - jsdom ships no type declarations and this repo does not install them.
+const { JSDOM } = (await import('jsdom')) as { JSDOM: new (html: string, options: JsdomOptions) => JsdomLike };
+
+/*
  * The bridge ships as a source string injected into an opaque-origin game document, so
  * it is the one part of the player that no type-checker and no import graph can reach.
- * These tests run the string that actually ships, in a document shaped like a real game
- * document, and read what it posts.
+ * These tests run the document `embedGameHtml` actually produces, in a JSDOM that
+ * executes scripts the way a browser does, and read what it posts.
  *
  * What it reports is the game's own account of its controls — the input the How-to-play
  * card trusts first. If the scraper silently stops finding rows, the card quietly falls
@@ -15,36 +26,34 @@ import { embedGameHtml } from './gamePlayer.js';
  * else in the suite would notice.
  */
 
-/** Pull the injected bridge out of an embedded document, as the iframe would run it. */
-function bridgeSource(): string {
-  const embedded = embedGameHtml('<html><head></head><body></body></html>');
-  const match = embedded.match(/<script>([\s\S]*?)<\/script>/);
-  if (!match?.[1]) throw new Error('no bridge script in the embedded document');
-  return match[1];
-}
-
 type Posted = { type?: string; rows?: unknown; kit?: unknown; hint?: unknown };
 
+let dom: JsdomLike | null = null;
+
 /**
- * Runs the bridge against a game-shaped document and returns everything it posted.
+ * Embeds a game-shaped document, runs it, and returns everything the bridge posted.
  *
- * `parent` is this same window under jsdom, so the bridge's `parent.postMessage` lands
- * on a listener here — the same path a real frame takes to reach the host.
+ * The whole `embedGameHtml` output is handed to JSDOM rather than a script pulled out of
+ * it, so the injection itself is under test too. `parent` is the same window here, so the
+ * bridge's `parent.postMessage` lands on a listener inside it — the path a real frame
+ * takes to reach the host.
  */
 async function runBridge(bodyHtml: string, gameKit?: Record<string, unknown>): Promise<Posted[]> {
-  document.body.innerHTML = bodyHtml;
-  if (gameKit) (window as unknown as Record<string, unknown>).GameKit = gameKit;
-
   const posted: Posted[] = [];
-  const collect = (event: MessageEvent) => {
-    if (event.data?.source === 'gdpl-player') posted.push(event.data as Posted);
-  };
-  window.addEventListener('message', collect);
-  // Indirect eval so the bridge's `var`s land on the window, as they do in a real frame.
-  (0, eval)(bridgeSource());
-  // jsdom queues postMessage delivery; let the microtask/macrotask queue drain.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  window.removeEventListener('message', collect);
+  dom = new JSDOM(embedGameHtml(`<html><head></head><body>${bodyHtml}</body></html>`), {
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+    // Both the stub and the listener have to exist before the bridge script runs: it
+    // reads GameKit and posts its first report during its own initialization.
+    beforeParse(win: FrameWindow) {
+      if (gameKit) win.GameKit = gameKit;
+      win.addEventListener('message', (event: MessageEvent) => {
+        if (event.data?.source === 'gdpl-player') posted.push(event.data as Posted);
+      });
+    },
+  });
+  // The bridge posts on DOMContentLoaded (or immediately), and JSDOM queues delivery.
+  await new Promise((resolve) => setTimeout(resolve, 20));
   return posted;
 }
 
@@ -53,8 +62,8 @@ function controlsFrom(posted: Posted[]): Posted | undefined {
 }
 
 afterEach(() => {
-  document.body.innerHTML = '';
-  delete (window as unknown as Record<string, unknown>).GameKit;
+  dom?.window.close();
+  dom = null;
 });
 
 describe('the bridge control scraper', () => {
@@ -203,6 +212,25 @@ describe('the bridge pad fallback', () => {
     const controls = controlsFrom(await runBridge(PAD, { wantsTouchControls: () => true }));
     const kit = (controls?.kit ?? []) as Array<{ action: string }>;
     expect(kit.some((row) => row.action === 'Fire')).toBe(true);
+  });
+
+  it('does not let a button label reach Object.prototype', async () => {
+    // Button labels are written by the game. Deduping them through a keyed object would
+    // make "__proto__" a property assignment on the prototype rather than an entry.
+    const controls = controlsFrom(
+      await runBridge(`
+        <div class="gamekit-touch-buttons">
+          <div class="gamekit-touch-btn">__proto__</div>
+          <div class="gamekit-touch-btn">constructor</div>
+          <div class="gamekit-touch-btn">Fire</div>
+        </div>`),
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect((controls?.kit as Array<{ action: string }>).map((row) => row.action)).toEqual([
+      '__proto__',
+      'constructor',
+      'Fire',
+    ]);
   });
 
   it('reports no pad on a desktop, where GameKit builds none', async () => {

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { embedGameHtml } from './gamePlayer.js';
+
+/*
+ * The bridge ships as a source string injected into an opaque-origin game document, so
+ * it is the one part of the player that no type-checker and no import graph can reach.
+ * These tests run the string that actually ships, in a document shaped like a real game
+ * document, and read what it posts.
+ *
+ * What it reports is the game's own account of its controls — the input the How-to-play
+ * card trusts first. If the scraper silently stops finding rows, the card quietly falls
+ * back to a catalog string that is English-only and absent on a deep link, and nothing
+ * else in the suite would notice.
+ */
+
+/** Pull the injected bridge out of an embedded document, as the iframe would run it. */
+function bridgeSource(): string {
+  const embedded = embedGameHtml('<html><head></head><body></body></html>');
+  const match = embedded.match(/<script>([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error('no bridge script in the embedded document');
+  return match[1];
+}
+
+type Posted = { type?: string; rows?: unknown; kit?: unknown; hint?: unknown };
+
+/**
+ * Runs the bridge against a game-shaped document and returns everything it posted.
+ *
+ * `parent` is this same window under jsdom, so the bridge's `parent.postMessage` lands
+ * on a listener here — the same path a real frame takes to reach the host.
+ */
+async function runBridge(bodyHtml: string, gameKit?: Record<string, unknown>): Promise<Posted[]> {
+  document.body.innerHTML = bodyHtml;
+  if (gameKit) (window as unknown as Record<string, unknown>).GameKit = gameKit;
+
+  const posted: Posted[] = [];
+  const collect = (event: MessageEvent) => {
+    if (event.data?.source === 'gdpl-player') posted.push(event.data as Posted);
+  };
+  window.addEventListener('message', collect);
+  // Indirect eval so the bridge's `var`s land on the window, as they do in a real frame.
+  (0, eval)(bridgeSource());
+  // jsdom queues postMessage delivery; let the microtask/macrotask queue drain.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  window.removeEventListener('message', collect);
+  return posted;
+}
+
+function controlsFrom(posted: Posted[]): Posted | undefined {
+  return posted.filter((message) => message.type === 'controls').at(-1);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete (window as unknown as Record<string, unknown>).GameKit;
+});
+
+describe('the bridge control scraper', () => {
+  it('reads the shell popup as key/action rows, already localized by the game', async () => {
+    // The markup every game template scaffolds. `dt` and `dd` are siblings inside the
+    // list, not wrapped per row, so pairing is positional.
+    const controls = controlsFrom(
+      await runBridge(`
+        <div class="game-controls">
+          <details class="legend">
+            <div class="legend-card">
+              <dl class="legend-keys">
+                <dt>&larr; &rarr; / A D</dt><dd>Skręt</dd>
+                <dt>Spacja</dt><dd>Ogień</dd>
+              </dl>
+            </div>
+          </details>
+        </div>`),
+    );
+    expect(controls?.rows).toEqual([
+      { keys: '← → / A D', action: 'Skręt' },
+      { keys: 'Spacja', action: 'Ogień' },
+    ]);
+  });
+
+  it('skips a term with no definition rather than pairing across rows', async () => {
+    // A hand-edited popup can leave a dangling dt. Pairing it with the *next* row's dd
+    // would attach every action to the wrong key from that point on.
+    const controls = controlsFrom(
+      await runBridge(`
+        <dl class="legend-keys">
+          <dt>W</dt><dd>Up</dd>
+          <dt>Orphan</dt>
+          <dt>S</dt><dd>Down</dd>
+        </dl>`),
+    );
+    expect(controls?.rows).toEqual([
+      { keys: 'W', action: 'Up' },
+      { keys: 'S', action: 'Down' },
+    ]);
+  });
+
+  it('reports the touch buttons GameKit mounted, which no other source can name', async () => {
+    const controls = controlsFrom(
+      await runBridge('<canvas id="game"></canvas>', {
+        controlsManifest: () => ({
+          pad: 'full',
+          look: false,
+          steer: 'origin',
+          buttons: [
+            { keys: [' '], label: 'Fire' },
+            { keys: ['shift', 'x'], label: 'Throttle' },
+          ],
+          touch: true,
+        }),
+      }),
+    );
+    expect(controls?.kit).toEqual([
+      { keys: ' ', action: 'Fire', touch: true },
+      { keys: 'shift / x', action: 'Throttle', touch: true },
+      { keys: '', action: '', pad: 'full' },
+    ]);
+  });
+
+  it('reports nothing from GameKit when the game mounted no input', async () => {
+    // A game whose script died before createInput, and an older snapshot built before
+    // controlsManifest existed, are the same case here: report what is known, not a guess.
+    expect(controlsFrom(await runBridge('<canvas id="game"></canvas>', {}))?.kit).toEqual([]);
+    expect(controlsFrom(await runBridge('<canvas id="game"></canvas>', { controlsManifest: () => null }))?.kit).toEqual(
+      [],
+    );
+  });
+
+  it('survives a GameKit that throws, because a broken game must still be playable', async () => {
+    const posted = await runBridge('<p class="hint">W to jump</p>', {
+      controlsManifest: () => {
+        throw new Error('game is on fire');
+      },
+    });
+    const controls = controlsFrom(posted);
+    expect(controls?.kit).toEqual([]);
+    expect(controls?.hint).toBe('W to jump');
+  });
+
+  it('falls back to the one-line hint every game ships', async () => {
+    const controls = controlsFrom(await runBridge('<p class="hint">A/D  steer,\n  Space fire</p>'));
+    expect(controls?.rows).toEqual([]);
+    // Whitespace is collapsed at the source: the hint is authored across lines in markup.
+    expect(controls?.hint).toBe('A/D steer, Space fire');
+  });
+
+  it('posts an empty report for a document with no controls anywhere', async () => {
+    // Not silence: the host needs to hear "this game said nothing" to fall back rather
+    // than wait forever for a message that is never coming.
+    const controls = controlsFrom(await runBridge('<canvas id="game"></canvas>'));
+    expect(controls).toBeDefined();
+    expect(controls?.rows).toEqual([]);
+    expect(controls?.hint).toBe('');
+  });
+});

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -155,3 +155,57 @@ describe('the bridge control scraper', () => {
     expect(controls?.hint).toBe('');
   });
 });
+
+describe('the bridge pad fallback', () => {
+  /*
+   * The manifest is the better source, but it only exists in a snapshot rebuilt after
+   * the games repo ships `controlsManifest`. Every published game today has a pad in the
+   * DOM instead, so this is what makes touch describable now rather than after a re-bake.
+   */
+  const PAD = `
+    <div class="gamekit-touch">
+      <div class="gamekit-touch-pad"></div>
+      <div class="gamekit-touch-buttons">
+        <div class="gamekit-touch-btn">Fire</div>
+        <div class="gamekit-touch-btn">Throttle</div>
+      </div>
+    </div>`;
+
+  it('reads the built pad when GameKit cannot be asked', async () => {
+    const controls = controlsFrom(await runBridge(PAD));
+    expect(controls?.kit).toEqual([
+      { keys: '', action: 'Fire', touch: true },
+      { keys: '', action: 'Throttle', touch: true },
+      { keys: '', action: '', pad: 'full' },
+    ]);
+  });
+
+  it('prefers the manifest when there is one, since it also knows the keys', async () => {
+    const controls = controlsFrom(
+      await runBridge(PAD, {
+        controlsManifest: () => ({
+          pad: 'full',
+          look: false,
+          steer: 'origin',
+          buttons: [{ keys: [' '], label: 'Fire' }],
+          touch: true,
+        }),
+      }),
+    );
+    expect(controls?.kit).toEqual([
+      { keys: ' ', action: 'Fire', touch: true },
+      { keys: '', action: '', pad: 'full' },
+    ]);
+  });
+
+  it('falls back to the pad when GameKit is present but answers nothing', async () => {
+    // An older snapshot: GameKit is there, `controlsManifest` is not.
+    const controls = controlsFrom(await runBridge(PAD, { wantsTouchControls: () => true }));
+    const kit = (controls?.kit ?? []) as Array<{ action: string }>;
+    expect(kit.some((row) => row.action === 'Fire')).toBe(true);
+  });
+
+  it('reports no pad on a desktop, where GameKit builds none', async () => {
+    expect(controlsFrom(await runBridge('<canvas id="game"></canvas>'))?.kit).toEqual([]);
+  });
+});

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -52,8 +52,12 @@ async function runBridge(bodyHtml: string, gameKit?: Record<string, unknown>): P
       });
     },
   });
-  // The bridge posts on DOMContentLoaded (or immediately), and JSDOM queues delivery.
-  await new Promise((resolve) => setTimeout(resolve, 20));
+  // Wait for the report rather than for a duration: a fixed sleep passes alone and flakes
+  // when the suite runs files in parallel. Every path through `sendControls` posts, even
+  // when the document says nothing, so "no message yet" always means "not yet".
+  for (let waited = 0; waited < 2000 && !posted.some((m) => m.type === 'controls'); waited += 5) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
   return posted;
 }
 
@@ -121,10 +125,37 @@ describe('the bridge control scraper', () => {
         }),
       }),
     );
+    // Posted as keycaps, not as GameKit's internal key names: " " is whitespace the host
+    // would collapse to nothing, losing the key and leaving an actionless row.
     expect(controls?.kit).toEqual([
-      { keys: ' ', action: 'Fire', touch: true },
-      { keys: 'shift / x', action: 'Throttle', touch: true },
+      { keys: 'Space', action: 'Fire', touch: true },
+      { keys: 'Shift / X', action: 'Throttle', touch: true },
       { keys: '', action: '', pad: 'full' },
+    ]);
+  });
+
+  it('names arrows and modifiers as keycaps, and does not walk the prototype doing it', async () => {
+    // The lookup is by key name, and key names come from game code — "constructor" must
+    // resolve to itself, not to Object.prototype.constructor.
+    const controls = controlsFrom(
+      await runBridge('<canvas id="game"></canvas>', {
+        controlsManifest: () => ({
+          pad: false,
+          look: false,
+          steer: false,
+          buttons: [
+            { keys: ['arrowup', 'w'], label: 'Climb' },
+            { keys: ['control'], label: 'Cut' },
+            { keys: ['constructor'], label: 'Odd' },
+          ],
+          touch: false,
+        }),
+      }),
+    );
+    expect(controls?.kit).toEqual([
+      { keys: 'Up / W', action: 'Climb', touch: true },
+      { keys: 'Ctrl', action: 'Cut', touch: true },
+      { keys: 'constructor', action: 'Odd', touch: true },
     ]);
   });
 
@@ -202,7 +233,7 @@ describe('the bridge pad fallback', () => {
       }),
     );
     expect(controls?.kit).toEqual([
-      { keys: ' ', action: 'Fire', touch: true },
+      { keys: 'Space', action: 'Fire', touch: true },
       { keys: '', action: '', pad: 'full' },
     ]);
   });

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -190,3 +190,35 @@ describe('resolveControlRows', () => {
     expect(resolveControlRows(null, '')).toEqual([]);
   });
 });
+
+describe('pad buttons read off the built pad', () => {
+  it('names the Touch row instead of becoming key rows with no keys', () => {
+    // These carry a label but no key, because on a touch device the key behind a button
+    // is not the question. Rendering them as key rows would show a column of blanks.
+    const controls = readReportedControls({
+      rows: [{ keys: 'A/D', action: 'Steer' }],
+      kit: [
+        { keys: '', action: 'Fire', touch: true },
+        { keys: '', action: 'Throttle', touch: true },
+        { keys: '', action: '', pad: 'full' },
+      ],
+    });
+    expect(controls?.padButtons).toEqual(['Fire', 'Throttle']);
+    expect(controls?.pad).toBe(true);
+    expect(resolveControlRows(controls, '')).toEqual([{ keys: 'A/D', action: 'Steer' }]);
+  });
+
+  it('still makes manifest buttons real rows, because those do know their key', () => {
+    const controls = readReportedControls({
+      kit: [{ keys: 'Space', action: 'Fire', touch: true }],
+    });
+    expect(controls?.padButtons).toEqual([]);
+    expect(controls?.kit).toEqual([{ keys: 'Space', action: 'Fire' }]);
+  });
+
+  it('is enough on its own to show the card for a game that reported nothing else', () => {
+    const controls = readReportedControls({ kit: [{ keys: '', action: 'Fire', touch: true }] });
+    expect(controls).not.toBeNull();
+    expect(controls?.padButtons).toEqual(['Fire']);
+  });
+});

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseControls } from './howToPlay.js';
+import { parseControls, readReportedControls, resolveControlRows } from './howToPlay.js';
 
 describe('parseControls', () => {
   it('splits on the semicolon when there is one, keeping commas inside a clause', () => {
@@ -78,5 +78,115 @@ describe('parseControls', () => {
     const twins = `${'y'.repeat(200)}a; ${'y'.repeat(200)}b`;
     const truncated = parseControls(twins);
     expect(truncated[0]?.action).toBe(truncated[1]?.action);
+  });
+});
+
+describe('readReportedControls', () => {
+  it('takes the rows a game reported about itself', () => {
+    const controls = readReportedControls({
+      rows: [
+        { keys: 'A/D', action: 'Steer' },
+        { keys: 'Space', action: 'Fire' },
+      ],
+      kit: [],
+      hint: 'A/D steer, Space fire',
+    });
+    expect(controls?.rows).toEqual([
+      { keys: 'A/D', action: 'Steer' },
+      { keys: 'Space', action: 'Fire' },
+    ]);
+  });
+
+  it('returns null for anything that carries nothing usable, which is the fallback signal', () => {
+    // Every one of these is reachable: a game with no how-to-play markup, a frame that
+    // died before GameKit ran, and a hostile frame posting whatever it likes.
+    expect(readReportedControls({ rows: [], kit: [], hint: '' })).toBeNull();
+    expect(readReportedControls(null)).toBeNull();
+    expect(readReportedControls('rows')).toBeNull();
+    expect(readReportedControls({ rows: 'not an array', kit: 42, hint: { nope: true } })).toBeNull();
+    expect(readReportedControls({ rows: [null, 7, 'x', { keys: 'A' }] })).toBeNull();
+  });
+
+  it('caps count and length, because this arrives from an AI-authored document', () => {
+    const controls = readReportedControls({
+      rows: Array.from({ length: 60 }, (_, i) => ({ keys: `k${i}`, action: `a${i}` })),
+      kit: [],
+      hint: '',
+    });
+    expect(controls?.rows).toHaveLength(14);
+
+    const long = readReportedControls({ rows: [{ keys: 'k'.repeat(500), action: 'a'.repeat(500) }] });
+    expect(long?.rows[0]?.keys).toHaveLength(80);
+    expect(long?.rows[0]?.action.endsWith('…')).toBe(true);
+  });
+
+  it('spends the length budget on visible text, not on whitespace', () => {
+    // Padding is collapsed before measuring; otherwise a game could push its real text
+    // past the cap with newlines and leave a blank row on the card.
+    const controls = readReportedControls({ rows: [{ keys: `${' '.repeat(200)}A/D`, action: '  Steer\n\n  ' }] });
+    expect(controls?.rows).toEqual([{ keys: 'A/D', action: 'Steer' }]);
+  });
+
+  it('passes markup through as text — the panel is the only thing that renders it', () => {
+    const controls = readReportedControls({ rows: [{ keys: '<img src=x onerror=alert(1)>', action: 'Jump' }] });
+    expect(controls?.rows[0]?.keys).toBe('<img src=x onerror=alert(1)>');
+  });
+
+  it('reads a mounted pad out of the GameKit rows', () => {
+    expect(readReportedControls({ kit: [{ pad: 'full' }] })?.pad).toBe(true);
+    expect(readReportedControls({ kit: [{ keys: 'Space', action: 'Fire' }] })?.pad).toBe(false);
+  });
+});
+
+describe('resolveControlRows', () => {
+  const catalog = 'Left/Right to move; Space to fire';
+
+  it('prefers what the game says about itself over what the catalog says about it', () => {
+    // The catalog string is a SPEC claim that can drift from the code; the reported rows
+    // are this document's own account, and are in the player's language.
+    const reported = readReportedControls({ rows: [{ keys: 'A/D', action: 'Skręt' }] });
+    expect(resolveControlRows(reported, catalog)).toEqual([{ keys: 'A/D', action: 'Skręt' }]);
+  });
+
+  it('falls back to the catalog when the game reported no structured rows', () => {
+    expect(resolveControlRows(null, catalog)).toEqual([
+      { keys: 'Left/Right', action: 'move' },
+      { keys: 'Space', action: 'fire' },
+    ]);
+  });
+
+  it('uses the one-line hint only when there is nothing else at all', () => {
+    // A deep link to a game with no legend markup: no catalog, no rows — but every game
+    // in the repo ships a `.hint`, so the card still has something true to show.
+    const reported = readReportedControls({ rows: [], kit: [], hint: 'W/A/S/D to move, Space to jump' });
+    expect(resolveControlRows(reported, '')).toEqual([
+      { keys: 'W/A/S/D', action: 'move' },
+      { keys: 'Space', action: 'jump' },
+    ]);
+    // …and never in place of a real source.
+    expect(resolveControlRows(reported, catalog)[0]).toEqual({ keys: 'Left/Right', action: 'move' });
+  });
+
+  it('appends GameKit touch buttons rather than merging them, since no keyboard row names them', () => {
+    const reported = readReportedControls({
+      rows: [{ keys: 'A/D', action: 'Steer' }],
+      kit: [{ keys: 'Space', action: 'Fire', touch: true }],
+    });
+    expect(resolveControlRows(reported, catalog)).toEqual([
+      { keys: 'A/D', action: 'Steer' },
+      { keys: 'Space', action: 'Fire' },
+    ]);
+  });
+
+  it('still caps the total once both sources have contributed', () => {
+    const reported = readReportedControls({
+      rows: Array.from({ length: 10 }, (_, i) => ({ keys: `k${i}`, action: `a${i}` })),
+      kit: Array.from({ length: 10 }, (_, i) => ({ keys: `b${i}`, action: `f${i}` })),
+    });
+    expect(resolveControlRows(reported, catalog)).toHaveLength(14);
+  });
+
+  it('returns nothing when no source has anything, which is how the control stays hidden', () => {
+    expect(resolveControlRows(null, '')).toEqual([]);
   });
 });

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -222,3 +222,23 @@ describe('pad buttons read off the built pad', () => {
     expect(controls?.padButtons).toEqual(['Fire']);
   });
 });
+
+describe('a game whose only answer is its pad', () => {
+  it('counts as having controls, so the trigger renders', () => {
+    // A generated game on a phone: it mounts a pad, but ships no legend, no hint and has
+    // no catalog entry. Naming its buttons is the entire answer to "how do I play this".
+    const controls = readReportedControls({
+      rows: [],
+      hint: '',
+      kit: [
+        { keys: '', action: 'Fire', touch: true },
+        { keys: '', action: '', pad: 'full' },
+      ],
+    });
+    expect(controls).not.toBeNull();
+    expect(controls?.pad).toBe(true);
+    expect(controls?.padButtons).toEqual(['Fire']);
+    // No keyboard rows to show — the caller must not read that as "nothing to show".
+    expect(resolveControlRows(controls, '')).toEqual([]);
+  });
+});

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -88,6 +88,13 @@ export interface ReportedControls {
   kit: ControlRow[];
   /** Whether GameKit reported mounting an on-screen d-pad. */
   pad: boolean;
+  /**
+   * Names of the on-screen buttons, when they were read off the built pad rather than
+   * out of the manifest. They carry no key, because on the device that has them the key
+   * is not the question — you tap the button — so they name the Touch row instead of
+   * becoming key rows of their own.
+   */
+  padButtons: string[];
   /** The game's one-line `.hint`, used only when nothing structured came back. */
   hint: string;
 }
@@ -132,13 +139,25 @@ export function readReportedControls(data: unknown): ReportedControls | null {
   if (!data || typeof data !== 'object') return null;
   const record = data as Record<string, unknown>;
   const kitRaw = Array.isArray(record.kit) ? (record.kit as Array<Record<string, unknown>>) : [];
+  const usable = kitRaw.filter((entry) => entry && typeof entry === 'object');
   const controls: ReportedControls = {
     rows: cleanRows(record.rows),
-    kit: cleanRows(kitRaw),
-    pad: kitRaw.some((entry) => entry && typeof entry === 'object' && typeof entry.pad === 'string' && entry.pad),
+    // Only entries naming their keys become rows; the rest describe the pad.
+    kit: cleanRows(usable.filter((entry) => typeof entry.keys === 'string' && entry.keys)),
+    pad: usable.some((entry) => typeof entry.pad === 'string' && entry.pad),
+    padButtons: usable
+      .filter((entry) => entry.touch === true && !entry.keys)
+      .map((entry) => cleanField(entry.action, MAX_REPORTED_LENGTH))
+      .filter((label) => label.length > 0)
+      .slice(0, MAX_ROWS),
     hint: cleanField(record.hint, MAX_ROW_LENGTH),
   };
-  const empty = controls.rows.length === 0 && controls.kit.length === 0 && !controls.hint && !controls.pad;
+  const empty =
+    controls.rows.length === 0 &&
+    controls.kit.length === 0 &&
+    controls.padButtons.length === 0 &&
+    !controls.hint &&
+    !controls.pad;
   return empty ? null : controls;
 }
 

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -64,3 +64,96 @@ export function parseControls(controls: string): ControlRow[] {
     .map((clause) => (clause.length > MAX_ROW_LENGTH ? `${clause.slice(0, MAX_ROW_LENGTH - 1)}…` : clause))
     .map(splitClause);
 }
+
+/* --------------------------------------------------------------------------
+ * What the game says about itself
+ * ------------------------------------------------------------------------ */
+
+/**
+ * A control list a game reported over the player bridge.
+ *
+ * Better than the catalog's `controls` in four ways that matter: it is already split
+ * into key and action (no guessing), it is in the player's language rather than always
+ * English, it can name a touch button, and it exists on a `/play/` deep link — where the
+ * catalog is never fetched and the placeholder entry carries an empty `controls`.
+ *
+ * It is also the least trustworthy input on this screen. It crosses a sandbox boundary
+ * from an AI-generated document, so nothing here is assumed: shapes are checked, counts
+ * and lengths are capped, and every string is rendered as a JSX text node.
+ */
+export interface ReportedControls {
+  /** Key→action rows the game's own how-to-play markup declares. */
+  rows: ControlRow[];
+  /** Rows GameKit vouches for, which is the only source that can describe touch. */
+  kit: ControlRow[];
+  /** Whether GameKit reported mounting an on-screen d-pad. */
+  pad: boolean;
+  /** The game's one-line `.hint`, used only when nothing structured came back. */
+  hint: string;
+}
+
+/** Longer than a key column ever legitimately is; also the cap on a reported action. */
+const MAX_REPORTED_LENGTH = 80;
+
+function cleanField(value: unknown, max: number): string {
+  if (typeof value !== 'string') return '';
+  // Collapse whitespace before measuring: a game could otherwise spend the whole budget
+  // on newlines and push the visible text out of the card.
+  const text = value.replace(/\s+/g, ' ').trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function cleanRows(value: unknown): ControlRow[] {
+  if (!Array.isArray(value)) return [];
+  const out: ControlRow[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as Record<string, unknown>;
+    const keys = cleanField(record.keys, MAX_REPORTED_LENGTH);
+    const action = cleanField(record.action, MAX_REPORTED_LENGTH);
+    // A row with neither half says nothing; a row with only keys is a key bound to no
+    // stated action, which reads as a mistake rather than as help.
+    if (!action) continue;
+    out.push({ keys, action });
+    if (out.length >= MAX_ROWS) break;
+  }
+  return out;
+}
+
+/**
+ * Validates a `controls` message from the player bridge into something renderable.
+ *
+ * Returns null when the game reported nothing usable, which is the signal to fall back
+ * to the catalog string. Deliberately total: any shape at all goes in, and what comes
+ * out is either well-formed or null — a hostile or broken frame cannot produce a third
+ * outcome, and cannot make the host throw while a game is running.
+ */
+export function readReportedControls(data: unknown): ReportedControls | null {
+  if (!data || typeof data !== 'object') return null;
+  const record = data as Record<string, unknown>;
+  const kitRaw = Array.isArray(record.kit) ? (record.kit as Array<Record<string, unknown>>) : [];
+  const controls: ReportedControls = {
+    rows: cleanRows(record.rows),
+    kit: cleanRows(kitRaw),
+    pad: kitRaw.some((entry) => entry && typeof entry === 'object' && typeof entry.pad === 'string' && entry.pad),
+    hint: cleanField(record.hint, MAX_ROW_LENGTH),
+  };
+  const empty = controls.rows.length === 0 && controls.kit.length === 0 && !controls.hint && !controls.pad;
+  return empty ? null : controls;
+}
+
+/**
+ * The rows to show, from the best source that has any.
+ *
+ * The game's own markup wins over the catalog because it is this game's account of
+ * itself rather than a spec claim about it, and it is localized. GameKit's rows are
+ * appended rather than merged: they name touch buttons, which the keyboard rows above
+ * them never duplicate. The `.hint` is a single sentence, so it is parsed with the same
+ * splitter the catalog string uses.
+ */
+export function resolveControlRows(reported: ReportedControls | null, catalog: string): ControlRow[] {
+  const declared = reported ? reported.rows : [];
+  const fallback = declared.length > 0 ? declared : parseControls(catalog);
+  const hinted = fallback.length > 0 ? fallback : parseControls(reported?.hint ?? '');
+  return [...hinted, ...(reported?.kit ?? [])].slice(0, MAX_ROWS);
+}


### PR DESCRIPTION
Builds on #356. That card reads the catalog's `controls` string, which was the only source available to it. This gives it a better one: the game document itself.

The catalog string is prose an agent wrote in a SPEC. It is English-only, it can drift from the code, it cannot name an on-screen touch button, and on a `/play/<slug>` deep link it is not there at all — the catalog is fetched on the home route only, so the player holds a placeholder entry whose `controls` is empty and the control never appeared. #356 documented that as a known gap needing "a per-game catalog read the API does not currently offer."

It doesn't. The game document has none of those problems, and it is always present, because it is the thing being played.

## Where the rows come from

New sources arrive over the existing player bridge, resolved game-first, catalog-second, hint-last:

- **The shell's how-to-play popup** (`.legend-keys`) — already a `dt`/`dd` key→action table, already localized by the game's own i18n. gamedevpl/www.gamedev.pl-games#172 scaffolds it into every template. It is invisible inside the player by construction, because it lives in `.game-controls`, which `HIDE_CHROME` hides — so reading it here is what makes that work reach a player at all.
- **`GameKit.controlsManifest()`** (gamedevpl/www.gamedev.pl-games#277) — the input config the game actually mounted, the only source that knows the *key* behind a touch button and the only one that answers on a desktop.
- **The pad GameKit already built** — read off `.gamekit-touch-btn` in the DOM. Weaker (names buttons, not their keys; exists only where a coarse pointer does) but it needs **nothing from the games repo and no re-bake**, so touch is describable on all 93 published games today. The manifest is preferred wherever it answers; this is the fallback, and it is why this PR has no hard dependency on the games side.

Touch rows are appended rather than merged, because no keyboard row ever names them. Pad button labels name the Touch row ("On-screen pad on touch screens — Fire, Throttle") rather than becoming key rows with an empty key column: on a device that has the buttons, the key behind one is not the question. The catalog string stays as the fallback for a game whose document reports nothing.

Everything is sent on load and again at 400ms, alongside the existing meta retry: i18n applies just after load, and GameKit resolves its config when the game calls `createInput`, which is after the bridge script runs. A later report replaces an earlier one, but an empty report never clears a card that already had content — otherwise a game that swaps its own chrome would blank the card mid-play.

## What this closes

**The deep-link gap.** A shared link is where a player has the least context — they have never seen the arcade — and it was the one place the card could not appear. No catalog read API, no new endpoint.

**English-only rows.** The card now speaks the player's language, because the game already did.

**Touch.** `native` and `controllers` games said nothing about touch. A mounted pad is now stated as fact by the game that mounted it, and believed over the catalog's build-time classification when the two disagree.

## Trust

This crosses a sandbox boundary out of an AI-generated document, so none of it is trusted. `readReportedControls` is total: any shape goes in, and what comes out is well-formed or `null` — a hostile or broken frame cannot produce a third outcome, and cannot make the host throw while a game is running. Counts and lengths are capped, whitespace is collapsed *before* measuring (or a game could spend the whole budget on newlines and push its real text off the card), rows with no action are dropped, and every string reaches the DOM as a JSX text node. Reports were already pinned to this theater's frame and to origin `"null"` by the existing listener; a test now holds that.

The sandbox invariant is untouched — nothing is read *across* the boundary. The frame reports what it chooses to, exactly as it already does for title, description, sound and Escape.

## Cost

None on the games side, and no snapshot re-bake: the bridge is injected by the player at serve time rather than baked into a snapshot. Games that report nothing behave exactly as before.

## One fix that is this branch's own doing

#356 sheds the bar copy of the control at 900px (measured: at 800px the bar copy pushed the vote widget over the game title). But `showMoreMenu` still tracked 768px, so between those widths the bar copy is hidden by CSS and no menu holds the other copy.

That gap could not be hit before this branch — `controls` only ever arrived from the catalog, and the catalog is wired to the one call site that also passes `reportSlug`, which forces the menu to exist. Now that the game document reports its own controls, drafts and generated games have them too, and those pass no `reportSlug`. The menu now also renders when a control has shed into it — still not merely because a game has controls, since on a wide screen the bar copy is the route and an overflow menu grown for nothing is what `isNarrow` exists to prevent.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` — all green, against merged master. 784 web tests across 90 files.

New: `gamePlayerBridge.test.ts` executes the bridge string that actually ships, in a document shaped like a real game document, and reads what it posts — that scraper is the one part of the player no type-checker and no import graph can reach, and if it silently stopped finding rows the card would quietly fall back with nothing else noticing. Plus validator and resolution-order tests in `howToPlay.test.ts`, and integration tests in `GameTheater.test.tsx` covering the deep-link case, game-over-catalog precedence, the empty re-report, a spoofed cross-origin report, and both reachability breakpoints (stubbed, since jsdom implements no `matchMedia` — an unstubbed breakpoint is not being tested).

Each regression test was verified to fail without its fix.