### PR TITLE
byoca(BY-01): round-bound agent channel tokens

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -241,10 +241,9 @@ describe('agent build channel', () => {
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
   });
 
-  it('tells an agent to stop when the operator canceled the job', async () => {
-    // This is the whole mechanism behind `agentBackend.cancel` on the Copilot backend:
-    // there is no kill endpoint, so cancellation is the job being terminal here — the
-    // live session learns on its next report, and its writes stop landing.
+  it('rejects the pre-cancel token after operator cancel bumps the round generation', async () => {
+    // Cancel closes the round (generation bump). The agent's held key is then stale;
+    // the 401 fresh-prompt body is the stop signal — no terminal-job exception.
     const store = new InMemoryStore();
     await seedSubmission(store);
     await store.recordJobTransition(ISSUE, {
@@ -253,21 +252,18 @@ describe('agent build channel', () => {
       by: 'operator',
       reason: 'operator_canceled',
     });
+    expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(2);
     app = await createApp(store);
 
     const response = await app.inject({
       method: 'POST',
       url: '/api/agent/build/progress',
-      headers: agentHeaders(),
+      headers: agentHeaders(ISSUE, 1),
       payload: { text: 'Still building away.' },
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.json()).toMatchObject({
-      accepted: false,
-      rejected: 'stopped',
-      control: { stop: true, reason: 'canceled' },
-    });
+    expect(response.statusCode).toBe(401);
+    expect(response.json().error).toBe(STALE_AGENT_TOKEN_REASON);
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
   });
 
@@ -326,6 +322,47 @@ describe('agent build channel', () => {
     });
     expect(expiredRes.statusCode).toBe(401);
     expect(expiredRes.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('rejects stale and expired tokens on terminal jobs with a strict 401 (no stopReason bypass)', async () => {
+    // Regression for the rejected resolveBuild exception: publishedAt is permanent, so
+    // letting a signature-valid stale/expired key through on stopReason would grant
+    // indefinite source/inbox reads and unguarded inbox/ack writes.
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionPublishedAt(ISSUE, '2026-07-31T12:00:00.000Z');
+    // Leave roundGeneration at 1 so a gen-99 key is clearly stale, not merely "closed".
+    app = await createApp(store);
+
+    const staleHeaders = agentHeaders(ISSUE, 99);
+    for (const req of [
+      { method: 'GET' as const, url: '/api/agent/build/sources' },
+      { method: 'GET' as const, url: '/api/agent/build/inbox' },
+      { method: 'POST' as const, url: '/api/agent/build/inbox/ack', payload: { ids: ['m1'] } },
+      { method: 'POST' as const, url: '/api/agent/build/progress', payload: { text: 'hello' } },
+    ]) {
+      const res = await app.inject({
+        method: req.method,
+        url: req.url,
+        headers: staleHeaders,
+        ...(req.payload ? { payload: req.payload } : {}),
+      });
+      expect(res.statusCode, req.url).toBe(401);
+      expect(res.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+    }
+
+    const expired = mintAgentToken(ISSUE, secret, {
+      roundGeneration: 1,
+      now: Date.now() - 20 * 24 * 60 * 60 * 1000,
+      ttlDays: 14,
+    });
+    const expiredSources = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/sources',
+      headers: { authorization: `Bearer ${expired}` },
+    });
+    expect(expiredSources.statusCode).toBe(401);
+    expect(expiredSources.json().error).toBe(STALE_AGENT_TOKEN_REASON);
   });
 
   it('still accepts a legacy token on a job that has never closed a round under the new model', async () => {

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import { mintAgentToken } from './agent-token.js';
+import { mintAgentToken, mintLegacyAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
@@ -65,8 +65,10 @@ async function seedSubmission(store: InMemoryStore, issueNumber = ISSUE) {
   await store.setSubmissionLocale(issueNumber, 'pl');
 }
 
-function agentHeaders(issueNumber = ISSUE) {
-  return { authorization: `Bearer ${mintAgentToken(issueNumber, secret)}` };
+function agentHeaders(issueNumber = ISSUE, roundGeneration = 1) {
+  return {
+    authorization: `Bearer ${mintAgentToken(issueNumber, secret, { roundGeneration })}`,
+  };
 }
 
 describe('agent build channel', () => {
@@ -295,6 +297,72 @@ describe('agent build channel', () => {
       payload,
     });
     expect(wrongScope.statusCode).toBe(401);
+  });
+
+  it('rejects a stale-generation or expired token with the fresh-prompt reason', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    const stale = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(ISSUE, 99),
+      payload: { text: 'hello' },
+    });
+    expect(stale.statusCode).toBe(401);
+    expect(stale.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+
+    const expired = mintAgentToken(ISSUE, secret, {
+      roundGeneration: 1,
+      now: Date.now() - 20 * 24 * 60 * 60 * 1000,
+      ttlDays: 14,
+    });
+    const expiredRes = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: { authorization: `Bearer ${expired}` },
+      payload: { text: 'hello' },
+    });
+    expect(expiredRes.statusCode).toBe(401);
+    expect(expiredRes.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('still accepts a legacy token on a job that has never closed a round under the new model', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    // Simulate a pre-migration record: strip the generation new creates stamp.
+    const legacy = await store.getSubmission(ISSUE);
+    const submissions = (store as unknown as { submissions: Map<number, import('./store.js').SubmissionRecord> })
+      .submissions;
+    submissions.set(ISSUE, { ...legacy!, roundGeneration: undefined });
+
+    app = await createApp(store);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: { authorization: `Bearer ${mintLegacyAgentToken(ISSUE, secret)}` },
+      payload: { kind: 'step', step: 'mechanics', text: 'Still the same round.' },
+    });
+    expect(response.statusCode).toBe(200);
+
+    // Closing the round initializes generation; the legacy token must not revive.
+    await store.recordJobTransition(ISSUE, {
+      to: 'ready_for_review',
+      at: '2026-07-31T12:00:00.000Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(1);
+
+    const afterClose = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: { authorization: `Bearer ${mintLegacyAgentToken(ISSUE, secret)}` },
+      payload: { text: 'too late' },
+    });
+    expect(afterClose.statusCode).toBe(401);
+    expect(afterClose.json().error).toBe(STALE_AGENT_TOKEN_REASON);
   });
 
   it('refuses a token for a build that does not exist', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -290,15 +290,14 @@ export async function registerAgentChannelRoutes(
       assertAgentTokenActive(claims, record, now());
     } catch (error) {
       if (!(error instanceof InvalidAgentTokenError)) throw error;
-      // Closing a round bumps the generation so the capability dies — but a connected
-      // agent still has to hear `control.stop` once. A cryptographically valid token
-      // for this job is enough to learn the job is over; every write path below still
-      // refuses on `stopReason`. An expired or stale key on a live round keeps the
-      // fresh-prompt answer.
-      if (!stopReason(record)) {
-        reply.status(401).send({ error: error.message || 'invalid build token' });
-        return null;
-      }
+      // Stale/expired tokens are a strict 401 in every case — including terminal jobs.
+      // `publishedAt` (and other stop reasons) are permanent; letting a signature-valid
+      // but generation-stale or expired key through would grant indefinite read of
+      // sources/inbox plus unguarded inbox/ack writes. The 401 body already is the
+      // stop signal ("this build is finished — get a fresh prompt…"). Terminal-receipt
+      // reads for a closed round's own gate verdict belong to BY-05/BY-06, not here.
+      reply.status(401).send({ error: error.message || 'invalid build token' });
+      return null;
     }
 
     return { issueNumber, record };

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { InvalidAgentTokenError, readBearerToken, verifyAgentToken } from './agent-token.js';
+import { assertAgentTokenActive, InvalidAgentTokenError, readBearerToken, verifyAgentToken } from './agent-token.js';
 import { InvalidUploadError, type GamesStore } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState } from './job-state.js';
@@ -268,21 +268,37 @@ export async function registerAgentChannelRoutes(
       return null;
     }
 
-    let issueNumber: number;
+    let claims;
     try {
-      issueNumber = verifyAgentToken(token, agentTokenSecret);
+      claims = verifyAgentToken(token, agentTokenSecret);
     } catch (error) {
       if (error instanceof InvalidAgentTokenError) {
-        reply.status(401).send({ error: 'invalid build token' });
+        reply.status(401).send({ error: error.message || 'invalid build token' });
         return null;
       }
       throw error;
     }
 
+    const issueNumber = claims.jobId;
     const record = await store.getSubmission(issueNumber);
     if (!record) {
       reply.status(404).send({ error: 'unknown build' });
       return null;
+    }
+
+    try {
+      assertAgentTokenActive(claims, record, now());
+    } catch (error) {
+      if (!(error instanceof InvalidAgentTokenError)) throw error;
+      // Closing a round bumps the generation so the capability dies — but a connected
+      // agent still has to hear `control.stop` once. A cryptographically valid token
+      // for this job is enough to learn the job is over; every write path below still
+      // refuses on `stopReason`. An expired or stale key on a live round keeps the
+      // fresh-prompt answer.
+      if (!stopReason(record)) {
+        reply.status(401).send({ error: error.message || 'invalid build token' });
+        return null;
+      }
     }
 
     return { issueNumber, record };

--- a/apps/api/src/agent-token.test.ts
+++ b/apps/api/src/agent-token.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertAgentTokenActive,
+  DEFAULT_SELF_BUILD_KEY_TTL_DAYS,
+  InvalidAgentTokenError,
+  mintAgentToken,
+  mintLegacyAgentToken,
+  selfBuildKeyTtlDays,
+  STALE_AGENT_TOKEN_REASON,
+  verifyAgentToken,
+} from './agent-token.js';
+
+describe('agent build-channel token', () => {
+  const secret = 'super-secret-key';
+  const now = Date.parse('2026-07-31T12:00:00.000Z');
+
+  afterEach(() => {
+    delete process.env.SELF_BUILD_KEY_TTL_DAYS;
+    delete process.env.SELF_BUILD_CONNECT_DAYS;
+  });
+
+  it('mints and verifies a round-scoped token', () => {
+    const token = mintAgentToken(42, secret, { roundGeneration: 1, now, ttlDays: 14 });
+    expect(verifyAgentToken(token, secret)).toEqual({
+      jobId: 42,
+      roundGeneration: 1,
+      exp: Math.floor(now / 1000) + 14 * 24 * 60 * 60,
+    });
+  });
+
+  it('accepts an active generation before expiry', () => {
+    const token = mintAgentToken(7, secret, { roundGeneration: 3, now, ttlDays: 14 });
+    const claims = verifyAgentToken(token, secret);
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 3 }, now)).not.toThrow();
+  });
+
+  it('rejects a stale generation with the fresh-prompt reason', () => {
+    const token = mintAgentToken(7, secret, { roundGeneration: 2, now, ttlDays: 14 });
+    const claims = verifyAgentToken(token, secret);
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 3 }, now)).toThrow(InvalidAgentTokenError);
+    try {
+      assertAgentTokenActive(claims, { roundGeneration: 3 }, now);
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidAgentTokenError);
+      expect((error as Error).message).toBe(STALE_AGENT_TOKEN_REASON);
+    }
+  });
+
+  it('rejects an expired key the same way as a stale generation', () => {
+    const token = mintAgentToken(7, secret, { roundGeneration: 1, now, ttlDays: 14 });
+    const claims = verifyAgentToken(token, secret);
+    const afterExpiry = now + 15 * 24 * 60 * 60 * 1000;
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 1 }, afterExpiry)).toThrowError(
+      STALE_AGENT_TOKEN_REASON,
+    );
+  });
+
+  it('regenerating a prompt mints a fresh exp without requiring a new generation', () => {
+    const first = mintAgentToken(9, secret, { roundGeneration: 4, now, ttlDays: 14 });
+    const later = now + 60_000;
+    const second = mintAgentToken(9, secret, { roundGeneration: 4, now: later, ttlDays: 14 });
+    const a = verifyAgentToken(first, secret);
+    const b = verifyAgentToken(second, secret);
+    expect(a.roundGeneration).toBe(b.roundGeneration);
+    expect(b.exp).toBeGreaterThan(a.exp!);
+    expect(() => assertAgentTokenActive(b, { roundGeneration: 4 }, later)).not.toThrow();
+  });
+
+  it('accepts a legacy token only while the job has no generation field', () => {
+    const token = mintLegacyAgentToken(11, secret);
+    const claims = verifyAgentToken(token, secret);
+    expect(claims).toEqual({ jobId: 11 });
+    expect(() => assertAgentTokenActive(claims, {}, now)).not.toThrow();
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 1 }, now)).toThrowError(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('rejects tampered claims', () => {
+    const token = mintAgentToken(5, secret, { roundGeneration: 1, now, ttlDays: 14 });
+    const decoded = Buffer.from(token, 'base64url').toString('utf8');
+    const [jobId, generation, exp, signature] = decoded.split('.');
+    const tamperedGeneration = Buffer.from(`${jobId}.${Number(generation) + 1}.${exp}.${signature}`, 'utf8').toString(
+      'base64url',
+    );
+    const tamperedExp = Buffer.from(`${jobId}.${generation}.${Number(exp) + 1}.${signature}`, 'utf8').toString(
+      'base64url',
+    );
+    const tamperedSig = Buffer.from(`${jobId}.${generation}.${exp}.${signature.slice(0, -1)}0`, 'utf8').toString(
+      'base64url',
+    );
+    expect(() => verifyAgentToken(tamperedGeneration, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyAgentToken(tamperedExp, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyAgentToken(tamperedSig, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyAgentToken('not-a-token', secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('defaults the TTL to 14 days and never exceeds the no-connect window', () => {
+    expect(selfBuildKeyTtlDays()).toBe(DEFAULT_SELF_BUILD_KEY_TTL_DAYS);
+    process.env.SELF_BUILD_KEY_TTL_DAYS = '30';
+    process.env.SELF_BUILD_CONNECT_DAYS = '14';
+    expect(selfBuildKeyTtlDays()).toBe(14);
+  });
+});

--- a/apps/api/src/agent-token.ts
+++ b/apps/api/src/agent-token.ts
@@ -5,16 +5,22 @@ export { readBearerToken } from './bearer.js';
 /**
  * Build-channel tokens (docs/agent-live-channel-plan.md §1).
  *
- * The coding agent needs to authenticate to our API from inside GitHub's sandbox.
- * Rather than distributing a shared secret into that environment, each build gets
- * its own capability token, minted from the issue number and handed to the agent in
- * the issue body it was assigned.
+ * The coding agent needs to authenticate to our API from inside its sandbox. Rather
+ * than distributing a shared secret into that environment, each build round gets its
+ * own capability token, minted from the job id and the round's generation, and handed
+ * to the agent in the brief it was assigned.
  *
  * It is deliberately scoped: the HMAC covers a scope string, so a build token and a
- * submission token for the same issue are different values even though both are keyed
+ * submission token for the same job are different values even though both are keyed
  * off SUBMISSION_TOKEN_SECRET. One can never be forged from — or mistaken for — the
  * other, which matters because the submission token can spend quota and stop a build
  * while this one may only talk about it.
+ *
+ * Round-scoped tokens also carry a generation and an expiry. Closing a round bumps the
+ * generation on the job document, so a copied token from an earlier round stops
+ * validating without a revocation list. The expiry is the backstop for a round that
+ * stalls after an agent connected: regenerating a prompt mints a fresh key with a new
+ * `exp` without touching the generation.
  */
 
 export class InvalidAgentTokenError extends Error {
@@ -26,44 +32,187 @@ export class InvalidAgentTokenError extends Error {
 
 const SCOPE = 'agent-channel-v1';
 
-function signIssueNumber(issueNumber: number, secret: string): string {
-  return createHmac('sha256', secret).update(`${SCOPE}:${issueNumber}`).digest('hex');
+/** Default lifetime for a round-scoped build key, in days. */
+export const DEFAULT_SELF_BUILD_KEY_TTL_DAYS = 14;
+
+/**
+ * The message every stale or expired build key answers with. Same wording whether the
+ * generation moved on or the clock did — the creator's fix is always "copy the current
+ * prompt from the Studio thread".
+ */
+export const STALE_AGENT_TOKEN_REASON = 'this build is finished — get a fresh prompt from your Studio thread';
+
+export interface AgentTokenClaims {
+  jobId: number;
+  /**
+   * Present on round-scoped tokens. Absent on the legacy jobId-only shape, which is
+   * still accepted for jobs that have never closed a round under the new model.
+   */
+  roundGeneration?: number;
+  /** Unix seconds. Present with {@link roundGeneration}. */
+  exp?: number;
 }
 
-export function mintAgentToken(issueNumber: number, secret: string): string {
-  return Buffer.from(`${issueNumber}.${signIssueNumber(issueNumber, secret)}`, 'utf8').toString('base64url');
+export interface MintAgentTokenOptions {
+  roundGeneration: number;
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+  /** Override {@link selfBuildKeyTtlDays}; useful in tests. */
+  ttlDays?: number;
 }
 
-export function verifyAgentToken(token: string, secret: string): number {
+/**
+ * Round-key lifetime. Reads `SELF_BUILD_KEY_TTL_DAYS` (default 14) and, when the
+ * no-connect window is configured, never exceeds it — a key that outlived the
+ * auto-abandon would contradict the promise that the round is over.
+ */
+export function selfBuildKeyTtlDays(): number {
+  const parsed = Number(process.env.SELF_BUILD_KEY_TTL_DAYS ?? DEFAULT_SELF_BUILD_KEY_TTL_DAYS);
+  const ttl = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_SELF_BUILD_KEY_TTL_DAYS;
+  const connectParsed = Number(process.env.SELF_BUILD_CONNECT_DAYS);
+  if (Number.isFinite(connectParsed) && connectParsed > 0) {
+    return Math.min(ttl, Math.floor(connectParsed));
+  }
+  return ttl;
+}
+
+function signLegacy(jobId: number, secret: string): string {
+  return createHmac('sha256', secret).update(`${SCOPE}:${jobId}`).digest('hex');
+}
+
+function signRoundScoped(jobId: number, roundGeneration: number, exp: number, secret: string): string {
+  return createHmac('sha256', secret).update(`${SCOPE}:${jobId}:${roundGeneration}:${exp}`).digest('hex');
+}
+
+function safeEqualHex(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+/**
+ * Mints a round-scoped build-channel token.
+ *
+ * The signature covers `(scope, jobId, roundGeneration, exp)`. Callers that only need
+ * a fresh `exp` for the same round (regenerating a Studio prompt) pass the current
+ * generation unchanged.
+ */
+export function mintAgentToken(jobId: number, secret: string, options: MintAgentTokenOptions): string {
+  if (!Number.isSafeInteger(jobId) || jobId <= 0) {
+    throw new InvalidAgentTokenError('invalid job id');
+  }
+  if (!Number.isSafeInteger(options.roundGeneration) || options.roundGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid round generation');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlDays = options.ttlDays ?? selfBuildKeyTtlDays();
+  const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
+  const signature = signRoundScoped(jobId, options.roundGeneration, exp, secret);
+  return Buffer.from(`${jobId}.${options.roundGeneration}.${exp}.${signature}`, 'utf8').toString('base64url');
+}
+
+/**
+ * Legacy mint: HMAC over `(scope, jobId)` only. Kept for tests that need to synthesize
+ * a pre-migration token; production minting always goes through {@link mintAgentToken}.
+ */
+export function mintLegacyAgentToken(jobId: number, secret: string): string {
+  return Buffer.from(`${jobId}.${signLegacy(jobId, secret)}`, 'utf8').toString('base64url');
+}
+
+/**
+ * Verifies the HMAC and returns the claims. Does **not** check generation against the
+ * job document or expiry against the clock — {@link assertAgentTokenActive} does that
+ * once the record is loaded.
+ */
+export function verifyAgentToken(token: string, secret: string): AgentTokenClaims {
   try {
     const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
-    if (parts.length !== 2) {
-      throw new InvalidAgentTokenError();
+
+    if (parts.length === 2) {
+      const [jobIdRaw, signature] = parts;
+      if (!jobIdRaw || !signature || !/^\d+$/.test(jobIdRaw) || !/^[a-f0-9]{64}$/i.test(signature)) {
+        throw new InvalidAgentTokenError();
+      }
+      const jobId = Number.parseInt(jobIdRaw, 10);
+      if (!Number.isSafeInteger(jobId) || jobId <= 0) {
+        throw new InvalidAgentTokenError();
+      }
+      if (!safeEqualHex(signature, signLegacy(jobId, secret))) {
+        throw new InvalidAgentTokenError();
+      }
+      return { jobId };
     }
 
-    const [issueNumberRaw, signature] = parts;
-    if (!issueNumberRaw || !signature || !/^\d+$/.test(issueNumberRaw) || !/^[a-f0-9]{64}$/i.test(signature)) {
-      throw new InvalidAgentTokenError();
+    if (parts.length === 4) {
+      const [jobIdRaw, generationRaw, expRaw, signature] = parts;
+      if (
+        !jobIdRaw ||
+        !generationRaw ||
+        !expRaw ||
+        !signature ||
+        !/^\d+$/.test(jobIdRaw) ||
+        !/^\d+$/.test(generationRaw) ||
+        !/^\d+$/.test(expRaw) ||
+        !/^[a-f0-9]{64}$/i.test(signature)
+      ) {
+        throw new InvalidAgentTokenError();
+      }
+      const jobId = Number.parseInt(jobIdRaw, 10);
+      const roundGeneration = Number.parseInt(generationRaw, 10);
+      const exp = Number.parseInt(expRaw, 10);
+      if (
+        !Number.isSafeInteger(jobId) ||
+        jobId <= 0 ||
+        !Number.isSafeInteger(roundGeneration) ||
+        roundGeneration < 1 ||
+        !Number.isSafeInteger(exp) ||
+        exp <= 0
+      ) {
+        throw new InvalidAgentTokenError();
+      }
+      if (!safeEqualHex(signature, signRoundScoped(jobId, roundGeneration, exp, secret))) {
+        throw new InvalidAgentTokenError();
+      }
+      return { jobId, roundGeneration, exp };
     }
 
-    const issueNumber = Number.parseInt(issueNumberRaw, 10);
-    if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
-      throw new InvalidAgentTokenError();
-    }
-
-    const expected = signIssueNumber(issueNumber, secret);
-    const actualBuffer = Buffer.from(signature, 'utf8');
-    const expectedBuffer = Buffer.from(expected, 'utf8');
-    if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
-      throw new InvalidAgentTokenError();
-    }
-
-    return issueNumber;
+    throw new InvalidAgentTokenError();
   } catch (error) {
     if (error instanceof InvalidAgentTokenError) {
       throw error;
     }
     throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Checks claims against the job's active generation and the clock.
+ *
+ * - Round-scoped token: generation must match, `exp` must be in the future.
+ * - Legacy token: accepted only while the job has no generation field yet (an
+ *   in-flight round that predates this model). The first round-close initializes
+ *   the field, after which legacy tokens fail like any other stale key.
+ */
+export function assertAgentTokenActive(
+  claims: AgentTokenClaims,
+  record: { roundGeneration?: number },
+  nowMs: number = Date.now(),
+): void {
+  const active = record.roundGeneration;
+
+  if (claims.roundGeneration !== undefined && claims.exp !== undefined) {
+    if (active === undefined || claims.roundGeneration !== active) {
+      throw new InvalidAgentTokenError(STALE_AGENT_TOKEN_REASON);
+    }
+    if (claims.exp * 1000 <= nowMs) {
+      throw new InvalidAgentTokenError(STALE_AGENT_TOKEN_REASON);
+    }
+    return;
+  }
+
+  // Legacy shape: only while the job has never been generation-scoped.
+  if (active !== undefined) {
+    throw new InvalidAgentTokenError(STALE_AGENT_TOKEN_REASON);
   }
 }
 

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -5,9 +5,11 @@ import {
   fromSubmissionStatus,
   isTerminal,
   JOB_STATES,
+  nextRoundGeneration,
   planObservedStatusTransition,
   reconcileAgentObservation,
   toSubmissionStatus,
+  transitionClosesRound,
   type JobState,
 } from './job-state.js';
 
@@ -37,6 +39,29 @@ describe('job state projection', () => {
     expect(toSubmissionStatus('abandoned')).toBe('abandoned');
     // Lossy on purpose: the public vocabulary has no terminal failure yet.
     expect(toSubmissionStatus('failed')).toBe('needs_changes');
+  });
+});
+
+describe('round-closing transitions', () => {
+  it('bumps generation on every closing outcome', () => {
+    expect(transitionClosesRound({ to: 'ready_for_review', at: 't', by: 'gate', reason: 'gate_green' })).toBe(true);
+    expect(transitionClosesRound({ to: 'needs_changes', at: 't', by: 'operator', reason: 'rejected' })).toBe(true);
+    expect(transitionClosesRound({ to: 'canceled', at: 't', by: 'creator', reason: 'abandoned' })).toBe(true);
+    expect(transitionClosesRound({ to: 'canceled', at: 't', by: 'operator', reason: 'operator_canceled' })).toBe(true);
+    expect(transitionClosesRound({ to: 'abandoned', at: 't', by: 'system', reason: 'no_connect' })).toBe(true);
+    expect(transitionClosesRound({ to: 'failed', at: 't', by: 'reconciler', reason: 'task_failed' })).toBe(true);
+  });
+
+  it('keeps the round open after a red gate so the session can repair', () => {
+    expect(transitionClosesRound({ to: 'needs_changes', at: 't', by: 'gate', reason: 'gate_red' })).toBe(false);
+    expect(transitionClosesRound({ to: 'submitted', at: 't', by: 'agent', reason: 'sources_delivered' })).toBe(false);
+    expect(transitionClosesRound({ to: 'building', at: 't', by: 'operator', reason: 'operator_retry' })).toBe(false);
+  });
+
+  it('initializes legacy jobs at 1 and increments thereafter', () => {
+    expect(nextRoundGeneration(undefined)).toBe(1);
+    expect(nextRoundGeneration(1)).toBe(2);
+    expect(nextRoundGeneration(7)).toBe(8);
   });
 });
 

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -116,6 +116,49 @@ export function canTransition(from: JobState, to: JobState): boolean {
 }
 
 /**
+ * Whether committing this transition ends the current build round — and must therefore
+ * bump the job's `roundGeneration` so the round's channel token dies.
+ *
+ * Closing events written through `recordJobTransition`:
+ * - delivery accepted (`ready_for_review`, typically `gate_green`)
+ * - round rejected into `needs_changes`, except `gate_red` — a red gate keeps the round
+ *   open so the live session can repair and re-deliver without a new token
+ * - creator/operator cancel or abandon
+ * - agent failure (`failed`) — terminal for the round
+ *
+ * Starting another round (creator feedback, operator retry) bumps in `resumeBuild`
+ * *before* the new token is minted, so the mint and the bump cannot race. That path
+ * is not classified here — a `building` → `building` `operator_retry` transition must
+ * not bump again after the mint.
+ */
+export function transitionClosesRound(transition: JobTransition): boolean {
+  switch (transition.to) {
+    case 'ready_for_review':
+      return true;
+    case 'canceled':
+    case 'abandoned':
+    case 'failed':
+      return true;
+    case 'needs_changes':
+      // Same-session repair after a red gate still holds the current token.
+      return transition.reason !== 'gate_red';
+    default:
+      return false;
+  }
+}
+
+/**
+ * Next channel-token generation after a round-closing transition.
+ *
+ * Legacy jobs have no field yet: the first close initializes it to `1`, which is what
+ * makes every subsequent round generation-scoped and stops old copied tokens. Jobs
+ * created with a generation already set simply increment.
+ */
+export function nextRoundGeneration(current: number | undefined): number {
+  return current === undefined ? 1 : current + 1;
+}
+
+/**
  * Why a job moved. Written onto every transition so the history explains itself — the
  * difference between "the build took 40 minutes" and "the build took 40 minutes because
  * it was re-dispatched twice after gate failures".

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -97,6 +97,20 @@ describe('InMemoryStore', () => {
     expect(await repairStore.bumpRoundGeneration(5)).toBe(2);
   });
 
+  it('ensureRoundGeneration initializes a legacy job without bumping an existing one', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(6, 'g:123', 'Legacy');
+    const map = (store as unknown as { submissions: Map<number, import('./store.js').SubmissionRecord> }).submissions;
+    map.set(6, { ...(await store.getSubmission(6))!, roundGeneration: undefined });
+
+    expect(await store.ensureRoundGeneration(6)).toBe(1);
+    expect((await store.getSubmission(6))?.roundGeneration).toBe(1);
+    // Idempotent: a job already on generation 3 stays there.
+    await store.bumpRoundGeneration(6);
+    await store.bumpRoundGeneration(6);
+    expect(await store.ensureRoundGeneration(6)).toBe(3);
+  });
+
   it('reports a missing submission rather than inventing one', async () => {
     const store = new InMemoryStore();
     expect(await store.recordJobTransition(404, { to: 'queued', at: '2026-07-30T10:00:00Z', by: 'system' })).toBe(

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -41,6 +41,62 @@ describe('InMemoryStore', () => {
     expect(record?.transitions?.map((t) => t.to)).toEqual(['queued', 'building']);
   });
 
+  it('bumps roundGeneration on each closing transition, and initializes legacy jobs', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(3, 'g:123', 'A game');
+    expect((await store.getSubmission(3))?.roundGeneration).toBe(1);
+
+    await store.recordJobTransition(3, {
+      to: 'ready_for_review',
+      at: '2026-07-30T10:00:00Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(3))?.roundGeneration).toBe(2);
+
+    await store.recordJobTransition(3, {
+      to: 'needs_changes',
+      at: '2026-07-30T10:01:00Z',
+      by: 'operator',
+      reason: 'rejected',
+    });
+    expect((await store.getSubmission(3))?.roundGeneration).toBe(3);
+
+    await store.recordJobTransition(3, {
+      to: 'canceled',
+      at: '2026-07-30T10:02:00Z',
+      by: 'operator',
+      reason: 'operator_canceled',
+    });
+    expect((await store.getSubmission(3))?.roundGeneration).toBe(4);
+
+    // Legacy job: no field until the first close initializes it.
+    const legacyStore = new InMemoryStore();
+    await legacyStore.createSubmission(4, 'g:123', 'Legacy');
+    const legacyMap = (legacyStore as unknown as { submissions: Map<number, import('./store.js').SubmissionRecord> })
+      .submissions;
+    legacyMap.set(4, { ...(await legacyStore.getSubmission(4))!, roundGeneration: undefined });
+    await legacyStore.recordJobTransition(4, {
+      to: 'canceled',
+      at: '2026-07-30T10:03:00Z',
+      by: 'creator',
+      reason: 'abandoned',
+    });
+    expect((await legacyStore.getSubmission(4))?.roundGeneration).toBe(1);
+
+    // A red gate does not close the round — same-session repair still holds the token.
+    const repairStore = new InMemoryStore();
+    await repairStore.createSubmission(5, 'g:123', 'Repair');
+    await repairStore.recordJobTransition(5, {
+      to: 'needs_changes',
+      at: '2026-07-30T10:04:00Z',
+      by: 'gate',
+      reason: 'gate_red',
+    });
+    expect((await repairStore.getSubmission(5))?.roundGeneration).toBe(1);
+    expect(await repairStore.bumpRoundGeneration(5)).toBe(2);
+  });
+
   it('reports a missing submission rather than inventing one', async () => {
     const store = new InMemoryStore();
     expect(await store.recordJobTransition(404, { to: 'queued', at: '2026-07-30T10:00:00Z', by: 'system' })).toBe(

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1034,6 +1034,14 @@ export interface Store {
    * generation. Returns the new value, or null when the job is gone.
    */
   bumpRoundGeneration(issueNumber: number): Promise<number | null>;
+  /**
+   * Returns the job's active generation, initializing it to `1` when absent.
+   *
+   * Used when minting a round-scoped channel token for a legacy job that has never
+   * closed a round under the new model: the mint must write the field it claims, or
+   * validation rejects the brand-new key (`active === undefined`).
+   */
+  ensureRoundGeneration(issueNumber: number): Promise<number | null>;
   /** Records the agent backend's last reported state, for stall detection. */
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
@@ -1683,6 +1691,14 @@ export class InMemoryStore implements Store {
     const roundGeneration = nextRoundGeneration(sub.roundGeneration);
     this.submissions.set(issueNumber, { ...sub, roundGeneration });
     return roundGeneration;
+  }
+
+  async ensureRoundGeneration(issueNumber: number): Promise<number | null> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return null;
+    if (sub.roundGeneration !== undefined) return sub.roundGeneration;
+    this.submissions.set(issueNumber, { ...sub, roundGeneration: 1 });
+    return 1;
   }
 
   async setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void> {
@@ -2712,6 +2728,18 @@ export class FirestoreStore implements Store {
       const roundGeneration = nextRoundGeneration(current.roundGeneration);
       tx.set(ref, { roundGeneration }, { merge: true });
       return roundGeneration;
+    });
+  }
+
+  async ensureRoundGeneration(issueNumber: number): Promise<number | null> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return null;
+      const current = snap.data() as SubmissionRecord;
+      if (current.roundGeneration !== undefined) return current.roundGeneration;
+      tx.set(ref, { roundGeneration: 1 }, { merge: true });
+      return 1;
     });
   }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { FieldValue, Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-tasks.js';
 import type { PublicationHealthCheck, PublicationRecord } from './games-store.js';
-import type { JobState, JobTransition } from './job-state.js';
+import { nextRoundGeneration, transitionClosesRound, type JobState, type JobTransition } from './job-state.js';
 import type { BuildEvent, SubmissionStatus } from './submission-status.js';
 
 /**
@@ -227,6 +227,17 @@ export interface SubmissionRecord {
    * the rounds themselves.
    */
   costs?: JobCostEntry[];
+  /**
+   * Active build-channel token generation for this job.
+   *
+   * Round-scoped channel tokens HMAC over this value; closing a round bumps it
+   * transactionally with the state transition (see {@link transitionClosesRound}), so a
+   * copied token from an earlier round stops validating without a revocation list.
+   * Absent only on legacy jobs that have not yet closed a round under this model —
+   * those still accept the pre-generation token shape until the first close initializes
+   * the field. New jobs start at `1`.
+   */
+  roundGeneration?: number;
 }
 
 /**
@@ -1013,9 +1024,16 @@ export interface Store {
    *
    * Callers decide *whether* to move (the rules live in job-state.ts); this only records
    * the decision. Returns false when the record is gone, so a caller can tell a no-op
-   * from a write.
+   * from a write. Round-closing transitions also bump `roundGeneration` in the same
+   * write (see `transitionClosesRound`).
    */
   recordJobTransition(issueNumber: number, transition: JobTransition): Promise<boolean>;
+  /**
+   * Advances `roundGeneration` without a state change — used when a new round starts
+   * (creator feedback / operator retry) so the mint that follows binds to the new
+   * generation. Returns the new value, or null when the job is gone.
+   */
+  bumpRoundGeneration(issueNumber: number): Promise<number | null>;
   /** Records the agent backend's last reported state, for stall detection. */
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
@@ -1622,6 +1640,9 @@ export class InMemoryStore implements Store {
       ownerUid,
       createdAt: new Date().toISOString(),
       title,
+      // New jobs are generation-scoped from the first mint; legacy records created
+      // before this field existed stay unset until their current round closes.
+      roundGeneration: 1,
     };
     this.submissions.set(issueNumber, record);
     return { ...record };
@@ -1645,13 +1666,23 @@ export class InMemoryStore implements Store {
   async recordJobTransition(issueNumber: number, transition: JobTransition): Promise<boolean> {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return false;
+    const closes = transitionClosesRound(transition);
     this.submissions.set(issueNumber, {
       ...sub,
       state: transition.to,
       stateSince: transition.at,
       transitions: [...(sub.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
+      ...(closes ? { roundGeneration: nextRoundGeneration(sub.roundGeneration) } : {}),
     });
     return true;
+  }
+
+  async bumpRoundGeneration(issueNumber: number): Promise<number | null> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return null;
+    const roundGeneration = nextRoundGeneration(sub.roundGeneration);
+    this.submissions.set(issueNumber, { ...sub, roundGeneration });
+    return roundGeneration;
   }
 
   async setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void> {
@@ -2621,6 +2652,9 @@ export class FirestoreStore implements Store {
       ownerUid,
       createdAt: new Date().toISOString(),
       title,
+      // New jobs are generation-scoped from the first mint; legacy records created
+      // before this field existed stay unset until their current round closes.
+      roundGeneration: 1,
     };
     await this.db.collection('submissions').doc(String(issueNumber)).set(record);
     return record;
@@ -2648,21 +2682,36 @@ export class FirestoreStore implements Store {
     // A transaction, not a merge: the status poll and the reconciler sweep can both
     // observe the same job at once, and appending to a list read outside a transaction
     // loses whichever write landed second — silently, and exactly under the concurrent
-    // load where the history matters most.
+    // load where the history matters most. The round-generation bump rides in the same
+    // write so a closing transition never leaves a stale channel token valid.
     return this.db.runTransaction(async (tx) => {
       const snap = await tx.get(ref);
       if (!snap.exists) return false;
       const current = snap.data() as SubmissionRecord;
+      const closes = transitionClosesRound(transition);
       tx.set(
         ref,
         {
           state: transition.to,
           stateSince: transition.at,
           transitions: [...(current.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
+          ...(closes ? { roundGeneration: nextRoundGeneration(current.roundGeneration) } : {}),
         },
         { merge: true },
       );
       return true;
+    });
+  }
+
+  async bumpRoundGeneration(issueNumber: number): Promise<number | null> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return null;
+      const current = snap.data() as SubmissionRecord;
+      const roundGeneration = nextRoundGeneration(current.roundGeneration);
+      tx.set(ref, { roundGeneration }, { merge: true });
+      return roundGeneration;
     });
   }
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { verifyAgentToken } from './agent-token.js';
+import { assertAgentTokenActive, verifyAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
@@ -2701,6 +2701,30 @@ describe('a session that finishes without delivering', () => {
     await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
 
     expect(briefs.at(-1)?.undelivered).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('remints a validating round-scoped token for a legacy job with no generation field', async () => {
+    // Pre-migration records have no roundGeneration. Undelivered resume remints a
+    // round-scoped key claiming generation 1 — that field must be written, or the
+    // brand-new token fails assertAgentTokenActive (active === undefined).
+    const { app, store, job, briefs, clock, token } = await jobWithFinishedSession();
+    const submissions = (store as unknown as { submissions: Map<number, import('./store.js').SubmissionRecord> })
+      .submissions;
+    const before = await store.getSubmission(job.issueNumber);
+    submissions.set(job.issueNumber, { ...before!, roundGeneration: undefined });
+
+    clock.t += 3 * 60 * 1000;
+    await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: getAuthHeaders() });
+
+    const reminted = briefs.at(-1)?.channelToken;
+    expect(reminted).toBeTruthy();
+    const after = await store.getSubmission(job.issueNumber);
+    expect(after?.roundGeneration).toBe(1);
+    const claims = verifyAgentToken(reminted!, secret);
+    expect(claims).toMatchObject({ jobId: job.issueNumber, roundGeneration: 1 });
+    expect(() => assertAgentTokenActive(claims, after!, clock.t)).not.toThrow();
 
     await app.close();
   });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mintAgentToken } from './agent-token.js';
+import { verifyAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
@@ -551,7 +551,12 @@ describe('submission routes', () => {
     expect(briefs[0].spec).toContain('This is a sufficiently long concept with markup and details.');
     expect(briefs[0].spec).not.toContain('<script>');
     expect(briefs[0].spec).not.toContain('<i>');
-    expect(briefs[0].channelToken).toBe(mintAgentToken(jobs[0].issueNumber, secret));
+    // Round-scoped: same job + generation. `exp` is wall-clock, so compare claims
+    // rather than the opaque string (a second boundary would flake an equality check).
+    expect(verifyAgentToken(briefs[0].channelToken, secret)).toMatchObject({
+      jobId: jobs[0].issueNumber,
+      roundGeneration: jobs[0].roundGeneration ?? 1,
+    });
   });
   it('gives two games of the same name addresses of their own', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 93 });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -666,10 +666,10 @@ export async function registerSubmissionRoutes(
             ...(draft.notes ? { notes: draft.notes } : {}),
           }
         : undefined;
-      // New jobs carry generation 1 from createSubmission; a missing record (or a
-      // legacy one that somehow reaches first dispatch without the field) still mints
-      // the round-scoped shape rather than the legacy jobId-only token.
-      const roundGeneration = (await store?.getSubmission(input.issueNumber))?.roundGeneration ?? 1;
+      // Persist generation before minting. New jobs already carry `1` from
+      // createSubmission; a legacy job without the field must be initialized here so
+      // the round-scoped token we hand the agent validates against the record.
+      const roundGeneration = (await store?.ensureRoundGeneration(input.issueNumber)) ?? 1;
       const result = await agentBackend.dispatch({
         issueNumber: input.issueNumber,
         ...(input.slug ? { slug: input.slug } : {}),
@@ -768,11 +768,11 @@ export async function registerSubmissionRoutes(
     try {
       // A new round closes the previous one's token. Bump *before* minting so the brief
       // carries the generation that is now active. An undelivered nudge is the same
-      // round continuing — the agent never uploaded, so its token must keep working.
-      let roundGeneration = record?.roundGeneration ?? 1;
-      if (!input.undelivered) {
-        roundGeneration = (await store.bumpRoundGeneration(input.issueNumber)) ?? roundGeneration + 1;
-      }
+      // round continuing — the agent never uploaded, so its token must keep working —
+      // but a legacy job still needs the field written so the reminted key validates.
+      const roundGeneration = input.undelivered
+        ? ((await store.ensureRoundGeneration(input.issueNumber)) ?? 1)
+        : ((await store.bumpRoundGeneration(input.issueNumber)) ?? (record?.roundGeneration ?? 0) + 1);
       const brief = {
         issueNumber: input.issueNumber,
         slug: record?.slug,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -666,12 +666,19 @@ export async function registerSubmissionRoutes(
             ...(draft.notes ? { notes: draft.notes } : {}),
           }
         : undefined;
+      // New jobs carry generation 1 from createSubmission; a missing record (or a
+      // legacy one that somehow reaches first dispatch without the field) still mints
+      // the round-scoped shape rather than the legacy jobId-only token.
+      const roundGeneration = (await store?.getSubmission(input.issueNumber))?.roundGeneration ?? 1;
       const result = await agentBackend.dispatch({
         issueNumber: input.issueNumber,
         ...(input.slug ? { slug: input.slug } : {}),
         spec: input.spec,
         locale: input.locale,
-        channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret),
+        channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret, {
+          roundGeneration,
+          now: now(),
+        }),
         apiBaseUrl: notifyAppBaseUrl,
         ...(input.slug ? { slug: input.slug } : {}),
         ...(input.feedback ? { feedback: input.feedback } : {}),
@@ -759,13 +766,23 @@ export async function registerSubmissionRoutes(
     const record = await store.getSubmission(input.issueNumber);
     const previous = record?.dispatch;
     try {
+      // A new round closes the previous one's token. Bump *before* minting so the brief
+      // carries the generation that is now active. An undelivered nudge is the same
+      // round continuing — the agent never uploaded, so its token must keep working.
+      let roundGeneration = record?.roundGeneration ?? 1;
+      if (!input.undelivered) {
+        roundGeneration = (await store.bumpRoundGeneration(input.issueNumber)) ?? roundGeneration + 1;
+      }
       const brief = {
         issueNumber: input.issueNumber,
         slug: record?.slug,
         spec: input.feedback,
         feedback: input.feedback,
         locale: input.locale,
-        channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret),
+        channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret, {
+          roundGeneration,
+          now: now(),
+        }),
         apiBaseUrl: notifyAppBaseUrl,
         ...(input.undelivered
           ? { undelivered: true, ...(previous?.workspace ? { previousWorkspace: previous.workspace } : {}) }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Extend the agent build-channel capability token to be round-scoped.

## Scope
1. Mint/validate HMAC over `(scope, jobId, roundGeneration, exp)` with active generation on the job document
2. TTL from `SELF_BUILD_KEY_TTL_DAYS` (default 14); expired keys fail like stale-generation with Studio-thread refresh reason
3. Bump generation on every round close (delivery accepted, reject, creator cancel/abandon, operator cancel/retry)
4. Legacy jobs keep jobId-only validation until current round closes, then initialize generation
5. Tests for round-trip, stale generation, expiry, closing bumps, legacy acceptance, tamper rejection
6. `ensureRoundGeneration` persists `roundGeneration: 1` on `dispatchBuild` / undelivered `resumeBuild` before mint so legacy remints validate
7. **Strict 401 on terminal jobs** (`f53c5aa8`): removed the `stopReason` bypass that let stale/expired tokens through on published/abandoned/canceled jobs. Adds regression covering sources/inbox/ack/progress.

## Out of scope
New endpoints, UI, self backend. Terminal-receipt reads for closed-round gate verdicts → BY-05/BY-06.

## Review
Addresses Claude Fable 5 / supervisor REQUEST_CHANGES on the stopReason exception.

## Next
Unblocks BY-02 (`self` builder backend).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

