### PR TITLE
chore: drop orphan GameKit motion module from serve contract

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -3,7 +3,6 @@
   "_comment": "Cross-repo serve contract. Website half: www.gamedev.pl apps/api/src/games-repo-contract.ts + CI contract:games-repo (PR #253). Keep GAME_KIT_MODULES as an array literal in tools/lib/assemble.ts for that scraper. maxProjectBytes must equal games Check 4 MAX_BUNDLE_BYTES (currently includes gfx3d reserve, look/spatial, mascotDraw, and a deliberate headroom band).",
   "gameKitModules": [
     "input",
-    "motion",
     "collision",
     "world",
     "ai",

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -79,10 +79,9 @@ describe('runGamesRepoContractCheck', () => {
   });
 
   it('allows the website to list modules the games tip has not shipped yet', async () => {
-    // Website-first add: GAME_KIT_MODULES here already includes `motion`, but main's
-    // assemble.ts still lists the pre-motion order. That window must stay green so the
-    // iframe / contract PR can land before the games-repo half.
-    const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => name !== 'motion');
+    // Website-first add: GAME_KIT_MODULES here already includes `voice`, but main's
+    // assemble.ts may still list the pre-voice order. That window must stay green.
+    const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => name !== 'voice');
     const olderAssemble = `
       const GAME_KIT_MODULES = [${withoutAheadExtras.map((name) => `'${name}'`).join(', ')}];
       const catalog = readMusicCatalog();

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -243,7 +243,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   // before the games-repo tip merges them. If a local-only module is NOT in this
   // list, it means games-repo dropped or rolled it back — that is drift, not an
   // intentional lead. (Codex review — PR #379.)
-  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['motion', 'sensing', 'voice']);
+  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice']);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const undeclaredExtras = websiteExtras.filter((m) => !DECLARED_AHEAD_MODULES.has(m));
   if (undeclaredExtras.length > 0) {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -40,7 +40,6 @@ describe('games-repo-contract (website half)', () => {
   it('lists GameKit modules in the post-draw-surface canonical order', () => {
     expect([...GAME_KIT_MODULES]).toEqual([
       'input',
-      'motion',
       'collision',
       'world',
       'ai',
@@ -73,7 +72,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'motion', 'collision', 'world', 'ai', 'gameplay',
+        'input', 'collision', 'world', 'ai', 'gameplay',
         'drawing', 'actors', 'gfx', 'gfx3d', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -23,7 +23,6 @@
 /** Canonical GameKit module order — must match games-repo `GAME_KIT_MODULES`. */
 export const GAME_KIT_MODULES = [
   'input',
-  'motion',
   'collision',
   'world',
   'ai',

--- a/docs/games-repo.md
+++ b/docs/games-repo.md
@@ -107,9 +107,9 @@ Two remain, and they're simpler than before.
 by creator specs and player remix requests. It runs in the player's browser, so the existing
 invariant is unchanged and non-negotiable: `sandbox="allow-scripts allow-pointer-lock"` with **no
 `allow-same-origin`** (see [`security-model.md`](./security-model.md)). Serving games from a
-separate, cookieless origin remains the right call. The play iframe also sets
-`allow="accelerometer; gyroscope; magnetometer"` so opt-in GameKit `motion` (phone tilt) can
-receive sensors inside that opaque origin — tilt stays optional; keyboard / pad remain enough.
+separate, cookieless origin remains the right call. Phone tilt (`GameKit.createSensing`) is
+owned by the shell and relayed into the iframe over `gdp` — games never read
+DeviceOrientation themselves. Tilt stays optional; keyboard / pad remain enough.
 
 **2. Creator-submitted specs are untrusted input.** The app files them into our repo under our
 identity, which is content submission rather than compute-on-behalf — a much weaker concern


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tilt shipped via **`sensing`** (shell relay), not the earlier `motion` spike from #379.

Remove unused `motion` from `GAME_KIT_MODULES` + assemble-contract fixture so the serve contract matches the games tip. Paired with games-repo [#97](https://github.com/gamedevpl/www.gamedev.pl-games/pull/97) retargeting `tilt-marble` onto `sensing`.

Iframe `allow="accelerometer; …"` can stay (harmless); sensors for play are read on the parent origin by `apps/web/src/sensing.ts`.

## Test plan

- [x] `vitest` games-repo-contract + contract-check

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-071938f5-ea8c-4d88-8926-a304e51f7d60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-071938f5-ea8c-4d88-8926-a304e51f7d60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

