### PR TITLE
Book real agent-session credits; stop briefing undelivered jobs as revisions

### DIFF
--- a/apps/api/src/agent-tasks.test.ts
+++ b/apps/api/src/agent-tasks.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { createAgentTasksClient, normalizeModel, parseAgentTask, resolveTaskBranch } from './agent-tasks.js';
+import {
+  createAgentTasksClient,
+  creditsFromUsageAmount,
+  normalizeModel,
+  parseAgentTask,
+  resolveTaskBranch,
+} from './agent-tasks.js';
 
 /** A settled task, shaped exactly as the live API answered on 2026-07-29. */
 const SETTLED_TASK = {
@@ -23,6 +29,7 @@ const SETTLED_TASK = {
       model: 'sweagent-capi:gpt-5.4',
       prompt: 'Add one blank line at the end of that file.',
       state: 'completed',
+      usage: { amount: 403451775000, type: 'ai_credits' },
     },
   ],
   state: 'completed',
@@ -51,11 +58,28 @@ function stubFetch(handler: (url: string, init: RequestInit) => unknown) {
   return { impl, calls };
 }
 
+describe('creditsFromUsageAmount', () => {
+  it('converts nano-credits to ledger credits', () => {
+    // Live reading from the 403-credit global-thermonuclear-strategy session.
+    expect(creditsFromUsageAmount(403451775000)).toBe(403.45);
+    expect(creditsFromUsageAmount(861100000000)).toBe(861.1);
+  });
+});
+
 describe('parseAgentTask', () => {
   it('lifts the branch and pull artifacts out of the artifact list', () => {
     const task = parseAgentTask(SETTLED_TASK);
     expect(task.branch).toEqual({ baseRef: 'main', headRef: 'copilot/fix-trailing-whitespace' });
     expect(task.pull).toEqual({ id: 4164924791, globalId: 'PR_kwDOTf4x3s74P7V3' });
+  });
+
+  it('keeps session usage so the ledger can book the real bill', () => {
+    // The parser used to drop `usage`, which is why every session was booked as 1 credit
+    // against bills of 46–861. The figure is nano-credits; conversion is the caller's job.
+    expect(parseAgentTask(SETTLED_TASK).sessions[0]?.usage).toEqual({
+      amount: 403451775000,
+      type: 'ai_credits',
+    });
   });
 
   it('reports no pull request when the task did not open one', () => {

--- a/apps/api/src/agent-tasks.ts
+++ b/apps/api/src/agent-tasks.ts
@@ -56,6 +56,18 @@ export const AGENT_TASK_MODELS = [
 ] as const;
 export type AgentTaskModel = (typeof AGENT_TASK_MODELS)[number];
 
+/**
+ * What GitHub billed for one session.
+ *
+ * `amount` is in **nano-credits** (1 credit = 1e9). Divide by 1e9 for credits; a credit
+ * is $0.01 (`USD_PER_CREDIT`). Present once the session has progressed far enough to
+ * report usage — typically final on completion, absent on a freshly queued session.
+ */
+export interface AgentSessionUsage {
+  amount: number;
+  type: string;
+}
+
 /** One agent run within a task. A task accumulates sessions; it does not replace them. */
 export interface AgentSession {
   id: string;
@@ -69,6 +81,18 @@ export interface AgentSession {
   createdAt?: string;
   updatedAt?: string;
   completedAt?: string;
+  /** What was billed. Absent until the session reports it. */
+  usage?: AgentSessionUsage;
+}
+
+/**
+ * Converts a session's nano-credit `usage.amount` into ledger credits.
+ *
+ * Rounded to the cent-of-a-credit so a 403451775000 reading becomes 403.45 rather than
+ * a float that cannot be quoted next to a dollar figure.
+ */
+export function creditsFromUsageAmount(amount: number): number {
+  return Math.round(amount / 1e7) / 100;
 }
 
 export interface AgentTask {
@@ -219,17 +243,24 @@ export function parseAgentTask(raw: Record<string, unknown>): AgentTask {
     name: asString(raw.name),
     htmlUrl: asString(raw.html_url),
     sessionCount: typeof raw.session_count === 'number' ? raw.session_count : rawSessions.length,
-    sessions: rawSessions.map((session) => ({
-      id: String(session.id ?? ''),
-      state: asState(session.state),
-      prompt: asString(session.prompt),
-      baseRef: asString(session.base_ref),
-      headRef: asString(session.head_ref),
-      model: normalizeModel(asString(session.model)),
-      createdAt: asString(session.created_at),
-      updatedAt: asString(session.updated_at),
-      completedAt: asString(session.completed_at),
-    })),
+    sessions: rawSessions.map((session) => {
+      const rawUsage = session.usage as { amount?: unknown; type?: unknown } | undefined;
+      const amount =
+        typeof rawUsage?.amount === 'number' && Number.isFinite(rawUsage.amount) ? rawUsage.amount : undefined;
+      const usageType = asString(rawUsage?.type);
+      return {
+        id: String(session.id ?? ''),
+        state: asState(session.state),
+        prompt: asString(session.prompt),
+        baseRef: asString(session.base_ref),
+        headRef: asString(session.head_ref),
+        model: normalizeModel(asString(session.model)),
+        createdAt: asString(session.created_at),
+        updatedAt: asString(session.updated_at),
+        completedAt: asString(session.completed_at),
+        ...(amount !== undefined && usageType ? { usage: { amount, type: usageType } } : {}),
+      };
+    }),
     branch: branchArtifact
       ? { baseRef: asString(branchArtifact.base_ref), headRef: asString(branchArtifact.head_ref) }
       : undefined,

--- a/apps/api/src/copilot-backend.test.ts
+++ b/apps/api/src/copilot-backend.test.ts
@@ -91,6 +91,23 @@ describe('buildPrompt', () => {
     expect(buildPrompt(BRIEF)).not.toContain('npm run restore');
   });
 
+  it('does not send an undelivered round looking for a store restore that cannot exist', () => {
+    // Creator feedback on a job that never delivered used to take the revision branch
+    // and open with `npm run restore`. The store had nothing; the agent paid for a
+    // full build under a prompt that told it not to rebuild.
+    const prompt = buildPrompt({
+      ...BRIEF,
+      feedback: 'Gdzie moja gra',
+      undelivered: true,
+      previousWorkspace: 'copilot/gamesglobal-thermonuclear-strategy',
+    });
+    expect(prompt).toContain('ended without delivering');
+    expect(prompt).toContain('copilot/gamesglobal-thermonuclear-strategy');
+    expect(prompt).not.toContain('npm run restore');
+    expect(prompt).not.toContain('revise it, do not rebuild it');
+    expect(prompt).toContain('Gdzie moja gra');
+  });
+
   it('truncates an oversized spec rather than sending it whole', () => {
     const prompt = buildPrompt({ ...BRIEF, spec: 'x'.repeat(20_000) });
     expect(prompt.length).toBeLessThan(12_000);
@@ -215,6 +232,28 @@ describe('observe and cancel', () => {
       state: 'in_progress',
       hasCandidate: false,
       workspace: 'copilot/tv-tycoon',
+    });
+  });
+
+  it('surfaces billed credits so the ledger can replace its dispatch placeholder', async () => {
+    const { client } = stubTasks(
+      task({
+        state: 'completed',
+        sessions: [
+          {
+            id: 's1',
+            state: 'completed',
+            usage: { amount: 403451775000, type: 'ai_credits' },
+          },
+        ],
+      }),
+    );
+    const backend = createCopilotBackend({ tasks: client, github: stubGithub() });
+
+    expect(await backend.observe('task-1', { hasCandidate: true })).toEqual({
+      state: 'completed',
+      hasCandidate: true,
+      sessionCredits: 403.45,
     });
   });
 

--- a/apps/api/src/copilot-backend.ts
+++ b/apps/api/src/copilot-backend.ts
@@ -11,7 +11,12 @@
 // over the build channel instead of into a commit somebody merges.
 
 import type { AgentBackend, BuildBrief, DispatchResult, SeedFiles } from './agent-backend.js';
-import { resolveTaskBranch, type AgentTaskModel, type AgentTasksClient } from './agent-tasks.js';
+import {
+  creditsFromUsageAmount,
+  resolveTaskBranch,
+  type AgentTaskModel,
+  type AgentTasksClient,
+} from './agent-tasks.js';
 import type { GitHubClient } from './github-client.js';
 import type { AgentObservation } from './job-state.js';
 
@@ -328,7 +333,17 @@ export function createCopilotBackend(options: CopilotBackendOptions): AgentBacke
       // agent has created one, so a dispatch that does not come back and ask never
       // learns where its own work lives.
       const workspace = resolveTaskBranch(task);
-      return { state: task.state, hasCandidate, ...(workspace ? { workspace } : {}) };
+      // Sum every session that has reported usage. A task can host more than one
+      // session; the ledger entry is keyed by the task ref, so the figure has to be
+      // the whole bill for that dispatch, not just the latest run.
+      const usageTotal = task.sessions.reduce((sum, session) => (session.usage ? sum + session.usage.amount : sum), 0);
+      const hasUsage = task.sessions.some((session) => session.usage);
+      return {
+        state: task.state,
+        hasCandidate,
+        ...(workspace ? { workspace } : {}),
+        ...(hasUsage ? { sessionCredits: creditsFromUsageAmount(usageTotal) } : {}),
+      };
     },
 
     async cancel(): Promise<{ enforced: boolean }> {

--- a/apps/api/src/job-costs.ts
+++ b/apps/api/src/job-costs.ts
@@ -9,11 +9,12 @@
 // (see `JobCostEntry`). Nothing is estimated, and nothing is inferred from state: a job
 // that took four sessions reports four whether or not its transitions still say so.
 //
-// The unit problem is narrower than it looks. Copilot bills a premium request per session
-// and exposes no token counts, so tokens stay absent — but a credit is not a proxy for
-// money, it *is* money in another unit, and converting it estimates nothing. What remains
-// genuinely unpriced is Cloud Build minutes behind the gate, which is a smaller and
-// nameable hole rather than the whole money column.
+// The unit problem is narrower than it looks. Copilot bills AI credits per session
+// (`session.usage.amount`, nano-credits) and exposes no token counts, so tokens stay
+// absent — but a credit is not a proxy for money, it *is* money in another unit, and
+// converting it estimates nothing. What remains genuinely unpriced is Cloud Build
+// minutes behind the gate, which is a smaller and nameable hole rather than the whole
+// money column.
 //
 // Where absence is still the truth, this module reports absence rather than zero: a job
 // with no ledger reads as unmeasured, not as free.
@@ -42,9 +43,13 @@ export interface JobCostSummary {
   title: string;
   slug?: string;
   state?: JobState;
-  /** Agent sessions started. One premium request each on the Copilot backend. */
+  /** Agent sessions started (ledger rows of kind `agent_session`). */
   sessions: number;
-  /** Premium requests booked. Equal to `sessions` today; separate because it need not be. */
+  /**
+   * AI credits booked. Equal to `sessions` only while every row still holds the
+   * dispatch placeholder of 1; once observation writes real usage, this is the sum of
+   * those figures (typically tens to hundreds per session).
+   */
   credits: number;
   /** Gate runs started for this job — one per delivery that reached the verifier. */
   gateRuns: number;

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -259,6 +259,15 @@ export interface AgentObservation {
    * round cannot resume the work, it can only start again somewhere else.
    */
   workspace?: string;
+  /**
+   * Credits billed across every session on this task, once usage is known.
+   *
+   * The ledger books a placeholder of 1 credit at dispatch (usage is not on the create
+   * response). Observation is what replaces it with the real figure — which can arrive
+   * after the job has already moved past the agent, so cost reconciliation must not be
+   * gated on job state the way lifecycle reconciliation is.
+   */
+  sessionCredits?: number;
 }
 
 export interface ReconcileResult {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -249,8 +249,19 @@ export interface JobCostEntry {
   by: string;
   /** The vendor's own id, so a line on a bill can be traced back to a job. */
   ref?: string;
-  /** Premium requests. One per agent session, which is how Copilot bills. */
+  /**
+   * AI credits billed. For an `agent_session` this starts as a placeholder of 1 at
+   * dispatch (usage is not on the create response) and is overwritten with the real
+   * `session.usage.amount / 1e9` once observation sees it — measured sessions run
+   * 46–861 credits, so leaving the placeholder would under-report by up to 860×.
+   */
   credits?: number;
+  /**
+   * True once `credits` came from the vendor's usage figure rather than the dispatch
+   * placeholder. Lets the reconciler stop re-polling a finished task for a cost it
+   * already has, without mistaking a real 1-credit session for an unmeasured one.
+   */
+  creditsMeasured?: boolean;
   /**
    * Model tokens, when the thing that spent them reports them.
    *
@@ -1041,6 +1052,12 @@ export interface Store {
    */
   recordJobCost(issueNumber: number, entry: JobCostEntry): Promise<void>;
   /**
+   * Overwrites the credits on an existing `agent_session` ledger entry identified by
+   * `ref`, once the vendor has reported real usage. No-op when no matching entry exists.
+   * Best-effort like {@link recordJobCost}: must never fail the poll that discovered it.
+   */
+  setJobCostCredits(issueNumber: number, ref: string, credits: number): Promise<void>;
+  /**
    * Records where a dispatched job's work actually lives, once the backend can say.
    *
    * Deliberately not `recordDispatch`: that appends a session ref, and the ref list is
@@ -1708,6 +1725,19 @@ export class InMemoryStore implements Store {
       ...sub,
       costs: [...(sub.costs ?? []), entry].slice(-MAX_JOB_COSTS),
     });
+  }
+
+  async setJobCostCredits(issueNumber: number, ref: string, credits: number): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub?.costs?.length) return;
+    let changed = false;
+    const costs = sub.costs.map((entry) => {
+      if (entry.kind !== 'agent_session' || entry.ref !== ref || entry.creditsMeasured) return entry;
+      changed = true;
+      return { ...entry, credits, creditsMeasured: true };
+    });
+    if (!changed) return;
+    this.submissions.set(issueNumber, { ...sub, costs });
   }
 
   async setDispatchWorkspace(issueNumber: number, workspace: string): Promise<void> {
@@ -2733,6 +2763,23 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return;
       const existing = (snap.data() as SubmissionRecord).costs ?? [];
       tx.set(ref, { costs: [...existing, entry].slice(-MAX_JOB_COSTS) }, { merge: true });
+    });
+  }
+
+  async setJobCostCredits(issueNumber: number, ref: string, credits: number): Promise<void> {
+    const docRef = this.db.collection('submissions').doc(String(issueNumber));
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return;
+      const existing = (snap.data() as SubmissionRecord).costs ?? [];
+      let changed = false;
+      const costs = existing.map((entry) => {
+        if (entry.kind !== 'agent_session' || entry.ref !== ref || entry.creditsMeasured) return entry;
+        changed = true;
+        return { ...entry, credits, creditsMeasured: true };
+      });
+      if (!changed) return;
+      tx.set(docRef, { costs }, { merge: true });
     });
   }
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -799,6 +799,76 @@ describe('submission routes', () => {
     expect(response.statusCode).toBe(200);
     expect(createIssueComment).not.toHaveBeenCalled();
     expect(briefs.at(-1)?.feedback).toContain('Make the parcels bigger');
+    // Nothing delivered yet — this is not a revision, however the creator phrased it.
+    expect(briefs.at(-1)?.undelivered).toBe(true);
+
+    await app.close();
+  });
+
+  it('briefs feedback on an undelivered job as recovery, not as a revision', async () => {
+    // Job #1000003: first round died on quota with nothing uploaded; creator feedback
+    // then opened with "revise it, do not rebuild it" and `npm run restore` against an
+    // empty store. The record already knows (`deliveredVersion`); use it.
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend, briefs } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setDispatchWorkspace(job.issueNumber, 'copilot/partial-work');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}/feedback`,
+      headers: authHeaders,
+      payload: { feedback: 'Gdzie moja gra — I played nothing yet.' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(briefs.at(-1)?.undelivered).toBe(true);
+    expect(briefs.at(-1)?.previousWorkspace).toBe('copilot/partial-work');
+    expect(briefs.at(-1)?.feedback).toContain('Gdzie moja gra');
+
+    await app.close();
+  });
+
+  it('briefs feedback on a delivered job as a revision that restores from the store', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend, briefs } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v20260731T153306124Z');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}/feedback`,
+      headers: authHeaders,
+      payload: { feedback: 'Make the parcels bigger and the asteroids slower.' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(briefs.at(-1)?.undelivered).toBeUndefined();
+    expect(briefs.at(-1)?.feedback).toContain('Make the parcels bigger');
 
     await app.close();
   });
@@ -1157,7 +1227,8 @@ describe('submission routes', () => {
 
   it('deletes the spent workspace once a new round has one of its own', async () => {
     // Branches are per-round and disposable: the game lives in the store, so a branch
-    // that has been superseded is litter in a repository people also read.
+    // that has been superseded is litter in a repository people also read. Only applies
+    // when the store actually has the game — an undelivered round keeps its branch.
     const { githubClient } = createGithubClientStub({ issueNumber: 77 });
     const { backend } = createBackendStub();
     const cleanup = vi.fn(async () => {});
@@ -1175,6 +1246,7 @@ describe('submission routes', () => {
     });
     const [job] = await store.listSubmissionsByOwner('g:test-user');
     await store.setDispatchWorkspace(job.issueNumber, 'copilot/old');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
 
     await app.inject({
       method: 'POST',
@@ -2749,6 +2821,10 @@ describe('what a build costs', () => {
     const created = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
     const { token } = created.json() as { token: string };
 
+    // A delivery so the feedback round is a real revision (not the undelivered path).
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+
     const feedback = await app.inject({
       method: 'POST',
       url: `/api/submissions/${token}/feedback`,
@@ -2760,6 +2836,54 @@ describe('what a build costs', () => {
     const [record] = await store.listSubmissionsByOwner('g:test-user');
     expect(record?.costs?.map((entry) => entry.ref)).toEqual(['task-1', 'task-2']);
     expect(record?.costs?.every((entry) => entry.credits === 1)).toBe(true);
+
+    await app.close();
+  });
+
+  it('overwrites the dispatch placeholder with the real bill once the session reports usage', async () => {
+    // The create response has no usage. Observation does — and that can arrive after
+    // delivery has already moved the job past the agent, so cost reconciliation must
+    // not be gated on job state the way lifecycle reconciliation is.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const observe = vi.fn(async () => ({
+      state: 'completed' as const,
+      hasCandidate: true,
+      sessionCredits: 403.45,
+    }));
+    const clock = { t: Date.now() };
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: { ...backend, observe },
+      submissionTokenSecret: secret,
+      now: () => clock.t,
+    });
+
+    const created = await app.inject({ method: 'POST', url: '/api/submissions', headers: authHeaders, payload: body });
+    const { token } = created.json() as { token: string };
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v1');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: new Date(clock.t).toISOString(),
+      by: 'agent',
+      reason: 'sources_uploaded',
+    });
+
+    clock.t += 3 * 60 * 1000;
+    await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+
+    const costs = (await store.getSubmission(job.issueNumber))?.costs;
+    expect(costs).toEqual([
+      {
+        kind: 'agent_session',
+        at: expect.any(String),
+        by: 'stub',
+        ref: 'task-1',
+        credits: 403.45,
+        creditsMeasured: true,
+      },
+    ]);
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -503,9 +503,9 @@ export async function registerSubmissionRoutes(
         at: new Date(now()).toISOString(),
         by: agentBackend.name,
         ref,
-        // One premium request per session. Tokens are not exposed by this backend at
-        // all, so recording a zero would be an invented measurement rather than a
-        // missing one — the field is simply absent until something can fill it.
+        // Placeholder: usage is not on the dispatch response. Observation overwrites
+        // this with the real `session.usage.amount / 1e9` once the session reports it
+        // (typically 46–861 credits). Leaving 1 forever under-reports by up to 860×.
         credits: 1,
       });
     } catch (error) {
@@ -1437,9 +1437,18 @@ export async function registerSubmissionRoutes(
     const refs = record.dispatch?.refs;
     if (!refs || refs.length === 0) return null;
     const state = record.state ?? 'queued';
-    // Only while the agent's own lifecycle is the open question. Once the job is past
-    // the agent (delivered, gated, terminal), its sessions stop being authoritative.
-    if (state !== 'queued' && state !== 'dispatched' && state !== 'building') return null;
+    const lastRef = refs[refs.length - 1];
+    // Cost reconciliation is independent of job state: usage is only final once the
+    // session completes, which can be after delivery has already moved the job past
+    // the agent. A placeholder of 1 credit stays until observation overwrites it.
+    const costPending = (record.costs ?? []).some(
+      (entry) => entry.kind === 'agent_session' && entry.ref === lastRef && !entry.creditsMeasured,
+    );
+    // Lifecycle observation only while the agent's own lifecycle is the open question.
+    // Once the job is past the agent (delivered, gated, terminal), sessions stop being
+    // authoritative for state — but we still observe when cost is unmeasured.
+    const agentActive = state === 'queued' || state === 'dispatched' || state === 'building';
+    if (!agentActive && !costPending) return null;
     const quietFrom = record.lastAgentSignalAt ?? record.stateSince ?? record.createdAt;
     const silence = now() - Date.parse(quietFrom);
     // A job whose branch we never learned is asked about regardless of how chatty it
@@ -1447,14 +1456,26 @@ export async function registerSubmissionRoutes(
     // a fresh dispatch and the creator's game starts again from nothing — so learning
     // it is not an error path, it is the normal completion of a dispatch.
     const needsWorkspace = !record.dispatch?.workspace;
-    if (!needsWorkspace && (!Number.isFinite(silence) || silence < observeQuietMs)) return null;
+    // Cost-only polls skip the quiet window: the session is already done, and waiting
+    // would only delay the ledger catching up with the bill.
+    if (!needsWorkspace && agentActive && (!Number.isFinite(silence) || silence < observeQuietMs)) return null;
     try {
       // The last ref is the session that owns the job now; earlier ones were
       // superseded by a resume and their fate stopped mattering when it started.
-      const observation = await agentBackend.observe(refs[refs.length - 1], {
+      const observation = await agentBackend.observe(lastRef, {
         hasCandidate: Boolean(record.deliveredVersion),
       });
       if (!observation) return null;
+      if (observation.sessionCredits !== undefined) {
+        try {
+          await store.setJobCostCredits(record.issueNumber, lastRef, observation.sessionCredits);
+        } catch (error) {
+          app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not reconcile agent session cost');
+        }
+      }
+      // A cost-only poll on a job past the agent: write the credits and stop. State
+      // transitions from a late observation would snatch a delivered candidate back.
+      if (!agentActive) return null;
       if (observation.workspace && observation.workspace !== record.dispatch?.workspace) {
         await store.setDispatchWorkspace(record.issueNumber, observation.workspace);
         // Learning the agent's own branch is proof it has forked, which is the exact
@@ -2194,11 +2215,18 @@ export async function registerSubmissionRoutes(
       // account is silently ignored. That whole apparatus — the marker, the relay
       // workflow, the licensed PAT — existed only to get a message to an agent through
       // someone else's system, and none of it is needed now that we dispatch directly.
+      //
+      // When nothing was ever delivered, this is not a revision: the store has nothing
+      // to restore, and briefing the agent as if it were one spends the opening of the
+      // prompt on a `npm run restore` that cannot work. The record already knows
+      // (`deliveredVersion`); pass that through so `buildPrompt` leads with recovery
+      // of the previous branch instead.
       const outcome = await resumeBuild({
         issueNumber,
         feedback: contextBlock ? `${sanitizedFeedback}\n\n${contextBlock}` : sanitizedFeedback,
         locale: creatorLocale,
         log: request.log,
+        ...(record?.deliveredVersion ? {} : { undelivered: true }),
       });
 
       // Queue the same request on the build channel, so an agent already mid-session


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the site halves of [gamedevpl/www.gamedev.pl-games#283](https://github.com/gamedevpl/www.gamedev.pl-games/issues/283) — filed here as #410 and #411.

## #410 — ledger under-reports by up to 860×

`recordSessionCost` booked every agent session as `credits: 1`. Real sessions report `usage.amount` in nano-credits (measured 46–861). The parser dropped `usage`, so `usdPerPublishedGame` and `usdOnUnpublished` were fiction.

**Fix:** parse `session.usage`, sum it on observe, and overwrite the dispatch placeholder via `setJobCostCredits` once the figure is known. Cost reconciliation runs even after the job has moved past the agent (usage often finalizes after delivery).

## #411 — feedback on an undelivered job was briefed as a revision

`/feedback` called `resumeBuild` without `undelivered`, so `buildPrompt` opened with "revise it, do not rebuild it" and `npm run restore` against an empty store. The record already has `deliveredVersion`.

**Fix:** pass `undelivered: true` when there is no delivered version. The agent gets the branch-recovery brief instead of a restore that cannot work.

## Games-repo remainder (not in this PR)

#283's remaining question — what a full build legitimately costs, and why the 195–861 spread — still needs session transcripts (UI-only; no logs API). Machine-readable notes from the same data:

- Cost tracks wall-clock more than prompt size or `custom_agent`.
- The 861-credit cancelled session (`pipe-pressure`, 49 min, 658-char prompt) ran **without** `game-builder`.
- The 403-credit "revision" was a from-scratch build after a failed undelivered round — #411 is the brief half of that; salvaging partial work from quota-killed sessions is still open on the games side.

## Verification

- `npm run type-check` and `npm run lint` clean
- Targeted API tests green (agent-tasks, copilot-backend, submissions, job-costs, admin)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63301f83-a581-4601-9f96-bca065fa4cfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63301f83-a581-4601-9f96-bca065fa4cfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

