### PR TITLE
byoca(BY-14b): MCP get_kit unpack path + gate poll timing

### DIFF
--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -206,11 +206,9 @@ describe('agent build reads (BY-04)', () => {
       engineRef: ENGINE,
       kitUrl: `https://signed.example/kits/${ENGINE}.tgz?sig=1`,
       sha256: SHA,
-      entry: 'SKILL.md',
+      entry: 'gamedevpl-creator-kit/SKILL.md',
     });
-    expect(res.json().unpack).toBe(
-      `curl -fsSL 'https://signed.example/kits/${ENGINE}.tgz?sig=1' | tar -xz && cd gamedevpl-creator-kit`,
-    );
+    expect(res.json().unpack).toBe(`curl -fsSL 'https://signed.example/kits/${ENGINE}.tgz?sig=1' | tar -xz`);
     expect(signReadUrl).toHaveBeenCalledWith(`kits/${ENGINE}.tgz`, expect.any(Number));
   });
 

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -208,7 +208,9 @@ describe('agent build reads (BY-04)', () => {
       sha256: SHA,
       entry: 'SKILL.md',
     });
-    expect(res.json().unpack).toContain(`kits/${ENGINE}.tgz`);
+    expect(res.json().unpack).toBe(
+      `curl -fsSL 'https://signed.example/kits/${ENGINE}.tgz?sig=1' | tar -xz && cd gamedevpl-creator-kit`,
+    );
     expect(signReadUrl).toHaveBeenCalledWith(`kits/${ENGINE}.tgz`, expect.any(Number));
   });
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -21,7 +21,14 @@ import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.
 import { InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
-import { KIT_ENTRY, KitRegistryError, kitUnpackCommand, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
+import {
+  KIT_ENTRY,
+  KitRegistryError,
+  exampleUnpackCommand,
+  kitUnpackCommand,
+  parseKitRegistry,
+  parseKitSidecar,
+} from './kit-registry.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 
@@ -1195,7 +1202,7 @@ export async function registerAgentChannelRoutes(
         title: example.title,
         tarballUrl,
         ...(sha256 ? { sha256 } : {}),
-        unpack: kitUnpackCommand(tarballUrl),
+        unpack: exampleUnpackCommand(tarballUrl),
       });
     },
   );

--- a/apps/api/src/kit-registry.ts
+++ b/apps/api/src/kit-registry.ts
@@ -76,8 +76,12 @@ export function parseKitSidecar(raw: string): KitSidecar {
 /** Tarball member root from games-repo pack-kit (`KIT_NAME`). */
 export const KIT_ROOT_DIR = 'gamedevpl-creator-kit';
 
-/** Path relative to {@link KIT_ROOT_DIR} — read after the unpack one-liner cds there. */
-export const KIT_ENTRY = 'SKILL.md';
+/**
+ * Path to open after unpack, relative to the directory where the unpack one-liner ran.
+ * Not a post-`cd` basename: coding-agent shells often start each command in a fresh
+ * process, so a trailing `cd` does not persist for `cat SKILL.md` / `npm ci`.
+ */
+export const KIT_ENTRY = `${KIT_ROOT_DIR}/SKILL.md`;
 
 /** Shell-escape a URL for single-quoted use in an unpack one-liner. */
 function shellSingleQuote(url: string): string {
@@ -86,12 +90,13 @@ function shellSingleQuote(url: string): string {
 
 /**
  * One-liner an agent can shell after get_kit — URL is substituted by the route.
- * Tarball roots at {@link KIT_ROOT_DIR}/, so the command cds there for the next step
- * (`cat SKILL.md`, `npm ci`, …).
+ * Extracts into {@link KIT_ROOT_DIR}/ under the current working directory. Follow
+ * {@link KIT_ENTRY} from that same cwd; do not rely on the shell remaining inside
+ * the kit directory after this process exits.
  */
 export function kitUnpackCommand(kitUrl: string): string {
   // Single-quoted URL so shell metacharacters in the signed query string stay inert.
-  return `curl -fsSL '${shellSingleQuote(kitUrl)}' | tar -xz && cd ${KIT_ROOT_DIR}`;
+  return `curl -fsSL '${shellSingleQuote(kitUrl)}' | tar -xz`;
 }
 
 /**

--- a/apps/api/src/kit-registry.ts
+++ b/apps/api/src/kit-registry.ts
@@ -73,11 +73,30 @@ export function parseKitSidecar(raw: string): KitSidecar {
   };
 }
 
+/** Tarball member root from games-repo pack-kit (`KIT_NAME`). */
+export const KIT_ROOT_DIR = 'gamedevpl-creator-kit';
+
+/** Path relative to {@link KIT_ROOT_DIR} — read after the unpack one-liner cds there. */
 export const KIT_ENTRY = 'SKILL.md';
 
-/** One-liner an agent can shell after get_kit — URL is substituted by the route. */
+/** Shell-escape a URL for single-quoted use in an unpack one-liner. */
+function shellSingleQuote(url: string): string {
+  return url.replace(/'/g, `'\\''`);
+}
+
+/**
+ * One-liner an agent can shell after get_kit — URL is substituted by the route.
+ * Tarball roots at {@link KIT_ROOT_DIR}/, so the command cds there for the next step
+ * (`cat SKILL.md`, `npm ci`, …).
+ */
 export function kitUnpackCommand(kitUrl: string): string {
   // Single-quoted URL so shell metacharacters in the signed query string stay inert.
-  const safe = kitUrl.replace(/'/g, `'\\''`);
-  return `curl -fsSL '${safe}' | tar -xz`;
+  return `curl -fsSL '${shellSingleQuote(kitUrl)}' | tar -xz && cd ${KIT_ROOT_DIR}`;
+}
+
+/**
+ * Exemplar tarballs root at `games/<slug>/` (pack into a kit checkout). No post-unpack cd.
+ */
+export function exampleUnpackCommand(tarballUrl: string): string {
+  return `curl -fsSL '${shellSingleQuote(tarballUrl)}' | tar -xz`;
 }

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -214,10 +214,18 @@ describe('POST /api/mcp (BY-05)', () => {
         'ack_inbox',
       ]),
     );
-    const start = (listed.json().result.tools as Array<{ name: string; description: string }>).find(
-      (t) => t.name === 'start',
-    );
+    const tools = listed.json().result.tools as Array<{ name: string; description: string }>;
+    const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
+
+    const getKit = tools.find((t) => t.name === 'get_kit');
+    expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
+    expect(getKit?.description).toMatch(/entry=SKILL\.md/);
+
+    const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
+    expect(gateVerdict?.description).toMatch(/2–5 minutes/);
+    expect(gateVerdict?.description).toMatch(/~30s/);
+    expect(gateVerdict?.description).toMatch(/terminal receipt/i);
   });
 
   it('start issues a sessionKey; subsequent tools work with it', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -220,11 +220,14 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const getKit = tools.find((t) => t.name === 'get_kit');
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
-    expect(getKit?.description).toMatch(/entry=SKILL\.md/);
+    expect(getKit?.description).toMatch(/entry=gamedevpl-creator-kit\/SKILL\.md/);
+    expect(getKit?.description).toMatch(/do not assume a `cd` persists/i);
 
     const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
     expect(gateVerdict?.description).toMatch(/2–5 minutes/);
     expect(gateVerdict?.description).toMatch(/~30s/);
+    expect(gateVerdict?.description).toMatch(/kit_outdated/);
+    expect(gateVerdict?.description).toMatch(/re-run get_kit/);
     expect(gateVerdict?.description).toMatch(/terminal receipt/i);
   });
 

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -501,9 +501,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_kit: {
       description:
-        'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner ' +
-        '(ends in gamedevpl-creator-kit/), entry=SKILL.md (relative to that directory). ' +
-        'Unpack and follow SKILL.md. Run kit checks green before submit_sources. ' +
+        'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner, ' +
+        'entry=gamedevpl-creator-kit/SKILL.md (path from the unpack working directory — ' +
+        'tarball roots at gamedevpl-creator-kit/; do not assume a `cd` persists across tool calls). ' +
+        'Unpack, open entry, follow SKILL.md. Run kit checks green before submit_sources. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -854,7 +855,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     get_gate_verdict: {
       description:
         'Poll the gate verdict for a delivery (default: latest). Verdicts typically land in 2–5 minutes; ' +
-        'poll every ~30s until green or red. Terminal receipt: still readable after the round closes ' +
+        'poll every ~30s until green, red, or kit_outdated. kit_outdated is terminal — stop polling, ' +
+        're-run get_kit, rebuild against the new kit, and deliver again (do not wait for green/red). ' +
+        'Terminal receipt: still readable after the round closes ' +
         "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
         'so the verdict stays readable if the round closes between polls. ' +
         'Expiry still applies. Wait for green before considering the round done. ' +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -501,7 +501,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_kit: {
       description:
-        'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner, entry=SKILL.md. ' +
+        'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner ' +
+        '(ends in gamedevpl-creator-kit/), entry=SKILL.md (relative to that directory). ' +
         'Unpack and follow SKILL.md. Run kit checks green before submit_sources. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -852,8 +853,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_gate_verdict: {
       description:
-        'Poll the gate verdict for a delivery (default: latest). Terminal receipt: still readable after the round closes ' +
-        "when your capability's generation owns that delivery (generation may be exactly one behind current). " +
+        'Poll the gate verdict for a delivery (default: latest). Verdicts typically land in 2–5 minutes; ' +
+        'poll every ~30s until green or red. Terminal receipt: still readable after the round closes ' +
+        "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
+        'so the verdict stays readable if the round closes between polls. ' +
         'Expiry still applies. Wait for green before considering the round done. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small MCP onboarding fixes from the first real external-agent run (CP-2). Description/snippet text only — no tool contract, auth, or UI changes.

## Changes

1. **`get_kit` unpack / entry** — tarball roots at `gamedevpl-creator-kit/`. Unpack is `curl … | tar -xz` (no `cd`); `entry` is `gamedevpl-creator-kit/SKILL.md` from the unpack working directory so fresh-process agent shells still find SKILL.md (Codex P1).
2. **`get_gate_verdict` description** — verdicts typically land in 2–5 minutes; poll every ~30s until **green, red, or `kit_outdated`**. `kit_outdated` is terminal: stop polling, re-run `get_kit`, rebuild, redeliver. Terminal receipt keeps the verdict readable if the round closes between polls.

## Tests

Snippet / description tests updated. `mcp-server.test.ts` + `agent-build-reads.test.ts` green locally.

## Protocol

Draft for owner review before merge. Can land in parallel with BY-14a; after BY-14c for M1-exit ordering preference.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

