### PR TITLE
fix(api): accept AGENT.json on game delivery

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -681,6 +681,7 @@ describe('agent build channel', () => {
       { path: 'game.ts', content: 'export {};' },
       { path: 'TRACE.json', content: '{"samples":[]}' },
       { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
+      { path: 'AGENT.json', content: '{"policy":"capture"}' },
     ];
 
     function stubGamesStore() {

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -19,6 +19,9 @@ const MINIMAL: SourceFile[] = [
   // a game that does not declare its progress landmarks, so a delivery without this one
   // reaches validate and stops there having produced nothing.
   { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
+  // Check 28's play policy — same status as TRACE/PLAYTEST. Without it the remote gate
+  // stops at agent-play after the upload was accepted.
+  { path: 'AGENT.json', content: '{"policy":"capture"}' },
 ];
 
 describe('validateSourceUpload — the delivery contract', () => {
@@ -87,6 +90,17 @@ describe('validateSourceUpload — the delivery contract', () => {
     expect(validateSourceUpload(MINIMAL).map((f) => f.path)).toContain('PLAYTEST.json');
     expect(() => validateSourceUpload(MINIMAL.filter((f) => f.path !== 'PLAYTEST.json'))).toThrow(
       /PLAYTEST\.json is required/,
+    );
+  });
+
+  it('accepts and requires the agent-play contract the harness checks against', () => {
+    // Third time: Check 28 landed requiring AGENT.json; this list lagged again. Agents
+    // that included the file were told the path was not deliverable, dropped it to match
+    // the allowlist error, and then failed the remote gate — exactly the retry loop that
+    // burned builder sessions after the game itself was done.
+    expect(validateSourceUpload(MINIMAL).map((f) => f.path)).toContain('AGENT.json');
+    expect(() => validateSourceUpload(MINIMAL.filter((f) => f.path !== 'AGENT.json'))).toThrow(
+      /AGENT\.json is required/,
     );
   });
 

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -19,8 +19,8 @@ const MINIMAL: SourceFile[] = [
   // a game that does not declare its progress landmarks, so a delivery without this one
   // reaches validate and stops there having produced nothing.
   { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
-  // Check 28's play policy — same status as TRACE/PLAYTEST. Without it the remote gate
-  // stops at agent-play after the upload was accepted.
+  // Check 28's play policy. Allowed (and present on the happy path); not hard-required
+  // at upload until in-flight workspaces drain — see ALLOWED_SOURCE_FILES note.
   { path: 'AGENT.json', content: '{"policy":"capture"}' },
 ];
 
@@ -93,15 +93,12 @@ describe('validateSourceUpload — the delivery contract', () => {
     );
   });
 
-  it('accepts and requires the agent-play contract the harness checks against', () => {
-    // Third time: Check 28 landed requiring AGENT.json; this list lagged again. Agents
-    // that included the file were told the path was not deliverable, dropped it to match
-    // the allowlist error, and then failed the remote gate — exactly the retry loop that
-    // burned builder sessions after the game itself was done.
+  it('accepts the agent-play contract without blocking pre-companion submit tools', () => {
+    // The bug this PR fixes is "path not deliverable" for AGENT.json — accepting the
+    // file is the unblock. Hard-requiring it would 400 in-flight workspaces that still
+    // ship the old submit tool; the gate's Check 28 covers absence until those drain.
     expect(validateSourceUpload(MINIMAL).map((f) => f.path)).toContain('AGENT.json');
-    expect(() => validateSourceUpload(MINIMAL.filter((f) => f.path !== 'AGENT.json'))).toThrow(
-      /AGENT\.json is required/,
-    );
+    expect(validateSourceUpload(MINIMAL.filter((f) => f.path !== 'AGENT.json'))).toHaveLength(MINIMAL.length - 1);
   });
 
   it('caps total upload size', () => {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -53,6 +53,12 @@ export const ALLOWED_SOURCE_FILES = [
   // this list stayed put, so agents that wrote a correct AGENT.json were told the path
   // was not deliverable, dropped it, and then failed the remote gate at Check 28 —
   // burning a session on allowlist archaeology instead of the game.
+  //
+  // Accepted here, but not hard-required yet: in-flight builder workspaces still ship the
+  // pre-companion submit tool that omits AGENT.json, and the two repos cannot deploy
+  // atomically. Requiring it at upload would 400 those deliveries before the gate could
+  // even run. Let Check 28 report the missing contract until old workspaces drain; then
+  // promote to a required upload (same path TRACE/PLAYTEST already took).
   'AGENT.json',
   'index.html',
   'game.ts',
@@ -183,16 +189,8 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
         '{"expectProgress": ["round-start"]}; list richer landmarks if your capture reaches them.',
     );
   }
-  // Same reasoning again for Check 28. Accepting a delivery without AGENT.json stores a
-  // version that cannot pass agent-play, which is exactly the loop that burned real
-  // builder sessions on submit retries after the game itself was done.
-  if (!seen.has('AGENT.json')) {
-    throw new InvalidUploadError(
-      "AGENT.json is required — the gate's agent-play stage needs it to choose a play " +
-        'policy (validate Check 28). The minimum is {"policy": "capture"}; write it next ' +
-        'to PLAYTEST.json, then deliver again.',
-    );
-  }
+  // AGENT.json is allowed above but deliberately not required here yet — see the
+  // ALLOWED_SOURCE_FILES note. Missing file → Check 28 on the gate, not a 400 at upload.
 
   return files.map((file) => ({ path: file.path.trim(), content: file.content }));
 }

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -47,6 +47,13 @@ export const ALLOWED_SOURCE_FILES = [
   // each delivered game reached validate and stopped there, with no gate artifacts and
   // therefore no draft preview for the creator watching.
   'PLAYTEST.json',
+  // Validate Check 28 (`tools/lib/agent-contract.ts`) requires AGENT.json so
+  // `npm run agent-play` knows whether to replay CAPTURE or load a closed-loop module.
+  // Same drift class as TRACE/PLAYTEST above: the check landed in the games repo while
+  // this list stayed put, so agents that wrote a correct AGENT.json were told the path
+  // was not deliverable, dropped it, and then failed the remote gate at Check 28 —
+  // burning a session on allowlist archaeology instead of the game.
+  'AGENT.json',
   'index.html',
   'game.ts',
   'style.css',
@@ -174,6 +181,16 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
       'PLAYTEST.json is required — it declares the progress landmarks your CAPTURE.json ' +
         'run must reach, and the gate refuses a game without one. The minimum is ' +
         '{"expectProgress": ["round-start"]}; list richer landmarks if your capture reaches them.',
+    );
+  }
+  // Same reasoning again for Check 28. Accepting a delivery without AGENT.json stores a
+  // version that cannot pass agent-play, which is exactly the loop that burned real
+  // builder sessions on submit retries after the game itself was done.
+  if (!seen.has('AGENT.json')) {
+    throw new InvalidUploadError(
+      "AGENT.json is required — the gate's agent-play stage needs it to choose a play " +
+        'policy (validate Check 28). The minimum is {"policy": "capture"}; write it next ' +
+        'to PLAYTEST.json, then deliver again.',
     );
   }
 

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -56,6 +56,7 @@ const MINIMAL_FILES = [
   { path: 'game.ts', content: 'export {};' },
   { path: 'TRACE.json', content: '{"samples":[]}' },
   { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
+  { path: 'AGENT.json', content: '{"policy":"capture"}' },
 ];
 
 function stubGamesStore() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Validate Check 28 in the games repo requires `AGENT.json`, but the site delivery allowlist (`ALLOWED_SOURCE_FILES`) omitted it — the same drift class as `TRACE.json` and `PLAYTEST.json` before it.

A real build session wrote a correct `AGENT.json`, got `path not deliverable`, dropped the file to match the allowlist error, then failed the remote gate at Check 28.

Paired with games-repo #297 / https://github.com/gamedevpl/www.gamedev.pl-games/pull/299

## What

- Add `AGENT.json` to `ALLOWED_SOURCE_FILES` (the actual unblock)
- **Do not hard-require it at upload yet** — in-flight workspaces still ship pre-companion `submit.mjs` that omits the file; requiring it would 400 those deliveries. Check 28 on the gate covers absence until old workspaces drain; promote to required later (same path TRACE/PLAYTEST took)
- Update fixtures / contract test for accept-without-require

## Pairing

Ship with the games-repo change that includes `AGENT.json` in `tools/submit.mjs` `FIXED_FILES`. Deploy this allowlist first (or together); the games-side hard-require is local to new builders.

Focused alternative to #428 if that draft is preferred for merge instead.

## Test plan

- [x] `npm run type-check && npm run lint`
- [x] `npm test -w apps/api -- src/games-store.test.ts` (accepts with/without AGENT.json)
- [x] `npm run build -w apps/api`
- [x] Addressed Codex P1: no hard-require until old submit tools drain

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4127c46-8a01-4084-bfef-ee5ec908062a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4127c46-8a01-4084-bfef-ee5ec908062a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

