### PR TITLE
byoca(BY-08): Studio self-build status copy + telemetry

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -136,13 +136,21 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     and `CREATE_STEPS` in `visit-funnel.ts` — the order in `CREATE_STEPS` _is_ the funnel's
     meaning. The waitlist funnel (`waitlist_step` / `WAITLIST_STEPS`) follows the same
     three-place contract beside it.
-- ~~Closed-beta waitlist funnel unmeasured~~ — **closed 2026-07-31**: `waitlist_step` on
-  the visit stream records `cta_clicked` → `joined`. Same three-place enum contract as
-  `create_step` (`visitTelemetry.ts`, `visit-telemetry.ts`, `WAITLIST_STEPS` in
-  `visit-funnel.ts`); rendered as a Waitlist block on `VisitFunnelPanel` beside Creating.
-  The Join CTA is visible before sign-in; the drop between click and join _is_ the
-  sign-in wall, so there is no separate `signin_required` rung (that name already means
-  the creation wall).
+  - ~~Closed-beta waitlist funnel unmeasured~~ — **closed 2026-07-31**: `waitlist_step` on
+    the visit stream records `cta_clicked` → `joined`. Same three-place enum contract as
+    `create_step` (`visitTelemetry.ts`, `visit-telemetry.ts`, `WAITLIST_STEPS` in
+    `visit-funnel.ts`); rendered as a Waitlist block on `VisitFunnelPanel` beside Creating.
+    The Join CTA is visible before sign-in; the drop between click and join _is_ the
+    sign-in wall, so there is no separate `signin_required` rung (that name already means
+    the creation wall).
+  - ~~BYOCA / self-build funnel unmeasured~~ — **closed 2026-08-01 (BY-08)**: `studio_step`
+    on the visit stream records `builder_chosen` → `connect_copied` → `agent_signaled` →
+    `gate_verdict`, each with a required `builder` dimension (`platform` | `self`). Optional
+    `detail` is a closed enum (`install` | `kickoff` | `green` | `red` | `kit_outdated`).
+    `create_step` may also carry optional `builder` once chosen. Same three-place contract
+    (`visitTelemetry.ts`, `visit-telemetry.ts`, `VisitEvent` in `store.ts`). Time-to-first
+    agent signal is `msSinceStart` on `agent_signaled`. No admin rollup yet — emission and
+    schema first; a VisitFunnelPanel Studio block is a follow-up.
 - ~~How-to-play opens recorded but unreadable~~ — **closed 2026-07-31** for the read
   path that [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) needs:
   `how_to_play_opened` carries `via: 'bar' | 'more'` and optional `reopen: true` (same

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -547,7 +547,14 @@ export interface TelemetryEvent {
 export interface VisitEvent {
   /** Per-tab uuid from `sessionStorage`. Dies with the tab; never a uid. */
   visitId: string;
-  type: 'visit_started' | 'route_viewed' | 'play_started' | 'how_to_play_opened' | 'create_step' | 'waitlist_step';
+  type:
+    | 'visit_started'
+    | 'route_viewed'
+    | 'play_started'
+    | 'how_to_play_opened'
+    | 'create_step'
+    | 'waitlist_step'
+    | 'studio_step';
   /** Server-anchored instant, derived like `TelemetryEvent.at`. */
   at: string;
   /** Milliseconds from visit start — the trustworthy measure of within-visit timing. */
@@ -556,8 +563,18 @@ export interface VisitEvent {
   entry?: string;
   /** `route_viewed`: the route kind now shown. Never its parameters. */
   route?: string;
-  /** `create_step` / `waitlist_step`: which funnel step this visit reached. */
+  /** `create_step` / `waitlist_step` / `studio_step`: which funnel step this visit reached. */
   step?: string;
+  /**
+   * `create_step` / `studio_step`: who builds the round (`platform` | `self`).
+   * Optional on legacy create_step rows; required on studio_step. Never a game identity.
+   */
+  builder?: string;
+  /**
+   * `studio_step`: closed detail (`install` | `kickoff` | `green` | `red` | `kit_outdated`).
+   * Never free text, never a game identity.
+   */
+  detail?: string;
   /**
    * `how_to_play_opened`: which chrome surface opened the card (`bar` | `more`).
    * Absent on events recorded before the field existed; never a game identity.

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -25,7 +25,13 @@ import { startHealthCheck } from './game-health.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import type { AgentBackend, SeedFiles } from './agent-backend.js';
 import { resolveBuilderBackend, type AgentBackendRegistry } from './agent-backend-env.js';
-import { isActiveBuildRound, isBuilderKind, selfBuildConnectDays, type BuilderKind } from './builder.js';
+import {
+  isActiveBuildRound,
+  isBuilderKind,
+  selfBuildConnectDays,
+  selfBuildDeliveryCap,
+  type BuilderKind,
+} from './builder.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import {
   canTransition,
@@ -1562,6 +1568,12 @@ export async function registerSubmissionRoutes(
     if (roundBuilder) status.builder = roundBuilder;
     const lastBuilder = record.defaultBuilder ?? record.builder;
     if (lastBuilder) status.defaultBuilder = lastBuilder;
+    // Delivery-cap is refused to the agent over the channel; echo it on status so the
+    // Studio can show honest copy without a new endpoint (BY-08). Only when nothing
+    // stronger (gate_red, task_failed, …) already explains the stop.
+    if (builderOf(record) === 'self' && !status.failure && (record.roundDeliveryCount ?? 0) >= selfBuildDeliveryCap()) {
+      status.failure = { reason: 'self_build_delivery_cap' };
+    }
     return status;
   }
 

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -239,6 +239,81 @@ describe('POST /api/telemetry/visit', () => {
     expect(bad.statusCode).toBe(400);
   });
 
+  it('records a studio step with builder (and optional detail) and rejects bad enums', async () => {
+    const ok = await post(app, {
+      visitId,
+      flushMsSinceStart: 12_000,
+      events: [
+        { type: 'studio_step', step: 'builder_chosen', builder: 'self', msSinceStart: 100 },
+        {
+          type: 'studio_step',
+          step: 'connect_copied',
+          builder: 'self',
+          detail: 'kickoff',
+          msSinceStart: 200,
+        },
+        { type: 'studio_step', step: 'agent_signaled', builder: 'self', msSinceStart: 12_000 },
+        {
+          type: 'studio_step',
+          step: 'gate_verdict',
+          builder: 'platform',
+          detail: 'green',
+          msSinceStart: 20_000,
+        },
+        {
+          type: 'create_step',
+          step: 'submission_created',
+          builder: 'self',
+          msSinceStart: 50,
+        },
+      ],
+    });
+    expect(ok.statusCode).toBe(202);
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'studio_step', step: 'builder_chosen', builder: 'self' }),
+        expect.objectContaining({
+          type: 'studio_step',
+          step: 'connect_copied',
+          builder: 'self',
+          detail: 'kickoff',
+        }),
+        expect.objectContaining({
+          type: 'studio_step',
+          step: 'agent_signaled',
+          builder: 'self',
+          msSinceStart: 12_000,
+        }),
+        expect.objectContaining({
+          type: 'studio_step',
+          step: 'gate_verdict',
+          builder: 'platform',
+          detail: 'green',
+        }),
+        expect.objectContaining({
+          type: 'create_step',
+          step: 'submission_created',
+          builder: 'self',
+        }),
+      ]),
+    );
+
+    const badStep = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'studio_step', step: 'hacked', builder: 'self', msSinceStart: 0 }],
+    });
+    expect(badStep.statusCode).toBe(400);
+
+    const missingBuilder = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'studio_step', step: 'builder_chosen', msSinceStart: 0 }],
+    });
+    expect(missingBuilder.statusCode).toBe(400);
+  });
+
   it('rejects an oversized batch', async () => {
     const response = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -59,6 +59,18 @@ const CreateStepSchema = z.enum([
  */
 const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
 /**
+ * Studio / self-build funnel (BY-08). Sibling to create steps — not ordered with them.
+ * Reaches a grouping key; closed enum on an open endpoint.
+ */
+const StudioStepSchema = z.enum(['builder_chosen', 'connect_copied', 'agent_signaled', 'gate_verdict']);
+/** Platform vs creator's own agent. Optional on create_step; required on studio_step. */
+const BuilderDimensionSchema = z.enum(['platform', 'self']);
+/**
+ * Closed detail for studio steps that carry one. Optional so steps without a detail
+ * (builder choice, first agent signal) stay valid.
+ */
+const StudioStepDetailSchema = z.enum(['install', 'kickoff', 'green', 'red', 'kit_outdated']);
+/**
  * Which chrome surface opened How to play. Optional so a tab still running the previous
  * client can record the open without `via` — the aggregate treats missing as unknown
  * rather than dropping the event. Closed enum: the value reaches a grouping key.
@@ -101,8 +113,20 @@ const EventSchema = z.discriminatedUnion('type', [
     reopen: z.literal(true).optional(),
     ...offsetField,
   }),
-  z.object({ type: z.literal('create_step'), step: CreateStepSchema, ...offsetField }),
+  z.object({
+    type: z.literal('create_step'),
+    step: CreateStepSchema,
+    builder: BuilderDimensionSchema.optional(),
+    ...offsetField,
+  }),
   z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
+  z.object({
+    type: z.literal('studio_step'),
+    step: StudioStepSchema,
+    builder: BuilderDimensionSchema,
+    detail: StudioStepDetailSchema.optional(),
+    ...offsetField,
+  }),
 ]);
 
 const RequestSchema = z.object({
@@ -193,8 +217,22 @@ export async function registerVisitTelemetryRoutes(
         case 'route_viewed':
           return { ...base, type: event.type, route: event.route };
         case 'create_step':
+          return {
+            ...base,
+            type: event.type,
+            step: event.step,
+            ...(event.builder === undefined ? {} : { builder: event.builder }),
+          };
         case 'waitlist_step':
           return { ...base, type: event.type, step: event.step };
+        case 'studio_step':
+          return {
+            ...base,
+            type: event.type,
+            step: event.step,
+            builder: event.builder,
+            ...(event.detail === undefined ? {} : { detail: event.detail }),
+          };
         case 'how_to_play_opened':
           return {
             ...base,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -52,7 +52,7 @@ import { saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa.js';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
-import { recordCreateStep } from './visitTelemetry.js';
+import { recordCreateStep, recordStudioStep } from './visitTelemetry.js';
 import { ClosedBetaSplash } from './ClosedBetaSplash.js';
 import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { ControllerView } from './mp/ControllerView.js';
@@ -589,7 +589,8 @@ export function App() {
       saveLastBuilder(response.token, builder);
 
       setSubmissionStatus('idle');
-      recordCreateStep('submission_created');
+      recordCreateStep('submission_created', builder);
+      recordStudioStep('builder_chosen', builder);
 
       // Only now is the QA panel done: it stayed up, in its submitting state, for the
       // whole call. A no-op when the spec never went through the gate.

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { BuilderKind } from './builderKind.js';
+import { recordStudioStep } from './visitTelemetry.js';
 
 type BuilderChoiceProps = {
   value: BuilderKind;
@@ -18,6 +19,11 @@ type BuilderChoiceProps = {
 export function BuilderChoice({ value, onChange, disabled = false, compact = false }: BuilderChoiceProps) {
   const { t } = useTranslation();
 
+  const select = (next: BuilderKind) => {
+    onChange(next);
+    recordStudioStep('builder_chosen', next);
+  };
+
   return (
     <fieldset className={`builder-choice${compact ? ' is-compact' : ''}`} disabled={disabled}>
       <legend className="builder-choice-legend">{t('builder.legend')}</legend>
@@ -28,7 +34,7 @@ export function BuilderChoice({ value, onChange, disabled = false, compact = fal
           aria-checked={value === 'platform'}
           className={`builder-choice-option${value === 'platform' ? ' is-selected' : ''}`}
           disabled={disabled}
-          onClick={() => onChange('platform')}
+          onClick={() => select('platform')}
         >
           <span className="builder-choice-option-title">{t('builder.platform.title')}</span>
           <span className="builder-choice-option-detail">{t('builder.platform.detail')}</span>
@@ -39,7 +45,7 @@ export function BuilderChoice({ value, onChange, disabled = false, compact = fal
           aria-checked={value === 'self'}
           className={`builder-choice-option${value === 'self' ? ' is-selected' : ''}`}
           disabled={disabled}
-          onClick={() => onChange('self')}
+          onClick={() => select('self')}
         >
           <span className="builder-choice-option-title">{t('builder.self.title')}</span>
           <span className="builder-choice-option-detail">{t('builder.self.detail')}</span>

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
+import { setVisitSessionForTesting, VisitSession, type WireVisitEvent } from './visitTelemetry.js';
 
 async function flush() {
   await Promise.resolve();
@@ -108,5 +109,62 @@ describe('StudioConnectCard', () => {
 
     expect(container.querySelector('.studio-connect')).toBeNull();
     await act(async () => root.unmount());
+  });
+
+  it('emits connect_copied studio telemetry with builder=self', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const events: WireVisitEvent[] = [];
+    const session = new VisitSession('v-connect', 0, (body) => {
+      events.push(...body.events);
+    });
+    setVisitSessionForTesting(session);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+        await flush();
+      });
+      await act(async () => {
+        await flush();
+      });
+
+      const copyButtons = [...container.querySelectorAll<HTMLButtonElement>('.status-share-copy')];
+      expect(copyButtons.length).toBeGreaterThanOrEqual(2);
+
+      await act(async () => {
+        copyButtons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flush();
+      });
+      await act(async () => {
+        copyButtons[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flush();
+      });
+      session.flush();
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'studio_step',
+            step: 'connect_copied',
+            builder: 'self',
+            detail: 'install',
+          }),
+          expect.objectContaining({
+            type: 'studio_step',
+            step: 'connect_copied',
+            builder: 'self',
+            detail: 'kickoff',
+          }),
+        ]),
+      );
+    } finally {
+      setVisitSessionForTesting(null);
+      await act(async () => root.unmount());
+    }
   });
 });

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 import { CONNECT_CLIENTS, getConnectPayload, type ConnectClient, type ConnectPayload } from './connectApi.js';
+import { recordStudioStep } from './visitTelemetry.js';
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
   claudeCode: 'connect.clients.claudeCode',
@@ -72,6 +73,8 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     } catch {
       // Snippet stays on screen to select by hand.
     }
+    // Count the click either way — clipboard denial still means they meant to connect.
+    recordStudioStep('connect_copied', 'self', which);
   };
 
   const expiresLabel = payload

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -566,12 +566,93 @@ describe('SubmissionStatusView', () => {
       });
 
       expect(container.querySelector('.studio-connect')).toBeNull();
+      // Active self round: composer routing says the agent will pick the note up.
+      expect(container.textContent).toContain('picks this up on its next check-in');
     } finally {
       await act(async () => {
         root.unmount();
       });
       vi.useRealTimers();
       vi.unstubAllGlobals();
+    }
+  });
+
+  it('resurfaces the connect card with quiet-self copy when a self agent goes silent', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const connectFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        installSnippets: {
+          claudeCode: 'claude mcp add gamedevpl https://example.test/api/mcp',
+          codex: 'url = "https://example.test/api/mcp"',
+          cursor: '{"mcpServers":{}}',
+          kimi: 'npx mcp-remote https://example.test/api/mcp',
+          cli: 'curl https://example.test/api/mcp',
+        },
+        kickoffPrompt: 'Build "Quiet Game" for gamedev.pl.\nStart with the gamedevpl tool, key: quiet.key',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    }));
+    vi.stubGlobal('fetch', connectFetch);
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      stall: 'quiet',
+      builder: 'self',
+      events: [],
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(SubmissionStatusView, { token: 'quiet-token', embedded: true }));
+        await flushEffects();
+        await flushEffects();
+      });
+
+      expect(container.querySelector('.status-warning')?.textContent).toContain("can't start it from here");
+      expect(container.querySelector('.studio-connect')).not.toBeNull();
+      expect(container.textContent).toContain('your agent will get this when you start it');
+      expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('names a delivery-cap stop for a self round', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      failure: { reason: 'self_build_delivery_cap' },
+      events: [],
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(SubmissionStatusView, { token: 'cap-token', embedded: true }));
+        await flushEffects();
+        await flushEffects();
+      });
+
+      expect(container.querySelector('.status-warning')?.textContent).toContain('delivery limit');
+      expect(container.querySelector('.studio-connect')).toBeNull();
+      expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
     }
   });
 

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -13,6 +13,12 @@ import {
   submitFeedback,
 } from './submissionApi.js';
 import { submitImprovement } from './studioApi.js';
+import { recordStudioStep } from './visitTelemetry.js';
+
+vi.mock('./visitTelemetry', async () => {
+  const actual = await vi.importActual<typeof import('./visitTelemetry')>('./visitTelemetry');
+  return { ...actual, recordStudioStep: vi.fn() };
+});
 
 vi.mock('./studioApi', async () => {
   const actual = await vi.importActual<typeof import('./studioApi')>('./studioApi');
@@ -37,6 +43,7 @@ const mockedGetChannelPlayable = vi.mocked(getChannelPlayable);
 const mockedSubmitFeedback = vi.mocked(submitFeedback);
 const mockedAbandonSubmission = vi.mocked(abandonSubmission);
 const mockedSubmitImprovement = vi.mocked(submitImprovement);
+const mockedRecordStudioStep = vi.mocked(recordStudioStep);
 
 async function flushEffects() {
   await Promise.resolve();
@@ -49,6 +56,7 @@ describe('SubmissionStatusView', () => {
     localStorage.clear();
     window.history.pushState(null, '', '/');
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('renders queued state copy', async () => {
@@ -1434,5 +1442,62 @@ describe('SubmissionStatusView stop & retry', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it('emits gate_verdict only on a live transition, not on reload of a finished build', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.useFakeTimers();
+
+    // Reload into an already-published self build: must not mint gate_verdict.
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'published',
+      builder: 'self',
+      stall: null,
+    });
+    window.history.pushState(null, '', '/status/verdict-reload');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'verdict-reload', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+    expect(mockedRecordStudioStep).not.toHaveBeenCalledWith('gate_verdict', expect.anything(), expect.anything());
+
+    await act(async () => {
+      root.unmount();
+    });
+    mockedRecordStudioStep.mockClear();
+
+    // Live transition: building → in_review should emit green once.
+    mockedGetSubmissionStatus
+      .mockResolvedValueOnce({ status: 'building', builder: 'self', stall: null })
+      .mockResolvedValue({ status: 'in_review', builder: 'self', stall: null });
+    window.history.pushState(null, '', '/status/verdict-live');
+    const live = document.createElement('div');
+    document.body.appendChild(live);
+    const liveRoot = createRoot(live);
+
+    await act(async () => {
+      liveRoot.render(createElement(SubmissionStatusView, { token: 'verdict-live', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+    expect(mockedRecordStudioStep).not.toHaveBeenCalledWith('gate_verdict', 'self', 'green');
+
+    await act(async () => {
+      vi.advanceTimersByTime(ACTIVE_POLL_MS);
+      await flushEffects();
+      await flushEffects();
+    });
+    expect(mockedRecordStudioStep).toHaveBeenCalledWith('gate_verdict', 'self', 'green');
+
+    await act(async () => {
+      liveRoot.unmount();
+    });
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1453,7 +1453,6 @@ describe('SubmissionStatusView stop & retry', () => {
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'published',
       builder: 'self',
-      stall: null,
     });
     window.history.pushState(null, '', '/status/verdict-reload');
     const container = document.createElement('div');
@@ -1474,8 +1473,8 @@ describe('SubmissionStatusView stop & retry', () => {
 
     // Live transition: building → in_review should emit green once.
     mockedGetSubmissionStatus
-      .mockResolvedValueOnce({ status: 'building', builder: 'self', stall: null })
-      .mockResolvedValue({ status: 'in_review', builder: 'self', stall: null });
+      .mockResolvedValueOnce({ status: 'building', builder: 'self' })
+      .mockResolvedValue({ status: 'in_review', builder: 'self' });
     window.history.pushState(null, '', '/status/verdict-live');
     const live = document.createElement('div');
     document.body.appendChild(live);

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -22,12 +22,22 @@ import {
 } from './submissionApi.js';
 import { statusPath, studioPath } from './router.js';
 import { formatRelativeTime } from './relativeTime.js';
+import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { submitImprovement } from './studioApi.js';
+import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
+
+function copyInputFromStatus(status: SubmissionStatus | null | undefined) {
+  return {
+    builder: status?.builder,
+    stall: status?.stall,
+    failureReason: status?.failure?.reason,
+  };
+}
 
 /** A self round waiting for the creator's agent — show the connect card, not stall copy. */
 function isAwaitingOwnAgent(status: SubmissionStatus | null | undefined): boolean {
-  return status?.stall === 'no_agent_yet';
+  return shouldShowConnectCard(copyInputFromStatus(status));
 }
 
 /**
@@ -172,7 +182,13 @@ function StatusTimeline({ current }: { current: SubmissionStatus['status'] }) {
 type PendingRevision = { text: string; at: number };
 
 /** Failure reasons with their own copy; anything newer gets the generic sentence. */
-const FAILURE_COPY_KEYS = new Set(['task_failed', 'task_timed_out', 'task_completed_without_delivery', 'gate_red']);
+const FAILURE_COPY_KEYS = new Set([
+  'task_failed',
+  'task_timed_out',
+  'task_completed_without_delivery',
+  'gate_red',
+  'self_build_delivery_cap',
+]);
 
 function failureCopyKey(reason: string): string {
   return FAILURE_COPY_KEYS.has(reason) ? reason : 'generic';
@@ -318,18 +334,54 @@ export function SubmissionStatusView({
 
   const publishedGameTitle = submittedTitle ?? status?.slug ?? t('statusView.publishedGameTitle');
   const heartbeatAt = latestAgentActivityAt(status);
+  const selfCopy = selfStatusCopy(copyInputFromStatus(status));
 
   /**
    * What is happening, in the creator's words.
    *
    * Only the phases that mean something the coarse status cannot say carry their own
    * sentence (see `statusView.phases`); everything else falls through to the status
-   * copy rather than being written twice and drifting.
+   * copy rather than being written twice and drifting. Self rounds replace the
+   * platform "an agent picks it up" sentence while still waiting to connect.
    */
   const stateDescription = status
-    ? (status.phase ? t(`statusView.phases.${status.phase}`, { defaultValue: '' }) : '') ||
-      t(`statusView.states.${status.status}.description`)
+    ? selfCopy === 'no_agent_yet'
+      ? t('statusView.stall.no_agent_yet')
+      : (status.phase ? t(`statusView.phases.${status.phase}`, { defaultValue: '' }) : '') ||
+        t(`statusView.states.${status.status}.description`)
     : '';
+
+  // Studio telemetry: first agent signal + gate verdict, with builder dimension.
+  // Dedupe lives in recordStudioStep; refs only detect the transitions worth emitting.
+  const prevStallRef = useRef<SubmissionStatus['stall'] | undefined>(undefined);
+  useEffect(() => {
+    if (!status) return;
+    const builder = status.builder && isBuilderKind(status.builder) ? status.builder : null;
+    if (!builder) {
+      prevStallRef.current = status.stall;
+      return;
+    }
+
+    if (prevStallRef.current === 'no_agent_yet' && status.stall !== 'no_agent_yet') {
+      recordStudioStep('agent_signaled', builder);
+    }
+
+    const failureReason = status.failure?.reason;
+    let verdict: StudioStepDetail | null = null;
+    if (failureReason === 'gate_red') verdict = 'red';
+    else if (failureReason === 'kit_outdated') verdict = 'kit_outdated';
+    else if (
+      status.status === 'in_review' ||
+      status.status === 'publishing' ||
+      status.status === 'published' ||
+      status.phase === 'ready_for_review'
+    ) {
+      verdict = 'green';
+    }
+    if (verdict) recordStudioStep('gate_verdict', builder, verdict);
+
+    prevStallRef.current = status.stall;
+  }, [status]);
 
   // No share link here any more. It used to be shown unconditionally and pointed at
   // `/draft/<slug>`, which was readable by any signed-in visitor who knew the slug.
@@ -523,8 +575,9 @@ export function SubmissionStatusView({
                     needs a sentence here — the thread's emptyLabel only shows when there
                     are no turns, which is exactly when a bounced build still has planning
                     notes and used to look like nothing was wrong.
-                    Self rounds waiting to connect get the connect card instead of stall
-                    copy — the card *is* the waiting state. */}
+                    Self rounds: no-agent-yet is the connect card alone; quiet keeps a
+                    self-specific warning *and* resurfaces the card (we cannot wake the
+                    agent). Delivery-cap is a failure sentence, not a stall. */}
                 {status.failure ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} />{' '}
@@ -534,7 +587,11 @@ export function SubmissionStatusView({
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t('statusView.states.needs_changes.description')}
                   </p>
-                ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
+                ) : selfCopy === 'no_agent_yet' ? null : selfCopy === 'quiet_agent' ? (
+                  <p className="status-warning">
+                    <PixelIcon name="signal" size={13} /> {t('statusView.stall.quietSelf')}
+                  </p>
+                ) : status.stall ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
                   </p>
@@ -578,6 +635,9 @@ export function SubmissionStatusView({
                     compact
                     chooseBuilder={canChooseBuilder(status)}
                     initialBuilder={resolveDefaultBuilder(token, status)}
+                    roundBuilder={status.builder && isBuilderKind(status.builder) ? status.builder : undefined}
+                    stall={status.stall}
+                    failureReason={status.failure?.reason}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                   />
                 ) : null}
@@ -645,12 +705,17 @@ export function SubmissionStatusView({
             ) : null}
 
             {/* A dead round outranks a slow one: when both are set, the failure is
-                the explanation and the stall is just its symptom. */}
+                the explanation and the stall is just its symptom. Self quiet keeps
+                its warning and resurfaces the connect card. */}
             {status.failure ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
               </p>
-            ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
+            ) : selfCopy === 'no_agent_yet' ? null : selfCopy === 'quiet_agent' ? (
+              <p className="status-warning">
+                <PixelIcon name="signal" size={13} /> {t('statusView.stall.quietSelf')}
+              </p>
+            ) : status.stall ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
               </p>
@@ -736,6 +801,9 @@ export function SubmissionStatusView({
                 building={!preview && !channelHtml}
                 chooseBuilder={canChooseBuilder(status)}
                 initialBuilder={resolveDefaultBuilder(token, status)}
+                roundBuilder={status.builder && isBuilderKind(status.builder) ? status.builder : undefined}
+                stall={status.stall}
+                failureReason={status.failure?.reason}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
               />
             ) : null}
@@ -921,6 +989,9 @@ function FeedbackPanel({
   compact = false,
   chooseBuilder = false,
   initialBuilder = 'platform',
+  roundBuilder,
+  stall,
+  failureReason,
   onSent,
 }: {
   token: string;
@@ -932,6 +1003,10 @@ function FeedbackPanel({
   /** Show builder choice — the next send opens a new round. */
   chooseBuilder?: boolean;
   initialBuilder?: BuilderKind;
+  /** Builder of the *current* round — drives self-build routing copy. */
+  roundBuilder?: BuilderKind;
+  stall?: SubmissionStatus['stall'];
+  failureReason?: string;
   onSent: (text: string) => void;
 }) {
   const { t } = useTranslation();
@@ -952,6 +1027,26 @@ function FeedbackPanel({
   }, [initialBuilder, token]);
 
   const trimmed = text.trim();
+  // When choosing a builder for a new round, the selector is the truth; otherwise the
+  // current round's builder drives the honest self-build routing note.
+  const routeBuilder = chooseBuilder ? builder : roundBuilder;
+  const composerRoute = selfComposerRoute({
+    builder: routeBuilder,
+    stall: chooseBuilder ? null : stall,
+    failureReason: chooseBuilder ? null : failureReason,
+  });
+  const sentSelfKey =
+    composerRoute === 'active'
+      ? 'statusView.feedback.sentSelfActive'
+      : composerRoute === 'waiting'
+        ? 'statusView.feedback.sentSelfWaiting'
+        : null;
+  const routeNoteKey =
+    composerRoute === 'active'
+      ? 'statusView.feedback.routeSelfActive'
+      : composerRoute === 'waiting'
+        ? 'statusView.feedback.routeSelfWaiting'
+        : null;
 
   // The composer grows with what is typed, which is what replaced the resize grip: once
   // the send button moved inside the box, a drag handle in the middle of its right edge
@@ -991,7 +1086,10 @@ function FeedbackPanel({
           );
         }
       }
-      if (roundBuilder) saveLastBuilder(token, roundBuilder);
+      if (roundBuilder) {
+        saveLastBuilder(token, roundBuilder);
+        recordStudioStep('builder_chosen', roundBuilder);
+      }
       setState('sent');
       setText('');
       // Back to the CSS height rather than the height the sent message grew it to: an
@@ -1013,6 +1111,10 @@ function FeedbackPanel({
       }
       setState('idle');
     }
+  };
+
+  const handleBuilderChange = (next: BuilderKind) => {
+    setBuilder(next);
   };
 
   // Three states, one box. The copy is the only thing that changes, and it changes so
@@ -1046,7 +1148,10 @@ function FeedbackPanel({
     return (
       <div className="status-feedback status-composer is-compact">
         {chooseBuilder ? (
-          <BuilderChoice value={builder} onChange={setBuilder} disabled={state === 'sending'} compact />
+          <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={state === 'sending'} compact />
+        ) : null}
+        {routeNoteKey && state !== 'sent' && !error && !notice ? (
+          <p className="status-feedback-route">{t(routeNoteKey)}</p>
         ) : null}
         {/* Field and send on one line. The button used to sit on a row of its own below
             the box, which cost a phone screen an entire line to say what an arrow beside
@@ -1091,7 +1196,7 @@ function FeedbackPanel({
               <p className="status-feedback-notice">{notice}</p>
             ) : (
               <span className="status-feedback-sent">
-                <PixelIcon name="check" size={13} /> {t('statusView.feedback.sent')}
+                <PixelIcon name="check" size={13} /> {t(sentSelfKey ?? 'statusView.feedback.sent')}
               </span>
             )}
           </div>
@@ -1104,7 +1209,12 @@ function FeedbackPanel({
     <div className="status-feedback status-composer">
       <h3 className="status-feedback-title">{t(titleKey)}</h3>
       <p className="status-feedback-hint">{t(hintKey)}</p>
-      {chooseBuilder ? <BuilderChoice value={builder} onChange={setBuilder} disabled={state === 'sending'} /> : null}
+      {chooseBuilder ? (
+        <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={state === 'sending'} />
+      ) : null}
+      {routeNoteKey && state !== 'sent' && !error && !notice ? (
+        <p className="status-feedback-route">{t(routeNoteKey)}</p>
+      ) : null}
       <textarea
         className="status-feedback-input"
         value={text}
@@ -1126,7 +1236,7 @@ function FeedbackPanel({
         </button>
         {state === 'sent' && !notice ? (
           <span className="status-feedback-sent">
-            <PixelIcon name="check" size={13} /> {t('statusView.feedback.sent')}
+            <PixelIcon name="check" size={13} /> {t(sentSelfKey ?? 'statusView.feedback.sent')}
           </span>
         ) : null}
       </div>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -35,7 +35,10 @@ function copyInputFromStatus(status: SubmissionStatus | null | undefined) {
   };
 }
 
-/** A self round waiting for the creator's agent — show the connect card, not stall copy. */
+/**
+ * Whether the Studio connect card should be on screen for this status snapshot.
+ * True for self rounds with no agent yet *or* a quiet agent (card resurfaced).
+ */
 function isAwaitingOwnAgent(status: SubmissionStatus | null | undefined): boolean {
   return shouldShowConnectCard(copyInputFromStatus(status));
 }
@@ -352,19 +355,14 @@ export function SubmissionStatusView({
     : '';
 
   // Studio telemetry: first agent signal + gate verdict, with builder dimension.
-  // Dedupe lives in recordStudioStep; refs only detect the transitions worth emitting.
+  // Emit only on transitions observed during this mount — a reload of an already
+  // finished submission must not mint a fresh gate_verdict (visit stream is per-tab).
   const prevStallRef = useRef<SubmissionStatus['stall'] | undefined>(undefined);
+  const prevVerdictRef = useRef<StudioStepDetail | null | undefined>(undefined);
+  const hasSeenStatusRef = useRef(false);
   useEffect(() => {
     if (!status) return;
     const builder = status.builder && isBuilderKind(status.builder) ? status.builder : null;
-    if (!builder) {
-      prevStallRef.current = status.stall;
-      return;
-    }
-
-    if (prevStallRef.current === 'no_agent_yet' && status.stall !== 'no_agent_yet') {
-      recordStudioStep('agent_signaled', builder);
-    }
 
     const failureReason = status.failure?.reason;
     let verdict: StudioStepDetail | null = null;
@@ -378,9 +376,19 @@ export function SubmissionStatusView({
     ) {
       verdict = 'green';
     }
-    if (verdict) recordStudioStep('gate_verdict', builder, verdict);
+
+    if (builder) {
+      if (prevStallRef.current === 'no_agent_yet' && status.stall !== 'no_agent_yet') {
+        recordStudioStep('agent_signaled', builder);
+      }
+      if (hasSeenStatusRef.current && verdict && prevVerdictRef.current !== verdict) {
+        recordStudioStep('gate_verdict', builder, verdict);
+      }
+    }
 
     prevStallRef.current = status.stall;
+    prevVerdictRef.current = verdict;
+    hasSeenStatusRef.current = true;
   }, [status]);
 
   // No share link here any more. It used to be shown unconditionally and pointed at

--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -98,9 +98,9 @@ describe('locale resources', () => {
     }
   });
 
-  // BYOCA connect/builder copy must never say "token" — creators see a paste-ready
-  // prompt with a "key", and the credential concept stays undescribed (BY-07).
-  it('never uses the word token in builder or connect copy', () => {
+  // BYOCA connect/builder/status copy must never say "token" — creators see a
+  // paste-ready prompt with a "key", and the credential concept stays undescribed.
+  it('never uses the word token in builder, connect, or self-build status copy', () => {
     for (const [lang, resource] of [
       ['en', en],
       ['pl', pl],
@@ -109,6 +109,13 @@ describe('locale resources', () => {
         const blob = JSON.stringify((resource as Record<string, unknown>)[section] ?? {});
         expect(blob, `${lang}.${section}`).not.toMatch(/\btoken\b/i);
       }
+      const statusView = (resource as { statusView: Record<string, unknown> }).statusView;
+      const selfBuildBlob = JSON.stringify({
+        stall: statusView.stall,
+        failure: statusView.failure,
+        feedback: statusView.feedback,
+      });
+      expect(selfBuildBlob, `${lang}.statusView self-build`).not.toMatch(/\btoken\b/i);
     }
   });
 });

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -482,6 +482,10 @@
       "submit": "Send feedback",
       "sending": "Sending…",
       "sent": "Sent! The agent will revise your game — watch the build log above.",
+      "routeSelfActive": "Your agent picks this up on its next check-in.",
+      "routeSelfWaiting": "Saved — your agent will get this when you start it.",
+      "sentSelfActive": "Sent — your agent picks this up on its next check-in.",
+      "sentSelfWaiting": "Saved — your agent will get this when you start it.",
       "noCapacity": "Saved — but no build round could start: the build agent is out of capacity right now. Your note is safe and the next round will read it.",
       "notStarted": "Saved — but a new build round didn't start. Your note is safe; we're looking into it.",
       "error": "We couldn't send that right now. Please try again in a moment.",
@@ -557,14 +561,16 @@
       "task_timed_out": "The build ran out of time before finishing. Your progress is safe — send feedback below to start another round.",
       "task_completed_without_delivery": "The agent finished without delivering the game. Send feedback below to start another round.",
       "gate_red": "This build didn't pass our automatic checks, so it can't go live yet. Send feedback below to start another round — the agent will see what failed and fix it.",
+      "self_build_delivery_cap": "This round hit its delivery limit, so your agent can't submit another build until you start a new round. Send a short note below to continue — your progress so far is safe.",
       "generic": "This build round ended with an error. Your progress is safe — send feedback below to start another round."
     },
     "stall": {
       "awaiting_input": "The agent is waiting for your input — reply below to keep the build moving.",
       "not_dispatched": "The build hasn't been picked up by an agent yet. It's been waiting longer than expected — we're looking into it.",
       "quiet": "The agent has been quiet for a while. It may still be working — or you can send feedback below to start another round.",
+      "quietSelf": "Your coding agent has been quiet. We can't start it from here — paste the prompt below into your agent when you're ready, or send a note that it will pick up on its next run.",
       "gate_not_started": "The game was delivered, but verification hasn't started yet. This is on our side — no action needed from you.",
-      "no_agent_yet": "Waiting for your coding agent — follow the steps below to connect it."
+      "no_agent_yet": "No agent yet — this round waits for your coding agent. Follow the steps below to connect it."
     },
     "tryAgain": "Try this idea again",
     "abandon": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -486,6 +486,10 @@
       "submit": "Wyślij uwagi",
       "sending": "Wysyłanie…",
       "sent": "Wysłano! Agent poprawi Twoją grę — obserwuj dziennik budowy powyżej.",
+      "routeSelfActive": "Twój agent odbierze to przy następnym odczycie skrzynki.",
+      "routeSelfWaiting": "Zapisano — Twój agent dostanie to, gdy go uruchomisz.",
+      "sentSelfActive": "Wysłano — Twój agent odbierze to przy następnym odczycie skrzynki.",
+      "sentSelfWaiting": "Zapisano — Twój agent dostanie to, gdy go uruchomisz.",
       "noCapacity": "Zapisano — ale nie udało się rozpocząć rundy budowania: agent nie ma teraz wolnych mocy. Twoja wiadomość jest bezpieczna i zostanie odczytana w kolejnej rundzie.",
       "notStarted": "Zapisano — ale nowa runda budowania się nie rozpoczęła. Twoja wiadomość jest bezpieczna; sprawdzamy, co się stało.",
       "error": "Nie udało się teraz tego wysłać. Spróbuj ponownie za chwilę.",
@@ -561,14 +565,16 @@
       "task_timed_out": "Budowanie nie zdążyło się skończyć w wyznaczonym czasie. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "task_completed_without_delivery": "Agent zakończył pracę, ale nie dostarczył gry. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "gate_red": "Ta wersja nie przeszła naszych automatycznych testów, więc jeszcze nie może trafić do arcade. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę — agent zobaczy, co nie przeszło, i to poprawi.",
+      "self_build_delivery_cap": "Ta runda wyczerpała limit dostarczeń, więc Twój agent nie może wysłać kolejnej wersji, dopóki nie zaczniesz nowej rundy. Wyślij poniżej krótką uwagę, aby kontynuować — dotychczasowe postępy są bezpieczne.",
       "generic": "Ta runda budowania zakończyła się błędem. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę."
     },
     "stall": {
       "awaiting_input": "Agent czeka na Twoją odpowiedź — napisz poniżej, aby budowa ruszyła dalej.",
       "not_dispatched": "Budowa nie została jeszcze podjęta przez agenta. Trwa to dłużej niż zwykle — sprawdzamy to.",
       "quiet": "Agent od dłuższej chwili nie daje znaku życia. Może wciąż pracuje — możesz też wysłać poniżej uwagi, aby rozpocząć kolejną rundę.",
+      "quietSelf": "Twój agent od dłuższej chwili milczy. Nie możemy go stąd uruchomić — wklej poniżej prompt do swojego agenta, gdy będziesz gotowy, albo wyślij uwagę, którą odbierze przy następnym uruchomieniu.",
       "gate_not_started": "Gra została dostarczona, ale weryfikacja jeszcze się nie rozpoczęła. To po naszej stronie — nie musisz nic robić.",
-      "no_agent_yet": "Czekamy na Twojego agenta — wykonaj kroki poniżej, żeby go podłączyć."
+      "no_agent_yet": "Nie ma jeszcze agenta — ta runda czeka na Twojego agenta. Wykonaj kroki poniżej, żeby go podłączyć."
     },
     "tryAgain": "Spróbuj z tym pomysłem jeszcze raz",
     "abandon": {

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
+
+describe('selfStatusCopy', () => {
+  it('is null for platform rounds', () => {
+    expect(selfStatusCopy({ builder: 'platform', stall: 'quiet' })).toBeNull();
+    expect(selfStatusCopy({ builder: 'platform', stall: 'no_agent_yet' })).toBeNull();
+  });
+
+  it('selects no_agent_yet before the first signal', () => {
+    expect(selfStatusCopy({ builder: 'self', stall: 'no_agent_yet' })).toBe('no_agent_yet');
+  });
+
+  it('selects quiet_agent after a signal has gone silent', () => {
+    expect(selfStatusCopy({ builder: 'self', stall: 'quiet' })).toBe('quiet_agent');
+  });
+
+  it('selects delivery_cap over stall when the round hit its ceiling', () => {
+    expect(
+      selfStatusCopy({
+        builder: 'self',
+        stall: 'quiet',
+        failureReason: 'self_build_delivery_cap',
+      }),
+    ).toBe('delivery_cap');
+    expect(
+      selfStatusCopy({
+        builder: 'platform',
+        failureReason: 'self_build_delivery_cap',
+      }),
+    ).toBe('delivery_cap');
+  });
+
+  it('is null while a self round is progressing normally', () => {
+    expect(selfStatusCopy({ builder: 'self', stall: null })).toBeNull();
+    expect(selfStatusCopy({ builder: 'self' })).toBeNull();
+  });
+});
+
+describe('shouldShowConnectCard', () => {
+  it('shows for no-agent-yet and quiet self rounds', () => {
+    expect(shouldShowConnectCard({ builder: 'self', stall: 'no_agent_yet' })).toBe(true);
+    expect(shouldShowConnectCard({ builder: 'self', stall: 'quiet' })).toBe(true);
+  });
+
+  it('hides when the delivery cap is reached or the agent is active', () => {
+    expect(
+      shouldShowConnectCard({
+        builder: 'self',
+        stall: 'quiet',
+        failureReason: 'self_build_delivery_cap',
+      }),
+    ).toBe(false);
+    expect(shouldShowConnectCard({ builder: 'self', stall: null })).toBe(false);
+    expect(shouldShowConnectCard({ builder: 'platform', stall: 'quiet' })).toBe(false);
+  });
+});
+
+describe('selfComposerRoute', () => {
+  it('is null when the platform is building', () => {
+    expect(selfComposerRoute({ builder: 'platform' })).toBeNull();
+    expect(selfComposerRoute({})).toBeNull();
+  });
+
+  it('is active while a self agent has a recent signal', () => {
+    expect(selfComposerRoute({ builder: 'self', stall: null })).toBe('active');
+    expect(selfComposerRoute({ builder: 'self' })).toBe('active');
+  });
+
+  it('is waiting before first signal, when quiet, or at the delivery cap', () => {
+    expect(selfComposerRoute({ builder: 'self', stall: 'no_agent_yet' })).toBe('waiting');
+    expect(selfComposerRoute({ builder: 'self', stall: 'quiet' })).toBe('waiting');
+    expect(
+      selfComposerRoute({
+        builder: 'self',
+        failureReason: 'self_build_delivery_cap',
+      }),
+    ).toBe('waiting');
+  });
+});

--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -1,0 +1,60 @@
+/**
+ * Honest status / composer copy for self-build rounds (BY-08).
+ *
+ * The platform cannot start or wake the creator's agent. Status copy and the
+ * composer's routing note must say so: waiting-to-connect, quiet after a signal,
+ * delivery-cap reached, and — after a send — whether a running agent will see the
+ * note on its next check-in or only once the creator starts it again.
+ *
+ * Pure functions so the selection is unit-tested without mounting Studio.
+ */
+
+export type SelfStatusCopy = 'no_agent_yet' | 'quiet_agent' | 'delivery_cap';
+
+/** Where a self-round composer message will actually go. */
+export type SelfComposerRoute = 'active' | 'waiting';
+
+export type SelfBuildCopyInput = {
+  builder?: 'platform' | 'self' | null;
+  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started' | 'no_agent_yet' | null;
+  failureReason?: string | null;
+};
+
+/**
+ * Which self-build status sentence (if any) the thread should show.
+ *
+ * Delivery-cap outranks stall: the round cannot accept more deliveries, and a quiet
+ * banner would misread that as "the agent wandered off".
+ */
+export function selfStatusCopy(input: SelfBuildCopyInput): SelfStatusCopy | null {
+  if (input.failureReason === 'self_build_delivery_cap') return 'delivery_cap';
+  if (input.builder !== 'self') return null;
+  if (input.stall === 'no_agent_yet') return 'no_agent_yet';
+  if (input.stall === 'quiet') return 'quiet_agent';
+  return null;
+}
+
+/**
+ * Whether the connect card belongs on screen.
+ *
+ * Shown before the first agent signal, and again when a connected agent has gone
+ * quiet — gamedev.pl cannot wake it, so the paste-ready prompt is the resume path.
+ */
+export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
+  const copy = selfStatusCopy(input);
+  return copy === 'no_agent_yet' || copy === 'quiet_agent';
+}
+
+/**
+ * Composer routing for a self round, or null when the platform is building.
+ *
+ * `waiting` covers both pre-first-signal and quiet — the message is saved, but no
+ * agent will see it until the creator starts theirs. `active` means a recent signal
+ * so the next check-in will pick the inbox up.
+ */
+export function selfComposerRoute(input: SelfBuildCopyInput): SelfComposerRoute | null {
+  if (input.builder !== 'self') return null;
+  if (input.failureReason === 'self_build_delivery_cap') return 'waiting';
+  if (input.stall === 'no_agent_yet' || input.stall === 'quiet') return 'waiting';
+  return 'active';
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2760,6 +2760,14 @@ body.player-open {
   line-height: 1.4;
 }
 
+/* Self-build routing note: honest about whether a running agent will see the message. */
+.status-feedback-route {
+  margin: 0 0 6px;
+  color: var(--muted, #9ca3af);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
 /* MOBILE RESPONSIVENESS */
 @media (max-width: 768px) {
   /* One row, not two. A stacked header cost 102px — an eighth of a phone

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('crypto', webcrypto);
 import {
   readVisitIdentity,
   recordCreateStep,
+  recordStudioStep,
   recordVisitEvent,
   recordWaitlistStep,
   referrerDomain,
@@ -317,6 +318,80 @@ describe('recordWaitlistStep', () => {
   it('is a silent no-op when tracking was never started', () => {
     setVisitSessionForTesting(null);
     expect(() => recordWaitlistStep('cta_clicked')).not.toThrow();
+  });
+});
+
+describe('recordCreateStep builder dimension', () => {
+  it('attaches an optional builder on create_step', () => {
+    const { batches, send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    setVisitSessionForTesting(session);
+
+    recordCreateStep('submission_created', 'self');
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    expect(batches[0].events).toEqual([
+      expect.objectContaining({ type: 'create_step', step: 'submission_created', builder: 'self' }),
+    ]);
+  });
+});
+
+describe('recordStudioStep', () => {
+  it('records studio funnel steps with a builder dimension, once per key', () => {
+    const { batches, send } = capture();
+    // Clock advances so agent_signaled's msSinceStart is time-to-first-signal.
+    let now = 0;
+    const session = new VisitSession('v1', 0, send, () => now);
+    setVisitSessionForTesting(session);
+
+    recordStudioStep('builder_chosen', 'self');
+    recordStudioStep('builder_chosen', 'self');
+    recordStudioStep('builder_chosen', 'platform');
+    recordStudioStep('connect_copied', 'self', 'install');
+    recordStudioStep('connect_copied', 'self', 'kickoff');
+    now = 12_000;
+    recordStudioStep('agent_signaled', 'self');
+    recordStudioStep('agent_signaled', 'self');
+    recordStudioStep('gate_verdict', 'self', 'red');
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    // Auto-flush at 5 may split the batch; gather every recorded event.
+    const recorded = batches.flatMap((batch) => batch.events);
+    expect(recorded).toEqual([
+      expect.objectContaining({ type: 'studio_step', step: 'builder_chosen', builder: 'self' }),
+      expect.objectContaining({ type: 'studio_step', step: 'builder_chosen', builder: 'platform' }),
+      expect.objectContaining({
+        type: 'studio_step',
+        step: 'connect_copied',
+        builder: 'self',
+        detail: 'install',
+      }),
+      expect.objectContaining({
+        type: 'studio_step',
+        step: 'connect_copied',
+        builder: 'self',
+        detail: 'kickoff',
+      }),
+      expect.objectContaining({
+        type: 'studio_step',
+        step: 'agent_signaled',
+        builder: 'self',
+        msSinceStart: 12_000,
+      }),
+      expect.objectContaining({
+        type: 'studio_step',
+        step: 'gate_verdict',
+        builder: 'self',
+        detail: 'red',
+      }),
+    ]);
+  });
+
+  it('is a silent no-op when tracking was never started', () => {
+    setVisitSessionForTesting(null);
+    expect(() => recordStudioStep('builder_chosen', 'self')).not.toThrow();
   });
 });
 

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -53,10 +53,19 @@ export type VisitEvent =
    * "the card did not answer". Distinct-visit rates are derived on the read side.
    */
   | { type: 'how_to_play_opened'; via: HowToPlayVia; reopen?: true }
-  /** A step of the creation funnel was reached. Carries no prompt text, ever. */
-  | { type: 'create_step'; step: CreateStep }
+  /**
+   * A step of the creation funnel was reached. Carries no prompt text, ever.
+   * Optional `builder` dimensions platform vs self-build once the creator has chosen.
+   */
+  | { type: 'create_step'; step: CreateStep; builder?: BuilderDimension }
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */
-  | { type: 'waitlist_step'; step: WaitlistStep };
+  | { type: 'waitlist_step'; step: WaitlistStep }
+  /**
+   * Studio / self-build funnel facts on the same visit stream as `create_step`.
+   * Always carries `builder` so BYOCA reach-to-publish is measurable without a
+   * parallel stream. No game slug, no uid — visit-scoped only.
+   */
+  | { type: 'studio_step'; step: StudioStep; builder: BuilderDimension; detail?: StudioStepDetail };
 
 /**
  * The creation funnel, in the order a creator meets it.
@@ -107,6 +116,23 @@ export type WaitlistStep =
  * Deep-link vs arcade is *not* here — that is visit `entry`, already on `visit_started`.
  */
 export type HowToPlayVia = 'bar' | 'more';
+
+/** Who builds the round — closed enum; reaches a grouping key. */
+export type BuilderDimension = 'platform' | 'self';
+
+/**
+ * Studio-side creator-funnel steps (BY-08). Sibling to `create_step`, not a rung of
+ * that ordered funnel — these answer builder choice, connect friction, time to first
+ * agent signal (`msSinceStart` on `agent_signaled`), and gate verdict per visit.
+ */
+export type StudioStep = 'builder_chosen' | 'connect_copied' | 'agent_signaled' | 'gate_verdict';
+
+/**
+ * Closed detail for studio steps that need one. `install` / `kickoff` are connect-card
+ * copies; `green` / `red` / `kit_outdated` are gate verdicts. Absent on steps that
+ * need none (builder choice, first agent signal).
+ */
+export type StudioStepDetail = 'install' | 'kickoff' | 'green' | 'red' | 'kit_outdated';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;
@@ -351,10 +377,14 @@ export function currentVisitId(): string | null {
  */
 let recordedSteps = new Set<CreateStep>();
 
-export function recordCreateStep(step: CreateStep): void {
+export function recordCreateStep(step: CreateStep, builder?: BuilderDimension): void {
   if (!currentSession || recordedSteps.has(step)) return;
   recordedSteps.add(step);
-  currentSession.record({ type: 'create_step', step });
+  currentSession.record({
+    type: 'create_step',
+    step,
+    ...(builder ? { builder } : {}),
+  });
 }
 
 let recordedWaitlistSteps = new Set<WaitlistStep>();
@@ -365,12 +395,39 @@ export function recordWaitlistStep(step: WaitlistStep): void {
   currentSession.record({ type: 'waitlist_step', step });
 }
 
+/**
+ * Studio steps already recorded for the live visit.
+ *
+ * Keyed by `step:builder` or `step:builder:detail` so connect install vs kickoff,
+ * gate green vs red, and platform vs self each count once without silencing
+ * unrelated steps.
+ */
+let recordedStudioSteps = new Set<string>();
+
+function studioStepKey(step: StudioStep, builder: BuilderDimension, detail?: StudioStepDetail): string {
+  return detail ? `${step}:${builder}:${detail}` : `${step}:${builder}`;
+}
+
+export function recordStudioStep(step: StudioStep, builder: BuilderDimension, detail?: StudioStepDetail): void {
+  if (!currentSession) return;
+  const key = studioStepKey(step, builder, detail);
+  if (recordedStudioSteps.has(key)) return;
+  recordedStudioSteps.add(key);
+  currentSession.record({
+    type: 'studio_step',
+    step,
+    builder,
+    ...(detail ? { detail } : {}),
+  });
+}
+
 /** Test seam: installs a session without touching the DOM. */
 export function setVisitSessionForTesting(session: VisitSession | null): void {
   currentSession = session;
   // Otherwise one test's steps would silence the next test's identical steps.
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
+  recordedStudioSteps = new Set();
 }
 
 export interface StartVisitTrackingOptions {

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -461,6 +461,7 @@ export function startVisitTracking(options: StartVisitTrackingOptions = {}): () 
   // stop deduping across it if these were not cleared with the session that owns them.
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
+  recordedStudioSteps = new Set();
 
   if (identity.isNew) {
     const referrer = referrerDomain(document.referrer ?? '', window.location.hostname);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Self-build rounds need honest Studio status/composer copy (the platform is not building) and product telemetry with a builder dimension so we can measure connect → first signal → gate.

## What

- State-aware composer notes for self rounds (active vs waiting)
- Status copy: no-agent-yet, quiet-agent, delivery-cap; connect card resurfaced when quiet
- EN + PL; never uses the word "token"
- Visit telemetry `studio_step` events with required `builder`: `builder_chosen`, `connect_copied`, `agent_signaled`, `gate_verdict`
- **`gate_verdict` only on a live transition** — reloading a finished submission does not inflate green/red counts
- Optional `builder` on existing `create_step`
- Web + API schema kept in sync per product-instrumentation contract

## Out of scope

No new API endpoints; MCP is BY-05 (#430).

## Test plan

- [x] Green gate (focused web tests)
- [x] Copy-state selection + telemetry emission + gate_verdict transition test
- [ ] Supervisor / owner review before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

