### PR TITLE
Write down two things that only existed in PR descriptions

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -202,6 +202,35 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     visit stream without joining to play events.
 - **Build economics are duration-only** — submission→publish timestamps and build events
   exist; revision-cycle counts are derivable; keep it that way as builds evolve.
+- ~~Shared zones were unmeasured~~ — **closed 2026-07-31**: `zone_link`
+  (`admitted` → `joined` → `lost`) on the play stream, aggregated as `zoneJoinRate` and
+  rendered as the Shared column beside Finished. It exists because the shell falls back
+  to solo play _in silence_ when it cannot reach the host — correct for the player, and
+  the reason a dead zone host and a healthy one are indistinguishable from outside. Three
+  rules came out of it, and they generalise to any signal the shell reports _about_ a
+  game rather than _from_ one:
+  - **The rung is the evidence, not the attempt.** `joined` fires on the arrival of a
+    snapshot, never on the socket opening. A connection that upgrades and is then closed
+    is exactly how the host failed on its first day; pinning the rung to the socket would
+    have had the metric reporting health throughout the outage.
+  - **A shell-owned signal needs its own channel _and_ its own budget.** `gamePlayer.ts`
+    does not accept these types over postMessage, so a game cannot claim to be shared
+    while sitting alone — but until they also had a session cap of their own, a frame
+    could flood past the shared 400-event ceiling and force its own zone to render `—`.
+    Separating the channel stops a game lying; separating the budget stops it silencing.
+  - **A ratio must not be able to exceed its own maximum.** Both rungs travel in
+    best-effort batches, so a session can land `joined` while the request carrying
+    `admitted` was lost. Count the numerator only inside the denominator's set; a session
+    missing its `admitted` is one more "no evidence", and the residual bias then
+    understates success rather than inventing it.
+- **A game with no rounds cannot report a score** — `score` is emitted only from the
+  transition into a terminal snapshot state (games-repo `shared/modules/core.ts`), so
+  ember-watch reports none since it became a continuous world (games-repo #163), and
+  `finishRate` / `winRate` / `medianBestScore` read `—` for it permanently. Half of that
+  is right: a world with no endings has no finish rate. The other half is a real loss —
+  saves are a meaningful score there, they just have no round boundary to be reported at.
+  Closing it means deciding what `score` means for a game that never ends, which is a
+  platform question rather than one game's, so it is named here rather than special-cased.
 
 ## Definition of done for instrumentation
 

--- a/docs/runbooks/zones-down-triage.md
+++ b/docs/runbooks/zones-down-triage.md
@@ -106,6 +106,20 @@ removed it deliberately, an app deploy wiped it — `--set-env-vars` replaces th
 Both deploy paths thread it through, so this should not happen; if it did, that is the
 bug, not the host.
 
+## Open: one failure nobody has explained
+
+**2026-07-29 22:11 UTC, revision `gamedev-world-00004-kq8`.** A single join was refused
+on a healthy host — the first thing A6 ever caught, hours after it was armed. The cause
+is unknown and now unknowable: `ZoneAdmissionError` carried only the wire reason at the
+time, so the error that `join` actually threw was discarded before it reached the log.
+That is fixed (the wrapper keeps its `cause`), which means the _next_ one will say.
+
+Keep it in mind if a `zone_unavailable` appears without an obvious cause. A single failed
+join is not necessarily a defect — a transient games-repo fetch or Firestore read would
+do it, and recovering on the next attempt is the design working — but one has happened,
+it was never explained, and a second of the same shape should not be waved through as
+"probably that transient thing again".
+
 ## What this runbook does not cover
 
 Zone _state_ problems — a world that loads but is wrong, stuck, or unplayable. That is a


### PR DESCRIPTION
Docs only. Both facts would have survived exactly as long as somebody remembered which PR to go read — which is the failure the "known gaps" list exists to prevent.

## The instrumentation skill

**The closed gap:** `zone_link` and the Shared column (#408).

**The three rules that came out of getting it wrong**, all of which generalise past zones to any signal the shell reports *about* a game rather than *from* one:

- **The rung is the evidence, not the attempt.** `joined` fires on a snapshot arriving, never on the socket opening — a connection that upgrades and is then closed is exactly how the host failed on its first day.
- **A shell-owned signal needs its own channel *and* its own budget.** Separating the channel stops a game lying about itself; separating the budget stops it silencing itself.
- **A ratio must not be able to exceed its own maximum.** Count the numerator only inside the denominator's set, and let the residual bias understate success rather than invent it.

Each was a review finding rather than something the tests caught, and each failed in the *reassuring* direction — worth knowing before writing the next such metric.

**The gap that stayed open:** a game with no rounds cannot report a `score`, since `score` is emitted only from the transition into a terminal snapshot state. Named rather than special-cased for ember-watch, because the question is what `score` means for any endless game.

## The zone runbook

The **22:11 UTC admission failure** on 29 July — one join refused on a healthy host, the first thing A6 ever caught. The cause was discarded by the error wrapper before it reached the log. That is fixed (#348), so the next one will say; this one stays unexplained.

It is in the runbook rather than an issue because that is where somebody triaging a `zone_unavailable` will already be looking. A single failed join is not necessarily a defect — but one has happened, it was never explained, and a second of the same shape should not be waved through as "probably that transient thing again".

No code. Lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4xHU2Ca1sZHqoP59Pvxx4)_