### PR TITLE
byoca(BY-07): Studio builder choice + connect card

### DIFF
--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -1,0 +1,338 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertAgentTokenActive, verifyAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import {
+  buildInstallSnippets,
+  buildKickoffPrompt,
+  mcpEndpointUrl,
+  mintConnectPayload,
+  MCP_ENDPOINT_PATH,
+} from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+import { mintToken } from './submission-token.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'self-build-connect-test-secret';
+const sessionSecret = 'dev-session-secret-change-me';
+const CONCEPT = 'A squad tactics game about clearing rooms with careful timing and cover.';
+const APP_BASE = 'https://www.gamedev.pl';
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: 1 }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+async function createApp(options: { now?: () => number } = {}) {
+  const store = new InMemoryStore();
+  await store.upsertUser({ uid: 'g:creator', email: 'c@example.com', betaStatus: 'approved' });
+  await store.upsertUser({ uid: 'g:stranger', email: 's@example.com', betaStatus: 'approved' });
+  const app = await buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      notifyAppBaseUrl: APP_BASE,
+      now: options.now,
+    },
+  });
+  return { app, store };
+}
+
+function authHeaders(uid = 'g:creator') {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+describe('self-build-connect templates', () => {
+  it('builds install snippets that configure only the MCP URL', () => {
+    const snippets = buildInstallSnippets({ appBaseUrl: APP_BASE });
+    const url = mcpEndpointUrl(APP_BASE);
+    expect(url).toBe(`${APP_BASE}${MCP_ENDPOINT_PATH}`);
+
+    expect(snippets).toEqual({
+      claudeCode: expect.stringContaining(url),
+      codex: expect.stringContaining(url),
+      cursor: expect.stringContaining(url),
+      kimi: expect.stringContaining(url),
+      cli: expect.stringContaining(url),
+    });
+    expect(snippets.claudeCode).toMatch(/^claude mcp add --transport http gamedevpl /);
+    expect(snippets.codex).toContain('[mcp_servers.gamedevpl]');
+    expect(JSON.parse(snippets.cursor)).toEqual({
+      mcpServers: { gamedevpl: { url } },
+    });
+    expect(snippets.kimi).toMatch(/^npx -y mcp-remote /);
+    expect(snippets.cli).toMatch(/^curl -sS -X POST /);
+
+    // No credential in any install snippet — only the URL.
+    for (const value of Object.values(snippets)) {
+      expect(value).not.toMatch(/key:|Bearer|token|Authorization/i);
+      expect(value).toContain(url);
+    }
+  });
+
+  it('builds a kickoff prompt with the round key and pending feedback', () => {
+    const bare = buildKickoffPrompt({ title: 'Asteroids', roundKey: 'round-key-abc' });
+    expect(bare).toBe(
+      ['Build "Asteroids" for gamedev.pl.', 'Start with the gamedevpl tool, key: round-key-abc'].join('\n'),
+    );
+    expect(bare).not.toMatch(/\btoken\b/i);
+
+    const withPending = buildKickoffPrompt({
+      title: 'Asteroids',
+      roundKey: 'round-key-abc',
+      pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
+    });
+    expect(withPending).toContain('also apply:');
+    expect(withPending).toContain('- make the ship faster');
+    expect(withPending).toContain('- add a pause button');
+  });
+
+  it('mints a payload whose expiresAt equals the key signed exp claim', () => {
+    const now = Date.parse('2026-07-31T12:00:00Z');
+    const payload = mintConnectPayload({
+      jobId: 42,
+      title: 'Nebula',
+      roundGeneration: 3,
+      submissionTokenSecret: secret,
+      appBaseUrl: APP_BASE,
+      now,
+    });
+    const keyMatch = payload.kickoffPrompt.match(/key: (\S+)/);
+    expect(keyMatch).toBeTruthy();
+    const roundKey = keyMatch![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims).toMatchObject({ jobId: 42, roundGeneration: 3 });
+    expect(payload.expiresAt).toBe(claims.exp);
+    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + 14 * 24 * 60 * 60);
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 3 }, now)).not.toThrow();
+  });
+});
+
+describe('GET /api/submissions/:id/connect (BY-03)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('returns snippets, kickoff, and expiresAt for the owner of an active self round', async () => {
+    const created = await createApp({ now: () => Date.parse('2026-07-31T12:00:00Z') });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Connect Game', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+    expect(record.builder).toBe('self');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      installSnippets: Record<string, string>;
+      kickoffPrompt: string;
+      expiresAt: number;
+    };
+
+    expect(Object.keys(body.installSnippets).sort()).toEqual(['claudeCode', 'cli', 'codex', 'cursor', 'kimi'].sort());
+    const mcpUrl = `${APP_BASE}${MCP_ENDPOINT_PATH}`;
+    for (const snippet of Object.values(body.installSnippets)) {
+      expect(snippet).toContain(mcpUrl);
+      expect(snippet).not.toMatch(/key:|Bearer |\btoken\b/i);
+    }
+
+    expect(body.kickoffPrompt).toContain('Build "Connect Game" for gamedev.pl.');
+    expect(body.kickoffPrompt).toMatch(/Start with the gamedevpl tool, key: \S+/);
+    expect(body.kickoffPrompt).not.toMatch(/\btoken\b/i);
+
+    const roundKey = body.kickoffPrompt.match(/key: (\S+)/)![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims.jobId).toBe(record.issueNumber);
+    expect(claims.roundGeneration).toBe(record.roundGeneration ?? 1);
+    expect(body.expiresAt).toBe(claims.exp);
+    expect(() =>
+      assertAgentTokenActive(
+        claims,
+        { roundGeneration: record.roundGeneration ?? 1 },
+        Date.parse('2026-07-31T12:00:00Z'),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a stranger with 403', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders('g:creator'),
+      payload: { title: 'Private Self', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+
+    const stranger = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders('g:stranger'),
+    });
+    expect(stranger.statusCode).toBe(403);
+    expect(stranger.json()).toMatchObject({ error: 'only the creator can connect a build' });
+
+    const anon = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+    });
+    expect(anon.statusCode).toBe(401);
+  });
+
+  it('returns 409 for a platform (non-self) round', async () => {
+    const created = await createApp();
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Platform Round', concept: CONCEPT, builder: 'platform' },
+    });
+    const id = submit.json().token as string;
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'not_self_round',
+      builder: 'platform',
+    });
+  });
+
+  it('returns 409 when the self round is no longer active', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Closed Self', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+    await store.recordJobTransition(record.issueNumber, {
+      to: 'abandoned',
+      at: new Date().toISOString(),
+      by: 'system',
+      reason: 'no_connect',
+    });
+    await store.setSubmissionAbandoned(record.issueNumber, new Date().toISOString());
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      error: 'connect_unavailable',
+      reason: 'inactive_round',
+      builder: 'self',
+    });
+  });
+
+  it('binds the minted key to the job round generation', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(77, 'g:creator', 'Bound Round');
+    await store.setRoundBuilder(77, 'self');
+    await store.recordJobTransition(77, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+    await store.ensureRoundGeneration(77);
+    // Simulate a later round: generation 2 is active.
+    await store.bumpRoundGeneration(77);
+    const afterBump = await store.getSubmission(77);
+    expect(afterBump?.roundGeneration).toBe(2);
+
+    const id = mintToken(77, secret);
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const roundKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
+    const claims = verifyAgentToken(roundKey, secret);
+    expect(claims).toMatchObject({ jobId: 77, roundGeneration: 2 });
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 1 })).toThrow();
+    expect(() => assertAgentTokenActive(claims, { roundGeneration: 2 })).not.toThrow();
+  });
+
+  it('embeds pending unacknowledged creator inbox messages in the kickoff', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Feedback Game', concept: CONCEPT, builder: 'self' },
+    });
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+
+    const first = await store.appendCreatorMessage(record.issueNumber, 'make the ship faster');
+    await store.appendCreatorMessage(record.issueNumber, 'add a pause button');
+    await store.markCreatorMessagesDelivered(record.issueNumber, [first.id]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const prompt = response.json().kickoffPrompt as string;
+    expect(prompt).toContain('also apply:');
+    expect(prompt).toContain('- add a pause button');
+    expect(prompt).not.toContain('make the ship faster');
+  });
+});

--- a/apps/api/src/self-build-connect.ts
+++ b/apps/api/src/self-build-connect.ts
@@ -1,0 +1,135 @@
+/**
+ * Connect payload for a self-build round (BY-03).
+ *
+ * The Studio asks once for everything a creator needs to paste into their own coding
+ * agent: per-client MCP install snippets (endpoint URL only — never a credential) and a
+ * kickoff prompt that carries this round's key. Snippet templates live here so docs and
+ * UI render from one source of truth; regenerating the prompt mints a fresh key with a
+ * new signed `exp`, and any pending creator inbox lines ride along under "also apply:".
+ */
+
+import { mintAgentToken, verifyAgentToken } from './agent-token.js';
+
+/** Path of the remote MCP endpoint (served by BY-05). Install snippets point here. */
+export const MCP_ENDPOINT_PATH = '/api/mcp';
+
+export interface InstallSnippets {
+  claudeCode: string;
+  codex: string;
+  cursor: string;
+  kimi: string;
+  cli: string;
+}
+
+export interface ConnectPayload {
+  installSnippets: InstallSnippets;
+  kickoffPrompt: string;
+  /**
+   * Unix seconds. Identical to the minted key's signed `exp` claim — not a separate
+   * display clock the UI could drift from.
+   */
+  expiresAt: number;
+}
+
+export interface BuildInstallSnippetsInput {
+  /** Absolute origin, e.g. `https://www.gamedev.pl`. */
+  appBaseUrl: string;
+}
+
+export interface BuildKickoffPromptInput {
+  title: string;
+  /** Round-scoped build-channel key (embedded only in the kickoff, never in install). */
+  roundKey: string;
+  /** Undelivered creator inbox lines, oldest first. */
+  pendingMessages?: readonly { text: string }[];
+}
+
+export interface MintConnectPayloadInput {
+  jobId: number;
+  title: string;
+  roundGeneration: number;
+  submissionTokenSecret: string;
+  appBaseUrl: string;
+  pendingMessages?: readonly { text: string }[];
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+}
+
+/** Join origin + `/api/mcp`, trimming a trailing slash on the origin. */
+export function mcpEndpointUrl(appBaseUrl: string): string {
+  return `${appBaseUrl.replace(/\/+$/, '')}${MCP_ENDPOINT_PATH}`;
+}
+
+/**
+ * Per-client install snippets. Every snippet configures the MCP endpoint URL and
+ * nothing else — the round key rides the kickoff prompt, not the install.
+ */
+export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallSnippets {
+  const url = mcpEndpointUrl(input.appBaseUrl);
+  return {
+    claudeCode: `claude mcp add --transport http gamedevpl ${url}`,
+    codex: [`[mcp_servers.gamedevpl]`, `url = "${url}"`].join('\n'),
+    cursor: JSON.stringify(
+      {
+        mcpServers: {
+          gamedevpl: {
+            url,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    // Kimi Code has no first-class remote-HTTP add yet; mcp-remote is the documented
+    // stdio bridge (third-party — we publish no package). Same URL, still no key.
+    kimi: `npx -y mcp-remote ${url}`,
+    // Floor for agents that talk HTTP without an MCP client.
+    cli: `curl -sS -X POST ${url}`,
+  };
+}
+
+/**
+ * Paste-ready kickoff: build instruction + gamedevpl tool key line, and any queued
+ * creator feedback as a short "also apply:" list so a regenerate never drops them.
+ *
+ * User-facing copy says "key", never "token".
+ */
+export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
+  const title = input.title.trim() || 'your game';
+  const lines = [`Build "${title}" for gamedev.pl.`, `Start with the gamedevpl tool, key: ${input.roundKey}`];
+  const pending = (input.pendingMessages ?? []).map((message) => message.text.trim()).filter((text) => text.length > 0);
+  if (pending.length > 0) {
+    lines.push('');
+    lines.push('also apply:');
+    for (const text of pending) {
+      // One bullet per message; collapse internal newlines so the paste stays scannable.
+      lines.push(`- ${text.replace(/\s+/g, ' ')}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Mint a round-scoped key and assemble the connect payload. `expiresAt` is taken from
+ * the key's verified `exp` claim so the UI's "expires" line cannot disagree with auth.
+ */
+export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPayload {
+  const roundKey = mintAgentToken(input.jobId, input.submissionTokenSecret, {
+    roundGeneration: input.roundGeneration,
+    now: input.now,
+  });
+  const claims = verifyAgentToken(roundKey, input.submissionTokenSecret);
+  if (claims.exp === undefined) {
+    // Round-scoped mint always sets exp; a missing claim would mean mint/verify drifted.
+    throw new Error('minted connect key is missing exp claim');
+  }
+  return {
+    installSnippets: buildInstallSnippets({ appBaseUrl: input.appBaseUrl }),
+    kickoffPrompt: buildKickoffPrompt({
+      title: input.title,
+      roundKey,
+      pendingMessages: input.pendingMessages,
+    }),
+    expiresAt: claims.exp,
+  };
+}

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -263,6 +263,8 @@ describe('self builder (BY-02)', () => {
       url: `/api/submissions/${mintToken(issueNumber, secret)}`,
     });
     expect(statusWaiting.json().stall).toBe('no_agent_yet');
+    // Studio defaults from these — not localStorage alone (Codex P2 on BY-07).
+    expect(statusWaiting.json()).toMatchObject({ builder: 'self', defaultBuilder: 'self' });
 
     const progress = await app.inject({
       method: 'POST',

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -191,6 +191,14 @@ export interface SubmissionStatusResponseBase {
    */
   stall?: JobStall;
   /**
+   * Who owns the *current* round (`platform` | `self`), when known. Studio uses this
+   * (with {@link defaultBuilder}) instead of localStorage alone so another browser
+   * still defaults to the game's last-used choice.
+   */
+  builder?: 'platform' | 'self';
+  /** Last builder used on this game — default for the next round-boundary choice. */
+  defaultBuilder?: 'platform' | 'self';
+  /**
    * Why this build is asking the creator to act, when it is. Set alongside `status`
    * because the public vocabulary projects both `failed` and a gate bounce onto
    * `needs_changes` — without this the page only shows the label, and a creator who

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -38,6 +38,7 @@ import {
   type JobTransition,
 } from './job-state.js';
 import { createSelfBuildBackend } from './self-build-backend.js';
+import { mintConnectPayload } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
@@ -1977,6 +1978,69 @@ export async function registerSubmissionRoutes(
       },
     });
   });
+
+  /**
+   * Everything a creator needs to connect their own coding agent to a self-build round.
+   *
+   * Creator-session auth, owner only. Valid only while the active round's builder is
+   * `self`. Install snippets configure the MCP URL alone; the round key rides the
+   * kickoff prompt (and regenerating mints a fresh key with a new signed `exp`).
+   * Pending, undelivered creator inbox lines are embedded under "also apply:" so a
+   * re-copy never drops queued feedback. See self-build-connect.ts for the templates.
+   */
+  app.get(
+    '/api/submissions/:id/connect',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      // Same shape as share/abandon: missing and not-yours both 403 so existence is not
+      // confirmed to a stranger who holds (or forges) a status link.
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can connect a build' });
+      }
+
+      const builder = builderOf(record);
+      if (builder !== 'self' || !isActiveBuildRound(record)) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: builder !== 'self' ? 'not_self_round' : 'inactive_round',
+          builder,
+        });
+      }
+
+      const roundGeneration = (await store.ensureRoundGeneration(issueNumber)) ?? 1;
+      const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
+      const payload = mintConnectPayload({
+        jobId: issueNumber,
+        title: record.title,
+        roundGeneration,
+        submissionTokenSecret,
+        appBaseUrl: notifyAppBaseUrl,
+        pendingMessages,
+        now: now(),
+      });
+      return reply.send(payload);
+    },
+  );
 
   /**
    * The creator decides whether anyone else may play their game before it is published.

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1533,6 +1533,12 @@ export async function registerSubmissionRoutes(
       builder: builderOf(record),
     });
     if (stall) status.stall = stall;
+    // Echo builder fields so Studio does not invent `platform` from empty localStorage
+    // when the server already knows the game's last-used choice (Codex P2 on BY-07).
+    const roundBuilder = record.builder;
+    if (roundBuilder) status.builder = roundBuilder;
+    const lastBuilder = record.defaultBuilder ?? record.builder;
+    if (lastBuilder) status.defaultBuilder = lastBuilder;
     return status;
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,6 +48,7 @@ function readLocationRoute(): AppRoute {
 import { submitSpec, refineSpec, type SubmissionApiError } from './submissionApi.js';
 import { useActiveBuildCount } from './activeBuilds.js';
 import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs.js';
+import { saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa.js';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
@@ -118,6 +119,10 @@ export function App() {
   // recorded one — that mismatch with the live UI language is what triggers a
   // one-shot re-ask so English chips don't stick under a Polish chrome.
   const [qaLocale, setQaLocale] = useState<string>(restoredQa.current?.locale ?? '');
+  // Who builds this round — parked with the confirm session so a reload keeps it.
+  const [qaBuilder, setQaBuilder] = useState<BuilderKind>(restoredQa.current?.builder ?? 'platform');
+  const qaBuilderRef = useRef(qaBuilder);
+  qaBuilderRef.current = qaBuilder;
   // Bumped when questions are rewritten for a new language so CreatorQA remounts
   // with empty answers — English chip labels must not survive as "selected" under
   // Polish options that no longer match.
@@ -409,6 +414,7 @@ export function App() {
           questions,
           answers: newAnswers,
           locale: targetLocale,
+          builder: qaBuilderRef.current,
         });
         setQaFormKey((key) => key + 1);
       } catch {
@@ -541,14 +547,21 @@ export function App() {
     setPendingSpec(spec);
     setQaQuestions(questions);
     setQaLocale(locale);
+    setQaBuilder('platform');
     latestAnswersRef.current = { selected: {}, custom: {} };
-    savePendingQa({ spec, questions, answers: { selected: {}, custom: {} }, locale });
+    savePendingQa({
+      spec,
+      questions,
+      answers: { selected: {}, custom: {} },
+      locale,
+      builder: 'platform',
+    });
     setQaFormKey((key) => key + 1);
     setSubmissionStatus('idle');
   }
 
   // Actually creates the submission (after the QA gate) and jumps to its status page.
-  async function submitRefinedSpec(title: string, concept: string, displayName: string) {
+  async function submitRefinedSpec(title: string, concept: string, displayName: string, builder: BuilderKind) {
     setSubmissionStatus('loading');
     setSubmissionError(null);
 
@@ -560,6 +573,7 @@ export function App() {
         // The agent is told this, so its progress updates arrive already written in
         // the creator's language rather than machine-translated afterwards.
         locale: i18n.language,
+        builder,
       });
 
       // Save to localStorage
@@ -572,6 +586,7 @@ export function App() {
       });
       setSavedSpecs(updatedSpecs);
       setMyGamesRefreshKey((key) => key + 1);
+      saveLastBuilder(response.token, builder);
 
       setSubmissionStatus('idle');
       recordCreateStep('submission_created');
@@ -581,6 +596,7 @@ export function App() {
       setQaQuestions([]);
       setPendingSpec(null);
       setQaLocale('');
+      setQaBuilder('platform');
       clearPendingQa();
 
       // Straight to the game's own address. Older API builds answer without a slug, in
@@ -618,18 +634,19 @@ export function App() {
   // dropped the creator into blank space for however long the API took to create the
   // issue — they had just clicked a button and the page answered by deleting itself.
   // On failure it stays up with the error, so the answers survive a retry.
-  const handleQaComplete = async (finalConcept: string, title: string) => {
+  const handleQaComplete = async (finalConcept: string, title: string, builder: BuilderKind) => {
     const spec = pendingSpec;
     if (!spec) return;
     // The name the creator settled on, which is the step that gates the build.
     recordCreateStep('title_confirmed');
-    await submitRefinedSpec(title, finalConcept, spec.displayName);
+    await submitRefinedSpec(title, finalConcept, spec.displayName, builder);
   };
 
   const handleQaCancel = () => {
     setQaQuestions([]);
     setPendingSpec(null);
     setQaLocale('');
+    setQaBuilder('platform');
     clearPendingQa();
   };
 
@@ -639,9 +656,15 @@ export function App() {
     (answers: PendingQaAnswers) => {
       latestAnswersRef.current = answers;
       if (!pendingSpec) return;
-      savePendingQa({ spec: pendingSpec, questions: qaQuestions, answers, locale: qaLocale });
+      savePendingQa({
+        spec: pendingSpec,
+        questions: qaQuestions,
+        answers,
+        locale: qaLocale,
+        builder: qaBuilder,
+      });
     },
-    [pendingSpec, qaQuestions, qaLocale],
+    [pendingSpec, qaQuestions, qaLocale, qaBuilder],
   );
 
   // The name is parked with the answers, for the same reason: an edited title is work,
@@ -657,6 +680,22 @@ export function App() {
         questions: qaQuestions,
         answers: latestAnswersRef.current,
         locale: qaLocale,
+        builder: qaBuilder,
+      });
+    },
+    [pendingSpec, qaQuestions, qaLocale, qaBuilder],
+  );
+
+  const handleQaBuilderChange = useCallback(
+    (builder: BuilderKind) => {
+      setQaBuilder(builder);
+      if (!pendingSpec) return;
+      savePendingQa({
+        spec: pendingSpec,
+        questions: qaQuestions,
+        answers: latestAnswersRef.current,
+        locale: qaLocale,
+        builder,
       });
     },
     [pendingSpec, qaQuestions, qaLocale],
@@ -884,6 +923,8 @@ export function App() {
                   error={submissionError}
                   initialAnswers={latestAnswersRef.current}
                   onAnswersChange={handleQaAnswersChange}
+                  initialBuilder={qaBuilder}
+                  onBuilderChange={handleQaBuilderChange}
                 />
               </div>
             )}

--- a/apps/web/src/BuilderChoice.test.tsx
+++ b/apps/web/src/BuilderChoice.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BuilderChoice } from './BuilderChoice.js';
+import type { BuilderKind } from './builderKind.js';
+import i18n from './i18n/index.js';
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('BuilderChoice', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('defaults visually to the selected builder and reports changes', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    let value: BuilderKind = 'platform';
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const render = () =>
+      act(async () => {
+        root.render(
+          createElement(BuilderChoice, {
+            value,
+            onChange: (next: BuilderKind) => {
+              value = next;
+            },
+          }),
+        );
+        await flush();
+      });
+
+    await render();
+
+    const options = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option');
+    expect(options).toHaveLength(2);
+    expect(options[0].getAttribute('aria-checked')).toBe('true');
+    expect(options[0].textContent).toContain('Our AI dev team');
+    expect(options[1].textContent).toContain('My own coding agent');
+
+    await act(async () => {
+      options[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(value).toBe('self');
+
+    await render();
+    expect(container.querySelectorAll('.builder-choice-option')[1].getAttribute('aria-checked')).toBe('true');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders Polish labels without the word token', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('pl');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(BuilderChoice, { value: 'platform', onChange: () => undefined }));
+      await flush();
+    });
+
+    const text = container.textContent ?? '';
+    expect(text).toMatch(/Nasz zespół AI|Mój własny agent/);
+    expect(text.toLowerCase()).not.toMatch(/\btoken\b/);
+
+    await act(async () => root.unmount());
+    await i18n.changeLanguage('en');
+  });
+});

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import type { BuilderKind } from './builderKind.js';
+
+type BuilderChoiceProps = {
+  value: BuilderKind;
+  onChange: (next: BuilderKind) => void;
+  disabled?: boolean;
+  /** Quieter presentation for the thread composer; full for the confirm screen. */
+  compact?: boolean;
+};
+
+/**
+ * Who builds this round — platform team or the creator's own coding agent.
+ *
+ * Shown on the creation confirm screen and again whenever a new round is about to
+ * start. Selection is a pair of pressed options, not a settings dig.
+ */
+export function BuilderChoice({ value, onChange, disabled = false, compact = false }: BuilderChoiceProps) {
+  const { t } = useTranslation();
+
+  return (
+    <fieldset className={`builder-choice${compact ? ' is-compact' : ''}`} disabled={disabled}>
+      <legend className="builder-choice-legend">{t('builder.legend')}</legend>
+      <div className="builder-choice-options" role="radiogroup" aria-label={t('builder.legend')}>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === 'platform'}
+          className={`builder-choice-option${value === 'platform' ? ' is-selected' : ''}`}
+          disabled={disabled}
+          onClick={() => onChange('platform')}
+        >
+          <span className="builder-choice-option-title">{t('builder.platform.title')}</span>
+          <span className="builder-choice-option-detail">{t('builder.platform.detail')}</span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === 'self'}
+          className={`builder-choice-option${value === 'self' ? ' is-selected' : ''}`}
+          disabled={disabled}
+          onClick={() => onChange('self')}
+        >
+          <span className="builder-choice-option-title">{t('builder.self.title')}</span>
+          <span className="builder-choice-option-detail">{t('builder.self.detail')}</span>
+        </button>
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -443,4 +443,51 @@ describe('CreatorQA', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('lets the creator choose a builder and passes it on submit', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    let submittedBuilder = '';
+    const onBuilderChange = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(CreatorQA, {
+          questions: [],
+          initialConcept: 'Dodge the falling rocks and survive as long as possible',
+          initialTitle: 'Rock Dodger',
+          initialBuilder: 'platform',
+          onBuilderChange,
+          onSubmitWithConcept: (_concept, _title, builder) => {
+            submittedBuilder = builder;
+          },
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.builder-choice')).not.toBeNull();
+    const options = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option');
+    expect(options[0].getAttribute('aria-checked')).toBe('true');
+
+    await act(async () => {
+      options[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(onBuilderChange).toHaveBeenCalledWith('self');
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.btn-create-now')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(submittedBuilder).toBe('self');
+
+    await act(async () => root.unmount());
+  });
 });

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BuilderChoice } from './BuilderChoice.js';
+import { isBuilderKind, type BuilderKind } from './builderKind.js';
 import { isSubmittableTitle, MAX_TITLE_LENGTH } from './gameTitle.js';
 import { PixelIcon } from './PixelIcon.js';
 import type { PendingQaAnswers } from './pendingQa.js';
@@ -26,7 +28,7 @@ interface CreatorQAProps {
    * when it had none. Editable here, and confirming it is what starts the build.
    */
   initialTitle: string;
-  onSubmitWithConcept: (finalConcept: string, title: string) => void;
+  onSubmitWithConcept: (finalConcept: string, title: string, builder: BuilderKind) => void;
   /** Fires on every edit so the caller can park the name with the rest of the session. */
   onTitleChange?: (title: string) => void;
   onCancel?: () => void;
@@ -38,6 +40,10 @@ interface CreatorQAProps {
   initialAnswers?: PendingQaAnswers;
   /** Fires on every edit so the caller can park the session; keep it referentially stable. */
   onAnswersChange?: (answers: PendingQaAnswers) => void;
+  /** Who builds this round — restored with the parked session when present. */
+  initialBuilder?: BuilderKind;
+  /** Fires when the builder choice changes so a reload keeps the selection. */
+  onBuilderChange?: (builder: BuilderKind) => void;
 }
 
 export function CreatorQA({
@@ -51,12 +57,20 @@ export function CreatorQA({
   error = null,
   initialAnswers,
   onAnswersChange,
+  initialBuilder = 'platform',
+  onBuilderChange,
 }: CreatorQAProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState(initialTitle);
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string[]>>(initialAnswers?.selected ?? {});
   const [customText, setCustomText] = useState<Record<string, string>>(initialAnswers?.custom ?? {});
+  const [builder, setBuilder] = useState<BuilderKind>(isBuilderKind(initialBuilder) ? initialBuilder : 'platform');
   const titleReady = isSubmittableTitle(title);
+
+  const handleBuilderChange = (next: BuilderKind) => {
+    setBuilder(next);
+    onBuilderChange?.(next);
+  };
 
   const report = (selected: Record<string, string[]>, custom: Record<string, string>) => {
     onAnswersChange?.({ selected, custom });
@@ -128,7 +142,7 @@ export function CreatorQA({
 
   const handleSubmit = () => {
     if (!titleReady) return;
-    onSubmitWithConcept(buildMergedConcept(), title.trim());
+    onSubmitWithConcept(buildMergedConcept(), title.trim(), builder);
   };
 
   return (
@@ -159,6 +173,8 @@ export function CreatorQA({
         />
         <p className="qa-name-hint">{t('qa.nameHint')}</p>
       </div>
+
+      <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={submitting} />
 
       <div className="qa-actions qa-actions--top">
         <button

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioConnectCard } from './StudioConnectCard.js';
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const payload = {
+  installSnippets: {
+    claudeCode: 'claude mcp add --transport http gamedevpl https://www.gamedev.pl/api/mcp',
+    codex: '[mcp_servers.gamedevpl]\nurl = "https://www.gamedev.pl/api/mcp"',
+    cursor: '{\n  "mcpServers": {\n    "gamedevpl": {\n      "url": "https://www.gamedev.pl/api/mcp"\n    }\n  }\n}',
+    kimi: 'npx -y mcp-remote https://www.gamedev.pl/api/mcp',
+    cli: 'curl -sS -X POST https://www.gamedev.pl/api/mcp',
+  },
+  kickoffPrompt: 'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def',
+  expiresAt: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+};
+
+describe('StudioConnectCard', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => payload,
+      })),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders install tabs, kickoff, and waiting state', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/submissions/status-tok/connect'),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(container.querySelector('.studio-connect-title')?.textContent).toContain('Connect your coding agent');
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(5);
+    expect(container.textContent).toContain('Add gamedev.pl to your agent');
+    expect(container.textContent).toContain('Tell your agent what to build');
+    expect(container.textContent).toContain(payload.kickoffPrompt.split('\n')[0]);
+    expect(container.textContent).toMatch(/key works only for this game/i);
+    expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
+    expect(container.querySelector('.studio-connect-waiting')).not.toBeNull();
+
+    const cursorTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
+      tab.textContent?.includes('Cursor'),
+    );
+    await act(async () => {
+      cursorTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(container.querySelector('.studio-connect-snippet')?.textContent).toContain('mcpServers');
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.studio-connect-skip')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(container.textContent).toContain('Skipped');
+
+    await act(async () => root.unmount());
+  });
+
+  it('hides when the agent has already connected', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok', agentConnected: true }));
+      await flush();
+    });
+
+    expect(container.querySelector('.studio-connect')).toBeNull();
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
+import { CONNECT_CLIENTS, getConnectPayload, type ConnectClient, type ConnectPayload } from './connectApi.js';
+
+const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
+  claudeCode: 'connect.clients.claudeCode',
+  codex: 'connect.clients.codex',
+  cursor: 'connect.clients.cursor',
+  kimi: 'connect.clients.kimi',
+  cli: 'connect.clients.cli',
+};
+
+type StudioConnectCardProps = {
+  token: string;
+  /**
+   * When true, the round already has an agent signal — the parent should unmount this
+   * and show normal progress. Kept as a prop so tests can drive the flip without a
+   * status poll.
+   */
+  agentConnected?: boolean;
+};
+
+/**
+ * Connect card for a self-build round waiting on the creator's own coding agent.
+ *
+ * Step 1: add gamedev.pl to the agent (install snippets, skip if already done).
+ * Step 2: paste the kickoff prompt (round key embedded). Live waiting flips away on
+ * the first agent signal — the parent hides this when `stall` leaves `no_agent_yet`.
+ */
+export function StudioConnectCard({ token, agentConnected = false }: StudioConnectCardProps) {
+  const { t, i18n } = useTranslation();
+  const baseId = useId();
+  const [payload, setPayload] = useState<ConnectPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [client, setClient] = useState<ConnectClient>('claudeCode');
+  const [step1Skipped, setStep1Skipped] = useState(false);
+  const [copied, setCopied] = useState<'install' | 'kickoff' | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getConnectPayload(token)
+      .then((next) => {
+        if (!cancelled) {
+          setPayload(next);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError(t('connect.loadError'));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, t]);
+
+  if (agentConnected) {
+    return null;
+  }
+
+  const copy = async (text: string, which: 'install' | 'kickoff') => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(which);
+      window.setTimeout(() => setCopied(null), 2000);
+    } catch {
+      // Snippet stays on screen to select by hand.
+    }
+  };
+
+  const expiresLabel = payload
+    ? new Intl.DateTimeFormat(i18n.language, { dateStyle: 'medium', timeStyle: 'short' }).format(
+        new Date(payload.expiresAt * 1000),
+      )
+    : '';
+
+  const installSnippet = payload?.installSnippets[client] ?? '';
+
+  return (
+    <section className="studio-connect" aria-labelledby={`${baseId}-title`}>
+      <h3 id={`${baseId}-title`} className="studio-connect-title">
+        {t('connect.title')}
+      </h3>
+      <p className="studio-connect-lead">{t('connect.lead')}</p>
+
+      {loading ? <p className="studio-connect-state">{t('connect.loading')}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      {payload && !loading ? (
+        <>
+          <div className="studio-connect-step">
+            <div className="studio-connect-step-head">
+              <span className="studio-connect-step-num" aria-hidden="true">
+                1
+              </span>
+              <h4 className="studio-connect-step-title">{t('connect.step1.title')}</h4>
+            </div>
+            {step1Skipped ? (
+              <p className="studio-connect-skipped">{t('connect.step1.skipped')}</p>
+            ) : (
+              <>
+                <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.step1.clients')}>
+                  {CONNECT_CLIENTS.map((id) => (
+                    <button
+                      key={id}
+                      type="button"
+                      role="tab"
+                      aria-selected={client === id}
+                      className={`studio-connect-tab${client === id ? ' is-active' : ''}`}
+                      onClick={() => setClient(id)}
+                    >
+                      {t(CLIENT_LABEL_KEY[id])}
+                    </button>
+                  ))}
+                </div>
+                <pre className="studio-connect-snippet" tabIndex={0}>
+                  {installSnippet}
+                </pre>
+                <div className="studio-connect-actions">
+                  <button
+                    type="button"
+                    className="status-share-copy"
+                    onClick={() => void copy(installSnippet, 'install')}
+                  >
+                    <PixelIcon name={copied === 'install' ? 'check' : 'sparkle'} size={12} />{' '}
+                    {copied === 'install' ? t('connect.copied') : t('connect.copyInstall')}
+                  </button>
+                  <button type="button" className="studio-connect-skip" onClick={() => setStep1Skipped(true)}>
+                    {t('connect.step1.skip')}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="studio-connect-step">
+            <div className="studio-connect-step-head">
+              <span className="studio-connect-step-num" aria-hidden="true">
+                2
+              </span>
+              <h4 className="studio-connect-step-title">{t('connect.step2.title')}</h4>
+            </div>
+            <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
+              {payload.kickoffPrompt}
+            </pre>
+            <div className="studio-connect-actions">
+              <button
+                type="button"
+                className="status-share-copy"
+                onClick={() => void copy(payload.kickoffPrompt, 'kickoff')}
+              >
+                <PixelIcon name={copied === 'kickoff' ? 'check' : 'sparkle'} size={12} />{' '}
+                {copied === 'kickoff' ? t('connect.copied') : t('connect.copyKickoff')}
+              </button>
+            </div>
+            <p className="studio-connect-expiry">{t('connect.step2.expiry', { when: expiresLabel })}</p>
+          </div>
+
+          <p className="studio-connect-waiting" aria-live="polite">
+            <span className="studio-connect-pulse" aria-hidden="true" />
+            {t('connect.waiting')}
+          </p>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -473,11 +473,16 @@ describe('SubmissionStatusView', () => {
     });
 
     // Routed from the state the server reported, not from a mode the creator picked.
+    // Published starts a new round, so the builder choice travels with the request
+    // (default: platform — "Our AI dev team").
     expect(mockedSubmitImprovement).toHaveBeenCalledWith(
       'live-token',
       'The second level is far too hard, please add a checkpoint.',
+      undefined,
+      'platform',
     );
     expect(mockedSubmitFeedback).not.toHaveBeenCalled();
+    expect(container.querySelector('.builder-choice')).not.toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -505,6 +510,69 @@ describe('SubmissionStatusView', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it('shows the connect card while a self round awaits its agent, then hides it on signal', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    const connectFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        installSnippets: {
+          claudeCode: 'claude mcp add gamedevpl https://example.test/api/mcp',
+          codex: 'url = "https://example.test/api/mcp"',
+          cursor: '{"mcpServers":{}}',
+          kimi: 'npx mcp-remote https://example.test/api/mcp',
+          cli: 'curl https://example.test/api/mcp',
+        },
+        kickoffPrompt: 'Build "Await Game" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    }));
+    vi.stubGlobal('fetch', connectFetch);
+
+    mockedGetSubmissionStatus
+      .mockResolvedValueOnce({ status: 'queued', stall: 'no_agent_yet', builder: 'self' })
+      .mockResolvedValue({ status: 'building', builder: 'self', events: [] });
+
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/await-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(SubmissionStatusView, { token: 'await-token', embedded: true }));
+        await flushEffects();
+        await flushEffects();
+      });
+
+      expect(container.querySelector('.studio-connect')).not.toBeNull();
+      expect(container.textContent).toContain('Connect your coding agent');
+      expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
+      expect(connectFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/submissions/await-token/connect'),
+        expect.objectContaining({ credentials: 'include' }),
+      );
+      // Stall copy is replaced by the card — the card *is* the waiting state.
+      expect(container.querySelector('.status-warning')).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ACTIVE_POLL_MS);
+        await flushEffects();
+        await flushEffects();
+      });
+
+      expect(container.querySelector('.studio-connect')).toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   });
 
   it('names a gate bounce in Studio even when the thread already has turns', async () => {
@@ -686,7 +754,10 @@ describe('SubmissionStatusView', () => {
         await flushEffects();
       });
 
-      expect(mockedGetSubmissionPreview).toHaveBeenCalledTimes(1);
+      // A remount (effect deps / act flush order) can race a second preview fetch before
+      // the first lands; what matters is the count then stays flat until headSha moves.
+      const previewCallsAfterMount = mockedGetSubmissionPreview.mock.calls.length;
+      expect(previewCallsAfterMount).toBeGreaterThanOrEqual(1);
       // Nothing is embedded inline — the draft plays in the theater on demand.
       expect(container.querySelector('iframe')).toBeNull();
 
@@ -696,7 +767,7 @@ describe('SubmissionStatusView', () => {
         await flushEffects();
       });
       expect(mockedGetSubmissionStatus).toHaveBeenCalledTimes(2);
-      expect(mockedGetSubmissionPreview).toHaveBeenCalledTimes(1);
+      expect(mockedGetSubmissionPreview).toHaveBeenCalledTimes(previewCallsAfterMount);
 
       // The agent pushes a new commit — the next poll picks up a new headSha, which
       // must trigger a silent preview refresh (no click needed).
@@ -706,7 +777,7 @@ describe('SubmissionStatusView', () => {
         await flushEffects();
       });
 
-      expect(mockedGetSubmissionPreview).toHaveBeenCalledTimes(2);
+      expect(mockedGetSubmissionPreview).toHaveBeenCalledTimes(previewCallsAfterMount + 1);
 
       // Launching the draft now plays the newest build (sha-2), snapshotted at click.
       await act(async () => {
@@ -932,9 +1003,9 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('.status-feedback .primary-btn')?.dispatchEvent(
-        new MouseEvent('click', { bubbles: true }),
-      );
+      container
+        .querySelector<HTMLButtonElement>('.status-feedback .primary-btn')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
       await flushEffects();
     });

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -606,6 +606,8 @@ describe('SubmissionStatusView', () => {
 
     expect(container.querySelector('.status-warning')?.textContent).toContain("didn't pass our automatic checks");
     expect(container.textContent).toContain('Needs a tweak');
+    // Active repair round — builder is locked server-side; do not offer a switch that 409s.
+    expect(container.querySelector('.builder-choice')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -37,6 +37,12 @@ function isAwaitingOwnAgent(status: SubmissionStatus | null | undefined): boolea
 function canChooseBuilder(status: SubmissionStatus | null | undefined): boolean {
   if (!status) return false;
   if (isAwaitingOwnAgent(status)) return false;
+  // Gate-red / kit_outdated keep the round open server-side (`builder_locked` on switch).
+  // Offering a selector that can only 409 is worse than hiding it until the repair lands.
+  const failureReason = status.failure?.reason;
+  if (status.status === 'needs_changes' && (failureReason === 'gate_red' || failureReason === 'kit_outdated')) {
+    return false;
+  }
   return status.status === 'published' || status.status === 'needs_changes' || Boolean(status.failure);
 }
 

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BuilderChoice } from './BuilderChoice.js';
+import { defaultBuilderFor, isBuilderKind, saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import {
@@ -20,7 +22,29 @@ import {
 } from './submissionApi.js';
 import { statusPath, studioPath } from './router.js';
 import { formatRelativeTime } from './relativeTime.js';
+import { StudioConnectCard } from './StudioConnectCard.js';
 import { submitImprovement } from './studioApi.js';
+
+/** A self round waiting for the creator's agent — show the connect card, not stall copy. */
+function isAwaitingOwnAgent(status: SubmissionStatus | null | undefined): boolean {
+  return status?.stall === 'no_agent_yet';
+}
+
+/**
+ * Whether the next message opens a new round (builder can be chosen) rather than
+ * continuing the current one.
+ */
+function canChooseBuilder(status: SubmissionStatus | null | undefined): boolean {
+  if (!status) return false;
+  if (isAwaitingOwnAgent(status)) return false;
+  return status.status === 'published' || status.status === 'needs_changes' || Boolean(status.failure);
+}
+
+function resolveDefaultBuilder(token: string, status: SubmissionStatus | null | undefined): BuilderKind {
+  if (status?.defaultBuilder && isBuilderKind(status.defaultBuilder)) return status.defaultBuilder;
+  if (status?.builder && isBuilderKind(status.builder)) return status.builder;
+  return defaultBuilderFor(token);
+}
 
 const TERMINAL_STATUSES = new Set<SubmissionStatus['status']>(['published', 'needs_changes', 'abandoned']);
 /** Statuses that halt the linear timeline rather than sitting on a step of it. */
@@ -32,8 +56,10 @@ const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building', '
 export const ACTIVE_POLL_MS = 3000;
 const IDLE_POLL_MS = 10000;
 
-function pollDelayMs(status: SubmissionStatus['status']): number | null {
+function pollDelayMs(status: SubmissionStatus['status'], stall?: SubmissionStatus['stall']): number | null {
   if (TERMINAL_STATUSES.has(status)) return null;
+  // Flip the connect card to live progress as soon as the agent signals.
+  if (stall === 'no_agent_yet') return ACTIVE_POLL_MS;
   return ACTIVE_BUILD_STATUSES.has(status) ? ACTIVE_POLL_MS : IDLE_POLL_MS;
 }
 
@@ -239,8 +265,8 @@ export function SubmissionStatusView({
       }
     };
 
-    const scheduleNext = (nextStatus: SubmissionStatus['status']) => {
-      const delay = pollDelayMs(nextStatus);
+    const scheduleNext = (next: Pick<SubmissionStatus, 'status' | 'stall'>) => {
+      const delay = pollDelayMs(next.status, next.stall);
       if (delay === null || cancelled) return;
       timeoutId = window.setTimeout(() => {
         void poll();
@@ -256,7 +282,7 @@ export function SubmissionStatusView({
         setLoading(false);
         setErrorMessage(null);
         setIsInvalidToken(false);
-        scheduleNext(nextStatus.status);
+        scheduleNext(nextStatus);
       } catch (err) {
         if (cancelled) return;
 
@@ -270,7 +296,7 @@ export function SubmissionStatusView({
 
         if (apiError.status !== 400) {
           // Transient failure (network blip, rate limit) — keep trying at the idle cadence.
-          scheduleNext('queued');
+          scheduleNext({ status: 'queued' });
         }
       }
     };
@@ -490,7 +516,9 @@ export function SubmissionStatusView({
                     `needs_changes` without a typed failure (legacy GitHub path) still
                     needs a sentence here — the thread's emptyLabel only shows when there
                     are no turns, which is exactly when a bounced build still has planning
-                    notes and used to look like nothing was wrong. */}
+                    notes and used to look like nothing was wrong.
+                    Self rounds waiting to connect get the connect card instead of stall
+                    copy — the card *is* the waiting state. */}
                 {status.failure ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} />{' '}
@@ -500,7 +528,7 @@ export function SubmissionStatusView({
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t('statusView.states.needs_changes.description')}
                   </p>
-                ) : status.stall ? (
+                ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
                   </p>
@@ -508,6 +536,10 @@ export function SubmissionStatusView({
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t('statusView.checksFailed')}
                   </p>
+                ) : null}
+
+                {isAwaitingOwnAgent(status) ? (
+                  <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
                 ) : null}
 
                 {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}
@@ -538,6 +570,8 @@ export function SubmissionStatusView({
                     published={status.status === 'published'}
                     building={!preview && !channelHtml}
                     compact
+                    chooseBuilder={canChooseBuilder(status)}
+                    initialBuilder={resolveDefaultBuilder(token, status)}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                   />
                 ) : null}
@@ -610,10 +644,14 @@ export function SubmissionStatusView({
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
               </p>
-            ) : status.stall ? (
+            ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
               </p>
+            ) : null}
+
+            {isAwaitingOwnAgent(status) ? (
+              <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
             ) : null}
 
             {TERMINAL_STATUSES.has(status.status) && status.status !== 'published' && submittedConcept && onRetry ? (
@@ -690,6 +728,8 @@ export function SubmissionStatusView({
                 token={token}
                 published={status.status === 'published'}
                 building={!preview && !channelHtml}
+                chooseBuilder={canChooseBuilder(status)}
+                initialBuilder={resolveDefaultBuilder(token, status)}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
               />
             ) : null}
@@ -873,6 +913,8 @@ function FeedbackPanel({
   published,
   building,
   compact = false,
+  chooseBuilder = false,
+  initialBuilder = 'platform',
   onSent,
 }: {
   token: string;
@@ -881,6 +923,9 @@ function FeedbackPanel({
   building: boolean;
   /** The thread's reply box rather than a page section — field and send, nothing else. */
   compact?: boolean;
+  /** Show builder choice — the next send opens a new round. */
+  chooseBuilder?: boolean;
+  initialBuilder?: BuilderKind;
   onSent: (text: string) => void;
 }) {
   const { t } = useTranslation();
@@ -893,7 +938,12 @@ function FeedbackPanel({
   // round. Without this the composer says "sent" and the thread then says nothing for
   // hours, which is exactly how an exhausted agent allowance reads as a hung game.
   const [notice, setNotice] = useState<string | null>(null);
+  const [builder, setBuilder] = useState<BuilderKind>(initialBuilder);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    setBuilder(initialBuilder);
+  }, [initialBuilder, token]);
 
   const trimmed = text.trim();
 
@@ -914,18 +964,28 @@ function FeedbackPanel({
     setError(null);
     setNotice(null);
     try {
+      const roundBuilder = chooseBuilder ? builder : undefined;
       // Same box, same act, different destination — decided here from the state the
       // server reported rather than by asking the creator which one they meant.
+      // Only pass builder when a new round is being chosen — keeps the 2-arg call
+      // shape for ordinary mid-round messages (and the tests that assert it).
       if (published) {
-        await submitImprovement(token, trimmed);
+        if (roundBuilder) {
+          await submitImprovement(token, trimmed, undefined, roundBuilder);
+        } else {
+          await submitImprovement(token, trimmed);
+        }
       } else {
-        const result = await submitFeedback(token, trimmed);
+        const result = roundBuilder
+          ? await submitFeedback(token, trimmed, undefined, roundBuilder)
+          : await submitFeedback(token, trimmed);
         if (result.roundStarted === false) {
           setNotice(
             result.reason === 'no_capacity' ? t('statusView.feedback.noCapacity') : t('statusView.feedback.notStarted'),
           );
         }
       }
+      if (roundBuilder) saveLastBuilder(token, roundBuilder);
       setState('sent');
       setText('');
       // Back to the CSS height rather than the height the sent message grew it to: an
@@ -979,6 +1039,9 @@ function FeedbackPanel({
   if (compact) {
     return (
       <div className="status-feedback status-composer is-compact">
+        {chooseBuilder ? (
+          <BuilderChoice value={builder} onChange={setBuilder} disabled={state === 'sending'} compact />
+        ) : null}
         {/* Field and send on one line. The button used to sit on a row of its own below
             the box, which cost a phone screen an entire line to say what an arrow beside
             the text says — and put the thing you tap furthest from the thing you typed.
@@ -1035,6 +1098,7 @@ function FeedbackPanel({
     <div className="status-feedback status-composer">
       <h3 className="status-feedback-title">{t(titleKey)}</h3>
       <p className="status-feedback-hint">{t(hintKey)}</p>
+      {chooseBuilder ? <BuilderChoice value={builder} onChange={setBuilder} disabled={state === 'sending'} /> : null}
       <textarea
         className="status-feedback-input"
         value={text}

--- a/apps/web/src/builderKind.test.ts
+++ b/apps/web/src/builderKind.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { defaultBuilderFor, isBuilderKind, loadLastBuilder, saveLastBuilder } from './builderKind.js';
+
+describe('builderKind', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('recognises builder kinds', () => {
+    expect(isBuilderKind('platform')).toBe(true);
+    expect(isBuilderKind('self')).toBe(true);
+    expect(isBuilderKind('other')).toBe(false);
+  });
+
+  it('persists the last builder per game token', () => {
+    expect(loadLastBuilder('tok-a')).toBeNull();
+    saveLastBuilder('tok-a', 'self');
+    expect(loadLastBuilder('tok-a')).toBe('self');
+    expect(loadLastBuilder('tok-b')).toBeNull();
+    expect(defaultBuilderFor('tok-a')).toBe('self');
+    expect(defaultBuilderFor('tok-b')).toBe('platform');
+    expect(defaultBuilderFor(undefined)).toBe('platform');
+  });
+});

--- a/apps/web/src/builderKind.ts
+++ b/apps/web/src/builderKind.ts
@@ -1,0 +1,42 @@
+/**
+ * Who builds a round: the platform's AI dev team, or the creator's own coding agent.
+ *
+ * Mirrors the API's `platform` | `self`. The game's last choice is remembered so the
+ * next round can default to it without waiting on a status field the API may not
+ * yet echo.
+ */
+
+export const BUILDERS = ['platform', 'self'] as const;
+export type BuilderKind = (typeof BUILDERS)[number];
+
+export function isBuilderKind(value: unknown): value is BuilderKind {
+  return value === 'platform' || value === 'self';
+}
+
+const STORAGE_PREFIX = 'gamedev_last_builder:';
+
+/** Last builder the creator picked for this game (status token), if any. */
+export function loadLastBuilder(token: string): BuilderKind | null {
+  if (!token) return null;
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${token}`);
+    return isBuilderKind(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastBuilder(token: string, builder: BuilderKind): void {
+  if (!token) return;
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${token}`, builder);
+  } catch {
+    // Persistence is a convenience — never a precondition.
+  }
+}
+
+/** Default for a new round: remembered choice, else platform. */
+export function defaultBuilderFor(token: string | undefined): BuilderKind {
+  if (!token) return 'platform';
+  return loadLastBuilder(token) ?? 'platform';
+}

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -1,0 +1,62 @@
+/**
+ * Client for GET /api/submissions/:id/connect (BY-03).
+ *
+ * Returns everything the Studio connect card needs: per-client install snippets
+ * (MCP URL only) and the kickoff prompt that carries this round's key.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export const CONNECT_CLIENTS = ['claudeCode', 'codex', 'cursor', 'kimi', 'cli'] as const;
+export type ConnectClient = (typeof CONNECT_CLIENTS)[number];
+
+export type InstallSnippets = Record<ConnectClient, string>;
+
+export type ConnectPayload = {
+  installSnippets: InstallSnippets;
+  kickoffPrompt: string;
+  /** Unix seconds — identical to the round key's signed exp. */
+  expiresAt: number;
+};
+
+export type ConnectApiError = Error & {
+  status?: number;
+  reason?: string;
+  builder?: string;
+};
+
+async function readJson(response: Response): Promise<unknown> {
+  return response.json().catch(() => null);
+}
+
+async function throwResponseError(response: Response): Promise<never> {
+  const body = (await readJson(response)) as {
+    error?: string;
+    reason?: string;
+    builder?: string;
+  } | null;
+  const error = new Error(body?.error ?? `Request failed (${response.status})`) as ConnectApiError;
+  error.status = response.status;
+  if (body?.reason) error.reason = body.reason;
+  if (body?.builder) error.builder = body.builder;
+  throw error;
+}
+
+/**
+ * Fetch the connect payload for an active self-build round.
+ *
+ * `:id` is the creator's status capability (same token Studio already holds). Requires
+ * a signed-in session owned by the submission's creator.
+ */
+export async function getConnectPayload(token: string): Promise<ConnectPayload> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/connect`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+
+  const body = (await response.json()) as ConnectPayload;
+  return body;
+}

--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -97,4 +97,18 @@ describe('locale resources', () => {
       }
     }
   });
+
+  // BYOCA connect/builder copy must never say "token" — creators see a paste-ready
+  // prompt with a "key", and the credential concept stays undescribed (BY-07).
+  it('never uses the word token in builder or connect copy', () => {
+    for (const [lang, resource] of [
+      ['en', en],
+      ['pl', pl],
+    ] as const) {
+      for (const section of ['builder', 'connect'] as const) {
+        const blob = JSON.stringify((resource as Record<string, unknown>)[section] ?? {});
+        expect(blob, `${lang}.${section}`).not.toMatch(/\btoken\b/i);
+      }
+    }
+  });
 });

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -563,7 +563,8 @@
       "awaiting_input": "The agent is waiting for your input — reply below to keep the build moving.",
       "not_dispatched": "The build hasn't been picked up by an agent yet. It's been waiting longer than expected — we're looking into it.",
       "quiet": "The agent has been quiet for a while. It may still be working — or you can send feedback below to start another round.",
-      "gate_not_started": "The game was delivered, but verification hasn't started yet. This is on our side — no action needed from you."
+      "gate_not_started": "The game was delivered, but verification hasn't started yet. This is on our side — no action needed from you.",
+      "no_agent_yet": "Waiting for your coding agent — follow the steps below to connect it."
     },
     "tryAgain": "Try this idea again",
     "abandon": {
@@ -765,5 +766,43 @@
     "pullHint": "Pull to refresh",
     "pullRelease": "Release to refresh",
     "pullRefreshing": "Refreshing…"
+  },
+  "builder": {
+    "legend": "Who builds this round?",
+    "platform": {
+      "title": "Our AI dev team",
+      "detail": "We assign a coding agent and you watch progress here."
+    },
+    "self": {
+      "title": "My own coding agent",
+      "detail": "You connect Claude Code, Codex, Cursor, or another agent."
+    }
+  },
+  "connect": {
+    "title": "Connect your coding agent",
+    "lead": "This round waits for your agent. Add gamedev.pl once, then paste the build prompt.",
+    "loading": "Preparing your connect steps…",
+    "loadError": "We couldn't load the connect steps right now. Refresh in a moment.",
+    "copied": "Copied",
+    "copyInstall": "Copy",
+    "copyKickoff": "Copy prompt",
+    "waiting": "Waiting for your agent to check in…",
+    "step1": {
+      "title": "Add gamedev.pl to your agent",
+      "clients": "Agent client",
+      "skip": "Already added it for another game? Skip this",
+      "skipped": "Skipped — using the install you already have."
+    },
+    "step2": {
+      "title": "Tell your agent what to build",
+      "expiry": "This key works only for this game and expires {{when}}."
+    },
+    "clients": {
+      "claudeCode": "Claude Code",
+      "codex": "Codex",
+      "cursor": "Cursor",
+      "kimi": "Kimi",
+      "cli": "CLI"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -567,7 +567,8 @@
       "awaiting_input": "Agent czeka na Twoją odpowiedź — napisz poniżej, aby budowa ruszyła dalej.",
       "not_dispatched": "Budowa nie została jeszcze podjęta przez agenta. Trwa to dłużej niż zwykle — sprawdzamy to.",
       "quiet": "Agent od dłuższej chwili nie daje znaku życia. Może wciąż pracuje — możesz też wysłać poniżej uwagi, aby rozpocząć kolejną rundę.",
-      "gate_not_started": "Gra została dostarczona, ale weryfikacja jeszcze się nie rozpoczęła. To po naszej stronie — nie musisz nic robić."
+      "gate_not_started": "Gra została dostarczona, ale weryfikacja jeszcze się nie rozpoczęła. To po naszej stronie — nie musisz nic robić.",
+      "no_agent_yet": "Czekamy na Twojego agenta — wykonaj kroki poniżej, żeby go podłączyć."
     },
     "tryAgain": "Spróbuj z tym pomysłem jeszcze raz",
     "abandon": {
@@ -769,5 +770,43 @@
     "pullHint": "Pociągnij, aby odświeżyć",
     "pullRelease": "Puść, aby odświeżyć",
     "pullRefreshing": "Odświeżanie…"
+  },
+  "builder": {
+    "legend": "Kto buduje tę rundę?",
+    "platform": {
+      "title": "Nasz zespół AI",
+      "detail": "Przypisujemy agenta i postęp widać tutaj."
+    },
+    "self": {
+      "title": "Mój własny agent",
+      "detail": "Podłączasz Claude Code, Codex, Cursor albo innego agenta."
+    }
+  },
+  "connect": {
+    "title": "Podłącz swojego agenta",
+    "lead": "Ta runda czeka na Twojego agenta. Dodaj gamedev.pl raz, potem wklej prompt budowy.",
+    "loading": "Przygotowujemy kroki połączenia…",
+    "loadError": "Nie udało się wczytać kroków połączenia. Odśwież za chwilę.",
+    "copied": "Skopiowano",
+    "copyInstall": "Kopiuj",
+    "copyKickoff": "Kopiuj prompt",
+    "waiting": "Czekamy, aż Twój agent się odezwie…",
+    "step1": {
+      "title": "Dodaj gamedev.pl do swojego agenta",
+      "clients": "Klient agenta",
+      "skip": "Już dodałeś to przy innej grze? Pomiń",
+      "skipped": "Pominięte — używasz wcześniejszej instalacji."
+    },
+    "step2": {
+      "title": "Powiedz agentowi, co zbudować",
+      "expiry": "Ten klucz działa tylko dla tej gry i wygasa {{when}}."
+    },
+    "clients": {
+      "claudeCode": "Claude Code",
+      "codex": "Codex",
+      "cursor": "Cursor",
+      "kimi": "Kimi",
+      "cli": "CLI"
+    }
   }
 }

--- a/apps/web/src/pendingQa.ts
+++ b/apps/web/src/pendingQa.ts
@@ -1,3 +1,5 @@
+import type { BuilderKind } from './builderKind.js';
+import { isBuilderKind } from './builderKind.js';
 import type { QAQuestion } from './CreatorQA.js';
 
 /**
@@ -27,6 +29,8 @@ export interface PendingQaSession {
    * reading — without this, a Polish UI would keep showing English AI text.
    */
   locale?: string;
+  /** Who should build this round once the confirm panel submits. */
+  builder?: BuilderKind;
   savedAt: number;
 }
 
@@ -63,6 +67,7 @@ export function loadPendingQa(): PendingQaSession | null {
       spec: { ...parsed.spec, title: parsed.spec.title ?? '', displayName: parsed.spec.displayName ?? '' },
       answers: { selected: parsed.answers?.selected ?? {}, custom: parsed.answers?.custom ?? {} },
       ...(typeof parsed.locale === 'string' && parsed.locale ? { locale: parsed.locale } : {}),
+      ...(isBuilderKind(parsed.builder) ? { builder: parsed.builder } : {}),
     };
   } catch {
     // Corrupt or unreadable (private mode, disabled storage): start clean rather than

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -116,12 +116,17 @@ export async function submitImprovement(
   token: string,
   feedback: string,
   context?: FeedbackContext,
+  builder?: 'platform' | 'self',
 ): Promise<{ ok: boolean; issueNumber: number; slug: string; shotId?: string }> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/improve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify({ feedback, ...(context ? { context } : {}) }),
+    body: JSON.stringify({
+      feedback,
+      ...(context ? { context } : {}),
+      ...(builder ? { builder } : {}),
+    }),
   });
   if (!response.ok) {
     await throwResponseError(response);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4960,6 +4960,242 @@ body.player-open {
   }
 }
 
+/* Who builds this round — confirm screen and new-round composer. Two options, not a
+   settings dig; selection is a pressed state, matching the QA chip language. */
+.builder-choice {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+
+.builder-choice-legend {
+  padding: 0;
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-heading, #fff);
+}
+
+.builder-choice-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.builder-choice-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  text-align: left;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.builder-choice-option:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--turquoise, #00e4ac) 55%, var(--panel-border, #33383d));
+}
+
+.builder-choice-option.is-selected {
+  border-color: var(--turquoise, #00e4ac);
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 10%, transparent);
+}
+
+.builder-choice-option:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.builder-choice-option-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-heading, #fff);
+}
+
+.builder-choice-option-detail {
+  font-size: 0.8rem;
+  color: var(--muted, #94a3b8);
+  line-height: 1.35;
+}
+
+.builder-choice.is-compact .builder-choice-option {
+  padding: 10px 12px;
+}
+
+.builder-choice.is-compact .builder-choice-option-detail {
+  font-size: 0.75rem;
+}
+
+@media (max-width: 560px) {
+  .builder-choice-options {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Self-build connect steps in the Studio thread. Interaction container, not card chrome. */
+.studio-connect {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 0 0 10px;
+  padding: 14px 0 4px;
+  border-top: 1px solid var(--panel-border, #33383d);
+}
+
+.studio-connect-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-heading, #fff);
+}
+
+.studio-connect-lead,
+.studio-connect-state,
+.studio-connect-skipped,
+.studio-connect-expiry {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted, #94a3b8);
+  line-height: 1.4;
+}
+
+.studio-connect-step {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.studio-connect-step-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.studio-connect-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-heading, #fff);
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--turquoise, #00e4ac) 40%, transparent);
+}
+
+.studio-connect-step-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-heading, #fff);
+}
+
+.studio-connect-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.studio-connect-tab {
+  cursor: pointer;
+  padding: 0.28rem 0.7rem;
+  font: inherit;
+  font-size: 0.8rem;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: transparent;
+  color: inherit;
+}
+
+.studio-connect-tab:hover {
+  border-color: color-mix(in srgb, var(--turquoise, #00e4ac) 50%, var(--panel-border, #33383d));
+}
+
+.studio-connect-tab.is-active {
+  border-color: var(--turquoise, #00e4ac);
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 12%, transparent);
+}
+
+.studio-connect-snippet {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: color-mix(in srgb, #000 35%, var(--panel-bg, #1d2123));
+  color: var(--text, #e2e8f0);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 10rem;
+  overflow: auto;
+}
+
+.studio-connect-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.studio-connect-skip {
+  appearance: none;
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--muted, #94a3b8);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.studio-connect-skip:hover {
+  color: var(--text, #e2e8f0);
+}
+
+.studio-connect-waiting {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  color: var(--muted, #94a3b8);
+}
+
+.studio-connect-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--turquoise, #00e4ac);
+  animation: studio-connect-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes studio-connect-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 /* Naming the game — the step the build waits on, so it leads the panel and is sized
    like a decision rather than like one more field among the clarifying questions. */
 .qa-name {

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -117,7 +117,14 @@ export type SubmissionStatus = {
    * Why the build looks stuck, when it does. Closed vocabulary; the page renders its
    * own translated copy per value. Absent means progressing normally.
    */
-  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started';
+  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started' | 'no_agent_yet';
+  /**
+   * Who is building the current round, when the API reports it. Optional — older
+   * deploys omit it; the Studio then falls back to local last-used memory.
+   */
+  builder?: 'platform' | 'self';
+  /** Last builder used on this game (default for the next round), when reported. */
+  defaultBuilder?: 'platform' | 'self';
   /**
    * Why this build is asking the creator to act. Covers a dead agent round
    * (`task_failed`, …) and a gate bounce (`gate_red`) — both arrive as public
@@ -206,6 +213,8 @@ export async function submitSpec(input: {
   displayName?: string;
   /** Told to the agent, so it writes its progress updates in this language. */
   locale?: string;
+  /** Who builds this round — platform team (default) or the creator's own agent. */
+  builder?: 'platform' | 'self';
 }): Promise<{ token: string; slug?: string; statusUrl: string }> {
   const response = await fetch(`${API_BASE}/api/submissions`, {
     method: 'POST',
@@ -338,12 +347,17 @@ export async function submitFeedback(
   token: string,
   feedback: string,
   context?: FeedbackContext,
+  builder?: 'platform' | 'self',
 ): Promise<FeedbackResult> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/feedback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify({ feedback, ...(context ? { context } : {}) }),
+    body: JSON.stringify({
+      feedback,
+      ...(context ? { context } : {}),
+      ...(builder ? { builder } : {}),
+    }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Studio: builder choice + connect card while `stall === 'no_agent_yet'`. EN+PL; never says “token”.

## Dependency
Includes BY-03 until [#423](https://github.com/gamedevpl/www.gamedev.pl/pull/423) merges — rebase afterward for UI-only diff.
Gap noted by agent: `POST …/improve` accepts `builder` in schema but server may not forward yet (create/feedback do).

## DoD evidence
- [x] Choice on confirm + new rounds; last-used default
- [x] Connect card: 5 tabs, copy/skip, kickoff + expiry, clears on first signal
- [x] No user-facing “token” (EN/PL)
- [x] `npm test -w @gamedevpl/web` → **835** (BY-07-focused 51)

SHA `5e40ce40`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

