### PR TITLE
Hide stop action for halted builds

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -345,6 +345,28 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('does not offer to stop a build that already needs changes', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'token-stopped',
+        title: 'Street Heist',
+        createdAt: '2026-07-30T09:00:00.000Z',
+        lastKnownStatus: 'needs_changes',
+        slug: 'street-heist',
+      },
+    ] satisfies StudioGame[]);
+
+    const { container, root } = await renderStudio({ selectedGame: 'street-heist', selectedTab: 'details' });
+
+    expect(container.querySelector('.status-abandon')).toBeNull();
+    expect(container.querySelector('.studio-share-toggle')).not.toBeNull();
+
+    root.unmount();
+  });
+
   it('puts the switch back when the change did not take', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -878,7 +878,7 @@ function DetailsPanel({
         <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
           <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
         </button>
-        {!published && game.lastKnownStatus !== 'abandoned' ? (
+        {game.lastKnownStatus && STUDIO_LIVE_STATUSES.has(game.lastKnownStatus) ? (
           <button
             type="button"
             className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}


### PR DESCRIPTION
### Motivation

- Prevent a contradictory UI where a stopped or "needs_changes" build still shows a "Stop build" control in the Creator Studio details panel.
- Preserve sharing/playtest controls for halted drafts so creators can still share and playtest a halted build.

### Description

- Change the details-panel stop button visibility to only render when the game status is genuinely live (uses `STUDIO_LIVE_STATUSES`) in `apps/web/src/CreatorStudioView.tsx`.
- Keep the draft sharing control visible for unpublished slugs and non-abandoned games (no change to `DraftShareControl` placement).
- Add a regression test `does not offer to stop a build that already needs changes` in `apps/web/src/CreatorStudioView.test.tsx` to assert the stop action is hidden for `lastKnownStatus: 'needs_changes'` while the share toggle remains present.
- Run Prettier on the changed files.

### Testing

- Ran `npx prettier --write apps/web/src/CreatorStudioView.tsx apps/web/src/CreatorStudioView.test.tsx` successfully.
- Ran `npm run test --workspace @gamedevpl/web -- --run CreatorStudioView.test.tsx` and the web test file passed (34 tests passed).
- Ran the repository green gate `npm run type-check && npm run lint && npm run test && npm run build` and all automated checks completed successfully (type-check, lint, test suites across packages, and production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d06312558832393e48c65c63c3973)