### PR TITLE
Plan richer how-to-play and style Goal/Scoring meta rows

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -158,7 +158,10 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
   published plays (`reportSlug`, same population as `play_started`), and
   `summarizeVisitFunnel` exposes `howToPlay` (opens/visits among playing visits, same-
   card repeat visits, via, byEntry with `playingVisits` denominators). Rendered on
-  `VisitFunnelPanel`. The product decision in #395 still waits on those numbers.
+  `VisitFunnelPanel`. The product decision in #395 is to ship the richer How to play
+  tone (Goal required; Scoring / Mode optional) via game `.legend-keys` — see
+  [`docs/how-to-play-plan.md`](../../../docs/how-to-play-plan.md). Funnel numbers still
+  inform discoverability; they no longer gate whether to ship the format.
 - ~~Creator return is under-measured~~ — **closed 2026-07-26**: `User.activeDays` (a
   capped list of `yyyy-mm-dd`, touched once per account per day from the auth hook)
   plus `summarizeCreatorMetrics` behind `GET /api/admin/telemetry/creators`. Use a list

--- a/apps/web/src/HowToPlayPanel.tsx
+++ b/apps/web/src/HowToPlayPanel.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { CatalogTouch } from './catalog.js';
 import { PixelIcon } from './PixelIcon.js';
-import type { ControlRow } from './howToPlay.js';
+import { isMetaControlRow, type ControlRow } from './howToPlay.js';
 
 type HowToPlayPanelProps = {
   open: boolean;
@@ -138,7 +138,10 @@ export function HowToPlayPanel({
           {rows.map((row, index) => (
             // Keyed by index on purpose: a controls string may repeat a clause, and two
             // long clauses can truncate to the same text, so the row text is not unique.
-            <div className={row.keys ? 'howto-row' : 'howto-row is-wide'} key={index}>
+            <div
+              className={!row.keys ? 'howto-row is-wide' : isMetaControlRow(row) ? 'howto-row is-meta' : 'howto-row'}
+              key={index}
+            >
               {/* A clause with no key/action shape still gets a term, hidden visually but
                   read aloud: a `dl` group that is a definition with nothing being defined
                   is invalid, and a screen reader announces it orphaned. */}

--- a/apps/web/src/howToPlay.test.ts
+++ b/apps/web/src/howToPlay.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { parseControls, readReportedControls, resolveControlRows } from './howToPlay.js';
+import { isMetaControlRow, parseControls, readReportedControls, resolveControlRows } from './howToPlay.js';
+
+describe('isMetaControlRow', () => {
+  it('recognizes reserved Goal / Scoring / Mode labels in EN and PL', () => {
+    expect(isMetaControlRow({ keys: 'Goal', action: 'Survive' })).toBe(true);
+    expect(isMetaControlRow({ keys: 'Cel', action: 'Przetrwaj' })).toBe(true);
+    expect(isMetaControlRow({ keys: 'Scoring', action: 'Points' })).toBe(true);
+    expect(isMetaControlRow({ keys: 'Punkty', action: 'Punkty' })).toBe(true);
+    expect(isMetaControlRow({ keys: 'Mode: Race', action: 'Lap' })).toBe(true);
+    expect(isMetaControlRow({ keys: 'Tryb: Wyścig', action: 'Okrążenie' })).toBe(true);
+    expect(isMetaControlRow({ keys: '← →', action: 'Move' })).toBe(false);
+    expect(isMetaControlRow({ keys: 'M', action: 'Mute' })).toBe(false);
+  });
+});
 
 describe('parseControls', () => {
   it('splits on the semicolon when there is one, keeping commas inside a clause', () => {

--- a/apps/web/src/howToPlay.ts
+++ b/apps/web/src/howToPlay.ts
@@ -35,6 +35,20 @@ export interface ControlRow {
   action: string;
 }
 
+/**
+ * Reserved legend labels (EN + PL) that are not keys — Goal, Scoring, Mode:….
+ *
+ * Matched on the already-localized `keys` string the bridge scraped, so either locale
+ * still gets the meta treatment on the host card. Keep in sync with the games-repo
+ * convention in docs/how-to-play-plan.md.
+ */
+const META_LABEL = /^(goal|cel|scoring|punkty|mode\s*:|tryb\s*:)/i;
+
+/** True when a row's term is a reserved how-to-play label, not a keycap. */
+export function isMetaControlRow(row: ControlRow): boolean {
+  return META_LABEL.test(row.keys.trim());
+}
+
 const SEPARATORS = [' to ', ' for '];
 
 function splitClause(clause: string): ControlRow {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3698,6 +3698,20 @@ body.player-open {
   text-transform: uppercase;
 }
 
+/* Goal / Scoring / Mode rows — reserved legend labels, not keycaps. */
+.howto-row.is-meta dt {
+  color: var(--turquoise);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+
+.howto-row.is-meta dd {
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
 /* A clause with no "X to Y" shape keeps its own line rather than being guessed apart. */
 .howto-row.is-wide dt {
   position: absolute;

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ survives only in this repo's early history.
 | [`notifications-plan.md`](./notifications-plan.md)                 | Notify creators/players of transitions: detection sweep, per-user storage, in-app → email → push       |
 | [`creator-qa-plan.md`](./creator-qa-plan.md)                       | Clarifying-questions pass before spec freeze — raises the hit rate of the one-shot agent run           |
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions              |
+| [`how-to-play-plan.md`](./how-to-play-plan.md)                     | Richer How to play (Goal / Scoring in `.legend-keys`) — decision, schema, phased catalog seal          |
 | [`path-routing-plan.md`](./path-routing-plan.md)                   | ✅ Path URLs for deep links (`/play/<slug>`, …) — History API, no hashbang                             |
 | [`recommendations.md`](./recommendations.md)                       | ✅ Home arcade sort from scorecards + signed-in play affinity                                          |
 | [`runbooks/`](./runbooks/README.md)                                | ✅ Incident procedures: site-down triage, deploy rollback, Firestore restore, secret rotation          |

--- a/docs/how-to-play-plan.md
+++ b/docs/how-to-play-plan.md
@@ -1,0 +1,56 @@
+# Richer how-to-play — plan
+
+> Decision: prefer a richer card tone (goal, optional scoring / per-mode) over a flat
+> key→action list alone. Tracked as [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395);
+> Visit funnel numbers from [#402](https://github.com/gamedevpl/www.gamedev.pl/pull/402) still
+> inform discoverability and whether the card is answering people, but they no longer
+> gate _whether_ to ship the richer format.
+
+## Shape (games own the prose)
+
+Richer content lives in the game's `.legend-keys` markup — already scraped by the player
+bridge, already localized, **zero GameKit bytes**. Do not put goal/scoring into
+`controlsManifest()` (input facts only; kit budget is tight).
+
+Reserved `dt` labels (English canonical + Polish twin):
+
+| Role    | `data-i18n-en` | `data-i18n-pl` | Required?                              |
+| ------- | -------------- | -------------- | -------------------------------------- |
+| Goal    | `Goal`         | `Cel`          | **Yes** once a game has `.legend-keys` |
+| Scoring | `Scoring`      | `Punkty`       | Optional                               |
+| Mode    | `Mode: …`      | `Tryb: …`      | Optional, repeatable                   |
+
+Key rows stay as today (`← → / A D` → Move). SPEC `controls:` remains the short English
+catalog / LLM string — keep it in sync with the legend, do not replace it with nested YAML
+(frontmatter is flat).
+
+## Host
+
+The theater card already renders every legend `dt`/`dd` as a `ControlRow`. Reserved labels
+get a distinct visual treatment (`howto-row is-meta`) so Goal / Scoring read as tone, not
+as fake keys. No slug on `how_to_play_opened`; streams stay unjoinable.
+
+## Rollout
+
+| Phase              | What                                                                                                                              | Seal                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **0 — Convention** | This doc; skill + copilot rule in games repo                                                                                      | Agents know the shape                    |
+| **1 — Soft seal**  | Validate Check 31: _if_ `.legend-keys` exists, Goal + i18n required                                                               | Pilots cannot ship a legend without Goal |
+| **2 — Templates**  | Land / extend [games#172](https://github.com/gamedevpl/www.gamedev.pl-games/pull/172) so `npm run create` scaffolds legend + Goal | New catalog games start rich             |
+| **3 — Catalog**    | Agent batch: add `.legend-keys` + Goal (+ Scoring where natural) to existing games                                                | Coverage grows                           |
+| **4 — Hard seal**  | Check 31 requires `.legend-keys` (and thus Goal) on every published game                                                          | Missing how-to-play fails the gate       |
+| **5 — Creator**    | `packages/game-generator` templates + any studio copy path emit the same markup                                                   | Creator games match catalog              |
+
+Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fails CI for
+~90 games at once.
+
+## Out of scope
+
+- Nested SPEC frontmatter for goal/scoring
+- Kit protocol changes for prose
+- Per-game open-rate joins (privacy)
+
+## Done when
+
+Every published game has a localized Goal in `.legend-keys`, templates and the creator
+generator emit it by default, and Check 31 fails a game that ships without it.

--- a/docs/how-to-play-plan.md
+++ b/docs/how-to-play-plan.md
@@ -35,10 +35,10 @@ as fake keys. No slug on `how_to_play_opened`; streams stay unjoinable.
 | Phase              | What                                                                                                                              | Seal                                     |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | **0 — Convention** | This doc; skill + copilot rule in games repo                                                                                      | Agents know the shape                    |
-| **1 — Soft seal**  | Validate Check 31: _if_ `.legend-keys` exists, Goal + i18n required                                                               | Pilots cannot ship a legend without Goal |
+| **1 — Soft seal**  | Validate Check 32: _if_ `.legend-keys` exists, Goal + i18n required                                                               | Pilots cannot ship a legend without Goal |
 | **2 — Templates**  | Land / extend [games#172](https://github.com/gamedevpl/www.gamedev.pl-games/pull/172) so `npm run create` scaffolds legend + Goal | New catalog games start rich             |
 | **3 — Catalog**    | Agent batch: add `.legend-keys` + Goal (+ Scoring where natural) to existing games                                                | Coverage grows                           |
-| **4 — Hard seal**  | Check 31 requires `.legend-keys` (and thus Goal) on every published game                                                          | Missing how-to-play fails the gate       |
+| **4 — Hard seal**  | Check 32 requires `.legend-keys` (and thus Goal) on every published game                                                          | Missing how-to-play fails the gate       |
 | **5 — Creator**    | `packages/game-generator` templates + any studio copy path emit the same markup                                                   | Creator games match catalog              |
 
 Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fails CI for
@@ -53,4 +53,4 @@ Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fa
 ## Done when
 
 Every published game has a localized Goal in `.legend-keys`, templates and the creator
-generator emit it by default, and Check 31 fails a game that ships without it.
+generator emit it by default, and Check 32 fails a game that ships without it.

--- a/docs/how-to-play-plan.md
+++ b/docs/how-to-play-plan.md
@@ -20,9 +20,9 @@ Reserved `dt` labels (English canonical + Polish twin):
 | Scoring | `Scoring`      | `Punkty`       | Optional                               |
 | Mode    | `Mode: …`      | `Tryb: …`      | Optional, repeatable                   |
 
-Key rows stay as today (`← → / A D` → Move). SPEC `controls:` remains the short English
-catalog / LLM string — keep it in sync with the legend, do not replace it with nested YAML
-(frontmatter is flat).
+Key rows stay as today (`← →` → Move — only keys the game actually binds). SPEC `controls:`
+remains the short English catalog / LLM string — keep it in sync with the legend, do not
+replace it with nested YAML (frontmatter is flat).
 
 ## Host
 
@@ -32,14 +32,14 @@ as fake keys. No slug on `how_to_play_opened`; streams stay unjoinable.
 
 ## Rollout
 
-| Phase              | What                                                                                                                              | Seal                                     |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| **0 — Convention** | This doc; skill + copilot rule in games repo                                                                                      | Agents know the shape                    |
-| **1 — Soft seal**  | Validate Check 32: _if_ `.legend-keys` exists, Goal + i18n required                                                               | Pilots cannot ship a legend without Goal |
-| **2 — Templates**  | Land / extend [games#172](https://github.com/gamedevpl/www.gamedev.pl-games/pull/172) so `npm run create` scaffolds legend + Goal | New catalog games start rich             |
-| **3 — Catalog**    | Agent batch: add `.legend-keys` + Goal (+ Scoring where natural) to existing games                                                | Coverage grows                           |
-| **4 — Hard seal**  | Check 32 requires `.legend-keys` (and thus Goal) on every published game                                                          | Missing how-to-play fails the gate       |
-| **5 — Creator**    | `packages/game-generator` templates + any studio copy path emit the same markup                                                   | Creator games match catalog              |
+| Phase                | What                                                                                                                                                                                                                                                                                 | Seal                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| **0 — Convention**   | This doc; skill + copilot rule in games repo                                                                                                                                                                                                                                         | Agents know the shape                    |
+| **1 — Soft seal**    | Validate Check 32: _if_ `.legend-keys` exists, Goal + i18n required                                                                                                                                                                                                                  | Pilots cannot ship a legend without Goal |
+| **2 — Templates**    | Land / extend [games#172](https://github.com/gamedevpl/www.gamedev.pl-games/pull/172) so `npm run create` scaffolds legend + Goal                                                                                                                                                    | New catalog games start rich             |
+| **3 — Catalog**      | Agent batch: add `.legend-keys` + Goal (+ Scoring where natural) to existing games                                                                                                                                                                                                   | Coverage grows                           |
+| **4 — Hard seal**    | Check 32 requires `.legend-keys` (and thus Goal) on every published game                                                                                                                                                                                                             | Missing how-to-play fails the gate       |
+| **5 — Creator path** | Keep games-repo `npm run create` / pack-kit templates and the agent contract (skills, game-builder) emitting `.legend-keys` + Goal — that is the production path for creator specs. Do **not** treat public-repo `packages/game-generator` (mock / local preview only) as this seal. | Creator deliveries match catalog         |
 
 Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fails CI for
 ~90 games at once.
@@ -49,8 +49,9 @@ Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fa
 - Nested SPEC frontmatter for goal/scoring
 - Kit protocol changes for prose
 - Per-game open-rate joins (privacy)
+- Wiring Goal into `packages/game-generator` mock templates (dev preview only; not production)
 
 ## Done when
 
-Every published game has a localized Goal in `.legend-keys`, templates and the creator
-generator emit it by default, and Check 32 fails a game that ships without it.
+Every published game has a localized Goal in `.legend-keys`, games-repo create / pack-kit /
+agent scaffolds emit it by default, and Check 32 fails a game that ships without it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records the product decision from [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395): ship a richer How to play tone (Goal required; Scoring / Mode optional) via each game's `.legend-keys` markup — not a new SPEC field and not GameKit prose.

Rebased onto latest `master`. Soft-seal check number in the plan is **Check 32** (games-repo Check 31 is the editor contract).

## This PR

- `docs/how-to-play-plan.md` — schema, host/kit boundaries, phased rollout (soft seal → templates → catalog → hard seal → creator path)
- Host card: reserved legend labels (`Goal`/`Cel`, `Scoring`/`Punkty`, `Mode:`/`Tryb:`) get `howto-row is-meta` styling so they read as tone, not fake keys
- Instrumentation playbook updated: #395 no longer waits on funnel numbers; funnel still informs discoverability
- Phase 5 targets games-repo create / pack-kit / agent contract (not mock `packages/game-generator`)

## Companion PRs

- games-repo: Check 32 soft seal + `dodge-the-falling-rocks` pilot
- ops: Q9 resolved

Visit funnel `howToPlay` metrics from #402 still inform discoverability; they no longer gate *whether* to do this.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6c8a180-8993-4412-bff7-f0f7762545eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6c8a180-8993-4412-bff7-f0f7762545eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

