### PR TITLE
Let a delivered job act on its gate verdict

### DIFF
--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -73,6 +73,34 @@ describe('transition rules', () => {
     expect(canTransition('needs_changes', 'queued')).toBe(true);
     expect(canTransition('ready_for_review', 'needs_changes')).toBe(true);
   });
+
+  // The gate reports by writing its verdict to the version manifest, which we read on a
+  // poll — so a delivered job goes straight from `submitted` to the outcome and is never
+  // seen mid-gate. When `gating` was the only exit, that made `submitted` a dead end:
+  // the reconciler computed the right target, canTransition refused it, and the job sat
+  // there telling the creator the gate had never started for as long as they watched.
+  it('lets a delivered job reach the gate verdict without passing through gating', () => {
+    expect(canTransition('submitted', 'ready_for_review')).toBe(true);
+    expect(canTransition('submitted', 'needs_changes')).toBe(true);
+    // Still reachable, for records written while it was a step and for a future gate
+    // that reports its start.
+    expect(canTransition('submitted', 'gating')).toBe(true);
+    // But not a shortcut past the moderation boundary.
+    expect(canTransition('submitted', 'published')).toBe(false);
+    expect(canTransition('submitted', 'publishing')).toBe(false);
+  });
+
+  // The shape of the bug rather than the instance: any state a reconciler can compute a
+  // target for has to be able to reach it. Read as "no state is a dead end that isn't
+  // meant to be one" — every non-terminal state must have somewhere to go.
+  it('gives every non-terminal state a way forward', () => {
+    for (const state of JOB_STATES.filter((s) => !isTerminal(s))) {
+      const forward = JOB_STATES.filter(
+        (target) => target !== state && canTransition(state, target) && !['canceled', 'abandoned'].includes(target),
+      );
+      expect(forward.length, `${state} has no exit other than cancel/abandon`).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('reconcileAgentObservation', () => {

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -74,6 +74,17 @@ describe('transition rules', () => {
     expect(canTransition('ready_for_review', 'needs_changes')).toBe(true);
   });
 
+  // A gate-red round is not always over: `mustFixGate` tells the live session to fix the
+  // cause and deliver again without a new dispatch. agent-channel records that upload
+  // only when this holds, so refusing it stranded a game the agent had already repaired.
+  it('lets a session repair a gate-red delivery without another round', () => {
+    expect(canTransition('needs_changes', 'submitted')).toBe(true);
+    // Still no way to skip the verification the redelivery exists to pass.
+    expect(canTransition('needs_changes', 'ready_for_review')).toBe(false);
+    expect(canTransition('needs_changes', 'publishing')).toBe(false);
+    expect(canTransition('needs_changes', 'published')).toBe(false);
+  });
+
   // The gate reports by writing its verdict to the version manifest, which we read on a
   // poll — so a delivered job goes straight from `submitted` to the outcome and is never
   // seen mid-gate. When `gating` was the only exit, that made `submitted` a dead end:

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -94,7 +94,15 @@ const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   // Improvements start a *new* job, so publishing is terminal for this one.
   published: [],
   // Another round: back to the queue, which is what dispatching a follow-up means.
-  needs_changes: ['queued', 'dispatched', 'building', 'canceled', 'abandoned'],
+  //
+  // `submitted` is here because a gate-red round is not always over. The session that
+  // delivered is often still alive, and `mustFixGate` tells it exactly that: fix the
+  // cause and deliver again, in the same session, with no new dispatch. That repaired
+  // upload has to be recordable — agent-channel only writes `submitted` when this allows
+  // it, and reconcileGateVerdict only reads a verdict from `submitted`/`gating`. Without
+  // this, a game the agent had already fixed sat in `needs_changes` with a green verdict
+  // nobody would look at, waiting on a round the creator should never have had to start.
+  needs_changes: ['queued', 'dispatched', 'building', 'submitted', 'canceled', 'abandoned'],
   // Same shape as needs_changes, for the same reason: a dead round must not orphan
   // the job, and feedback after a failure *is* the retry. Still terminal to the
   // reconciler — `isTerminal` guards it, so only a creator or operator moves it.

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -29,7 +29,15 @@ export const JOB_STATES = [
   'building',
   /** The agent delivered candidate sources; nothing has verified them yet. */
   'submitted',
-  /** Our own gate is running against the delivered sources. */
+  /**
+   * Our own gate is running against the delivered sources.
+   *
+   * Nothing writes this today. The gate runs in Cloud Build and reports by writing its
+   * verdict to the version manifest, which we read on a poll — so the job goes from
+   * `submitted` to the verdict in one hop and is never observed mid-gate. Kept because
+   * stored records may still hold it and the projection reads it, not because it is a
+   * step anything passes through.
+   */
   'gating',
   /** Gate green. Waiting on the human review that is the moderation boundary. */
   'ready_for_review',
@@ -72,7 +80,13 @@ const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   queued: ['dispatched', 'building', 'canceled', 'abandoned', 'failed'],
   dispatched: ['building', 'submitted', 'failed', 'canceled', 'abandoned'],
   building: ['submitted', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
-  submitted: ['gating', 'failed', 'canceled', 'abandoned'],
+  // The verdict is read off the version manifest in a single poll, so a delivered job
+  // reaches its outcome without ever being seen in `gating`. Listing only `gating` here
+  // made `submitted` a trap: reconcileGateVerdict computes `ready_for_review` or
+  // `needs_changes`, canTransition refused both, and nothing else writes `gating` — so
+  // every job that arrived here stayed, showing "delivered, gate never started" for as
+  // long as the creator kept the page open.
+  submitted: ['gating', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
   gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
   ready_for_review: ['publishing', 'needs_changes', 'canceled', 'abandoned'],
   // A failed bake must be able to fall back, or a job strands with no way home.

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -8,6 +8,7 @@ import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } f
 import type { ContentChecker } from './moderation.js';
 import { InMemoryStore, type Store } from './store.js';
 import { mintToken } from './submission-token.js';
+import { canTransition } from './job-state.js';
 import type { AgentBackend, BuildBrief } from './agent-backend.js';
 import type { GamesStore } from './games-store.js';
 import { JOB_ID_FLOOR } from './store.js';
@@ -989,6 +990,81 @@ describe('submission routes', () => {
     expect(status.json().phase).toBe('ready_for_review');
     // And the warning the creator was staring at is gone with the state that caused it.
     expect(status.json().stall).toBeUndefined();
+
+    await app.close();
+  });
+
+  // The other half of the same path, and the one that only became reachable once the
+  // gate verdict could land at all: a red gate does not necessarily end the round. The
+  // session that delivered is usually still alive, and `mustFixGate` tells it to fix the
+  // cause and deliver again with no new dispatch. That repaired upload has to be able to
+  // re-enter `submitted`, or its green verdict sits in a manifest nobody reads and the
+  // creator is asked to start a round the agent already finished.
+  it('reads the verdict on a redelivery the agent made after a gate refusal', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 98 });
+    const { backend } = createBackendStub();
+    const gamesStore = {
+      // Version-aware on purpose: v3 is what the gate refused, v4 is the repair.
+      getManifest: async (_slug: string, version: string) => ({
+        slug: 'space-parcels',
+        version,
+        createdAt: '2026-07-31T10:00:00.000Z',
+        issueNumber: 98,
+        sourceFiles: [],
+        gate:
+          version === 'v3'
+            ? { green: false, ranAt: '2026-07-31T10:30:00.000Z', report: 'trace diff' }
+            : { green: true, ranAt: '2026-07-31T11:15:00.000Z' },
+      }),
+    } as unknown as GamesStore;
+
+    // The status answer is cached for 60s, so the two polls below need to be further
+    // apart than that — otherwise the second reads the first's answer and this proves
+    // nothing about the transition it exists to check.
+    const clock = { t: Date.now() };
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+      now: () => clock.t,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const url = `/api/submissions/${mintToken(job.issueNumber, secret)}`;
+
+    await store.setSubmissionSlug(job.issueNumber, 'space-parcels');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v3');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-07-31T10:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const refused = await app.inject({ method: 'GET', url, headers: authHeaders });
+    expect(refused.json().phase).toBe('needs_changes');
+
+    // The repair, recorded the way agent-channel records one — which it can only do when
+    // the transition is legal from where the refusal left the job.
+    expect(canTransition('needs_changes', 'submitted')).toBe(true);
+    clock.t += 61_000;
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v4');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-07-31T11:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const repaired = await app.inject({ method: 'GET', url, headers: authHeaders });
+    expect(repaired.json().phase).toBe('ready_for_review');
 
     await app.close();
   });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -933,6 +933,66 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  // The bug this covers was visible to creators and invisible to us: a delivered game
+  // whose gate had passed kept showing "delivered, but verification hasn't started —
+  // that's on our side" indefinitely. The gate had run and its verdict was in the
+  // manifest; the job could not act on it, because `submitted` listed only `gating` as
+  // an exit and nothing writes `gating`. The reconciler computed `ready_for_review`,
+  // canTransition refused it, and the job sat in `submitted` until the creator gave up.
+  it('acts on a gate verdict for a job still sitting in submitted', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 97 });
+    const { backend } = createBackendStub();
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'space-parcels',
+        version: 'v3',
+        createdAt: '2026-07-31T10:00:00.000Z',
+        issueNumber: 97,
+        sourceFiles: [],
+        gate: { green: true, ranAt: '2026-07-31T10:30:00.000Z' },
+      }),
+    } as unknown as GamesStore;
+
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+
+    // The shape a real delivery leaves behind: the agent channel marked the sources
+    // delivered, and the gate wrote its verdict to that version's manifest.
+    await store.setSubmissionSlug(job.issueNumber, 'space-parcels');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v3');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-07-31T10:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    expect(status.statusCode).toBe(200);
+    expect(status.json().phase).toBe('ready_for_review');
+    // And the warning the creator was staring at is gone with the state that caused it.
+    expect(status.json().stall).toBeUndefined();
+
+    await app.close();
+  });
+
   it('reports the job phase alongside the status, so the page can say which wait this is', async () => {
     // `toSubmissionStatus` is lossy on purpose — `gating` and `building` arrive as one
     // word, and `ready_for_review` (delivered, checked, waiting on us) arrives as the
@@ -1140,7 +1200,6 @@ describe('submission routes', () => {
 
     await app.close();
   });
-
 
   it('abandons a native job without closing anything on GitHub', async () => {
     const { githubClient, closeIssue, closePullRequest } = createGithubClientStub({ issueNumber: 77 });


### PR DESCRIPTION
A creator watched *"the game was delivered, but verification hasn't started yet — that's on our side, you don't need to do anything"* sit above their composer for hours, under a thread that already said the gate had passed. Both were true. The gate had run, its verdict was in the version manifest, and the job could not act on it.

## What was wrong

`submitted` listed `gating` as its only way forward, and nothing writes `gating`. The gate runs in Cloud Build and reports by writing its verdict to the version manifest, which we read on a poll — so a job goes from delivered to its outcome in one hop and is never observed mid-gate. `reconcileGateVerdict` computed the right target and `canTransition` refused it:

```
canTransition('submitted', 'ready_for_review')  -> false
canTransition('submitted', 'needs_changes')     -> false
detectStall(submitted) at +0.2h / +1h / +5h / +48h  -> gate_not_started (every time)
```

So every job that reached `submitted` stayed there, showing a stall warning that was accurate and permanent. Since `submitted` and `gating` both project to `building` for creators, the page also kept reporting the game as still being written.

Games that publish normally are the ones that skip `submitted` entirely: `building → ready_for_review` is legal, so a job whose agent task reports `completed` before the channel marks delivery is unaffected. That is why this has not stopped everything.

## The change

`submitted` can now reach the verdict directly. `gating` stays reachable — stored records may hold it, and a gate that one day reports its own start would use it — and the state's own doc comment now says nothing writes it today, so the next reader does not re-derive the assumption that something does.

## Tests

- The transition itself, and that it is not a shortcut past the moderation boundary (`published`/`publishing` stay refused from `submitted`).
- The behaviour: a job sitting in `submitted` whose manifest carries a green verdict reaches `ready_for_review` on the next status poll, with no stall. **Checked that this fails without the fix** — `expected 'submitted' to be 'ready_for_review'` — rather than assumed.
- The class rather than the instance: every non-terminal state must have an exit other than cancel or abandon. A dead end should surface as a red test, not as an amber panel a creator has to sit and read.

## Note for whoever deploys this

Jobs currently stuck in `submitted` are not migrated. The reconciler runs on the status poll, so opening such a game in the studio after this ships should move it on and clear the warning. A game that stays put after that has no verdict in its manifest, which is a different problem — the gate genuinely never ran — and wants looking at separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD3KJLV3broyoVUnu26GDm)_