### PR TITLE
Lockstep games-repo #281: assemble-contract v2 platform ceiling

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "_comment": "Cross-repo serve contract. Website half: www.gamedev.pl apps/api/src/games-repo-contract.ts + CI contract:games-repo (PR #253). Keep GAME_KIT_MODULES as an array literal in tools/lib/assemble.ts for that scraper. maxProjectBytes must equal games Check 4 MAX_BUNDLE_BYTES (currently includes gfx3d reserve, look/spatial, mascotDraw, and a deliberate headroom band).",
+  "version": 2,
+  "_comment": "Cross-repo serve contract. Website half: www.gamedev.pl apps/api/src/games-repo-contract.ts + CI contract:games-repo (PR #253). Keep GAME_KIT_MODULES as an array literal in tools/lib/assemble.ts for that scraper. maxProjectBytes = authorBudgetBytes + platformCeilingBytes. The author gate is measured (assembled − platformBytes); the ceiling is serve-compat only. Feature-by-feature archaeology: docs/platform-byte-ledger.md in the games repo.",
   "gameKitModules": [
     "input",
     "collision",
@@ -23,28 +23,7 @@
     "voice"
   ],
   "authorBudgetBytes": 204800,
-  "platformAllowancesBytes": {
-    "touch": 13061,
-    "restart": 2477,
-    "music": 7741,
-    "touchHint": 89,
-    "progress": 613,
-    "universalInput": 3191,
-    "pointerPoll": 7083,
-    "drawSurface": 9459,
-    "pointerRelease": 430,
-    "hostPause": 1473,
-    "mascotDraw": 679,
-    "headroom": 74931,
-    "gfx3d": 96000,
-    "lookControls": 4683,
-    "spatialAudio": 2977,
-    "zone": 12000,
-    "sensing": 6500,
-    "voice": 8000,
-    "world": 15000,
-    "gameplay": 9000
-  },
+  "platformCeilingBytes": 275387,
   "maxProjectBytes": 480187,
   "audio": {
     "musicField": "string",

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -28,12 +28,16 @@ describe('games-repo-contract (website half)', () => {
       '../fixtures/games-repo/shared/assemble-contract.json',
     );
     const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as {
+      version: number;
       maxProjectBytes: number;
       gameKitModules: string[];
       authorBudgetBytes: number;
+      platformCeilingBytes: number;
     };
+    expect(fixture.version).toBe(2);
     expect(fixture.maxProjectBytes).toBe(MAX_PROJECT_BYTES);
     expect(fixture.authorBudgetBytes).toBe(GAME_BUDGET_BYTES);
+    expect(fixture.platformCeilingBytes).toBe(GAMEKIT_PLATFORM_BYTES);
     expect(fixture.gameKitModules).toEqual([...GAME_KIT_MODULES]);
   });
 
@@ -80,56 +84,24 @@ describe('games-repo source extractors', () => {
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);
   });
 
-  it('evaluates MAX_BUNDLE_BYTES across named platform allowances', () => {
-    // Values mirror games-repo validate.ts, allowance for allowance, so the total
-    // is the real MAX_PROJECT_BYTES rather than a made-up sum that happens to land
-    // on it. Two of them are `a + b` sums over there — an allowance that was raised
-    // keeps the original and the raise side by side instead of collapsing to one
-    // opaque number — so the extractor has to evaluate those, not just read literals.
+  it('evaluates MAX_BUNDLE_BYTES from the single platform ceiling', () => {
+    // Games-repo #281 collapsed the per-feature ledger into one GAMEKIT_PLATFORM_BYTES.
+    // The extractor still has to resolve `BUDGET + PLATFORM` (and `a + b` / `a * b`
+    // forms inside those consts), not only bare literals.
+    const source = `
+      const GAME_BUDGET_BYTES = 200 * 1024;
+      const GAMEKIT_PLATFORM_BYTES = 275_387;
+      const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
+    `;
+    expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
+  });
+
+  it('still evaluates a + b allowance expressions when a tip uses them', () => {
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_RESTART_BYTES = 2_477;
-      const GAMEKIT_MUSIC_BYTES = 7_091 + 650;
-      const GAMEKIT_TOUCH_HINT_BYTES = 89;
-      const GAMEKIT_PROGRESS_BYTES = 307;
-      const GAMEKIT_UNIVERSAL_INPUT_BYTES = 3_191;
-      const GAMEKIT_POINTER_POLL_BYTES = 7_083;
-      const GAMEKIT_DRAW_SURFACE_BYTES = 9_459;
-      const GAMEKIT_POINTER_RELEASE_BYTES = 430;
-      const GAMEKIT_HOST_PAUSE_BYTES = 1_473;
-      const GAMEKIT_MASCOT_DRAW_BYTES = 679;
-      const GAMEKIT_HEADROOM_BYTES = 75_237;
-      const GAMEKIT_GFX3D_BYTES = 96_000;
-      const GAMEKIT_LOOK_CONTROLS_BYTES = 4_683;
-      const GAMEKIT_SPATIAL_AUDIO_BYTES = 2_977;
-      const GAMEKIT_ZONE_BYTES = 12_000;
-      const GAMEKIT_VOICE_BYTES = 8_000;
-      const GAMEKIT_WORLD_BYTES = 15_000;
-      const GAMEKIT_GAMEPLAY_BYTES = 9_000;
-      const GAMEKIT_SENSING_BYTES = 6_500;
-      const MAX_BUNDLE_BYTES =
-        GAME_BUDGET_BYTES +
-        GAMEKIT_TOUCH_BYTES +
-        GAMEKIT_RESTART_BYTES +
-        GAMEKIT_MUSIC_BYTES +
-        GAMEKIT_TOUCH_HINT_BYTES +
-        GAMEKIT_PROGRESS_BYTES +
-        GAMEKIT_UNIVERSAL_INPUT_BYTES +
-        GAMEKIT_POINTER_POLL_BYTES +
-        GAMEKIT_DRAW_SURFACE_BYTES +
-        GAMEKIT_POINTER_RELEASE_BYTES +
-        GAMEKIT_HOST_PAUSE_BYTES +
-        GAMEKIT_MASCOT_DRAW_BYTES +
-        GAMEKIT_HEADROOM_BYTES +
-        GAMEKIT_GFX3D_BYTES +
-        GAMEKIT_LOOK_CONTROLS_BYTES +
-        GAMEKIT_SPATIAL_AUDIO_BYTES +
-        GAMEKIT_ZONE_BYTES +
-        GAMEKIT_VOICE_BYTES +
-        GAMEKIT_WORLD_BYTES +
-        GAMEKIT_GAMEPLAY_BYTES +
-        GAMEKIT_SENSING_BYTES;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 262_326;
+      const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
   });

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -58,67 +58,20 @@ export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 export const GAME_BUDGET_BYTES = 200 * 1024;
 
 /**
- * Sum of GameKit platform allowances outside the author budget (touch, restart,
- * music, touch hint, progress, universal input, pointer poll, draw surface,
- * pointer release, host pause, mascot draw, headroom, gfx3d, look, spatial, …). Together with
+ * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
+ * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (480_187, matching games-repo `shared/assemble-contract.json` `maxProjectBytes`). Not a round KiB.
+ * (480_187, matching `maxProjectBytes`). Not a round KiB.
  *
- * Last moved by the sensing capability (games-repo camera-ar-platform Phase 0): +6_500
- * for a named `sensing` reserve (measured 5_132 transpiled), 473_687 → 480_187. Opt-in
- * like `zone`, and since games-repo #282 the reserve is belt-and-braces: Check 4 bills
- * each author for measured author bytes, so a game that skips sensing cannot spend its
- * reserve either way.
+ * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
+ * over there bills each author for measured `assembled − platformBytes` against the
+ * 200 KiB author budget; this number is serve-compat only so a game that clears that
+ * gate is not refused here. Feature-by-feature archaeology lives in the games repo's
+ * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
+ * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Before that, games-repo convergence Pass #10 (carjack-city open-world promotion):
- * +15_000 (`world`) and +9_000 (`gameplay`) named reserves, 449_687 → 473_687. Both
- * modules shipped tiny and charged to the author budget; Pass #10 grew them into real
- * capability layers (grids/spiral search/loop paths/2D camera; arcade vehicle physics/
- * combo/ticker — measured 13_263 and 7_371 transpiled), and the first game to select
- * them, carjack-city, was also the tightest bundle in the catalog. This side is
- * deliberately ahead of games-repo `main` on the `voice` module, which the raise
- * carries forward untouched. Same opt-in-reserve argument as `zone`.
- *
- * Before that, voice Layer 0: +8_000 named `voice` reserve, 441_687 → 449_687.
- *
- * Before that, games-repo #163: +12_000 for a named `zone` reserve, 429_687 → 441_687.
- * The module shipped charged to the author budget, on the reasoning that it is small and
- * opt-in the way `save` and `commons` are. biplane-skirmish disproved that on arrival —
- * the first published game to select `zone` landed 20 bytes under the ceiling, which made
- * the next byte spent anywhere in the shared kit a break in a live game rather than a cost
- * to the author who spent it. That is the same argument `gfx3d` has a reserve for.
- *
- * Before that, games-repo #124 (Scene3D B11 scene management): `gfx3d`
- * 80_000 → 96_000 (+16_000, 413_687 → 429_687).
- *
- * Before that, games-repo #123 (Scene3D B10 effects): `gfx3d` 56_000 → 80_000
- * (+24_000, 389_687 → 413_687).
- *
- * Before that, games-repo #120 (Scene3D B8/B9): two new named allowances on top
- * of the B7 `gfx3d` 56_000 reserve — +4_683 (`lookControls`) and +2_977
- * (`spatialAudio`), 382_027 → 389_687.
- *
- * Before that, games-repo #117 (Scene3D B7): `gfx3d` 40_000 → 56_000 (+16_000,
- * 366_027 → 382_027) for procedural textures, point lights and bloom.
- *
- * Before that, games-repo #113 (the voxel and third-person pilots): `gfx3d`
- * 32_000 → 40_000 (+8_000, 358_027 → 366_027) for the scene3d template and the
- * chase camera those pilots share. Same opt-in shape as the band below.
- *
- * `presence` (games-repo P2.5) moves none of this. Like every other module it is only
- * inlined when a `GAME.json` asks for it, so it comes out of the 200 KiB author budget
- * rather than the platform allowances here.
- *
- * Before that, games-repo #111 (the `gfx3d` kit): +32_000 (`gfx3d`) for an
- * opt-in Lambert-mesh scene module measured at ~31.5 KiB transpiled. It is only
- * inlined when a `GAME.json` asks for it, so unlike the allowances below it is
- * not bytes every game pays — but the cap is a single number, and a gfx3d game
- * that clears Check 4 over there has to assemble here to be playable at all.
- * That is the same shape as the touch-layer drift that put block-cascade and
- * rooftop-dash live answering 422.
- *
- * Before that, games-repo #102: +679 (`mascotDraw`) and +75_237 (`headroom`) — 30% of
- * the 250_790 ceiling — plus earlier host-pause / touch steer raises.
+ * Last numeric move before the ledger collapse: sensing capability (games-repo
+ * camera-ar-platform Phase 0) +6_500, 473_687 → 480_187 total.
  */
 export const GAMEKIT_PLATFORM_BYTES = 275_387;
 

--- a/docs/games-repo-validation-spec.md
+++ b/docs/games-repo-validation-spec.md
@@ -21,15 +21,15 @@ This specification defines the quality gates enforced on incoming pull requests 
 
 ### 2. Game Bundle Size Cap
 
-- Calculate total byte size of all files in the individual game directory.
-- Hard failure if the author's own bytes exceed 204,800 (200 KiB).
-- On top of that sits the GameKit platform allowance — the touch pad, restart button,
-  music glue and friends that every assembled game carries whether it asked or not.
-  Charging those to the author would silently shrink what they may write, so the served
-  cap is author budget + allowances. The live numbers are `GAME_BUDGET_BYTES` and
-  `GAMEKIT_PLATFORM_BYTES` in `apps/api/src/games-repo-contract.ts`, which
-  `apps/api/src/assemble.ts` re-exports as `MAX_PROJECT_BYTES` — do not restate them
-  here, or this page becomes a third copy to keep in lockstep.
+- Hard failure if the author's own bytes exceed 204,800 (200 KiB). Games-repo Check 4
+  measures those as `assembled − platformBytes` (selected GameKit modules, inlined audio,
+  shell CSS) — a platform change cannot break a published game whose author spent nothing.
+- On top of that sits a single serve-compat platform ceiling for the touch pad, restart
+  button, music glue, opt-in reserves, and friends. The served cap is author budget +
+  that ceiling. The live numbers are `GAME_BUDGET_BYTES` and `GAMEKIT_PLATFORM_BYTES` in
+  `apps/api/src/games-repo-contract.ts`, which `apps/api/src/assemble.ts` re-exports as
+  `MAX_PROJECT_BYTES` — do not restate them here, or this page becomes a third copy to
+  keep in lockstep.
 
 #### Raising the cap: merge the website half first
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Website half of [games-repo #281](https://github.com/gamedevpl/www.gamedev.pl-games/issues/281) (paired games-repo PR on the same branch name).

## What changed

Games-repo #282 already bills authors for measured `assembled − platformBytes`. #281's remaining piece collapses the per-feature platform allowance ledger into **one** serve-compat ceiling. This side vendors that contract shape:

- `apps/api/fixtures/games-repo/shared/assemble-contract.json` → **version 2**, `platformCeilingBytes` instead of `platformAllowancesBytes`
- Serve cap number **unchanged** (`MAX_PROJECT_BYTES` = 480_187)
- Extractor tests cover the single-ceiling `MAX_BUNDLE_BYTES = GAME_BUDGET + GAMEKIT_PLATFORM` form (and still cover `a + b` expressions)

## Merge order

**Merge this PR first**, then the games-repo half. Same reason as the validation-spec rule for budget moves: a contract-shape tip the website fixture does not recognize is worse than a website tip that already knows v2.

## Out of scope

No serve-cap raise, no GameKit module changes, no gameplay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea3ae5ea-6659-4be6-97b1-42dc50dd9631?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea3ae5ea-6659-4be6-97b1-42dc50dd9631&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

