### PR TITLE
fix(studio): operator reject must remove the game from the creator shelf

### DIFF
--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -78,6 +78,38 @@ describe('GET /api/me/studio', () => {
     expect(res.statusCode).toBe(401);
     await app.close();
   });
+
+  it('hides abandoned and operator-canceled games from the shelf', async () => {
+    await store.createSubmission(10, 'g:creator', 'Keep me');
+    await store.createSubmission(11, 'g:creator', 'Creator stopped');
+    await store.setSubmissionAbandoned(11, `${today}T12:00:00.000Z`);
+    await store.createSubmission(12, 'g:creator', 'Operator rejected');
+    // Pre-fix shape: cancel wrote state but not abandonedAt — still must not shelf.
+    await store.recordJobTransition(12, {
+      to: 'canceled',
+      at: `${today}T12:00:00.000Z`,
+      by: 'operator',
+      reason: 'operator_canceled',
+    });
+
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      submissionRoutes: { submissionTokenSecret },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio',
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const games = (res.json() as { games: CreatorStudioGame[] }).games;
+    expect(games.map((game) => game.title)).toEqual(['Keep me']);
+
+    await app.close();
+  });
 });
 
 describe('GET /api/me/studio/health', () => {
@@ -240,13 +272,16 @@ describe('GET /api/me/studio/scorecards', () => {
     // Asserted as an exact key set rather than by searching the serialized body: themes are
     // player-written text, so a player who writes "too many sessions" would otherwise fail
     // this test against a route that is behaving perfectly.
-    await store.putScorecard('sky-dodge', card('sky-dodge', {
-      untrusted: {
-        errorSamples: [],
-        progressLabels: [],
-        feedbackThemes: [{ theme: 'too many sessions before the finishRate improves', count: 3 }],
-      },
-    }));
+    await store.putScorecard(
+      'sky-dodge',
+      card('sky-dodge', {
+        untrusted: {
+          errorSamples: [],
+          progressLabels: [],
+          feedbackThemes: [{ theme: 'too many sessions before the finishRate improves', count: 3 }],
+        },
+      }),
+    );
 
     const body = (await get()).json() as CreatorScorecardsResponse;
 

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -162,7 +162,9 @@ export async function registerCreatorStudioRoutes(
 
     const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: MAX_STUDIO_GAMES });
     const games: CreatorStudioGame[] = records
-      .filter((record) => !record.abandonedAt)
+      // `abandonedAt` is the shelf contract; also drop `canceled` so an operator
+      // reject that predated writing `abandonedAt` does not leave a zombie row.
+      .filter((record) => !record.abandonedAt && record.state !== 'canceled')
       .map((record) => ({
         token: options.mintStatusToken!(record.issueNumber),
         title: record.title,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,13 +15,23 @@ async function main() {
   if (process.env.NODE_ENV !== 'production' && process.env.DEV_SEED_STUDIO === '1' && store instanceof InMemoryStore) {
     const uid = 'g:studio-demo';
     await store.upsertUser({ uid, name: 'Studio Demo', email: 'studio-demo@example.com' });
-    await store.createSubmission(101, uid, 'Sky Dodge');
-    await store.setSubmissionSlug(101, 'sky-dodge');
-    await store.setSubmissionPublishedAt(101, new Date(Date.now() - 3 * 86400_000).toISOString());
-    await store.setSubmissionLastStatus(101, 'published');
-    await store.setSubmissionNotifiedStatus(101, 'published');
-    await store.createSubmission(102, uid, 'Arena Tag');
-    await store.setSubmissionSlug(102, 'arena-tag');
+    // Mirror the live shelf that motivated the operator-cancel fix: a rejected
+    // street-heist must not appear beside the creator's other drafts.
+    await store.createSubmission(100, uid, 'Can we make a game like Grand Theft Auto');
+    await store.setSubmissionSlug(100, 'street-heist');
+    await store.recordJobTransition(100, {
+      to: 'canceled',
+      at: new Date(Date.now() - 20 * 3600_000).toISOString(),
+      by: 'operator',
+      reason: 'operator_canceled',
+    });
+    // Pre-fix shape (no abandonedAt) — shelf must still hide it via state === 'canceled'.
+    await store.createSubmission(101, uid, 'Global Thermonuclear Strategy');
+    await store.setSubmissionSlug(101, 'global-thermonuclear');
+    await store.setSubmissionLastStatus(101, 'building');
+    await store.setSubmissionNotifiedStatus(101, 'building');
+    await store.createSubmission(102, uid, 'A game tycoon like where I run a studio');
+    await store.setSubmissionSlug(102, 'studio-tycoon');
     await store.setSubmissionLastStatus(102, 'building');
     await store.setSubmissionNotifiedStatus(102, 'building');
     // Extra shelf rows so local QA can exercise search/filters/mobile switcher at 10+.
@@ -32,13 +42,13 @@ async function main() {
       status: 'published' | 'building' | 'queued' | 'in_review' | 'needs_changes';
       daysAgo: number;
     }> = [
-      { issue: 103, title: 'Neon Drift', slug: 'neon-drift', status: 'published', daysAgo: 8 },
-      { issue: 104, title: 'Puzzle Dock', slug: 'puzzle-dock', status: 'published', daysAgo: 12 },
-      { issue: 105, title: 'Bolt Rush', status: 'queued', daysAgo: 0 },
-      { issue: 106, title: 'Castle Siege', slug: 'castle-siege', status: 'published', daysAgo: 20 },
-      { issue: 107, title: 'Orbit Hop', status: 'in_review', daysAgo: 1 },
-      { issue: 108, title: 'Tide Pool', slug: 'tide-pool', status: 'published', daysAgo: 30 },
-      { issue: 109, title: 'Pixel Ranch', slug: 'pixel-ranch', status: 'published', daysAgo: 40 },
+      { issue: 103, title: 'Sky Dodge', slug: 'sky-dodge', status: 'published', daysAgo: 3 },
+      { issue: 104, title: 'Neon Drift', slug: 'neon-drift', status: 'published', daysAgo: 8 },
+      { issue: 105, title: 'Puzzle Dock', slug: 'puzzle-dock', status: 'published', daysAgo: 12 },
+      { issue: 106, title: 'Bolt Rush', status: 'queued', daysAgo: 0 },
+      { issue: 107, title: 'Castle Siege', slug: 'castle-siege', status: 'published', daysAgo: 20 },
+      { issue: 108, title: 'Orbit Hop', status: 'in_review', daysAgo: 1 },
+      { issue: 109, title: 'Tide Pool', slug: 'tide-pool', status: 'published', daysAgo: 30 },
       { issue: 110, title: 'Ghost Circuit', status: 'needs_changes', daysAgo: 5 },
       { issue: 111, title: 'Forest Dash', slug: 'forest-dash', status: 'published', daysAgo: 55 },
       { issue: 112, title: 'Sumo Mini', slug: 'sumo-mini', status: 'published', daysAgo: 60 },

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2874,6 +2874,9 @@ describe('operator cancel and retry', () => {
 
     const record = await store.getSubmission(job.issueNumber);
     expect(record?.state).toBe('canceled');
+    // Shelf filters on `abandonedAt`. Without it, an operator reject left the game
+    // on the creator's studio with Playtest still offered.
+    expect(record?.abandonedAt).toBeTruthy();
     const last = record?.transitions?.at(-1);
     expect(last).toMatchObject({ to: 'canceled', by: 'operator', reason: 'operator_canceled' });
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1961,10 +1961,11 @@ export async function registerSubmissionRoutes(
 
     const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: 50 });
     return reply.send({
-      // Abandoned builds are gone as far as the creator is concerned — they asked
-      // for them to stop, so they don't belong in "your games".
+      // Abandoned / operator-canceled builds are gone as far as the creator is
+      // concerned — they don't belong in "your games". `state === 'canceled'` heals
+      // jobs canceled before the operator path wrote `abandonedAt`.
       submissions: records
-        .filter((record) => !record.abandonedAt)
+        .filter((record) => !record.abandonedAt && record.state !== 'canceled')
         .map((record) => ({
           token: mintToken(record.issueNumber, submissionTokenSecret),
           title: record.title,
@@ -2383,6 +2384,23 @@ export async function registerSubmissionRoutes(
       } catch (cancelError) {
         request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed; job is canceled regardless');
       }
+    }
+
+    // Same bookkeeping as a creator abandon. Without `abandonedAt` the job is terminal
+    // for the queue but still sits on the creator's studio shelf — a reject from this
+    // console left street-heist looking "Stopped" with Playtest still offered, because
+    // the shelf only filters on `abandonedAt`, not on job state.
+    const afterCancel = await store.getSubmission(issueNumber);
+    if (afterCancel?.dispatch?.workspace) {
+      await releaseWorkspace(issueNumber, afterCancel.dispatch.workspace, request.log);
+    }
+    if (afterCancel?.dispatch?.seedWorkspace) {
+      await releaseWorkspace(issueNumber, afterCancel.dispatch.seedWorkspace, request.log);
+      await store.clearDispatchSeedWorkspace(issueNumber);
+    }
+    await store.setSubmissionAbandoned(issueNumber, at);
+    for (const key of [...statusCache.keys()]) {
+      if (key.startsWith(`${issueNumber}:`)) statusCache.delete(key);
     }
 
     return reply.send({ ok: true, state: 'canceled', stopEnforced });

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -531,7 +531,7 @@
       },
       "abandoned": {
         "label": "Stopped",
-        "description": "You stopped this build. The agent is no longer working on it — start a new idea whenever you like."
+        "description": "This build was stopped. The agent is no longer working on it — start a new idea whenever you like."
       }
     },
     "phases": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -535,7 +535,7 @@
       },
       "abandoned": {
         "label": "Zatrzymana",
-        "description": "Zatrzymałeś tę grę. Agent już nad nią nie pracuje — możesz zacząć nowy pomysł, kiedy zechcesz."
+        "description": "Ta gra została zatrzymana. Agent już nad nią nie pracuje — możesz zacząć nowy pomysł, kiedy zechcesz."
       }
     },
     "phases": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Rejecting a build from the operator console (Cancel) left it on the creator’s studio shelf.

Visible on street-heist after operator cancel: status **Zatrzymana**, checklist still “4 of 4 done”, **Playtest** and **Stop build** still offered — because cancel only wrote job state `canceled`, while the shelf filters on `abandonedAt`.

## Fix

Operator cancel now mirrors creator abandon:

- set `abandonedAt`
- release dispatch / seed workspaces
- clear the status cache

Shelf list endpoints (`/api/me/studio`, `/api/submissions/mine`) also hide `state === 'canceled'`, so jobs canceled before this fix leave the shelf without a data migration.

Abandoned copy no longer says “you stopped” — operator reject uses the same status.

## How it looks

Seeded locally with a canceled *Can we make a game like Grand Theft Auto* (`street-heist`, no `abandonedAt`) plus the other drafts from that shelf. After the fix the picker shows **12 games** — street-heist is gone:

[Studio game picker after operator cancel — street-heist absent](https://cursor.com/agents/bc-2ab6ce19-6b18-4339-9589-7079c574990b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-after-cancel-picker.webp)

[Studio thread on next remaining draft](https://cursor.com/agents/bc-2ab6ce19-6b18-4339-9589-7079c574990b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-after-cancel-full.webp)

[studio-after-operator-cancel.mp4](https://cursor.com/agents/bc-2ab6ce19-6b18-4339-9589-7079c574990b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio-after-operator-cancel.mp4)

## Tests

- operator cancel asserts `abandonedAt`
- studio shelf hides abandoned + canceled-without-abandonedAt

`apps/api` submissions + creator-studio suites green (139).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ab6ce19-6b18-4339-9589-7079c574990b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ab6ce19-6b18-4339-9589-7079c574990b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

