### PR TITLE
byoca(BY-14c): fix Studio play for self-build ready_for_review

### DIFF
--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -738,10 +738,11 @@ describe('self-build Studio preview (BY-14c)', () => {
     return { store, token, slug, issueNumber, version };
   }
 
-  it('advertises preview.slug on status once a self-build version is delivered', async () => {
+  it('advertises preview.slug on status once a gate artifact exists for the delivery', async () => {
     // The regression: nativeJobStatus returned top-level slug but never preview.slug,
     // so SubmissionStatusView never called getSubmissionPreview and the Play control
-    // stayed dark even after gate green.
+    // stayed dark even after gate green. Artifact presence (not deliveredVersion alone)
+    // is the readiness signal — see the delivered-without-artifact case below.
     const { token, slug } = await deliverSelfBuild(
       'bundle.html',
       '<!doctype html><title>Studio Play</title><canvas></canvas>',
@@ -823,6 +824,49 @@ describe('self-build Studio preview (BY-14c)', () => {
       url: `/api/submissions/${token}`,
       headers: authHeaders(),
     });
+    expect(status.json().preview).toBeUndefined();
+  });
+
+  it('does not advertise preview after delivery until a gate artifact exists', async () => {
+    // deliveredVersion alone is the pre-artifact window: Studio must not see
+    // preview.slug yet, or a 409 would stick until headSha changes.
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Awaiting Gate', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const slug = submit.json().slug as string;
+    const token = submit.json().token as string;
+
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      const record = (await created.store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.builder).toBe('self');
+      issueNumber = record!.issueNumber;
+    });
+
+    const delivery = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
+    });
+    expect(delivery.json()).toMatchObject({ accepted: true });
+    expect((await created.store.getSubmission(issueNumber))!.deliveredVersion).toBeTruthy();
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders(),
+    });
+    expect(status.statusCode).toBe(200);
+    expect(status.json()).toMatchObject({ builder: 'self', slug });
     expect(status.json().preview).toBeUndefined();
   });
 });

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -59,7 +59,10 @@ const MINIMAL_FILES = [
   { path: 'AGENT.json', content: '{"policy":"capture"}' },
 ];
 
-function stubGamesStore() {
+function stubGamesStore(options?: {
+  /** When set, getManifest reports this gate verdict for every stored version. */
+  gateGreen?: boolean;
+}) {
   const stored: Array<{
     slug: string;
     issueNumber: number;
@@ -68,6 +71,7 @@ function stubGamesStore() {
     files: unknown[];
   }> = [];
   const versions = new Map<string, { files: typeof MINIMAL_FILES; backend?: string; kitEngineRef?: string }>();
+  const derived = new Map<string, Buffer>();
   const gamesStore = {
     putCandidateSources: async (input: {
       slug: string;
@@ -107,6 +111,9 @@ function stubGamesStore() {
         backend: hit.backend,
         kitEngineRef: hit.kitEngineRef,
         sourceFiles: hit.files.map((f) => f.path),
+        ...(options?.gateGreen !== undefined
+          ? { gate: { green: options.gateGreen, ranAt: new Date().toISOString() } }
+          : {}),
       };
     },
     getSourceFile: async (slug: string, version: string, path: string) => {
@@ -115,11 +122,14 @@ function stubGamesStore() {
     },
     putGateResult: async () => {},
     putHealthResult: async () => {},
-    putDerivedArtifact: async () => {},
-    getDerivedArtifact: async () => null,
+    putDerivedArtifact: async (slug: string, version: string, name: string, body: Buffer) => {
+      derived.set(`${slug}:${version}:${name}`, body);
+    },
+    getDerivedArtifact: async (slug: string, version: string, name: string) =>
+      derived.get(`${slug}:${version}:${name}`) ?? null,
     getKitRegistry: async () => null,
   } as unknown as GamesStore;
-  return { gamesStore, stored };
+  return { gamesStore, stored, derived };
 }
 
 const KIT_REF = 'abcdef1234567890';
@@ -664,5 +674,155 @@ describe('self builder (BY-02)', () => {
       expect(record?.dispatch?.refs?.length).toBeGreaterThan(0);
     });
     expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+  });
+});
+
+describe('self-build Studio preview (BY-14c)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  /**
+   * Self-build → channel sources → gate artifact → creator session hits the same
+   * `/api/submissions/:token/preview` route Studio's play surface uses.
+   */
+  async function deliverSelfBuild(artifact: 'bundle.html' | 'preview.html', html: string) {
+    // Gate-green jobs advertise a green verdict; the pre-green window has no gate
+    // field yet (distinct from gate-red, which would bounce to needs_changes).
+    const { gamesStore, derived } = stubGamesStore(artifact === 'bundle.html' ? { gateGreen: true } : undefined);
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Studio Play', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const slug = submit.json().slug as string;
+    const token = submit.json().token as string;
+
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      const record = (await store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.builder).toBe('self');
+      issueNumber = record!.issueNumber;
+    });
+
+    const delivery = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
+    });
+    expect(delivery.json()).toMatchObject({ accepted: true });
+    const version = (await store.getSubmission(issueNumber))!.deliveredVersion!;
+    expect(version).toBeTruthy();
+
+    derived.set(`${slug}:${version}:${artifact}`, Buffer.from(html));
+
+    if (artifact === 'bundle.html') {
+      await store.recordJobTransition(issueNumber, {
+        to: 'ready_for_review',
+        at: new Date().toISOString(),
+        by: 'gate',
+        reason: 'gate_green',
+      });
+    }
+
+    return { store, token, slug, issueNumber, version };
+  }
+
+  it('advertises preview.slug on status once a self-build version is delivered', async () => {
+    // The regression: nativeJobStatus returned top-level slug but never preview.slug,
+    // so SubmissionStatusView never called getSubmissionPreview and the Play control
+    // stayed dark even after gate green.
+    const { token, slug } = await deliverSelfBuild(
+      'bundle.html',
+      '<!doctype html><title>Studio Play</title><canvas></canvas>',
+    );
+
+    const status = await app!.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders(),
+    });
+    expect(status.statusCode).toBe(200);
+    expect(status.json()).toMatchObject({
+      builder: 'self',
+      phase: 'ready_for_review',
+      slug,
+      preview: { slug },
+      progress: { headSha: expect.any(String) },
+    });
+    // Self deliveries do not push channel playables — Studio must use /preview.
+    expect(status.json().playable).toBeUndefined();
+  });
+
+  it('serves the gate-green bundle to the creator through Studio preview auth', async () => {
+    const html = '<!doctype html><title>Gate Green</title><canvas id="game"></canvas>';
+    const { token, slug } = await deliverSelfBuild('bundle.html', html);
+
+    const preview = await app!.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}/preview`,
+      headers: authHeaders(),
+    });
+    expect(preview.statusCode).toBe(200);
+    // Delivery adopts the SPEC frontmatter title (`Self Built` in MINIMAL_FILES).
+    expect(preview.json()).toEqual({ slug, title: 'Self Built', html });
+  });
+
+  it('serves preview.html for a delivered-but-ungated self-build (pre-green window)', async () => {
+    // Gate decides publishability; the author can still watch the candidate. A red
+    // (or not-yet-finished) run stores preview.html — same contract as platform builds.
+    const html = '<!doctype html><title>Ungated Draft</title><canvas></canvas>';
+    const { token, slug, store, issueNumber } = await deliverSelfBuild('preview.html', html);
+    expect((await store.getSubmission(issueNumber))?.state).toBe('submitted');
+
+    const status = await app!.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders(),
+    });
+    expect(status.json()).toMatchObject({ builder: 'self', preview: { slug } });
+
+    const preview = await app!.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}/preview`,
+      headers: authHeaders(),
+    });
+    expect(preview.statusCode).toBe(200);
+    expect(preview.json()).toEqual({ slug, title: 'Self Built', html });
+  });
+
+  it('does not advertise preview before the first self-build delivery', async () => {
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'No Delivery Yet', concept: CONCEPT, builder: 'self' },
+    });
+    const token = submit.json().token as string;
+    await vi.waitFor(async () => {
+      const record = (await created.store.listSubmissionsByOwner('g:creator'))[0];
+      expect(record?.state).toBe('dispatched');
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders(),
+    });
+    expect(status.json().preview).toBeUndefined();
   });
 });

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -148,10 +148,12 @@ export interface SubmissionStatusResponseBase {
   phase?: JobState;
   slug?: string;
   /**
-   * Present when the creator can load a Studio draft via `/api/submissions/:token/preview`.
-   * Set for an open PR (slug on that branch) and for a native/self-build job once a
-   * candidate version has been delivered — the gate's `bundle.html` / `preview.html`
-   * is what that route serves. Absent before the first delivery.
+   * Signal to attempt/poll Studio draft loading via `/api/submissions/:token/preview`.
+   * Set for an open PR (slug on that branch) and for a native/self-build job once the
+   * gate has stored `bundle.html` or `preview.html` for the delivered version.
+   * Presence means "try loading," not a guarantee the route returns 200 on the same
+   * tick — a brief 409 (`no preview available…`) can still land if the artifact was
+   * just written or the store is catching up. Absent before the first storable draft.
    */
   preview?: { slug: string };
   /**

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -148,9 +148,10 @@ export interface SubmissionStatusResponseBase {
   phase?: JobState;
   slug?: string;
   /**
-   * Present while an unmerged PR is open (building/in_review): the creator can
-   * play the in-progress game straight from the PR branch, before the human
-   * merge. `slug` is the game directory on that branch.
+   * Present when the creator can load a Studio draft via `/api/submissions/:token/preview`.
+   * Set for an open PR (slug on that branch) and for a native/self-build job once a
+   * candidate version has been delivered — the gate's `bundle.html` / `preview.html`
+   * is what that route serves. Absent before the first delivery.
    */
   preview?: { slug: string };
   /**

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1534,16 +1534,33 @@ export async function registerSubmissionRoutes(
       // lossy by design, and the page needs the loss back to describe the wait honestly.
       ...(record.abandonedAt ? {} : { phase: state }),
       ...(record.slug ? { slug: record.slug } : {}),
-      // Studio's play surface only fetches `/preview` when `preview.slug` is set (the
-      // same signal the PR-derived path used to emit). A self-build delivery has no PR
-      // and often no channel `playable[]` either — sources land in the games store and
-      // the gate writes `bundle.html` / `preview.html`. Without this field the thread
-      // never asked for that document, so a gate-green ready_for_review job looked
-      // unplayable to its own creator (BY-14c). Advertise only once a version exists:
-      // before delivery there is nothing to serve, and a premature 409 would paint an
-      // error under an empty Play control.
-      ...(record.slug && record.deliveredVersion ? { preview: { slug: record.slug } } : {}),
     };
+    // Studio's play surface only fetches `/preview` when `preview.slug` is set (the
+    // same signal the PR-derived path used to emit). A self-build delivery has no PR
+    // and often no channel `playable[]` either — sources land in the games store and
+    // the gate writes `bundle.html` / `preview.html`. Without this field the thread
+    // never asked for that document, so a gate-green ready_for_review job looked
+    // unplayable to its own creator (BY-14c).
+    //
+    // Advertise only once a gate-built artifact exists for the delivered version —
+    // not merely once `deliveredVersion` is set. `onSourcesDelivered` persists the
+    // version before the async gate writes the HTML, and Studio's preview effect
+    // keys on slug + headSha only: a first-delivery 409 is never retried while those
+    // stay unchanged (Codex P1). Presence of `preview.slug` is therefore a readiness
+    // signal to attempt loading, not a promise that the route is warm on the same
+    // tick — but it must not flip on until something is actually storable.
+    if (record.slug && record.deliveredVersion) {
+      const gamesStore = options.agentChannel?.gamesStore;
+      if (gamesStore) {
+        const [bundle, previewHtml] = await Promise.all([
+          gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'bundle.html'),
+          gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'preview.html'),
+        ]);
+        if (bundle || previewHtml) {
+          status.preview = { slug: record.slug };
+        }
+      }
+    }
     // `failed` and a gate bounce both project onto public `needs_changes`. Without a
     // reason the Studio page only says the label — creators click the notification,
     // land on a thread of old planning notes, and never learn *why* the build stopped

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1534,6 +1534,15 @@ export async function registerSubmissionRoutes(
       // lossy by design, and the page needs the loss back to describe the wait honestly.
       ...(record.abandonedAt ? {} : { phase: state }),
       ...(record.slug ? { slug: record.slug } : {}),
+      // Studio's play surface only fetches `/preview` when `preview.slug` is set (the
+      // same signal the PR-derived path used to emit). A self-build delivery has no PR
+      // and often no channel `playable[]` either — sources land in the games store and
+      // the gate writes `bundle.html` / `preview.html`. Without this field the thread
+      // never asked for that document, so a gate-green ready_for_review job looked
+      // unplayable to its own creator (BY-14c). Advertise only once a version exists:
+      // before delivery there is nothing to serve, and a premature 409 would paint an
+      // error under an empty Play control.
+      ...(record.slug && record.deliveredVersion ? { preview: { slug: record.slug } } : {}),
     };
     // `failed` and a gate bounce both project onto public `needs_changes`. Without a
     // reason the Studio page only says the label — creators click the notification,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1551,13 +1551,18 @@ export async function registerSubmissionRoutes(
     // tick — but it must not flip on until something is actually storable.
     if (record.slug && record.deliveredVersion) {
       const gamesStore = options.agentChannel?.gamesStore;
-      if (gamesStore) {
-        const [bundle, previewHtml] = await Promise.all([
-          gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'bundle.html'),
-          gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'preview.html'),
-        ]);
-        if (bundle || previewHtml) {
-          status.preview = { slug: record.slug };
+      if (gamesStore?.getDerivedArtifact) {
+        try {
+          const [bundle, previewHtml] = await Promise.all([
+            gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'bundle.html'),
+            gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'preview.html'),
+          ]);
+          if (bundle || previewHtml) {
+            status.preview = { slug: record.slug };
+          }
+        } catch {
+          // Preview readiness is advisory. A store miss or stub without artifacts must
+          // not 502 the status page the creator is polling.
         }
       }
     }

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -420,6 +420,53 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('loads Studio preview for a self-build ready_for_review job with no channel playable', async () => {
+    // BY-14c: self deliveries land in the games store; status advertises preview.slug
+    // (no playable[]). The embedded thread must still fetch /preview and offer Play.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'in_review',
+      phase: 'ready_for_review',
+      builder: 'self',
+      slug: 'studio-play',
+      preview: { slug: 'studio-play' },
+      progress: { headSha: 'v1', commits: [], checklist: [] },
+    });
+    mockedGetSubmissionPreview.mockResolvedValue({
+      slug: 'studio-play',
+      title: 'Studio Play',
+      html: '<!doctype html><canvas id="game"></canvas>',
+    });
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'self-ready-token', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(mockedGetSubmissionPreview).toHaveBeenCalledWith('self-ready-token');
+    expect(mockedGetChannelPlayable).not.toHaveBeenCalled();
+    const playDraft = container.querySelector<HTMLButtonElement>('.studio-thread-context .status-play-cta');
+    expect(playDraft?.textContent).toContain('Play the draft');
+
+    await act(async () => {
+      playDraft?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    const iframe = container.querySelector('iframe');
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-pointer-lock');
+    expect(iframe?.getAttribute('srcdoc') ?? '').toContain('id="game"');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('falls back to the coarse status copy for a phase with nothing of its own to say', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({ status: 'building', phase: 'building' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

M1-exit blocker from CP-2: a self-build job can reach gate-green `ready_for_review` with a playable gate artifact available, but the creator still cannot play the candidate from Studio.

## Cause (DoD)

`nativeJobStatus` advertised a top-level `slug` for delivered candidates but **did not set `preview: { slug }`**. The Studio play surface only fetches `/api/jobs/:id/preview` when `status.preview.slug` is present (`StudioThread.tsx`). Self-builds have no PR and usually no channel-playable entry, so without `preview` the play control never appears — even though preview HTML / gate bundle already exist.

This is an API shape gap, not a UI self-build special-case.

## Fix

Advertise `preview: { slug }` when a gate-built `bundle.html` or `preview.html` exists for the delivered version (not merely when `deliveredVersion` is set — that races the async gate write, and Studio does not retry a stuck 409; Codex P1).

JSDoc clarifies that `preview` is a signal to attempt/poll loading, not a same-tick 200 guarantee (Copilot).

## Tests

- Assembled-app repro: self-build → sources delivered → gate green → creator-session preview returns a playable document.
- Regression: delivered-but-ungated (`preview.html`) and gate-green (`bundle`) on a self-build job.
- New: delivered version with **no** derived artifact yet → `preview` absent.
- `self-build.test.ts` 16 green locally after the review follow-up.

## Protocol

Draft for owner review before merge. Merge before declaring M1 exit (play + Publish + share link).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

