### PR TITLE
byoca(BY-11): gate hardening audit

### DIFF
--- a/apps/api/scripts/run-gate.ts
+++ b/apps/api/scripts/run-gate.ts
@@ -112,8 +112,16 @@ async function main(): Promise<void> {
         // it would otherwise pull is ~200 MB of capture media it will never read.
         const clone = await run('git', ['clone', '--depth', '1', '--branch', engineRef, url, dir], process.cwd());
         if (clone.code !== 0) throw new Error(`could not fetch harness at ${engineRef}`);
+        // Drop the PAT from the remote before any agent-authored tree runs: check:game
+        // executes under this harness, and `.git/config` would otherwise hand the token
+        // to anything that reads the remote URL (hostile-input invariant, BY-11).
+        const scrub = await run('git', ['remote', 'set-url', 'origin', `https://github.com/${repo}.git`], dir);
+        if (scrub.code !== 0) throw new Error('could not scrub harness git credentials');
         const install = await run('npm', ['ci', '--no-audit', '--no-fund'], dir);
         if (install.code !== 0) throw new Error('harness install failed');
+        // Same reason for the process env: spawn inherits it, and check:game must not.
+        delete process.env.GAMES_REPO_TOKEN;
+        delete process.env.GITHUB_TOKEN;
         return dir;
       },
     },

--- a/apps/api/src/gate-trigger.test.ts
+++ b/apps/api/src/gate-trigger.test.ts
@@ -95,6 +95,27 @@ describe('createCloudBuildGateTrigger', () => {
     expect(JSON.stringify(calls[0]!.body)).not.toContain('agent-tasks-token');
   });
 
+  it('runs as the least-privilege gate-runner SA with hard machine and time caps', async () => {
+    // Hostile sources inherit whatever the build SA can do. Default Cloud Build /
+    // Compute identities are too wide; caps live in the CONFIG we pin, not in the
+    // candidate (BY-11 / infra/gate-hardening.md).
+    const { impl, calls } = stubFetch();
+    const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
+
+    await trigger!({ slug: 'comet-courier', version: 'v1' });
+
+    const body = calls[0]!.body;
+    expect(body.serviceAccount).toBe(
+      'projects/gamedevpl/serviceAccounts/gate-runner@gamedevpl.iam.gserviceaccount.com',
+    );
+    expect(body.options).toMatchObject({
+      logging: 'CLOUD_LOGGING_ONLY',
+      machineType: 'E2_HIGHCPU_8',
+      diskSizeGb: 50,
+    });
+    expect(body.timeout).toBe('1800s');
+  });
+
   it('does not fail a delivery when the gate cannot be started', async () => {
     // The sources are already stored and the agent has finished. Answering it with an
     // error would make it upload everything again, storing a duplicate version of a

--- a/apps/api/src/gate-trigger.ts
+++ b/apps/api/src/gate-trigger.ts
@@ -34,6 +34,11 @@ export interface GateTriggerOptions {
   gamesRepo?: string;
   /** Secret Manager resource holding a contents:read PAT on the games repo. */
   gamesTokenSecret?: string;
+  /**
+   * Email of the least-privilege SA the build runs as (store write + github-token).
+   * Defaults to `gate-runner@${project}.iam.gserviceaccount.com`.
+   */
+  serviceAccountEmail?: string;
   fetchImpl?: typeof fetch;
   getAccessToken?: () => Promise<string>;
 }
@@ -56,6 +61,11 @@ const DEFAULTS = {
   gamesTokenSecret: 'github-token',
 };
 
+/** Hard caps — keep identical to `infra/cloudbuild-gate.yaml`. */
+const GATE_MACHINE_TYPE = 'E2_HIGHCPU_8';
+const GATE_DISK_SIZE_GB = 50;
+const GATE_TIMEOUT = '1800s';
+
 /**
  * The build the gate runs in.
  *
@@ -63,6 +73,10 @@ const DEFAULTS = {
  * version for when someone needs to check one candidate without going through delivery.
  * The reasoning behind the machine type, the timeout and the choice of credential is
  * documented there and applies identically here.
+ *
+ * Hostile-input invariant: submitted sources must never reshape this CONFIG. Slug and
+ * version are data for CLI args only; step images, SA, secrets, and caps stay pinned.
+ * See `infra/gate-hardening.md`.
  */
 function buildSpec(
   options: Required<Omit<GateTriggerOptions, 'fetchImpl' | 'getAccessToken'>>,
@@ -125,8 +139,14 @@ function buildSpec(
         },
       ],
     },
-    options: { logging: 'CLOUD_LOGGING_ONLY', machineType: 'E2_HIGHCPU_8' },
-    timeout: '3600s',
+    // Least-privilege identity — not the project default Cloud Build SA.
+    serviceAccount: `projects/${options.project}/serviceAccounts/${options.serviceAccountEmail}`,
+    options: {
+      logging: 'CLOUD_LOGGING_ONLY',
+      machineType: GATE_MACHINE_TYPE,
+      diskSizeGb: GATE_DISK_SIZE_GB,
+    },
+    timeout: GATE_TIMEOUT,
     // Searchable in the Cloud Build history: "show me every gate run for this game" —
     // and health runs carry their own tag so a fleet re-check reads as one, not as a
     // wave of failing acceptance gates.
@@ -164,6 +184,7 @@ export function createCloudBuildGateTrigger(
     platformRef: options.platformRef ?? DEFAULTS.platformRef,
     gamesRepo: options.gamesRepo ?? DEFAULTS.gamesRepo,
     gamesTokenSecret: options.gamesTokenSecret ?? DEFAULTS.gamesTokenSecret,
+    serviceAccountEmail: options.serviceAccountEmail ?? `gate-runner@${options.project}.iam.gserviceaccount.com`,
   };
 
   const fetchImpl = options.fetchImpl ?? fetch;
@@ -218,5 +239,8 @@ export function gateTriggerOptionsFromEnv(): GateTriggerOptions | null {
     ...(process.env.GATE_PLATFORM_REPO?.trim() ? { platformRepo: process.env.GATE_PLATFORM_REPO.trim() } : {}),
     ...(process.env.GATE_PLATFORM_REF?.trim() ? { platformRef: process.env.GATE_PLATFORM_REF.trim() } : {}),
     ...(process.env.GAMES_REPO?.trim() ? { gamesRepo: process.env.GAMES_REPO.trim() } : {}),
+    ...(process.env.GATE_SERVICE_ACCOUNT?.trim()
+      ? { serviceAccountEmail: process.env.GATE_SERVICE_ACCOUNT.trim() }
+      : {}),
   };
 }

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,19 +6,23 @@ Manual or local builds continue to be supported via `infra/deploy-api.sh`.
 
 No Terraform configuration is used or required for this repository.
 
+The upload quality gate (`cloudbuild-gate.yaml`, started by the API on delivery) treats
+candidate sources as hostile input. Inventory, caps, and owner follow-ups:
+[`gate-hardening.md`](./gate-hardening.md).
+
 ## Scripts
 
 All are idempotent and **owner-run** — they need `gcloud` authenticated against the
 project, which agent tooling can read but not write.
 
-| Script                | What it provisions                                                            | When to run                                                                                           |
-| --------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `setup-wif.sh`        | Workload Identity Federation for GitHub Actions                               | Once, before the first deploy                                                                         |
-| `setup-gcp.sh`        | Firestore, IAM, session secret, telemetry TTL, snapshot bucket                | Once, then after adding a resource it manages                                                         |
-| `setup-backups.sh`    | Firestore PITR + daily export to GCS, export SA and its IAM                   | Once. **Then drill the restore** — see `docs/runbooks/restore-firestore.md`                           |
-| `setup-monitoring.sh` | Per-service uptime check + A1/A2, project-wide A3/A4 and A6/A7, email channel | **Once per service** (`SERVICE=…`), per `ALERT_EMAIL`. Prints the manual step for A5 (billing budget) |
-| `deploy-api.sh`       | Manual deploy of the app service                                              | Rarely — CI deploys on merge to `master`                                                              |
-| `deploy-world.sh`     | Manual deploy of the zone host                                                | Rarely; inert unless `ZONE_HOST_URL` is set                                                           |
+| Script                | What it provisions                                                             | When to run                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `setup-wif.sh`        | Workload Identity Federation for GitHub Actions                                | Once, before the first deploy                                                                         |
+| `setup-gcp.sh`        | Firestore, IAM, session secret, telemetry TTL, snapshot bucket, gate-runner SA | Once, then after adding a resource it manages                                                         |
+| `setup-backups.sh`    | Firestore PITR + daily export to GCS, export SA and its IAM                    | Once. **Then drill the restore** — see `docs/runbooks/restore-firestore.md`                           |
+| `setup-monitoring.sh` | Per-service uptime check + A1/A2, project-wide A3/A4 and A6/A7, email channel  | **Once per service** (`SERVICE=…`), per `ALERT_EMAIL`. Prints the manual step for A5 (billing budget) |
+| `deploy-api.sh`       | Manual deploy of the app service                                               | Rarely — CI deploys on merge to `master`                                                              |
+| `deploy-world.sh`     | Manual deploy of the zone host                                                 | Rarely; inert unless `ZONE_HOST_URL` is set                                                           |
 
 Backups and alerting exist because neither Cloud Run nor Firestore provides them by
 default: without `setup-backups.sh` a wrong delete is unrecoverable, and without

--- a/infra/cloudbuild-gate.yaml
+++ b/infra/cloudbuild-gate.yaml
@@ -4,6 +4,26 @@
 # sources over the build channel, and nothing publishes until this run has passed against
 # them, using our engine and producing our artifacts.
 #
+# =============================================================================
+# HOSTILE-INPUT INVARIANT (BY-11)
+# -----------------------------------------------------------------------------
+# Submitted game sources are attacker-controlled. Anything reachable from a gate
+# run — this service account, every secretEnv value, the metadata server, network
+# egress, and writable paths under /workspace and /tmp — is considered reachable
+# by that attacker.
+#
+# Consequences enforced here and in apps/api/src/gate-trigger.ts (keep in step):
+#   - Build CONFIG is ours alone. Step images, entrypoints, apt packages, npm
+#     scripts, machine type, timeout, service account, and secret bindings are
+#     pinned in this file / the trigger. Slug and version are the only per-run
+#     inputs, and they appear only as single-quoted CLI args — never as step
+#     names, images, substitution keys that reshape the graph, or tsconfig.
+#   - Candidate files are data. The runner materializes them into a clean harness
+#     at our pinned engine ref and runs our check:game toolchain against them.
+#   - Minimal identity. The build runs as gate-runner@… (store write + one
+#     read-only games-repo PAT), not the project default Cloud Build SA.
+# =============================================================================
+#
 # Cloud Build rather than a Cloud Run job, for now, for one practical reason: the gate
 # needs a browser and ffmpeg to capture, and `cloud-builders` images already carry an
 # apt-capable Debian userland, so the toolchain is a package install rather than a second
@@ -13,11 +33,14 @@
 # Invoked with the slug and version of the candidate to check:
 #
 #   gcloud builds submit --no-source --config infra/cloudbuild-gate.yaml \
-#     --substitutions=_SLUG=comet-courier,_VERSION=v20260730T100000Z
+#     --substitutions=_SLUG=comet-courier,_VERSION=v20260730T100000Z \
+#     --service-account=projects/gamedevpl/serviceAccounts/gate-runner@gamedevpl.iam.gserviceaccount.com
 #
 # It exits non-zero on a red gate. That is a normal outcome for a build in progress — the
 # agent gets the report and another round — but it must be visible, because a gate whose
 # failures nobody notices is not a gate.
+#
+# Inventory and owner-console follow-ups: infra/gate-hardening.md
 substitutions:
   _SLUG: ''
   _VERSION: ''
@@ -28,6 +51,9 @@ substitutions:
   # ref the candidate was built against, which only the manifest knows.
   _PLATFORM_REPO: 'https://github.com/gamedevpl/www.gamedev.pl.git'
   _PLATFORM_REF: 'master'
+  # Dedicated least-privilege identity (created by infra/setup-gcp.sh). Must be the full
+  # resource name — Cloud Build rejects a bare email when serviceAccount is set in-config.
+  _GATE_SERVICE_ACCOUNT: 'projects/gamedevpl/serviceAccounts/gate-runner@gamedevpl.iam.gserviceaccount.com'
 steps:
   - id: checkout-platform
     name: gcr.io/cloud-builders/git
@@ -36,6 +62,9 @@ steps:
   - id: run-gate
     name: node:22
     entrypoint: bash
+    # Sole secret in this environment. Deliberately not session/OAuth/dispatch tokens —
+    # see availableSecrets. The runner drops GAMES_REPO_TOKEN from the process env (and
+    # strips it from the harness git remote) before check:game runs agent-authored code.
     secretEnv: ['GAMES_REPO_TOKEN']
     env:
       - 'GAMES_STORE_BUCKET=${_GAMES_STORE_BUCKET}'
@@ -74,12 +103,17 @@ availableSecrets:
     - versionName: projects/$PROJECT_ID/secrets/github-token/versions/latest
       env: 'GAMES_REPO_TOKEN'
 
+# Runs as gate-runner@… — not the project Cloud Build/Compute default SA. Required when
+# using a user-managed SA: logging must be CLOUD_LOGGING_ONLY (no GCS log bucket write).
+serviceAccount: '${_GATE_SERVICE_ACCOUNT}'
+
 options:
   logging: CLOUD_LOGGING_ONLY
-  # The capture step is the expensive one — it runs a real browser through a scripted
-  # play — so the gate gets a bigger machine than the image build does.
+  # Hard caps per run. Capture needs CPU; larger machine types and longer timeouts are
+  # refused by omission — raise only with a reviewed change to this file and gate-trigger.
   machineType: 'E2_HIGHCPU_8'
+  diskSizeGb: 50
 
 # A game that takes longer than this is not going to be rescued by waiting: the whole
-# check chain for one game is minutes, and an hour means something is wedged.
-timeout: '3600s'
+# check chain for one game is minutes. Half an hour is already generous for a wedged run.
+timeout: '1800s'

--- a/infra/gate-hardening.md
+++ b/infra/gate-hardening.md
@@ -1,0 +1,89 @@
+# Gate Cloud Build hardening (BY-11)
+
+Engineering inventory of what a quality-gate run can reach, what this repo pins in
+config, and which controls still need an owner-side GCP console (or `gcloud`) change.
+No product/strategy content — ops runbooks for non-engineering topics live elsewhere.
+
+Related config: [`cloudbuild-gate.yaml`](./cloudbuild-gate.yaml),
+[`setup-gcp.sh`](./setup-gcp.sh), [`apps/api/src/gate-trigger.ts`](../apps/api/src/gate-trigger.ts),
+[`apps/api/scripts/run-gate.ts`](../apps/api/scripts/run-gate.ts).
+
+## Invariant
+
+Submitted sources are **hostile input**. Anything a gate step can read, call, or write
+is treated as attacker-reachable. Build **CONFIG** (images, steps, SA, secrets, caps)
+is ours; candidate files are **data** materialized into our pinned harness only.
+
+## Inventory — what a run can reach
+
+| Surface                    | Before hardening                                                                                     | Intended after owner applies `setup-gcp.sh` + this config                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Service account**        | Unspecified → project Cloud Build / Compute default (often broad: Editor-class or runtime SA powers) | `gate-runner@PROJECT.iam.gserviceaccount.com` only                                                                                     |
+| **SA roles (intended)**    | n/a / ambient                                                                                        | Games-store object admin **on that bucket only**; `secretmanager.secretAccessor` **on `github-token` only**; `roles/logging.logWriter` |
+| **Secrets in step env**    | `GAMES_REPO_TOKEN` (`github-token`, contents:read)                                                   | Same sole secret; runner unsets it and scrubs the harness `git` remote **before** `check:game`                                         |
+| **Metadata server**        | GCE metadata credentials for the build SA                                                            | Same mechanism; blast radius limited by the gate SA’s IAM                                                                              |
+| **Network egress**         | Default Cloud Build pool: unrestricted egress                                                        | Still unrestricted until owner adds a private pool / VPC egress policy (below)                                                         |
+| **Writable paths**         | `/workspace`, `/tmp`, container root FS                                                              | Unchanged (ephemeral VM); no durable write except via games-store API                                                                  |
+| **Source of build CONFIG** | This YAML + inline `gate-trigger` spec                                                               | Unchanged — slug/version are CLI data only                                                                                             |
+| **Timeout / machine**      | `3600s`, `E2_HIGHCPU_8`, default disk                                                                | `1800s`, `E2_HIGHCPU_8`, `diskSizeGb: 50`                                                                                              |
+
+### Egress the run actually needs
+
+Allow-list target if/when a private worker pool or VPC-SC perimeter is applied:
+
+1. **GitHub** (`github.com`) — shallow clone of the platform repo (public) and the games-repo harness (PAT).
+2. **npm** (`registry.npmjs.org` and the registry’s CDN hosts) — `npm ci` for platform + harness.
+3. **Debian apt** mirrors used by `node:22` — `ffmpeg`, `chromium`, `git`, `ca-certificates`.
+4. **GCS JSON API** (`storage.googleapis.com`) — read candidate sources; write manifest / derived artifacts.
+5. **Secret Manager** — fetched by Cloud Build into `secretEnv` before steps (not by game code).
+6. **Container image pulls** — `gcr.io/cloud-builders/git`, `node:22` (Cloud Build infrastructure).
+
+No other Google APIs, no Firestore, no Cloud Run admin, no Artifact Registry push, no
+ability to start further builds should be granted to `gate-runner`.
+
+### Writable / durable paths
+
+- Ephemeral: `/workspace/platform`, harness under `$TMPDIR/gate-harness-*`, apt/npm caches.
+- Durable (via SA): objects under `gs://$GAMES_STORE_BUCKET/…` for the candidate version
+  (manifest gate/health fields, `bundle.html` / `preview.html`, capture media).
+
+## What this PR tightens in config
+
+1. **Invariant comment block** in `cloudbuild-gate.yaml` (and matching notes in the trigger).
+2. **Pinned `serviceAccount`** to `gate-runner@…` in YAML and `gate-trigger.ts`.
+3. **Hard caps**: timeout `1800s`, `machineType: E2_HIGHCPU_8`, `diskSizeGb: 50`.
+4. **Sole secret** remains `github-token` → `GAMES_REPO_TOKEN`; no other `secretEnv`.
+5. **`setup-gcp.sh`** creates `gate-runner` and binds the least-privilege roles above;
+   grants the Cloud Run runtime SA `roles/iam.serviceAccountUser` **on that SA** so
+   delivery can `actAs` it when submitting builds.
+6. **`run-gate.ts`**: after harness fetch/install, strip token from env and `git remote`
+   so `check:game` (agent-authored tree) does not inherit the PAT.
+
+## Owner console / `gcloud` actions (not done by merge alone)
+
+These require project credentials. Re-run or perform after merging:
+
+1. **Apply SA + IAM** — `./infra/setup-gcp.sh` (or the gate-runner block alone). Until this
+   exists, builds that set `serviceAccount: gate-runner@…` will fail to start.
+2. **Confirm default Cloud Build SA is not still Editor** — historically
+   `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` received broad project roles. Gate
+   builds must not rely on it; audit and remove excess roles if present
+   (`gcloud projects get-iam-policy`).
+3. **Confirm `github-token` is contents:read only** on `gamedevpl/www.gamedev.pl-games`
+   (and not a dispatch / workflow PAT). Rotate if scope is wider than clone.
+4. **Egress restriction (recommended, console/Terraform-or-gcloud)** — Cloud Build YAML
+   cannot allow-list destinations. Owner options:
+   - Private worker pool attached to a VPC with egress firewall / Cloud NAT allow-list
+     matching the destinations above; or
+   - VPC Service Controls perimeter around the project with appropriate egress rules.
+     Until then, treat open egress as accepted residual risk bounded by the gate SA.
+5. **Optional: drop project-wide `roles/iam.serviceAccountUser` on the runtime SA** if it
+   was granted only so Cloud Build could run as arbitrary SAs — prefer the
+   per-SA binding `setup-gcp.sh` adds on `gate-runner` only.
+
+## Out of scope / unchanged
+
+- Game iframe sandbox (`allow-scripts allow-pointer-lock`, no `allow-same-origin`) — not
+  touched; browser publish path is a different trust boundary
+  ([`docs/security-model.md`](../docs/security-model.md)).
+- No secrets or tokens are committed in this change.

--- a/infra/gate-hardening.md
+++ b/infra/gate-hardening.md
@@ -19,7 +19,7 @@ is ours; candidate files are **data** materialized into our pinned harness only.
 | Surface                    | Before hardening                                                                                     | Intended after owner applies `setup-gcp.sh` + this config                                                                              |
 | -------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | **Service account**        | Unspecified → project Cloud Build / Compute default (often broad: Editor-class or runtime SA powers) | `gate-runner@PROJECT.iam.gserviceaccount.com` only                                                                                     |
-| **SA roles (intended)**    | n/a / ambient                                                                                        | Games-store object admin **on that bucket only**; `secretmanager.secretAccessor` **on `github-token` only**; `roles/logging.logWriter` |
+| **SA roles (intended)**    | n/a / ambient                                                                                        | Games-store `roles/storage.objectAdmin` **on that bucket only** (includes delete — see below); `secretmanager.secretAccessor` **on `github-token` only**; `roles/logging.logWriter` |
 | **Secrets in step env**    | `GAMES_REPO_TOKEN` (`github-token`, contents:read)                                                   | Same sole secret; runner unsets it and scrubs the harness `git` remote **before** `check:game`                                         |
 | **Metadata server**        | GCE metadata credentials for the build SA                                                            | Same mechanism; blast radius limited by the gate SA’s IAM                                                                              |
 | **Network egress**         | Default Cloud Build pool: unrestricted egress                                                        | Still unrestricted until owner adds a private pool / VPC egress policy (below)                                                         |
@@ -45,7 +45,41 @@ ability to start further builds should be granted to `gate-runner`.
 
 - Ephemeral: `/workspace/platform`, harness under `$TMPDIR/gate-harness-*`, apt/npm caches.
 - Durable (via SA): objects under `gs://$GAMES_STORE_BUCKET/…` for the candidate version
-  (manifest gate/health fields, `bundle.html` / `preview.html`, capture media).
+  (manifest gate/health fields, `bundle.html` / `preview.html`, capture media). The SA
+  role that enables those writes is `objectAdmin`, which also permits **delete/overwrite
+  of every object in the bucket** — see “Store IAM: why objectAdmin” below.
+
+
+## Store IAM: why `objectAdmin` (delete on every stored game)
+
+The brief asks for “store write only.” The gate SA is granted
+`roles/storage.objectAdmin` on the games-store bucket instead. That role includes
+**delete** on every object in the bucket — including published games — and it is held by
+the identity that executes hostile candidate code by design. This is not sloppiness: it
+is forced by the current write pattern.
+
+`putGateResult` / `putHealthResult` update each candidate version’s **manifest in place**.
+GCS has no IAM role that permits overwrite-without-delete (a replace is implementationally
+a delete + create of the same name). `roles/storage.objectCreator` + `objectViewer` cannot
+perform that update, so the gate cannot record a verdict without `objectAdmin` (or an
+equally powerful custom role with `storage.objects.delete`).
+
+Accepted residual risk until a compensating control lands: a compromised gate run can
+delete or overwrite any store object the SA can name, not merely “create namespaced
+immutable objects.”
+
+### Compensating controls (owner console — required follow-up)
+
+Add these to the post-merge owner list (not done by merging this PR):
+
+1. **Enable object versioning and/or soft-delete retention** on `GAMES_STORE_BUCKET`, so
+   a hostile (or buggy) gate run’s deletions/overwrites remain recoverable for a defined
+   retention window. Prefer both if cost allows: versioning for overwrite recovery,
+   soft-delete for explicit deletes.
+2. **Longer-term (record, do not block):** route verdict/manifest writes through the API’s
+   own runtime identity (or a narrow “manifest writer” SA the gate calls via an internal
+   endpoint), so the Cloud Build gate SA can drop to `objectCreator` + `objectViewer` and
+   lose bucket-wide delete.
 
 ## What this PR tightens in config
 
@@ -80,6 +114,11 @@ These require project credentials. Re-run or perform after merging:
 5. **Optional: drop project-wide `roles/iam.serviceAccountUser` on the runtime SA** if it
    was granted only so Cloud Build could run as arbitrary SAs — prefer the
    per-SA binding `setup-gcp.sh` adds on `gate-runner` only.
+6. **Bucket versioning / soft-delete on the games store** — compensating control for
+   `gate-runner`’s `objectAdmin` (see “Store IAM: why objectAdmin” above). Enable before
+   or immediately after flipping production builds onto `gate-runner`.
+7. **Optional longer-term:** move manifest/verdict writes off the gate SA so it can drop
+   to `objectCreator`+`objectViewer` (API-mediated writes).
 
 ## Out of scope / unchanged
 

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -273,6 +273,9 @@ else
     --project="$PROJECT_ID"
 fi
 
+# objectAdmin (includes delete) is forced by in-place manifest updates — see
+# infra/gate-hardening.md "Store IAM: why objectAdmin". Compensate with bucket
+# versioning / soft-delete (owner console).
 gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${GATE_SA_EMAIL}" \
   --role="roles/storage.objectAdmin" \

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -238,7 +238,7 @@ fi
 # version. It gets objectCreator + objectViewer rather than objectAdmin — create and read
 # but never delete — so a compromised runtime cannot destroy stored games, and the
 # immutable version ids mean it has no existing path worth overwriting anyway. The
-# deployer keeps objectAdmin because the bake and the gate also prune and rewrite.
+# deployer keeps objectAdmin for the bake; the gate writes through its own SA (below).
 gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${DEPLOYER_SA}" \
   --role="roles/storage.objectAdmin" \
@@ -258,23 +258,65 @@ done
 # games — versioned history is the rollback path and the creator's own record of work.
 echo "    IAM applied (deployer: admin, Cloud Run: read+create). No lifecycle: these are originals."
 
+# Dedicated identity for gate Cloud Build runs (cloudbuild-gate.yaml / gate-trigger.ts).
+# Submitted sources are hostile: the build must not inherit the project default Cloud
+# Build or Compute SA. Store write on this bucket + read of github-token + logWriter
+# only — see infra/gate-hardening.md.
+GATE_SA_NAME="${GATE_SA_NAME:-gate-runner}"
+GATE_SA_EMAIL="${GATE_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+echo "==> Ensuring gate-runner service account ${GATE_SA_EMAIL}"
+if gcloud iam service-accounts describe "$GATE_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    Service account already exists."
+else
+  gcloud iam service-accounts create "$GATE_SA_NAME" \
+    --display-name="Games quality gate runner" \
+    --project="$PROJECT_ID"
+fi
+
+gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
+  --member="serviceAccount:${GATE_SA_EMAIL}" \
+  --role="roles/storage.objectAdmin" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${GATE_SA_EMAIL}" \
+  --role="roles/logging.logWriter" \
+  --condition=None \
+  >/dev/null
+
+# Narrow accessor on the one secret the gate may hold — not a project-wide secretAccessor.
+if gcloud secrets describe github-token --project="$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud secrets add-iam-policy-binding github-token \
+    --member="serviceAccount:${GATE_SA_EMAIL}" \
+    --role="roles/secretmanager.secretAccessor" \
+    --project="$PROJECT_ID" \
+    >/dev/null
+  echo "    gate-runner may read secret github-token."
+else
+  echo "    WARN: secret github-token missing — create it before gate runs can clone the harness."
+fi
+
 # The runtime starts the gate itself when a game is delivered (gate-trigger.ts). Without
 # this a candidate is stored and never verified, so it can never publish and the upload
 # path ends in a queue nobody drains.
 #
 # builds.editor rather than a narrower role because submitting a build is what it does;
-# there is no "submit only" role. serviceAccountUser is the second half: Cloud Build runs
-# as a service account, and starting a build means acting as one.
-echo "==> Letting the runtime start gate builds"
-for role in roles/cloudbuild.builds.editor roles/iam.serviceAccountUser; do
-  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-    --member="serviceAccount:${RUN_SA}" \
-    --role="$role" \
-    --condition=None \
-    >/dev/null
-done
+# there is no "submit only" role. actAs is scoped to gate-runner (not project-wide
+# serviceAccountUser) so the runtime cannot launch builds as arbitrary identities.
+echo "==> Letting the runtime start gate builds as ${GATE_SA_EMAIL}"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${RUN_SA}" \
+  --role="roles/cloudbuild.builds.editor" \
+  --condition=None \
+  >/dev/null
+gcloud iam service-accounts add-iam-policy-binding "$GATE_SA_EMAIL" \
+  --member="serviceAccount:${RUN_SA}" \
+  --role="roles/iam.serviceAccountUser" \
+  --project="$PROJECT_ID" \
+  >/dev/null
 gcloud services enable cloudbuild.googleapis.com --project="$PROJECT_ID" >/dev/null
-echo "    Cloud Run may submit gate builds."
+echo "    Cloud Run may submit gate builds as gate-runner."
 
 echo ""
-echo "==> Done. Firestore database, snapshot bucket, IAM roles (datastore.user, aiplatform.user), session-secret, telemetry TTL, and the scorecards read index configured for project ${PROJECT_ID}."
+echo "==> Done. Firestore database, snapshot bucket, IAM roles (datastore.user, aiplatform.user), session-secret, telemetry TTL, scorecards read index, and gate-runner SA configured for project ${PROJECT_ID}."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Audit and harden the game gate Cloud Build path under the assumption that submitted sources are hostile input.

## Changes
- Hostile-input invariant comment block in `infra/cloudbuild-gate.yaml`
- Inventory + hardening note: `infra/gate-hardening.md`
- Pin gate builds to dedicated `gate-runner` service account (YAML + trigger wiring)
- Caps: timeout / machine type / disk documented and set
- PAT scrub before `check:game`; slug/version treated as data only
- Tests updated for gate-trigger SA wiring

## Doc amendment (`bb468317`)
Documents that `gate-runner` gets `objectAdmin` (includes **delete** on every stored game) because in-place manifest updates have no overwrite-without-delete IAM role in GCS. Adds compensating owner-console controls:
1. Enable object versioning and/or soft-delete retention on the store bucket
2. Longer-term: route verdict writes through the API identity so the gate SA can drop to `objectCreator`+`objectViewer`

## Owner console actions (post-merge)
1. Run `./infra/setup-gcp.sh` so `gate-runner` exists
2. Audit/strip Editor-class roles on the default Cloud Build SA
3. Confirm `github-token` is contents:read only
4. Egress allow-list (private pool/VPC or VPC-SC)
5. Optional: drop project-wide `roles/iam.serviceAccountUser` on the runtime SA
6. **Bucket versioning / soft-delete** (compensating for objectAdmin)
7. Optional longer-term: API-mediated manifest writes

## Review
Addresses Claude Fable 5 required doc amendment before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

