### PR TITLE
Give the slug backfill an operator path that needs no browser

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "token:mint": "tsx scripts/access-token.ts mint",
     "token:list": "tsx scripts/access-token.ts list",
     "token:revoke": "tsx scripts/access-token.ts revoke",
+    "slug:backfill": "tsx scripts/slug-backfill.ts",
     "player:erase": "tsx scripts/erase-player-signals.ts",
     "verify:erase": "tsx scripts/verify-erase-signals.ts"
   },

--- a/apps/api/scripts/slug-backfill.ts
+++ b/apps/api/scripts/slug-backfill.ts
@@ -1,0 +1,95 @@
+// Give an address to every game still missing one, from the command line.
+//
+//   npm run slug:backfill -w @gamedevpl/api -- --dry-run   # report, write nothing
+//   npm run slug:backfill -w @gamedevpl/api --             # actually name them
+//
+// The operator sibling of POST /api/admin/slug-backfill, for when nobody can reach an
+// admin browser session. Both call `runSlugBackfill`, so the work list, the collision
+// rules and the claim read-back cannot drift between them — which matters more here than
+// usual, because a slug is a permanent public address.
+//
+// Talks to Firestore with your ambient gcloud credentials, like `beta:approve` and
+// `token:mint`. There is no dev/prod switch — check `gcloud config get-value project`
+// before running this against the live site, and always rehearse with --dry-run first.
+//
+// The one thing the store cannot answer on its own is whether a name is already taken by
+// a game published from the games repo. The server asks GitHub (or the snapshot); this
+// reads the published snapshot in GCS, which is what production actually serves and which
+// the same gcloud credentials can already read — no GitHub token needed. If that read
+// fails the run stops rather than mint a name that may collide; --skip-catalog proceeds
+// anyway, which is only safe when you know the backlog's titles.
+
+import { createGcsSnapshotStore } from '../src/game-snapshot.js';
+import { runSlugBackfill } from '../src/slug-backfill.js';
+import { FirestoreStore } from '../src/store.js';
+
+// Same default as infra/deploy-api.sh: ${PROJECT_ID}-games-snapshots.
+const SNAPSHOT_BUCKET = process.env.GAMES_SNAPSHOT_BUCKET ?? 'gamedevpl-games-snapshots';
+
+function usage(): never {
+  console.error(
+    [
+      'Usage:',
+      '  slug:backfill -- --dry-run      # show what it would name, write nothing',
+      '  slug:backfill --                # name them',
+      '',
+      'Options:',
+      '  --skip-catalog                  # do not check names against published games',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+/** Slugs already spoken for by a game in the published snapshot. */
+async function loadPublishedSlugs(): Promise<Set<string>> {
+  const entries = await createGcsSnapshotStore({ bucket: SNAPSHOT_BUCKET }).getCatalog();
+  if (!entries) throw new Error('no snapshot is published');
+  // Every entry, not just the published ones: a name that has been taken down is still
+  // spent, and handing it to a different game would resurrect a dead address.
+  return new Set(entries.map((entry) => entry.slug));
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const unknown = args.find((arg) => !['--dry-run', '--skip-catalog'].includes(arg));
+  if (unknown) usage();
+
+  const dryRun = args.includes('--dry-run');
+  const skipCatalog = args.includes('--skip-catalog');
+
+  let published = new Set<string>();
+  if (skipCatalog) {
+    console.error('warning: skipping the published-catalog check; a minted name may collide with a published game');
+  } else {
+    try {
+      published = await loadPublishedSlugs();
+      console.error(`catalog: ${published.size} published slug(s) treated as taken (gs://${SNAPSHOT_BUCKET})`);
+    } catch (error) {
+      console.error(`Could not read the published catalog: ${(error as Error).message}`);
+      console.error('Retry, or pass --skip-catalog to name games without that check.');
+      process.exit(1);
+    }
+  }
+
+  const store = new FirestoreStore();
+
+  // The store half of the server's `isSlugClaimed`: another submission, or a game
+  // published through the store. `except` excuses a record's own slug, which is what
+  // makes the claim read-back's retry able to keep a name it already holds.
+  const isSlugClaimed = async (slug: string, except?: number): Promise<boolean> => {
+    if (published.has(slug)) return true;
+    const existing = await store.getSubmissionBySlug(slug);
+    if (existing && existing.issueNumber !== except) return true;
+    return Boolean(await store.getPublication(slug));
+  };
+
+  const result = await runSlugBackfill({ store, isSlugClaimed, dryRun });
+  console.log(JSON.stringify(result, null, 2));
+
+  if (result.failed > 0) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error('slug backfill failed:', error);
+  process.exit(1);
+});

--- a/apps/api/src/slug-backfill.test.ts
+++ b/apps/api/src/slug-backfill.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { runSlugBackfill } from './slug-backfill.js';
+import { InMemoryStore } from './store.js';
+
+// The HTTP route's own tests live in submissions.test.ts. These cover the shared loop
+// directly, because the `slug:backfill` CLI reaches it without a server and its probe
+// answers from the store alone — the paths differ in what "taken" means, not in the
+// naming.
+describe('slug backfill', () => {
+  /** The store half of `isSlugClaimed`, which is all the CLI has. */
+  const storeProbe =
+    (store: InMemoryStore) =>
+    async (slug: string, except?: number): Promise<boolean> => {
+      const existing = await store.getSubmissionBySlug(slug);
+      if (existing && existing.issueNumber !== except) return true;
+      return Boolean(await store.getPublication(slug));
+    };
+
+  async function storeWithTitles(titles: string[]) {
+    const store = new InMemoryStore();
+    let issueNumber = 500;
+    // A record with no slug is exactly what the flow used to write, and what every game
+    // predating minting-at-submission still looks like.
+    for (const title of titles) await store.createSubmission(issueNumber++, 'g:creator', title);
+    return store;
+  }
+
+  it('names every slug-less game after its title', async () => {
+    const store = await storeWithTitles(['Space Miner', 'Łódź Nights']);
+
+    const result = await runSlugBackfill({ store, isSlugClaimed: storeProbe(store), dryRun: false });
+
+    expect(result).toMatchObject({ ok: true, dryRun: false, scanned: 2, named: 2, failed: 0 });
+    expect((await store.getSubmission(500))?.slug).toBe('space-miner');
+    expect((await store.getSubmission(501))?.slug).toBe('lodz-nights');
+  });
+
+  it('writes nothing when rehearsing, and still refuses to promise one name twice', async () => {
+    const store = await storeWithTitles(['Space Miner', 'Space Miner']);
+
+    const result = await runSlugBackfill({ store, isSlugClaimed: storeProbe(store), dryRun: true });
+
+    expect(result).toMatchObject({ dryRun: true, scanned: 2, named: 2, failed: 0 });
+    expect(result.games.map((game) => game.slug)).toEqual(['space-miner', 'space-miner-2']);
+    expect((await store.getSubmission(500))?.slug).toBeUndefined();
+    expect((await store.getSubmission(501))?.slug).toBeUndefined();
+  });
+
+  it('leaves an abandoned build unnamed — its creator stopped it', async () => {
+    const store = await storeWithTitles(['Space Miner']);
+    await store.setSubmissionAbandoned(500, new Date().toISOString());
+
+    const result = await runSlugBackfill({ store, isSlugClaimed: storeProbe(store), dryRun: true });
+
+    expect(result).toMatchObject({ scanned: 0, games: [] });
+  });
+
+  it('does not hand a backlog game a name a published game already answers to', async () => {
+    const store = await storeWithTitles(['Space Miner']);
+    await store.setPublication({
+      slug: 'space-miner',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: new Date().toISOString(),
+    });
+
+    const result = await runSlugBackfill({ store, isSlugClaimed: storeProbe(store), dryRun: true });
+
+    expect(result.games[0]?.slug).toBe('space-miner-2');
+  });
+});

--- a/apps/api/src/slug-backfill.ts
+++ b/apps/api/src/slug-backfill.ts
@@ -1,0 +1,117 @@
+// Giving an address to games that predate minting-at-submission.
+//
+// Two callers, one implementation: the operator route (POST /api/admin/slug-backfill)
+// and the CLI (`npm run slug:backfill`). They exist separately because the route needs a
+// browser session and the CLI needs only gcloud credentials, but what they *do* must not
+// drift — this writes permanent public addresses, and a second implementation would be a
+// second set of collision rules.
+
+import { mintGameSlug } from './slug.js';
+import type { SubmissionRecord } from './store.js';
+
+/** The slice of the store a backfill touches. */
+export interface SlugBackfillStore {
+  listSubmissionsMissingSlug(): Promise<SubmissionRecord[]>;
+  setSubmissionSlug(issueNumber: number, slug: string): Promise<void>;
+  getSubmissionBySlug(slug: string): Promise<SubmissionRecord | null>;
+}
+
+/** Whether anything already answers to this name; `except` excuses a record's own slug. */
+export type SlugClaimProbe = (slug: string, except?: number) => Promise<boolean>;
+
+export interface SlugBackfillResult {
+  ok: true;
+  dryRun: boolean;
+  scanned: number;
+  named: number;
+  failed: number;
+  games: Array<{ issueNumber: number; title: string; slug: string | null }>;
+}
+
+/**
+ * Reads back a slug a job just wrote, and settles who actually holds it.
+ *
+ * `getSubmissionBySlug` is the same oracle every later lookup uses — the draft route, the
+ * play route, the delivery check — so asking it "who owns this name" is exactly the
+ * question that matters, and it answers deterministically even when two records share a
+ * slug. Whoever it does not name has lost the race and takes a different name; the winner
+ * is undisturbed and never learns any of this happened.
+ *
+ * Returns the slug this job ended up with, or null when even the second attempt lost.
+ */
+export async function settleSlugClaim(
+  store: SlugBackfillStore,
+  issueNumber: number,
+  slug: string,
+  title: string,
+  isSlugClaimed: SlugClaimProbe,
+): Promise<string | null> {
+  const holds = async (candidate: string): Promise<boolean> => {
+    const holder = await store.getSubmissionBySlug(candidate);
+    return holder?.issueNumber === issueNumber;
+  };
+
+  if (await holds(slug)) return slug;
+
+  // Lost. Mint again, this time treating anything we do not ourselves hold as taken,
+  // and write it before re-reading — the second write is what makes the second read
+  // meaningful.
+  const retry = await mintGameSlug(title, async (candidate) => {
+    if (candidate === slug) return true;
+    return isSlugClaimed(candidate, issueNumber);
+  });
+  await store.setSubmissionSlug(issueNumber, retry);
+  return (await holds(retry)) ? retry : null;
+}
+
+/**
+ * Names every slug-less, non-abandoned submission.
+ *
+ * Abandoned builds are skipped by the work list itself ({@link SlugBackfillStore.listSubmissionsMissingSlug}):
+ * their creator stopped them, so they need no address and taking one would only crowd the
+ * namespace.
+ *
+ * `dryRun` rehearses — it mints and reports, and writes nothing.
+ */
+export async function runSlugBackfill(options: {
+  store: SlugBackfillStore;
+  isSlugClaimed: SlugClaimProbe;
+  dryRun: boolean;
+  /** Overridable so the HTTP route can keep using its own GitHub-aware settle path. */
+  confirmSlugClaim?: (issueNumber: number, slug: string, title: string) => Promise<string | null>;
+}): Promise<SlugBackfillResult> {
+  const { store, isSlugClaimed, dryRun } = options;
+  const confirm =
+    options.confirmSlugClaim ??
+    ((issueNumber: number, slug: string, title: string) =>
+      settleSlugClaim(store, issueNumber, slug, title, isSlugClaimed));
+
+  const pending = await store.listSubmissionsMissingSlug();
+
+  // Names handed out earlier in this run. Redundant on the write path, where the store
+  // already knows, and load-bearing on the dry run, where nothing is written and two
+  // games with the same title would otherwise both be promised the same slug.
+  const mintedHere = new Set<string>();
+  const games: SlugBackfillResult['games'] = [];
+
+  for (const record of pending) {
+    const isTaken = async (candidate: string): Promise<boolean> =>
+      mintedHere.has(candidate) || (await isSlugClaimed(candidate, record.issueNumber));
+    const wanted = await mintGameSlug(record.title, isTaken);
+
+    if (dryRun) {
+      mintedHere.add(wanted);
+      games.push({ issueNumber: record.issueNumber, title: record.title, slug: wanted });
+      continue;
+    }
+
+    await store.setSubmissionSlug(record.issueNumber, wanted);
+    // Same read-back as submission creation: the write is a claim, not a grant.
+    const settled = await confirm(record.issueNumber, wanted, record.title);
+    if (settled) mintedHere.add(settled);
+    games.push({ issueNumber: record.issueNumber, title: record.title, slug: settled });
+  }
+
+  const named = games.filter((game) => game.slug !== null).length;
+  return { ok: true, dryRun, scanned: pending.length, named, failed: pending.length - named, games };
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -42,6 +42,7 @@ import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
 import { isAdminSession } from './admin.js';
 import { peekQuota } from './quota-gate.js';
 import { mintGameSlug } from './slug.js';
+import { runSlugBackfill, settleSlugClaim } from './slug-backfill.js';
 import { type BuildPreviewSummary, type BuildShotSummary, type Store, type SubmissionRecord } from './store.js';
 import {
   CREATOR_FEEDBACK_MARKER,
@@ -1275,32 +1276,13 @@ export async function registerSubmissionRoutes(
   /**
    * Reads back a slug this job just wrote, and settles who actually holds it.
    *
-   * `getSubmissionBySlug` is the same oracle every later lookup uses — the draft route,
-   * the play route, the delivery check — so asking it "who owns this name" is exactly the
-   * question that matters, and it answers deterministically even when two records share
-   * a slug. Whoever it does not name has lost the race and takes a different name; the
-   * winner is undisturbed and never learns any of this happened.
-   *
-   * Returns the slug this job ended up with, or null when even the second attempt lost.
+   * The settling itself is {@link settleSlugClaim}, shared with the backfill CLI; this
+   * binds it to this server's store and its GitHub-aware `isSlugClaimed`.
    */
   async function confirmSlugClaim(issueNumber: number, slug: string, title: string): Promise<string | null> {
+    // No store means nothing can hold a name against us, so the claim stands as written.
     if (!store) return slug;
-    const holds = async (candidate: string): Promise<boolean> => {
-      const holder = await store.getSubmissionBySlug(candidate);
-      return holder?.issueNumber === issueNumber;
-    };
-
-    if (await holds(slug)) return slug;
-
-    // Lost. Mint again, this time treating anything we do not ourselves hold as taken,
-    // and write it before re-reading — the second write is what makes the second read
-    // meaningful.
-    const retry = await mintGameSlug(title, async (candidate) => {
-      if (candidate === slug) return true;
-      return isSlugClaimed(candidate, issueNumber);
-    });
-    await store.setSubmissionSlug(issueNumber, retry);
-    return (await holds(retry)) ? retry : null;
+    return settleSlugClaim(store, issueNumber, slug, title, isSlugClaimed);
   }
 
   /**
@@ -2568,40 +2550,19 @@ export async function registerSubmissionRoutes(
    * Sequential on purpose. Each mint asks the store what is taken, so the previous
    * write has to be visible before the next candidate is judged; running these
    * concurrently would reintroduce the race the claim read-back exists to settle.
+   *
+   * The loop itself lives in `slug-backfill.ts`, shared with the `slug:backfill` CLI —
+   * the operator path for when nobody can reach an admin browser session.
    */
   app.post<{ Querystring: { dryRun?: string } }>('/api/admin/slug-backfill', async (request, reply) => {
     if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
     if (!store) return reply.status(503).send({ error: 'store_unavailable' });
 
     const dryRun = request.query.dryRun === '1' || request.query.dryRun === 'true';
-    const pending = await store.listSubmissionsMissingSlug();
-
-    // Names handed out earlier in this run. Redundant on the write path, where the store
-    // already knows, and load-bearing on the dry run, where nothing is written and two
-    // games with the same title would otherwise both be promised the same slug.
-    const mintedHere = new Set<string>();
-    const games: Array<{ issueNumber: number; title: string; slug: string | null }> = [];
-
-    for (const record of pending) {
-      const isTaken = async (candidate: string): Promise<boolean> =>
-        mintedHere.has(candidate) || (await isSlugClaimed(candidate, record.issueNumber));
-      const wanted = await mintGameSlug(record.title, isTaken);
-
-      if (dryRun) {
-        mintedHere.add(wanted);
-        games.push({ issueNumber: record.issueNumber, title: record.title, slug: wanted });
-        continue;
-      }
-
-      await store.setSubmissionSlug(record.issueNumber, wanted);
-      // Same read-back as submission creation: the write is a claim, not a grant.
-      const settled = await confirmSlugClaim(record.issueNumber, wanted, record.title);
-      if (settled) mintedHere.add(settled);
-      games.push({ issueNumber: record.issueNumber, title: record.title, slug: settled });
-    }
-
-    const named = games.filter((game) => game.slug !== null).length;
-    const result = { ok: true, dryRun, scanned: pending.length, named, failed: pending.length - named, games };
+    // This route's own settle path, so the retry mint still consults the games-repo
+    // catalog through `isSlugClaimed` as it does everywhere else in the server.
+    const result = await runSlugBackfill({ store, isSlugClaimed, dryRun, confirmSlugClaim });
+    const { named } = result;
     // Logged as well as returned: this changes permanent addresses, and the response
     // goes to one browser tab that may not be open the next time anyone asks what ran.
     request.log.info({ dryRun, scanned: result.scanned, named, failed: result.failed }, 'slug backfill complete');

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -250,6 +250,39 @@ Two things worth knowing before you run it:
   (a dropped connection during the vote walk) can leave feedback deleted and some votes
   still standing — re-run it, the command is idempotent and finishes the job.
 
+## Naming games that predate slugs
+
+A slug is minted at submission now, so this is for records written before that and for
+anything that died between the record and its slug. Those games still work — the studio
+addresses them by status token — but a token in the URL bar is what slugs exist to stop.
+
+There are two ways in, and they run the same code (`runSlugBackfill`): the operator route
+`POST /api/admin/slug-backfill?dryRun=1`, which needs an admin browser session, and the
+CLI, which needs only gcloud credentials for the project:
+
+```bash
+npm run slug:backfill -w @gamedevpl/api -- --dry-run   # report, write nothing
+npm run slug:backfill -w @gamedevpl/api --             # name them
+```
+
+Always rehearse first: a slug is a permanent public address. The dry run prints the exact
+`{issueNumber, title, slug}` it would write, including the collisions it resolves — two
+games called "Space Miner" get `space-miner` and `space-miner-2`, in the same run.
+
+Abandoned builds are skipped on purpose. Their creator stopped them, so they need no
+address, and taking one would only spend a name.
+
+The CLI reads the published catalog from `gs://…-games-snapshots` before it starts, so a
+minted name cannot collide with a published game — the server asks GitHub for the same
+list, but the snapshot is what production actually serves and gcloud can already read it.
+If that read fails the run stops rather than guess; `--skip-catalog` overrides, which is
+only safe when you already know the backlog's titles.
+
+The API is not involved and there is nothing to deploy. Note that
+`POST /api/admin/slug-backfill` is `isAdminSession`-only and answers 404 to a personal
+access token by design (see [agent access tokens](agent-access-tokens.md)) — the CLI is
+the path for when no browser session is available, not a way around that rule.
+
 ## How to deploy manually
 
 [`apps/api/Dockerfile`](../apps/api/Dockerfile) is a multi-stage image built from the repo root


### PR DESCRIPTION
Closes part of #393 — the tooling half.

`POST /api/admin/slug-backfill` is `isAdminSession`-only, which is right and also
useless on a day nobody can reach an admin browser session. This adds the CLI
sibling of `beta:approve` / `token:mint`:

```bash
npm run slug:backfill -w @gamedevpl/api -- --dry-run   # report, write nothing
npm run slug:backfill -w @gamedevpl/api --             # name them
```

It talks to Firestore with ambient gcloud credentials, like the other operator
commands. It does **not** weaken `isAdminSession` or let a PAT near the route.

## One implementation, two entry points

The loop moves to `slug-backfill.ts` and both callers use it, so the work list,
the collision rules and the claim read-back cannot drift. A slug is a permanent
public address; a second implementation would be a second set of rules for
handing them out. `confirmSlugClaim` in `submissions.ts` is now a thin binding
over the shared `settleSlugClaim` — same behaviour, one copy.

The route keeps passing its own settle path, so its retry mint still consults
the games-repo catalog through `isSlugClaimed` exactly as before.

## What the CLI does about the third namespace

The server asks GitHub whether a name is already a published game. The CLI has
no GitHub token, so it reads the published catalog from `gs://…-games-snapshots`
with the same gcloud credentials — the list production actually serves. If that
read fails the run stops rather than mint a name that might collide;
`--skip-catalog` overrides for when you already know the backlog's titles.

## Verified against production

Dry run → real run → dry run, in that order, against live Firestore. The backlog
is already empty: 20 submissions, 19 slugged, and the one without a slug is
abandoned (skipped by design). All three runs reported `scanned: 0`, `games: []`,
and the catalog read saw 93 published slugs. Details in #393.

Gate: `npm run type-check`, `npm run lint`, and the full API suite (1559 tests)
all green. No deploy, no schema change, no games-repo edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)