### PR TITLE
Make the studio-shell browser gate assert without a shelf (#392)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,8 @@ When one shape holds across widths, write it **once, outside every media query**
 media blocks carry only what genuinely differs. A rule that must never be forgotten cannot
 live in a place where it has to be remembered twice. The same applies to the test: a guard
 pinned to a single viewport stops guarding the moment the layout gains a second one, so cover
-each band the CSS assembles differently — see `apps/e2e/src/studio-shell.test.ts`.
+each band the CSS assembles differently — see `apps/e2e/src/studio-shell.test.ts`
+(that gate stubs the shelf/status JSON so an empty `bot:e2e` shelf cannot skip the check).
 
 ## Current architecture
 

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -88,6 +88,16 @@ Never work around this by disabling TLS verification or unsetting `HTTPS_PROXY`.
 [`.claude/skills/browse-live-site/SKILL.md`](../../.claude/skills/browse-live-site/SKILL.md)
 for driving the same setup by hand.
 
+## Studio shell layout gate
+
+`src/studio-shell.test.ts` checks that an open Creator Studio thread owns the window
+(no page scroll, transcript scroller of its own, bottom bars never cover the composer)
+at every CSS band. It **stubs** `/api/me/studio` and the fixture game's status response
+rather than borrowing whatever happens to sit on `bot:e2e`'s shelf: an empty shelf used
+to make all four widths skip while the deploy still went green (#392). The real React
+tree and stylesheet still run; only the JSON is replaced, so the suite stays read-only
+against production.
+
 ## Adding a test
 
 Two rules, both learned the hard way:

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { APIRequestContext, Browser, Page } from 'playwright-core';
+import type { APIRequestContext, Browser, Page, Route } from 'playwright-core';
 import {
   collectProblems,
   describeProblems,
@@ -34,6 +34,13 @@ import {
  * next change to the shell reintroduced both failures at every width above 800 — a review
  * caught what this test was written to catch, because this test never went there. Each
  * entry below is a band the shell is assembled by different rules in.
+ *
+ * Data is stubbed, not borrowed from `bot:e2e`'s shelf. The layout contract is CSS and
+ * the real React tree; which games that identity happens to own is not part of it, and
+ * a gate that skipped when the shelf was empty shipped the bugs above twice (#386, #391).
+ * Stubbing the shelf + status responses keeps the suite read-only against production
+ * (no submission, no agent build) and means an emptied shelf cannot turn the gate into
+ * four green ticks that asserted nothing.
  */
 const prereq = e2ePrerequisites();
 if (!prereq.ok) {
@@ -53,6 +60,69 @@ const VIEWPORTS = [
   { label: 'desktop', width: 1440, height: 900 },
 ] as const;
 
+/** Stable ids used only inside the stubbed responses — never written to the API. */
+const FIXTURE_TOKEN = 'e2e-studio-shell-token';
+const FIXTURE_SLUG = 'e2e-studio-shell';
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Give `/studio` a game with a composer without touching production shelf state.
+ *
+ * The SPA still mounts CreatorStudioView + SubmissionStatusView and applies the real
+ * stylesheet; only the JSON those views fetch is replaced.
+ */
+async function stubStudioThreadData(page: Page) {
+  await page.route('**/api/me/studio**', async (route) => {
+    const path = new URL(route.request().url()).pathname.replace(/\/$/, '');
+    if (path.endsWith('/api/me/studio/health')) {
+      await fulfillJson(route, { days: [], truncated: false, games: [] });
+      return;
+    }
+    if (path.endsWith('/api/me/studio/scorecards')) {
+      await fulfillJson(route, { scorecards: [] });
+      return;
+    }
+    if (path.endsWith('/api/me/studio')) {
+      await fulfillJson(route, {
+        games: [
+          {
+            token: FIXTURE_TOKEN,
+            title: 'E2E Studio Shell Fixture',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            lastKnownStatus: 'published',
+            slug: FIXTURE_SLUG,
+            publishedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ],
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route(`**/api/submissions/${FIXTURE_TOKEN}**`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fulfill({ status: 405, contentType: 'application/json', body: '{"error":"method not allowed"}' });
+      return;
+    }
+    const path = new URL(route.request().url()).pathname.replace(/\/$/, '');
+    if (path.endsWith(`/api/submissions/${FIXTURE_TOKEN}`)) {
+      // Terminal status so the view stops polling; composer still mounts for any
+      // non-abandoned state (SubmissionStatusView, embedded + compact).
+      await fulfillJson(route, { status: 'published', slug: FIXTURE_SLUG });
+      return;
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
+  });
+}
+
 describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
   let browser: Browser;
   let api: APIRequestContext;
@@ -63,6 +133,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
     browser = await launchSiteBrowser();
     const context = await signedInContext(browser, api);
     page = await context.newPage();
+    await stubStudioThreadData(page);
   });
 
   afterAll(async () => {
@@ -126,14 +197,14 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await visit(page, '/studio', 4_000);
 
-      // The bot identity's shelf is whatever previous runs left behind. With no games
-      // there is no thread and nothing to assert — say so rather than passing quietly,
-      // because a guard that silently stops guarding is worse than no guard.
-      const hasComposer = await page.locator('.status-composer.is-compact').count();
-      if (hasComposer === 0) {
-        console.warn('[e2e] studio shell: the e2e account has no games open in the studio; layout check skipped');
-        expect(describeProblems(watcher.drain())).toBe('');
-        return;
+      // The fixture must put a composer on screen. If it does not, the shell CSS under
+      // test never ran — fail loudly rather than green-ticking an empty assertion.
+      try {
+        await page.waitForSelector('.status-composer.is-compact', { state: 'visible', timeout: 15_000 });
+      } catch {
+        expect.fail(
+          'studio shell fixture did not open a thread with a composer — the layout gate would assert nothing',
+        );
       }
 
       const shell = await page.evaluate(() => {
@@ -141,8 +212,11 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         return {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
+          gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
         };
       });
+
+      expect(shell.gameOpen, 'the studio should mark a game open so the shell CSS applies').toBe(true);
 
       // The page owning the window is the precondition for the rest: it is what removes
       // the scroll a reader would otherwise use to escape a bar sitting on the composer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #392.

## Problem

`apps/e2e/src/studio-shell.test.ts` is meant to guard the Creator Studio shell layout (page must not scroll, transcript needs its own scroller, bottom bars must not cover the composer) at four viewport widths. When `bot:e2e` had no games on its shelf, all four checks **skipped with a warning** while the deploy browser gate still went green — so the bugs this gate exists for shipped twice (#386, then again in #391).

## Approach

Instead of seeding a real game onto the e2e identity (and coupling the gate to mutable shelf state), the suite now **stubs** the JSON those views fetch:

- `GET /api/me/studio` → one fixture game
- `GET /api/me/studio/health` and `/scorecards` → empty
- `GET /api/submissions/<fixture-token>` → published status (composer still mounts for any non-abandoned state)

The real React tree (`CreatorStudioView` + embedded `SubmissionStatusView`) and the real stylesheet still run. If the fixture fails to put a composer on screen, the test **fails** instead of skipping.

This stays read-only against production (no `POST /api/submissions`, no agent build) and answers the issue’s “should skip become a failure?” question by making an empty assertion impossible.

## Docs

- Short note in `apps/e2e/README.md`
- Pointer in `AGENTS.md` layout section

## Verification

- `npm run type-check && npm run lint && npm run test && npm run build` — green
- `npm run type-check -w @gamedevpl/e2e` — green
- Full `npm run e2e` against a candidate needs `GAMEDEV_ACCESS_TOKEN` (not available in this agent env); expected to exercise the four viewport cases for real on the next deploy gate run
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f6e3ab7-ee4d-4f2c-9240-e3e63ddcdfa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f6e3ab7-ee4d-4f2c-9240-e3e63ddcdfa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

