### PR TITLE
feat(player): shell mic bridge for shout-game loudness

### DIFF
--- a/apps/web/src/GameFrame.tsx
+++ b/apps/web/src/GameFrame.tsx
@@ -29,6 +29,10 @@ type GameFrameProps = GameFrameSource & {
  * so opt-in GameKit `motion` (phone tilt) can receive DeviceOrientation /
  * DeviceMotion inside the opaque-origin frame. Sensors stay optional for every
  * game; keyboard / pad remain enough to finish.
+ *
+ * Microphone loudness for shout games is owned by the theater shell
+ * (`useVoiceMeterBridge`). Opaque-origin documents cannot call `getUserMedia`
+ * without `allow-same-origin`, which we never grant.
  */
 export function GameFrame(props: GameFrameProps) {
   const localRef = useRef<HTMLIFrameElement>(null);

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -15,6 +15,7 @@ import { recordVisitEvent } from './visitTelemetry.js';
 import { useGameSaveBridge } from './gameSave.js';
 import { usePresenceBridge } from './presence.js';
 import { useSensingBridge } from './sensing.js';
+import { useVoiceMeterBridge } from './voiceMeter.js';
 import { useWorldBridge } from './world.js';
 import { useZoneBridge } from './zone.js';
 import { useScreenWakeLock } from './useScreenWakeLock.js';
@@ -199,6 +200,11 @@ export function GameTheater({
   // arbiter no longer has is a desync on the first tick.
   useZoneBridge(frameRef, reportSlug);
 
+  // Loudness mic for shout games (voice-on-phones Layer 0). Opaque sandboxed iframes
+  // cannot call getUserMedia; the theater header owns the gesture and relays levels.
+  // Quiet until createVoiceMeter posts voice:hello.
+  const voiceMeter = useVoiceMeterBridge(frameRef);
+
   // Device tilt for games that ask for it (games-repo camera-ar-platform Phase 0). Not
   // keyed on a slug: it touches no API and reads nothing durable — the shell relays
   // orientation readings into the frame, and the readings never leave the browser. On
@@ -346,6 +352,32 @@ export function GameTheater({
     </button>
   );
 
+  const micLabel =
+    voiceMeter.status === 'pending'
+      ? t('player.micPending')
+      : voiceMeter.status === 'denied'
+        ? t('player.micDenied')
+        : voiceMeter.status === 'unsupported'
+          ? t('player.micUnsupported')
+          : voiceMeter.live
+            ? t('player.micOn')
+            : t('player.micOff');
+
+  const micControl = (className: string) =>
+    voiceMeter.available ? (
+      <button
+        type="button"
+        className={className}
+        onClick={voiceMeter.toggle}
+        aria-pressed={voiceMeter.live}
+        aria-label={micLabel}
+        disabled={voiceMeter.status === 'unsupported' || voiceMeter.status === 'pending'}
+      >
+        <PixelIcon name="mic" size={13} />
+        <span className="btn-label">{micLabel}</span>
+      </button>
+    ) : null;
+
   // The one thing a player needs before the first key press, and the game's own copy of
   // it is hidden inside the frame by HIDE_CHROME. Reuses `theater-menu-item` in the
   // overflow menu so the four hand-enumerated selector lists in styles.css keep working.
@@ -425,6 +457,7 @@ export function GameTheater({
             {/* Desktop: sound + fullscreen sit on the bar. Phone: they move into More. */}
             {howToPlayControl('secondary-btn howto-btn howto-bar')}
             {soundControl('secondary-btn sound-btn theater-desktop-chrome')}
+            {micControl('secondary-btn mic-btn theater-desktop-chrome')}
             {fullscreenControl('secondary-btn fullscreen-btn theater-desktop-chrome')}
             {showMoreMenu && (
               <div className={`theater-more${moreOpen ? ' is-open' : ''}`} ref={moreRef}>
@@ -443,6 +476,7 @@ export function GameTheater({
                 <div className="theater-more-panel" role="menu">
                   {howToPlayControl('theater-menu-item howto-menu')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
+                  {micControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
                   {reportSlug && (
                     <>

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -332,12 +332,14 @@ export function GameTheater({
     };
   }, [moreOpen]);
 
-  // The menu also has to exist wherever a control has shed into it. How-to-play sheds at
-  // 900px while sound and fullscreen shed at 768px, so between those widths a game with
-  // no `reportSlug` (a draft, a generated game — no catalog entry, but the game document
-  // still reports its own controls) would have had the bar copy hidden by CSS and no menu
-  // to fall back to, and the control would have vanished entirely.
-  const showMoreMenu = Boolean(reportSlug) || isNarrow || (hasControls && isMidWidth);
+  // The menu also has to exist wherever a control has shed into it. How-to-play and Mic
+  // shed at 900px while sound and fullscreen shed at 768px, so between those widths a
+  // game with no `reportSlug` (a draft, a generated game — no catalog entry, but the
+  // game document still reports its own controls) — or a shout game that only needs Mic
+  // — would have had the bar copy hidden by CSS and no menu to fall back to, and the
+  // control would have vanished entirely.
+  const showMoreMenu =
+    Boolean(reportSlug) || isNarrow || (hasControls && isMidWidth) || (voiceMeter.available && isMidWidth);
 
   const soundControl = (className: string) => (
     <button
@@ -457,7 +459,9 @@ export function GameTheater({
             {/* Desktop: sound + fullscreen sit on the bar. Phone: they move into More. */}
             {howToPlayControl('secondary-btn howto-btn howto-bar')}
             {soundControl('secondary-btn sound-btn theater-desktop-chrome')}
-            {micControl('secondary-btn mic-btn theater-desktop-chrome')}
+            {/* Mic sheds at 900px with How-to-play (not 768px with sound) — Polish
+                "Mikrofon: …" labels otherwise clip the title at mid widths. */}
+            {micControl('secondary-btn mic-btn mic-bar')}
             {fullscreenControl('secondary-btn fullscreen-btn theater-desktop-chrome')}
             {showMoreMenu && (
               <div className={`theater-more${moreOpen ? ' is-open' : ''}`} ref={moreRef}>
@@ -475,8 +479,8 @@ export function GameTheater({
                 </button>
                 <div className="theater-more-panel" role="menu">
                   {howToPlayControl('theater-menu-item howto-menu')}
+                  {micControl('theater-menu-item mic-menu')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
-                  {micControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
                   {reportSlug && (
                     <>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -127,6 +127,11 @@
   "player": {
     "soundOn": "Sound: On",
     "soundOff": "Sound: Off",
+    "micOn": "Mic: On",
+    "micOff": "Mic: Off",
+    "micPending": "Mic: …",
+    "micDenied": "Mic: Denied",
+    "micUnsupported": "Mic: N/A",
     "fullscreen": "Fullscreen",
     "exitFullscreen": "Exit Fullscreen",
     "rotateLandscape": "Turn your phone sideways to play",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -127,6 +127,11 @@
   "player": {
     "soundOn": "Dźwięk: Wł.",
     "soundOff": "Dźwięk: Wył.",
+    "micOn": "Mikrofon: Wł.",
+    "micOff": "Mikrofon: Wył.",
+    "micPending": "Mikrofon: …",
+    "micDenied": "Mikrofon: Odmowa",
+    "micUnsupported": "Mikrofon: Brak",
     "fullscreen": "Pełny ekran",
     "exitFullscreen": "Zamknij pełny ekran",
     "rotateLandscape": "Obróć telefon poziomo, aby zagrać",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3469,20 +3469,23 @@ body.player-open {
   opacity: 1;
 }
 
-/* This control sheds to the More menu earlier than sound and fullscreen do (900px, not
-   768px). Measured at 800px: with it on the bar, the actions row grows until the vote
-   widget overlaps the game title, because the meta column does not shrink. Below the
-   breakpoint the bar copy is hidden and the menu copy takes over; above it, the reverse.
-   The second query starts at 900.02px (not 901px) so fractional widths between 900 and
-   901 — ordinary at non-integer zoom / HiDPI — do not leave both copies visible. */
+/* How-to-play and Mic shed to the More menu earlier than sound and fullscreen do
+   (900px, not 768px). Measured at 800px: with them on the bar, the actions row grows
+   until the vote widget overlaps the game title, because the meta column does not
+   shrink — Mic's Polish labels make that worse. Below the breakpoint the bar copy is
+   hidden and the menu copy takes over; above it, the reverse. The second query starts
+   at 900.02px (not 901px) so fractional widths between 900 and 901 — ordinary at
+   non-integer zoom / HiDPI — do not leave both copies visible. */
 @media (max-width: 900px) {
-  .game-theater-actions .howto-bar {
+  .game-theater-actions .howto-bar,
+  .game-theater-actions .mic-bar {
     display: none !important;
   }
 }
 
 @media (min-width: 900.02px) {
-  .game-theater-actions .theater-more-panel .howto-menu {
+  .game-theater-actions .theater-more-panel .howto-menu,
+  .game-theater-actions .theater-more-panel .mic-menu {
     display: none !important;
   }
 }

--- a/apps/web/src/voiceMeter.test.tsx
+++ b/apps/web/src/voiceMeter.test.tsx
@@ -11,10 +11,13 @@ function frame(payload: Record<string, unknown>) {
 }
 
 describe('parseVoiceMeterMessage', () => {
-  it('accepts hello / start / stop from the game', () => {
+  it('accepts hello / stop from the game', () => {
     expect(parseVoiceMeterMessage(frame({ t: 'voice:hello' }))).toEqual({ t: 'voice:hello' });
-    expect(parseVoiceMeterMessage(frame({ t: 'voice:start' }))).toEqual({ t: 'voice:start' });
     expect(parseVoiceMeterMessage(frame({ t: 'voice:stop' }))).toEqual({ t: 'voice:stop' });
+  });
+
+  it('rejects voice:start so sticky permission cannot skip the theater Mic gesture', () => {
+    expect(parseVoiceMeterMessage(frame({ t: 'voice:start' }))).toBeNull();
   });
 
   it('drops foreign namespaces, versions, and unknown types', () => {
@@ -141,6 +144,21 @@ describe('useVoiceMeterBridge', () => {
 
     expect(latest?.status).toBe('live');
     expect(toGame.some((m) => m.t === 'voice:state' && m.status === 'live')).toBe(true);
+  });
+
+  it('ignores a game voice:start message (shell Mic gesture only)', async () => {
+    const { fromGame } = mount();
+    act(() => fromGame({ t: 'voice:hello' }));
+    toGame.length = 0;
+
+    await act(async () => {
+      fromGame({ t: 'voice:start' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.status).toBe('idle');
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
   });
 
   it('stops a pending or live mic when the document is hidden', async () => {

--- a/apps/web/src/voiceMeter.test.tsx
+++ b/apps/web/src/voiceMeter.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
+import { parseVoiceMeterMessage, useVoiceMeterBridge } from './voiceMeter.js';
+
+function frame(payload: Record<string, unknown>) {
+  return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload };
+}
+
+describe('parseVoiceMeterMessage', () => {
+  it('accepts hello / start / stop from the game', () => {
+    expect(parseVoiceMeterMessage(frame({ t: 'voice:hello' }))).toEqual({ t: 'voice:hello' });
+    expect(parseVoiceMeterMessage(frame({ t: 'voice:start' }))).toEqual({ t: 'voice:start' });
+    expect(parseVoiceMeterMessage(frame({ t: 'voice:stop' }))).toEqual({ t: 'voice:stop' });
+  });
+
+  it('drops foreign namespaces, versions, and unknown types', () => {
+    expect(parseVoiceMeterMessage({ t: 'voice:hello' })).toBeNull();
+    expect(parseVoiceMeterMessage({ ns: 'other', v: PROTOCOL_VERSION, t: 'voice:hello' })).toBeNull();
+    expect(parseVoiceMeterMessage({ ns: BRIDGE_NAMESPACE, v: 99, t: 'voice:hello' })).toBeNull();
+    expect(parseVoiceMeterMessage(frame({ t: 'voice:level', value: 0.5 }))).toBeNull();
+    expect(parseVoiceMeterMessage(null)).toBeNull();
+  });
+});
+
+function Harness({ onBridge }: { onBridge?: (bridge: ReturnType<typeof useVoiceMeterBridge>) => void }) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const bridge = useVoiceMeterBridge(frameRef);
+  onBridge?.(bridge);
+  return <iframe ref={frameRef} title="game" />;
+}
+
+describe('useVoiceMeterBridge', () => {
+  let toGame: Array<Record<string, unknown>>;
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let latest: ReturnType<typeof useVoiceMeterBridge> | null;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    toGame = [];
+    latest = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = null;
+
+    class FakeAnalyser {
+      fftSize = 1024;
+      smoothingTimeConstant = 0;
+      connect() {}
+      disconnect() {}
+      getByteTimeDomainData(target: Uint8Array) {
+        for (let i = 0; i < target.length; i++) target[i] = 128 + (i % 2 === 0 ? 40 : -40);
+      }
+    }
+    class FakeAudioContext {
+      state = 'running';
+      createMediaStreamSource() {
+        return { connect() {} };
+      }
+      createAnalyser() {
+        return new FakeAnalyser();
+      }
+      resume() {
+        this.state = 'running';
+        return Promise.resolve();
+      }
+      close() {
+        return Promise.resolve();
+      }
+    }
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({
+          getTracks: () => [{ stop: vi.fn() }],
+        })),
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function mount() {
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <Harness
+          onBridge={(bridge) => {
+            latest = bridge;
+          }}
+        />,
+      );
+    });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const gameWindow = iframe.contentWindow as Window;
+    vi.spyOn(gameWindow, 'postMessage').mockImplementation(((message: Record<string, unknown>) => {
+      toGame.push(message);
+    }) as typeof gameWindow.postMessage);
+
+    const fromGame = (payload: Record<string, unknown>) => {
+      window.dispatchEvent(new MessageEvent('message', { data: frame(payload), source: gameWindow }));
+    };
+    return { fromGame };
+  }
+
+  it('stays quiet until the game says voice:hello, then announces idle', () => {
+    const { fromGame } = mount();
+    expect(latest?.available).toBe(false);
+    expect(toGame).toEqual([]);
+
+    act(() => fromGame({ t: 'voice:hello' }));
+    expect(latest?.available).toBe(true);
+    expect(toGame).toContainEqual({
+      ns: BRIDGE_NAMESPACE,
+      v: PROTOCOL_VERSION,
+      t: 'voice:state',
+      status: 'idle',
+    });
+  });
+
+  it('toggle starts the mic after hello and relays live state', async () => {
+    const { fromGame } = mount();
+    act(() => fromGame({ t: 'voice:hello' }));
+    toGame.length = 0;
+
+    await act(async () => {
+      latest!.toggle();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.status).toBe('live');
+    expect(toGame.some((m) => m.t === 'voice:state' && m.status === 'live')).toBe(true);
+  });
+
+  it('stops a pending or live mic when the document is hidden', async () => {
+    const { fromGame } = mount();
+    act(() => fromGame({ t: 'voice:hello' }));
+
+    await act(async () => {
+      latest!.toggle();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(latest?.status).toBe('live');
+
+    await act(async () => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(latest?.status).toBe('idle');
+  });
+});

--- a/apps/web/src/voiceMeter.ts
+++ b/apps/web/src/voiceMeter.ts
@@ -15,7 +15,7 @@ import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 
 export type VoiceMeterShellStatus = 'unsupported' | 'idle' | 'pending' | 'live' | 'denied';
 
-export type VoiceMeterGameMessage = { t: 'voice:hello' } | { t: 'voice:start' } | { t: 'voice:stop' };
+export type VoiceMeterGameMessage = { t: 'voice:hello' } | { t: 'voice:stop' };
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -24,7 +24,9 @@ function isObject(value: unknown): value is Record<string, unknown> {
 /** Narrows one message out of the game frame. Returns null for anything else. */
 export function parseVoiceMeterMessage(raw: unknown): VoiceMeterGameMessage | null {
   if (!isObject(raw) || raw.ns !== BRIDGE_NAMESPACE || raw.v !== PROTOCOL_VERSION) return null;
-  if (raw.t === 'voice:hello' || raw.t === 'voice:start' || raw.t === 'voice:stop') {
+  // `voice:start` is deliberately rejected: sticky mic permission would let untrusted
+  // iframe code open capture without a theater Mic gesture (Codex P1 on #406).
+  if (raw.t === 'voice:hello' || raw.t === 'voice:stop') {
     return { t: raw.t };
   }
   return null;
@@ -196,13 +198,6 @@ export function useVoiceMeterBridge(frameRef: MutableRefObject<HTMLIFrameElement
 
       if (!availableRef.current) return;
 
-      if (message.t === 'voice:start') {
-        // Games may ask, but sticky permission is the only case that works without a
-        // fresh top-level gesture. Harmless no-op when the browser still needs a tap.
-        startMic();
-        return;
-      }
-
       if (message.t === 'voice:stop') {
         stopMic();
       }
@@ -223,7 +218,7 @@ export function useVoiceMeterBridge(frameRef: MutableRefObject<HTMLIFrameElement
       availableRef.current = false;
       teardown();
     };
-  }, [frameRef, publishStatus, startMic, stopMic, teardown]);
+  }, [frameRef, publishStatus, stopMic, teardown]);
 
   return {
     /** True once a game with createVoiceMeter has said hello. */

--- a/apps/web/src/voiceMeter.ts
+++ b/apps/web/src/voiceMeter.ts
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
+
+/**
+ * Shell half of GameKit loudness (voice-on-phones Layer 0).
+ *
+ * Published games run in an opaque-origin sandboxed iframe (`allow-scripts` without
+ * `allow-same-origin`). Browsers reject `getUserMedia` there even when the iframe has
+ * `allow="microphone"`, so the top-level theater captures the mic after a real header
+ * gesture and relays smoothed-ready levels into the frame over the gdp bridge.
+ *
+ * Nothing runs until a game posts `voice:hello` (createVoiceMeter while embedded), so
+ * mounting this for every published play costs silent games nothing.
+ */
+
+export type VoiceMeterShellStatus = 'unsupported' | 'idle' | 'pending' | 'live' | 'denied';
+
+export type VoiceMeterGameMessage = { t: 'voice:hello' } | { t: 'voice:start' } | { t: 'voice:stop' };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrows one message out of the game frame. Returns null for anything else. */
+export function parseVoiceMeterMessage(raw: unknown): VoiceMeterGameMessage | null {
+  if (!isObject(raw) || raw.ns !== BRIDGE_NAMESPACE || raw.v !== PROTOCOL_VERSION) return null;
+  if (raw.t === 'voice:hello' || raw.t === 'voice:start' || raw.t === 'voice:stop') {
+    return { t: raw.t };
+  }
+  return null;
+}
+
+function mediaSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === 'function' &&
+    !!(window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)
+  );
+}
+
+/**
+ * Captures microphone loudness on the real origin and posts `voice:state` /
+ * `voice:level` into `frameRef`. Returns UI state for the theater Mic control.
+ */
+export function useVoiceMeterBridge(frameRef: MutableRefObject<HTMLIFrameElement | null>) {
+  const [available, setAvailable] = useState(false);
+  const [status, setStatus] = useState<VoiceMeterShellStatus>(() => (mediaSupported() ? 'idle' : 'unsupported'));
+
+  const statusRef = useRef(status);
+  statusRef.current = status;
+  const availableRef = useRef(false);
+  const streamRef = useRef<MediaStream | null>(null);
+  const contextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const timeDomainRef = useRef<Uint8Array | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const levelRef = useRef(0);
+
+  const postToGame = useCallback(
+    (payload: Record<string, unknown>) => {
+      frameRef.current?.contentWindow?.postMessage({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload }, '*');
+    },
+    [frameRef],
+  );
+
+  const publishStatus = useCallback(
+    (next: VoiceMeterShellStatus) => {
+      statusRef.current = next;
+      setStatus(next);
+      if (availableRef.current) postToGame({ t: 'voice:state', status: next });
+    },
+    [postToGame],
+  );
+
+  const teardown = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    analyserRef.current = null;
+    timeDomainRef.current = null;
+    levelRef.current = 0;
+    if (contextRef.current) {
+      try {
+        void contextRef.current.close();
+      } catch {
+        /* ignore */
+      }
+      contextRef.current = null;
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) track.stop();
+      streamRef.current = null;
+    }
+  }, []);
+
+  const stopMic = useCallback(() => {
+    teardown();
+    if (statusRef.current === 'unsupported') return;
+    publishStatus('idle');
+  }, [publishStatus, teardown]);
+
+  const pumpLevels = useCallback(() => {
+    const analyser = analyserRef.current;
+    const timeDomain = timeDomainRef.current;
+    if (!analyser || !timeDomain || statusRef.current !== 'live') return;
+    analyser.getByteTimeDomainData(timeDomain as Uint8Array<ArrayBuffer>);
+    let sum = 0;
+    for (let i = 0; i < timeDomain.length; i++) {
+      const v = (timeDomain[i]! - 128) / 128;
+      sum += v * v;
+    }
+    const rms = Math.sqrt(sum / timeDomain.length);
+    const boosted = Math.min(1, rms * 4);
+    // Light shell-side smoothing; the kit applies its own smoothing on top.
+    levelRef.current = levelRef.current * 0.55 + boosted * 0.45;
+    postToGame({ t: 'voice:level', value: levelRef.current });
+    rafRef.current = requestAnimationFrame(pumpLevels);
+  }, [postToGame]);
+
+  const startMic = useCallback(() => {
+    if (!availableRef.current) return;
+    if (statusRef.current === 'live' || statusRef.current === 'pending' || statusRef.current === 'unsupported') {
+      return;
+    }
+    if (!mediaSupported()) {
+      publishStatus('unsupported');
+      return;
+    }
+
+    const AC =
+      window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    // Unlock inside the theater Mic gesture before awaiting permission.
+    if (!contextRef.current) contextRef.current = new AC();
+    if (contextRef.current.state === 'suspended') void contextRef.current.resume();
+
+    publishStatus('pending');
+    void navigator.mediaDevices
+      .getUserMedia({ audio: true, video: false })
+      .then((mediaStream) => {
+        if (statusRef.current !== 'pending' || document.hidden || !availableRef.current) {
+          for (const track of mediaStream.getTracks()) track.stop();
+          if (statusRef.current === 'pending' && document.hidden) stopMic();
+          return;
+        }
+        streamRef.current = mediaStream;
+        const context = contextRef.current;
+        if (!context) {
+          for (const track of mediaStream.getTracks()) track.stop();
+          publishStatus('unsupported');
+          return;
+        }
+        const source = context.createMediaStreamSource(mediaStream);
+        const analyser = context.createAnalyser();
+        analyser.fftSize = 1024;
+        analyser.smoothingTimeConstant = 0.4;
+        analyserRef.current = analyser;
+        timeDomainRef.current = new Uint8Array(analyser.fftSize);
+        source.connect(analyser);
+        if (context.state === 'suspended') void context.resume();
+        publishStatus('live');
+        rafRef.current = requestAnimationFrame(pumpLevels);
+      })
+      .catch(() => {
+        teardown();
+        publishStatus('denied');
+      });
+  }, [publishStatus, pumpLevels, stopMic, teardown]);
+
+  const toggle = useCallback(() => {
+    if (statusRef.current === 'live' || statusRef.current === 'pending') stopMic();
+    else startMic();
+  }, [startMic, stopMic]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    function onMessage(event: MessageEvent) {
+      if (cancelled) return;
+      if (!frameRef.current || event.source !== frameRef.current.contentWindow) return;
+      const message = parseVoiceMeterMessage(event.data);
+      if (!message) return;
+
+      if (message.t === 'voice:hello') {
+        availableRef.current = true;
+        setAvailable(true);
+        const initial: VoiceMeterShellStatus = mediaSupported()
+          ? statusRef.current === 'live' || statusRef.current === 'pending' || statusRef.current === 'denied'
+            ? statusRef.current
+            : 'idle'
+          : 'unsupported';
+        publishStatus(initial);
+        return;
+      }
+
+      if (!availableRef.current) return;
+
+      if (message.t === 'voice:start') {
+        // Games may ask, but sticky permission is the only case that works without a
+        // fresh top-level gesture. Harmless no-op when the browser still needs a tap.
+        startMic();
+        return;
+      }
+
+      if (message.t === 'voice:stop') {
+        stopMic();
+      }
+    }
+
+    function onVisibility() {
+      if (document.hidden && (statusRef.current === 'live' || statusRef.current === 'pending')) {
+        stopMic();
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('message', onMessage);
+      document.removeEventListener('visibilitychange', onVisibility);
+      availableRef.current = false;
+      teardown();
+    };
+  }, [frameRef, publishStatus, startMic, stopMic, teardown]);
+
+  return {
+    /** True once a game with createVoiceMeter has said hello. */
+    available,
+    status,
+    live: status === 'live',
+    toggle,
+    stop: stopMic,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opaque sandboxed game iframes cannot call `getUserMedia` (no `allow-same-origin`). This ships the theater half of voice loudness Layer 0 so shout games work on the published site.

- New `useVoiceMeterBridge` — quiet until the game posts `voice:hello`, then theater Mic control captures on a real header gesture and relays `voice:state` / `voice:level` over gdp
- **Mic starts only from the theater Mic click** — game `voice:start` is rejected (Codex P1: sticky permission must not let untrusted iframe code open capture)
- Stops pending/live mic when the tab is hidden
- Unlock `AudioContext` inside the Mic gesture before awaiting permission
- **Mic sheds into More at 900px** with How-to-play (Codex P2: mid-width title clipping, esp. Polish labels)
- i18n en/pl for Mic labels
- Pairs with games-repo #275 (`createVoiceMeter` shell-relay path)

## Test plan
- [x] `vitest run src/voiceMeter.test.tsx` (incl. reject `voice:start`)
- [x] `GameTheater.test.tsx`
- [x] CI green after master merge
- [ ] Manual: play a voice-module game in theater, enable Mic, shout peaks reach the game HUD

## Related
- Games: https://github.com/gamedevpl/www.gamedev.pl-games/pull/275
- Codex review on #406 (P1 gesture-only start, P2 mid-width Mic shed) — addressed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5adf4d-35a4-414f-a92c-5e3022509296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5adf4d-35a4-414f-a92c-5e3022509296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

