### PR TITLE
Raise serve cap to 473,687 for the games-repo world + gameplay reserves

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -37,9 +37,11 @@
     "gfx3d": 96000,
     "lookControls": 4683,
     "spatialAudio": 2977,
-    "zone": 12000
+    "zone": 12000,
+    "world": 15000,
+    "gameplay": 9000
   },
-  "maxProjectBytes": 441687,
+  "maxProjectBytes": 465687,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -19,7 +19,7 @@ describe('the size cap', () => {
   it('matches the budget the games repo enforces in Check 4', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247).
-    expect(MAX_PROJECT_BYTES).toBe(441_687);
+    expect(MAX_PROJECT_BYTES).toBe(465_687);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(441_687);
+    expect(MAX_PROJECT_BYTES).toBe(465_687);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -101,6 +101,8 @@ describe('games-repo source extractors', () => {
       const GAMEKIT_LOOK_CONTROLS_BYTES = 4_683;
       const GAMEKIT_SPATIAL_AUDIO_BYTES = 2_977;
       const GAMEKIT_ZONE_BYTES = 12_000;
+      const GAMEKIT_WORLD_BYTES = 15_000;
+      const GAMEKIT_GAMEPLAY_BYTES = 9_000;
       const MAX_BUNDLE_BYTES =
         GAME_BUDGET_BYTES +
         GAMEKIT_TOUCH_BYTES +
@@ -118,7 +120,9 @@ describe('games-repo source extractors', () => {
         GAMEKIT_GFX3D_BYTES +
         GAMEKIT_LOOK_CONTROLS_BYTES +
         GAMEKIT_SPATIAL_AUDIO_BYTES +
-        GAMEKIT_ZONE_BYTES;
+        GAMEKIT_ZONE_BYTES +
+        GAMEKIT_WORLD_BYTES +
+        GAMEKIT_GAMEPLAY_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -49,9 +49,17 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * music, touch hint, progress, universal input, pointer poll, draw surface,
  * pointer release, host pause, mascot draw, headroom, gfx3d, look, spatial, …). Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (441_687, matching games-repo `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB.
+ * (465_687, matching games-repo `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB.
  *
- * Last moved by games-repo #163: +12_000 for a named `zone` reserve, 429_687 → 441_687.
+ * Last moved by games-repo convergence Pass #10 (carjack-city open-world promotion):
+ * +15_000 (`world`) and +9_000 (`gameplay`) named reserves, 441_687 → 465_687. Both
+ * modules shipped tiny and charged to the author budget; Pass #10 grew them into real
+ * capability layers (grids/spiral search/loop paths/2D camera; arcade vehicle physics/
+ * combo/ticker — measured 13_263 and 7_371 transpiled), and the first game to select
+ * them, carjack-city, was also the tightest bundle in the catalog (1_472 bytes under
+ * the old ceiling before selecting them). Same opt-in-reserve argument as `zone`.
+ *
+ * Before that, games-repo #163: +12_000 for a named `zone` reserve, 429_687 → 441_687.
  * The module shipped charged to the author budget, on the reasoning that it is small and
  * opt-in the way `save` and `commons` are. biplane-skirmish disproved that on arrival —
  * the first published game to select `zone` landed 20 bytes under the ceiling, which made
@@ -90,7 +98,7 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Before that, games-repo #102: +679 (`mascotDraw`) and +75_237 (`headroom`) — 30% of
  * the 250_790 ceiling — plus earlier host-pause / touch steer raises.
  */
-export const GAMEKIT_PLATFORM_BYTES = 236_887;
+export const GAMEKIT_PLATFORM_BYTES = 260_887;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
Website half of a cross-repo contract move, paired with
**gamedevpl/www.gamedev.pl-games#278**.

## ⚠️ Merge order: this side first

`games-repo-contract.ts` documents why, and it is not order-neutral. Merging the games
repo first opens a window where the build ceiling sits above the serve ceiling, and a
game that grows into that gap bakes as a failure *quietly* — a partial bake leaves the
pointer on the previous snapshot, so the site keeps serving and the merged game simply
never appears. Website-first cannot do that: a serve cap above the build cap means no
assemblable game is refused here. `contract:games-repo` now explicitly tolerates
website-ahead, which is exactly the state this leaves the repos in.

## What changed

`MAX_PROJECT_BYTES` 449,687 → 473,687, via `GAMEKIT_PLATFORM_BYTES` 244,887 → 268,887.

- `apps/api/src/games-repo-contract.ts` — the constant plus a history entry
- `apps/api/fixtures/games-repo/shared/assemble-contract.json` — vendored snapshot gains
  `world: 15000` and `gameplay: 9000`; `maxProjectBytes` follows
- `apps/api/src/games-repo-contract.test.ts` — expected total, and the extractor fixture
  that mirrors games-repo `validate.ts` allowance for allowance
- `apps/api/src/assemble.test.ts` — the size-cap assertion (its own comment says to move
  it to match the games repo rather than relax it, which is what this does)

**Rebased onto the `voice` reserve.** #381 landed the +8,000 `voice` reserve
(441,687 → 449,687) and the `voice` module while this branch was open. Both are carried
forward untouched and the Pass #10 raise stacks on top of them, rather than either side
clobbering the other.

## Why the games repo needs it

Games-repo convergence Pass #10 promotes `carjack-city`'s generic systems into GameKit —
arcade vehicle physics, a 2D chase camera, loop paths, spiral search, a combo chain, a
message ticker, tile/hull collision resolvers, and the sim→presentation frame-events bus.
Those live in the `world` and `gameplay` modules, which shipped tiny and were charged to
the 200 KiB author budget.

`carjack-city` cannot afford them there. It is the tightest bundle in the catalog: #276
("make the cars the point") had to re-encode the engine sample at 11 kHz to claw back
2,646 bytes just to fit its own new car code. Both modules therefore graduate to named
opt-in reserves, the same argument that gave `zone` one in games-repo #163 and `voice`
one in #381: a module nobody pays for unless they ask for it gets a reserve rather than a
slice of another game's author budget.

Measured transpiled at the Pass #10 tip: `world` 13,263 → 15,000 reserve; `gameplay`
7,371 → 9,000 reserve. With both selected, carjack-city assembles at 459,041 — 6,646
under the new ceiling. `GAME_BUDGET_BYTES` is unchanged at 200 KiB, so this does not let
games grow.

## Verification

`npx vitest run` in `apps/api`: **91 files, 1,548 tests, all passing.**