### PR TITLE
fix(api): thread builder through post-publish improve

### DIFF
--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2967,6 +2967,77 @@ describe('POST /api/submissions/:token/improve', () => {
     expect(source?.dispatch).toBeUndefined();
     await app.close();
   });
+
+  it('inherits the source game’s last-used builder when the body omits builder', async () => {
+    // Regression: improve used to create a blank job and let dispatchBuild default to
+    // platform, so a self-built published game silently went to Copilot on the next
+    // post-publish change — even when Studio later started sending builder again.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const published = await store.allocateJobId();
+    await store.createSubmission(published, 'g:test-user', 'Self Crashy');
+    await store.setSubmissionSlug(published, 'self-crashy');
+    await store.setRoundBuilder(published, 'self');
+    await store.setSubmissionPublishedAt(published, '2026-07-01T00:00:00.000Z');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(published, secret)}/improve`,
+      headers: authHeaders,
+      payload: { feedback: 'Keep the self agent on this revision of the published game.' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const jobId = res.json().jobId as number;
+    expect(jobId).not.toBe(published);
+    const improvement = await store.getSubmission(jobId);
+    expect(improvement?.builder).toBe('self');
+    expect(improvement?.defaultBuilder).toBe('self');
+    expect(improvement?.dispatch?.backend).toBe('self');
+    expect(improvement?.dispatch?.refs).toEqual([`self:${jobId}`]);
+    await app.close();
+  });
+
+  it('honours an explicit builder on improve, overriding the source game’s last builder', async () => {
+    const stub = createGithubClientStub({});
+    const { backend, briefs } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const published = await store.allocateJobId();
+    await store.createSubmission(published, 'g:test-user', 'Was Self');
+    await store.setSubmissionSlug(published, 'was-self');
+    await store.setRoundBuilder(published, 'self');
+    await store.setSubmissionPublishedAt(published, '2026-07-01T00:00:00.000Z');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(published, secret)}/improve`,
+      headers: authHeaders,
+      payload: {
+        feedback: 'Hand this published revision back to the platform team for once.',
+        builder: 'platform',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const jobId = res.json().jobId as number;
+    const improvement = await store.getSubmission(jobId);
+    expect(improvement?.builder).toBe('platform');
+    expect(improvement?.defaultBuilder).toBe('platform');
+    expect(improvement?.dispatch?.backend).toBe('stub');
+    expect(briefs.at(-1)?.issueNumber).toBe(jobId);
+    await app.close();
+  });
 });
 
 /**

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -366,6 +366,11 @@ export interface SubmissionRoutesHandle {
     title: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
+    /**
+     * Who builds the new improvement job. Defaults to the source game's last-used
+     * builder (`builder` / `defaultBuilder`), then `platform`.
+     */
+    builder?: BuilderKind;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
 }
 
@@ -976,12 +981,22 @@ export async function registerSubmissionRoutes(
     title: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
+    /**
+     * Who builds this improvement. Explicit choice wins; otherwise inherit the source
+     * game's last-used builder. A new job has neither field until dispatch sets them,
+     * so omitting this used to silently route every post-publish improve to `platform`.
+     */
+    builder?: BuilderKind;
   }): Promise<{ route: 'job'; jobId: number } | null> {
     if (!store) return null;
     const source = await store.getSubmission(input.issueNumber);
     // Without a slug there is no game to improve, and dispatching would quietly
     // commission a brand-new one against a creator's improvement request.
     if (!source?.slug) return null;
+
+    // Resolve against the *source* game before the new job exists. `dispatchBuild`
+    // would otherwise ask `builderOf` on a blank record and always pick `platform`.
+    const builder = input.builder ?? builderOf(source);
 
     const jobId = await store.allocateJobId();
     await store.createSubmission(jobId, source.ownerUid, source.title);
@@ -1007,6 +1022,7 @@ export async function registerSubmissionRoutes(
       slug: source.slug,
       locale: input.locale,
       log: input.log,
+      builder,
     });
     // The job exists either way. A failed dispatch leaves it `queued`, which the operator
     // queue already reports as `not_dispatched` — a visible stall rather than a silently
@@ -2516,6 +2532,7 @@ export async function registerSubmissionRoutes(
         }
       }
       const contextBlock = formatPlaytestContextBlock(parsed.data.context, shotId);
+      const requestedBuilder = parsed.data.builder;
       const started = await startImprovementRound({
         issueNumber,
         text: contextBlock ? `${sanitizedFeedback}\n\n${contextBlock}` : sanitizedFeedback,
@@ -2523,6 +2540,9 @@ export async function registerSubmissionRoutes(
         // The record was already loaded above for the ownership check.
         locale: record.locale ?? 'en',
         log: request.log,
+        // Publishing is terminal — this opens a *new* job, so builder choice is always
+        // a round-boundary decision (no active-round lock like draft feedback).
+        ...(requestedBuilder && isBuilderKind(requestedBuilder) ? { builder: requestedBuilder } : {}),
       });
       if (!started) {
         return reply.status(502).send({ error: 'failed to submit improvement request' });

--- a/apps/api/src/suggestion-sweep.ts
+++ b/apps/api/src/suggestion-sweep.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import type { BuilderKind } from './builder.js';
 import type { InternalAuthVerifier } from './internal-auth.js';
 import { routeScorecard, type Suggestion, type SuggestionClass } from './suggestions.js';
 import { OPEN_SUGGESTION_STATUSES, type Scorecard, type Store, type SuggestionRecord } from './store.js';
@@ -117,6 +118,7 @@ export interface SuggestionSweepDeps {
     title: string;
     locale: string;
     log: { error: (context: object, message: string) => void };
+    builder?: BuilderKind;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
   /** Builds the brief an autonomously dispatched agent receives. */
   buildBrief?: (record: SuggestionRecord, untrusted: Scorecard['untrusted'] | null) => string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-publish `POST /api/submissions/:token/improve` accepted an optional `builder` (and Studio on #424 sends it) but `startImprovementRound` never took it. The new improvement job was created blank, so `dispatchBuild`’s `builderOf(existing)` always fell through to `platform` — every improve silently went to Copilot regardless of creator choice or the source game’s last-used builder.

This is a deliberate **API-only** follow-up (not bundled into BY-07 / #424) per one-task-one-branch.

## Fix

- `startImprovementRound` accepts optional `builder`
- Resolve against the **source** job: `input.builder ?? builderOf(source)` before the new job exists
- Pass that into `dispatchBuild` (which already persists via `setRoundBuilder`)
- Improve route forwards `parsed.data.builder` when valid
- Suggestion inbox / sweep callers omit builder → inherit source last-used (correct for autonomous / approved player-evidence improves)

## Definition of done

- [x] Improve body `builder` reaches the new job’s round builder — evidence: route passes `requestedBuilder` into `startImprovementRound`; test “honours an explicit builder on improve”
- [x] Omitted builder defaults to source game last-used (`builder` / `defaultBuilder`), not hard `platform` — evidence: resolve uses `builderOf(source)` before create; test “inherits the source game’s last-used builder”
- [x] Suggestion-inbox path unchanged / still inherits — evidence: inbox call site omits `builder`; sweep type widened optionally; existing inbox/sweep suites green
- [x] Tests — `npm run test -w @gamedevpl/api -- src/submissions.test.ts -t improve` (6 passed); full API suite **1619/1619**; lint + api type-check green

## Merge order (owner)

1. Merge #421 + #422 + #423 (Fable-approved)
2. Merge **this** PR
3. Rebase #424 onto master, then merge #424

Wave 4 (BY-05 + BY-08) stays blocked until that sequence lands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

