### PR TITLE
byoca(BY-03): connect payload endpoint for self-build rounds

### DIFF
--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -241,6 +241,50 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     });
   });
 
+  it('refuses to mint after a race closes the round between the first read and generation mint', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(99, 'g:creator', 'Race Close');
+    await store.setRoundBuilder(99, 'self');
+    await store.recordJobTransition(99, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+    await store.ensureRoundGeneration(99);
+
+    const originalGet = store.getSubmission.bind(store);
+    let reads = 0;
+    store.getSubmission = async (issueNumber: number) => {
+      const hit = await originalGet(issueNumber);
+      reads += 1;
+      // After the connect handler's first ownership/builder check, close the round
+      // before ensureRoundGeneration / the revalidation read.
+      if (reads === 1 && hit) {
+        await store.recordJobTransition(99, {
+          to: 'ready_for_review',
+          at: new Date().toISOString(),
+          by: 'gate',
+          reason: 'gate_green',
+        });
+      }
+      return originalGet(issueNumber);
+    };
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(99, secret)}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'inactive_round',
+    });
+  });
+
   it('does not unlock connect from defaultBuilder alone when the active round builder is unset', async () => {
     const created = await createApp();
     app = created.app;

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -157,6 +157,7 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
       headers: authHeaders(),
     });
     expect(response.statusCode).toBe(200);
+    expect(response.headers['cache-control']).toBe('no-store');
     const body = response.json() as {
       installSnippets: Record<string, string>;
       kickoffPrompt: string;
@@ -230,6 +231,36 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     const response = await app.inject({
       method: 'GET',
       url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'not_self_round',
+      builder: 'platform',
+    });
+  });
+
+  it('does not unlock connect from defaultBuilder alone when the active round builder is unset', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(88, 'g:creator', 'Legacy Default');
+    // Simulate a stale default without an active-round builder field.
+    await store.setRoundBuilder(88, 'self');
+    const sub = await store.getSubmission(88);
+    const map = (store as unknown as { submissions: Map<number, typeof sub> }).submissions;
+    map.set(88, { ...sub!, builder: undefined, defaultBuilder: 'self' });
+    await store.recordJobTransition(88, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(88, secret)}/connect`,
       headers: authHeaders(),
     });
     expect(response.statusCode).toBe(409);

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -1,0 +1,338 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertAgentTokenActive, verifyAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import {
+  buildInstallSnippets,
+  buildKickoffPrompt,
+  mcpEndpointUrl,
+  mintConnectPayload,
+  MCP_ENDPOINT_PATH,
+} from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+import { mintToken } from './submission-token.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'self-build-connect-test-secret';
+const sessionSecret = 'dev-session-secret-change-me';
+const CONCEPT = 'A squad tactics game about clearing rooms with careful timing and cover.';
+const APP_BASE = 'https://www.gamedev.pl';
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: 1 }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+async function createApp(options: { now?: () => number } = {}) {
+  const store = new InMemoryStore();
+  await store.upsertUser({ uid: 'g:creator', email: 'c@example.com', betaStatus: 'approved' });
+  await store.upsertUser({ uid: 'g:stranger', email: 's@example.com', betaStatus: 'approved' });
+  const app = await buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      notifyAppBaseUrl: APP_BASE,
+      now: options.now,
+    },
+  });
+  return { app, store };
+}
+
+function authHeaders(uid = 'g:creator') {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+describe('self-build-connect templates', () => {
+  it('builds install snippets that configure only the MCP URL', () => {
+    const snippets = buildInstallSnippets({ appBaseUrl: APP_BASE });
+    const url = mcpEndpointUrl(APP_BASE);
+    expect(url).toBe(`${APP_BASE}${MCP_ENDPOINT_PATH}`);
+
+    expect(snippets).toEqual({
+      claudeCode: expect.stringContaining(url),
+      codex: expect.stringContaining(url),
+      cursor: expect.stringContaining(url),
+      kimi: expect.stringContaining(url),
+      cli: expect.stringContaining(url),
+    });
+    expect(snippets.claudeCode).toMatch(/^claude mcp add --transport http gamedevpl /);
+    expect(snippets.codex).toContain('[mcp_servers.gamedevpl]');
+    expect(JSON.parse(snippets.cursor)).toEqual({
+      mcpServers: { gamedevpl: { url } },
+    });
+    expect(snippets.kimi).toMatch(/^npx -y mcp-remote /);
+    expect(snippets.cli).toMatch(/^curl -sS -X POST /);
+
+    // No credential in any install snippet — only the URL.
+    for (const value of Object.values(snippets)) {
+      expect(value).not.toMatch(/key:|Bearer|token|Authorization/i);
+      expect(value).toContain(url);
+    }
+  });
+
+  it('builds a kickoff prompt with the round key and pending feedback', () => {
+    const bare = buildKickoffPrompt({ title: 'Asteroids', roundKey: 'round-key-abc' });
+    expect(bare).toBe(
+      ['Build "Asteroids" for gamedev.pl.', 'Start with the gamedevpl tool, key: round-key-abc'].join('\n'),
+    );
+    expect(bare).not.toMatch(/\btoken\b/i);
+
+    const withPending = buildKickoffPrompt({
+      title: 'Asteroids',
+      roundKey: 'round-key-abc',
+      pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
+    });
+    expect(withPending).toContain('also apply:');
+    expect(withPending).toContain('- make the ship faster');
+    expect(withPending).toContain('- add a pause button');
+  });
+
+  it('mints a payload whose expiresAt equals the key signed exp claim', () => {
+    const now = Date.parse('2026-07-31T12:00:00Z');
+    const payload = mintConnectPayload({
+      jobId: 42,
+      title: 'Nebula',
+      roundGeneration: 3,
+      submissionTokenSecret: secret,
+      appBaseUrl: APP_BASE,
+      now,
+    });
+    const keyMatch = payload.kickoffPrompt.match(/key: (\S+)/);
+    expect(keyMatch).toBeTruthy();
+    const roundKey = keyMatch![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims).toMatchObject({ jobId: 42, roundGeneration: 3 });
+    expect(payload.expiresAt).toBe(claims.exp);
+    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + 14 * 24 * 60 * 60);
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 3 }, now)).not.toThrow();
+  });
+});
+
+describe('GET /api/submissions/:id/connect (BY-03)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('returns snippets, kickoff, and expiresAt for the owner of an active self round', async () => {
+    const created = await createApp({ now: () => Date.parse('2026-07-31T12:00:00Z') });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Connect Game', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+    expect(record.builder).toBe('self');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      installSnippets: Record<string, string>;
+      kickoffPrompt: string;
+      expiresAt: number;
+    };
+
+    expect(Object.keys(body.installSnippets).sort()).toEqual(['claudeCode', 'cli', 'codex', 'cursor', 'kimi'].sort());
+    const mcpUrl = `${APP_BASE}${MCP_ENDPOINT_PATH}`;
+    for (const snippet of Object.values(body.installSnippets)) {
+      expect(snippet).toContain(mcpUrl);
+      expect(snippet).not.toMatch(/key:|Bearer |\btoken\b/i);
+    }
+
+    expect(body.kickoffPrompt).toContain('Build "Connect Game" for gamedev.pl.');
+    expect(body.kickoffPrompt).toMatch(/Start with the gamedevpl tool, key: \S+/);
+    expect(body.kickoffPrompt).not.toMatch(/\btoken\b/i);
+
+    const roundKey = body.kickoffPrompt.match(/key: (\S+)/)![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims.jobId).toBe(record.issueNumber);
+    expect(claims.roundGeneration).toBe(record.roundGeneration ?? 1);
+    expect(body.expiresAt).toBe(claims.exp);
+    expect(() =>
+      assertAgentTokenActive(
+        claims,
+        { roundGeneration: record.roundGeneration ?? 1 },
+        Date.parse('2026-07-31T12:00:00Z'),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a stranger with 403', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders('g:creator'),
+      payload: { title: 'Private Self', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+
+    const stranger = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders('g:stranger'),
+    });
+    expect(stranger.statusCode).toBe(403);
+    expect(stranger.json()).toMatchObject({ error: 'only the creator can connect a build' });
+
+    const anon = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+    });
+    expect(anon.statusCode).toBe(401);
+  });
+
+  it('returns 409 for a platform (non-self) round', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Platform Round', concept: CONCEPT, builder: 'platform' },
+    });
+    const id = submit.json().token as string;
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'not_self_round',
+      builder: 'platform',
+    });
+  });
+
+  it('returns 409 when the self round is no longer active', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Closed Self', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+    await store.recordJobTransition(record.issueNumber, {
+      to: 'abandoned',
+      at: new Date().toISOString(),
+      by: 'system',
+      reason: 'no_connect',
+    });
+    await store.setSubmissionAbandoned(record.issueNumber, new Date().toISOString());
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'inactive_round',
+      builder: 'self',
+    });
+  });
+
+  it('binds the minted key to the job round generation', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(77, 'g:creator', 'Bound Round');
+    await store.setRoundBuilder(77, 'self');
+    await store.recordJobTransition(77, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+    await store.ensureRoundGeneration(77);
+    // Simulate a later round: generation 2 is active.
+    await store.bumpRoundGeneration(77);
+    const afterBump = await store.getSubmission(77);
+    expect(afterBump?.roundGeneration).toBe(2);
+
+    const id = mintToken(77, secret);
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const roundKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims).toMatchObject({ jobId: 77, roundGeneration: 2 });
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 1 })).toThrow();
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 2 })).not.toThrow();
+  });
+
+  it('embeds pending unacknowledged creator inbox messages in the kickoff', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Feedback Game', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+
+    const first = await store.appendCreatorMessage(record.issueNumber, 'make the ship faster');
+    await store.appendCreatorMessage(record.issueNumber, 'add a pause button');
+    await store.markCreatorMessagesDelivered(record.issueNumber, [first.id]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const prompt = response.json().kickoffPrompt as string;
+    expect(prompt).toContain('also apply:');
+    expect(prompt).toContain('- add a pause button');
+    expect(prompt).not.toContain('make the ship faster');
+  });
+});

--- a/apps/api/src/self-build-connect.ts
+++ b/apps/api/src/self-build-connect.ts
@@ -1,0 +1,135 @@
+/**
+ * Connect payload for a self-build round (BY-03).
+ *
+ * The Studio asks once for everything a creator needs to paste into their own coding
+ * agent: per-client MCP install snippets (endpoint URL only — never a credential) and a
+ * kickoff prompt that carries this round's key. Snippet templates live here so docs and
+ * UI render from one source of truth; regenerating the prompt mints a fresh key with a
+ * new signed `exp`, and any pending creator inbox lines ride along under "also apply:".
+ */
+
+import { mintAgentToken, verifyAgentToken } from './agent-token.js';
+
+/** Path of the remote MCP endpoint (served by BY-05). Install snippets point here. */
+export const MCP_ENDPOINT_PATH = '/api/mcp';
+
+export interface InstallSnippets {
+  claudeCode: string;
+  codex: string;
+  cursor: string;
+  kimi: string;
+  cli: string;
+}
+
+export interface ConnectPayload {
+  installSnippets: InstallSnippets;
+  kickoffPrompt: string;
+  /**
+   * Unix seconds. Identical to the minted key's signed `exp` claim — not a separate
+   * display clock the UI could drift from.
+   */
+  expiresAt: number;
+}
+
+export interface BuildInstallSnippetsInput {
+  /** Absolute origin, e.g. `https://www.gamedev.pl`. */
+  appBaseUrl: string;
+}
+
+export interface BuildKickoffPromptInput {
+  title: string;
+  /** Round-scoped build-channel key (embedded only in the kickoff, never in install). */
+  roundKey: string;
+  /** Undelivered creator inbox lines, oldest first. */
+  pendingMessages?: readonly { text: string }[];
+}
+
+export interface MintConnectPayloadInput {
+  jobId: number;
+  title: string;
+  roundGeneration: number;
+  submissionTokenSecret: string;
+  appBaseUrl: string;
+  pendingMessages?: readonly { text: string }[];
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+}
+
+/** Join origin + `/api/mcp`, trimming a trailing slash on the origin. */
+export function mcpEndpointUrl(appBaseUrl: string): string {
+  return `${appBaseUrl.replace(/\/+$/, '')}${MCP_ENDPOINT_PATH}`;
+}
+
+/**
+ * Per-client install snippets. Every snippet configures the MCP endpoint URL and
+ * nothing else — the round key rides the kickoff prompt, not the install.
+ */
+export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallSnippets {
+  const url = mcpEndpointUrl(input.appBaseUrl);
+  return {
+    claudeCode: `claude mcp add --transport http gamedevpl ${url}`,
+    codex: [`[mcp_servers.gamedevpl]`, `url = "${url}"`].join('\n'),
+    cursor: JSON.stringify(
+      {
+        mcpServers: {
+          gamedevpl: {
+            url,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    // Kimi Code has no first-class remote-HTTP add yet; mcp-remote is the documented
+    // stdio bridge (third-party — we publish no package). Same URL, still no key.
+    kimi: `npx -y mcp-remote ${url}`,
+    // Floor for agents that talk HTTP without an MCP client.
+    cli: `curl -sS -X POST ${url}`,
+  };
+}
+
+/**
+ * Paste-ready kickoff: build instruction + gamedevpl tool key line, and any queued
+ * creator feedback as a short "also apply:" list so a regenerate never drops them.
+ *
+ * User-facing copy says "key", never "token".
+ */
+export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
+  const title = input.title.trim() || 'your game';
+  const lines = [`Build "${title}" for gamedev.pl.`, `Start with the gamedevpl tool, key: ${input.roundKey}`];
+  const pending = (input.pendingMessages ?? []).map((message) => message.text.trim()).filter((text) => text.length > 0);
+  if (pending.length > 0) {
+    lines.push('');
+    lines.push('also apply:');
+    for (const text of pending) {
+      // One bullet per message; collapse internal newlines so the paste stays scannable.
+      lines.push(`- ${text.replace(/\s+/g, ' ')}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Mint a round-scoped key and assemble the connect payload. `expiresAt` is taken from
+ * the key's verified `exp` claim so the UI's "expires" line cannot disagree with auth.
+ */
+export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPayload {
+  const roundKey = mintAgentToken(input.jobId, input.submissionTokenSecret, {
+    roundGeneration: input.roundGeneration,
+    now: input.now,
+  });
+  const claims = verifyAgentToken(roundKey, input.submissionTokenSecret);
+  if (claims.exp === undefined) {
+    // Round-scoped mint always sets exp; a missing claim would mean mint/verify drifted.
+    throw new Error('minted connect key is missing exp claim');
+  }
+  return {
+    installSnippets: buildInstallSnippets({ appBaseUrl: input.appBaseUrl }),
+    kickoffPrompt: buildKickoffPrompt({
+      title: input.title,
+      roundKey,
+      pendingMessages: input.pendingMessages,
+    }),
+    expiresAt: claims.exp,
+  };
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2006,7 +2006,7 @@ export async function registerSubmissionRoutes(
         issueNumber = verifyToken(id, submissionTokenSecret);
       } catch (error) {
         if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid submission' });
+          return reply.status(400).send({ error: 'invalid submission token' });
         }
         throw error;
       }

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2018,7 +2018,10 @@ export async function registerSubmissionRoutes(
         return reply.status(403).send({ error: 'only the creator can connect a build' });
       }
 
-      const builder = builderOf(record);
+      // Gate on the *active round's* builder field, not `builderOf` (which falls back to
+      // `defaultBuilder`). A legacy/platform round that once used self must not unlock
+      // connect just because defaultBuilder still says self.
+      const builder = record.builder ?? 'platform';
       if (builder !== 'self' || !isActiveBuildRound(record)) {
         return reply.status(409).send({
           error: 'connect_unavailable',
@@ -2038,7 +2041,8 @@ export async function registerSubmissionRoutes(
         pendingMessages,
         now: now(),
       });
-      return reply.send(payload);
+      // Kickoff embeds a round key — never let intermediaries cache it.
+      return reply.header('Cache-Control', 'no-store').send(payload);
     },
   );
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1898,6 +1898,10 @@ export async function registerSubmissionRoutes(
       // which since seeding is minutes rather than milliseconds, on every submission.
       const dispatchLog = request.log;
       const builder: BuilderKind = parsed.data.builder ?? 'platform';
+      // Persist before the response returns. Connect (and Studio) read `record.builder`
+      // immediately; if we only wrote it inside background dispatch, a fast /connect
+      // after submit saw platform and returned a permanent-looking 409 (Codex P2).
+      await store.setRoundBuilder(jobId, builder, { resetRoundBudget: false });
       void dispatchBuild({
         issueNumber: jobId,
         // The agent is told where to build rather than left to name the place itself.
@@ -2031,11 +2035,25 @@ export async function registerSubmissionRoutes(
       }
 
       const roundGeneration = (await store.ensureRoundGeneration(issueNumber)) ?? 1;
+      // Re-read after ensureRoundGeneration: a closing transition can race between the
+      // first snapshot and minting. Without this we could mint generation N+1 for a
+      // round that just closed to ready_for_review (Codex P1) — channel auth only
+      // compares generations, and that state is not a stopReason.
+      const fresh = await store.getSubmission(issueNumber);
+      const freshBuilder = fresh?.builder ?? 'platform';
+      if (!fresh || freshBuilder !== 'self' || !isActiveBuildRound(fresh)) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: freshBuilder !== 'self' ? 'not_self_round' : 'inactive_round',
+          builder: freshBuilder,
+        });
+      }
+      const activeGeneration = fresh.roundGeneration ?? roundGeneration;
       const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
       const payload = mintConnectPayload({
         jobId: issueNumber,
-        title: record.title,
-        roundGeneration,
+        title: fresh.title,
+        roundGeneration: activeGeneration,
         submissionTokenSecret,
         appBaseUrl: notifyAppBaseUrl,
         pendingMessages,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -38,6 +38,7 @@ import {
   type JobTransition,
 } from './job-state.js';
 import { createSelfBuildBackend } from './self-build-backend.js';
+import { mintConnectPayload } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
@@ -1977,6 +1978,69 @@ export async function registerSubmissionRoutes(
       },
     });
   });
+
+  /**
+   * Everything a creator needs to connect their own coding agent to a self-build round.
+   *
+   * Creator-session auth, owner only. Valid only while the active round's builder is
+   * `self`. Install snippets configure the MCP URL alone; the round key rides the
+   * kickoff prompt (and regenerating mints a fresh key with a new signed `exp`).
+   * Pending, undelivered creator inbox lines are embedded under "also apply:" so a
+   * re-copy never drops queued feedback. See self-build-connect.ts for the templates.
+   */
+  app.get(
+    '/api/submissions/:id/connect',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      // Same shape as share/abandon: missing and not-yours both 403 so existence is not
+      // confirmed to a stranger who holds (or forges) a status link.
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can connect a build' });
+      }
+
+      const builder = builderOf(record);
+      if (builder !== 'self' || !isActiveBuildRound(record)) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: builder !== 'self' ? 'not_self_round' : 'inactive_round',
+          builder,
+        });
+      }
+
+      const roundGeneration = (await store.ensureRoundGeneration(issueNumber)) ?? 1;
+      const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
+      const payload = mintConnectPayload({
+        jobId: issueNumber,
+        title: record.title,
+        roundGeneration,
+        submissionTokenSecret,
+        appBaseUrl: notifyAppBaseUrl,
+        pendingMessages,
+        now: now(),
+      });
+      return reply.send(payload);
+    },
+  );
 
   /**
    * The creator decides whether anyone else may play their game before it is published.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `GET /api/submissions/:id/connect` for Studio: MCP install snippets (URL only), kickoff prompt with freshly minted round-scoped key, and `expiresAt` from the key’s signed `exp`.

## DoD evidence
- [x] Route creator-session, owner only; active `builder: 'self'` — stranger 403 / platform 409 / inactive 409
- [x] `{ installSnippets, kickoffPrompt, expiresAt }` — URL-only snippets; kickoff uses `key:`; `expiresAt === verifyAgentToken(...).exp`
- [x] Pending inbox under `also apply:`
- [x] Snippet templates one module — claudeCode / codex / cursor / kimi / cli
- [x] Round-binding via `mintAgentToken` + `ensureRoundGeneration`
- [x] Out of scope: no Studio UI, no MCP

## Commands (agent)
- `npm test -w @gamedevpl/api` → **1622/1622**

SHA `eefeb784`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

