### PR TITLE
fix(api): admit store-published slugs in votes/telemetry/recommendations

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -51,7 +51,7 @@ import { registerTelemetryRoutes, type TelemetryRoutesOptions } from './telemetr
 import { registerVisitTelemetryRoutes } from './visit-telemetry.js';
 import { registerVoteRoutes, type VoteRoutesOptions } from './votes.js';
 import { registerRecommendationRoutes, type RecommendationRoutesOptions } from './recommendations.js';
-import { createPublishedSlugGateFromEnv } from './published-slugs.js';
+import { createCombinedPublishedSlugGate, createPublishedSlugGateFromEnv } from './published-slugs.js';
 import { createCatalogGenreSourceFromEnv } from './catalog-genre-source.js';
 import { peekQuota } from './quota-gate.js';
 import { registerRateLimit } from './rate-limit.js';
@@ -275,9 +275,14 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // request.user and records nothing that identifies a player.
   //
   // One env-derived gate is shared by telemetry, votes, and written feedback: all
-  // three ask the same question ("is this a published catalog slug?") and must not
-  // drift. Call-site overrides still win via the spreads below.
-  const envPublishedSlugs = await createPublishedSlugGateFromEnv();
+  // three ask the same question ("is this a published slug?") and must not drift.
+  // The combined gate OR's the games-repo catalog with store publications so
+  // self-build games (never in catalog.json) are visible to the same callers the
+  // /play route already serves. Call-site overrides still win via the spreads below.
+  const envPublishedSlugs = createCombinedPublishedSlugGate({
+    repoGate: await createPublishedSlugGateFromEnv(),
+    store,
+  });
   await registerTelemetryRoutes(app, {
     store,
     publishedSlugs: envPublishedSlugs,

--- a/apps/api/src/published-slugs.test.ts
+++ b/apps/api/src/published-slugs.test.ts
@@ -159,4 +159,17 @@ describe('createCombinedPublishedSlugGate', () => {
     expect(await gate.isPublished('self-build')).toBe(true);
     expect(await gate.isPublished('stranger')).toBe(false);
   });
+
+  it('fails closed when the store read throws', async () => {
+    const gate = createCombinedPublishedSlugGate({
+      repoGate: null,
+      store: {
+        getPublication: async () => {
+          throw new Error('firestore unavailable');
+        },
+      },
+    });
+
+    expect(await gate.isPublished('anything')).toBe(false);
+  });
 });

--- a/apps/api/src/published-slugs.test.ts
+++ b/apps/api/src/published-slugs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { createPublishedSlugGate } from './published-slugs.js';
+import { createCombinedPublishedSlugGate, createPublishedSlugGate } from './published-slugs.js';
+import { InMemoryStore } from './store.js';
 
 type Entry = { slug: string; status: string };
 
@@ -89,5 +90,73 @@ describe('createPublishedSlugGate', () => {
 
     // No cache to fall back on: dropping data beats letting any string become a key.
     expect(await gate.isPublished('arena-tag')).toBe(false);
+  });
+});
+
+describe('createCombinedPublishedSlugGate', () => {
+  async function storeWithPublication(
+    slug: string,
+    state: 'published' | 'archived' | 'disabled',
+  ): Promise<InMemoryStore> {
+    const store = new InMemoryStore();
+    await store.setPublication({
+      slug,
+      state,
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    return store;
+  }
+
+  it('admits a repo-catalog slug unchanged', async () => {
+    const fake = fakeClient([{ slug: 'arena-tag', status: 'published' }]);
+    const gate = createCombinedPublishedSlugGate({
+      repoGate: createPublishedSlugGate({ client: fake.client }),
+      store: new InMemoryStore(),
+    });
+
+    expect(await gate.isPublished('arena-tag')).toBe(true);
+  });
+
+  it('admits a store-published slug with no repo-catalog entry', async () => {
+    const fake = fakeClient([]);
+    const store = await storeWithPublication('miniature-warfare-2d', 'published');
+    const gate = createCombinedPublishedSlugGate({
+      repoGate: createPublishedSlugGate({ client: fake.client }),
+      store,
+    });
+
+    expect(await gate.isPublished('miniature-warfare-2d')).toBe(true);
+  });
+
+  it('refuses a slug that is neither in the catalog nor store-published', async () => {
+    const fake = fakeClient([{ slug: 'arena-tag', status: 'draft' }]);
+    const gate = createCombinedPublishedSlugGate({
+      repoGate: createPublishedSlugGate({ client: fake.client }),
+      store: new InMemoryStore(),
+    });
+
+    expect(await gate.isPublished('arena-tag')).toBe(false);
+    expect(await gate.isPublished('never-existed')).toBe(false);
+  });
+
+  it('refuses a store publication whose state is not published', async () => {
+    const fake = fakeClient([]);
+    for (const state of ['archived', 'disabled'] as const) {
+      const store = await storeWithPublication('retired-game', state);
+      const gate = createCombinedPublishedSlugGate({
+        repoGate: createPublishedSlugGate({ client: fake.client }),
+        store,
+      });
+      expect(await gate.isPublished('retired-game')).toBe(false);
+    }
+  });
+
+  it('still admits store-published slugs when the repo gate is absent', async () => {
+    const store = await storeWithPublication('self-build', 'published');
+    const gate = createCombinedPublishedSlugGate({ repoGate: null, store });
+
+    expect(await gate.isPublished('self-build')).toBe(true);
+    expect(await gate.isPublished('stranger')).toBe(false);
   });
 });

--- a/apps/api/src/published-slugs.ts
+++ b/apps/api/src/published-slugs.ts
@@ -83,9 +83,11 @@ export function createPublishedSlugGate(options: PublishedSlugGateOptions): Publ
 }
 
 /**
- * Builds the gate from the environment, or returns null when the games repo is not
- * configured (secret-less deploys run browse/play-only). A null gate means telemetry
- * accepts and drops, exactly as it does for an unknown slug.
+ * Builds the repo-catalog gate from the environment, or returns null when the games
+ * repo is not configured (secret-less deploys run browse/play-only). A null result
+ * means there is no catalog view — not "drop every slug". Callers that need the full
+ * published set should wrap this with `createCombinedPublishedSlugGate`, which still
+ * admits store-published self-build games when the catalog gate is absent.
  *
  * In local development (no token, not production/test) the gate reads the same
  * fixture/checkout catalog the browse surface serves — otherwise every vote and
@@ -133,8 +135,14 @@ export function createCombinedPublishedSlugGate(options: CombinedPublishedSlugGa
   return {
     async isPublished(slug: string): Promise<boolean> {
       if (repoGate && (await repoGate.isPublished(slug))) return true;
-      const publication = await store.getPublication(slug);
-      return publication?.state === 'published';
+      try {
+        const publication = await store.getPublication(slug);
+        return publication?.state === 'published';
+      } catch {
+        // A transient store failure must not turn into a rejected play session or a
+        // 500 on vote/telemetry. Fail closed: dropping a signal beats inventing one.
+        return false;
+      }
     },
   };
 }

--- a/apps/api/src/published-slugs.ts
+++ b/apps/api/src/published-slugs.ts
@@ -1,4 +1,5 @@
 import { createGitHubClient, type GitHubClient } from './github-client.js';
+import type { Store } from './store.js';
 
 /**
  * "Is this slug a published game?" — the gate on telemetry intake.
@@ -10,10 +11,15 @@ import { createGitHubClient, type GitHubClient } from './github-client.js';
  * at all — they predate the submission flow or were seeded. `publishedAt` marks
  * "this creator's build was merged and they were told", not "this game is playable".
  *
- * Catalog membership is the honest question, and it also does the job the old gate
- * was reaching for: a creator playtesting an unmerged draft is playing a branch
- * preview, which is not in the published catalog, so draft traffic still stays out
- * of the funnel — this time for a reason that holds.
+ * Catalog membership is the honest question for repo-published games, and it also
+ * does the job the old gate was reaching for: a creator playtesting an unmerged
+ * draft is playing a branch preview, which is not in the published catalog, so
+ * draft traffic still stays out of the funnel — this time for a reason that holds.
+ *
+ * Self-build games never enter that catalog: they land in the games-store bucket
+ * and are recorded via `store.getPublication(slug)`. `createCombinedPublishedSlugGate`
+ * OR's that path with the repo-catalog gate so votes, telemetry, and recommendations
+ * see the same published set the `/play` route already does.
  *
  * Cached with a generous TTL because building the catalog fans out into a dozen-plus
  * contents-API calls, and that fan-out has already caused one rate-limit outage
@@ -85,9 +91,7 @@ export function createPublishedSlugGate(options: PublishedSlugGateOptions): Publ
  * fixture/checkout catalog the browse surface serves — otherwise every vote and
  * play-telemetry flush would 404 against fixture slugs that are clearly published.
  */
-export async function createPublishedSlugGateFromEnv(
-  fetchImpl?: typeof fetch,
-): Promise<PublishedSlugGate | null> {
+export async function createPublishedSlugGateFromEnv(fetchImpl?: typeof fetch): Promise<PublishedSlugGate | null> {
   const token = process.env.GITHUB_TOKEN?.trim();
   const repo = process.env.GAMES_REPO?.trim();
   if (token && repo) {
@@ -102,4 +106,35 @@ export async function createPublishedSlugGateFromEnv(
   }
 
   return null;
+}
+
+export interface CombinedPublishedSlugGateOptions {
+  /** Repo-catalog gate; null/undefined when the games repo is not configured. */
+  repoGate?: PublishedSlugGate | null;
+  /** Publication registry — the authority for self-build (store-published) games. */
+  store: Pick<Store, 'getPublication'>;
+}
+
+/**
+ * OR of the repo-catalog gate and the store publication registry.
+ *
+ * Self-build games never appear in `catalog.json`; they are published via
+ * `store.setPublication({ state: 'published', ... })`. The `/play` route already
+ * checks that path first (`storePublishedGame` in submissions.ts). Votes, telemetry,
+ * and recommendations share one `PublishedSlugGate` built in app.ts — wrapping that
+ * single construction site here keeps those callers from drifting apart again.
+ *
+ * Cheap by construction: one `getPublication` read per miss on the repo gate, the
+ * same cost `/play` already pays. The repo gate keeps its own TTL cache untouched.
+ */
+export function createCombinedPublishedSlugGate(options: CombinedPublishedSlugGateOptions): PublishedSlugGate {
+  const { repoGate, store } = options;
+
+  return {
+    async isPublished(slug: string): Promise<boolean> {
+      if (repoGate && (await repoGate.isPublished(slug))) return true;
+      const publication = await store.getPublication(slug);
+      return publication?.state === 'published';
+    },
+  };
 }

--- a/apps/api/src/recommendations.test.ts
+++ b/apps/api/src/recommendations.test.ts
@@ -113,6 +113,26 @@ describe('recommendation routes', () => {
     await server.close();
   });
 
+  it('records play for a store-published slug with no repo-catalog entry', async () => {
+    // No publishedSlugs override: exercises the combined gate wired in app.ts.
+    await store.setPublication({
+      slug: 'miniature-warfare-2d',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const server = await buildApp({ store, sessionSecret });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/games/miniature-warfare-2d/played',
+      headers: authHeaders('g:alice'),
+    });
+    expect(res.statusCode).toBe(204);
+    expect((await store.listPlayAffinity('g:alice'))[0]?.slug).toBe('miniature-warfare-2d');
+    await server.close();
+  });
+
   it('returns community recommendations without a session', async () => {
     await store.putScorecard(
       'arcade-hit',

--- a/apps/api/src/telemetry.test.ts
+++ b/apps/api/src/telemetry.test.ts
@@ -125,6 +125,27 @@ describe('POST /api/telemetry', () => {
     await app.close();
   });
 
+  it('records events for a store-published slug with no repo-catalog entry', async () => {
+    // No telemetryRoutes.publishedSlugs override: exercises the combined gate in app.ts.
+    await store.setPublication({
+      slug: 'miniature-warfare-2d',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const app = await buildApp({ store, sessionSecret });
+
+    const res = await post(app, {
+      slug: 'miniature-warfare-2d',
+      sessionId,
+      events: [{ type: 'game_opened' }],
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json()).toEqual({ accepted: 1 });
+    expect(await store.listTelemetryEvents(today(), { slug: 'miniature-warfare-2d' })).toHaveLength(1);
+    await app.close();
+  });
+
   it('drops everything when no games repo is configured, rather than trusting the slug', async () => {
     const app = await buildApp({ store, sessionSecret, telemetryRoutes: { publishedSlugs: null } });
     const res = await post(app, { slug: 'space-hop', sessionId, events: [{ type: 'game_opened' }] });

--- a/apps/api/src/votes.test.ts
+++ b/apps/api/src/votes.test.ts
@@ -231,6 +231,32 @@ describe('vote routes', () => {
     expect(res.statusCode).toBe(404);
     await app.close();
   });
+
+  it('admits a store-published slug with no repo-catalog entry', async () => {
+    // No voteRoutes.publishedSlugs override: exercises the combined gate wired in app.ts
+    // (repo catalog is null under NODE_ENV=test; store publication must open the gate).
+    await store.setPublication({
+      slug: 'miniature-warfare-2d',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const app = await buildApp({ store, sessionSecret });
+
+    const get = await app.inject({ method: 'GET', url: '/api/games/miniature-warfare-2d/votes' });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toEqual({ up: 0, down: 0, mine: null });
+
+    const post = await app.inject({
+      method: 'POST',
+      url: '/api/games/miniature-warfare-2d/vote',
+      headers: authHeaders('g:alice'),
+      payload: { value: 'up' },
+    });
+    expect(post.statusCode).toBe(200);
+    expect(post.json()).toEqual({ up: 1, down: 0, mine: 'up' });
+    await app.close();
+  });
 });
 
 describe('InMemoryStore votes', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Self-build published games (e.g. `miniature-warfare-2d`) play fine at `/play/:slug`, but `GET /api/games/:slug/votes`, `POST /api/games/:slug/vote`, play telemetry intake, and `POST /api/games/:slug/played` all treated them as unpublished.

Root cause: the shared `PublishedSlugGate` was built only from the games-repo `catalog.json`. Self-build games never enter that catalog — they are published via `store.setPublication({ state: 'published' })`. The `/play` route already checks the store first (`storePublishedGame`); votes/telemetry/recommendations did not.

## Fix

- Add `createCombinedPublishedSlugGate({ repoGate, store })` whose `isPublished` is true if the existing repo-catalog gate says yes **or** `store.getPublication(slug)?.state === 'published'`.
- Wire it once at the `envPublishedSlugs` construction site in `app.ts`, so votes, telemetry, recommendations, and the other shared consumers pick it up without per-route patches.
- Repo-catalog TTL cache is untouched; store path is one `getPublication` read per miss (same cost `/play` already pays).
- Store read failures fail closed (`false`), matching the repo gate's posture — a transient Firestore error must not 500 vote/telemetry.
- Docstring for `createPublishedSlugGateFromEnv` updated: null means "no catalog view", not "drop everything" (combined gate still admits store publications).

## Tests

- Unit: repo-catalog slug still admitted; store-published-only admitted; unknown/draft refused; `archived`/`disabled` publication refused; works with null repo gate; fails closed when store throws.
- Route-level (via default app.ts wiring, no override): GET/POST votes, telemetry intake, and POST `/played` succeed for a store-published slug.
- Full `apps/api` suite: 1709 passed (plus the new fail-closed unit test).

Out of scope: `/play` path, repo-catalog gate internals, vote UI, new telemetry fields.

## Copilot review

Addressed both inline comments (docstring + fail-closed on store errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f65456c-60ad-4cf0-a15b-4e73ba0c5b9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f65456c-60ad-4cf0-a15b-4e73ba0c5b9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

