### PR TITLE
fix(api): stop self-build double round-close on deliver-without-progress

### DIFF
--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -20,7 +20,7 @@ import { selfBuildDeliveryCap } from './builder.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import { InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
-import { canTransition, resolveJobState } from './job-state.js';
+import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import { KIT_ENTRY, KitRegistryError, kitUnpackCommand, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
@@ -380,17 +380,31 @@ export async function registerAgentChannelRoutes(
    * For self rounds this is the entire state advance — there is no external task to
    * observe. Harmless for platform rounds that are already `building` via the
    * reconciler: `canTransition` refuses a no-op.
+   *
+   * Returns the effective state after the call. Callers that continue the walk
+   * (notably sources → `submitted`) must use this rather than the request-local
+   * `record.state`, which is stale the moment we write — a delivery that raced
+   * background dispatch while still `queued` used to skip `submitted`, leave the
+   * job in `building`, and let the reconciler close the round a generation early.
    */
-  async function markBuildingFromChannel(issueNumber: number, record: SubmissionRecord): Promise<void> {
-    if (!store) return;
-    const current = record.state ?? 'queued';
-    if (!canTransition(current, 'building')) return;
-    await store.recordJobTransition(issueNumber, {
-      to: 'building',
-      at: new Date().toISOString(),
-      by: 'agent',
-      reason: 'channel_signal',
-    });
+  async function markBuildingFromChannel(issueNumber: number, record: SubmissionRecord): Promise<JobState> {
+    const fallback = (record.state ?? 'queued') as JobState;
+    if (!store) return fallback;
+    const current = fallback;
+    if (canTransition(current, 'building')) {
+      await store.recordJobTransition(issueNumber, {
+        to: 'building',
+        at: new Date().toISOString(),
+        by: 'agent',
+        reason: 'channel_signal',
+      });
+      return 'building';
+    }
+    // Already at/past building, or a walk that refuses — prefer the store over the
+    // request snapshot (another writer, or a prior call in this same handler, may
+    // have moved it).
+    const fresh = await store.getSubmission(issueNumber);
+    return (fresh?.state ?? current) as JobState;
   }
 
   /**
@@ -547,10 +561,14 @@ export async function registerAgentChannelRoutes(
       };
 
       const stored = await store!.appendBuildEvent(issueNumber, event);
-      await markBuildingFromChannel(issueNumber, record);
+      const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
       options.onEvent?.(issueNumber);
 
-      return reply.send({ accepted: true, event: stored, ...(await channelState(issueNumber, record)) });
+      return reply.send({
+        accepted: true,
+        event: stored,
+        ...(await channelState(issueNumber, { ...record, state: stateAfterSignal })),
+      });
     },
   );
 
@@ -795,7 +813,11 @@ export async function registerAgentChannelRoutes(
       }
 
       try {
-        await markBuildingFromChannel(issueNumber, record);
+        // Fresh walk state — not `record.state`. Delivery often races the background
+        // dispatch that flips `queued`→`dispatched`; the local snapshot stays `queued`,
+        // and `canTransition('queued','submitted')` is false, so the protective
+        // transition was skipped and the job stayed `building` (CP-1 double-close).
+        const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
         const { version } = await options.gamesStore.putCandidateSources({
           slug,
           issueNumber,
@@ -835,8 +857,7 @@ export async function registerAgentChannelRoutes(
         // whatever it might have said. `submitted` is the state the reconciler refuses
         // to move, which is exactly the protection this needs.
         if (store) {
-          const current = record.state ?? 'building';
-          if (canTransition(current, 'submitted')) {
+          if (canTransition(stateAfterSignal, 'submitted')) {
             await store.recordJobTransition(issueNumber, {
               to: 'submitted',
               at: new Date().toISOString(),
@@ -862,10 +883,11 @@ export async function registerAgentChannelRoutes(
         }
         options.onEvent?.(issueNumber);
 
+        const fresh = store ? ((await store.getSubmission(issueNumber)) ?? record) : record;
         return reply.send({
           accepted: true,
           delivery: { slug, version },
-          ...(await channelState(issueNumber, record)),
+          ...(await channelState(issueNumber, fresh)),
         });
       } catch (error) {
         // A rejected upload is the agent's to fix, so the reason goes back in full. This

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -388,23 +388,22 @@ export async function registerAgentChannelRoutes(
    * job in `building`, and let the reconciler close the round a generation early.
    */
   async function markBuildingFromChannel(issueNumber: number, record: SubmissionRecord): Promise<JobState> {
-    const fallback = (record.state ?? 'queued') as JobState;
-    if (!store) return fallback;
-    const current = fallback;
-    if (canTransition(current, 'building')) {
-      await store.recordJobTransition(issueNumber, {
-        to: 'building',
-        at: new Date().toISOString(),
-        by: 'agent',
-        reason: 'channel_signal',
-      });
-      return 'building';
+    const current = (record.state ?? 'queued') as JobState;
+    if (!store) return current;
+    if (!canTransition(current, 'building')) {
+      // Common case: already `building` (every progress call after the first). The
+      // request-local snapshot from resolveBuild is fresh enough — avoid an extra
+      // store read on the hot path. Callers that need a post-write snapshot (sources)
+      // re-read explicitly.
+      return current;
     }
-    // Already at/past building, or a walk that refuses — prefer the store over the
-    // request snapshot (another writer, or a prior call in this same handler, may
-    // have moved it).
-    const fresh = await store.getSubmission(issueNumber);
-    return (fresh?.state ?? current) as JobState;
+    await store.recordJobTransition(issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'agent',
+      reason: 'channel_signal',
+    });
+    return 'building';
   }
 
   /**

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -646,4 +646,85 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(res.isError).toBe(true);
     expect(JSON.stringify(res.structured)).toMatch(/kitEngineRef/i);
   });
+
+  it('terminal receipt after deliver-without-progress: readable on all three transports', async () => {
+    // Full assembled-app sequence (not a hard-set generation delta): queued self job →
+    // MCP submit_sources with no report_progress → gate-green closes once → receipt.
+    const store = new InMemoryStore();
+    await seedJob(store);
+    await store.recordJobTransition(ISSUE, {
+      to: 'queued',
+      at: '2026-08-01T11:00:00.000Z',
+      by: 'creator',
+      reason: 'submitted',
+    });
+    await store.recordDispatch(ISSUE, { backend: 'self', ref: `self:${ISSUE}` });
+    expect((await store.getSubmission(ISSUE))?.state).toBe('queued');
+
+    const { gamesStore } = stubGamesStore({ green: true, ranAt: '2026-08-01T12:30:00.000Z' });
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+    const originalKey = roundKey(1);
+
+    const started = await callTool(app, 'start', { key: originalKey }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const submitted = await callTool(
+      app,
+      'submit_sources',
+      {
+        sessionKey,
+        kitEngineRef: ENGINE,
+        files: MINIMAL_FILES.map((f) => ({ ...f, encoding: 'utf8' })),
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(submitted.isError).toBe(false);
+    expect((await store.getSubmission(ISSUE))?.state).toBe('submitted');
+    expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(1);
+
+    await store.recordJobTransition(ISSUE, {
+      to: 'ready_for_review',
+      at: '2026-08-01T12:30:00.000Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(2);
+
+    const viaSession = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(viaSession.isError).toBe(false);
+    expect(viaSession.structured).toMatchObject({
+      status: 'green',
+      deliveryId: 'v1',
+      access: 'terminal_receipt',
+    });
+
+    const viaBearer = await callTool(
+      app,
+      'get_gate_verdict',
+      {},
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${originalKey}` },
+    );
+    expect(viaBearer.isError).toBe(false);
+    expect(viaBearer.structured).toMatchObject({ status: 'green', access: 'terminal_receipt' });
+
+    const viaHttp = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/gate',
+      headers: { authorization: `Bearer ${originalKey}` },
+    });
+    expect(viaHttp.statusCode).toBe(200);
+    expect(viaHttp.json()).toMatchObject({ status: 'green', deliveryId: 'v1', access: 'terminal_receipt' });
+
+    const write = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, text: 'should not write' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(write.isError).toBe(true);
+
+    const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(brief.isError).toBe(true);
+  });
 });

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -559,4 +559,66 @@ describe('self builder (BY-02)', () => {
     expect(response.statusCode).toBe(401);
     expect(response.json().error).toMatch(/fresh prompt/i);
   });
+
+  it('delivery with no prior progress lands submitted; reconciler does not double-close the round', async () => {
+    // CP-1 regression: submit_sources while still `queued` (racing background dispatch)
+    // used a stale local state for the `submitted` guard, left the job in `building`,
+    // and let self observe() close the round before the gate — generation jumped +2
+    // and the terminal-receipt window never matched.
+    let clock = Date.parse('2026-08-01T12:00:00.000Z');
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({
+      gamesStore,
+      now: () => clock,
+      internalAuthVerifier: { verify: async () => true },
+    });
+    app = created.app;
+    const { store } = created;
+
+    const issueNumber = 77;
+    await store.createSubmission(issueNumber, 'g:creator', 'No Progress Race');
+    await store.setSubmissionSlug(issueNumber, 'no-progress-race');
+    await store.setRoundBuilder(issueNumber, 'self');
+    await store.recordJobTransition(issueNumber, {
+      to: 'queued',
+      at: new Date(clock).toISOString(),
+      by: 'creator',
+      reason: 'submitted',
+    });
+    // Refs exist (dispatch recorded) but state is still queued — the live race shape.
+    await store.recordDispatch(issueNumber, { backend: 'self', ref: `self:${issueNumber}` });
+    expect((await store.getSubmission(issueNumber))?.state).toBe('queued');
+    const initialGen = (await store.getSubmission(issueNumber))!.roundGeneration ?? 1;
+
+    const delivery = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug: 'no-progress-race', files: MINIMAL_FILES, kitEngineRef: KIT_REF },
+    });
+    expect(delivery.statusCode).toBe(200);
+    expect(delivery.json()).toMatchObject({ accepted: true });
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+    expect((await store.getSubmission(issueNumber))?.roundGeneration).toBe(initialGen);
+
+    // Past the observe quiet window — reconciler must not move a submitted self job.
+    clock += 3 * 60 * 1000;
+    const sweep = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer internal' },
+    });
+    expect(sweep.statusCode).toBe(200);
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+    expect((await store.getSubmission(issueNumber))?.roundGeneration).toBe(initialGen);
+
+    // Only the gate's own closing transition bumps generation — exactly +1.
+    await store.recordJobTransition(issueNumber, {
+      to: 'ready_for_review',
+      at: new Date(clock).toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(issueNumber))?.roundGeneration).toBe(initialGen + 1);
+  });
 });

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -621,4 +621,48 @@ describe('self builder (BY-02)', () => {
     });
     expect((await store.getSubmission(issueNumber))?.roundGeneration).toBe(initialGen + 1);
   });
+
+  it('late background dispatch does not regress a submitted self delivery', async () => {
+    // Codex P1: create fires dispatchBuild unawaited; if the agent delivers first,
+    // the late `to: 'dispatched'` write must not yank submitted → dispatched.
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Late Dispatch Race', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const slug = submit.json().slug as string;
+
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      const record = (await store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.builder).toBe('self');
+      issueNumber = record!.issueNumber;
+    });
+
+    // Deliver immediately — typically still queued while background dispatch runs.
+    const delivery = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
+    });
+    expect(delivery.json()).toMatchObject({ accepted: true });
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+
+    // Wait until the fire-and-forget dispatch has recorded its ref (and attempted its
+    // state write). State must remain submitted — not regress to dispatched.
+    await vi.waitFor(async () => {
+      const record = await store.getSubmission(issueNumber);
+      expect(record?.dispatch?.backend).toBe('self');
+      expect(record?.dispatch?.refs?.length).toBeGreaterThan(0);
+    });
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+  });
 });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -843,12 +843,9 @@ export async function registerSubmissionRoutes(
           by: 'system',
           reason: `dispatched_to_${selected.name}`,
         });
-      } else {
-        input.log.info(
-          { issueNumber: input.issueNumber, from, backend: selected.name },
-          'skipping dispatched transition; job already past dispatch',
-        );
       }
+      // else: agent already advanced past dispatch (e.g. delivered while we were still
+      // opening the round). Refs/cost above are durable; do not regress state.
       return true;
     } catch (error) {
       // A failed dispatch leaves the job `queued`, which is exactly what the operator

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -829,12 +829,26 @@ export async function registerSubmissionRoutes(
         });
       }
       await recordSessionCost(input.issueNumber, result.ref, selected, input.log);
-      await store.recordJobTransition(input.issueNumber, {
-        to: 'dispatched',
-        at: new Date(now()).toISOString(),
-        by: 'system',
-        reason: `dispatched_to_${selected.name}`,
-      });
+      // Dispatch is fire-and-forget from create — a self agent can deliver (→ building /
+      // submitted) before this line runs. recordJobTransition does not refuse walk
+      // regressions, so an unconditional `dispatched` write would yank a submitted job
+      // back to agent-active and re-open the CP-1 double-close. Only advance when the
+      // walk still allows it; refs/cost above are already durable either way.
+      const latest = await store.getSubmission(input.issueNumber);
+      const from = latest?.state ?? 'queued';
+      if (canTransition(from, 'dispatched')) {
+        await store.recordJobTransition(input.issueNumber, {
+          to: 'dispatched',
+          at: new Date(now()).toISOString(),
+          by: 'system',
+          reason: `dispatched_to_${selected.name}`,
+        });
+      } else {
+        input.log.info(
+          { issueNumber: input.issueNumber, from, backend: selected.name },
+          'skipping dispatched transition; job already past dispatch',
+        );
+      }
       return true;
     } catch (error) {
       // A failed dispatch leaves the job `queued`, which is exactly what the operator


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

CP-1 found a contract bug live: MCP `start` → `submit_sources` with no intervening `report_progress` left the job in `building`, the reconciler closed the round (+1 generation), then the gate closed again (+1). The terminal-receipt window (`generation` exactly one behind) never matched, so every post-green `get_gate_verdict` returned "this build is finished" on all transports.

Fails closed (no security hole) — but it breaks the documented wait-for-green loop.

## Root cause

In `POST /api/agent/build/sources`, `markBuildingFromChannel` wrote `building` to the store while the request-local `record` stayed at the pre-delivery state (`queued` when racing background dispatch). The protective `submitted` transition was guarded with `canTransition(record.state, 'submitted')` — and `queued → submitted` is illegal — so it was silently skipped.

A second race (Codex P1): even after landing `submitted`, fire-and-forget `dispatchBuild` could later write unconditional `dispatched` and regress the job back to agent-active.

## What

1. `markBuildingFromChannel` returns the effective `JobState` after the call; sources uses it for the `submitted` guard. No extra store read on the common already-building progress path.
2. `dispatchBuild` only writes `dispatched` when `canTransition(current, 'dispatched')` — never regresses `building`/`submitted`.
3. Progress handler uses the returned state in its `channelState` reply.
4. Receipt-window semantics and token/MCP layers untouched.

## DoD evidence

| Item | Test |
| --- | --- |
| Delivery without progress lands `submitted`, not `building` | `self-build.test.ts` → `delivery with no prior progress lands submitted; reconciler does not double-close the round` |
| Reconciler sweep after quiet window does not transition / bump generation | same |
| Gate-green alone leaves `roundGeneration === initial + 1` | same |
| Late background dispatch does not regress `submitted` → `dispatched` | `self-build.test.ts` → `late background dispatch does not regress a submitted self delivery` |
| Terminal receipt on sessionKey / Bearer / plain HTTP after that sequence; writes + non-receipt reads still rejected | `mcp-server.test.ts` → `terminal receipt after deliver-without-progress: readable on all three transports` |
| Existing suites green | `npm test -w @gamedevpl/api`; type-check + lint clean |

## Out of scope

MCP tool changes, UI, token shape, widening the receipt window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

