### PR TITLE
byoca(BY-06): delivery hardening — allowlist, kit window, gate screenshots

### DIFF
--- a/apps/api/scripts/run-gate.ts
+++ b/apps/api/scripts/run-gate.ts
@@ -138,11 +138,15 @@ async function main(): Promise<void> {
     });
   } else {
     // The resolved sha rides along so the manifest ends up pinned to what was actually
-    // checked — the first run stamps it, later runs leave the pin alone.
+    // checked — the first run stamps it, later runs leave the pin alone. screenshot /
+    // kit_outdated ride along so the API reconciler can post the frame and surface the
+    // status without re-deriving either from the bucket listing.
     await store.putGateResult(slug, version, {
       green: outcome.green,
       report: outcome.report,
       engineRef: outcome.engineCommit,
+      ...(outcome.status ? { status: outcome.status } : {}),
+      ...(outcome.screenshot ? { screenshot: outcome.screenshot } : {}),
     });
   }
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -684,9 +684,14 @@ describe('agent build channel', () => {
     ];
 
     function stubGamesStore() {
-      const stored: Array<{ slug: string; issueNumber: number; files: unknown[] }> = [];
+      const stored: Array<{ slug: string; issueNumber: number; files: unknown[]; kitEngineRef?: string }> = [];
       const gamesStore = {
-        putCandidateSources: async (input: { slug: string; issueNumber: number; files: unknown[] }) => {
+        putCandidateSources: async (input: {
+          slug: string;
+          issueNumber: number;
+          files: unknown[];
+          kitEngineRef?: string;
+        }) => {
           stored.push(input);
           const { validateSourceUpload } = await import('./games-store.js');
           validateSourceUpload(input.files as Array<{ path: string; content: string }>);
@@ -697,6 +702,7 @@ describe('agent build channel', () => {
         putGateResult: async () => {},
         putDerivedArtifact: async () => {},
         getDerivedArtifact: async () => null,
+        getKitRegistry: async () => null,
       } as unknown as GamesStore;
       return { gamesStore, stored };
     }
@@ -711,11 +717,40 @@ describe('agent build channel', () => {
         method: 'POST',
         url: '/api/agent/build/sources',
         headers: agentHeaders(),
-        payload: { slug: 'comet-courier', files: MINIMAL },
+        payload: {
+          slug: 'comet-courier',
+          files: MINIMAL,
+          kitEngineRef: 'abcdef1234567890',
+        },
       });
 
       expect(response.json()).toMatchObject({ accepted: true, delivery: { slug: 'comet-courier', version: 'v1' } });
-      expect(stored[0]).toMatchObject({ slug: 'comet-courier', issueNumber: ISSUE });
+      expect(stored[0]).toMatchObject({
+        slug: 'comet-courier',
+        issueNumber: ISSUE,
+        kitEngineRef: 'abcdef1234567890',
+      });
+    });
+
+    it('rejects config-shaped filenames at the sources endpoint, naming the path', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          files: [...MINIMAL, { path: 'package.json', content: '{}' }],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('package.json');
+      expect(response.json().error).toMatch(/Config or executable-shaped/i);
     });
 
     it('adopts the SPEC title so the shelf stops showing a truncated prompt', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -126,6 +126,17 @@ const BuildSourcesInputSchema = z.object({
     )
     .min(1, 'files is required')
     .max(64, 'too many files'),
+  /**
+   * Creator Kit engineRef the sources were built against. Required for self-build
+   * deliveries (BY-06); the gate compares it to `kits/current.json`'s N/N−1 window.
+   */
+  kitEngineRef: z
+    .string()
+    .trim()
+    .min(7, 'kitEngineRef must be a kit engine commit')
+    .max(64)
+    .regex(/^[0-9a-f]+$/i, 'kitEngineRef must be a hex commit sha')
+    .optional(),
 });
 
 const BuildPreviewInputSchema = z.object({
@@ -374,6 +385,8 @@ export async function registerAgentChannelRoutes(
         // The tail is where the chain names the check that stopped it; the runner has
         // already trimmed to 4000 characters for exactly this reason.
         ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
+        // `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game.
+        ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
       };
     } catch (error) {
       app.log.warn({ err: error, issueNumber: record.issueNumber, slug }, 'could not read the gate verdict');
@@ -418,11 +431,15 @@ export async function registerAgentChannelRoutes(
         ...(gate && !gate.green
           ? {
               mustFixGate:
-                `The gate ran against your delivery and refused it (${gate.version}). You are not ` +
-                'done: nothing can be published until it passes. Read `gate.report` below — it ends ' +
-                'with the check that stopped the chain — fix the cause in your game, and deliver ' +
-                'again with `npm run submit -- <slug>`. Re-delivering without a fix just stores ' +
-                'another version that fails the same way.',
+                gate.status === 'kit_outdated'
+                  ? `The gate refused your delivery (${gate.version}) because the Creator Kit is ` +
+                    'outdated (`kit_outdated`). Refresh the kit (re-run get_kit), rebuild against ' +
+                    'it, and deliver again with the new kitEngineRef.'
+                  : `The gate ran against your delivery and refused it (${gate.version}). You are not ` +
+                    'done: nothing can be published until it passes. Read `gate.report` below — it ends ' +
+                    'with the check that stopped the chain — fix the cause in your game, and deliver ' +
+                    'again with `npm run submit -- <slug>`. Re-delivering without a fix just stores ' +
+                    'another version that fails the same way.',
             }
           : {}),
         ...(record.deliveredVersion
@@ -697,6 +714,16 @@ export async function registerAgentChannelRoutes(
             ...(await channelState(issueNumber, record)),
           });
         }
+        // Self-build deliveries must name the kit they built against — without it the
+        // gate cannot apply the N/N−1 window and would burn a delivery slot guessing.
+        if (!parsed.data.kitEngineRef) {
+          return reply.status(400).send({
+            error:
+              'kitEngineRef is required for self-build deliveries — send the engineRef from ' +
+              'the Creator Kit you built against (kit.json / get_kit).',
+            reason: 'kit_engine_ref_required',
+          });
+        }
       }
 
       // The job's own slug wins whenever it has one. A build that has already been
@@ -732,6 +759,7 @@ export async function registerAgentChannelRoutes(
           // Provenance: which backend built this version. Backend name on the dispatch
           // ('copilot' / 'self') is the durable record; builder is the round selector.
           backend: record.dispatch?.backend ?? record.builder,
+          ...(parsed.data.kitEngineRef ? { kitEngineRef: parsed.data.kitEngineRef } : {}),
         });
         // Recorded before the gate is asked to run: this is what the creator's preview
         // reads, and a delivered game should be playable on the status page whether or

--- a/apps/api/src/builder.test.ts
+++ b/apps/api/src/builder.test.ts
@@ -15,11 +15,17 @@ describe('builder helpers', () => {
     expect(isBuilderKind('copilot')).toBe(false);
   });
 
-  it('treats gate-red needs_changes as an active round', () => {
+  it('treats gate-red / kit_outdated needs_changes as an active round', () => {
     expect(
       isActiveBuildRound({
         state: 'needs_changes',
         transitions: [{ to: 'needs_changes', at: 't', by: 'gate', reason: 'gate_red' }],
+      }),
+    ).toBe(true);
+    expect(
+      isActiveBuildRound({
+        state: 'needs_changes',
+        transitions: [{ to: 'needs_changes', at: 't', by: 'gate', reason: 'kit_outdated' }],
       }),
     ).toBe(true);
     expect(

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -31,8 +31,8 @@ export function selfBuildDeliveryCap(): number {
 /**
  * Whether the current round is still live — builder must not change until it closes.
  *
- * Includes gate-red `needs_changes`: that outcome keeps the round open so the same
- * session can repair and re-deliver without a new kickoff.
+ * Includes gate-red / kit_outdated `needs_changes`: those keep the round open so the
+ * same session can repair (or refresh the kit) and re-deliver without a new kickoff.
  */
 export function isActiveBuildRound(record: { state?: JobState; transitions?: JobTransition[] }): boolean {
   const state = record.state;
@@ -46,7 +46,7 @@ export function isActiveBuildRound(record: { state?: JobState; transitions?: Job
       return true;
     case 'needs_changes': {
       const last = [...(record.transitions ?? [])].reverse().find((transition) => transition.to === 'needs_changes');
-      return last?.reason === 'gate_red';
+      return last?.reason === 'gate_red' || last?.reason === 'kit_outdated';
     }
     default:
       return false;

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createGcsGamesStore,
   defaultVersionId,
+  forbiddenDeliveryPathReason,
   InvalidUploadError,
   MAX_UPLOAD_BYTES,
   validateSourceUpload,
@@ -104,6 +105,55 @@ describe('validateSourceUpload — the delivery contract', () => {
     expect(() => validateSourceUpload([...MINIMAL, { path: 'notes.txt', content: 'x' }])).toThrow(
       /Deliver only your own game's files/,
     );
+  });
+
+  it('accept/reject matrix for the delivery filename allowlist', () => {
+    const accept = [
+      'GAME.json',
+      'CAPTURE.json',
+      'style.css',
+      'game/loop.ts',
+      'game/systems/physics.ts',
+      'entities/player.ts',
+    ];
+    for (const path of accept) {
+      expect(
+        validateSourceUpload([...MINIMAL, { path, content: path.endsWith('.json') ? '{}' : 'export {};' }]).map(
+          (f) => f.path,
+        ),
+      ).toContain(path);
+    }
+
+    const reject = [
+      'package.json',
+      'package-lock.json',
+      'tsconfig.json',
+      'tsconfig.build.json',
+      'pnpm-lock.yaml',
+      'yarn.lock',
+      '.env',
+      '.github/workflows/ci.yml',
+      'vite.config.ts', // .ts but config basename — wait, EXTRA allows *.ts; forbid by basename
+      'setup.js',
+      'index.mjs',
+      'run.cjs',
+      'media/opening.png',
+      'Dockerfile',
+      'script.sh',
+    ];
+    for (const path of reject) {
+      const reason = forbiddenDeliveryPathReason(path);
+      // Config-shaped paths must name themselves in the refusal.
+      if (reason) {
+        expect(reason).toContain(path);
+        expect(() => validateSourceUpload([...MINIMAL, { path, content: 'x' }])).toThrow(
+          new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        );
+      } else {
+        // Non-config leftovers (e.g. notes) still refuse via the allowlist.
+        expect(() => validateSourceUpload([...MINIMAL, { path, content: 'x' }])).toThrow(/path not deliverable/);
+      }
+    }
   });
 });
 

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -114,6 +114,9 @@ export class InvalidUploadError extends Error {
   }
 }
 
+/** Hint derived from {@link ALLOWED_SOURCE_FILES} so refusal text cannot drift from the contract. */
+const ALLOWED_SOURCES_HINT = `${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules`;
+
 /**
  * True when a path is config-shaped or executable-config: tsconfig*, package*.json,
  * lockfiles, workflows, shell/JS entrypoints, dotfiles. The reason always names `path`.
@@ -123,8 +126,7 @@ export function forbiddenDeliveryPathReason(path: string): string | null {
   if (path.startsWith('.') || path.split('/').some((segment) => segment.startsWith('.'))) {
     return (
       `path not deliverable: ${path}. Dotfiles and hidden paths are config/executable-shaped — ` +
-      'deliver only game sources (SPEC.md, GAME.json, CAPTURE.json, PLAYTEST.json, index.html, ' +
-      'style.css, game.ts, and your own .ts modules).'
+      `deliver only game sources (${ALLOWED_SOURCES_HINT}).`
     );
   }
   if (path === 'media' || path.startsWith('media/')) {
@@ -136,8 +138,7 @@ export function forbiddenDeliveryPathReason(path: string): string | null {
   if (FORBIDDEN_DELIVERY_BASENAME.test(basename) || FORBIDDEN_DELIVERY_EXTENSION.test(basename)) {
     return (
       `path not deliverable: ${path}. Config or executable-shaped files are refused — ` +
-      'deliver only game sources (SPEC.md, GAME.json, CAPTURE.json, PLAYTEST.json, index.html, ' +
-      'style.css, game.ts, and your own .ts modules).'
+      `deliver only game sources (${ALLOWED_SOURCES_HINT}).`
     );
   }
   if (path.includes('.github/') || basename === 'Dockerfile' || basename === 'Makefile') {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -19,6 +19,7 @@
 
 import { randomBytes } from 'node:crypto';
 import { GoogleAuth } from 'google-auth-library';
+import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from './kit-window.js';
 
 /**
  * Files an agent is allowed to deliver, and nothing else.
@@ -28,6 +29,10 @@ import { GoogleAuth } from 'google-auth-library';
  * structurally true instead of merely requested: there is no path an upload can name that
  * reaches `shared/`, `tools/`, or another game's directory, so a prompt-injected or
  * simply confused agent cannot widen its own scope.
+ *
+ * Game-shape only: SPEC / GAME / CAPTURE / PLAYTEST / TRACE, the playable trio, and the
+ * game's own `.ts` modules (including under `game/`). Media bytes are produced by our
+ * gate, never uploaded — `media/` paths are refused below.
  */
 export const ALLOWED_SOURCE_FILES = [
   'SPEC.md',
@@ -56,9 +61,19 @@ export const ALLOWED_SOURCE_FILES = [
 /**
  * Additional source files a game may carry beyond the fixed set — its own modules only.
  * Kept narrow on purpose: relative imports inside the game directory are the one thing
- * games legitimately add, and everything else is a smell.
+ * games legitimately add, and everything else is a smell. Covers modules under `game/`
+ * and other in-game modules (`entities/player.ts`, …).
  */
 const EXTRA_SOURCE_PATTERN = /^[a-z0-9][a-z0-9/-]{0,60}\.ts$/;
+
+/**
+ * Config-shaped or executable-config paths an externally-authored delivery must never
+ * carry. Named separately from the allowlist so the rejection reason can point at the
+ * offending path as a config/exec smell rather than a vague "not deliverable".
+ */
+const FORBIDDEN_DELIVERY_BASENAME =
+  /^(tsconfig(\..*)?\.json|package(-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|composer\.json|\.npmrc|\.eslintrc(\..*)?|vite\.config\..+|webpack\.config\..+|rollup\.config\..+|jest\.config\..+|vitest\.config\..+)$/i;
+const FORBIDDEN_DELIVERY_EXTENSION = /\.(js|mjs|cjs|jsx|tsx|sh|bash|zsh|ps1|bat|cmd|exe|bin|yml|yaml|toml|lock)$/i;
 
 /**
  * First path segments a game may not use.
@@ -100,6 +115,38 @@ export class InvalidUploadError extends Error {
 }
 
 /**
+ * True when a path is config-shaped or executable-config: tsconfig*, package*.json,
+ * lockfiles, workflows, shell/JS entrypoints, dotfiles. The reason always names `path`.
+ */
+export function forbiddenDeliveryPathReason(path: string): string | null {
+  const basename = path.split('/').pop() ?? path;
+  if (path.startsWith('.') || path.split('/').some((segment) => segment.startsWith('.'))) {
+    return (
+      `path not deliverable: ${path}. Dotfiles and hidden paths are config/executable-shaped — ` +
+      'deliver only game sources (SPEC.md, GAME.json, CAPTURE.json, PLAYTEST.json, index.html, ' +
+      'style.css, game.ts, and your own .ts modules).'
+    );
+  }
+  if (path === 'media' || path.startsWith('media/')) {
+    return (
+      `path not deliverable: ${path}. Media is produced by the platform gate, not uploaded — ` +
+      'deliver game sources only.'
+    );
+  }
+  if (FORBIDDEN_DELIVERY_BASENAME.test(basename) || FORBIDDEN_DELIVERY_EXTENSION.test(basename)) {
+    return (
+      `path not deliverable: ${path}. Config or executable-shaped files are refused — ` +
+      'deliver only game sources (SPEC.md, GAME.json, CAPTURE.json, PLAYTEST.json, index.html, ' +
+      'style.css, game.ts, and your own .ts modules).'
+    );
+  }
+  if (path.includes('.github/') || basename === 'Dockerfile' || basename === 'Makefile') {
+    return `path not deliverable: ${path}. Workflow/build files are refused — deliver only game sources.`;
+  }
+  return null;
+}
+
+/**
  * Validates an upload against the delivery contract.
  *
  * Returns the files to store; throws {@link InvalidUploadError} with a message meant for
@@ -126,7 +173,10 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
     }
     if (seen.has(path)) throw new InvalidUploadError(`duplicate path: ${path}`);
 
-    if (path.startsWith('.') || RESERVED_SEGMENTS.has(path.split('/')[0])) {
+    const forbidden = forbiddenDeliveryPathReason(path);
+    if (forbidden) throw new InvalidUploadError(forbidden);
+
+    if (RESERVED_SEGMENTS.has(path.split('/')[0])) {
       throw new InvalidUploadError(
         `path not deliverable: ${path}. \`${path.split('/')[0]}\` belongs to the harness — ` +
           'GameKit, the tooling and other games are read-only context.',
@@ -139,7 +189,7 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
     if (!allowed) {
       throw new InvalidUploadError(
         `path not deliverable: ${path}. Deliver only your own game's files ` +
-          `(${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules).`,
+          `(${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules under the game).`,
       );
     }
 
@@ -195,11 +245,17 @@ export interface VersionManifest {
    *
    * Pinned rather than floating: a game that passed the gate did so against a specific
    * GameKit, and "it worked when we accepted it" has to remain checkable after the engine
-   * moves on.
+   * moves on. Distinct from {@link kitEngineRef}: that is what the agent *claimed* at
+   * delivery; this is what the gate *resolved* when it checked.
    */
   engineRef?: string;
+  /**
+   * The Creator Kit engineRef the sources were built against (from the delivery's
+   * `kitEngineRef`). Compared by the gate to `kits/current.json`'s N/N−1 window.
+   */
+  kitEngineRef?: string;
   /** Verdict of our own gate. A version without a green one is never publishable. */
-  gate?: { green: boolean; ranAt: string; report?: string };
+  gate?: GateVerdict;
   /**
    * The most recent *health* verdict: the same check re-run later against the current
    * engine, asking "does this game still work on today's GameKit".
@@ -213,6 +269,20 @@ export interface VersionManifest {
   health?: { green: boolean; ranAt: string; engineRef?: string; report?: string };
   sourceFiles: string[];
 }
+
+/** What the gate wrote onto a candidate — green, red, or a kit-window refusal. */
+export type GateVerdict = {
+  green: boolean;
+  ranAt: string;
+  report?: string;
+  /**
+   * Machine-readable outcome. Absent means ordinary green/red from `check:game`.
+   * `kit_outdated` means the delivery's kitEngineRef is outside the supported window.
+   */
+  status?: 'kit_outdated';
+  /** First capture PNG under the version prefix, when the run produced one. */
+  screenshot?: string;
+};
 
 export type PublicationState = 'published' | 'archived' | 'disabled';
 
@@ -264,6 +334,8 @@ export interface GamesStore {
     backend?: string;
     model?: string;
     engineRef?: string;
+    /** Creator Kit engineRef the sources were built against (BY-06). */
+    kitEngineRef?: string;
   }): Promise<{ version: string; manifest: VersionManifest }>;
   getManifest(slug: string, version: string): Promise<VersionManifest | null>;
   getSourceFile(slug: string, version: string, path: string): Promise<string | null>;
@@ -278,7 +350,13 @@ export interface GamesStore {
   putGateResult(
     slug: string,
     version: string,
-    result: { green: boolean; report?: string; engineRef?: string },
+    result: {
+      green: boolean;
+      report?: string;
+      engineRef?: string;
+      status?: 'kit_outdated';
+      screenshot?: string;
+    },
   ): Promise<void>;
   /**
    * Records a *health* verdict — the check re-run against the current engine, long
@@ -293,6 +371,11 @@ export interface GamesStore {
   /** Stores an artifact the gate produced — bundle or media. Agents never write these. */
   putDerivedArtifact(slug: string, version: string, name: string, body: Buffer, contentType: string): Promise<void>;
   getDerivedArtifact(slug: string, version: string, name: string): Promise<Buffer | null>;
+  /**
+   * The Creator Kit support window (`kits/current.json`). Null when the registry has
+   * not been published yet — callers must not invent a window from listing order.
+   */
+  getKitRegistry(): Promise<KitRegistry | null>;
 }
 
 export interface GcsGamesStoreOptions {
@@ -394,6 +477,7 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
         backend: input.backend,
         model: input.model,
         engineRef: input.engineRef,
+        ...(input.kitEngineRef ? { kitEngineRef: input.kitEngineRef } : {}),
         sourceFiles: files.map((file) => file.path),
       };
       // Written last: a manifest is what makes a version real, so a run that dies
@@ -419,7 +503,13 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       const existing = await readObject(`${prefix}/manifest.json`);
       if (!existing) throw new Error(`no manifest for ${slug}@${version}`);
       const manifest = JSON.parse(existing.toString('utf8')) as VersionManifest;
-      manifest.gate = { green: result.green, ranAt: new Date(now()).toISOString(), report: result.report };
+      manifest.gate = {
+        green: result.green,
+        ranAt: new Date(now()).toISOString(),
+        report: result.report,
+        ...(result.status ? { status: result.status } : {}),
+        ...(result.screenshot ? { screenshot: result.screenshot } : {}),
+      };
       // First writer wins: the ref the *first* gate run checked against is the one the
       // verdict is reproducible against, and a re-run must not quietly repin it.
       if (result.engineRef && !manifest.engineRef) manifest.engineRef = result.engineRef;
@@ -446,6 +536,12 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
 
     async getDerivedArtifact(slug, version, name) {
       return readObject(`${versionPrefix(slug, version)}/${name}`);
+    },
+
+    async getKitRegistry() {
+      const body = await readObject(KIT_REGISTRY_OBJECT);
+      if (!body) return null;
+      return parseKitRegistry(body.toString('utf8'));
     },
   };
 }

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -195,6 +195,31 @@ describe('runGate', () => {
     expect(outcome.artifacts).toEqual(['preview.html']);
   });
 
+  it('still returns a red verdict when capture media upload fails', async () => {
+    // Optional screenshots must not discard the actionable report (Codex P1).
+    const harness = await harnessDir();
+    const { store } = stubStore({
+      putDerivedArtifact: async (_s, _v, name) => {
+        if (name.startsWith('media/')) throw new Error('GCS unavailable');
+      },
+    });
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: async () => harness,
+      assembleBundle: stubAssemble,
+      run: async () => {
+        await mkdir(path.join(harness, 'games/comet-courier/media'), { recursive: true });
+        await writeFile(path.join(harness, 'games/comet-courier/media/opening.png'), 'png-bytes');
+        return { code: 1, output: 'Check 12: capture diverged' };
+      },
+    });
+
+    expect(outcome.green).toBe(false);
+    expect(outcome.report).toContain('capture diverged');
+    expect(outcome.artifacts).toEqual(['preview.html']);
+  });
+
   it('reports a red verdict even when the candidate cannot be assembled at all', async () => {
     // The common case for "no preview": sources that fail the check precisely because
     // they do not assemble. The verdict is still the answer, and a gate that crashed

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -25,6 +25,7 @@ function stubStore(overrides: Partial<GamesStore> = {}) {
     putCandidateSources: vi.fn(),
     putGateResult: vi.fn(),
     getDerivedArtifact: async () => null,
+    getKitRegistry: async () => null,
     ...overrides,
   } as unknown as GamesStore;
   return { store, derived };
@@ -239,6 +240,61 @@ describe('runGate', () => {
       'media/opening.png',
     ]);
     expect(outcome.artifacts).toContain('bundle.html');
+    expect(outcome.screenshot).toBe('media/opening.png');
+  });
+
+  it('refuses a delivery whose kitEngineRef is outside kits/current.json', async () => {
+    const prepareHarness = vi.fn(async () => harnessDir());
+    const run = vi.fn(async () => ({ code: 0, output: '' }));
+    const { store } = stubStore({
+      getManifest: async () => ({
+        ...MANIFEST,
+        kitEngineRef: 'cccccccccccccccccccccccccccccccccccccccc',
+      }),
+    });
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness,
+      run,
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({
+        current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        updatedAt: '2026-07-31T12:00:00.000Z',
+      }),
+    });
+
+    expect(outcome).toMatchObject({ green: false, status: 'kit_outdated' });
+    expect(outcome.report).toMatch(/^kit_outdated:/);
+    expect(outcome.report).toContain('cccccccccccccccccccccccccccccccccccccccc');
+    // No harness, no check:game — the window refusal is the whole verdict.
+    expect(prepareHarness).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('accepts a kitEngineRef that is the registry previous (N−1)', async () => {
+    const previous = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const { store } = stubStore({
+      getManifest: async () => ({ ...MANIFEST, kitEngineRef: previous }),
+    });
+    const run = vi.fn(async () => ({ code: 0, output: '' }));
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run,
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({
+        current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        previous,
+        updatedAt: '2026-07-31T12:00:00.000Z',
+      }),
+    });
+
+    expect(outcome.green).toBe(true);
+    expect(outcome.status).toBeUndefined();
+    expect(run).toHaveBeenCalled();
   });
 
   it('serves the assembler’s document, not the games repo’s own build output', async () => {

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -310,18 +310,29 @@ async function storeCaptureMedia(
   harness: string,
   roots: NonNullable<GateRunnerDeps['artifactRoots']>,
 ): Promise<string[]> {
-  const mediaDir = path.join(harness, roots.media(slug));
-  const { readdir } = await import('node:fs/promises');
-  const entries = await readdir(mediaDir).catch(() => [] as string[]);
-  const stored: string[] = [];
-  for (const entry of entries) {
-    if (!MEDIA_EXTENSIONS.includes(path.extname(entry).toLowerCase())) continue;
-    const body = await readFile(path.join(mediaDir, entry)).catch(() => null);
-    if (!body) continue;
-    await deps.store.putDerivedArtifact(slug, version, `media/${entry}`, body, contentTypeFor(entry));
-    stored.push(`media/${entry}`);
+  // Best-effort end to end: a red check already has a report the agent can act on, and
+  // a transient GCS blip on an optional screenshot must not discard that verdict
+  // (Codex: awaited throw here used to prevent putGateResult).
+  try {
+    const mediaDir = path.join(harness, roots.media(slug));
+    const { readdir } = await import('node:fs/promises');
+    const entries = await readdir(mediaDir).catch(() => [] as string[]);
+    const stored: string[] = [];
+    for (const entry of entries) {
+      if (!MEDIA_EXTENSIONS.includes(path.extname(entry).toLowerCase())) continue;
+      const body = await readFile(path.join(mediaDir, entry)).catch(() => null);
+      if (!body) continue;
+      try {
+        await deps.store.putDerivedArtifact(slug, version, `media/${entry}`, body, contentTypeFor(entry));
+        stored.push(`media/${entry}`);
+      } catch {
+        // Skip this file; keep trying the rest.
+      }
+    }
+    return stored;
+  } catch {
+    return [];
   }
-  return stored;
 }
 
 /** Stores what the check produced, so the shipped artifacts are the verified ones. */

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -23,7 +23,9 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { GameProject } from '@gamedevpl/game-generator';
 import { assembleGameHtml } from './assemble.js';
+import { firstGateScreenshotPath } from './gate-screenshot.js';
 import type { GamesStore, VersionManifest } from './games-store.js';
+import { isKitEngineRefSupported, kitOutdatedReport, type KitRegistry } from './kit-window.js';
 import { createLocalGamesClient } from './local-games-repo.js';
 
 export interface GateOutcome {
@@ -41,6 +43,10 @@ export interface GateOutcome {
    * was rendered — the sha that makes "it worked when we checked" checkable later.
    */
   engineCommit?: string;
+  /** Set when the delivery's kitEngineRef is outside `kits/current.json`'s window. */
+  status?: 'kit_outdated';
+  /** First capture PNG path under the version prefix, when one was stored. */
+  screenshot?: string;
 }
 
 export interface GateRunOptions {
@@ -69,6 +75,11 @@ export interface GateRunnerDeps {
    * Injected so the runner can be tested without esbuild or a games-repo tree.
    */
   assembleBundle?: (harness: string, slug: string) => Promise<string | null>;
+  /**
+   * The Creator Kit N/N−1 window. Injected so tests can fix the registry without GCS;
+   * production reads `kits/current.json` via {@link GamesStore.getKitRegistry}.
+   */
+  readKitRegistry?: () => Promise<KitRegistry | null>;
 }
 
 const DEFAULT_ARTIFACT_ROOTS = {
@@ -141,6 +152,23 @@ export async function runGate(
     return { green: false, report: `no such version: ${slug}@${version}`, artifacts: [], durationMs: 0 };
   }
 
+  // Kit window before any harness work: a delivery outside N/N−1 must not burn a
+  // check:game run. Health re-gates skip this — they ask about today's engine, not
+  // whether the original kit claim was still supported.
+  const healthRun = Boolean(options.engineRef);
+  if (!healthRun && manifest.kitEngineRef) {
+    const registry = await (deps.readKitRegistry ?? (() => deps.store.getKitRegistry()))().catch(() => null);
+    if (registry && !isKitEngineRefSupported(manifest.kitEngineRef, registry)) {
+      return {
+        green: false,
+        status: 'kit_outdated',
+        report: kitOutdatedReport(manifest.kitEngineRef, registry),
+        artifacts: [],
+        durationMs: now() - startedAt,
+      };
+    }
+  }
+
   // Deliveries do not pin an engine commit yet — dispatch targets `main`, a moving
   // branch — so a first gate run checks against wherever `main` stands and stamps the
   // resolved sha back onto the manifest (see the caller). A *re*-run of a stamped
@@ -168,6 +196,12 @@ export async function runGate(
     // modified GameKit fails here, which is precisely the thing worth catching.
     const check = await deps.run('npm', ['run', 'check:game', '--', slug], harness);
     if (check.code !== 0) {
+      // Preview for the creator; media when capture got far enough — both best-effort.
+      const artifacts = [
+        ...(await storePreview(deps, slug, version, harness)),
+        ...(await storeCaptureMedia(deps, slug, version, harness, roots)),
+      ];
+      const screenshot = firstGateScreenshotPath(artifacts);
       return {
         green: false,
         // The tail, not the head: the chain fails at the bottom and the last lines are
@@ -180,9 +214,10 @@ export async function runGate(
         // with no explanation. Stored under its own name, never `bundle.html`: publishing
         // checks `manifest.gate.green` and the play route reads only the bundle, so an
         // unverified document has no path to a player either way.
-        artifacts: await storePreview(deps, slug, version, harness),
+        artifacts,
         durationMs: now() - startedAt,
         ...(engineCommit ? { engineCommit } : {}),
+        ...(screenshot ? { screenshot } : {}),
       };
     }
 
@@ -204,12 +239,14 @@ export async function runGate(
       };
     }
 
+    const screenshot = firstGateScreenshotPath(artifacts);
     return {
       green: true,
       report: `check:game passed against engine ${engineCommit ?? engineRef}; ${artifacts.length} artifacts stored`,
       artifacts,
       durationMs: now() - startedAt,
       ...(engineCommit ? { engineCommit } : {}),
+      ...(screenshot ? { screenshot } : {}),
     };
   } finally {
     // The harness is disposable and can be large. Leaving it behind is how a long-lived
@@ -265,6 +302,28 @@ async function storePreview(deps: GateRunnerDeps, slug: string, version: string,
   }
 }
 
+/** Stores capture media the check left under the game directory, when any. */
+async function storeCaptureMedia(
+  deps: GateRunnerDeps,
+  slug: string,
+  version: string,
+  harness: string,
+  roots: NonNullable<GateRunnerDeps['artifactRoots']>,
+): Promise<string[]> {
+  const mediaDir = path.join(harness, roots.media(slug));
+  const { readdir } = await import('node:fs/promises');
+  const entries = await readdir(mediaDir).catch(() => [] as string[]);
+  const stored: string[] = [];
+  for (const entry of entries) {
+    if (!MEDIA_EXTENSIONS.includes(path.extname(entry).toLowerCase())) continue;
+    const body = await readFile(path.join(mediaDir, entry)).catch(() => null);
+    if (!body) continue;
+    await deps.store.putDerivedArtifact(slug, version, `media/${entry}`, body, contentTypeFor(entry));
+    stored.push(`media/${entry}`);
+  }
+  return stored;
+}
+
 /** Stores what the check produced, so the shipped artifacts are the verified ones. */
 async function collectArtifacts(
   deps: GateRunnerDeps,
@@ -289,17 +348,7 @@ async function collectArtifacts(
     'text/html; charset=utf-8',
   );
   stored.push('bundle.html');
-
-  const mediaDir = path.join(harness, roots.media(slug));
-  const { readdir } = await import('node:fs/promises');
-  const entries = await readdir(mediaDir).catch(() => [] as string[]);
-  for (const entry of entries) {
-    if (!MEDIA_EXTENSIONS.includes(path.extname(entry).toLowerCase())) continue;
-    const body = await readFile(path.join(mediaDir, entry)).catch(() => null);
-    if (!body) continue;
-    await deps.store.putDerivedArtifact(slug, version, `media/${entry}`, body, contentTypeFor(entry));
-    stored.push(`media/${entry}`);
-  }
+  stored.push(...(await storeCaptureMedia(deps, slug, version, harness, roots)));
 
   return stored;
 }

--- a/apps/api/src/gate-screenshot.test.ts
+++ b/apps/api/src/gate-screenshot.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { firstGateScreenshotPath, PLATFORM_CHECK_SHOT_LABEL, postGateScreenshotToThread } from './gate-screenshot.js';
+import type { GamesStore } from './games-store.js';
+import { InMemoryStore } from './store.js';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01]);
+
+describe('gate screenshot posting', () => {
+  it('picks opening.png when present, else the first media PNG', () => {
+    expect(firstGateScreenshotPath(['bundle.html', 'media/gameplay.mp4', 'media/mid.png', 'media/opening.png'])).toBe(
+      'media/opening.png',
+    );
+    expect(firstGateScreenshotPath(['media/zebra.png', 'media/alpha.png'])).toBe('media/alpha.png');
+    expect(firstGateScreenshotPath(['bundle.html', 'preview.html'])).toBeUndefined();
+  });
+
+  it('posts the PNG onto the build thread with the platform-check label', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(42, 'g:owner', 'Shot Game');
+    const gamesStore = {
+      getDerivedArtifact: async (_slug: string, _version: string, name: string) =>
+        name === 'media/opening.png' ? PNG : null,
+    } as unknown as GamesStore;
+
+    const posted = await postGateScreenshotToThread({
+      store,
+      gamesStore,
+      issueNumber: 42,
+      slug: 'shot-game',
+      version: 'v1',
+      screenshotPath: 'media/opening.png',
+    });
+
+    expect(posted?.id).toBeTruthy();
+    const shots = await store.listBuildShots(42);
+    expect(shots).toHaveLength(1);
+    expect(shots[0]?.label).toBe(PLATFORM_CHECK_SHOT_LABEL);
+    const full = await store.getBuildShot(42, shots[0]!.id);
+    expect(full?.data).toBe(PNG.toString('base64'));
+  });
+
+  it('skips non-PNG or missing artifacts rather than failing the reconcile', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(7, 'g:owner', 'Empty');
+    const gamesStore = {
+      getDerivedArtifact: async () => Buffer.from('not-a-png'),
+    } as unknown as GamesStore;
+
+    await expect(
+      postGateScreenshotToThread({
+        store,
+        gamesStore,
+        issueNumber: 7,
+        slug: 'empty',
+        version: 'v1',
+        screenshotPath: 'media/opening.png',
+      }),
+    ).resolves.toBeNull();
+    expect(await store.countBuildShots(7)).toBe(0);
+  });
+});

--- a/apps/api/src/gate-screenshot.ts
+++ b/apps/api/src/gate-screenshot.ts
@@ -1,0 +1,52 @@
+/**
+ * Posts the first PNG a gate capture produced into the build thread.
+ *
+ * Same store path as agent-sent shots (`appendBuildShot`), so the studio renders it
+ * identically. The label marks it as ours — a platform check frame, not an agent push.
+ */
+
+import type { GamesStore } from './games-store.js';
+import type { Store } from './store.js';
+
+/** Caption shown on the thread for a gate-produced frame. */
+export const PLATFORM_CHECK_SHOT_LABEL = 'Platform check';
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const MAX_SHOT_BYTES = 300 * 1024;
+
+/**
+ * Picks the first screenshot path from a gate artifact list. Prefers the capture
+ * harness's `opening.png` when present; otherwise the lexicographically first PNG so
+ * the same artifact list always yields the same frame.
+ */
+export function firstGateScreenshotPath(artifacts: readonly string[]): string | undefined {
+  const pngs = artifacts.filter((name) => /^media\/.+\.png$/i.test(name));
+  const opening = pngs.find((name) => /\/opening\.png$/i.test(name));
+  if (opening) return opening;
+  return [...pngs].sort((a, b) => a.localeCompare(b))[0];
+}
+
+/**
+ * Loads one gate-produced PNG and appends it as a build shot. Best effort: a missing
+ * or non-PNG artifact must not fail the reconcile that already moved the job.
+ */
+export async function postGateScreenshotToThread(input: {
+  store: Store;
+  gamesStore: GamesStore;
+  issueNumber: number;
+  slug: string;
+  version: string;
+  /** Path under the version prefix, e.g. `media/opening.png`. */
+  screenshotPath: string;
+}): Promise<{ id: string } | null> {
+  const body = await input.gamesStore.getDerivedArtifact(input.slug, input.version, input.screenshotPath);
+  if (!body) return null;
+  if (body.length === 0 || body.length > MAX_SHOT_BYTES) return null;
+  if (!body.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) return null;
+
+  const stored = await input.store.appendBuildShot(input.issueNumber, {
+    data: body.toString('base64'),
+    label: PLATFORM_CHECK_SHOT_LABEL,
+  });
+  return { id: stored.id };
+}

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -55,6 +55,7 @@ describe('round-closing transitions', () => {
 
   it('keeps the round open after a red gate so the session can repair', () => {
     expect(transitionClosesRound({ to: 'needs_changes', at: 't', by: 'gate', reason: 'gate_red' })).toBe(false);
+    expect(transitionClosesRound({ to: 'needs_changes', at: 't', by: 'gate', reason: 'kit_outdated' })).toBe(false);
     expect(transitionClosesRound({ to: 'submitted', at: 't', by: 'agent', reason: 'sources_delivered' })).toBe(false);
     expect(transitionClosesRound({ to: 'building', at: 't', by: 'operator', reason: 'operator_retry' })).toBe(false);
   });

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -121,8 +121,9 @@ export function canTransition(from: JobState, to: JobState): boolean {
  *
  * Closing events written through `recordJobTransition`:
  * - delivery accepted (`ready_for_review`, typically `gate_green`)
- * - round rejected into `needs_changes`, except `gate_red` — a red gate keeps the round
- *   open so the live session can repair and re-deliver without a new token
+ * - round rejected into `needs_changes`, except `gate_red` / `kit_outdated` — those keep
+ *   the round open so the live session can repair (or refresh the kit) and re-deliver
+ *   without a new token
  * - creator/operator cancel or abandon
  * - agent failure (`failed`) — terminal for the round
  *
@@ -140,8 +141,8 @@ export function transitionClosesRound(transition: JobTransition): boolean {
     case 'failed':
       return true;
     case 'needs_changes':
-      // Same-session repair after a red gate still holds the current token.
-      return transition.reason !== 'gate_red';
+      // Same-session repair after a red gate / stale kit still holds the current token.
+      return transition.reason !== 'gate_red' && transition.reason !== 'kit_outdated';
     default:
       return false;
   }

--- a/apps/api/src/kit-window.test.ts
+++ b/apps/api/src/kit-window.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { isKitEngineRefSupported, kitOutdatedReport, parseKitRegistry, type KitRegistry } from './kit-window.js';
+
+const REGISTRY: KitRegistry = {
+  current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  updatedAt: '2026-07-31T12:00:00.000Z',
+};
+
+describe('kit window (kits/current.json)', () => {
+  it('parses the registry document', () => {
+    expect(parseKitRegistry(JSON.stringify(REGISTRY))).toEqual(REGISTRY);
+  });
+
+  it('accepts current and previous, refuses everything else', () => {
+    expect(isKitEngineRefSupported(REGISTRY.current, REGISTRY)).toBe(true);
+    expect(isKitEngineRefSupported(REGISTRY.previous!, REGISTRY)).toBe(true);
+    expect(isKitEngineRefSupported('cccccccccccccccccccccccccccccccccccccccc', REGISTRY)).toBe(false);
+    expect(isKitEngineRefSupported('', REGISTRY)).toBe(false);
+  });
+
+  it('treats a null previous as a single-ref window', () => {
+    const onlyCurrent: KitRegistry = { ...REGISTRY, previous: null };
+    expect(isKitEngineRefSupported(onlyCurrent.current, onlyCurrent)).toBe(true);
+    expect(isKitEngineRefSupported(REGISTRY.previous!, onlyCurrent)).toBe(false);
+  });
+
+  it('never invents a window from ancestry — only exact registry membership', () => {
+    // A parent of `current` that is not recorded as `previous` is outside the window.
+    // The packer is path-filtered; git parents are not the authority.
+    expect(isKitEngineRefSupported('dddddddddddddddddddddddddddddddddddddddd', REGISTRY)).toBe(false);
+  });
+
+  it('names the refresh action in the kit_outdated report', () => {
+    const report = kitOutdatedReport('cccccccccccccccccccccccccccccccccccccccc', REGISTRY);
+    expect(report).toMatch(/^kit_outdated:/);
+    expect(report).toContain('cccccccccccccccccccccccccccccccccccccccc');
+    expect(report).toContain(REGISTRY.current);
+    expect(report).toContain(REGISTRY.previous!);
+    expect(report).toMatch(/get_kit|Refresh the Creator Kit/i);
+  });
+});

--- a/apps/api/src/kit-window.test.ts
+++ b/apps/api/src/kit-window.test.ts
@@ -12,6 +12,10 @@ describe('kit window (kits/current.json)', () => {
     expect(parseKitRegistry(JSON.stringify(REGISTRY))).toEqual(REGISTRY);
   });
 
+  it('rejects an empty-string previous (null is the only “no previous”)', () => {
+    expect(() => parseKitRegistry(JSON.stringify({ ...REGISTRY, previous: '' }))).toThrow(/previous/);
+  });
+
   it('accepts current and previous, refuses everything else', () => {
     expect(isKitEngineRefSupported(REGISTRY.current, REGISTRY)).toBe(true);
     expect(isKitEngineRefSupported(REGISTRY.previous!, REGISTRY)).toBe(true);

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -30,8 +30,10 @@ export function parseKitRegistry(raw: string): KitRegistry {
   if (typeof obj.current !== 'string' || !obj.current) {
     throw new Error('kits/current.json.current must be a non-empty string');
   }
-  if (!(obj.previous === null || typeof obj.previous === 'string')) {
-    throw new Error('kits/current.json.previous must be a string or null');
+  // Empty string is not "no previous" — null is. Accepting "" would shrink the window
+  // silently and produce confusing kit_outdated reports.
+  if (!(obj.previous === null || (typeof obj.previous === 'string' && obj.previous.length > 0))) {
+    throw new Error('kits/current.json.previous must be a non-empty string or null');
   }
   if (typeof obj.updatedAt !== 'string' || !obj.updatedAt) {
     throw new Error('kits/current.json.updatedAt must be a non-empty string');

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -1,0 +1,68 @@
+/**
+ * Creator Kit support window — N / N−1 from `kits/current.json`.
+ *
+ * The registry document is the only authority for which engine refs a delivery may
+ * claim. Do not infer previous from git parents (the packer is path-filtered, so a
+ * parent commit usually is not the previous kit) or from bucket listing order
+ * (undefined). BY-10 owns the publisher; this module is the consumer rule the gate
+ * and delivery path share.
+ */
+
+export type KitRegistry = {
+  current: string;
+  previous: string | null;
+  updatedAt: string;
+};
+
+export const KIT_REGISTRY_OBJECT = 'kits/current.json';
+
+export function parseKitRegistry(raw: string): KitRegistry {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('kits/current.json is not valid JSON', { cause: error });
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('kits/current.json must be an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.current !== 'string' || !obj.current) {
+    throw new Error('kits/current.json.current must be a non-empty string');
+  }
+  if (!(obj.previous === null || typeof obj.previous === 'string')) {
+    throw new Error('kits/current.json.previous must be a string or null');
+  }
+  if (typeof obj.updatedAt !== 'string' || !obj.updatedAt) {
+    throw new Error('kits/current.json.updatedAt must be a non-empty string');
+  }
+  return {
+    current: obj.current,
+    previous: obj.previous,
+    updatedAt: obj.updatedAt,
+  };
+}
+
+/** True when `engineRef` is the registry's current or previous kit. */
+export function isKitEngineRefSupported(engineRef: string, registry: KitRegistry): boolean {
+  if (!engineRef) return false;
+  if (engineRef === registry.current) return true;
+  if (registry.previous !== null && engineRef === registry.previous) return true;
+  return false;
+}
+
+/**
+ * Message the agent sees on a `kit_outdated` verdict. Names the supported window and
+ * the refresh action — re-running get_kit is cheaper than guessing a commit.
+ */
+export function kitOutdatedReport(kitEngineRef: string, registry: KitRegistry): string {
+  const window =
+    registry.previous === null
+      ? `current=${registry.current}`
+      : `current=${registry.current}, previous=${registry.previous}`;
+  return (
+    `kit_outdated: delivery was built against kitEngineRef=${kitEngineRef}, which is ` +
+    `outside the supported window (${window}). Refresh the Creator Kit (re-run get_kit / ` +
+    `fetch the current kit) and rebuild against it before delivering again.`
+  );
+}

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -59,18 +59,29 @@ const MINIMAL_FILES = [
 ];
 
 function stubGamesStore() {
-  const stored: Array<{ slug: string; issueNumber: number; backend?: string; files: unknown[] }> = [];
-  const versions = new Map<string, { files: typeof MINIMAL_FILES; backend?: string }>();
+  const stored: Array<{
+    slug: string;
+    issueNumber: number;
+    backend?: string;
+    kitEngineRef?: string;
+    files: unknown[];
+  }> = [];
+  const versions = new Map<string, { files: typeof MINIMAL_FILES; backend?: string; kitEngineRef?: string }>();
   const gamesStore = {
     putCandidateSources: async (input: {
       slug: string;
       issueNumber: number;
       files: typeof MINIMAL_FILES;
       backend?: string;
+      kitEngineRef?: string;
     }) => {
       stored.push(input);
       const version = `v${stored.length}`;
-      versions.set(`${input.slug}:${version}`, { files: input.files, backend: input.backend });
+      versions.set(`${input.slug}:${version}`, {
+        files: input.files,
+        backend: input.backend,
+        kitEngineRef: input.kitEngineRef,
+      });
       return {
         version,
         manifest: {
@@ -79,6 +90,7 @@ function stubGamesStore() {
           createdAt: new Date().toISOString(),
           issueNumber: input.issueNumber,
           backend: input.backend,
+          kitEngineRef: input.kitEngineRef,
           sourceFiles: input.files.map((f) => f.path),
         },
       };
@@ -92,6 +104,7 @@ function stubGamesStore() {
         createdAt: new Date().toISOString(),
         issueNumber: 0,
         backend: hit.backend,
+        kitEngineRef: hit.kitEngineRef,
         sourceFiles: hit.files.map((f) => f.path),
       };
     },
@@ -103,9 +116,12 @@ function stubGamesStore() {
     putHealthResult: async () => {},
     putDerivedArtifact: async () => {},
     getDerivedArtifact: async () => null,
+    getKitRegistry: async () => null,
   } as unknown as GamesStore;
   return { gamesStore, stored };
 }
+
+const KIT_REF = 'abcdef1234567890';
 
 async function createApp(options: {
   platform?: AgentBackend;
@@ -277,11 +293,40 @@ describe('self builder (BY-02)', () => {
       method: 'POST',
       url: '/api/agent/build/sources',
       headers: agentHeaders(issueNumber),
-      payload: { slug, files: MINIMAL_FILES },
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
     });
     expect(delivery.json()).toMatchObject({ accepted: true });
     expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
     expect(stored[0]?.backend).toBe('self');
+  });
+
+  it('rejects a self-build delivery that omits kitEngineRef', async () => {
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Need Kit Ref', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES },
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.json()).toMatchObject({ reason: 'kit_engine_ref_required' });
+    expect(refused.json().error).toMatch(/kitEngineRef/i);
   });
 
   it('enforces SELF_BUILD_DELIVERY_CAP with a machine-readable refusal', async () => {
@@ -309,7 +354,7 @@ describe('self builder (BY-02)', () => {
         method: 'POST',
         url: '/api/agent/build/sources',
         headers: agentHeaders(issueNumber),
-        payload: { slug, files: MINIMAL_FILES },
+        payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
       });
       expect(ok.json().accepted).toBe(true);
     }
@@ -317,7 +362,7 @@ describe('self builder (BY-02)', () => {
       method: 'POST',
       url: '/api/agent/build/sources',
       headers: agentHeaders(issueNumber),
-      payload: { slug, files: MINIMAL_FILES },
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
     });
     expect(refused.json()).toMatchObject({
       accepted: false,
@@ -400,7 +445,7 @@ describe('self builder (BY-02)', () => {
       method: 'POST',
       url: '/api/agent/build/sources',
       headers: agentHeaders(issueNumber),
-      payload: { slug, files: MINIMAL_FILES },
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
     });
     await store.recordJobTransition(issueNumber, {
       to: 'ready_for_review',
@@ -479,9 +524,10 @@ describe('self builder (BY-02)', () => {
       method: 'POST',
       url: '/api/agent/build/sources',
       headers: agentHeaders(issueNumber),
-      payload: { slug, files: MINIMAL_FILES },
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
     });
     expect(stored[0]?.backend).toBe('self');
+    expect(stored[0]?.kitEngineRef).toBe(KIT_REF);
     expect((await store.getSubmission(issueNumber))?.builder).toBe('self');
   });
 

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -118,7 +118,7 @@ describe('InMemoryStore', () => {
     );
   });
 
-  it('treats a duplicate same-state transition as a no-op (concurrent reconciler)', async () => {
+  it('treats a duplicate same-state+reason transition as a no-op (concurrent reconciler)', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(7, 'g:123', 'Race');
     expect(
@@ -146,6 +146,31 @@ describe('InMemoryStore', () => {
     ).toBe(false);
     const record = await store.getSubmission(7);
     expect(record?.transitions?.filter((t) => t.to === 'needs_changes')).toHaveLength(1);
+  });
+
+  it('still records a same-state transition when the reason is new (operator retry)', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(8, 'g:123', 'Retry');
+    await store.recordJobTransition(8, {
+      to: 'building',
+      at: '2026-07-30T10:00:00Z',
+      by: 'reconciler',
+      reason: 'task_in_progress',
+    });
+    expect(
+      await store.recordJobTransition(8, {
+        to: 'building',
+        at: '2026-07-30T10:05:00Z',
+        by: 'operator',
+        reason: 'operator_retry',
+      }),
+    ).toBe(true);
+    const record = await store.getSubmission(8);
+    expect(record?.transitions?.at(-1)).toMatchObject({
+      to: 'building',
+      by: 'operator',
+      reason: 'operator_retry',
+    });
   });
 
   it('caps transition history so a flapping reconciler cannot grow the document', async () => {

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -118,6 +118,36 @@ describe('InMemoryStore', () => {
     );
   });
 
+  it('treats a duplicate same-state transition as a no-op (concurrent reconciler)', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(7, 'g:123', 'Race');
+    expect(
+      await store.recordJobTransition(7, {
+        to: 'submitted',
+        at: '2026-07-30T10:00:00Z',
+        by: 'system',
+      }),
+    ).toBe(true);
+    expect(
+      await store.recordJobTransition(7, {
+        to: 'needs_changes',
+        at: '2026-07-30T10:01:00Z',
+        by: 'gate',
+        reason: 'gate_red',
+      }),
+    ).toBe(true);
+    expect(
+      await store.recordJobTransition(7, {
+        to: 'needs_changes',
+        at: '2026-07-30T10:01:01Z',
+        by: 'gate',
+        reason: 'gate_red',
+      }),
+    ).toBe(false);
+    const record = await store.getSubmission(7);
+    expect(record?.transitions?.filter((t) => t.to === 'needs_changes')).toHaveLength(1);
+  });
+
   it('caps transition history so a flapping reconciler cannot grow the document', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(2, 'g:123', 'A game');

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1735,10 +1735,13 @@ export class InMemoryStore implements Store {
   async recordJobTransition(issueNumber: number, transition: JobTransition): Promise<boolean> {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return false;
-    // Idempotent: concurrent reconcilers that both observed `submitted` must not both
-    // "win" — the loser sees `state === transition.to` and returns false so gate
-    // screenshots (keyed off `recorded`) post once.
-    if (sub.state === transition.to) return false;
+    // Idempotent for concurrent *identical* arrivals (status poll + notify sweep both
+    // seeing `submitted`→`needs_changes`/`gate_red`). Same-state with a *new* reason
+    // is intentional — operator retry re-enters `building` with `operator_retry`.
+    if (sub.state === transition.to) {
+      const last = sub.transitions?.at(-1);
+      if (last?.to === transition.to && last?.reason === transition.reason) return false;
+    }
     const closes = transitionClosesRound(transition);
     const next: SubmissionRecord = {
       ...sub,
@@ -2826,10 +2829,13 @@ export class FirestoreStore implements Store {
       const snap = await tx.get(ref);
       if (!snap.exists) return false;
       const current = snap.data() as SubmissionRecord;
-      // Same race as InMemoryStore: concurrent status poll + notify sweep both see
-      // `submitted` before either commits. Without this, both return true and each posts
-      // a platform gate screenshot (Codex P2 on BY-06).
-      if (current.state === transition.to) return false;
+      // Same race as InMemoryStore: concurrent identical arrivals must not both "win"
+      // (gate screenshots key off `recorded`). Same-state with a new reason is allowed
+      // (operator retry re-enters `building`).
+      if (current.state === transition.to) {
+        const last = current.transitions?.at(-1);
+        if (last?.to === transition.to && last?.reason === transition.reason) return false;
+      }
       const closes = transitionClosesRound(transition);
       if (closes) {
         const next: SubmissionRecord = {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1735,6 +1735,10 @@ export class InMemoryStore implements Store {
   async recordJobTransition(issueNumber: number, transition: JobTransition): Promise<boolean> {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return false;
+    // Idempotent: concurrent reconcilers that both observed `submitted` must not both
+    // "win" — the loser sees `state === transition.to` and returns false so gate
+    // screenshots (keyed off `recorded`) post once.
+    if (sub.state === transition.to) return false;
     const closes = transitionClosesRound(transition);
     const next: SubmissionRecord = {
       ...sub,
@@ -2822,6 +2826,10 @@ export class FirestoreStore implements Store {
       const snap = await tx.get(ref);
       if (!snap.exists) return false;
       const current = snap.data() as SubmissionRecord;
+      // Same race as InMemoryStore: concurrent status poll + notify sweep both see
+      // `submitted` before either commits. Without this, both return true and each posts
+      // a platform gate screenshot (Codex P2 on BY-06).
+      if (current.state === transition.to) return false;
       const closes = transitionClosesRound(transition);
       if (closes) {
         const next: SubmissionRecord = {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1069,6 +1069,70 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('posts the gate capture screenshot into the build thread on reconcile', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 197 });
+    const { backend } = createBackendStub();
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x11]);
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'space-parcels',
+        version: 'v3',
+        createdAt: '2026-07-31T10:00:00.000Z',
+        issueNumber: 197,
+        sourceFiles: [],
+        gate: {
+          green: true,
+          ranAt: '2026-07-31T10:30:00.000Z',
+          screenshot: 'media/opening.png',
+        },
+      }),
+      getDerivedArtifact: async (_slug: string, _version: string, name: string) =>
+        name === 'media/opening.png' ? png : null,
+    } as unknown as GamesStore;
+
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionSlug(job.issueNumber, 'space-parcels');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v3');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-07-31T10:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    const shots = await store.listBuildShots(job.issueNumber);
+    expect(shots).toHaveLength(1);
+    expect(shots[0]?.label).toBe('Platform check');
+    // Reconcile is once-only: a second poll must not double-post the frame.
+    await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+    expect(await store.countBuildShots(job.issueNumber)).toBe(1);
+
+    await app.close();
+  });
+
   // The other half of the same path, and the one that only became reachable once the
   // gate verdict could land at all: a red gate does not necessarily end the round. The
   // session that delivered is usually still alive, and `mustFixGate` tells it to fix the

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -6,6 +6,7 @@ import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-ch
 import { mintAgentToken } from './agent-token.js';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { createCreationGate, CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js';
+import { postGateScreenshotToThread } from './gate-screenshot.js';
 import {
   catalogEntryFromSpec,
   createGitHubClient,
@@ -1717,10 +1718,25 @@ export async function registerSubmissionRoutes(
         to,
         at: verdict.ranAt,
         by: 'gate',
-        reason: verdict.green ? 'gate_green' : 'gate_red',
+        reason: verdict.green ? 'gate_green' : verdict.status === 'kit_outdated' ? 'kit_outdated' : 'gate_red',
       };
       const recorded = await store.recordJobTransition(record.issueNumber, transition);
-      return recorded ? transition : null;
+      if (!recorded) return null;
+      // First time we act on this verdict: post the capture frame into the thread so the
+      // creator sees what the platform check saw, on the same path as agent-sent shots.
+      if (verdict.screenshot) {
+        await postGateScreenshotToThread({
+          store,
+          gamesStore,
+          issueNumber: record.issueNumber,
+          slug: record.slug,
+          version: record.deliveredVersion,
+          screenshotPath: verdict.screenshot,
+        }).catch((error) => {
+          app.log.warn({ err: error, issueNumber: record.issueNumber }, 'could not post gate screenshot');
+        });
+      }
+      return transition;
     } catch (error) {
       app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not read the gate verdict');
       return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Filename allowlist at sources delivery; required `kitEngineRef` + `kit_outdated` from `kits/current.json` N/N−1; gate capture screenshot auto-posted to thread.

## DoD evidence
- [x] Allowlist accept/reject — path named in reason (`games-store.ts`)
- [x] Gate screenshot stamp + reconcile post (`gate-screenshot.ts`)
- [x] Self missing `kitEngineRef` rejected; window via `kit-window.ts` / registry only
- [x] Channel surfaces `kit_outdated`; round stays open
- [x] Path validation / rate caps / strict-401 unchanged

## Commands (agent)
- `npm test -w @gamedevpl/api` → **1627/1627**

SHA `3eaa2923`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

