### PR TITLE
infra: bake games-store versioning, soft-delete, noncurrent prune

### DIFF
--- a/infra/gate-hardening.md
+++ b/infra/gate-hardening.md
@@ -72,10 +72,10 @@ immutable objects.”
 
 Add these to the post-merge owner list (not done by merging this PR):
 
-1. **Enable object versioning and/or soft-delete retention** on `GAMES_STORE_BUCKET`, so
-   a hostile (or buggy) gate run’s deletions/overwrites remain recoverable for a defined
-   retention window. Prefer both if cost allows: versioning for overwrite recovery,
-   soft-delete for explicit deletes.
+1. **Object versioning + soft-delete + noncurrent prune** on `GAMES_STORE_BUCKET` —
+   applied by `setup-gcp.sh` (versioning on, soft-delete 30d, lifecycle deletes
+   noncurrent versions after 30d). Live originals are never aged out. Re-run
+   `./infra/setup-gcp.sh` if a fresh project is missing these.
 2. **Longer-term (record, do not block):** route verdict/manifest writes through the API’s
    own runtime identity (or a narrow “manifest writer” SA the gate calls via an internal
    endpoint), so the Cloud Build gate SA can drop to `objectCreator` + `objectViewer` and
@@ -114,9 +114,10 @@ These require project credentials. Re-run or perform after merging:
 5. **Optional: drop project-wide `roles/iam.serviceAccountUser` on the runtime SA** if it
    was granted only so Cloud Build could run as arbitrary SAs — prefer the
    per-SA binding `setup-gcp.sh` adds on `gate-runner` only.
-6. **Bucket versioning / soft-delete on the games store** — compensating control for
-   `gate-runner`’s `objectAdmin` (see “Store IAM: why objectAdmin” above). Enable before
-   or immediately after flipping production builds onto `gate-runner`.
+6. **Bucket versioning / soft-delete / noncurrent prune** — applied by `setup-gcp.sh`
+   (see store-bucket block). Confirm with
+   `gcloud storage buckets describe gs://$GAMES_STORE_BUCKET --format='yaml(versioning_enabled,soft_delete_policy,lifecycle_config)'`
+   after the first post-BY-11 run if you have not already.
 7. **Optional longer-term:** move manifest/verdict writes off the gate SA so it can drop
    to `objectCreator`+`objectViewer` (API-mediated writes).
 

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -253,10 +253,37 @@ for role in roles/storage.objectViewer roles/storage.objectCreator; do
     >/dev/null
 done
 
-# Deliberately NO lifecycle rule. The snapshot bucket expires old objects because they
-# are rebuildable; these are the originals. A rule that deleted them would delete the
-# games — versioned history is the rollback path and the creator's own record of work.
-echo "    IAM applied (deployer: admin, Cloud Run: read+create). No lifecycle: these are originals."
+# Live objects are never aged out — these are the originals, not a rebuildable
+# projection. Object versioning + soft-delete are the BY-11 compensating controls
+# for gate-runner's objectAdmin (overwrite/delete recovery); the lifecycle rule
+# only deletes *noncurrent* versions so versioning does not grow unbounded.
+# See infra/gate-hardening.md "Store IAM: why objectAdmin".
+echo "    IAM applied (deployer: admin, Cloud Run: read+create)."
+echo "    Ensuring object versioning, 30d soft-delete, and noncurrent-version prune…"
+gcloud storage buckets update "gs://${STORE_BUCKET}" \
+  --versioning \
+  --soft-delete-duration=30d \
+  --project="$PROJECT_ID" \
+  >/dev/null
+STORE_LIFECYCLE_FILE="$(mktemp)"
+cat > "$STORE_LIFECYCLE_FILE" <<'EOF'
+{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": { "type": "Delete" },
+        "condition": { "isLive": false, "daysSinceNoncurrentTime": 30 }
+      }
+    ]
+  }
+}
+EOF
+gcloud storage buckets update "gs://${STORE_BUCKET}" \
+  --lifecycle-file="$STORE_LIFECYCLE_FILE" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+rm -f "$STORE_LIFECYCLE_FILE"
+echo "    Versioning on; soft-delete 30d; noncurrent versions pruned after 30d."
 
 # Dedicated identity for gate Cloud Build runs (cloudbuild-gate.yaml / gate-trigger.ts).
 # Submitted sources are hostile: the build must not inherit the project default Cloud

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -329,8 +329,8 @@ grant_gate_with_retry() {
 }
 
 # objectAdmin (includes delete) is forced by in-place manifest updates — see
-# infra/gate-hardening.md "Store IAM: why objectAdmin". Compensate with bucket
-# versioning / soft-delete (owner console).
+# infra/gate-hardening.md "Store IAM: why objectAdmin". Compensated above with
+# versioning + soft-delete + noncurrent prune on this bucket.
 grant_gate_with_retry gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${GATE_SA_EMAIL}" \
   --role="roles/storage.objectAdmin" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
BY-11 compensating control for `gate-runner`’s `objectAdmin`: versioning + soft-delete recover hostile/buggy deletes and overwrites. Without a prune rule, noncurrent versions grow forever. Owner already enabled versioning and 30d soft-delete by hand; this makes the full set durable in `setup-gcp.sh`.

## What
On the games store bucket, every `setup-gcp.sh` run now ensures:
1. `--versioning`
2. `--soft-delete-duration=30d`
3. Lifecycle: delete only **noncurrent** versions after 30 days (`isLive: false`)

Live originals are never aged out. Docs in `infra/gate-hardening.md` updated.

## Owner after merge
Either re-run `./infra/setup-gcp.sh`, or apply the lifecycle once now (versioning + soft-delete already done):

```bash
cat > /tmp/games-store-lifecycle.json <<'EOF'
{
  "lifecycle": {
    "rule": [
      {
        "action": { "type": "Delete" },
        "condition": { "isLive": false, "daysSinceNoncurrentTime": 30 }
      }
    ]
  }
}
EOF
gcloud storage buckets update gs://gamedevpl-games-store \
  --lifecycle-file=/tmp/games-store-lifecycle.json
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

