### PR TITLE
Fix games-store rough edges from first e2e run (#398)

### DIFF
--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -104,6 +104,36 @@ describe('GET /api/me/studio', () => {
     await app.close();
   });
 
+  it('prefers lastStatus over lastNotifiedStatus so a just-published game is not still "building"', async () => {
+    // `in_review` shares a notification event with `building`, so lastNotifiedStatus
+    // can lag while lastStatus is current — and publish writes lastStatus immediately.
+    await store.createSubmission(20, 'g:creator', 'Just shipped');
+    await store.setSubmissionSlug(20, 'just-shipped');
+    await store.setSubmissionPublishedAt(20, `${today}T12:00:00.000Z`);
+    await store.setSubmissionNotifiedStatus(20, 'building');
+    await store.setSubmissionLastStatus(20, 'published');
+
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      submissionRoutes: { submissionTokenSecret },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio',
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { games: CreatorStudioGame[] }).games[0]).toMatchObject({
+      title: 'Just shipped',
+      lastKnownStatus: 'published',
+    });
+
+    await app.close();
+  });
+
   it('requires a session', async () => {
     const app = await buildApp({
       store,

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -204,7 +204,11 @@ export async function registerCreatorStudioRoutes(
       token: options.mintStatusToken!(tip.issueNumber),
       title: tip.title,
       createdAt: tip.createdAt,
-      lastKnownStatus: tip.lastNotifiedStatus ?? null,
+      // Prefer `lastStatus` (kept current on every derivation, and written at publish)
+      // over `lastNotifiedStatus` (only moves when a notification fires — `in_review`
+      // shares an event with `building`, so the studio would otherwise keep saying
+      // "building" for a game waiting on review, or for one that just went live).
+      lastKnownStatus: tip.lastStatus ?? tip.lastNotifiedStatus ?? null,
       ...(tip.slug ? { slug: tip.slug } : {}),
       ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
       ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1620,7 +1620,14 @@ function parseCommittedMultiplayer(value: unknown): CatalogGameMultiplayer | nul
   return { mode: 'controllers', minPlayers: multiplayer.minPlayers, maxPlayers: multiplayer.maxPlayers };
 }
 
-function parseGameMedia(metadataJson: string | null): CatalogGameMedia | null {
+/**
+ * Turns a capture harness `media/metadata.json` into the catalog's media shape.
+ *
+ * Exported so the store-publish path can apply the same allowlist the repo path uses
+ * when serving `/api/games/:slug/media/:filename` — a second parser would be a second
+ * answer to "which filenames are public".
+ */
+export function parseGameMedia(metadataJson: string | null): CatalogGameMedia | null {
   if (!metadataJson) {
     return null;
   }

--- a/apps/api/src/job-admin-routes.test.ts
+++ b/apps/api/src/job-admin-routes.test.ts
@@ -207,6 +207,9 @@ describe('POST /api/admin/jobs/:issueNumber/publish', () => {
     expect(record?.state).toBe('published');
     expect(record?.transitions?.map((entry) => entry.to)).toEqual(['publishing', 'published']);
     expect(record?.publishedAt).toBeTruthy();
+    // The creator rail reads `lastStatus`, not `state` — without this a published game
+    // also kept rendering as an in-progress "yours" card.
+    expect(record?.lastStatus).toBe('published');
 
     await app.close();
   });

--- a/apps/api/src/job-admin-routes.ts
+++ b/apps/api/src/job-admin-routes.ts
@@ -186,6 +186,12 @@ export async function registerJobAdminRoutes(
     });
     await store.recordJobTransition(issueNumber, { to: 'published', at, by: 'operator', reason: 'published' });
     await store.setSubmissionPublishedAt(issueNumber, at);
+    // The creator rail reads `lastStatus`, not `state`. Writing it here is what stops a
+    // published game from also rendering as an in-progress "yours" card: the notify
+    // sweep that normally keeps `lastStatus` current only walks *active* submissions,
+    // and a terminal job is one sweep away from falling out of that set. `lastNotifiedStatus`
+    // is left alone so the next sweep can still emit the published notification.
+    await store.setSubmissionLastStatus(issueNumber, 'published');
 
     return reply.send({ ok: true, slug: record.slug, version: record.deliveredVersion, publishedAt: at });
   });

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -176,6 +176,8 @@ describe('InMemoryStore', () => {
   it('caps transition history so a flapping reconciler cannot grow the document', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(2, 'g:123', 'A game');
+    // Alternate states so every write is a real move — same-state writes are refused
+    // and would otherwise leave the history short of the cap.
     for (let i = 0; i < MAX_JOB_TRANSITIONS + 10; i += 1) {
       await store.recordJobTransition(2, {
         to: i % 2 === 0 ? 'building' : 'queued',
@@ -190,6 +192,35 @@ describe('InMemoryStore', () => {
     expect(record?.transitions?.at(-1)?.at).toBe(
       new Date(Date.parse('2026-07-30T10:00:00Z') + (MAX_JOB_TRANSITIONS + 9) * 1000).toISOString(),
     );
+  });
+
+  it('refuses a same-state reconciler write so a re-observation cannot reset the state clock', async () => {
+    // Stronger than identical-reason no-op: a different reason from a non-operator
+    // must not look like a move either (ready_for_review / gate_green → ready_for_review
+    // / derived_from_github was the #398 rough edge).
+    const store = new InMemoryStore();
+    await store.createSubmission(9, 'g:123', 'A game');
+    await store.recordJobTransition(9, {
+      to: 'ready_for_review',
+      at: '2026-07-30T10:00:00Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+
+    expect(
+      await store.recordJobTransition(9, {
+        to: 'ready_for_review',
+        at: '2026-07-30T12:30:00Z',
+        by: 'reconciler',
+        reason: 'derived_from_github',
+      }),
+    ).toBe(false);
+
+    const record = await store.getSubmission(9);
+    expect(record?.stateSince).toBe('2026-07-30T10:00:00Z');
+    expect(record?.transitions).toEqual([
+      { to: 'ready_for_review', at: '2026-07-30T10:00:00Z', by: 'gate', reason: 'gate_green' },
+    ]);
   });
 
   it('handles submission tracking', async () => {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2224,11 +2224,14 @@ export class InMemoryStore implements Store {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return false;
     // Idempotent for concurrent *identical* arrivals (status poll + notify sweep both
-    // seeing `submitted`→`needs_changes`/`gate_red`). Same-state with a *new* reason
-    // is intentional — operator retry re-enters `building` with `operator_retry`.
+    // seeing `submitted`→`needs_changes`/`gate_red`). Same-state with a *new* reason is
+    // intentional only for the operator — a quiet-build retry re-enters `building` with
+    // `operator_retry`. A reconciler/gate re-observation with a different reason would
+    // only reset `stateSince` and overwrite the reason that actually moved the job.
     if (sub.state === transition.to) {
       const last = sub.transitions?.at(-1);
       if (last?.to === transition.to && last?.reason === transition.reason) return false;
+      if (transition.by !== 'operator') return false;
     }
     const closes = transitionClosesRound(transition);
     const next: SubmissionRecord = {
@@ -3811,10 +3814,11 @@ export class FirestoreStore implements Store {
       const current = snap.data() as SubmissionRecord;
       // Same race as InMemoryStore: concurrent identical arrivals must not both "win"
       // (gate screenshots key off `recorded`). Same-state with a new reason is allowed
-      // (operator retry re-enters `building`).
+      // only for the operator (quiet-build retry); see InMemoryStore.recordJobTransition.
       if (current.state === transition.to) {
         const last = current.transitions?.at(-1);
         if (last?.to === transition.to && last?.reason === transition.reason) return false;
+        if (transition.by !== 'operator') return false;
       }
       const closes = transitionClosesRound(transition);
       if (closes) {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2965,8 +2965,8 @@ describe('games published from the store rather than the repo', () => {
     expect(mp4.headers['content-type']).toMatch(/video\/mp4/);
 
     // Filenames the metadata does not declare stay behind the API boundary.
-    const secret = await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/secret.png' });
-    expect(secret.statusCode).toBe(404);
+    const undeclared = await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/secret.png' });
+    expect(undeclared.statusCode).toBe(404);
 
     await app.close();
   });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2874,12 +2874,26 @@ describe('status route under store pressure', () => {
 });
 
 describe('games published from the store rather than the repo', () => {
+  const MEDIA_METADATA = JSON.stringify({
+    captures: {
+      opening: { file: 'opening.png' },
+      gameplay: { file: 'gameplay.png' },
+    },
+    video: { file: 'gameplay.mp4' },
+  });
+
   /** A store holding one published version: its spec, and the bundle the gate assembled. */
   function publishedGamesStore(bundle = '<!doctype html><meta name="ai-provenance" content="x" />game') {
     return {
       getSourceFile: async (_slug: string, _version: string, path: string) =>
         path === 'SPEC.md' ? '---\ntitle: Comet Courier\ngenre: arcade\n---\n' : null,
-      getDerivedArtifact: async () => Buffer.from(bundle, 'utf8'),
+      getDerivedArtifact: async (_slug: string, _version: string, name: string) => {
+        if (name === 'bundle.html') return Buffer.from(bundle, 'utf8');
+        if (name === 'media/metadata.json') return Buffer.from(MEDIA_METADATA, 'utf8');
+        if (name === 'media/opening.png') return Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+        if (name === 'media/gameplay.mp4') return Buffer.from('fake-mp4');
+        return null;
+      },
       getManifest: async () => null,
       putCandidateSources: async () => ({ version: 'v1', manifest: {} }),
       putGateResult: async () => {},
@@ -2920,8 +2934,39 @@ describe('games published from the store rather than the repo', () => {
     expect(response.statusCode).toBe(200);
     const entry = response.json().find((item: CatalogGameEntry) => item.slug === 'comet-courier');
     // Described by the same parser the repo path uses, so the two cannot disagree about
-    // what a game's genre is.
-    expect(entry).toMatchObject({ title: 'Comet Courier', genre: 'arcade', status: 'published' });
+    // what a game's genre is. Media comes from the gate's derived artifacts — stubbing
+    // the sibling reader used to leave every store card with `media: null`.
+    expect(entry).toMatchObject({
+      title: 'Comet Courier',
+      genre: 'arcade',
+      status: 'published',
+      media: {
+        screenshots: [
+          { name: 'opening', file: 'opening.png' },
+          { name: 'gameplay', file: 'gameplay.png' },
+        ],
+        video: 'gameplay.mp4',
+      },
+    });
+
+    await app.close();
+  });
+
+  it('serves store-published gallery media from the published version’s derived artifacts', async () => {
+    const { app } = await appWithPublication(publishedGamesStore());
+
+    const png = await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/opening.png' });
+    expect(png.statusCode).toBe(200);
+    expect(png.headers['content-type']).toMatch(/image\/png/);
+    expect(png.rawPayload).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const mp4 = await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/gameplay.mp4' });
+    expect(mp4.statusCode).toBe(200);
+    expect(mp4.headers['content-type']).toMatch(/video\/mp4/);
+
+    // Filenames the metadata does not declare stay behind the API boundary.
+    const secret = await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/secret.png' });
+    expect(secret.statusCode).toBe(404);
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -13,6 +13,7 @@ import { profileBylineName, toPublicCreatorProfile } from './creator-profile.js'
 import {
   catalogEntryFromSpec,
   createGitHubClient,
+  parseGameMedia,
   parseSpecTitle,
   type CatalogGameEntry,
   type GitHubClient,
@@ -3353,7 +3354,11 @@ export async function registerSubmissionRoutes(
           if (record.lastStatus !== status.status) {
             await store.setSubmissionLastStatus(record.issueNumber, status.status);
           }
-          await recordDerivedJobState(record, status.status);
+          // Use the post-reconcile snapshot: the gate/agent observation above may already
+          // have moved the job, and feeding the pre-reconcile record into the derived-status
+          // planner would plan the same destination again (ready_for_review → ready_for_review)
+          // and reset `stateSince` / overwrite the reason that actually moved it.
+          await recordDerivedJobState(current, status.status);
           const statusToken = mintToken(record.issueNumber, submissionTokenSecret);
           const result = await notifyOnTransition(buildNotifyDeps(), record, status, statusToken);
           if (result.emitted) emitted += 1;
@@ -3846,6 +3851,30 @@ export async function registerSubmissionRoutes(
   }
 
   /**
+   * Gallery bytes for a store-published game, or null when this slug is not one / the
+   * filename is not on its media allowlist.
+   *
+   * Same allowlist rule as the repo path: only filenames declared by the validated
+   * `media/metadata.json` are readable. The gate stores that metadata (and the png/mp4)
+   * as derived artifacts on the published version.
+   */
+  async function readStorePublishedMedia(slug: string, filename: string): Promise<Buffer | null> {
+    const gamesStore = options.agentChannel?.gamesStore;
+    if (!store || !gamesStore) return null;
+    const publication = await store.getPublication(slug);
+    if (publication?.state !== 'published') return null;
+    const mediaMetadata = await gamesStore.getDerivedArtifact(slug, publication.currentVersion, 'media/metadata.json');
+    const media = parseGameMedia(mediaMetadata?.toString('utf8') ?? null);
+    if (!media) return null;
+    const allowed = new Set([
+      ...media.screenshots.map((screenshot) => screenshot.file),
+      ...(media.video ? [media.video] : []),
+    ]);
+    if (!allowed.has(filename)) return null;
+    return gamesStore.getDerivedArtifact(slug, publication.currentVersion, `media/${filename}`);
+  }
+
+  /**
    * The catalog entries for games published from the store rather than from the repo.
    *
    * A delivered game is never committed, so the games-repo catalog cannot see it and a
@@ -3875,7 +3904,19 @@ export async function registerSubmissionRoutes(
       for (const record of publications) {
         const spec = await gamesStore.getSourceFile(record.slug, record.currentVersion, 'SPEC.md');
         if (spec === null) continue;
-        const entry = catalogEntryFromSpec(record.slug, spec, () => null);
+        // Media lives as derived artifacts (`media/metadata.json` + png/mp4), produced by
+        // the gate — not as source. The repo path supplies a real sibling reader; stubbing
+        // it here is why every store-published card came back with `media: null` even
+        // though the bytes were already in the bucket and `/api/games/:slug/media/:file`
+        // was already wired.
+        const mediaMetadata = await gamesStore.getDerivedArtifact(
+          record.slug,
+          record.currentVersion,
+          'media/metadata.json',
+        );
+        const entry = catalogEntryFromSpec(record.slug, spec, (name) =>
+          name === 'media/metadata.json' && mediaMetadata ? mediaMetadata.toString('utf8') : null,
+        );
         // Published is a decision the operator already made and recorded here; the
         // spec's own `status` describes the repo workflow this game never went through.
         if (!entry) continue;
@@ -3962,25 +4003,31 @@ export async function registerSubmissionRoutes(
         ...(entry?.media?.screenshots.map((screenshot) => screenshot.file) ?? []),
         ...(entry?.media?.video ? [entry.media.video] : []),
       ]);
-      if (!entry || !allowedFiles.has(parsedParams.data.filename)) {
-        return reply.status(404).send({ error: 'media not found' });
-      }
 
       // The catalog allowlist above still gates every read, so the snapshot can
       // only ever answer for a filename the validated metadata already vouches for.
-      let body: Buffer;
-      if (snapshotReader) {
-        const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
-        if (!snapshotMedia) {
-          return reply.status(404).send({ error: 'media not found' });
+      let body: Buffer | null = null;
+      if (entry && allowedFiles.has(parsedParams.data.filename)) {
+        if (snapshotReader) {
+          const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
+          body = snapshotMedia?.body ?? null;
+        } else {
+          const media = await githubClient.getGameMedia(
+            publishedRef,
+            parsedParams.data.slug,
+            parsedParams.data.filename,
+          );
+          body = media ? Buffer.from(media) : null;
         }
-        body = snapshotMedia.body;
-      } else {
-        const media = await githubClient.getGameMedia(publishedRef, parsedParams.data.slug, parsedParams.data.filename);
-        if (!media) {
-          return reply.status(404).send({ error: 'media not found' });
-        }
-        body = Buffer.from(media);
+      }
+
+      // Store-published games never land in the repo catalog or the snapshot bake, so
+      // the allowlist and the bytes both come from the version the operator published.
+      if (!body) {
+        body = await readStorePublishedMedia(parsedParams.data.slug, parsedParams.data.filename);
+      }
+      if (!body) {
+        return reply.status(404).send({ error: 'media not found' });
       }
 
       const cacheEntry = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes code bugs from the first end-to-end games-store run ([#398](https://github.com/gamedevpl/www.gamedev.pl/issues/398)).

Rebased onto current `master` (studio shelf is now games-not-jobs via #463; creator attribution stays on publish-gated profiles from #455).

## Changes

### Store-published games show screenshots/video
`storeCatalogEntries` reads `media/metadata.json` from the gate’s derived artifacts, and `/api/games/:slug/media/:filename` falls through to the published version’s derived media when the slug is not in the repo catalog.

### Published game no longer appears twice
Operator publish writes `lastStatus: published`. Creator studio (and `/mine`) prefer `lastStatus` over `lastNotifiedStatus`. `lastNotifiedStatus` is left for the notify sweep so the published notification can still fire.

### Same-state transitions no longer reset the state clock
`recordJobTransition` refuses identical concurrent duplicates and non-operator same-state writes with a new reason. Operator quiet-build retry still allowed. Notify sweep feeds the post-reconcile snapshot into the derived-status planner.

## Intentionally not in this PR

**Creator attribution** — already shipped as publish-gated creator profiles (#455).

**Re-gate button** — needs a hand click in a real browser before any code change (automation false alarm likely).

**Cloud Build queue latency** — observation only (scheduling wait, not gate work).

## Test plan
- [x] Unit/API tests for media, publish `lastStatus`, same-state refusal, studio preference
- [x] Rebased onto master; conflicts resolved against owner-games / creator-profile shape
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

