### PR TITLE
fix: restore published sources when editing a published game

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1021,6 +1021,87 @@ describe('agent build channel', () => {
       expect(response.json()).toEqual({ delivery: null, files: [] });
     });
 
+    it('restores the live publication for an improvement job that has not delivered yet', async () => {
+      // An improvement is a *new* job on a published slug (job-state.ts: publishing is
+      // terminal). That job inherits the slug before it has a deliveredVersion of its
+      // own — without the publication fallback, restore reports nothing and the agent
+      // rebuilds from the spec instead of revising the game the creator played.
+      const IMPROVEMENT = 1000004;
+      const store = new InMemoryStore();
+      await seedSubmission(store, IMPROVEMENT);
+      await store.setSubmissionSlug(IMPROVEMENT, 'global-thermonuclear-strategy');
+      await store.setPublication({
+        slug: 'global-thermonuclear-strategy',
+        state: 'published',
+        currentVersion: 'v3',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      });
+      app = await createApp(store, {
+        gamesStore: storeWithVersion({
+          'SPEC.md': '# Global Thermonuclear Strategy',
+          'game.ts': 'export const tick = () => {};',
+        }),
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(IMPROVEMENT),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        delivery: { slug: 'global-thermonuclear-strategy', version: 'v3' },
+        files: [
+          { path: 'SPEC.md', content: '# Global Thermonuclear Strategy' },
+          { path: 'game.ts', content: 'export const tick = () => {};' },
+        ],
+      });
+    });
+
+    it('prefers this job’s own delivery over the publication when both exist', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v2');
+      await store.setPublication({
+        slug: 'comet-courier',
+        state: 'published',
+        currentVersion: 'v1',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      });
+      app = await createApp(store, {
+        gamesStore: storeWithVersion({ 'SPEC.md': '# Candidate v2' }),
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/sources', headers: agentHeaders() });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ delivery: { slug: 'comet-courier', version: 'v2' } });
+    });
+
+    it('does not restore a taken-down publication as if it were still live', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setPublication({
+        slug: 'comet-courier',
+        state: 'disabled',
+        currentVersion: 'v1',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+        takedownAt: '2026-07-15T00:00:00.000Z',
+        takedownReason: 'withdrawn',
+      });
+      app = await createApp(store, {
+        gamesStore: storeWithVersion({ 'SPEC.md': '# Gone' }),
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/sources', headers: agentHeaders() });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ delivery: null, files: [] });
+    });
+
     it('refuses a version with holes rather than restoring a game missing files', async () => {
       // A manifest listing a file the bucket does not have is a broken version, not a
       // partial one — handing it back would have the agent "restore" a deletion it

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -808,7 +808,7 @@ export async function registerAgentChannelRoutes(
   );
 
   /**
-   * Hands a build back its own last delivery.
+   * Hands a build back the sources it should continue from.
    *
    * The channel was upload-only, and that quietly made the agent's *branch* the real
    * home of a game: a follow-up session could only continue the work if it happened to
@@ -817,8 +817,14 @@ export async function registerAgentChannelRoutes(
    * The store already holds every delivered version, immutably; this is the read that
    * makes it the source of truth rather than a copy nobody can get back.
    *
+   * Prefer the job's own last delivery. When this job has not delivered yet but its
+   * slug is already published — the shape of every post-publish improvement, which is a
+   * *new* job on an existing game — fall back to the live publication. Without that,
+   * `npm run restore` reports nothing to restore and the agent rebuilds a stranger's
+   * game instead of revising the one the creator asked to change.
+   *
    * Scoped to the job's own game by the same token that authorizes its delivery, so a
-   * build can restore what it delivered and nothing else.
+   * build can restore what it (or its published predecessor) delivered and nothing else.
    */
   app.get(
     '/api/agent/build/sources',
@@ -831,16 +837,28 @@ export async function registerAgentChannelRoutes(
       if (!options.gamesStore) {
         return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
       }
+
+      const slug = record.slug;
+      let version = record.deliveredVersion;
+      // An improvement job inherits the slug before it has delivered anything of its
+      // own. The publication pointer is what is live — the version the creator played.
+      if (slug && !version) {
+        const publication = await store!.getPublication(slug);
+        if (publication?.state === 'published') {
+          version = publication.currentVersion;
+        }
+      }
+
       // Nothing delivered yet is the ordinary state of a first build, not an error:
       // the agent starts from the repository, exactly as it does today.
-      if (!record.slug || !record.deliveredVersion) {
+      if (!slug || !version) {
         return reply.send({ delivery: null, files: [] });
       }
 
-      const manifest = await options.gamesStore.getManifest(record.slug, record.deliveredVersion);
+      const manifest = await options.gamesStore.getManifest(slug, version);
       if (!manifest) {
         request.log.error(
-          { slug: record.slug, version: record.deliveredVersion },
+          { slug, version },
           'delivered version has no manifest — the store lost a version a job still points at',
         );
         return reply.status(502).send({ error: 'the delivered version could not be read back' });
@@ -849,7 +867,7 @@ export async function registerAgentChannelRoutes(
       const files = await Promise.all(
         manifest.sourceFiles.map(async (path) => ({
           path,
-          content: await options.gamesStore!.getSourceFile(record.slug!, record.deliveredVersion!, path),
+          content: await options.gamesStore!.getSourceFile(slug, version, path),
         })),
       );
       // A manifest listing a file the bucket does not have is a broken version, not a
@@ -857,15 +875,12 @@ export async function registerAgentChannelRoutes(
       // deletion it never made.
       const missing = files.filter((file) => file.content === null).map((file) => file.path);
       if (missing.length > 0) {
-        request.log.error(
-          { slug: record.slug, version: record.deliveredVersion, missing },
-          'delivered version is missing files its manifest lists',
-        );
+        request.log.error({ slug, version, missing }, 'delivered version is missing files its manifest lists');
         return reply.status(502).send({ error: 'the delivered version could not be read back' });
       }
 
       return reply.send({
-        delivery: { slug: record.slug, version: record.deliveredVersion },
+        delivery: { slug, version },
         files,
       });
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a creator asks to improve a **published** game, the platform correctly starts a *new* job (publishing is terminal). That job inherits the slug but has no `deliveredVersion` yet.

`GET /api/agent/build/sources` only looked at the current job’s delivery, so `npm run restore` printed “nothing delivered yet” and the agent rebuilt from the spec instead of revising the live game — exactly what happened for `global-thermonuclear-strategy`.

## Fix

If the job has a slug but no delivery of its own, fall back to the **live publication** (`state === 'published'`) for that slug. The job’s own delivery still wins once it exists; taken-down publications are not restored.

## Test plan

- [x] Unit: improvement job without `deliveredVersion` restores publication sources
- [x] Unit: job’s own delivery preferred over publication
- [x] Unit: disabled publication → empty restore (same as first build)
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d0f0fd7-3642-48cb-a8e3-cef3b03c0652?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d0f0fd7-3642-48cb-a8e3-cef3b03c0652&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

