### PR TITLE
feat: Waitlist tab in the operator console

### DIFF
--- a/.claude/skills/managing-beta-participants/SKILL.md
+++ b/.claude/skills/managing-beta-participants/SKILL.md
@@ -50,9 +50,23 @@ accounts sign in, which they cannot.
 
 ## Approving or Managing Participants
 
-### 1. Using the NPM Command (Recommended)
+### 1. Using the Operator Console (Recommended)
 
-Approve access dynamically in Firestore using the helper script in `apps/api`:
+Signed-in operators (`ADMIN_UIDS`) open **`/admin/waitlist`** — a tab on the
+operator console. From there you can:
+
+- list applicants (filter pending / approved / rejected / all);
+- approve, reject, or reset an existing row;
+- pre-approve by email before the person has visited (creates
+  `waitlist/email:<lower>` the same way the CLI does).
+
+Join notifications deep-link here. The same writes go through
+`GET|POST /api/admin/waitlist` (session-only admin, 404 to everyone else).
+
+### 2. Using the NPM Command (scripts / agents)
+
+Approve access dynamically in Firestore using the helper script in `apps/api`
+when you are not at a browser:
 
 ```bash
 # From repository root

--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -564,6 +564,7 @@ describe('GET /api/admin/summary', () => {
       by: 'gate',
       reason: 'gate_green',
     });
+    await store.upsertWaitlistEntry({ uid: 'g:waiter', email: 'waiter@example.com' });
     const app = await appWith(store);
 
     const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:boss') });
@@ -574,6 +575,7 @@ describe('GET /api/admin/summary', () => {
     expect(body.alerts[0]).toMatchObject({ kind: 'review_ready', issueNumber: 1_000_001, title: 'Comet Courier' });
     expect(body.queue).toMatchObject({ active: 1, stalled: 0, byState: { ready_for_review: 1 } });
     expect(body.limits.paused).toBe(false);
+    expect(body.waitlist.pending).toBe(1);
   });
 
   it('reports the breaker an operator just pulled', async () => {
@@ -590,6 +592,103 @@ describe('GET /api/admin/summary', () => {
     const res = await app.inject({ method: 'GET', url: '/api/admin/summary', headers: authHeaders('g:boss') });
 
     expect((res.json() as AdminSummaryResponse).limits.paused).toBe(true);
+  });
+});
+
+describe('/api/admin/waitlist', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:player' });
+  });
+
+  it('lists pending applicants for an operator', async () => {
+    await store.upsertWaitlistEntry({ uid: 'g:waiter', email: 'waiter@example.com', name: 'Waiter' });
+    await store.upsertWaitlistEntry({ uid: 'g:in', email: 'in@example.com' });
+    await store.setWaitlistStatus('g:in', 'approved');
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/waitlist?status=pending',
+      headers: authHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      entries: [expect.objectContaining({ uid: 'g:waiter', email: 'waiter@example.com', status: 'pending' })],
+    });
+    await app.close();
+  });
+
+  it('approves an existing applicant by uid', async () => {
+    await store.upsertWaitlistEntry({ uid: 'g:waiter', email: 'waiter@example.com' });
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/waitlist/g%3Awaiter',
+      headers: authHeaders('g:boss'),
+      payload: { status: 'approved' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ uid: 'g:waiter', status: 'approved' });
+    expect(await store.isWaitlistApproved('g:waiter')).toBe(true);
+    await app.close();
+  });
+
+  it('pre-approves by email when no row exists yet', async () => {
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/waitlist',
+      headers: authHeaders('g:boss'),
+      payload: { email: 'Friend@Example.com' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      uid: 'email:friend@example.com',
+      email: 'friend@example.com',
+      status: 'approved',
+    });
+    expect(await store.isWaitlistApproved('g:other', 'friend@example.com')).toBe(true);
+    await app.close();
+  });
+
+  it('is invisible to everyone else', async () => {
+    await store.upsertWaitlistEntry({ uid: 'g:waiter', email: 'waiter@example.com' });
+    const app = await appWith(store);
+
+    for (const headers of [authHeaders('g:player'), {}]) {
+      expect((await app.inject({ method: 'GET', url: '/api/admin/waitlist', headers })).statusCode).toBe(404);
+      expect(
+        (
+          await app.inject({
+            method: 'POST',
+            url: '/api/admin/waitlist',
+            headers,
+            payload: { email: 'x@y.z' },
+          })
+        ).statusCode,
+      ).toBe(404);
+      expect(
+        (
+          await app.inject({
+            method: 'POST',
+            url: '/api/admin/waitlist/g%3Awaiter',
+            headers,
+            payload: { status: 'approved' },
+          })
+        ).statusCode,
+      ).toBe(404);
+    }
+    expect(await store.isWaitlistApproved('g:waiter')).toBe(false);
+    await app.close();
   });
 });
 

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -24,6 +24,7 @@ import {
   type TelemetryEvent,
   type User,
   type VisitEvent,
+  type WaitlistEntry,
 } from './store.js';
 
 /**
@@ -176,7 +177,40 @@ export interface AdminSummaryResponse {
   alerts: OperatorAlert[];
   queue: { active: number; stalled: number; byState: Partial<Record<JobState, number>> };
   limits: { paused: boolean; globalDailySubmissionCap: number; todaySubmissions: number };
+  /** Closed-beta applicants still waiting — drives the Waitlist tab badge. */
+  waitlist: { pending: number };
 }
+
+export interface WaitlistListResponse {
+  entries: WaitlistEntry[];
+}
+
+/** How many waitlist rows one console read may return. Matches the store default. */
+const MAX_WAITLIST_ENTRIES = 200;
+
+const WaitlistStatusSchema = z.enum(['pending', 'approved', 'rejected']);
+
+const WaitlistListQuerySchema = z.object({
+  status: WaitlistStatusSchema.optional(),
+});
+
+const WaitlistStatusBodySchema = z.object({
+  status: WaitlistStatusSchema,
+});
+
+const WaitlistPreapproveSchema = z.object({
+  email: z.string().trim().email('invalid email').max(254),
+  status: WaitlistStatusSchema.default('approved'),
+});
+
+const WaitlistUidParamsSchema = z.object({
+  // Same shape the auth layer mints (`g:` / `a:`) plus the `email:` pre-approve prefix
+  // the CLI and this surface use when the person has not signed in yet.
+  uid: z
+    .string()
+    .trim()
+    .regex(/^(?:g:|a:|email:)[^\s]+$/i, 'invalid uid'),
+});
 
 export function isAdmin(uid: string | undefined, adminUids: Set<string> | undefined): boolean {
   return uid !== undefined && adminUids !== undefined && adminUids.has(uid);
@@ -260,7 +294,11 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       return reply.status(404).send({ error: 'not found' });
     }
 
-    const [records, limits] = await Promise.all([store.listActiveSubmissions(), readCreationLimits()]);
+    const [records, limits, pendingWaitlist] = await Promise.all([
+      store.listActiveSubmissions(),
+      readCreationLimits(),
+      store.countWaitlistEntries('pending'),
+    ]);
     const at = now();
     const queue = buildJobQueue(records, at);
     const body: AdminSummaryResponse = {
@@ -271,8 +309,79 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
         globalDailySubmissionCap: limits.effective.globalDailySubmissionCap,
         todaySubmissions: limits.today.submissions,
       },
+      waitlist: { pending: pendingWaitlist },
     };
     return reply.status(200).send(body);
+  });
+
+  /**
+   * Closed-beta waitlist — list, approve, reject, pre-approve.
+   *
+   * Until this existed the only verbs were `npm run beta:approve` and the Firestore
+   * console, which meant approving someone meant finding a laptop. The panel is the
+   * same store writes the CLI makes; the CLI stays as the fallback for agents and
+   * scripts (see `.claude/skills/managing-beta-participants/SKILL.md`).
+   */
+  app.get('/api/admin/waitlist', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = WaitlistListQuerySchema.safeParse(request.query ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
+    }
+
+    const entries = await store.listWaitlistEntries({
+      ...(parsed.data.status ? { status: parsed.data.status } : {}),
+      limit: MAX_WAITLIST_ENTRIES,
+    });
+    const body: WaitlistListResponse = { entries };
+    return reply.status(200).send(body);
+  });
+
+  app.post<{ Params: { uid: string } }>('/api/admin/waitlist/:uid', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const params = WaitlistUidParamsSchema.safeParse(request.params ?? {});
+    if (!params.success) {
+      return reply.status(400).send({ error: params.error.issues[0]?.message ?? 'invalid uid' });
+    }
+    const parsed = WaitlistStatusBodySchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+    }
+
+    const entry = await store.setWaitlistStatus(params.data.uid, parsed.data.status);
+    if (!entry) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    app.log.info(
+      { uid: entry.uid, status: entry.status, by: request.user!.uid },
+      'waitlist status changed by operator',
+    );
+    return reply.status(200).send(entry);
+  });
+
+  /** Pre-approve (or reject) by email before the person has a uid row. */
+  app.post('/api/admin/waitlist', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = WaitlistPreapproveSchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+    }
+
+    const entry = await store.setWaitlistStatusByEmail(parsed.data.email, parsed.data.status);
+    app.log.info(
+      { uid: entry.uid, email: entry.email, status: entry.status, by: request.user!.uid },
+      'waitlist status set by email by operator',
+    );
+    return reply.status(200).send(entry);
   });
 
   /**

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -312,7 +312,7 @@ describe('POST /api/waitlist', () => {
     expect(notes[0]).toMatchObject({
       id: 'op-waitlist-g:20010',
       type: 'operator.waitlist_joined',
-      link: '/admin/telemetry',
+      link: '/admin/waitlist',
       params: { title: 'Newbie', email: 'newbie@example.com' },
     });
 

--- a/apps/api/src/notify.test.ts
+++ b/apps/api/src/notify.test.ts
@@ -554,7 +554,7 @@ describe('emitWaitlistJoined', () => {
     await store.upsertUser({ uid: 'g:boss', email: 'boss@example.com' });
   });
 
-  it('notifies every operator and links them to telemetry', async () => {
+  it('notifies every operator and links them to the waitlist panel', async () => {
     await store.upsertUser({ uid: 'g:second', email: 'second@example.com' });
 
     const { created } = await emitWaitlistJoined(
@@ -568,13 +568,13 @@ describe('emitWaitlistJoined', () => {
       id: 'op-waitlist-g:waiter',
       type: 'operator.waitlist_joined',
       titleKey: 'notifications.operator.waitlist_joined.title',
-      link: '/admin/telemetry',
+      link: '/admin/waitlist',
       params: { title: 'Waiter', email: 'waiter@example.com' },
     });
     expect(mailer.sent).toHaveLength(2);
     expect(mailer.sent[0].subject).toContain('waitlist');
     expect(mailer.sent[0].text).toContain('waiter@example.com');
-    expect(mailer.sent[0].text).toContain('/admin/telemetry');
+    expect(mailer.sent[0].text).toContain('/admin/waitlist');
     expect(mailer.sent[0].text).not.toContain('Job #');
   });
 

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -263,9 +263,10 @@ export async function emitOperatorAlert(
  * Tell every operator someone asked to join the closed beta.
  *
  * Same fan-out as `emitOperatorAlert` (in-app + email + push, no unsubscribe), but not
- * shaped like a job: there is no issue number, and the deep link is the telemetry panel
- * where the waitlist funnel lives rather than the build queue. Idempotent per applicant
- * uid (`op-waitlist-{uid}`), so a visitor who clicks Join twice is one notification.
+ * shaped like a job: there is no issue number, and the deep link is the Waitlist panel
+ * where the applicant can be approved rather than the build queue. Idempotent per
+ * applicant uid (`op-waitlist-{uid}`), so a visitor who clicks Join twice is one
+ * notification.
  */
 export async function emitWaitlistJoined(
   deps: EmitDeps & { adminUids: Iterable<string> },
@@ -304,8 +305,8 @@ export async function emitWaitlistJoined(
 /** Where an operator notification lands: the queue, which is where the action is. */
 const OPERATOR_ALERT_LINK = '/admin/queue';
 
-/** Waitlist joins land on telemetry — that is where the waitlist funnel is measured. */
-const WAITLIST_ALERT_LINK = '/admin/telemetry';
+/** Waitlist joins land on the membership panel — that is where the applicant is acted on. */
+const WAITLIST_ALERT_LINK = '/admin/waitlist';
 
 /**
  * Best-effort, like every other send here: a failed alert email must not fail the caller.

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -56,6 +56,7 @@ describe('isKnownSpaShellPath', () => {
     '/admin/costs',
     '/admin/telemetry',
     '/admin/tokens',
+    '/admin/waitlist',
     '/join/K7M3QP',
   ])('treats %s as a known shell path (HTTP 200)', (path) => {
     expect(isKnownSpaShellPath(path)).toBe(true);

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -28,7 +28,7 @@ const STUDIO_PATTERN = /^\/studio(?:\/[^/]+(?:\/(?:thread|details|playtest|overv
 // The operator console. Its sections are listed rather than matched loosely, so the
 // shell and the client's router agree about what is a real page and what is a typo —
 // the same contract the studio tabs above keep.
-const ADMIN_PATTERN = /^\/admin(?:\/(?:queue|costs|telemetry|limits|tokens|suggestions))?$/;
+const ADMIN_PATTERN = /^\/admin(?:\/(?:queue|costs|telemetry|limits|tokens|suggestions|waitlist))?$/;
 /** Last path segment looks like a file (`sw.js`, `icon.png`, `foo.woff2`). */
 const STATIC_ASSET_PATTERN = /\/[^/]+\.[a-zA-Z0-9]+$/;
 

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -146,7 +146,11 @@ function fakeFirestore() {
     where: (field: string, op: string, value: unknown) => makeQuery([path], null).where(field, op, value),
     count: () => makeQuery([path], null).count(),
     get: async () => ({
-      docs: idsUnder(path).map((id) => ({ id, data: () => docs.get(key(path, id)) ?? {} })),
+      docs: idsUnder(path).map((id) => ({
+        id,
+        data: () => docs.get(key(path, id)) ?? {},
+        ref: makeRef(path, id),
+      })),
     }),
   });
 
@@ -282,6 +286,32 @@ describe('FirestoreStore.upsertWaitlistEntry', () => {
       status: 'approved',
     });
     expect(await store.isWaitlistApproved('g:other', 'new@example.com')).toBe(true);
+  });
+
+  it('lowercases emails on join and heals a legacy mixed-case row on approve', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    const joined = await store.upsertWaitlistEntry({ uid: 'g:mix', email: 'Friend@Example.com' });
+    expect(joined.email).toBe('friend@example.com');
+    expect(docs.get(key('waitlist', 'g:mix'))?.email).toBe('friend@example.com');
+
+    // Simulate a row written before normalisation — mixed case still on disk.
+    docs.set(key('waitlist', 'g:legacy'), {
+      uid: 'g:legacy',
+      email: 'Legacy@Example.com',
+      requestedAt: '2026-07-01T00:00:00.000Z',
+      status: 'pending',
+    });
+
+    const healed = await store.setWaitlistStatusByEmail('legacy@example.com', 'approved');
+    expect(healed).toMatchObject({ uid: 'g:legacy', email: 'legacy@example.com', status: 'approved' });
+    expect(docs.get(key('waitlist', 'g:legacy'))).toMatchObject({
+      email: 'legacy@example.com',
+      status: 'approved',
+    });
+    // No duplicate email: row beside the healed join.
+    expect([...docs.keys()].filter((k) => k.startsWith('waitlist/'))).toHaveLength(2);
   });
 });
 

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -95,6 +95,12 @@ function fakeFirestore() {
       const previous = options?.merge ? (docs.get(key(collection, id)) ?? {}) : {};
       docs.set(key(collection, id), { ...previous, ...data });
     },
+    update: async (data: Record<string, unknown>) => {
+      rejectUndefined(data);
+      rejectNestedArrays(data);
+      if (!docs.has(key(collection, id))) throw new Error('no document to update');
+      docs.set(key(collection, id), { ...docs.get(key(collection, id))!, ...data });
+    },
     delete: async () => {
       docs.delete(key(collection, id));
     },
@@ -107,18 +113,21 @@ function fakeFirestore() {
       path.endsWith(`/${group}`),
     );
 
-  const makeQuery = (paths: string[], filter: ((data: Record<string, unknown>) => boolean) | null) => {
-    const rows = () =>
-      paths.flatMap((path) =>
+  const makeQuery = (paths: string[], filter: ((data: Record<string, unknown>) => boolean) | null, max?: number) => {
+    const rows = () => {
+      const found = paths.flatMap((path) =>
         idsUnder(path)
           .map((id) => ({ path, id, data: docs.get(key(path, id)) ?? {} }))
           .filter((row) => (filter ? filter(row.data) : true)),
       );
+      return max === undefined ? found : found.slice(0, max);
+    };
     const query = {
       where: (field: string, op: string, value: unknown) => {
         if (op !== '==') throw new Error(`fake supports == only, got ${op}`);
-        return makeQuery(paths, (data) => (filter ? filter(data) : true) && data[field] === value);
+        return makeQuery(paths, (data) => (filter ? filter(data) : true) && data[field] === value, max);
       },
+      limit: (n: number) => makeQuery(paths, filter, n),
       count: () => ({ get: async () => ({ data: () => ({ count: rows().length }) }) }),
       get: async () => {
         const found = rows();

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -254,6 +254,26 @@ describe('FirestoreStore.upsertWaitlistEntry', () => {
     const entry = await store.upsertWaitlistEntry({ uid: 'g:3', email: 'a@b.c' });
     expect(entry.status).toBe('approved');
   });
+
+  it('lists, counts, and pre-approves by email', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.upsertWaitlistEntry({ uid: 'g:1', email: 'one@example.com' });
+    await store.upsertWaitlistEntry({ uid: 'g:2', email: 'two@example.com' });
+    await store.setWaitlistStatus('g:2', 'approved');
+
+    expect(await store.countWaitlistEntries('pending')).toBe(1);
+    expect((await store.listWaitlistEntries({ status: 'pending' })).map((row) => row.uid)).toEqual(['g:1']);
+
+    const created = await store.setWaitlistStatusByEmail('New@Example.com', 'approved');
+    expect(created).toMatchObject({
+      uid: 'email:new@example.com',
+      email: 'new@example.com',
+      status: 'approved',
+    });
+    expect(await store.isWaitlistApproved('g:other', 'new@example.com')).toBe(true);
+  });
 });
 
 describe('FirestoreStore game saves', () => {

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -293,6 +293,37 @@ describe('InMemoryStore', () => {
     expect(await store.isWaitlistApproved('g:other', 'APPROVED@example.com')).toBe(true);
     expect(await store.isWaitlistApproved('g:other', 'unknown@example.com')).toBe(false);
   });
+
+  it('lists waitlist entries newest first and filters by status', async () => {
+    const store = new InMemoryStore();
+    await store.upsertWaitlistEntry({ uid: 'g:old', email: 'old@example.com' });
+    await store.setWaitlistStatus('g:old', 'approved');
+    // requestedAt is stamped on upsert; a later join sorts first.
+    await store.upsertWaitlistEntry({ uid: 'g:new', email: 'new@example.com' });
+
+    const pending = await store.listWaitlistEntries({ status: 'pending' });
+    expect(pending.map((entry) => entry.uid)).toEqual(['g:new']);
+    expect(await store.countWaitlistEntries('pending')).toBe(1);
+    expect(await store.countWaitlistEntries('approved')).toBe(1);
+
+    const all = await store.listWaitlistEntries();
+    expect(all.map((entry) => entry.uid)).toEqual(['g:new', 'g:old']);
+  });
+
+  it('pre-approves by email when no waitlist row exists yet', async () => {
+    const store = new InMemoryStore();
+    const created = await store.setWaitlistStatusByEmail('Friend@Example.com', 'approved');
+    expect(created).toMatchObject({
+      uid: 'email:friend@example.com',
+      email: 'friend@example.com',
+      status: 'approved',
+    });
+    expect(await store.isWaitlistApproved('g:whoever', 'friend@example.com')).toBe(true);
+
+    await store.upsertWaitlistEntry({ uid: 'g:joined', email: 'joined@example.com' });
+    const updated = await store.setWaitlistStatusByEmail('joined@example.com', 'rejected');
+    expect(updated).toMatchObject({ uid: 'g:joined', status: 'rejected' });
+  });
 });
 
 /**

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -331,6 +331,16 @@ describe('InMemoryStore', () => {
     const updated = await store.setWaitlistStatusByEmail('joined@example.com', 'rejected');
     expect(updated).toMatchObject({ uid: 'g:joined', status: 'rejected' });
   });
+
+  it('stores waitlist emails lowercased so approve-by-email finds a mixed-case join', async () => {
+    const store = new InMemoryStore();
+    const joined = await store.upsertWaitlistEntry({ uid: 'g:mix', email: 'Friend@Example.com' });
+    expect(joined.email).toBe('friend@example.com');
+
+    const approved = await store.setWaitlistStatusByEmail('FRIEND@example.com', 'approved');
+    expect(approved).toMatchObject({ uid: 'g:mix', status: 'approved' });
+    expect(store.waitlistEntries()).toHaveLength(1);
+  });
 });
 
 /**

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -295,19 +295,26 @@ describe('InMemoryStore', () => {
   });
 
   it('lists waitlist entries newest first and filters by status', async () => {
-    const store = new InMemoryStore();
-    await store.upsertWaitlistEntry({ uid: 'g:old', email: 'old@example.com' });
-    await store.setWaitlistStatus('g:old', 'approved');
-    // requestedAt is stamped on upsert; a later join sorts first.
-    await store.upsertWaitlistEntry({ uid: 'g:new', email: 'new@example.com' });
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-08-01T10:00:00.000Z'));
+      const store = new InMemoryStore();
+      await store.upsertWaitlistEntry({ uid: 'g:old', email: 'old@example.com' });
+      await store.setWaitlistStatus('g:old', 'approved');
+      // requestedAt is stamped on upsert; a later join sorts first.
+      vi.setSystemTime(new Date('2026-08-01T11:00:00.000Z'));
+      await store.upsertWaitlistEntry({ uid: 'g:new', email: 'new@example.com' });
 
-    const pending = await store.listWaitlistEntries({ status: 'pending' });
-    expect(pending.map((entry) => entry.uid)).toEqual(['g:new']);
-    expect(await store.countWaitlistEntries('pending')).toBe(1);
-    expect(await store.countWaitlistEntries('approved')).toBe(1);
+      const pending = await store.listWaitlistEntries({ status: 'pending' });
+      expect(pending.map((entry) => entry.uid)).toEqual(['g:new']);
+      expect(await store.countWaitlistEntries('pending')).toBe(1);
+      expect(await store.countWaitlistEntries('approved')).toBe(1);
 
-    const all = await store.listWaitlistEntries();
-    expect(all.map((entry) => entry.uid)).toEqual(['g:new', 'g:old']);
+      const all = await store.listWaitlistEntries();
+      expect(all.map((entry) => entry.uid)).toEqual(['g:new', 'g:old']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('pre-approves by email when no waitlist row exists yet', async () => {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2325,10 +2325,13 @@ export class InMemoryStore implements Store {
   }): Promise<WaitlistEntry> {
     const now = new Date().toISOString();
     const existing = this.waitlist.get(entry.uid);
+    // Lowercase at write so equality queries (Firestore `where email ==`) and the
+    // pre-approve path agree — mixed-case joins used to miss and mint a second row.
+    const rawEmail = entry.email ?? existing?.email;
 
     const updated: WaitlistEntry = {
       uid: entry.uid,
-      email: entry.email ?? existing?.email,
+      email: rawEmail !== undefined ? rawEmail.toLowerCase() : undefined,
       name: entry.name ?? existing?.name,
       requestedAt: now,
       locale: entry.locale ?? existing?.locale,
@@ -3694,10 +3697,14 @@ export class FirestoreStore implements Store {
     const docRef = this.db.collection('waitlist').doc(entry.uid);
     const snap = await docRef.get();
     const existing = snap.exists ? (snap.data() as WaitlistEntry) : null;
+    // Same normalisation as InMemoryStore: email queries are case-sensitive in
+    // Firestore, and setWaitlistStatusByEmail / isWaitlistApproved look up the
+    // lowercased form.
+    const rawEmail = entry.email !== undefined ? entry.email : existing?.email;
 
     const record: WaitlistEntry = {
       uid: entry.uid,
-      email: entry.email,
+      email: rawEmail !== undefined ? rawEmail.toLowerCase() : undefined,
       name: entry.name,
       requestedAt: now,
       locale: entry.locale,
@@ -3767,7 +3774,16 @@ export class FirestoreStore implements Store {
     if (!querySnap.empty) {
       const doc = querySnap.docs[0]!;
       await doc.ref.update({ status });
-      return { ...(doc.data() as WaitlistEntry), status };
+      return { ...(doc.data() as WaitlistEntry), status, email: emailLower };
+    }
+    // Rows written before email was normalised may still hold mixed case; find and
+    // heal them so an approve does not mint a duplicate `email:` doc beside the
+    // original join. Cheap at closed-beta scale (one collection read, operator-only).
+    const legacySnap = await this.db.collection('waitlist').get();
+    const legacy = legacySnap.docs.find((doc) => (doc.data() as WaitlistEntry).email?.toLowerCase() === emailLower);
+    if (legacy) {
+      await legacy.ref.update({ status, email: emailLower });
+      return { ...(legacy.data() as WaitlistEntry), status, email: emailLower };
     }
     const now = new Date().toISOString();
     const created: WaitlistEntry = {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1373,6 +1373,23 @@ export interface Store {
   isWaitlistApproved(uid: string, email?: string): Promise<boolean>;
   setWaitlistStatus(uid: string, status: WaitlistStatus): Promise<WaitlistEntry | null>;
   /**
+   * Operator listing of the closed-beta waitlist.
+   *
+   * Sorted newest-request first. When `status` is set, only that status is returned.
+   * Bounded by `limit` (default 200) so a growing list cannot ship the whole collection
+   * in one console poll — at closed-beta scale the cap is generous; past that the panel
+   * filters by status rather than paging.
+   */
+  listWaitlistEntries(opts?: { status?: WaitlistStatus; limit?: number }): Promise<WaitlistEntry[]>;
+  /** Cheap count for the console tab badge. Optional status filter. */
+  countWaitlistEntries(status?: WaitlistStatus): Promise<number>;
+  /**
+   * Approve / reject / reset by email — including pre-approval before the person has
+   * ever visited. Mirrors `npm run beta:approve`: finds an existing row by email, or
+   * creates `waitlist/email:<lower>` with the requested status.
+   */
+  setWaitlistStatusByEmail(email: string, status: WaitlistStatus): Promise<WaitlistEntry>;
+  /**
    * Idempotent by notification id: a second emit for the same id is a no-op and
    * returns `created: false` (a crashed/re-run sweep can safely re-emit).
    */
@@ -2349,6 +2366,44 @@ export class InMemoryStore implements Store {
     return { ...updated };
   }
 
+  async listWaitlistEntries(opts?: { status?: WaitlistStatus; limit?: number }): Promise<WaitlistEntry[]> {
+    const limit = opts?.limit ?? 200;
+    const rows = Array.from(this.waitlist.values()).filter(
+      (entry) => opts?.status === undefined || entry.status === opts.status,
+    );
+    rows.sort((a, b) => b.requestedAt.localeCompare(a.requestedAt));
+    return rows.slice(0, limit).map((entry) => ({ ...entry }));
+  }
+
+  async countWaitlistEntries(status?: WaitlistStatus): Promise<number> {
+    if (status === undefined) return this.waitlist.size;
+    let count = 0;
+    for (const entry of this.waitlist.values()) {
+      if (entry.status === status) count += 1;
+    }
+    return count;
+  }
+
+  async setWaitlistStatusByEmail(email: string, status: WaitlistStatus): Promise<WaitlistEntry> {
+    const emailLower = email.toLowerCase();
+    for (const entry of this.waitlist.values()) {
+      if (entry.email?.toLowerCase() === emailLower) {
+        const updated: WaitlistEntry = { ...entry, status };
+        this.waitlist.set(entry.uid, updated);
+        return { ...updated };
+      }
+    }
+    const now = new Date().toISOString();
+    const created: WaitlistEntry = {
+      uid: `email:${emailLower}`,
+      email: emailLower,
+      requestedAt: now,
+      status,
+    };
+    this.waitlist.set(created.uid, created);
+    return { ...created };
+  }
+
   async createNotification(
     uid: string,
     notification: Omit<StoredNotification, 'readAt' | 'emailedAt'> & { createdAt?: string },
@@ -2732,8 +2787,7 @@ export class InMemoryStore implements Store {
     if (record) this.accessTokens.set(tokenId, { ...record, lastUsedAt: at });
   }
 
-  // Test/inspection only — not part of the Store interface. Production code never
-  // reads the waitlist back (v1 promotion is manual, via the Firestore console).
+  // Test/inspection only — production reads go through `listWaitlistEntries`.
   waitlistEntries(): WaitlistEntry[] {
     return Array.from(this.waitlist.values());
   }
@@ -3684,6 +3738,46 @@ export class FirestoreStore implements Store {
     await docRef.update({ status });
     const updatedSnap = await docRef.get();
     return updatedSnap.data() as WaitlistEntry;
+  }
+
+  async listWaitlistEntries(opts?: { status?: WaitlistStatus; limit?: number }): Promise<WaitlistEntry[]> {
+    // Equality-only (no orderBy) so a status filter needs no composite index; sort and
+    // slice in memory. The waitlist stays small at closed-beta scale, and the same
+    // posture as `listAccessTokens` keeps an operator page from depending on a new
+    // index that only fails in production.
+    const limit = opts?.limit ?? 200;
+    const collection = this.db.collection('waitlist');
+    const snap =
+      opts?.status === undefined ? await collection.get() : await collection.where('status', '==', opts.status).get();
+    const rows = snap.docs.map((doc) => doc.data() as WaitlistEntry);
+    rows.sort((a, b) => b.requestedAt.localeCompare(a.requestedAt));
+    return rows.slice(0, limit);
+  }
+
+  async countWaitlistEntries(status?: WaitlistStatus): Promise<number> {
+    const collection = this.db.collection('waitlist');
+    const query = status === undefined ? collection : collection.where('status', '==', status);
+    const snap = await query.count().get();
+    return snap.data().count;
+  }
+
+  async setWaitlistStatusByEmail(email: string, status: WaitlistStatus): Promise<WaitlistEntry> {
+    const emailLower = email.toLowerCase();
+    const querySnap = await this.db.collection('waitlist').where('email', '==', emailLower).limit(1).get();
+    if (!querySnap.empty) {
+      const doc = querySnap.docs[0]!;
+      await doc.ref.update({ status });
+      return { ...(doc.data() as WaitlistEntry), status };
+    }
+    const now = new Date().toISOString();
+    const created: WaitlistEntry = {
+      uid: `email:${emailLower}`,
+      email: emailLower,
+      requestedAt: now,
+      status,
+    };
+    await this.db.collection('waitlist').doc(created.uid).set(stripUndefined(created));
+    return created;
   }
 
   private notificationRef(uid: string, id: string) {

--- a/apps/web/src/AdminConsole.test.tsx
+++ b/apps/web/src/AdminConsole.test.tsx
@@ -26,12 +26,14 @@ vi.mock('./CostsPanel.js', () => ({ CostsPanel: () => createElement('p', null, '
 vi.mock('./CreationLimitsPanel.js', () => ({ CreationLimitsPanel: () => createElement('p', null, 'limits-panel') }));
 vi.mock('./AccessTokensPanel.js', () => ({ AccessTokensPanel: () => createElement('p', null, 'tokens-panel') }));
 vi.mock('./SuggestionsPanel.js', () => ({ SuggestionsPanel: () => createElement('p', null, 'suggestions-panel') }));
+vi.mock('./WaitlistPanel.js', () => ({ WaitlistPanel: () => createElement('p', null, 'waitlist-panel') }));
 
 function summary(overrides: Partial<AdminSummary> = {}): AdminSummary {
   return {
     alerts: [],
     queue: { active: 2, stalled: 0, byState: { building: 2 } },
     limits: { paused: false, globalDailySubmissionCap: 50, todaySubmissions: 3 },
+    waitlist: { pending: 0 },
     ...overrides,
   };
 }
@@ -232,6 +234,22 @@ describe('AdminConsole', () => {
     });
 
     expect(onNavigate).toHaveBeenCalledWith('/admin/tokens');
+
+    await act(async () => root.unmount());
+  });
+
+  it('routes to the waitlist section and badges pending applicants', async () => {
+    mocked.fetchAdminSummary.mockResolvedValue(summary({ waitlist: { pending: 3 } }));
+
+    const { container, root } = await render('waitlist');
+
+    expect(container.textContent).toContain('waitlist-panel');
+    const waitlistTab = Array.from(container.querySelectorAll('.admin-tab')).find((tab) =>
+      tab.textContent?.startsWith('Waitlist'),
+    );
+    expect(waitlistTab?.classList.contains('is-active')).toBe(true);
+    expect(waitlistTab?.getAttribute('href')).toBe('/admin/waitlist');
+    expect(waitlistTab?.querySelector('.admin-tab-badge')?.textContent).toBe('3');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/AdminConsole.tsx
+++ b/apps/web/src/AdminConsole.tsx
@@ -5,6 +5,7 @@ import { CostsPanel } from './CostsPanel.js';
 import { CreationLimitsPanel } from './CreationLimitsPanel.js';
 import { GameHealthView } from './GameHealthView.js';
 import { SuggestionsPanel } from './SuggestionsPanel.js';
+import { WaitlistPanel } from './WaitlistPanel.js';
 import { fetchAdminSummary, type AdminSummary, type OperatorAlert } from './adminApi.js';
 import { ADMIN_SECTIONS, adminPath, type AdminSection } from './router.js';
 
@@ -28,6 +29,7 @@ const SECTION_LABELS: Record<AdminSection, string> = {
   limits: 'Limits',
   tokens: 'Tokens',
   suggestions: 'Suggestions',
+  waitlist: 'Waitlist',
 };
 
 const ALERT_COPY: Record<OperatorAlert['kind'], string> = {
@@ -230,6 +232,11 @@ export function AdminConsole({ section, onNavigate }: { section: AdminSection; o
                 paused
               </span>
             ) : null}
+            {candidate === 'waitlist' && summary && summary.waitlist.pending > 0 ? (
+              <span className="admin-tab-badge" aria-label={`${summary.waitlist.pending} waiting for access`}>
+                {summary.waitlist.pending}
+              </span>
+            ) : null}
           </a>
         ))}
       </nav>
@@ -250,6 +257,7 @@ export function AdminConsole({ section, onNavigate }: { section: AdminSection; o
       {section === 'limits' && <CreationLimitsPanel onChanged={() => void load()} />}
       {section === 'tokens' && <AccessTokensPanel />}
       {section === 'suggestions' && <SuggestionsPanel />}
+      {section === 'waitlist' && <WaitlistPanel />}
     </section>
   );
 }

--- a/apps/web/src/WaitlistPanel.test.tsx
+++ b/apps/web/src/WaitlistPanel.test.tsx
@@ -109,4 +109,38 @@ describe('WaitlistPanel', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('ignores a stale filter response that resolves after a newer one', async () => {
+    let resolvePending!: (entries: WaitlistEntry[]) => void;
+    mocked.fetchWaitlist.mockImplementation((status: string) => {
+      if (status === 'pending') {
+        return new Promise<WaitlistEntry[]>((resolve) => {
+          resolvePending = resolve;
+        });
+      }
+      return Promise.resolve([entry({ uid: 'g:in', email: 'in@example.com', status: 'approved', name: 'In' })]);
+    });
+
+    const { container, root } = await render();
+    const approved = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Approved',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      approved.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('In');
+    // Pending finally arrives — must not overwrite the Approved list.
+    await act(async () => {
+      resolvePending([entry()]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('In');
+    expect(container.textContent).not.toContain('Waiter');
+
+    await act(async () => root.unmount());
+  });
 });

--- a/apps/web/src/WaitlistPanel.test.tsx
+++ b/apps/web/src/WaitlistPanel.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WaitlistPanel } from './WaitlistPanel.js';
+import type { WaitlistEntry } from './adminApi.js';
+
+const mocked = vi.hoisted(() => ({
+  fetchWaitlist: vi.fn(),
+  setWaitlistStatus: vi.fn(),
+  setWaitlistStatusByEmail: vi.fn(),
+}));
+
+vi.mock('./adminApi.js', () => mocked);
+
+function entry(overrides: Partial<WaitlistEntry> = {}): WaitlistEntry {
+  return {
+    uid: 'g:waiter',
+    email: 'waiter@example.com',
+    name: 'Waiter',
+    requestedAt: new Date(Date.now() - 45 * 60_000).toISOString(),
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+async function render() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(WaitlistPanel));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+/** Types into a controlled input the way React's onChange expects. */
+async function type(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  await act(async () => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('WaitlistPanel', () => {
+  it('lists pending applicants and can approve one', async () => {
+    mocked.fetchWaitlist.mockResolvedValue([entry()]);
+    mocked.setWaitlistStatus.mockResolvedValue(entry({ status: 'approved' }));
+
+    const { container, root } = await render();
+
+    expect(mocked.fetchWaitlist).toHaveBeenCalledWith('pending');
+    expect(container.textContent).toContain('Waiter');
+    expect(container.textContent).toContain('waiter@example.com');
+
+    const approve = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Approve' && !button.closest('.admin-tokens-form'),
+    ) as HTMLButtonElement;
+    await act(async () => {
+      approve.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocked.setWaitlistStatus).toHaveBeenCalledWith('g:waiter', 'approved');
+
+    await act(async () => root.unmount());
+  });
+
+  it('pre-approves by email', async () => {
+    mocked.fetchWaitlist.mockResolvedValue([]);
+    mocked.setWaitlistStatusByEmail.mockResolvedValue(
+      entry({ uid: 'email:friend@example.com', email: 'friend@example.com', status: 'approved', name: undefined }),
+    );
+
+    const { container, root } = await render();
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement;
+    await type(input, 'friend@example.com');
+    const approve = Array.from(container.querySelectorAll('.admin-tokens-form button')).find(
+      (button) => button.textContent === 'Approve',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      approve.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocked.setWaitlistStatusByEmail).toHaveBeenCalledWith('friend@example.com', 'approved');
+
+    await act(async () => root.unmount());
+  });
+
+  it('tells a non-operator nothing', async () => {
+    mocked.fetchWaitlist.mockResolvedValue(null);
+
+    const { container, root } = await render();
+
+    expect(container.textContent).toBe('Not found.');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/WaitlistPanel.tsx
+++ b/apps/web/src/WaitlistPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   fetchWaitlist,
   setWaitlistStatus,
@@ -43,10 +43,15 @@ export function WaitlistPanel() {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [email, setEmail] = useState('');
+  // Monotonic id so a slow Pending fetch cannot overwrite an Approved list the
+  // operator already switched to (Copilot + Codex both flagged this race).
+  const loadGeneration = useRef(0);
 
   const load = useCallback(async (status: WaitlistStatus | 'all') => {
+    const generation = ++loadGeneration.current;
     try {
       const result = await fetchWaitlist(status);
+      if (generation !== loadGeneration.current) return;
       if (result === null) {
         setState('forbidden');
         return;
@@ -54,6 +59,7 @@ export function WaitlistPanel() {
       setEntries(result);
       setState('ready');
     } catch {
+      if (generation !== loadGeneration.current) return;
       setState('error');
     }
   }, []);
@@ -108,9 +114,10 @@ export function WaitlistPanel() {
     }
   }, [email, filter, load]);
 
+  // Filters stay mounted during the first load so a slow Pending fetch cannot
+  // trap the operator — they can switch to Approved while it is still in flight,
+  // which is also the race the generation guard below exists for.
   if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
-  if (state === 'loading' && !entries) return <p className="health-empty">Reading the waitlist…</p>;
-  if (state === 'error' && !entries) return <p className="health-empty">Could not read the waitlist.</p>;
 
   const now = Date.now();
 
@@ -153,6 +160,9 @@ export function WaitlistPanel() {
       </div>
 
       {message && <p className="admin-limits-message">{message}</p>}
+
+      {state === 'loading' && !entries && <p className="health-empty">Reading the waitlist…</p>}
+      {state === 'error' && !entries && <p className="health-empty">Could not read the waitlist.</p>}
 
       {entries && entries.length === 0 && (
         <p className="health-empty">{filter === 'pending' ? 'Nobody is waiting.' : 'No entries in this filter.'}</p>

--- a/apps/web/src/WaitlistPanel.tsx
+++ b/apps/web/src/WaitlistPanel.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchWaitlist,
+  setWaitlistStatus,
+  setWaitlistStatusByEmail,
+  type WaitlistEntry,
+  type WaitlistStatus,
+} from './adminApi.js';
+
+/**
+ * Closed-beta waitlist membership — list, approve, reject, pre-approve by email.
+ *
+ * Until this panel the only verbs were `npm run beta:approve` and the Firestore
+ * console. Approving someone from a phone mid-day is the whole point: a join
+ * notification that links here should end in a status change, not in "find a
+ * laptop".
+ *
+ * Pre-approve by email matches the CLI: if they have never visited, an
+ * `email:user@…` row is created so the first verified sign-in grants access.
+ */
+
+const FILTERS: Array<{ value: WaitlistStatus | 'all'; label: string }> = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'all', label: 'All' },
+];
+
+function since(at: string, now: number): string {
+  const ms = Math.max(0, now - Date.parse(at));
+  if (!Number.isFinite(ms)) return '';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export function WaitlistPanel() {
+  const [filter, setFilter] = useState<WaitlistStatus | 'all'>('pending');
+  const [entries, setEntries] = useState<WaitlistEntry[] | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [email, setEmail] = useState('');
+
+  const load = useCallback(async (status: WaitlistStatus | 'all') => {
+    try {
+      const result = await fetchWaitlist(status);
+      if (result === null) {
+        setState('forbidden');
+        return;
+      }
+      setEntries(result);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    setState('loading');
+    void load(filter);
+  }, [filter, load]);
+
+  const changeStatus = useCallback(
+    async (uid: string, status: WaitlistStatus) => {
+      setBusy(true);
+      setMessage(null);
+      try {
+        const result = await setWaitlistStatus(uid, status);
+        if ('error' in result) {
+          setMessage(result.error);
+          return;
+        }
+        setMessage(`${result.email ?? result.uid} → ${status}`);
+        await load(filter);
+      } catch {
+        setMessage('could not reach the API');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [filter, load],
+  );
+
+  const preapprove = useCallback(async () => {
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await setWaitlistStatusByEmail(trimmed, 'approved');
+      if ('error' in result) {
+        setMessage(result.error);
+        return;
+      }
+      setEmail('');
+      setMessage(`approved ${result.email ?? result.uid}`);
+      // An approve against a pending filter would disappear from the list; switch so
+      // the row the operator just wrote is still on screen.
+      if (filter === 'pending') setFilter('approved');
+      else await load(filter);
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(false);
+    }
+  }, [email, filter, load]);
+
+  if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
+  if (state === 'loading' && !entries) return <p className="health-empty">Reading the waitlist…</p>;
+  if (state === 'error' && !entries) return <p className="health-empty">Could not read the waitlist.</p>;
+
+  const now = Date.now();
+
+  return (
+    <section className="admin-waitlist">
+      <h2 className="health-section-title">Waitlist</h2>
+      <p className="health-summary">
+        Closed-beta membership. Approving grants sign-in without a redeploy; rejecting or resetting updates the same
+        Firestore row the CLI writes.
+      </p>
+
+      <div className="admin-waitlist-filters" role="group" aria-label="Filter by status">
+        {FILTERS.map((candidate) => (
+          <button
+            key={candidate.value}
+            type="button"
+            className={candidate.value === filter ? 'is-active' : undefined}
+            disabled={busy}
+            onClick={() => setFilter(candidate.value)}
+          >
+            {candidate.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="admin-tokens-form">
+        <label>
+          Pre-approve email
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="friend@example.com"
+            disabled={busy}
+          />
+        </label>
+        <button type="button" disabled={busy || !email.trim()} onClick={() => void preapprove()}>
+          Approve
+        </button>
+      </div>
+
+      {message && <p className="admin-limits-message">{message}</p>}
+
+      {entries && entries.length === 0 && (
+        <p className="health-empty">{filter === 'pending' ? 'Nobody is waiting.' : 'No entries in this filter.'}</p>
+      )}
+
+      {entries && entries.length > 0 && (
+        <div className="health-table-scroll">
+          <table className="health-table">
+            <thead>
+              <tr>
+                <th>Person</th>
+                <th>Status</th>
+                <th>Joined</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <tr key={entry.uid} className={`admin-waitlist-row is-${entry.status}`}>
+                  <td>
+                    <div className="admin-waitlist-person">
+                      <span className="admin-waitlist-name">{entry.name ?? entry.email ?? entry.uid}</span>
+                      {entry.email && entry.name ? <span className="admin-waitlist-email">{entry.email}</span> : null}
+                      <span className="admin-waitlist-uid">{entry.uid}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <span className={`admin-waitlist-status is-${entry.status}`}>{entry.status}</span>
+                  </td>
+                  <td title={entry.requestedAt}>{since(entry.requestedAt, now)}</td>
+                  <td className="admin-waitlist-actions">
+                    {entry.status !== 'approved' && (
+                      <button type="button" disabled={busy} onClick={() => void changeStatus(entry.uid, 'approved')}>
+                        Approve
+                      </button>
+                    )}
+                    {entry.status !== 'rejected' && (
+                      <button type="button" disabled={busy} onClick={() => void changeStatus(entry.uid, 'rejected')}>
+                        Reject
+                      </button>
+                    )}
+                    {entry.status !== 'pending' && (
+                      <button type="button" disabled={busy} onClick={() => void changeStatus(entry.uid, 'pending')}>
+                        Reset
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -25,6 +25,18 @@ export interface AdminSummary {
   alerts: OperatorAlert[];
   queue: { active: number; stalled: number; byState: Record<string, number> };
   limits: { paused: boolean; globalDailySubmissionCap: number; todaySubmissions: number };
+  waitlist: { pending: number };
+}
+
+export type WaitlistStatus = 'pending' | 'approved' | 'rejected';
+
+export interface WaitlistEntry {
+  uid: string;
+  email?: string;
+  name?: string;
+  requestedAt: string;
+  locale?: string;
+  status: WaitlistStatus;
 }
 
 /**
@@ -189,4 +201,46 @@ export async function revokeAccessToken(tokenId: string): Promise<{ ok: boolean 
     credentials: 'include',
   });
   return { ok: res.ok };
+}
+
+export async function fetchWaitlist(status?: WaitlistStatus | 'all'): Promise<WaitlistEntry[] | null> {
+  const query = status && status !== 'all' ? `?status=${encodeURIComponent(status)}` : '';
+  const res = await fetch(`${API_BASE}/api/admin/waitlist${query}`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`waitlist failed (${res.status})`);
+  return ((await res.json()) as { entries: WaitlistEntry[] }).entries;
+}
+
+export async function setWaitlistStatus(
+  uid: string,
+  status: WaitlistStatus,
+): Promise<WaitlistEntry | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/waitlist/${encodeURIComponent(uid)}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+  if (res.ok) return (await res.json()) as WaitlistEntry;
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
+}
+
+/**
+ * Pre-approve (or reject / reset) by email. Creates an `email:` row when the person
+ * has never joined — same write the `beta:approve` CLI makes.
+ */
+export async function setWaitlistStatusByEmail(
+  email: string,
+  status: WaitlistStatus = 'approved',
+): Promise<WaitlistEntry | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/waitlist`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, status }),
+  });
+  if (res.ok) return (await res.json()) as WaitlistEntry;
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
 }

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -44,7 +44,7 @@ export function isStudioTab(value: string): value is StudioTab {
  * things to look at. In the URL so a refresh, a bookmark, or the link in an alert
  * notification lands on the section it meant rather than on whichever one is first.
  */
-export const ADMIN_SECTIONS = ['queue', 'costs', 'telemetry', 'limits', 'tokens', 'suggestions'] as const;
+export const ADMIN_SECTIONS = ['queue', 'costs', 'telemetry', 'limits', 'tokens', 'suggestions', 'waitlist'] as const;
 export type AdminSection = (typeof ADMIN_SECTIONS)[number];
 
 export function isAdminSection(value: string): value is AdminSection {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9121,7 +9121,9 @@ body.player-open {
 }
 
 .admin-limits-controls,
-.admin-tokens-form {
+.admin-tokens-form,
+.admin-waitlist-filters,
+.admin-waitlist-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
@@ -9129,9 +9131,20 @@ body.player-open {
   margin: 0.75rem 0;
 }
 
+.admin-waitlist-filters {
+  align-items: center;
+}
+
+.admin-waitlist-actions {
+  margin: 0;
+  gap: 0.35rem;
+}
+
 .admin-limits-controls button,
 .admin-tokens-form button,
-.admin-tokens button {
+.admin-tokens button,
+.admin-waitlist-filters button,
+.admin-waitlist-actions button {
   cursor: pointer;
   padding: 0.3rem 0.7rem;
   font: inherit;
@@ -9142,9 +9155,16 @@ body.player-open {
   color: inherit;
 }
 
+.admin-waitlist-filters button.is-active {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  font-weight: 600;
+}
+
 .admin-limits-controls button:disabled,
 .admin-tokens-form button:disabled,
-.admin-tokens button:disabled {
+.admin-tokens button:disabled,
+.admin-waitlist-filters button:disabled,
+.admin-waitlist-actions button:disabled {
   opacity: 0.5;
   cursor: default;
 }
@@ -9194,6 +9214,38 @@ body.player-open {
 
 .admin-token-row.is-expired {
   opacity: 0.55;
+}
+
+.admin-waitlist-person {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 10rem;
+}
+
+.admin-waitlist-name {
+  font-weight: 600;
+}
+
+.admin-waitlist-email,
+.admin-waitlist-uid {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  word-break: break-all;
+}
+
+.admin-waitlist-status {
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.admin-waitlist-status.is-approved {
+  color: var(--accent, #00e4ac);
+}
+
+.admin-waitlist-status.is-rejected {
+  color: var(--danger, #c0392b);
 }
 
 .admin-suggestion-class {

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -53,20 +53,22 @@ explicit click.
   operator telemetry panel beside Creating.
 - **Operator notify:** each new applicant fans out `operator.waitlist_joined` to
   every `ADMIN_UIDS` account (in-app bell + email + push, same posture as queue
-  alerts — no unsubscribe). Idempotent per uid. Deep link: `/admin/telemetry`.
+  alerts — no unsubscribe). Idempotent per uid. Deep link: `/admin/waitlist`.
+
 ## Store
 
 `Store` interface gains `upsertWaitlistEntry(entry)` (+ `InMemoryStore` and
 `FirestoreStore` implementations; Firestore collection `waitlist`, doc id =
-uid). No reads needed in-app for v1 — the owner reads the collection in the
-Firestore console.
+uid). Operator reads/writes go through `listWaitlistEntries` /
+`setWaitlistStatus` / `setWaitlistStatusByEmail` and the `/api/admin/waitlist`
+routes behind the console tab.
 
-## Promotion flow (v1 = deliberately manual)
+## Promotion flow
 
-Owner reads `waitlist` collection → adds chosen uid to `BETA_ALLOWED_UIDS`
-repo variable → redeploys (or asks Claude to). At beta scale this is fine.
-v2 (only if the list grows): store-backed allowlist — `waitlist/{uid}.status
-= 'approved'` consulted by the auth check, no redeploy per invite.
+Primary: operator console **`/admin/waitlist`** — approve / reject / pre-approve
+by email (Firestore `status: 'approved'`, no redeploy). Fallback: `npm run
+beta:approve` or the env allowlists (`BETA_ALLOWED_EMAILS` /
+`BETA_ALLOWED_UIDS`) when a script or agent needs to act without a browser.
 
 ## Tests
 
@@ -91,4 +93,9 @@ v2 (only if the list grows): store-backed allowlist — `waitlist/{uid}.status
 ## Explicitly not in v1
 
 - Email-form waitlist (unverified input, bots, moderation surface — no).
-- Admin UI for the waitlist; invite emails; counts on the splash page.
+- Invite emails from the console (CLI `beta:invite` remains); counts on the splash page.
+
+## Later addition
+
+- Admin UI for the waitlist shipped as the operator console **Waitlist** tab
+  (`/admin/waitlist`) — list, approve/reject/reset, pre-approve by email.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Waitlist** tab to `/admin` so operators can manage closed-beta membership without the CLI or Firestore console.

- Store: `listWaitlistEntries`, `countWaitlistEntries`, `setWaitlistStatusByEmail`
- API: `GET|POST /api/admin/waitlist` and `POST /api/admin/waitlist/:uid` (session-admin only, 404 otherwise)
- UI: `/admin/waitlist` — filter by status, approve/reject/reset rows, pre-approve by email
- Summary badge shows pending count; join notifications deep-link here instead of telemetry

## Review follow-ups

Addressed Copilot + Codex feedback:
- Waitlist emails are lowercased on write; approve-by-email heals legacy mixed-case rows instead of minting duplicates
- Filter loads use a generation guard so stale responses cannot overwrite the current list

## Test plan

- [x] Unit tests for store / admin routes / panel / console tab
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] Copilot + Codex review comments addressed
- [ ] Manual: sign in as admin → `/admin/waitlist` lists pending; Approve grants access; pre-approve by email creates `email:` row
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3b25b8d-e90d-4132-832d-438d33e6c9a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3b25b8d-e90d-4132-832d-438d33e6c9a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

