### PR TITLE
Make how_to_play_opened answer the #395 questions

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -129,20 +129,29 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
   on the operator page. Both admin reads share one partition-scan budget, so the two
   views cannot drift in how they report truncation.
   - ~~Creator funnel starts too late~~ — **closed 2026-07-26**: `create_step` on the visit
-  stream records `prompt_started` → `spec_submitted` → `signin_required` → `qa_shown` →
-  `submission_created`. Steps dedupe per visit (a rung means "this visit got this far"),
-  and the aggregate dedupes again so a replayed flush cannot inflate one. Adding a rung
-  means touching the enum in `visitTelemetry.ts`, the zod enum in `visit-telemetry.ts`,
-  and `CREATE_STEPS` in `visit-funnel.ts` — the order in `CREATE_STEPS` _is_ the funnel's
-  meaning. The waitlist funnel (`waitlist_step` / `WAITLIST_STEPS`) follows the same
-  three-place contract beside it.
+    stream records `prompt_started` → `spec_submitted` → `signin_required` → `qa_shown` →
+    `submission_created`. Steps dedupe per visit (a rung means "this visit got this far"),
+    and the aggregate dedupes again so a replayed flush cannot inflate one. Adding a rung
+    means touching the enum in `visitTelemetry.ts`, the zod enum in `visit-telemetry.ts`,
+    and `CREATE_STEPS` in `visit-funnel.ts` — the order in `CREATE_STEPS` _is_ the funnel's
+    meaning. The waitlist funnel (`waitlist_step` / `WAITLIST_STEPS`) follows the same
+    three-place contract beside it.
 - ~~Closed-beta waitlist funnel unmeasured~~ — **closed 2026-07-31**: `waitlist_step` on
   the visit stream records `cta_clicked` → `joined`. Same three-place enum contract as
   `create_step` (`visitTelemetry.ts`, `visit-telemetry.ts`, `WAITLIST_STEPS` in
   `visit-funnel.ts`); rendered as a Waitlist block on `VisitFunnelPanel` beside Creating.
-  The Join CTA is visible before sign-in; the drop between click and join *is* the
+  The Join CTA is visible before sign-in; the drop between click and join _is_ the
   sign-in wall, so there is no separate `signin_required` rung (that name already means
   the creation wall).
+- ~~How-to-play opens recorded but unreadable~~ — **closed 2026-07-31** for the read
+  path that [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) needs:
+  `how_to_play_opened` now carries `via: 'bar' | 'more'` (optional on intake so a tab
+  still on the previous client is not dropped), every open is kept (unlike create/
+  waitlist steps — a second open is the "card did not answer" signal), and
+  `summarizeVisitFunnel` exposes `howToPlay` (opens, distinct visits, repeat visits,
+  via breakdown, byEntry for deep-link vs arcade). Rendered on `VisitFunnelPanel`.
+  The product decision in #395 — whether a richer per-game format is worth building —
+  still waits on those numbers; this only makes the questions answerable.
 - ~~Creator return is under-measured~~ — **closed 2026-07-26**: `User.activeDays` (a
   capped list of `yyyy-mm-dd`, touched once per account per day from the auth hook)
   plus `summarizeCreatorMetrics` behind `GET /api/admin/telemetry/creators`. Use a list

--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -145,13 +145,12 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
   the creation wall).
 - ~~How-to-play opens recorded but unreadable~~ — **closed 2026-07-31** for the read
   path that [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) needs:
-  `how_to_play_opened` now carries `via: 'bar' | 'more'` (optional on intake so a tab
-  still on the previous client is not dropped), every open is kept (unlike create/
-  waitlist steps — a second open is the "card did not answer" signal), and
-  `summarizeVisitFunnel` exposes `howToPlay` (opens, distinct visits, repeat visits,
-  via breakdown, byEntry for deep-link vs arcade). Rendered on `VisitFunnelPanel`.
-  The product decision in #395 — whether a richer per-game format is worth building —
-  still waits on those numbers; this only makes the questions answerable.
+  `how_to_play_opened` carries `via: 'bar' | 'more'` and optional `reopen: true` (same
+  theater card opened again — not "opened twice in the visit"), is recorded only for
+  published plays (`reportSlug`, same population as `play_started`), and
+  `summarizeVisitFunnel` exposes `howToPlay` (opens/visits among playing visits, same-
+  card repeat visits, via, byEntry with `playingVisits` denominators). Rendered on
+  `VisitFunnelPanel`. The product decision in #395 still waits on those numbers.
 - ~~Creator return is under-measured~~ — **closed 2026-07-26**: `User.activeDays` (a
   capped list of `yyyy-mm-dd`, touched once per account per day from the auth hook)
   plus `summarizeCreatorMetrics` behind `GET /api/admin/telemetry/creators`. Use a list

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -488,6 +488,11 @@ export interface VisitEvent {
   route?: string;
   /** `create_step` / `waitlist_step`: which funnel step this visit reached. */
   step?: string;
+  /**
+   * `how_to_play_opened`: which chrome surface opened the card (`bar` | `more`).
+   * Absent on events recorded before the field existed; never a game identity.
+   */
+  via?: string;
   /** `visit_started`: bare hostname of an external referrer. Never a full URL. */
   referrer?: string;
   utmSource?: string;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -493,6 +493,12 @@ export interface VisitEvent {
    * Absent on events recorded before the field existed; never a game identity.
    */
   via?: string;
+  /**
+   * `how_to_play_opened`: true when this open is a second-or-later open of the *same*
+   * theater card (same published play). Absent means first open — or a legacy event
+   * recorded before the field existed. Never a game identity.
+   */
+  reopen?: boolean;
   /** `visit_started`: bare hostname of an external referrer. Never a full URL. */
   referrer?: string;
   utmSource?: string;

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -187,4 +187,66 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.plays).toBe(1);
     expect(funnel.entries).toEqual([{ entry: 'unknown', visits: 1, plays: 1 }]);
   });
+
+  it('answers how-to-play open rate, repeats, via, and deep-link vs arcade', () => {
+    const opened = (visitId: string, via: string | undefined, msSinceStart: number): VisitEvent => ({
+      visitId,
+      type: 'how_to_play_opened',
+      at: '2026-07-26T10:00:00.000Z',
+      msSinceStart,
+      ...(via === undefined ? {} : { via }),
+    });
+
+    const funnel = summarizeVisitFunnel([
+      // Arcade visit: opened twice from the bar — the "card did not answer" case.
+      started('a', { entry: 'home' }),
+      played('a', 1_000),
+      opened('a', 'bar', 2_000),
+      opened('a', 'bar', 5_000),
+      // Deep-link visit: opened once from More.
+      started('b', { entry: 'play' }),
+      played('b', 500),
+      opened('b', 'more', 800),
+      // Played, never opened — in the open-rate denominator, not the numerator.
+      started('c', { entry: 'home' }),
+      played('c', 1_000),
+      // Legacy open with no via — must still count, under unknown.
+      started('d', { entry: 'home' }),
+      played('d', 1_000),
+      opened('d', undefined, 1_500),
+    ]);
+
+    expect(funnel.howToPlay.opens).toBe(4);
+    expect(funnel.howToPlay.visits).toBe(3);
+    expect(funnel.howToPlay.repeatVisits).toBe(1);
+    expect(funnel.howToPlay.via).toEqual([
+      { via: 'bar', opens: 2, visits: 1 },
+      { via: 'more', opens: 1, visits: 1 },
+      { via: 'unknown', opens: 1, visits: 1 },
+    ]);
+    expect(funnel.howToPlay.byEntry.find((row) => row.entry === 'home')).toEqual({
+      entry: 'home',
+      visits: 2,
+      opens: 3,
+    });
+    expect(funnel.howToPlay.byEntry.find((row) => row.entry === 'play')).toEqual({
+      entry: 'play',
+      visits: 1,
+      opens: 1,
+    });
+  });
+
+  it('emits zeroed how-to-play via rows when nobody opened the card', () => {
+    const funnel = summarizeVisitFunnel([started('a'), played('a', 1_000)]);
+    expect(funnel.howToPlay).toEqual({
+      opens: 0,
+      visits: 0,
+      repeatVisits: 0,
+      via: [
+        { via: 'bar', opens: 0, visits: 0 },
+        { via: 'more', opens: 0, visits: 0 },
+      ],
+      byEntry: [],
+    });
+  });
 });

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -188,32 +188,36 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.entries).toEqual([{ entry: 'unknown', visits: 1, plays: 1 }]);
   });
 
-  it('answers how-to-play open rate, repeats, via, and deep-link vs arcade', () => {
-    const opened = (visitId: string, via: string | undefined, msSinceStart: number): VisitEvent => ({
+  it('answers how-to-play open rate, same-card reopens, via, and deep-link vs arcade', () => {
+    const opened = (visitId: string, via: string | undefined, msSinceStart: number, reopen?: true): VisitEvent => ({
       visitId,
       type: 'how_to_play_opened',
       at: '2026-07-26T10:00:00.000Z',
       msSinceStart,
       ...(via === undefined ? {} : { via }),
+      ...(reopen === undefined ? {} : { reopen }),
     });
 
     const funnel = summarizeVisitFunnel([
-      // Arcade visit: opened twice from the bar — the "card did not answer" case.
+      // Arcade visit: same card opened again — the "card did not answer" case.
       started('a', { entry: 'home' }),
       played('a', 1_000),
       opened('a', 'bar', 2_000),
-      opened('a', 'bar', 5_000),
+      opened('a', 'bar', 5_000, true),
       // Deep-link visit: opened once from More.
       started('b', { entry: 'play' }),
       played('b', 500),
       opened('b', 'more', 800),
-      // Played, never opened — in the open-rate denominator, not the numerator.
+      // Played, never opened — in the open-rate and byEntry denominators.
       started('c', { entry: 'home' }),
       played('c', 1_000),
       // Legacy open with no via — must still count, under unknown.
       started('d', { entry: 'home' }),
       played('d', 1_000),
       opened('d', undefined, 1_500),
+      // Opened without a published play — excluded from the numerator entirely.
+      started('e', { entry: 'home' }),
+      opened('e', 'bar', 100),
     ]);
 
     expect(funnel.howToPlay.opens).toBe(4);
@@ -226,14 +230,42 @@ describe('summarizeVisitFunnel', () => {
     ]);
     expect(funnel.howToPlay.byEntry.find((row) => row.entry === 'home')).toEqual({
       entry: 'home',
+      playingVisits: 3,
       visits: 2,
       opens: 3,
     });
     expect(funnel.howToPlay.byEntry.find((row) => row.entry === 'play')).toEqual({
       entry: 'play',
+      playingVisits: 1,
       visits: 1,
       opens: 1,
     });
+  });
+
+  it('does not treat one open per game in a multi-game visit as a same-card reopen', () => {
+    // Two plays, one how-to-play open each, neither flagged reopen — normal arcade depth.
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      played('a', 1_000),
+      {
+        visitId: 'a',
+        type: 'how_to_play_opened',
+        at: '2026-07-26T10:00:00.000Z',
+        msSinceStart: 1_500,
+        via: 'bar',
+      },
+      played('a', 10_000),
+      {
+        visitId: 'a',
+        type: 'how_to_play_opened',
+        at: '2026-07-26T10:00:00.000Z',
+        msSinceStart: 11_000,
+        via: 'bar',
+      },
+    ]);
+    expect(funnel.howToPlay.opens).toBe(2);
+    expect(funnel.howToPlay.visits).toBe(1);
+    expect(funnel.howToPlay.repeatVisits).toBe(0);
   });
 
   it('emits zeroed how-to-play via rows when nobody opened the card', () => {
@@ -246,7 +278,7 @@ describe('summarizeVisitFunnel', () => {
         { via: 'bar', opens: 0, visits: 0 },
         { via: 'more', opens: 0, visits: 0 },
       ],
-      byEntry: [],
+      byEntry: [{ entry: 'home', playingVisits: 1, visits: 0, opens: 0 }],
     });
   });
 });

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -67,7 +67,41 @@ export interface VisitFunnel {
    * present — including zeroes. Same posture as `creating`.
    */
   waitlist: Array<{ step: WaitlistStep; visits: number }>;
+  /**
+   * How to play card usage — the numbers that decide whether a richer per-game format
+   * is worth building (github.com/gamedevpl/www.gamedev.pl/issues/395).
+   *
+   * Opens stay as raw counts so a second open in one visit stays visible; `visits` is
+   * the distinct-visit denominator the open-rate question needs. Deep-link vs arcade is
+   * `byEntry` (visit landing), not a field on the open event — the streams stay
+   * unjoinable and the entry is already on `visit_started`.
+   */
+  howToPlay: HowToPlayFunnel;
 }
+
+export interface HowToPlayFunnel {
+  /** Total `how_to_play_opened` events in the window. */
+  opens: number;
+  /** Distinct visits that opened the card at least once. */
+  visits: number;
+  /** Visits that opened the card two or more times — "the card did not answer me". */
+  repeatVisits: number;
+  /**
+   * Opens and distinct visits by chrome surface. Always both `bar` and `more`, zeroes
+   * included, so a missing surface reads as zero rather than "nothing to see".
+   * Events recorded before `via` existed fall into `unknown`.
+   */
+  via: Array<{ via: HowToPlayVia | 'unknown'; opens: number; visits: number }>;
+  /**
+   * Distinct visits that opened, grouped by visit landing. `play` is a shared-link /
+   * deep-link arrival; `home` is the arcade path. Busiest first.
+   */
+  byEntry: Array<{ entry: string; visits: number; opens: number }>;
+}
+
+export const HOW_TO_PLAY_VIAS = ['bar', 'more'] as const;
+
+export type HowToPlayVia = (typeof HOW_TO_PLAY_VIAS)[number];
 
 /** Step order is the funnel's meaning, so it is declared once and reused. */
 export const CREATE_STEPS = [
@@ -99,6 +133,10 @@ interface VisitRollup {
   plays: number;
   /** Offset of the first play within the visit, or undefined if it never played. */
   firstPlayMs?: number;
+  /** How many times this visit opened How to play. */
+  howToPlayOpens: number;
+  /** Surfaces that opened it — for the via visit counts (a visit can use both). */
+  howToPlayVias: Set<string>;
 }
 
 function median(values: number[]): number {
@@ -124,6 +162,8 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       plays: 0,
       steps: new Set<string>(),
       waitlistSteps: new Set<string>(),
+      howToPlayOpens: 0,
+      howToPlayVias: new Set<string>(),
     };
 
     if (event.type === 'visit_started') {
@@ -146,6 +186,12 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       if (rollup.firstPlayMs === undefined || event.msSinceStart < rollup.firstPlayMs) {
         rollup.firstPlayMs = event.msSinceStart;
       }
+    } else if (event.type === 'how_to_play_opened') {
+      // Every open counts — unlike create/waitlist steps. A second open is the
+      // "card did not answer" signal issue #395 wants; distinct-visit rates are
+      // derived below from `howToPlayOpens > 0`.
+      rollup.howToPlayOpens += 1;
+      rollup.howToPlayVias.add(event.via ?? 'unknown');
     }
     // `route_viewed` needs no rollup of its own yet: it exists so a future
     // step-by-step funnel can be built without another schema change.
@@ -204,6 +250,47 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     }
   });
 
+  const openedHowTo = rollups.filter((rollup) => rollup.howToPlayOpens > 0);
+  const viaVisits = new Map<string, number>();
+  for (const via of HOW_TO_PLAY_VIAS) viaVisits.set(via, 0);
+  const byHowToEntry = new Map<string, { visits: number; opens: number }>();
+  let howToOpens = 0;
+  for (const rollup of openedHowTo) {
+    howToOpens += rollup.howToPlayOpens;
+    for (const via of rollup.howToPlayVias) {
+      viaVisits.set(via, (viaVisits.get(via) ?? 0) + 1);
+    }
+    const entryKey = rollup.entry ?? 'unknown';
+    const entry = byHowToEntry.get(entryKey) ?? { visits: 0, opens: 0 };
+    entry.visits += 1;
+    entry.opens += rollup.howToPlayOpens;
+    byHowToEntry.set(entryKey, entry);
+  }
+
+  // Opens-per-via are counted from events, not from visit rollups: a visit that opened
+  // from the bar twice and from More once must not put three opens into both buckets.
+  // Visit counts above already use the Set of vias the visit touched.
+  const viaOpens = new Map<string, number>();
+  for (const via of HOW_TO_PLAY_VIAS) viaOpens.set(via, 0);
+  for (const event of events) {
+    if (event.type !== 'how_to_play_opened') continue;
+    const via = event.via ?? 'unknown';
+    viaOpens.set(via, (viaOpens.get(via) ?? 0) + 1);
+  }
+
+  const viaRows: Array<{ via: HowToPlayVia | 'unknown'; opens: number; visits: number }> = [
+    ...HOW_TO_PLAY_VIAS.map((via) => ({
+      via,
+      opens: viaOpens.get(via) ?? 0,
+      visits: viaVisits.get(via) ?? 0,
+    })),
+  ];
+  const unknownOpens = viaOpens.get('unknown') ?? 0;
+  const unknownVisits = viaVisits.get('unknown') ?? 0;
+  if (unknownOpens > 0 || unknownVisits > 0) {
+    viaRows.push({ via: 'unknown', opens: unknownOpens, visits: unknownVisits });
+  }
+
   return {
     visits: rollups.length,
     bounces: rollups.length - playing.length,
@@ -227,5 +314,12 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       step,
       visits: rollups.filter((rollup) => rollup.waitlistSteps.has(step)).length,
     })),
+    howToPlay: {
+      opens: howToOpens,
+      visits: openedHowTo.length,
+      repeatVisits: openedHowTo.filter((rollup) => rollup.howToPlayOpens >= 2).length,
+      via: viaRows,
+      byEntry: rank(byHowToEntry, (entry, value) => ({ entry, ...value })),
+    },
   };
 }

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -80,11 +80,18 @@ export interface VisitFunnel {
 }
 
 export interface HowToPlayFunnel {
-  /** Total `how_to_play_opened` events in the window. */
+  /**
+   * Total `how_to_play_opened` events among visits that also played — the same
+   * population as `visitsWithPlay`, so the open rate cannot exceed 100%.
+   */
   opens: number;
-  /** Distinct visits that opened the card at least once. */
+  /** Distinct playing visits that opened the card at least once. */
   visits: number;
-  /** Visits that opened the card two or more times — "the card did not answer me". */
+  /**
+   * Playing visits that reopened the *same* theater card (`reopen: true`). Not
+   * "opened twice in the visit" — opening once per game in a multi-game sitting is
+   * not this signal.
+   */
   repeatVisits: number;
   /**
    * Opens and distinct visits by chrome surface. Always both `bar` and `more`, zeroes
@@ -93,10 +100,12 @@ export interface HowToPlayFunnel {
    */
   via: Array<{ via: HowToPlayVia | 'unknown'; opens: number; visits: number }>;
   /**
-   * Distinct visits that opened, grouped by visit landing. `play` is a shared-link /
-   * deep-link arrival; `home` is the arcade path. Busiest first.
+   * Per visit landing: how many playing visits, how many of those opened, and opens.
+   * `play` is a shared-link / deep-link arrival; `home` is the arcade path. Every
+   * entry with a playing visit appears (zero opens included) so rates are readable.
+   * Busiest by playing visits first.
    */
-  byEntry: Array<{ entry: string; visits: number; opens: number }>;
+  byEntry: Array<{ entry: string; playingVisits: number; visits: number; opens: number }>;
 }
 
 export const HOW_TO_PLAY_VIAS = ['bar', 'more'] as const;
@@ -137,6 +146,8 @@ interface VisitRollup {
   howToPlayOpens: number;
   /** Surfaces that opened it — for the via visit counts (a visit can use both). */
   howToPlayVias: Set<string>;
+  /** True when any open carried `reopen: true` — same-card reopen, not multi-game. */
+  howToPlayReopened: boolean;
 }
 
 function median(values: number[]): number {
@@ -164,6 +175,7 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       waitlistSteps: new Set<string>(),
       howToPlayOpens: 0,
       howToPlayVias: new Set<string>(),
+      howToPlayReopened: false,
     };
 
     if (event.type === 'visit_started') {
@@ -187,11 +199,12 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
         rollup.firstPlayMs = event.msSinceStart;
       }
     } else if (event.type === 'how_to_play_opened') {
-      // Every open counts — unlike create/waitlist steps. A second open is the
-      // "card did not answer" signal issue #395 wants; distinct-visit rates are
-      // derived below from `howToPlayOpens > 0`.
+      // Every open counts — unlike create/waitlist steps. Same-card reopens are
+      // flagged on the event (`reopen`); visit-wide open count alone is not that
+      // signal (two games opened once each would look like a repeat).
       rollup.howToPlayOpens += 1;
       rollup.howToPlayVias.add(event.via ?? 'unknown');
+      if (event.reopen === true) rollup.howToPlayReopened = true;
     }
     // `route_viewed` needs no rollup of its own yet: it exists so a future
     // step-by-step funnel can be built without another schema change.
@@ -250,21 +263,23 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     }
   });
 
-  const openedHowTo = rollups.filter((rollup) => rollup.howToPlayOpens > 0);
+  // Numerator and denominator share one population: visits that recorded a published
+  // play. Opens from drafts / generated games / failed loads (no `play_started`) stay
+  // out so the rate cannot read as "1 of 0" or above 100%.
+  const openedHowTo = playing.filter((rollup) => rollup.howToPlayOpens > 0);
+  const playingVisitIds = new Set(
+    Array.from(visits.entries())
+      .filter(([, rollup]) => rollup.plays > 0)
+      .map(([visitId]) => visitId),
+  );
   const viaVisits = new Map<string, number>();
   for (const via of HOW_TO_PLAY_VIAS) viaVisits.set(via, 0);
-  const byHowToEntry = new Map<string, { visits: number; opens: number }>();
   let howToOpens = 0;
   for (const rollup of openedHowTo) {
     howToOpens += rollup.howToPlayOpens;
     for (const via of rollup.howToPlayVias) {
       viaVisits.set(via, (viaVisits.get(via) ?? 0) + 1);
     }
-    const entryKey = rollup.entry ?? 'unknown';
-    const entry = byHowToEntry.get(entryKey) ?? { visits: 0, opens: 0 };
-    entry.visits += 1;
-    entry.opens += rollup.howToPlayOpens;
-    byHowToEntry.set(entryKey, entry);
   }
 
   // Opens-per-via are counted from events, not from visit rollups: a visit that opened
@@ -274,6 +289,7 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
   for (const via of HOW_TO_PLAY_VIAS) viaOpens.set(via, 0);
   for (const event of events) {
     if (event.type !== 'how_to_play_opened') continue;
+    if (!playingVisitIds.has(event.visitId)) continue;
     const via = event.via ?? 'unknown';
     viaOpens.set(via, (viaOpens.get(via) ?? 0) + 1);
   }
@@ -289,6 +305,21 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
   const unknownVisits = viaVisits.get('unknown') ?? 0;
   if (unknownOpens > 0 || unknownVisits > 0) {
     viaRows.push({ via: 'unknown', opens: unknownOpens, visits: unknownVisits });
+  }
+
+  // Every entry that has a playing visit appears, including zero openers — otherwise
+  // 10 of 1,000 home players and 5 of 10 deep-link players both render as raw counts
+  // with no denominator and look like "home wins".
+  const byHowToEntry = new Map<string, { playingVisits: number; visits: number; opens: number }>();
+  for (const rollup of playing) {
+    const entryKey = rollup.entry ?? 'unknown';
+    const entry = byHowToEntry.get(entryKey) ?? { playingVisits: 0, visits: 0, opens: 0 };
+    entry.playingVisits += 1;
+    if (rollup.howToPlayOpens > 0) {
+      entry.visits += 1;
+      entry.opens += rollup.howToPlayOpens;
+    }
+    byHowToEntry.set(entryKey, entry);
   }
 
   return {
@@ -317,9 +348,11 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     howToPlay: {
       opens: howToOpens,
       visits: openedHowTo.length,
-      repeatVisits: openedHowTo.filter((rollup) => rollup.howToPlayOpens >= 2).length,
+      repeatVisits: openedHowTo.filter((rollup) => rollup.howToPlayReopened).length,
       via: viaRows,
-      byEntry: rank(byHowToEntry, (entry, value) => ({ entry, ...value })),
+      byEntry: Array.from(byHowToEntry, ([entry, value]) => ({ entry, ...value })).sort(
+        (a, b) => b.playingVisits - a.playingVisits || b.visits - a.visits || a.entry.localeCompare(b.entry),
+      ),
     },
   };
 }

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -105,6 +105,22 @@ describe('POST /api/telemetry/visit', () => {
     expect(events[0]).not.toHaveProperty('via');
   });
 
+  it('stores reopen: true on a same-card how_to_play_opened', async () => {
+    await post(app, {
+      visitId,
+      flushMsSinceStart: 500,
+      events: [
+        { type: 'how_to_play_opened', via: 'bar', msSinceStart: 100 },
+        { type: 'how_to_play_opened', via: 'bar', reopen: true, msSinceStart: 500 },
+      ],
+    });
+
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events).toHaveLength(2);
+    expect(events[0]).not.toHaveProperty('reopen');
+    expect(events[1]?.reopen).toBe(true);
+  });
+
   it('never stores a game identity, even if a client sends one', async () => {
     await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -71,7 +71,7 @@ describe('POST /api/telemetry/visit', () => {
     expect(events.filter((event) => event.type === 'play_started')).toHaveLength(2);
   });
 
-  it('records how_to_play_opened as itself, and without a game identity', async () => {
+  it('records how_to_play_opened as itself, with via, and without a game identity', async () => {
     // The mapper ends in a `default` branch that relabels anything unmatched as
     // `play_started`, so a member with no case of its own is silently mislabelled
     // rather than rejected — which no schema error would ever reveal.
@@ -80,14 +80,29 @@ describe('POST /api/telemetry/visit', () => {
       flushMsSinceStart: 400,
       events: [
         { type: 'play_started', msSinceStart: 100 },
-        { type: 'how_to_play_opened', slug: 'space-hop', msSinceStart: 400 },
+        { type: 'how_to_play_opened', via: 'bar', slug: 'space-hop', msSinceStart: 400 },
       ],
     });
 
     const events = await store.listVisitEvents(today(), { visitId });
-    expect(events.filter((event) => event.type === 'how_to_play_opened')).toHaveLength(1);
+    const opened = events.filter((event) => event.type === 'how_to_play_opened');
+    expect(opened).toHaveLength(1);
+    expect(opened[0]?.via).toBe('bar');
     expect(events.filter((event) => event.type === 'play_started')).toHaveLength(1);
     expect(JSON.stringify(events)).not.toContain('space-hop');
+  });
+
+  it('accepts a how_to_play_opened without via from a previous client', async () => {
+    await post(app, {
+      visitId,
+      flushMsSinceStart: 200,
+      events: [{ type: 'how_to_play_opened', msSinceStart: 200 }],
+    });
+
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('how_to_play_opened');
+    expect(events[0]).not.toHaveProperty('via');
   });
 
   it('never stores a game identity, even if a client sends one', async () => {

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -97,6 +97,8 @@ const EventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('how_to_play_opened'),
     via: HowToPlayViaSchema.optional(),
+    /** True only — a client that sends `false` is treated the same as omitting it. */
+    reopen: z.literal(true).optional(),
     ...offsetField,
   }),
   z.object({ type: z.literal('create_step'), step: CreateStepSchema, ...offsetField }),
@@ -198,6 +200,7 @@ export async function registerVisitTelemetryRoutes(
             ...base,
             type: event.type,
             ...(event.via === undefined ? {} : { via: event.via }),
+            ...(event.reopen === true ? { reopen: true } : {}),
           };
         default:
           return { ...base, type: 'play_started' };

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -59,6 +59,12 @@ const CreateStepSchema = z.enum([
  */
 const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
 /**
+ * Which chrome surface opened How to play. Optional so a tab still running the previous
+ * client can record the open without `via` — the aggregate treats missing as unknown
+ * rather than dropping the event. Closed enum: the value reaches a grouping key.
+ */
+const HowToPlayViaSchema = z.enum(['bar', 'more']);
+/**
  * Acquisition strings are re-validated here rather than trusted from the client. The
  * browser filters them for cleanliness; this filters them because a value that reaches a
  * grouping key must not be able to carry punctuation, markup, or an address.
@@ -88,7 +94,11 @@ const EventSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('route_viewed'), route: RouteKindSchema, ...offsetField }),
   z.object({ type: z.literal('play_started'), ...offsetField }),
-  z.object({ type: z.literal('how_to_play_opened'), ...offsetField }),
+  z.object({
+    type: z.literal('how_to_play_opened'),
+    via: HowToPlayViaSchema.optional(),
+    ...offsetField,
+  }),
   z.object({ type: z.literal('create_step'), step: CreateStepSchema, ...offsetField }),
   z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
 ]);
@@ -184,7 +194,11 @@ export async function registerVisitTelemetryRoutes(
         case 'waitlist_step':
           return { ...base, type: event.type, step: event.step };
         case 'how_to_play_opened':
-          return { ...base, type: event.type };
+          return {
+            ...base,
+            type: event.type,
+            ...(event.via === undefined ? {} : { via: event.via }),
+          };
         default:
           return { ...base, type: 'play_started' };
       }

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -60,6 +60,16 @@ const EMPTY_FUNNEL: VisitFunnel = {
   entries: [],
   referrers: [],
   campaigns: [],
+  howToPlay: {
+    opens: 0,
+    visits: 0,
+    repeatVisits: 0,
+    via: [
+      { via: 'bar', opens: 0, visits: 0 },
+      { via: 'more', opens: 0, visits: 0 },
+    ],
+    byEntry: [],
+  },
 };
 
 const EMPTY_CREATORS: CreatorsResponse = {

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -36,6 +36,7 @@ vi.mock('./useScreenWakeLock', () => ({
 }));
 
 import { GameTheater } from './GameTheater.js';
+import { setVisitSessionForTesting, VisitSession, type WireVisitEvent } from './visitTelemetry.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;
@@ -397,5 +398,57 @@ describe('GameTheater how-to-play reachability', () => {
     } finally {
       restore();
     }
+  });
+});
+
+describe('GameTheater how-to-play visit telemetry', () => {
+  let batches: Array<{ events: WireVisitEvent[] }>;
+  let session: VisitSession;
+
+  beforeEach(() => {
+    batches = [];
+    session = new VisitSession('visit-howto', Date.now(), (body) => {
+      batches.push(body);
+    });
+    setVisitSessionForTesting(session);
+  });
+
+  afterEach(() => {
+    setVisitSessionForTesting(null);
+  });
+
+  it('records via and same-card reopen for a published play', async () => {
+    await draw({ controls: 'Arrow keys to move' });
+    await click(container.querySelector('.howto-btn'));
+    await click(container.querySelector('.howto-close'));
+    await click(container.querySelector('.howto-btn'));
+    session.flush();
+
+    const opens = batches.flatMap((batch) => batch.events).filter((event) => event.type === 'how_to_play_opened');
+    expect(opens).toEqual([
+      expect.objectContaining({ type: 'how_to_play_opened', via: 'bar' }),
+      expect.objectContaining({ type: 'how_to_play_opened', via: 'bar', reopen: true }),
+    ]);
+    expect(opens[0]).not.toHaveProperty('reopen');
+  });
+
+  it('does not record how_to_play_opened for a draft theater', async () => {
+    // Draft / generated theaters share the card UI but must not enter the open-rate
+    // numerator against a denominator that only counts published plays.
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <GameTheater
+          title="Draft"
+          badge={{ icon: 'rocket', label: 'AI' }}
+          source={{ html: '<canvas></canvas>' }}
+          onExit={() => undefined}
+          controls="Space to jump"
+        />,
+      );
+    });
+    await click(container.querySelector('.howto-btn'));
+    session.flush();
+    expect(batches.flatMap((batch) => batch.events)).toEqual([]);
   });
 });

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -342,7 +342,7 @@ export function GameTheater({
   // The one thing a player needs before the first key press, and the game's own copy of
   // it is hidden inside the frame by HIDE_CHROME. Reuses `theater-menu-item` in the
   // overflow menu so the four hand-enumerated selector lists in styles.css keep working.
-  const howToPlayControl = (className: string) =>
+  const howToPlayControl = (className: string, via: 'bar' | 'more') =>
     hasControls ? (
       <button
         type="button"
@@ -350,7 +350,7 @@ export function GameTheater({
         onClick={() => {
           setMoreOpen(false);
           setHowToOpen(true);
-          recordVisitEvent({ type: 'how_to_play_opened' });
+          recordVisitEvent({ type: 'how_to_play_opened', via });
         }}
         aria-haspopup="dialog"
         aria-expanded={howToOpen}
@@ -401,7 +401,7 @@ export function GameTheater({
             {/* Thumbs are first-class: the one signal people expect without hunting. */}
             {reportSlug ? <VoteWidget slug={reportSlug} /> : null}
             {/* Desktop: sound + fullscreen sit on the bar. Phone: they move into More. */}
-            {howToPlayControl('secondary-btn howto-btn howto-bar')}
+            {howToPlayControl('secondary-btn howto-btn howto-bar', 'bar')}
             {soundControl('secondary-btn sound-btn theater-desktop-chrome')}
             {fullscreenControl('secondary-btn fullscreen-btn theater-desktop-chrome')}
             {showMoreMenu && (
@@ -419,7 +419,7 @@ export function GameTheater({
                   <PixelIcon name="menu" size={14} />
                 </button>
                 <div className="theater-more-panel" role="menu">
-                  {howToPlayControl('theater-menu-item howto-menu')}
+                  {howToPlayControl('theater-menu-item howto-menu', 'more')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
                   {reportSlug && (

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -106,6 +106,10 @@ export function GameTheater({
   const moreRef = useRef<HTMLDivElement | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
   const [howToOpen, setHowToOpen] = useState(false);
+  // Per theater mount, not per visit: opening once in game A and once in game B is not
+  // a "card did not answer" signal. The theater remounts when the slug changes (`key`),
+  // so this resets with each published play without needing a game identity on the wire.
+  const howToOpenedOnceRef = useRef(false);
 
   // Playing is the one thing you do here without touching the screen for minutes at
   // a time, which is exactly when a phone dims and sleeps. Hold the screen awake.
@@ -350,7 +354,17 @@ export function GameTheater({
         onClick={() => {
           setMoreOpen(false);
           setHowToOpen(true);
-          recordVisitEvent({ type: 'how_to_play_opened', via });
+          // Same population as `play_started`: published games only. Drafts and
+          // generated playtests must not inflate the open-rate numerator against a
+          // denominator that only counts real catalog plays.
+          if (!reportSlug) return;
+          const reopen = howToOpenedOnceRef.current;
+          howToOpenedOnceRef.current = true;
+          recordVisitEvent({
+            type: 'how_to_play_opened',
+            via,
+            ...(reopen ? { reopen: true as const } : {}),
+          });
         }}
         aria-haspopup="dialog"
         aria-expanded={howToOpen}

--- a/apps/web/src/GrowthPanel.test.tsx
+++ b/apps/web/src/GrowthPanel.test.tsx
@@ -63,6 +63,16 @@ function visitsWith({ visitsWithPlay, submitted }: { visitsWithPlay: number; sub
         { step: 'submission_created', visits: submitted },
       ],
       waitlist: [],
+      howToPlay: {
+        opens: 0,
+        visits: 0,
+        repeatVisits: 0,
+        via: [
+          { via: 'bar', opens: 0, visits: 0 },
+          { via: 'more', opens: 0, visits: 0 },
+        ],
+        byEntry: [],
+      },
     },
   };
 }

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -29,6 +29,16 @@ function funnel(overrides: Partial<VisitFunnel> = {}): VisitFunnel {
     campaigns: [],
     creating: [],
     waitlist: [],
+    howToPlay: {
+      opens: 0,
+      visits: 0,
+      repeatVisits: 0,
+      via: [
+        { via: 'bar', opens: 0, visits: 0 },
+        { via: 'more', opens: 0, visits: 0 },
+      ],
+      byEntry: [],
+    },
     ...overrides,
   };
 }
@@ -175,5 +185,43 @@ describe('VisitFunnelPanel', () => {
       }),
     );
     expect(text).toContain('Nobody clicked Join waitlist');
+  });
+
+  it('reports how-to-play open rate against playing visits, not against all visits', () => {
+    // 2 of 4 playing visits opened. Dividing by all visits (10) would show 20% and
+    // misread the question the block exists to answer.
+    const text = render(
+      response({
+        visits: 10,
+        visitsWithPlay: 4,
+        plays: 6,
+        howToPlay: {
+          opens: 5,
+          visits: 2,
+          repeatVisits: 1,
+          via: [
+            { via: 'bar', opens: 4, visits: 2 },
+            { via: 'more', opens: 1, visits: 1 },
+          ],
+          byEntry: [
+            { entry: 'home', visits: 1, opens: 3 },
+            { entry: 'play', visits: 1, opens: 2 },
+          ],
+        },
+      }),
+    );
+    expect(text).toContain('How to play');
+    expect(text).toContain('50% of playing visits opened');
+    expect(text).toContain('theater bar');
+    expect(text).toContain('More menu');
+    expect(text).toContain('deep link (/play)');
+    expect(text).toContain('arcade (home)');
+    // 1 of 2 openers opened again — 50%, not 10% of all visits.
+    expect(text).toContain('50% opened again');
+  });
+
+  it('says so when nobody opened How to play', () => {
+    const text = render(response({ visits: 3, visitsWithPlay: 2, plays: 2 }));
+    expect(text).toContain('Nobody opened How to play');
   });
 });

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -204,8 +204,8 @@ describe('VisitFunnelPanel', () => {
             { via: 'more', opens: 1, visits: 1 },
           ],
           byEntry: [
-            { entry: 'home', visits: 1, opens: 3 },
-            { entry: 'play', visits: 1, opens: 2 },
+            { entry: 'home', playingVisits: 100, visits: 1, opens: 3 },
+            { entry: 'play', playingVisits: 2, visits: 1, opens: 2 },
           ],
         },
       }),
@@ -216,8 +216,11 @@ describe('VisitFunnelPanel', () => {
     expect(text).toContain('More menu');
     expect(text).toContain('deep link (/play)');
     expect(text).toContain('arcade (home)');
-    // 1 of 2 openers opened again — 50%, not 10% of all visits.
-    expect(text).toContain('50% opened again');
+    // 1 of 2 openers reopened the same card — 50%, not 10% of all visits.
+    expect(text).toContain('50% reopened the same card');
+    // byEntry rates: 1/100 home vs 1/2 play — not raw opener counts.
+    expect(text).toContain('1%');
+    expect(text).toContain('50%');
   });
 
   it('says so when nobody opened How to play', () => {

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -238,13 +238,13 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
             <>
               {/*
                * Open rate is visits-that-opened / playing visits — not opens / plays.
-               * Opens stay as a separate count so a second open in one visit (the
-               * "card did not answer" signal) stays visible beside the rate.
+               * Repeat rate is same-card reopens (`reopen: true`), not "opened twice in
+               * the visit" (which would count one open per game in a multi-game sitting).
                */}
               <p className="funnel-howto-summary">
                 {percent(funnel.howToPlay.visits, funnel.visitsWithPlay)} of playing visits opened the card (
                 {funnel.howToPlay.visits} of {funnel.visitsWithPlay}). {funnel.howToPlay.opens} opens total;{' '}
-                {percent(funnel.howToPlay.repeatVisits, funnel.howToPlay.visits)} opened again in the same visit.
+                {percent(funnel.howToPlay.repeatVisits, funnel.howToPlay.visits)} reopened the same card.
               </p>
               <table className="health-table">
                 <thead>
@@ -274,10 +274,13 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                     <tr>
                       <th scope="col">Visit landed on</th>
                       <th scope="col" className="num">
-                        Visits
+                        Playing
                       </th>
                       <th scope="col" className="num">
-                        Opens
+                        Opened
+                      </th>
+                      <th scope="col" className="num">
+                        Rate
                       </th>
                     </tr>
                   </thead>
@@ -285,8 +288,9 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                     {funnel.howToPlay.byEntry.map((row) => (
                       <tr key={row.entry}>
                         <td>{HOW_TO_ENTRY_LABELS[row.entry] ?? row.entry}</td>
+                        <td className="num">{row.playingVisits}</td>
                         <td className="num">{row.visits}</td>
-                        <td className="num">{row.opens}</td>
+                        <td className="num">{percent(row.visits, row.playingVisits)}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -30,6 +30,17 @@ const WAITLIST_LABELS: Record<string, string> = {
   joined: 'joined waitlist',
 };
 
+const HOW_TO_VIA_LABELS: Record<string, string> = {
+  bar: 'theater bar',
+  more: 'More menu',
+  unknown: 'unknown (pre-via clients)',
+};
+
+const HOW_TO_ENTRY_LABELS: Record<string, string> = {
+  play: 'deep link (/play)',
+  home: 'arcade (home)',
+};
+
 function bucketLabel(upToSeconds: number | null): string {
   if (upToSeconds === null) return 'slower';
   if (upToSeconds < 60) return `≤ ${upToSeconds}s`;
@@ -216,6 +227,72 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                 ))}
               </tbody>
             </table>
+          )}
+        </div>
+
+        <div className="funnel-block">
+          <h3>How to play</h3>
+          {funnel.howToPlay.opens === 0 ? (
+            <p className="health-empty">Nobody opened How to play in this window.</p>
+          ) : (
+            <>
+              {/*
+               * Open rate is visits-that-opened / playing visits — not opens / plays.
+               * Opens stay as a separate count so a second open in one visit (the
+               * "card did not answer" signal) stays visible beside the rate.
+               */}
+              <p className="funnel-howto-summary">
+                {percent(funnel.howToPlay.visits, funnel.visitsWithPlay)} of playing visits opened the card (
+                {funnel.howToPlay.visits} of {funnel.visitsWithPlay}). {funnel.howToPlay.opens} opens total;{' '}
+                {percent(funnel.howToPlay.repeatVisits, funnel.howToPlay.visits)} opened again in the same visit.
+              </p>
+              <table className="health-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Opened from</th>
+                    <th scope="col" className="num">
+                      Opens
+                    </th>
+                    <th scope="col" className="num">
+                      Visits
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {funnel.howToPlay.via.map((row) => (
+                    <tr key={row.via}>
+                      <td>{HOW_TO_VIA_LABELS[row.via] ?? row.via}</td>
+                      <td className="num">{row.opens}</td>
+                      <td className="num">{row.visits}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {funnel.howToPlay.byEntry.length > 0 && (
+                <table className="health-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Visit landed on</th>
+                      <th scope="col" className="num">
+                        Visits
+                      </th>
+                      <th scope="col" className="num">
+                        Opens
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {funnel.howToPlay.byEntry.map((row) => (
+                      <tr key={row.entry}>
+                        <td>{HOW_TO_ENTRY_LABELS[row.entry] ?? row.entry}</td>
+                        <td className="num">{row.visits}</td>
+                        <td className="num">{row.opens}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
           )}
         </div>
 

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -51,6 +51,14 @@ export async function fetchGameHealth(days: number): Promise<HealthResponse | nu
   return (await res.json()) as HealthResponse;
 }
 
+export interface HowToPlayFunnel {
+  opens: number;
+  visits: number;
+  repeatVisits: number;
+  via: Array<{ via: string; opens: number; visits: number }>;
+  byEntry: Array<{ entry: string; visits: number; opens: number }>;
+}
+
 export interface VisitFunnel {
   visits: number;
   bounces: number;
@@ -68,6 +76,8 @@ export interface VisitFunnel {
   creating: Array<{ step: string; visits: number }>;
   /** Closed-beta waitlist funnel in step order, every step present even at zero. */
   waitlist: Array<{ step: string; visits: number }>;
+  /** How to play card usage — open rate, repeats, and where it was opened. */
+  howToPlay: HowToPlayFunnel;
 }
 
 export interface VisitsResponse {

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -56,7 +56,7 @@ export interface HowToPlayFunnel {
   visits: number;
   repeatVisits: number;
   via: Array<{ via: string; opens: number; visits: number }>;
-  byEntry: Array<{ entry: string; visits: number; opens: number }>;
+  byEntry: Array<{ entry: string; playingVisits: number; visits: number; opens: number }>;
 }
 
 export interface VisitFunnel {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6373,6 +6373,13 @@ body.player-open {
   overflow-x: auto;
 }
 
+.funnel-howto-summary {
+  margin: 0 0 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
 .funnel-block h3 {
   margin: 0 0 0.5rem;
   font-size: 0.9375rem;

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -47,11 +47,12 @@ export type VisitEvent =
    * stream. What this answers is how often players need the controls spelled out —
    * and, with `via`, whether they found the bar control or had to dig into More.
    *
-   * Every open is recorded (unlike create/waitlist steps): a second open in the same
-   * visit is the signal that the card did not answer the first time. Distinct-visit
-   * rates are derived on the read side.
+   * Recorded only for published plays (same population as `play_started`). Every open
+   * of the *current* theater card is kept: `reopen: true` marks a second-or-later open
+   * of that card, so multi-game sittings that open each game once are not counted as
+   * "the card did not answer". Distinct-visit rates are derived on the read side.
    */
-  | { type: 'how_to_play_opened'; via: HowToPlayVia }
+  | { type: 'how_to_play_opened'; via: HowToPlayVia; reopen?: true }
   /** A step of the creation funnel was reached. Carries no prompt text, ever. */
   | { type: 'create_step'; step: CreateStep }
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -44,9 +44,14 @@ export type VisitEvent =
   /**
    * The player opened the "How to play" card. No slug, for the same reason
    * `play_started` carries none: the visit stream must stay unjoinable with the play
-   * stream. What this answers is how often players need the controls spelled out.
+   * stream. What this answers is how often players need the controls spelled out —
+   * and, with `via`, whether they found the bar control or had to dig into More.
+   *
+   * Every open is recorded (unlike create/waitlist steps): a second open in the same
+   * visit is the signal that the card did not answer the first time. Distinct-visit
+   * rates are derived on the read side.
    */
-  | { type: 'how_to_play_opened' }
+  | { type: 'how_to_play_opened'; via: HowToPlayVia }
   /** A step of the creation funnel was reached. Carries no prompt text, ever. */
   | { type: 'create_step'; step: CreateStep }
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */
@@ -92,6 +97,15 @@ export type WaitlistStep =
   | 'cta_clicked'
   /** `POST /api/waitlist` succeeded for this visit. */
   | 'joined';
+
+/**
+ * Which chrome surface opened the How to play card.
+ *
+ * Closed enum: the value reaches a grouping key. `bar` is the theater-bar button;
+ * `more` is the same control after it sheds into the overflow menu on a narrow viewport.
+ * Deep-link vs arcade is *not* here — that is visit `entry`, already on `visit_started`.
+ */
+export type HowToPlayVia = 'bar' | 'more';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes nothing yet — [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) is a *decision* ticket, and the decision still needs numbers. This PR is the small recording change the issue said might be required so those numbers exist.

## What was wrong

`how_to_play_opened` has been on the visit stream since #356, but:

1. every open was recorded (good for repeats) with no way to read distinct *visits that opened*,
2. nothing said whether the control was the theater bar or the More menu,
3. `summarizeVisitFunnel` ignored the event entirely, so the operator page could not show any of it.

## What this does

- Client records `via: 'bar' | 'more'` on each open, and `reopen: true` when the *same* theater card is opened again (theater remounts per slug, so one open per game in a multi-game sitting is not a repeat). Opens are **not** visit-deduped.
- Recorded only when `reportSlug` is set — same published-play population as `play_started`. Drafts/generated playtests share the card UI but stay out of the numerator.
- Intake accepts `via` / `reopen` as optional so older clients are not dropped; missing `via` aggregates as `unknown`.
- Still no slug — visit and play streams stay unjoinable. Deep-link vs arcade comes from visit `entry` (`play` vs `home`).
- `summarizeVisitFunnel` exposes `howToPlay`: opens/visits among playing visits, same-card `repeatVisits`, via breakdown, `byEntry` with `playingVisits` denominators.
- `VisitFunnelPanel` renders a How to play block with those numbers.

## Codex follow-up (this revision)

Addressed the three review notes on `9f7c2237`:

1. **P1** — repeats are same-card (`reopen`), not visit-wide open count ≥ 2
2. **P1** — open-rate numerator gated to published / playing visits
3. **P2** — `byEntry` includes `playingVisits` so deep-link vs arcade is a rate

## Measurement contract

Affects none of the seven always-on questions directly. It closes the gap that blocked answering #395:

| Question | Query |
| --- | --- |
| Open rate | `howToPlay.visits / visitsWithPlay` |
| Same-card reopens | `howToPlay.repeatVisits / howToPlay.visits` |
| Bar vs More | `howToPlay.via` |
| Deep link vs arcade | `howToPlay.byEntry` (`visits / playingVisits` per entry) |

After deploy, the decision in #395 is "what do these numbers say", not "build a richer format from taste".
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6c8a180-8993-4412-bff7-f0f7762545eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6c8a180-8993-4412-bff7-f0f7762545eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

