### PR TITLE
byoca(BY-02): self builder backend, registry routing, lifecycle

### DIFF
--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -1,31 +1,42 @@
-// Builds the coding-agent backend from the environment.
+// Builds the coding-agent backend registry from the environment.
 //
 // Kept apart from app.ts so that "which backend, configured how" is one readable
 // decision rather than a branch buried in server wiring — and so a second backend can be
 // added here without touching the server at all.
 
 import type { AgentBackend } from './agent-backend.js';
+import type { BuilderKind } from './builder.js';
 import { createAgentTasksClient, type AgentTaskModel } from './agent-tasks.js';
 import { createCopilotBackend } from './copilot-backend.js';
 import { VertexGameSeeder, type GameSeeder } from './game-seed.js';
 import { createGitHubClient } from './github-client.js';
 import { createArchiveSeedContextSource } from './seed-context.js';
+import { createSelfBuildBackend, type SelfBuildBackendOptions } from './self-build-backend.js';
 
 interface Logger {
   info: (context: object, message: string) => void;
   warn: (context: object, message: string) => void;
 }
 
+/** Registry keyed by the round's builder. `self` is always present; platform needs creds. */
+export interface AgentBackendRegistry {
+  platform?: AgentBackend;
+  self: AgentBackend;
+}
+
+export function resolveBuilderBackend(registry: AgentBackendRegistry, builder: BuilderKind): AgentBackend | undefined {
+  return builder === 'self' ? registry.self : registry.platform;
+}
+
 /**
- * Returns a backend, or undefined when this environment is not set up to dispatch.
+ * Returns a platform backend, or undefined when this environment is not set up to
+ * dispatch Copilot.
  *
  * Undefined is a supported state, not a failure: local development has no dispatch
- * credential, and an environment can run the whole product without one — submissions
- * still succeed and the games repo's label workflow still starts builds. Refusing to
- * boot without it would make the credential a hard dependency of serving the site,
- * which is the coupling this work exists to remove.
+ * credential, and an environment can run the whole product without one — self builds
+ * still work, and submissions that ask for the platform builder wait in `queued`.
  */
-export function createAgentBackendFromEnv(log?: Logger): AgentBackend | undefined {
+export function createPlatformBackendFromEnv(log?: Logger): AgentBackend | undefined {
   // Deliberately its own credential rather than reusing GITHUB_TOKEN. The agent tasks
   // API needs a user-to-server token (installation tokens are unsupported), and keeping
   // it separate means dispatch and serving fail independently — a dispatch PAT expiring
@@ -52,6 +63,30 @@ export function createAgentBackendFromEnv(log?: Logger): AgentBackend | undefine
     createPullRequest: false,
     ...(log ? { log } : {}),
   });
+}
+
+/**
+ * Builds the registry. Self is always available (no external credential); platform
+ * follows {@link createPlatformBackendFromEnv}.
+ */
+export function createAgentBackendRegistryFromEnv(
+  log?: Logger,
+  selfOptions?: SelfBuildBackendOptions,
+): AgentBackendRegistry {
+  const platform = createPlatformBackendFromEnv(log);
+  const self = createSelfBuildBackend(selfOptions);
+  if (!platform) {
+    log?.info({ backend: 'self' }, 'self-build backend enabled (no platform dispatch credential)');
+  }
+  return { ...(platform ? { platform } : {}), self };
+}
+
+/**
+ * @deprecated Prefer {@link createAgentBackendRegistryFromEnv}. Kept so older call sites
+ * that expect a single backend still resolve the platform adapter.
+ */
+export function createAgentBackendFromEnv(log?: Logger): AgentBackend | undefined {
+  return createPlatformBackendFromEnv(log);
 }
 
 /**

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { assertAgentTokenActive, InvalidAgentTokenError, readBearerToken, verifyAgentToken } from './agent-token.js';
+import { selfBuildDeliveryCap } from './builder.js';
 import { InvalidUploadError, type GamesStore } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState } from './job-state.js';
@@ -207,7 +208,13 @@ export interface AgentChannelOptions {
   }) => Promise<{ buildId?: string } | void> | void;
 }
 
-type RejectionReason = 'stopped' | 'rate_limited' | 'too_many_events' | 'too_many_shots';
+type RejectionReason =
+  | 'stopped'
+  | 'rate_limited'
+  | 'too_many_events'
+  | 'too_many_shots'
+  /** Self-round sources-delivery budget exhausted; machine-readable for agents. */
+  | 'delivery_cap';
 
 /** Sliding-window limiter keyed by build. The token is the identity, not the IP. */
 function isRateLimited(buckets: Map<number, number[]>, key: number, currentTime: number, max: number): boolean {
@@ -314,6 +321,25 @@ export async function registerAgentChannelRoutes(
     // implementing it.
     if (resolveJobState(record) === 'canceled') return 'canceled';
     return null;
+  }
+
+  /**
+   * First channel activity on a waiting job is the moment it becomes `building`.
+   *
+   * For self rounds this is the entire state advance — there is no external task to
+   * observe. Harmless for platform rounds that are already `building` via the
+   * reconciler: `canTransition` refuses a no-op.
+   */
+  async function markBuildingFromChannel(issueNumber: number, record: SubmissionRecord): Promise<void> {
+    if (!store) return;
+    const current = record.state ?? 'queued';
+    if (!canTransition(current, 'building')) return;
+    await store.recordJobTransition(issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'agent',
+      reason: 'channel_signal',
+    });
   }
 
   /**
@@ -464,6 +490,7 @@ export async function registerAgentChannelRoutes(
       };
 
       const stored = await store!.appendBuildEvent(issueNumber, event);
+      await markBuildingFromChannel(issueNumber, record);
       options.onEvent?.(issueNumber);
 
       return reply.send({ accepted: true, event: stored, ...(await channelState(issueNumber, record)) });
@@ -655,6 +682,22 @@ export async function registerAgentChannelRoutes(
       if (isRateLimited(submitsByBuild, issueNumber, now(), maxSubmitsPerWindow)) {
         return reply.send({ accepted: false, rejected: 'rate_limited', ...(await channelState(issueNumber, record)) });
       }
+      // Self rounds bound gate spend per round. The budget resets when a new round
+      // opens, so exhausting it never bricks the game's next attempt.
+      if (record.builder === 'self') {
+        const cap = selfBuildDeliveryCap();
+        const used = record.roundDeliveryCount ?? 0;
+        if (used >= cap) {
+          return reply.send({
+            accepted: false,
+            rejected: 'delivery_cap',
+            reason: 'self_build_delivery_cap',
+            deliveryCap: cap,
+            deliveriesUsed: used,
+            ...(await channelState(issueNumber, record)),
+          });
+        }
+      }
 
       // The job's own slug wins whenever it has one. A build that has already been
       // associated with a game cannot deliver into a different one, whatever it sends.
@@ -681,16 +724,23 @@ export async function registerAgentChannelRoutes(
       }
 
       try {
+        await markBuildingFromChannel(issueNumber, record);
         const { version } = await options.gamesStore.putCandidateSources({
           slug,
           issueNumber,
           files: parsed.data.files,
+          // Provenance: which backend built this version. Backend name on the dispatch
+          // ('copilot' / 'self') is the durable record; builder is the round selector.
+          backend: record.dispatch?.backend ?? record.builder,
         });
         // Recorded before the gate is asked to run: this is what the creator's preview
         // reads, and a delivered game should be playable on the status page whether or
         // not anything ever verifies it. The gate decides whether it may be *published*,
         // which is a different question from whether its author can watch it.
         await store?.setSubmissionDeliveredVersion(issueNumber, version);
+        if (store && record.builder === 'self') {
+          await store.incrementRoundDeliveryCount(issueNumber);
+        }
         // The shelf, studio, and notifications all show `record.title`. Games that
         // predated the naming step still carry the truncated prompt there, even after
         // the agent wrote a real name into SPEC.md — and publish already prefers the

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerJobAdminRoutes } from './job-admin-routes.js';
-import { createAgentBackendFromEnv, createGameSeederFromEnv } from './agent-backend-env.js';
+import { createGameSeederFromEnv, createPlatformBackendFromEnv } from './agent-backend-env.js';
 import { createGcsGamesStore } from './games-store.js';
 import { createCloudBuildGateTrigger, gateTriggerOptionsFromEnv } from './gate-trigger.js';
 import { registerAdminRoutes } from './admin.js';
@@ -210,7 +210,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // people its alerts are addressed to. Two lists would drift, and the failure mode of
     // drift here is an alert nobody receives.
     adminUids,
-    agentBackend: options.submissionRoutes?.agentBackend ?? createAgentBackendFromEnv(app.log),
+    agentBackend: options.submissionRoutes?.agentBackend,
+    // Platform only here — `self` is wired inside registerSubmissionRoutes with store
+    // callbacks for seed persistence. Passing a pre-built self would skip those.
+    agentBackends:
+      options.submissionRoutes?.agentBackends ??
+      (options.submissionRoutes?.agentBackend ? undefined : { platform: createPlatformBackendFromEnv(app.log) }),
     gameSeeder: options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log),
     agentChannel: {
       ...options.submissionRoutes?.agentChannel,

--- a/apps/api/src/builder.test.ts
+++ b/apps/api/src/builder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SELF_BUILD_CONNECT_DAYS,
+  DEFAULT_SELF_BUILD_DELIVERY_CAP,
+  isActiveBuildRound,
+  isBuilderKind,
+  selfBuildConnectDays,
+  selfBuildDeliveryCap,
+} from './builder.js';
+
+describe('builder helpers', () => {
+  it('recognises builder kinds', () => {
+    expect(isBuilderKind('self')).toBe(true);
+    expect(isBuilderKind('platform')).toBe(true);
+    expect(isBuilderKind('copilot')).toBe(false);
+  });
+
+  it('treats gate-red needs_changes as an active round', () => {
+    expect(
+      isActiveBuildRound({
+        state: 'needs_changes',
+        transitions: [{ to: 'needs_changes', at: 't', by: 'gate', reason: 'gate_red' }],
+      }),
+    ).toBe(true);
+    expect(
+      isActiveBuildRound({
+        state: 'needs_changes',
+        transitions: [{ to: 'needs_changes', at: 't', by: 'operator', reason: 'rejected' }],
+      }),
+    ).toBe(false);
+    expect(isActiveBuildRound({ state: 'building' })).toBe(true);
+    expect(isActiveBuildRound({ state: 'failed' })).toBe(false);
+  });
+
+  it('reads connect and delivery caps from env with defaults', () => {
+    delete process.env.SELF_BUILD_CONNECT_DAYS;
+    delete process.env.SELF_BUILD_DELIVERY_CAP;
+    expect(selfBuildConnectDays()).toBe(DEFAULT_SELF_BUILD_CONNECT_DAYS);
+    expect(selfBuildDeliveryCap()).toBe(DEFAULT_SELF_BUILD_DELIVERY_CAP);
+    process.env.SELF_BUILD_CONNECT_DAYS = '21';
+    process.env.SELF_BUILD_DELIVERY_CAP = '5';
+    expect(selfBuildConnectDays()).toBe(21);
+    expect(selfBuildDeliveryCap()).toBe(5);
+    delete process.env.SELF_BUILD_CONNECT_DAYS;
+    delete process.env.SELF_BUILD_DELIVERY_CAP;
+  });
+});

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -1,0 +1,54 @@
+// Which coding agent builds a round: the platform's (Copilot) or the creator's own.
+//
+// A property of the *round*, not the game. The game keeps a default (= last used) so the
+// next round can offer a sensible choice; an active round never switches mid-flight.
+
+import type { JobState, JobTransition } from './job-state.js';
+
+export const BUILDERS = ['platform', 'self'] as const;
+export type BuilderKind = (typeof BUILDERS)[number];
+
+export function isBuilderKind(value: unknown): value is BuilderKind {
+  return value === 'platform' || value === 'self';
+}
+
+/** Default lifetime before a self round with no agent signal is auto-abandoned. */
+export const DEFAULT_SELF_BUILD_CONNECT_DAYS = 14;
+
+/** Default per-round sources-delivery ceiling for self builds (bounds gate spend). */
+export const DEFAULT_SELF_BUILD_DELIVERY_CAP = 20;
+
+export function selfBuildConnectDays(): number {
+  const parsed = Number(process.env.SELF_BUILD_CONNECT_DAYS ?? DEFAULT_SELF_BUILD_CONNECT_DAYS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_SELF_BUILD_CONNECT_DAYS;
+}
+
+export function selfBuildDeliveryCap(): number {
+  const parsed = Number(process.env.SELF_BUILD_DELIVERY_CAP ?? DEFAULT_SELF_BUILD_DELIVERY_CAP);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_SELF_BUILD_DELIVERY_CAP;
+}
+
+/**
+ * Whether the current round is still live — builder must not change until it closes.
+ *
+ * Includes gate-red `needs_changes`: that outcome keeps the round open so the same
+ * session can repair and re-deliver without a new kickoff.
+ */
+export function isActiveBuildRound(record: { state?: JobState; transitions?: JobTransition[] }): boolean {
+  const state = record.state;
+  switch (state) {
+    case 'queued':
+    case 'dispatched':
+    case 'building':
+    case 'submitted':
+    case 'gating':
+    case 'publishing':
+      return true;
+    case 'needs_changes': {
+      const last = [...(record.transitions ?? [])].reverse().find((transition) => transition.to === 'needs_changes');
+      return last?.reason === 'gate_red';
+    }
+    default:
+      return false;
+  }
+}

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -8,6 +8,7 @@ import {
   nextRoundGeneration,
   planObservedStatusTransition,
   reconcileAgentObservation,
+  shouldAutoAbandonSelfRound,
   toSubmissionStatus,
   transitionClosesRound,
   type JobState,
@@ -280,5 +281,70 @@ describe('detectStall', () => {
   it('says nothing about finished jobs', () => {
     expect(detectStall({ state: 'published', stateSince: ago(10 * HOUR), now: NOW })).toBeNull();
     expect(detectStall({ state: 'failed', stateSince: ago(10 * HOUR), now: NOW })).toBeNull();
+  });
+
+  it('exposes no_agent_yet for self rounds before the first channel signal', () => {
+    expect(
+      detectStall({
+        state: 'dispatched',
+        stateSince: ago(HOUR),
+        builder: 'self',
+        now: NOW,
+      }),
+    ).toBe('no_agent_yet');
+    // Once the agent has spoken, ordinary quiet detection applies.
+    expect(
+      detectStall({
+        state: 'building',
+        stateSince: ago(HOUR),
+        lastAgentSignalAt: ago(HOUR),
+        builder: 'self',
+        now: NOW,
+      }),
+    ).toBe('quiet');
+    // Platform rounds keep the old not_dispatched / quiet vocabulary.
+    expect(detectStall({ state: 'dispatched', stateSince: ago(HOUR), builder: 'platform', now: NOW })).toBe(
+      'not_dispatched',
+    );
+  });
+});
+
+describe('shouldAutoAbandonSelfRound', () => {
+  const DAY = 24 * HOUR;
+
+  it('abandons only self rounds that never connected past the window', () => {
+    expect(
+      shouldAutoAbandonSelfRound({
+        builder: 'self',
+        roundOpenedAt: ago(15 * DAY),
+        now: NOW,
+        connectDays: 14,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutoAbandonSelfRound({
+        builder: 'self',
+        roundOpenedAt: ago(2 * DAY),
+        now: NOW,
+        connectDays: 14,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoAbandonSelfRound({
+        builder: 'self',
+        lastAgentSignalAt: ago(15 * DAY),
+        roundOpenedAt: ago(15 * DAY),
+        now: NOW,
+        connectDays: 14,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoAbandonSelfRound({
+        builder: 'platform',
+        roundOpenedAt: ago(15 * DAY),
+        now: NOW,
+        connectDays: 14,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -376,7 +376,13 @@ export type JobStall =
   /** A live session that has said nothing for a while. The old heuristic, kept. */
   | 'quiet'
   /** Delivered, but our own gate never picked it up. Our bug, not the agent's. */
-  | 'gate_not_started';
+  | 'gate_not_started'
+  /**
+   * A self-build round waiting for the creator's agent to connect. Distinct from
+   * `not_dispatched` / `quiet`: nothing is wedged — the platform dispatched locally and
+   * is idle on purpose until the first channel signal.
+   */
+  | 'no_agent_yet';
 
 export interface StallThresholds {
   notDispatchedMs: number;
@@ -406,6 +412,11 @@ export interface StallInput {
   agentState?: AgentTaskState;
   now: number;
   thresholds?: StallThresholds;
+  /**
+   * When `'self'`, silence before the first channel signal is `no_agent_yet` rather
+   * than a stall — the platform is waiting on purpose.
+   */
+  builder?: 'platform' | 'self';
 }
 
 /**
@@ -423,6 +434,16 @@ export function detectStall(input: StallInput): JobStall | null {
   // Explicit beats inferred: if the agent says it is waiting for us, there is nothing to
   // deduce from timestamps and no waiting period worth observing.
   if (input.agentState === 'waiting_for_user') return 'awaiting_input';
+
+  // Self rounds before the first channel signal are waiting, not stalled. After the
+  // first signal, ordinary quiet detection applies.
+  if (
+    input.builder === 'self' &&
+    !input.lastAgentSignalAt &&
+    (input.state === 'queued' || input.state === 'dispatched' || input.state === 'building')
+  ) {
+    return 'no_agent_yet';
+  }
 
   const sinceState = input.now - Date.parse(input.stateSince);
   if (!Number.isFinite(sinceState)) return null;
@@ -445,4 +466,27 @@ export function detectStall(input: StallInput): JobStall | null {
   }
 
   return null;
+}
+
+/**
+ * Whether a self round with no agent signal has outlived the connect window and should
+ * be auto-abandoned. Pure: the sweep supplies the clock and the configured window.
+ */
+export function shouldAutoAbandonSelfRound(input: {
+  builder?: 'platform' | 'self';
+  lastAgentSignalAt?: string;
+  abandonedAt?: string;
+  state?: JobState;
+  /** When the current round opened (typically `stateSince` after dispatch). */
+  roundOpenedAt: string;
+  now: number;
+  connectDays: number;
+}): boolean {
+  if (input.builder !== 'self') return false;
+  if (input.lastAgentSignalAt || input.abandonedAt) return false;
+  if (input.state && isTerminal(input.state)) return false;
+  const opened = Date.parse(input.roundOpenedAt);
+  if (!Number.isFinite(opened)) return false;
+  const windowMs = input.connectDays * 24 * 60 * 60 * 1000;
+  return input.now - opened >= windowMs;
 }

--- a/apps/api/src/self-build-backend.test.ts
+++ b/apps/api/src/self-build-backend.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SeedFiles } from './agent-backend.js';
+import { createSelfBuildBackend, parseSelfBuildRef, selfBuildRef } from './self-build-backend.js';
+
+const seed: SeedFiles = {
+  slug: 'demo',
+  files: [{ path: 'SPEC.md', content: '# Demo\n' }],
+  references: ['other'],
+};
+
+describe('createSelfBuildBackend', () => {
+  it('dispatches a self ref with no external call and persists the seed', async () => {
+    const persistSeed = vi.fn(async () => {});
+    const backend = createSelfBuildBackend({ persistSeed });
+
+    const result = await backend.dispatch({
+      issueNumber: 1001,
+      spec: 'a game',
+      channelToken: 'tok',
+      apiBaseUrl: 'https://example.test',
+      seed,
+    });
+
+    expect(backend.name).toBe('self');
+    expect(result).toEqual({ ref: 'self:1001' });
+    expect(result.seedWorkspace).toBeUndefined();
+    expect(persistSeed).toHaveBeenCalledWith(1001, seed);
+  });
+
+  it('resume reuses a stored seed instead of persisting again', async () => {
+    const persistSeed = vi.fn(async () => {});
+    const readSeed = vi.fn(async () => seed);
+    const backend = createSelfBuildBackend({ persistSeed, readSeed });
+
+    const result = await backend.resume(
+      {
+        issueNumber: 7,
+        spec: 'feedback',
+        feedback: 'make it louder',
+        channelToken: 'tok',
+        apiBaseUrl: 'https://example.test',
+        seed: { ...seed, notes: 'fresh' },
+      },
+      { ref: 'self:7' },
+    );
+
+    expect(result.ref).toBe('self:7');
+    expect(readSeed).toHaveBeenCalledWith(7);
+    expect(persistSeed).not.toHaveBeenCalled();
+  });
+
+  it('observe projects channel signals with no external reads', async () => {
+    const readSignals = vi.fn(async () => ({ lastAgentSignalAt: '2026-07-31T12:00:00Z' }));
+    const backend = createSelfBuildBackend({ readSignals });
+
+    await expect(backend.observe('self:3', { hasCandidate: false })).resolves.toEqual({
+      state: 'in_progress',
+      hasCandidate: false,
+    });
+    await expect(backend.observe('self:3', { hasCandidate: true })).resolves.toEqual({
+      state: 'completed',
+      hasCandidate: true,
+    });
+    readSignals.mockResolvedValueOnce({});
+    await expect(backend.observe('self:3', { hasCandidate: false })).resolves.toEqual({
+      state: 'queued',
+      hasCandidate: false,
+    });
+  });
+
+  it('cancel is cooperative', async () => {
+    const backend = createSelfBuildBackend();
+    await expect(backend.cancel('self:1')).resolves.toEqual({ enforced: false });
+  });
+
+  it('parses self refs', () => {
+    expect(selfBuildRef(42)).toBe('self:42');
+    expect(parseSelfBuildRef('self:42')).toBe(42);
+    expect(parseSelfBuildRef('copilot:abc')).toBeNull();
+  });
+});

--- a/apps/api/src/self-build-backend.ts
+++ b/apps/api/src/self-build-backend.ts
@@ -1,0 +1,95 @@
+// The "self" agent backend: the creator's own coding agent builds the game.
+//
+// The platform dispatches nothing external. A round opens a channel (token + job record),
+// optionally stores a generated seed draft on the job, and waits for channel activity.
+// Progress, delivery and stop all travel through the existing build channel — the same
+// path Copilot uses for upload and inbox — so gate, store and publication stay unaware
+// of who is typing on the other end.
+
+import type { AgentBackend, BuildBrief, DispatchResult, SeedFiles } from './agent-backend.js';
+import type { AgentObservation } from './job-state.js';
+
+export interface SelfBuildSignals {
+  lastAgentSignalAt?: string;
+  deliveredVersion?: string;
+}
+
+export interface SelfBuildBackendOptions {
+  /**
+   * Persists a generated seed on the job document. Self builds never commit a seed
+   * branch — the draft lives on the record until the agent (or a later round) reads it.
+   */
+  persistSeed?: (issueNumber: number, seed: SeedFiles) => Promise<void>;
+  /**
+   * Returns a previously stored seed for this job, when one exists. Resume reuses it
+   * rather than inventing a second draft of a game already in progress.
+   */
+  readSeed?: (issueNumber: number) => Promise<SeedFiles | undefined>;
+  /** Channel-side signals the reconciler projects into an observation. */
+  readSignals?: (issueNumber: number) => Promise<SelfBuildSignals | null>;
+}
+
+/** Opaque ref recorded on the job. Parseable back to the job id for observe. */
+export function selfBuildRef(issueNumber: number): string {
+  return `self:${issueNumber}`;
+}
+
+export function parseSelfBuildRef(ref: string): number | null {
+  const match = /^self:(\d+)$/.exec(ref);
+  if (!match) return null;
+  const id = Number(match[1]);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export function createSelfBuildBackend(options: SelfBuildBackendOptions = {}): AgentBackend {
+  async function openRound(brief: BuildBrief): Promise<DispatchResult> {
+    // Prefer a seed already stored on the job (resume of the same round) over inventing
+    // another. A brief.seed from the caller still wins when nothing is stored yet —
+    // that is the first-dispatch path after the seeder ran.
+    const existing = options.readSeed ? await options.readSeed(brief.issueNumber) : undefined;
+    const seed = existing ?? brief.seed;
+    if (seed && options.persistSeed && !existing) {
+      await options.persistSeed(brief.issueNumber, seed);
+    }
+    return { ref: selfBuildRef(brief.issueNumber) };
+  }
+
+  return {
+    name: 'self',
+
+    async dispatch(brief: BuildBrief): Promise<DispatchResult> {
+      return openRound(brief);
+    },
+
+    async resume(brief: BuildBrief, _previous: DispatchResult): Promise<DispatchResult> {
+      return openRound(brief);
+    },
+
+    /**
+     * Projects channel signals into the vendor-neutral observation shape.
+     *
+     * No external reads: the store already knows whether the agent has spoken and
+     * whether anything was delivered. Returning `queued` before the first signal is
+     * what keeps self rounds out of Copilot-style "not_dispatched" stalls.
+     */
+    async observe(ref: string, { hasCandidate }: { hasCandidate: boolean }): Promise<AgentObservation | null> {
+      const issueNumber = parseSelfBuildRef(ref);
+      if (issueNumber === null) return null;
+      const signals = options.readSignals ? await options.readSignals(issueNumber) : null;
+      const delivered = hasCandidate || Boolean(signals?.deliveredVersion);
+      if (delivered) {
+        return { state: 'completed', hasCandidate: true };
+      }
+      if (signals?.lastAgentSignalAt) {
+        return { state: 'in_progress', hasCandidate: false };
+      }
+      return { state: 'queued', hasCandidate: false };
+    },
+
+    async cancel(): Promise<{ enforced: boolean }> {
+      // Same cooperative stop as Copilot: the channel's control.stop tells a live agent
+      // to exit; nothing here can kill a process on the creator's machine.
+      return { enforced: false };
+    },
+  };
+}

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -1,0 +1,513 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentBackend, BuildBrief, SeedFiles } from './agent-backend.js';
+import { mintAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { GamesStore } from './games-store.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { InMemoryStore } from './store.js';
+import { mintToken } from './submission-token.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'self-build-test-secret';
+const sessionSecret = 'dev-session-secret-change-me';
+const CONCEPT = 'A squad tactics game about clearing rooms with careful timing and cover.';
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: 1 }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+function platformStub() {
+  const briefs: BuildBrief[] = [];
+  const backend: AgentBackend = {
+    name: 'copilot',
+    dispatch: async (brief) => {
+      briefs.push(brief);
+      return { ref: `copilot-${briefs.length}`, workspace: `copilot/branch-${briefs.length}` };
+    },
+    resume: async (brief) => {
+      briefs.push(brief);
+      return { ref: `copilot-r-${briefs.length}`, workspace: `copilot/branch-r-${briefs.length}` };
+    },
+    observe: async () => null,
+    cancel: async () => ({ enforced: false }),
+  };
+  return { backend, briefs };
+}
+
+const MINIMAL_FILES = [
+  { path: 'SPEC.md', content: '---\ntitle: Self Built\n---\n' },
+  { path: 'index.html', content: '<!doctype html>' },
+  { path: 'game.ts', content: 'export {};' },
+  { path: 'TRACE.json', content: '{"samples":[]}' },
+  { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
+];
+
+function stubGamesStore() {
+  const stored: Array<{ slug: string; issueNumber: number; backend?: string; files: unknown[] }> = [];
+  const versions = new Map<string, { files: typeof MINIMAL_FILES; backend?: string }>();
+  const gamesStore = {
+    putCandidateSources: async (input: {
+      slug: string;
+      issueNumber: number;
+      files: typeof MINIMAL_FILES;
+      backend?: string;
+    }) => {
+      stored.push(input);
+      const version = `v${stored.length}`;
+      versions.set(`${input.slug}:${version}`, { files: input.files, backend: input.backend });
+      return {
+        version,
+        manifest: {
+          slug: input.slug,
+          version,
+          createdAt: new Date().toISOString(),
+          issueNumber: input.issueNumber,
+          backend: input.backend,
+          sourceFiles: input.files.map((f) => f.path),
+        },
+      };
+    },
+    getManifest: async (slug: string, version: string) => {
+      const hit = versions.get(`${slug}:${version}`);
+      if (!hit) return null;
+      return {
+        slug,
+        version,
+        createdAt: new Date().toISOString(),
+        issueNumber: 0,
+        backend: hit.backend,
+        sourceFiles: hit.files.map((f) => f.path),
+      };
+    },
+    getSourceFile: async (slug: string, version: string, path: string) => {
+      const hit = versions.get(`${slug}:${version}`);
+      return hit?.files.find((f) => f.path === path)?.content ?? null;
+    },
+    putGateResult: async () => {},
+    putHealthResult: async () => {},
+    putDerivedArtifact: async () => {},
+    getDerivedArtifact: async () => null,
+  } as unknown as GamesStore;
+  return { gamesStore, stored };
+}
+
+async function createApp(options: {
+  platform?: AgentBackend;
+  gameSeeder?: {
+    seed: (input: { slug: string; title: string; spec: string }) => Promise<
+      SeedFiles & {
+        compiles: boolean;
+        usage: { model: string; inputTokens: number; outputTokens: number };
+        elapsedMs: number;
+      }
+    >;
+  };
+  gamesStore?: GamesStore;
+  now?: () => number;
+  internalAuthVerifier?: { verify: (header: string | undefined) => Promise<boolean> };
+}) {
+  const store = new InMemoryStore();
+  await store.upsertUser({ uid: 'g:creator', email: 'c@example.com', betaStatus: 'approved' });
+  const app = await buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      now: options.now,
+      internalAuthVerifier: options.internalAuthVerifier,
+      ...(options.platform ? { agentBackend: options.platform } : {}),
+      ...(options.gameSeeder ? { gameSeeder: options.gameSeeder } : {}),
+      ...(options.gamesStore ? { agentChannel: { gamesStore: options.gamesStore } } : {}),
+    },
+  });
+  return { app, store };
+}
+
+function authHeaders(uid = 'g:creator') {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+function agentHeaders(issueNumber: number, roundGeneration = 1) {
+  return {
+    authorization: `Bearer ${mintAgentToken(issueNumber, secret, { roundGeneration })}`,
+  };
+}
+
+describe('self builder (BY-02)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+    delete process.env.SELF_BUILD_DELIVERY_CAP;
+    delete process.env.SELF_BUILD_CONNECT_DAYS;
+  });
+
+  it('routes self vs platform per round and leaves Copilot path unchanged for platform', async () => {
+    const { backend, briefs } = platformStub();
+    const created = await createApp({ platform: backend });
+    app = created.app;
+    const { store } = created;
+
+    const platformSubmit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Platform Game', concept: CONCEPT, builder: 'platform' },
+    });
+    expect(platformSubmit.statusCode).toBe(200);
+    // Background dispatch — wait briefly for the voided promise.
+    await vi.waitFor(async () => {
+      const records = await store.listSubmissionsByOwner('g:creator');
+      expect(records[0]?.dispatch?.backend).toBe('copilot');
+    });
+    expect(briefs).toHaveLength(1);
+    expect(briefs[0]?.seed).toBeUndefined();
+
+    const selfSubmit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Self Game', concept: CONCEPT, builder: 'self' },
+    });
+    expect(selfSubmit.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      const records = await store.listSubmissionsByOwner('g:creator');
+      const selfJob = records.find((r) => r.title === 'Self Game');
+      expect(selfJob?.builder).toBe('self');
+      expect(selfJob?.defaultBuilder).toBe('self');
+      expect(selfJob?.dispatch?.backend).toBe('self');
+      expect(selfJob?.dispatch?.refs.at(-1)).toMatch(/^self:\d+$/);
+    });
+    // Platform stub was not called again for the self round.
+    expect(briefs).toHaveLength(1);
+  });
+
+  it('stores a generated seed on the job for self rounds (no seed branch)', async () => {
+    const seedFiles: SeedFiles = {
+      slug: 'seeded-self',
+      files: [{ path: 'SPEC.md', content: '# Seed\n' }],
+      references: ['ref-a'],
+    };
+    const gameSeeder = {
+      seed: async () => ({
+        ...seedFiles,
+        compiles: true,
+        elapsedMs: 1,
+        usage: { model: 'test-model', inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const created = await createApp({ gameSeeder });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Seeded Self', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+
+    await vi.waitFor(async () => {
+      const record = (await store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.seed?.files).toEqual(seedFiles.files);
+      expect(record?.dispatch?.seedWorkspace).toBeUndefined();
+      expect(record?.dispatch?.refs?.[0]).toMatch(/^self:/);
+    });
+  });
+
+  it('walks queued→building→submitted on channel signals for a self round', async () => {
+    const { gamesStore, stored } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Walk State', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const slug = submit.json().slug as string;
+
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      const record = (await store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.state).toBe('dispatched');
+      issueNumber = record!.issueNumber;
+    });
+
+    const statusWaiting = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}`,
+    });
+    expect(statusWaiting.json().stall).toBe('no_agent_yet');
+
+    const progress = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(issueNumber),
+      payload: { text: 'Scaffolding the loop.' },
+    });
+    expect(progress.statusCode).toBe(200);
+    expect((await store.getSubmission(issueNumber))?.state).toBe('building');
+
+    const delivery = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES },
+    });
+    expect(delivery.json()).toMatchObject({ accepted: true });
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+    expect(stored[0]?.backend).toBe('self');
+  });
+
+  it('enforces SELF_BUILD_DELIVERY_CAP with a machine-readable refusal', async () => {
+    process.env.SELF_BUILD_DELIVERY_CAP = '2';
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Cap Game', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+      expect((await store.getSubmission(issueNumber))?.builder).toBe('self');
+    });
+
+    for (let i = 0; i < 2; i += 1) {
+      const ok = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(issueNumber),
+        payload: { slug, files: MINIMAL_FILES },
+      });
+      expect(ok.json().accepted).toBe(true);
+    }
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES },
+    });
+    expect(refused.json()).toMatchObject({
+      accepted: false,
+      rejected: 'delivery_cap',
+      reason: 'self_build_delivery_cap',
+      deliveryCap: 2,
+      deliveriesUsed: 2,
+    });
+  });
+
+  it('auto-abandons a self round with no agent connect after SELF_BUILD_CONNECT_DAYS', async () => {
+    process.env.SELF_BUILD_CONNECT_DAYS = '14';
+    const opened = Date.parse('2026-07-01T00:00:00Z');
+    let clock = opened;
+    const created = await createApp({
+      now: () => clock,
+      internalAuthVerifier: { verify: async () => true },
+    });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'No Connect', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      const record = (await store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.state).toBe('dispatched');
+      issueNumber = record!.issueNumber;
+    });
+
+    clock = opened + 15 * 24 * 60 * 60 * 1000;
+    const sweep = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer internal' },
+    });
+    expect(sweep.statusCode).toBe(200);
+    const abandoned = await store.getSubmission(issueNumber);
+    expect(abandoned?.state).toBe('abandoned');
+    expect(abandoned?.abandonedAt).toBeTruthy();
+    expect(abandoned?.transitions?.at(-1)?.reason).toBe('no_connect');
+  });
+
+  it('switches builder both directions only at a round boundary', async () => {
+    const { backend, briefs } = platformStub();
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ platform: backend, gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Switch Game', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    // Mid-round switch refused.
+    const mid = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
+      headers: authHeaders(),
+      payload: { feedback: 'Please switch builders now please.', builder: 'platform' },
+    });
+    expect(mid.statusCode).toBe(409);
+    expect(mid.json()).toMatchObject({ error: 'builder_locked', reason: 'active_round', builder: 'self' });
+
+    // Deliver + close the round via gate-green transition so a new round can choose.
+    await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES },
+    });
+    await store.recordJobTransition(issueNumber, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    // ready_for_review closes the round; bounce to needs_changes (reject) to open feedback.
+    await store.recordJobTransition(issueNumber, {
+      to: 'needs_changes',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'rejected',
+    });
+
+    const switchToPlatform = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
+      headers: authHeaders(),
+      payload: {
+        feedback: 'Please have the platform team finish this game carefully.',
+        builder: 'platform',
+      },
+    });
+    expect(switchToPlatform.statusCode).toBe(200);
+    await vi.waitFor(() => expect(briefs.length).toBeGreaterThan(0));
+    const afterPlatform = await store.getSubmission(issueNumber);
+    expect(afterPlatform?.builder).toBe('platform');
+    expect(afterPlatform?.defaultBuilder).toBe('platform');
+    expect(afterPlatform?.dispatch?.backend).toBe('copilot');
+    // self→platform carries latest candidate sources as brief.seed.
+    expect(briefs.at(-1)?.seed?.files.some((f) => f.path === 'SPEC.md')).toBe(true);
+
+    await store.recordJobTransition(issueNumber, {
+      to: 'needs_changes',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'rejected',
+    });
+    const switchToSelf = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
+      headers: authHeaders(),
+      payload: {
+        feedback: 'I will finish this myself with my own agent now.',
+        builder: 'self',
+      },
+    });
+    expect(switchToSelf.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      const record = await store.getSubmission(issueNumber);
+      expect(record?.builder).toBe('self');
+      expect(record?.dispatch?.backend).toBe('self');
+    });
+  });
+
+  it('records builder provenance on delivered versions', async () => {
+    const { gamesStore, stored } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Provenance', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES },
+    });
+    expect(stored[0]?.backend).toBe('self');
+    expect((await store.getSubmission(issueNumber))?.builder).toBe('self');
+  });
+
+  it('preserves strict 401 for stale tokens on terminal self jobs (no stopReason bypass)', async () => {
+    const created = await createApp({});
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(99, 'g:creator', 'Terminal');
+    await store.setRoundBuilder(99, 'self');
+    await store.recordJobTransition(99, {
+      to: 'abandoned',
+      at: new Date().toISOString(),
+      by: 'system',
+      reason: 'no_connect',
+    });
+    await store.setSubmissionAbandoned(99, new Date().toISOString());
+    // Round close bumps generation to 2; mint against the previous one.
+    const stale = mintAgentToken(99, secret, { roundGeneration: 1 });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: { authorization: `Bearer ${stale}` },
+      payload: { text: 'still here' },
+    });
+    expect(response.statusCode).toBe(401);
+    expect(response.json().error).toMatch(/fresh prompt/i);
+  });
+});

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { FieldValue, Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-tasks.js';
+import type { SeedFiles } from './agent-backend.js';
+import type { BuilderKind } from './builder.js';
 import type { PublicationHealthCheck, PublicationRecord } from './games-store.js';
 import { nextRoundGeneration, transitionClosesRound, type JobState, type JobTransition } from './job-state.js';
 import type { BuildEvent, SubmissionStatus } from './submission-status.js';
@@ -238,6 +240,28 @@ export interface SubmissionRecord {
    * the field. New jobs start at `1`.
    */
   roundGeneration?: number;
+  /**
+   * Which builder owns the *current* round: the platform's coding agent, or the
+   * creator's own. Absent on legacy jobs (= platform).
+   */
+  builder?: BuilderKind;
+  /**
+   * Last builder used on this game. The next round defaults to it so switching is an
+   * explicit choice at a round boundary rather than a settings dig.
+   */
+  defaultBuilder?: BuilderKind;
+  /**
+   * Generated round-0 draft stored on the job for a self build.
+   *
+   * Self builds never commit a seed branch — the files live here until an agent (or a
+   * later read endpoint) consumes them. Cleared when a new round opens.
+   */
+  seed?: SeedFiles;
+  /**
+   * How many sources deliveries this round has accepted. Self rounds cap this
+   * (`SELF_BUILD_DELIVERY_CAP`); resets when a new round opens.
+   */
+  roundDeliveryCount?: number;
 }
 
 /**
@@ -1066,6 +1090,15 @@ export interface Store {
   ensureRoundGeneration(issueNumber: number): Promise<number | null>;
   /** Records the agent backend's last reported state, for stall detection. */
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;
+  /**
+   * Records which builder owns the current round and updates the game's default.
+   * Starting a new round also resets per-round counters (deliveries, stored seed).
+   */
+  setRoundBuilder(issueNumber: number, builder: BuilderKind, options?: { resetRoundBudget?: boolean }): Promise<void>;
+  /** Stores (or clears) the generated seed draft on a self-build job. */
+  setSubmissionSeed(issueNumber: number, seed: SeedFiles | null): Promise<void>;
+  /** Increments and returns the per-round sources-delivery count. */
+  incrementRoundDeliveryCount(issueNumber: number): Promise<number>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
   recordDispatch(
     issueNumber: number,
@@ -1703,13 +1736,15 @@ export class InMemoryStore implements Store {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return false;
     const closes = transitionClosesRound(transition);
-    this.submissions.set(issueNumber, {
+    const next: SubmissionRecord = {
       ...sub,
       state: transition.to,
       stateSince: transition.at,
       transitions: [...(sub.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
-      ...(closes ? { roundGeneration: nextRoundGeneration(sub.roundGeneration) } : {}),
-    });
+      ...(closes ? { roundGeneration: nextRoundGeneration(sub.roundGeneration), roundDeliveryCount: 0 } : {}),
+    };
+    if (closes) delete next.seed;
+    this.submissions.set(issueNumber, next);
     return true;
   }
 
@@ -1717,7 +1752,9 @@ export class InMemoryStore implements Store {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return null;
     const roundGeneration = nextRoundGeneration(sub.roundGeneration);
-    this.submissions.set(issueNumber, { ...sub, roundGeneration });
+    const next: SubmissionRecord = { ...sub, roundGeneration, roundDeliveryCount: 0 };
+    delete next.seed;
+    this.submissions.set(issueNumber, next);
     return roundGeneration;
   }
 
@@ -1732,6 +1769,46 @@ export class InMemoryStore implements Store {
   async setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void> {
     const sub = this.submissions.get(issueNumber);
     if (sub) this.submissions.set(issueNumber, { ...sub, agentState });
+  }
+
+  async setRoundBuilder(
+    issueNumber: number,
+    builder: BuilderKind,
+    options?: { resetRoundBudget?: boolean },
+  ): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    const reset = options?.resetRoundBudget ?? false;
+    const next: SubmissionRecord = {
+      ...sub,
+      builder,
+      defaultBuilder: builder,
+    };
+    if (reset) {
+      delete next.seed;
+      next.roundDeliveryCount = 0;
+    }
+    this.submissions.set(issueNumber, next);
+  }
+
+  async setSubmissionSeed(issueNumber: number, seed: SeedFiles | null): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    if (seed) {
+      this.submissions.set(issueNumber, { ...sub, seed });
+      return;
+    }
+    const next = { ...sub };
+    delete next.seed;
+    this.submissions.set(issueNumber, next);
+  }
+
+  async incrementRoundDeliveryCount(issueNumber: number): Promise<number> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return 0;
+    const roundDeliveryCount = (sub.roundDeliveryCount ?? 0) + 1;
+    this.submissions.set(issueNumber, { ...sub, roundDeliveryCount });
+    return roundDeliveryCount;
   }
 
   async allocateJobId(): Promise<number> {
@@ -2746,16 +2823,28 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return false;
       const current = snap.data() as SubmissionRecord;
       const closes = transitionClosesRound(transition);
-      tx.set(
-        ref,
-        {
+      if (closes) {
+        const next: SubmissionRecord = {
+          ...current,
           state: transition.to,
           stateSince: transition.at,
           transitions: [...(current.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
-          ...(closes ? { roundGeneration: nextRoundGeneration(current.roundGeneration) } : {}),
-        },
-        { merge: true },
-      );
+          roundGeneration: nextRoundGeneration(current.roundGeneration),
+          roundDeliveryCount: 0,
+        };
+        delete next.seed;
+        tx.set(ref, next);
+      } else {
+        tx.set(
+          ref,
+          {
+            state: transition.to,
+            stateSince: transition.at,
+            transitions: [...(current.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
+          },
+          { merge: true },
+        );
+      }
       return true;
     });
   }
@@ -2767,7 +2856,9 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return null;
       const current = snap.data() as SubmissionRecord;
       const roundGeneration = nextRoundGeneration(current.roundGeneration);
-      tx.set(ref, { roundGeneration }, { merge: true });
+      const next: SubmissionRecord = { ...current, roundGeneration, roundDeliveryCount: 0 };
+      delete next.seed;
+      tx.set(ref, next);
       return roundGeneration;
     });
   }
@@ -2786,6 +2877,61 @@ export class FirestoreStore implements Store {
 
   async setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void> {
     await this.db.collection('submissions').doc(String(issueNumber)).set({ agentState }, { merge: true });
+  }
+
+  async setRoundBuilder(
+    issueNumber: number,
+    builder: BuilderKind,
+    options?: { resetRoundBudget?: boolean },
+  ): Promise<void> {
+    const reset = options?.resetRoundBudget ?? false;
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    if (!reset) {
+      await ref.set({ builder, defaultBuilder: builder }, { merge: true });
+      return;
+    }
+    // Clearing seed on a new round: merge cannot delete a field, so read-modify-write.
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return;
+      const current = snap.data() as SubmissionRecord;
+      const next: SubmissionRecord = {
+        ...current,
+        builder,
+        defaultBuilder: builder,
+        roundDeliveryCount: 0,
+      };
+      delete next.seed;
+      tx.set(ref, next);
+    });
+  }
+
+  async setSubmissionSeed(issueNumber: number, seed: SeedFiles | null): Promise<void> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    if (seed) {
+      await ref.set({ seed }, { merge: true });
+      return;
+    }
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return;
+      const current = snap.data() as SubmissionRecord;
+      const next = { ...current };
+      delete next.seed;
+      tx.set(ref, next);
+    });
+  }
+
+  async incrementRoundDeliveryCount(issueNumber: number): Promise<number> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return 0;
+      const current = snap.data() as SubmissionRecord;
+      const roundDeliveryCount = (current.roundDeliveryCount ?? 0) + 1;
+      tx.set(ref, { roundDeliveryCount }, { merge: true });
+      return roundDeliveryCount;
+    });
   }
 
   async allocateJobId(): Promise<number> {

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -179,7 +179,8 @@ export interface SubmissionStatusResponseBase {
   playable?: BuildPlayableItem[];
   /**
    * Why this build looks stuck, when it does — `awaiting_input`, `not_dispatched`,
-   * `quiet`, or `gate_not_started`. Absent means it is progressing normally.
+   * `quiet`, `gate_not_started`, or `no_agent_yet` (self round waiting to connect).
+   * Absent means it is progressing normally.
    *
    * The creator-experience review's open finding was that we could say "the agent has
    * been quiet" but never "the agent errored", so a stuck build and a slow one read

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -22,6 +22,8 @@ import {
 import { startHealthCheck } from './game-health.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import type { AgentBackend, SeedFiles } from './agent-backend.js';
+import { resolveBuilderBackend, type AgentBackendRegistry } from './agent-backend-env.js';
+import { isActiveBuildRound, isBuilderKind, selfBuildConnectDays, type BuilderKind } from './builder.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import {
   canTransition,
@@ -30,10 +32,12 @@ import {
   planObservedStatusTransition,
   reconcileAgentObservation,
   resolveJobState,
+  shouldAutoAbandonSelfRound,
   toSubmissionStatus,
   type JobState,
   type JobTransition,
 } from './job-state.js';
+import { createSelfBuildBackend } from './self-build-backend.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
@@ -68,6 +72,11 @@ const CreateSubmissionRequestSchema = z.object({
   displayName: z.string().trim().max(40, 'display name must be at most 40 characters').optional(),
   /** The language the creator is using, so the agent can report progress in it. */
   locale: z.string().trim().max(10).optional(),
+  /**
+   * Who builds this round. Defaults to `platform`. Studio UI (out of scope here) will
+   * surface the choice; the API accepts it so routing is testable without the card.
+   */
+  builder: z.enum(['platform', 'self']).optional(),
 });
 
 // Re-exported for callers (and tests) that knew it here; it now lives with the status
@@ -108,6 +117,11 @@ const FeedbackRequestSchema = z.object({
     .trim()
     .min(10, 'feedback must be at least 10 characters')
     .max(2000, 'feedback must be at most 2000 characters'),
+  /**
+   * Builder for the *new* round this feedback opens. Refused while the current round
+   * is still active — switching is a round-boundary decision only.
+   */
+  builder: z.enum(['platform', 'self']).optional(),
   /**
    * Optional playtest attachment from Creator Studio: a paused-frame PNG (base64,
    * no data: prefix) plus a small instrumentation digest. Treated as data, never
@@ -239,10 +253,16 @@ export interface SubmissionRoutesOptions {
   translator?: Translator;
   /** Caps and seams for the agent build channel; see registerAgentChannelRoutes. */
   /**
-   * Which coding-agent backend builds submitted games. Absent means dispatch is not
-   * wired in this environment and the games repo's label workflow still starts builds.
+   * Which coding-agent backend builds submitted games. Treated as the `platform` entry
+   * of the registry when {@link agentBackends} is omitted — keeps existing tests and
+   * call sites working unchanged.
    */
   agentBackend?: AgentBackend;
+  /**
+   * Per-builder registry. When set, wins over {@link agentBackend}. `self` is always
+   * filled in (a default self backend) if the caller omits it.
+   */
+  agentBackends?: Partial<AgentBackendRegistry> & { platform?: AgentBackend };
   /**
    * Writes the first draft a new build starts from. Absent means every build starts from
    * an empty directory, which is what they all did before seeding existed.
@@ -403,8 +423,45 @@ export async function registerSubmissionRoutes(
   const improvementRateLimitWindowMs = 60 * 60 * 1000;
   const maxImprovementsPerWindow = 10;
   const internalAuthVerifier = options.internalAuthVerifier ?? createInternalAuthVerifierFromEnv();
-  const agentBackend = options.agentBackend;
   const gameSeeder = options.gameSeeder;
+  const gamesStoreForSeed = options.agentChannel?.gamesStore;
+
+  function buildAgentRegistry(): AgentBackendRegistry {
+    const selfOptions = store
+      ? {
+          persistSeed: async (issueNumber: number, seed: SeedFiles) => {
+            await store.setSubmissionSeed(issueNumber, seed);
+          },
+          readSeed: async (issueNumber: number) => {
+            const record = await store.getSubmission(issueNumber);
+            return record?.seed;
+          },
+          readSignals: async (issueNumber: number) => {
+            const record = await store.getSubmission(issueNumber);
+            if (!record) return null;
+            return {
+              lastAgentSignalAt: record.lastAgentSignalAt,
+              deliveredVersion: record.deliveredVersion,
+            };
+          },
+        }
+      : undefined;
+    // An explicit `agentBackend` (tests, one-off wiring) wins over the env registry's
+    // platform entry — same precedence the single-backend option had before the registry.
+    const self = options.agentBackends?.self ?? createSelfBuildBackend(selfOptions);
+    const platform = options.agentBackend ?? options.agentBackends?.platform;
+    return { ...(platform ? { platform } : {}), self };
+  }
+
+  const agentBackends = buildAgentRegistry();
+
+  function backendFor(builder: BuilderKind | undefined): AgentBackend | undefined {
+    return resolveBuilderBackend(agentBackends, builder ?? 'platform');
+  }
+
+  function builderOf(record: SubmissionRecord | null | undefined): BuilderKind {
+    return record?.builder ?? record?.defaultBuilder ?? 'platform';
+  }
   /**
    * When to stop generating seeds nobody can place.
    *
@@ -494,14 +551,16 @@ export async function registerSubmissionRoutes(
   async function recordSessionCost(
     issueNumber: number,
     ref: string,
+    backend: AgentBackend,
     log: { error: (context: object, message: string) => void },
   ): Promise<void> {
-    if (!store || !agentBackend) return;
+    // Self builds run on the creator's machine — there is no platform agent session to bill.
+    if (!store || backend.name === 'self') return;
     try {
       await store.recordJobCost(issueNumber, {
         kind: 'agent_session',
         at: new Date(now()).toISOString(),
-        by: agentBackend.name,
+        by: backend.name,
         ref,
         // Placeholder: usage is not on the dispatch response. Observation overwrites
         // this with the real `session.usage.amount / 1e9` once the session reports it
@@ -510,6 +569,27 @@ export async function registerSubmissionRoutes(
       });
     } catch (error) {
       log.error({ err: error, issueNumber }, 'could not record the cost of an agent session');
+    }
+  }
+
+  /**
+   * Latest candidate/published sources as a BuildBrief.seed — used when a self→platform
+   * switch hands Copilot the game the creator's agent already delivered.
+   */
+  async function seedFromLatestDelivery(record: SubmissionRecord): Promise<SeedFiles | undefined> {
+    if (!gamesStoreForSeed || !record.slug || !record.deliveredVersion) return undefined;
+    try {
+      const manifest = await gamesStoreForSeed.getManifest(record.slug, record.deliveredVersion);
+      if (!manifest) return undefined;
+      const files: { path: string; content: string }[] = [];
+      for (const path of manifest.sourceFiles) {
+        const content = await gamesStoreForSeed.getSourceFile(record.slug, record.deliveredVersion, path);
+        if (content === null) return undefined;
+        files.push({ path, content });
+      }
+      return { slug: record.slug, files, references: [] };
+    } catch {
+      return undefined;
     }
   }
 
@@ -648,29 +728,41 @@ export async function registerSubmissionRoutes(
     slug?: string;
     /** What to change about the existing game. Untrusted text: data, never instructions. */
     feedback?: string;
+    /** Who builds this round. Defaults to the game's last builder, then `platform`. */
+    builder?: BuilderKind;
   }): Promise<boolean> {
     // Without the signing secret there is no per-job channel credential to give the
     // agent, and an agent that cannot report or deliver is worse than one never started.
-    if (!agentBackend || !submissionTokenSecret) return false;
+    if (!submissionTokenSecret || !store) return false;
+    const existing = await store.getSubmission(input.issueNumber);
+    const builder = input.builder ?? builderOf(existing);
+    const selected = backendFor(builder);
+    if (!selected) return false;
     try {
+      await store.setRoundBuilder(input.issueNumber, builder, { resetRoundBudget: false });
       // Before the brief is built, so the agent is told about a draft only when one is
       // really there — and so the slug it mints is on the record the brief reads from.
       // A seed is written into `games/<slug>/`, so a job without a slug cannot have one.
       // Every new submission has one by now; the guard is for the paths that do not.
-      const draft = input.feedback || !input.slug ? undefined : await seedBuild({ ...input, slug: input.slug });
-      const seed: SeedFiles | undefined = draft
-        ? {
-            slug: draft.slug,
-            files: draft.files,
-            references: draft.references,
-            ...(draft.notes ? { notes: draft.notes } : {}),
-          }
-        : undefined;
+      // Self rounds reuse a seed already on the job (resume of the same round).
+      const storedSeed = builder === 'self' ? existing?.seed : undefined;
+      const draft =
+        storedSeed || input.feedback || !input.slug ? undefined : await seedBuild({ ...input, slug: input.slug });
+      const seed: SeedFiles | undefined = storedSeed
+        ? storedSeed
+        : draft
+          ? {
+              slug: draft.slug,
+              files: draft.files,
+              references: draft.references,
+              ...(draft.notes ? { notes: draft.notes } : {}),
+            }
+          : undefined;
       // Persist generation before minting. New jobs already carry `1` from
       // createSubmission; a legacy job without the field must be initialized here so
       // the round-scoped token we hand the agent validates against the record.
-      const roundGeneration = (await store?.ensureRoundGeneration(input.issueNumber)) ?? 1;
-      const result = await agentBackend.dispatch({
+      const roundGeneration = (await store.ensureRoundGeneration(input.issueNumber)) ?? 1;
+      const result = await selected.dispatch({
         issueNumber: input.issueNumber,
         ...(input.slug ? { slug: input.slug } : {}),
         spec: input.spec,
@@ -684,19 +776,18 @@ export async function registerSubmissionRoutes(
         ...(input.feedback ? { feedback: input.feedback } : {}),
         ...(seed ? { seed } : {}),
       });
-      // A seed that went in without a workspace coming back is a backend that could not
-      // place it. Inferred rather than reported because it is true of every backend: the
-      // seam promises a `seedWorkspace` when a seed was staged, so its absence is the
-      // signal, whatever the reason underneath.
-      if (seed && !result.seedWorkspace) {
+      // A seed that went in without a workspace coming back is a *platform* backend that
+      // could not place it. Self builds store the seed on the job (no branch), so the
+      // absence of seedWorkspace is expected and must not mute the seeder.
+      if (seed && !result.seedWorkspace && builder === 'platform') {
         seedStagingMutedUntil = now() + SEED_STAGING_COOLDOWN_MS;
         input.log.error(
           { issueNumber: input.issueNumber, mutedForMs: SEED_STAGING_COOLDOWN_MS },
           'the generated seed could not be staged; pausing seeding rather than generating drafts nobody can place',
         );
       }
-      await store?.recordDispatch(input.issueNumber, {
-        backend: agentBackend.name,
+      await store.recordDispatch(input.issueNumber, {
+        backend: selected.name,
         ref: result.ref,
         workspace: result.workspace,
         seedWorkspace: result.seedWorkspace,
@@ -717,12 +808,12 @@ export async function registerSubmissionRoutes(
           input.log.error({ err: error, issueNumber: input.issueNumber }, 'seed preview failed');
         });
       }
-      await recordSessionCost(input.issueNumber, result.ref, input.log);
-      await store?.recordJobTransition(input.issueNumber, {
+      await recordSessionCost(input.issueNumber, result.ref, selected, input.log);
+      await store.recordJobTransition(input.issueNumber, {
         to: 'dispatched',
         at: new Date(now()).toISOString(),
         by: 'system',
-        reason: `dispatched_to_${agentBackend.name}`,
+        reason: `dispatched_to_${selected.name}`,
       });
       return true;
     } catch (error) {
@@ -761,10 +852,16 @@ export async function registerSubmissionRoutes(
      * fact an audit of that job would want.
      */
     transition?: { by: JobTransition['by']; reason: string };
+    /** Builder for the new round. Ignored on undelivered nudges (same round). */
+    builder?: BuilderKind;
   }): Promise<ResumeOutcome> {
-    if (!agentBackend || !submissionTokenSecret || !store) return { started: false, reason: 'not_configured' };
+    if (!submissionTokenSecret || !store) return { started: false, reason: 'not_configured' };
     const record = await store.getSubmission(input.issueNumber);
     const previous = record?.dispatch;
+    const previousBuilder = builderOf(record);
+    const builder = input.undelivered ? previousBuilder : (input.builder ?? record?.defaultBuilder ?? previousBuilder);
+    const selected = backendFor(builder);
+    if (!selected) return { started: false, reason: 'not_configured' };
     try {
       // A new round closes the previous one's token. Bump *before* minting so the brief
       // carries the generation that is now active. An undelivered nudge is the same
@@ -773,6 +870,18 @@ export async function registerSubmissionRoutes(
       const roundGeneration = input.undelivered
         ? ((await store.ensureRoundGeneration(input.issueNumber)) ?? 1)
         : ((await store.bumpRoundGeneration(input.issueNumber)) ?? (record?.roundGeneration ?? 0) + 1);
+      if (!input.undelivered) {
+        await store.setRoundBuilder(input.issueNumber, builder, { resetRoundBudget: true });
+      }
+      // self→platform: hand Copilot the latest delivered sources as the brief seed so
+      // the platform round continues the game rather than starting from nothing.
+      const switchSeed =
+        !input.undelivered && previousBuilder === 'self' && builder === 'platform' && record
+          ? await seedFromLatestDelivery(record)
+          : undefined;
+      // After a round bump the stored seed was cleared; only an undelivered nudge
+      // (same round) still has one to reuse. `record` was loaded before the reset.
+      const reusedSelfSeed = input.undelivered && builder === 'self' ? record?.seed : undefined;
       const brief = {
         issueNumber: input.issueNumber,
         slug: record?.slug,
@@ -787,19 +896,24 @@ export async function registerSubmissionRoutes(
         ...(input.undelivered
           ? { undelivered: true, ...(previous?.workspace ? { previousWorkspace: previous.workspace } : {}) }
           : {}),
+        ...(switchSeed ? { seed: switchSeed } : {}),
+        ...(reusedSelfSeed ? { seed: reusedSelfSeed } : {}),
       };
-      const result = previous?.refs.length
-        ? await agentBackend.resume(brief, {
-            ref: previous.refs[previous.refs.length - 1],
-            workspace: previous.workspace,
+      // Resume against the *selected* backend. When the builder changes at a round
+      // boundary the previous ref belongs to a different backend — start fresh.
+      const sameBackend = previous?.backend === selected.name && Boolean(previous?.refs.length);
+      const result = sameBackend
+        ? await selected.resume(brief, {
+            ref: previous!.refs[previous!.refs.length - 1],
+            workspace: previous!.workspace,
           })
-        : await agentBackend.dispatch(brief);
+        : await selected.dispatch(brief);
       await store.recordDispatch(input.issueNumber, {
-        backend: agentBackend.name,
+        backend: selected.name,
         ref: result.ref,
         workspace: result.workspace,
       });
-      await recordSessionCost(input.issueNumber, result.ref, input.log);
+      await recordSessionCost(input.issueNumber, result.ref, selected, input.log);
       // The previous workspace is spent the moment a new round has one of its own: the
       // round that follows restores the game from the store rather than from a branch.
       // Deleted after the dispatch succeeds, never before — a round that failed to
@@ -912,9 +1026,11 @@ export async function registerSubmissionRoutes(
     workspace: string,
     log: { error: (context: object, message: string) => void },
   ): Promise<void> {
-    if (!agentBackend?.cleanup) return;
+    // Workspace cleanup is a platform (Copilot) concern — self rounds have none.
+    const cleanupBackend = agentBackends.platform;
+    if (!cleanupBackend?.cleanup) return;
     try {
-      await agentBackend.cleanup({ ref: '', workspace });
+      await cleanupBackend.cleanup({ ref: '', workspace });
     } catch (error) {
       log.error({ err: error, issueNumber, workspace }, 'could not delete a spent build workspace');
     }
@@ -1413,6 +1529,7 @@ export async function registerSubmissionRoutes(
       lastAgentSignalAt: record.lastAgentSignalAt,
       agentState: record.agentState,
       now: now(),
+      builder: builderOf(record),
     });
     if (stall) status.stall = stall;
     return status;
@@ -1450,7 +1567,9 @@ export async function registerSubmissionRoutes(
    * minute, and the quiet window means a healthy, chatty build never triggers it.
    */
   async function reconcileNativeJob(record: SubmissionRecord): Promise<JobTransition | null> {
-    if (!agentBackend || !store) return null;
+    if (!store) return null;
+    const selected = backendFor(builderOf(record));
+    if (!selected) return null;
     const refs = record.dispatch?.refs;
     if (!refs || refs.length === 0) return null;
     const state = record.state ?? 'queued';
@@ -1472,14 +1591,25 @@ export async function registerSubmissionRoutes(
     // is. Without the branch a revision cannot resume the work — `resume` degrades to
     // a fresh dispatch and the creator's game starts again from nothing — so learning
     // it is not an error path, it is the normal completion of a dispatch.
-    const needsWorkspace = !record.dispatch?.workspace;
+    const needsWorkspace = !record.dispatch?.workspace && selected.name !== 'self';
+    // Self rounds project from channel signals; ask as soon as a signal exists so
+    // queued/dispatched advances to building without waiting out the quiet window.
+    const selfNeedsProjection =
+      selected.name === 'self' && agentActive && Boolean(record.lastAgentSignalAt) && state !== 'building';
     // Cost-only polls skip the quiet window: the session is already done, and waiting
     // would only delay the ledger catching up with the bill.
-    if (!needsWorkspace && agentActive && (!Number.isFinite(silence) || silence < observeQuietMs)) return null;
+    if (
+      !needsWorkspace &&
+      !selfNeedsProjection &&
+      agentActive &&
+      (!Number.isFinite(silence) || silence < observeQuietMs)
+    ) {
+      return null;
+    }
     try {
       // The last ref is the session that owns the job now; earlier ones were
       // superseded by a resume and their fate stopped mattering when it started.
-      const observation = await agentBackend.observe(lastRef, {
+      const observation = await selected.observe(lastRef, {
         hasCandidate: Boolean(record.deliveredVersion),
       });
       if (!observation) return null;
@@ -1766,6 +1896,7 @@ export async function registerSubmissionRoutes(
       // Fastify request — headers, body, reply — alive for as long as dispatch runs,
       // which since seeding is minutes rather than milliseconds, on every submission.
       const dispatchLog = request.log;
+      const builder: BuilderKind = parsed.data.builder ?? 'platform';
       void dispatchBuild({
         issueNumber: jobId,
         // The agent is told where to build rather than left to name the place itself.
@@ -1774,6 +1905,7 @@ export async function registerSubmissionRoutes(
         slug,
         spec: issueBody,
         locale: creatorLocale,
+        builder,
         log: dispatchLog,
       }).catch((error: unknown) => {
         dispatchLog.error({ err: error, issueNumber: jobId }, 'background dispatch failed');
@@ -1945,9 +2077,10 @@ export async function registerSubmissionRoutes(
       // so a live session keeps running and the guarantee we actually give the creator
       // is that the job is terminal and whatever arrives afterwards is discarded.
       const ref = record.dispatch?.refs.at(-1);
-      if (agentBackend && ref) {
+      const cancelBackend = backendFor(builderOf(record));
+      if (cancelBackend && ref) {
         try {
-          await agentBackend.cancel(ref);
+          await cancelBackend.cancel(ref);
         } catch (cancelError) {
           request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed');
         }
@@ -2238,12 +2371,24 @@ export async function registerSubmissionRoutes(
       // prompt on a `npm run restore` that cannot work. The record already knows
       // (`deliveredVersion`); pass that through so `buildPrompt` leads with recovery
       // of the previous branch instead.
+      const requestedBuilder = parsed.data.builder;
+      if (record && requestedBuilder && isActiveBuildRound(record)) {
+        const current = builderOf(record);
+        if (requestedBuilder !== current) {
+          return reply.status(409).send({
+            error: 'builder_locked',
+            reason: 'active_round',
+            builder: current,
+          });
+        }
+      }
       const outcome = await resumeBuild({
         issueNumber,
         feedback: contextBlock ? `${sanitizedFeedback}\n\n${contextBlock}` : sanitizedFeedback,
         locale: creatorLocale,
         log: request.log,
         ...(record?.deliveredVersion ? {} : { undelivered: true }),
+        ...(requestedBuilder && isBuilderKind(requestedBuilder) ? { builder: requestedBuilder } : {}),
       });
 
       // Queue the same request on the build channel, so an agent already mid-session
@@ -2423,9 +2568,10 @@ export async function registerSubmissionRoutes(
     // than "stopped".
     let stopEnforced = false;
     const refs = record.dispatch?.refs;
-    if (agentBackend && refs?.length) {
+    const cancelBackend = backendFor(builderOf(record));
+    if (cancelBackend && refs?.length) {
       try {
-        stopEnforced = (await agentBackend.cancel(refs[refs.length - 1])).enforced;
+        stopEnforced = (await cancelBackend.cancel(refs[refs.length - 1])).enforced;
       } catch (cancelError) {
         request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed; job is canceled regardless');
       }
@@ -2476,7 +2622,7 @@ export async function registerSubmissionRoutes(
   app.post<{ Params: { issueNumber: string } }>('/api/admin/jobs/:issueNumber/retry', async (request, reply) => {
     if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
     if (!store) return reply.status(503).send({ error: 'store_unavailable' });
-    if (!agentBackend || !submissionTokenSecret) {
+    if (!submissionTokenSecret) {
       return reply.status(503).send({ error: 'agent_backend_unavailable' });
     }
     const issueNumber = Number(request.params.issueNumber);
@@ -2484,6 +2630,9 @@ export async function registerSubmissionRoutes(
 
     const record = await store.getSubmission(issueNumber);
     if (!record) return reply.status(404).send({ error: 'not_found' });
+    if (!backendFor(builderOf(record))) {
+      return reply.status(503).send({ error: 'agent_backend_unavailable' });
+    }
 
     const state = resolveJobState(record);
     if (!state || !OPERATOR_RETRY_STATES.has(state)) {
@@ -2725,6 +2874,42 @@ export async function registerSubmissionRoutes(
       const pendingFeedback = new Map<number, string>();
       for (const record of active) {
         try {
+          // Self rounds with no agent signal ever: auto-abandon after the connect window
+          // so a forgotten kickoff does not leave a live channel capability forever.
+          if (
+            shouldAutoAbandonSelfRound({
+              builder: builderOf(record),
+              lastAgentSignalAt: record.lastAgentSignalAt,
+              abandonedAt: record.abandonedAt,
+              state: record.state,
+              roundOpenedAt: record.stateSince ?? record.createdAt,
+              now: now(),
+              connectDays: selfBuildConnectDays(),
+            })
+          ) {
+            const at = new Date(now()).toISOString();
+            const cancelBackend = backendFor(builderOf(record));
+            const ref = record.dispatch?.refs.at(-1);
+            if (cancelBackend && ref) {
+              try {
+                await cancelBackend.cancel(ref);
+              } catch (cancelError) {
+                request.log.error(
+                  { err: cancelError, issueNumber: record.issueNumber },
+                  'self no-connect cancel failed',
+                );
+              }
+            }
+            await store.recordJobTransition(record.issueNumber, {
+              to: 'abandoned',
+              at,
+              by: 'system',
+              reason: 'no_connect',
+            });
+            await store.setSubmissionAbandoned(record.issueNumber, at);
+            continue;
+          }
+
           // Unread-request detection. A creator's change request is dispatched to the
           // agent and queued here; the queue is what an agent already mid-session
           // drains. If dispatch succeeded but no agent ever collects — a dead session,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a `self` agent backend so creators can build via their own coding agent over the existing build channel (no platform dispatch). Each round records `builder: 'platform' | 'self'` and selects from a backend registry; self rounds get job-stored seeds, `no_agent_yet` / no-connect auto-abandon, and a per-round delivery cap. Round-boundary switching works both ways (self→platform seeds Copilot from the latest store delivery).

Rebased onto master after BY-01 merged (`10f5afd5`, BY-02-only).

## DoD evidence
- [x] 1. builder per round + registry — `apps/api/src/builder.ts`, `apps/api/src/store.ts` (`builder` / `defaultBuilder`), `resolveBuilderBackend` in `agent-backend-env.ts`, `setRoundBuilder` in `submissions.ts`; test `routes self vs platform per round and leaves Copilot path unchanged for platform`
- [x] 2. `createSelfBuildBackend()` — `apps/api/src/self-build-backend.ts` (`dispatch` → `self:<jobId>`, persist seed, no branch; `resume` reuses seed; `observe` from channel; `cancel` → `{enforced:false}`); `self-build-backend.test.ts`
- [x] 3a. no stall before first signal → `no_agent_yet` — `job-state.ts`; tests in `self-build.test.ts` / `job-state.test.ts`
- [x] 3b. auto-abandon after `SELF_BUILD_CONNECT_DAYS` — `shouldAutoAbandonSelfRound` + submissions sweep; test `auto-abandons a self round with no agent connect after SELF_BUILD_CONNECT_DAYS`
- [x] 3c. `SELF_BUILD_DELIVERY_CAP` on sources — `agent-channel.ts` (`rejected: 'delivery_cap'`); test `enforces SELF_BUILD_DELIVERY_CAP with a machine-readable refusal`
- [x] 4. round-boundary switching — `isActiveBuildRound` + `builder_locked`; self→platform `seedFromLatestDelivery`; test `switches builder both directions only at a round boundary`
- [x] 5. Tests: routing / seed / state walk / cap / no-connect / switch / provenance — `self-build.test.ts`
- [x] Copilot/platform path unchanged — platform stub test + `copilot-backend.test.ts` still pass
- [x] Strict-401 / no stopReason stale bypass preserved — regression in `agent-channel.test.ts` + self coverage `preserves strict 401 for stale tokens on terminal self jobs`

## Commands (agent-reported; supervisor will re-verify)
- `npm run type-check` / `lint` / `build` → pass
- `npm test -w @gamedevpl/api` → 1612/1612

## Out of scope
MCP, Studio UI, connect endpoint, token shape (BY-01).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

