### PR TITLE
fix(studio): left-edge shelf rail and phone drawer, drop switcher combo

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -34,7 +34,7 @@ async function main() {
     await store.setSubmissionSlug(102, 'studio-tycoon');
     await store.setSubmissionLastStatus(102, 'building');
     await store.setSubmissionNotifiedStatus(102, 'building');
-    // Extra shelf rows so local QA can exercise search/filters/mobile switcher at 10+.
+    // Extra shelf rows so local QA can exercise search/filters/compact rail + drawer at 10+.
     const extras: Array<{
       issue: number;
       title: string;

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -63,8 +63,7 @@ const VIEWPORTS = [
 /** Stable ids used only inside the stubbed responses — never written to the API. */
 const FIXTURE_TOKEN = 'e2e-studio-shell-token';
 const FIXTURE_SLUG = 'e2e-studio-shell';
-/** Enough games to trip focus mode (STUDIO_SHELF_TOOLS_AT = 5), which is the desktop
- *  path that used to re-cage the work surface after the shelf collapsed. */
+/** Enough games to trip the compact left rail (STUDIO_SHELF_TOOLS_AT = 5). */
 const FOCUS_SHELF_SIZE = 5;
 
 async function fulfillJson(route: Route, body: unknown) {
@@ -92,10 +91,9 @@ function fixtureGames() {
  * The SPA still mounts CreatorStudioView + SubmissionStatusView and applies the real
  * stylesheet; only the JSON those views fetch is replaced.
  *
- * Five games, not one: a single-game shelf never enters focus mode, and that is the
- * desktop state where a capped reading column used to float in empty gutters after the
- * shelf hid. Stubbing under the threshold made the gate green while the live screen
- * with a real shelf was wrong.
+ * Five games, not one: a single-game shelf never enters the compact-rail path, and that
+ * is the desktop state this gate has to keep honest (work surface beside a skinny rail,
+ * not a floating card and not a "switch game" combo).
  */
 async function stubStudioThreadData(page: Page) {
   await page.route('**/api/me/studio**', async (route) => {
@@ -223,14 +221,20 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
           gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
-          focusMode: Boolean(layout?.classList.contains('is-focus')),
+          compactShelf: Boolean(layout?.classList.contains('is-compact-shelf')),
+          shelfOpen: Boolean(layout?.classList.contains('is-shelf-open')),
           detailWidth: detail?.getBoundingClientRect().width ?? 0,
           viewportWidth: window.innerWidth,
+          hasSwitcher: Boolean(document.querySelector('.studio-game-switcher')),
+          hasShelf: Boolean(document.querySelector('.studio-shelf')),
         };
       });
 
       expect(shell.gameOpen, 'the studio should mark a game open so the shell CSS applies').toBe(true);
-      expect(shell.focusMode, 'the fixture shelf must be large enough to enter focus mode').toBe(true);
+      expect(shell.compactShelf, 'the fixture shelf must be large enough to enter compact-rail mode').toBe(true);
+      expect(shell.shelfOpen, 'compact shelf should start collapsed/closed').toBe(false);
+      expect(shell.hasSwitcher, 'the switch-game combo must stay gone').toBe(false);
+      expect(shell.hasShelf, 'the shelf itself must remain in the tree as a rail/drawer').toBe(true);
 
       // The page owning the window is the precondition for the rest: it is what removes
       // the scroll a reader would otherwise use to escape a bar sitting on the composer.
@@ -244,13 +248,12 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         /^(auto|scroll)$/,
       );
 
-      // Desktop focus mode used to leave a ~1080px column floating in gutters after the
-      // shelf hid. The work surface should own the window width (padding aside).
+      // Desktop compact rail (~56px) leaves the work surface owning the rest of the window.
       if (viewport.width >= 801) {
         expect(
           shell.detailWidth,
-          `focus-mode work surface should be full-bleed at ${viewport.width}px, not a centred card`,
-        ).toBeGreaterThan(viewport.width - 80);
+          `compact-rail work surface should fill the window beside the rail at ${viewport.width}px`,
+        ).toBeGreaterThan(viewport.width - 120);
       }
 
       for (const bar of BOTTOM_BARS) {

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -63,6 +63,9 @@ const VIEWPORTS = [
 /** Stable ids used only inside the stubbed responses — never written to the API. */
 const FIXTURE_TOKEN = 'e2e-studio-shell-token';
 const FIXTURE_SLUG = 'e2e-studio-shell';
+/** Enough games to trip focus mode (STUDIO_SHELF_TOOLS_AT = 5), which is the desktop
+ *  path that used to re-cage the work surface after the shelf collapsed. */
+const FOCUS_SHELF_SIZE = 5;
 
 async function fulfillJson(route: Route, body: unknown) {
   await route.fulfill({
@@ -72,11 +75,27 @@ async function fulfillJson(route: Route, body: unknown) {
   });
 }
 
+function fixtureGames() {
+  return Array.from({ length: FOCUS_SHELF_SIZE }, (_, i) => ({
+    token: i === 0 ? FIXTURE_TOKEN : `${FIXTURE_TOKEN}-${i}`,
+    title: i === 0 ? 'E2E Studio Shell Fixture' : `E2E Studio Shell Fixture ${i + 1}`,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastKnownStatus: 'published' as const,
+    slug: i === 0 ? FIXTURE_SLUG : `${FIXTURE_SLUG}-${i}`,
+    publishedAt: '2026-01-02T00:00:00.000Z',
+  }));
+}
+
 /**
  * Give `/studio` a game with a composer without touching production shelf state.
  *
  * The SPA still mounts CreatorStudioView + SubmissionStatusView and applies the real
  * stylesheet; only the JSON those views fetch is replaced.
+ *
+ * Five games, not one: a single-game shelf never enters focus mode, and that is the
+ * desktop state where a capped reading column used to float in empty gutters after the
+ * shelf hid. Stubbing under the threshold made the gate green while the live screen
+ * with a real shelf was wrong.
  */
 async function stubStudioThreadData(page: Page) {
   await page.route('**/api/me/studio**', async (route) => {
@@ -90,18 +109,7 @@ async function stubStudioThreadData(page: Page) {
       return;
     }
     if (path.endsWith('/api/me/studio')) {
-      await fulfillJson(route, {
-        games: [
-          {
-            token: FIXTURE_TOKEN,
-            title: 'E2E Studio Shell Fixture',
-            createdAt: '2026-01-01T00:00:00.000Z',
-            lastKnownStatus: 'published',
-            slug: FIXTURE_SLUG,
-            publishedAt: '2026-01-02T00:00:00.000Z',
-          },
-        ],
-      });
+      await fulfillJson(route, { games: fixtureGames() });
       return;
     }
     await route.continue();
@@ -209,14 +217,20 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
 
       const shell = await page.evaluate(() => {
         const scroller = document.querySelector('.studio-thread-scroll');
+        const detail = document.querySelector('.studio-detail');
+        const layout = document.querySelector('.studio-layout');
         return {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
           gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
+          focusMode: Boolean(layout?.classList.contains('is-focus')),
+          detailWidth: detail?.getBoundingClientRect().width ?? 0,
+          viewportWidth: window.innerWidth,
         };
       });
 
       expect(shell.gameOpen, 'the studio should mark a game open so the shell CSS applies').toBe(true);
+      expect(shell.focusMode, 'the fixture shelf must be large enough to enter focus mode').toBe(true);
 
       // The page owning the window is the precondition for the rest: it is what removes
       // the scroll a reader would otherwise use to escape a bar sitting on the composer.
@@ -229,6 +243,15 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       expect(shell.scrollerOverflowY, 'the transcript needs its own scroller once the page has none').toMatch(
         /^(auto|scroll)$/,
       );
+
+      // Desktop focus mode used to leave a ~1080px column floating in gutters after the
+      // shelf hid. The work surface should own the window width (padding aside).
+      if (viewport.width >= 801) {
+        expect(
+          shell.detailWidth,
+          `focus-mode work surface should be full-bleed at ${viewport.width}px, not a centred card`,
+        ).toBeGreaterThan(viewport.width - 80);
+      }
 
       for (const bar of BOTTOM_BARS) {
         const { overlapsComposer, sendIsHittable } = await coverageBy(bar);

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -211,6 +211,43 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('locks body scroll while the phone shelf drawer is open', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(manyGames(6));
+    // jsdom has no matchMedia; width is the same fallback the drawer uses in embedded
+    // webviews. Narrow enough that the shelf is off-canvas, not the desktop rail.
+    const width = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true });
+
+    const { container, root } = await renderStudio();
+
+    const shelf = container.querySelector('.studio-shelf');
+    expect(shelf?.hasAttribute('inert')).toBe(true);
+    expect(shelf?.getAttribute('aria-hidden')).toBe('true');
+
+    const openShelf = container.querySelector('.studio-shelf-open');
+    expect(openShelf).toBeTruthy();
+    await act(async () => {
+      openShelf!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(container.querySelector('.studio-shelf')?.hasAttribute('inert')).toBe(false);
+    expect(container.querySelector('.studio-shelf')?.getAttribute('aria-hidden')).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(document.body.style.overflow).not.toBe('hidden');
+    expect(container.querySelector('.studio-shelf')?.hasAttribute('inert')).toBe(true);
+
+    Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+    root.unmount();
+  });
+
   it('persists the selected tab in the URL', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -146,7 +146,7 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
-  it('opens the game picker from the switcher', async () => {
+  it('opens the games shelf from the open control', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -154,19 +154,20 @@ describe('CreatorStudioView', () => {
 
     const { container, root } = await renderStudio();
 
-    const switcher = container.querySelector('.studio-game-switcher');
-    expect(switcher).toBeTruthy();
+    const openShelf = container.querySelector('.studio-shelf-open');
+    expect(openShelf).toBeTruthy();
 
     await act(async () => {
-      switcher!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      openShelf!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.querySelector('[role="dialog"]')?.textContent).toMatch(/Choose a game/i);
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
+    expect(container.querySelector('.studio-shelf-backdrop')).toBeTruthy();
 
     root.unmount();
   });
 
-  it('closes picker on Escape while in playtest tab without exiting playtest', async () => {
+  it('closes the shelf on Escape while in playtest tab without exiting playtest', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -174,27 +175,27 @@ describe('CreatorStudioView', () => {
 
     const { container, root } = await renderStudio({ selectedGame: 'game-2', selectedTab: 'playtest' });
 
-    const switcher = container.querySelector('.studio-game-switcher');
-    expect(switcher).toBeTruthy();
+    const openShelf = container.querySelector('.studio-shelf-open');
+    expect(openShelf).toBeTruthy();
 
     await act(async () => {
-      switcher!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      openShelf!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.querySelector('.studio-picker')).toBeTruthy();
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
 
     await act(async () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     });
 
-    expect(container.querySelector('.studio-picker')).toBeFalsy();
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(false);
     expect(container.querySelector('.studio-panel')?.classList.contains('is-playtesting')).toBe(true);
 
     root.unmount();
     authUser = null;
   });
 
-  it('enters focus mode once the shelf has many games selected', async () => {
+  it('collapses a long shelf to a rail after a game is selected', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -202,8 +203,10 @@ describe('CreatorStudioView', () => {
 
     const { container, root } = await renderStudio();
 
-    expect(container.querySelector('.studio-layout')?.classList.contains('is-focus')).toBe(true);
-    expect(container.querySelector('.studio-game-switcher')?.textContent).toMatch(/10 games/i);
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-compact-shelf')).toBe(true);
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(false);
+    expect(container.querySelector('.studio-shelf')).toBeTruthy();
+    expect(container.querySelector('.studio-game-switcher')).toBeNull();
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -46,9 +46,10 @@ import {
  * and it always targets the game's current state — published or not, there is only ever
  * the tip to work on.
  *
- * Shelf scales past a handful of games: compact rows, search/filter once the list grows,
- * and on narrow viewports a game switcher (picker sheet) so the thread is not buried
- * under ten cards.
+ * Shelf scales past a handful of games: compact rows, search/filter once the list grows.
+ * On a desktop with a long shelf it collapses to a left-edge rail of dots (not a "switch
+ * game" combo); expand it to get the full list back. On a phone with a game open the
+ * shelf is never permanently in the page — it is a drawer over ~90% of the width.
  *
  * Selection + surface live in the URL (`/studio/<slug>/<surface>`) so a refresh or a
  * shared link reopens the same place. The five old tab names still resolve, onto
@@ -161,10 +162,10 @@ export function CreatorStudioView({
   const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'thread');
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
-  const [pickerOpen, setPickerOpen] = useState(false);
+  /** Desktop rail expand, or mobile drawer open. Closed by default once a game is open. */
+  const [shelfOpen, setShelfOpen] = useState(false);
   const shelfSearchId = useId();
-  const pickerSearchId = useId();
-  const pickerSearchRef = useRef<HTMLInputElement>(null!);
+  const shelfSearchRef = useRef<HTMLInputElement>(null!);
 
   // What the URL is asking for, readable from inside the shelf fetch below without
   // making that fetch re-run every time the address changes. Seeded rather than
@@ -343,12 +344,17 @@ export function CreatorStudioView({
   }, [detailsIsSheet]);
 
   useEffect(() => {
-    if (!pickerOpen) return;
+    if (!shelfOpen || !activeGame) return;
     const previous = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    const frame = window.requestAnimationFrame(() => pickerSearchRef.current?.focus());
+    // Only the phone drawer needs to freeze the page; the desktop rail expands in flow.
+    const narrow =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(max-width: 800px)').matches
+        : window.innerWidth <= 800;
+    if (narrow) document.body.style.overflow = 'hidden';
+    const frame = window.requestAnimationFrame(() => shelfSearchRef.current?.focus());
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setPickerOpen(false);
+      if (event.key === 'Escape') setShelfOpen(false);
     };
     window.addEventListener('keydown', onKey);
     return () => {
@@ -356,14 +362,14 @@ export function CreatorStudioView({
       window.cancelAnimationFrame(frame);
       window.removeEventListener('keydown', onKey);
     };
-  }, [pickerOpen]);
+  }, [shelfOpen, activeGame]);
 
   function selectGame(token: string) {
     const next = games.find((game) => game.token === token) ?? null;
     const nextTab = defaultTabFor();
     setSelected(token);
     setTab(nextTab);
-    setPickerOpen(false);
+    setShelfOpen(false);
     if (next) onNavigate(studioPath(studioAddress(next), nextTab));
   }
 
@@ -438,26 +444,48 @@ export function CreatorStudioView({
           className={[
             'studio-layout',
             activeGame ? 'is-game-open' : '',
-            // Once the shelf is no longer a glanceable handful, collapse it after
-            // selection so the work surface owns the viewport (desktop + mobile).
-            activeGame && showShelfTools ? 'is-focus' : '',
+            // Long shelf on a desktop: collapse to a left-edge rail of dots after pick.
+            // Phones ignore this — they always use the drawer once a game is open.
+            activeGame && showShelfTools ? 'is-compact-shelf' : '',
+            shelfOpen ? 'is-shelf-open' : '',
           ]
             .filter(Boolean)
             .join(' ')}
         >
+          {activeGame && shelfOpen ? (
+            <div
+              className="modal-backdrop studio-shelf-backdrop"
+              role="presentation"
+              onClick={() => setShelfOpen(false)}
+            />
+          ) : null}
+
           <aside className="studio-shelf" aria-label={t('studioPanel.shelfAria')}>
             <div className="studio-shelf-head">
               <h2 className="studio-shelf-heading">{t('studioPanel.shelf.heading')}</h2>
               <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: games.length })}</span>
+              {activeGame ? (
+                <button
+                  type="button"
+                  className="studio-shelf-edge-toggle"
+                  onClick={() => setShelfOpen((open) => !open)}
+                  aria-expanded={shelfOpen}
+                  aria-label={shelfOpen ? t('studioPanel.shelf.collapseShelf') : t('studioPanel.shelf.expandShelf')}
+                >
+                  <PixelIcon name={shelfOpen ? 'collapse' : 'expand'} size={12} />
+                </button>
+              ) : null}
             </div>
             <button type="button" className="studio-shelf-new" onClick={() => onNavigate('/')}>
-              <PixelIcon name="sparkle" size={12} /> {t('studioPanel.shelf.newGame')}
+              <PixelIcon name="sparkle" size={12} />{' '}
+              <span className="studio-shelf-new-label">{t('studioPanel.shelf.newGame')}</span>
             </button>
             <StudioShelfControls
               searchInputId={shelfSearchId}
+              searchRef={shelfSearchRef}
               query={shelfQuery}
               filter={shelfFilter}
-              showTools={showShelfTools}
+              showTools={showShelfTools || (shelfOpen && games.length > 1)}
               buildingCount={buildingCount}
               liveCount={liveCount}
               totalCount={games.length}
@@ -474,23 +502,13 @@ export function CreatorStudioView({
               <div className="studio-detail-head">
                 <button
                   type="button"
-                  className="studio-game-switcher"
-                  onClick={() => setPickerOpen(true)}
-                  aria-haspopup="dialog"
-                  aria-expanded={pickerOpen}
+                  className="studio-shelf-open"
+                  onClick={() => setShelfOpen(true)}
+                  aria-expanded={shelfOpen}
+                  aria-label={t('studioPanel.shelf.openShelf')}
                 >
-                  <span className="studio-game-switcher-meta">
-                    <span className="studio-game-switcher-label">{t('studioPanel.shelf.switcher')}</span>
-                    <span className="studio-game-switcher-count">
-                      {t('studioPanel.shelf.count', { count: games.length })}
-                    </span>
-                  </span>
-                  <span className="studio-game-switcher-title">{activeGame.title}</span>
-                  {activeGame.slug ? <code className="studio-slug">{activeGame.slug}</code> : null}
-                  {/* Not `expand`: once a phone puts this button and the Details button on
-                      one row, the same icon appeared twice on that row meaning two
-                      different things. A folder is the other games. */}
                   <PixelIcon name="folder" size={12} />
+                  <span className="studio-shelf-open-label">{t('studioPanel.shelf.openShelf')}</span>
                 </button>
                 <div className="studio-detail-title-row">
                   <div className="studio-detail-title-block">
@@ -559,7 +577,7 @@ export function CreatorStudioView({
                     game={activeGame}
                     published={isStudioGamePublished(activeGame)}
                     onExit={() => openTab('thread')}
-                    pickerOpen={pickerOpen}
+                    shelfOpen={shelfOpen}
                   />
                 ) : null}
 
@@ -620,51 +638,6 @@ export function CreatorStudioView({
               </div>
             </div>
           ) : null}
-        </div>
-      ) : null}
-
-      {pickerOpen ? (
-        <div
-          className="modal-backdrop studio-picker-backdrop"
-          role="presentation"
-          onClick={(event) => {
-            if (event.target === event.currentTarget) setPickerOpen(false);
-          }}
-        >
-          <div
-            className="studio-picker"
-            role="dialog"
-            aria-modal="true"
-            aria-label={t('studioPanel.shelf.pickerTitle')}
-          >
-            <header className="studio-picker-header">
-              <div>
-                <h2>{t('studioPanel.shelf.pickerTitle')}</h2>
-                <p>{t('studioPanel.shelf.count', { count: games.length })}</p>
-              </div>
-              <button
-                type="button"
-                className="modal-close-btn"
-                onClick={() => setPickerOpen(false)}
-                aria-label={t('studioPanel.shelf.closePicker')}
-              >
-                <PixelIcon name="close" size={14} />
-              </button>
-            </header>
-            <StudioShelfControls
-              searchInputId={pickerSearchId}
-              searchRef={pickerSearchRef}
-              query={shelfQuery}
-              filter={shelfFilter}
-              showTools={showShelfTools || games.length > 1}
-              buildingCount={buildingCount}
-              liveCount={liveCount}
-              totalCount={games.length}
-              onQueryChange={setShelfQuery}
-              onFilterChange={setShelfFilter}
-            />
-            {shelfList}
-          </div>
         </div>
       ) : null}
     </section>
@@ -769,6 +742,7 @@ function StudioShelfList({
               className={`studio-shelf-item${active ? ' is-active' : ''}${building ? ' is-live' : ''}${published ? ' is-published' : ''}`}
               onClick={() => onSelect(game.token)}
               aria-current={active ? 'true' : undefined}
+              title={game.title}
             >
               {/* A dot, not a label. Every row used to carry its status in words and its
                   age beside it, which made a list of five games a wall of small text with

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -66,6 +66,9 @@ const WINDOWS = [1, 7, 30];
  */
 const SHEET_MAX_WIDTH = 1099;
 const SHEET_QUERY = `(max-width: ${SHEET_MAX_WIDTH}px)`;
+/** Matches the phone drawer breakpoint in styles.css — shelf off-canvas when a game is open. */
+const SHELF_DRAWER_MAX_WIDTH = 800;
+const SHELF_DRAWER_QUERY = `(max-width: ${SHELF_DRAWER_MAX_WIDTH}px)`;
 
 type NavigateOptions = { replace?: boolean };
 
@@ -164,6 +167,8 @@ export function CreatorStudioView({
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
   /** Desktop rail expand, or mobile drawer open. Closed by default once a game is open. */
   const [shelfOpen, setShelfOpen] = useState(false);
+  /** True when the shelf is the phone drawer (off-canvas), not the desktop rail. */
+  const [shelfIsDrawer, setShelfIsDrawer] = useState(false);
   const shelfSearchId = useId();
   const shelfSearchRef = useRef<HTMLInputElement>(null!);
 
@@ -344,14 +349,22 @@ export function CreatorStudioView({
   }, [detailsIsSheet]);
 
   useEffect(() => {
+    const query = typeof window.matchMedia === 'function' ? window.matchMedia(SHELF_DRAWER_QUERY) : null;
+    const sync = () => setShelfIsDrawer(query ? query.matches : window.innerWidth <= SHELF_DRAWER_MAX_WIDTH);
+    sync();
+    query?.addEventListener('change', sync);
+    window.addEventListener('resize', sync);
+    return () => {
+      query?.removeEventListener('change', sync);
+      window.removeEventListener('resize', sync);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!shelfOpen || !activeGame) return;
     const previous = document.body.style.overflow;
     // Only the phone drawer needs to freeze the page; the desktop rail expands in flow.
-    const narrow =
-      typeof window.matchMedia === 'function'
-        ? window.matchMedia('(max-width: 800px)').matches
-        : window.innerWidth <= 800;
-    if (narrow) document.body.style.overflow = 'hidden';
+    if (shelfIsDrawer) document.body.style.overflow = 'hidden';
     const frame = window.requestAnimationFrame(() => shelfSearchRef.current?.focus());
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setShelfOpen(false);
@@ -362,7 +375,7 @@ export function CreatorStudioView({
       window.cancelAnimationFrame(frame);
       window.removeEventListener('keydown', onKey);
     };
-  }, [shelfOpen, activeGame]);
+  }, [shelfOpen, activeGame, shelfIsDrawer]);
 
   function selectGame(token: string) {
     const next = games.find((game) => game.token === token) ?? null;
@@ -460,7 +473,21 @@ export function CreatorStudioView({
             />
           ) : null}
 
-          <aside className="studio-shelf" aria-label={t('studioPanel.shelfAria')}>
+          {/* Phone drawer, closed: keep it out of the tab order and the accessibility tree.
+              Desktop compact rail stays interactive while collapsed — only the drawer is
+              off-canvas. `inert` is set via the DOM (React 18 does not wire the prop);
+              aria-hidden covers AT that skips inert. */}
+          <aside
+            className="studio-shelf"
+            aria-label={t('studioPanel.shelfAria')}
+            aria-hidden={activeGame && shelfIsDrawer && !shelfOpen ? true : undefined}
+            ref={(el) => {
+              if (!el) return;
+              const closed = Boolean(activeGame && shelfIsDrawer && !shelfOpen);
+              if (closed) el.setAttribute('inert', '');
+              else el.removeAttribute('inert');
+            }}
+          >
             <div className="studio-shelf-head">
               <h2 className="studio-shelf-heading">{t('studioPanel.shelf.heading')}</h2>
               <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: games.length })}</span>
@@ -603,7 +630,7 @@ export function CreatorStudioView({
                           type="button"
                           className="modal-close-btn"
                           onClick={() => openTab('thread')}
-                          aria-label={t('studioPanel.shelf.closePicker')}
+                          aria-label={t('studioPanel.close')}
                         >
                           <PixelIcon name="close" size={14} />
                         </button>

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -136,7 +136,7 @@ describe('StudioPlaytestPanel theater', () => {
     root.unmount();
   });
 
-  it('does not exit on Escape when pickerOpen is true', async () => {
+  it('does not exit on Escape when shelfOpen is true', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -146,7 +146,7 @@ describe('StudioPlaytestPanel theater', () => {
     const root = createRoot(container);
 
     await act(async () => {
-      root.render(createElement(StudioPlaytestPanel, { game, published: true, onExit, pickerOpen: true }));
+      root.render(createElement(StudioPlaytestPanel, { game, published: true, onExit, shelfOpen: true }));
     });
     await act(async () => {
       await Promise.resolve();

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -51,8 +51,8 @@ type StudioPlaytestPanelProps = {
   published: boolean;
   /** Leave theater — typically returns to Overview so Studio chrome is usable again. */
   onExit: () => void;
-  /** True when the game switcher picker overlay is open above the playtest surface. */
-  pickerOpen?: boolean;
+  /** True when the games shelf drawer/rail is open above the playtest surface. */
+  shelfOpen?: boolean;
 };
 
 /**
@@ -104,7 +104,7 @@ function toContext(
   };
 }
 
-export function StudioPlaytestPanel({ game, published, onExit, pickerOpen }: StudioPlaytestPanelProps) {
+export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: StudioPlaytestPanelProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const exitRef = useRef<HTMLButtonElement | null>(null);
@@ -123,9 +123,9 @@ export function StudioPlaytestPanel({ game, published, onExit, pickerOpen }: Stu
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
   const requestExit = useCallback(() => {
-    if (pickerOpen) return;
+    if (shelfOpen) return;
     onExitRef.current();
-  }, [pickerOpen]);
+  }, [shelfOpen]);
   // Escape inside the sandboxed game never reaches the parent — the bridge relays it.
   useGamePlayer(frameRef, active, requestExit);
 
@@ -170,11 +170,11 @@ export function StudioPlaytestPanel({ game, published, onExit, pickerOpen }: Stu
   // theater never mounts and the Close control used to be missing entirely.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !pickerOpen) requestExit();
+      if (event.key === 'Escape' && !shelfOpen) requestExit();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [requestExit, pickerOpen]);
+  }, [requestExit, shelfOpen]);
 
   // Scroll lock + focus handoff while the theater owns the viewport.
   useEffect(() => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -258,8 +258,9 @@
         "live": "Live"
       },
       "noMatches": "No games match that search.",
-      "switcher": "Switch game",
-      "pickerTitle": "Choose a game",
+      "openShelf": "Your games",
+      "expandShelf": "Expand games list",
+      "collapseShelf": "Collapse games list",
       "closePicker": "Close game list"
     },
     "tabs": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -243,6 +243,7 @@
     "empty": "You have not commissioned a game yet.",
     "gameNotFound": "We couldn't find that game on your shelf. It may have been stopped, or the link may belong to someone else.",
     "createFirst": "Create your first game",
+    "close": "Close",
     "shelfAria": "Your games",
     "shelf": {
       "heading": "Your games",
@@ -260,8 +261,7 @@
       "noMatches": "No games match that search.",
       "openShelf": "Your games",
       "expandShelf": "Expand games list",
-      "collapseShelf": "Collapse games list",
-      "closePicker": "Close game list"
+      "collapseShelf": "Collapse games list"
     },
     "tabs": {
       "thread": "Thread",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -243,6 +243,7 @@
     "empty": "Nie zleciłeś jeszcze żadnej gry.",
     "gameNotFound": "Nie znaleźliśmy tej gry na Twojej półce. Mogła zostać zatrzymana albo link należy do kogoś innego.",
     "createFirst": "Stwórz pierwszą grę",
+    "close": "Zamknij",
     "shelfAria": "Twoje gry",
     "shelf": {
       "heading": "Twoje gry",
@@ -262,8 +263,7 @@
       "noMatches": "Żadna gra nie pasuje do tego wyszukiwania.",
       "openShelf": "Twoje gry",
       "expandShelf": "Rozwiń listę gier",
-      "collapseShelf": "Zwiń listę gier",
-      "closePicker": "Zamknij listę gier"
+      "collapseShelf": "Zwiń listę gier"
     },
     "tabs": {
       "thread": "Wątek",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -260,8 +260,9 @@
         "live": "Na żywo"
       },
       "noMatches": "Żadna gra nie pasuje do tego wyszukiwania.",
-      "switcher": "Zmień grę",
-      "pickerTitle": "Wybierz grę",
+      "openShelf": "Twoje gry",
+      "expandShelf": "Rozwiń listę gier",
+      "collapseShelf": "Zwiń listę gier",
       "closePicker": "Zamknij listę gier"
     },
     "tabs": {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4693,10 +4693,8 @@ body.player-open {
    broken one.
 
    800px, not 900, because that is where the studio itself changes shape: below it the
-   shelf collapses into the switcher and the detail's own title row is hidden. Between
-   801 and 900 the shelf is still stacked above the thread and the title row is the only
-   place the game is named — an earlier draft of this ran to 900 and left that band with
-   no title on screen at all. */
+   shelf becomes a drawer and the open-shelf control joins the title row. Between 801 and
+   900 the shelf is still a column beside the thread. */
 @media (max-width: 800px) {
   /* Every wrapper between the shell and the transcript has to give up its height, or the
      scroller at the bottom of the chain has nothing to measure itself against. */
@@ -4723,66 +4721,42 @@ body.player-open {
     max-width: 100%;
   }
 
-  /* The switcher holds a slug, and a slug can be longer than a phone. It never showed
-     because the grid used to cap the column; once the shell became a flex chain the row
-     sized to its content and pushed everything past the right edge. Truncate it here
-     rather than letting one long name decide the width of the screen. */
-  .app:has(.studio-layout.is-game-open) .studio-detail-head,
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher {
-    min-width: 0;
-    max-width: 100%;
-  }
-
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher .studio-slug {
-    /* Overrides the flex-shrink: 0 the chip carries everywhere else. A slug that refuses
-       to shrink is a slug that decides how wide the screen is. */
-    flex-shrink: 1;
-    min-width: 0;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* The switcher directly above already names the game; repeating it in the status line
-     is what pushed that line onto two rows. */
-  .app:has(.studio-layout.is-game-open) .studio-thread-context .studio-slug {
-    display: none;
-  }
-
-  /* Two rows of chrome above the conversation — a switcher row and an actions row —
-     was about 150px of a phone screen spent on furniture. One row: which game, and the
-     two things you can do to it. `display: contents` is what lets the actions join that
-     row without moving them in the markup, where their place beside the title is right
-     on every wider screen. */
   .app:has(.studio-layout.is-game-open) .studio-detail-head {
+    min-width: 0;
+    max-width: 100%;
     flex-direction: row;
     align-items: center;
     gap: 8px;
   }
 
-  .app:has(.studio-layout.is-game-open) .studio-detail-title-row {
-    display: contents;
-  }
-
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher {
-    flex: 1;
-  }
-
-  /* "Switch game / 1 game" spells out what the chevron already says, and the slug is
-     repeated in the address bar and again on the details sheet. The title is the thing
-     you actually need to see, and it was the one item the row had no width for. */
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher-meta,
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher .studio-slug,
-  .app:has(.studio-layout.is-game-open) .studio-detail-title-block {
+  /* The title row already names the game; repeating the slug in the status line is what
+     pushed that line onto two rows. */
+  .app:has(.studio-layout.is-game-open) .studio-thread-context .studio-slug {
     display: none;
   }
 
-  .app:has(.studio-layout.is-game-open) .studio-game-switcher-title {
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-row {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-block {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-block h2 {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-detail-title-block .studio-slug {
+    display: none;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-head-actions {
@@ -4888,21 +4862,12 @@ body.player-open {
 
 /* The same app shell, shaped for a desktop.
    The phone got this in #386 and the reasoning does not stop at 800px: the studio is a
-   place you sit in, not a page you read down. On a 1440 window today it is a 1180px card
-   floating in the middle of a document, the composer lands wherever the transcript
-   happens to end, and the thing under a scroll from it is the marketing footer.
-
-   Full bleed here means the shell owns the window — shelf as a rail from the header to
-   the bottom edge, transcript with its own scroller, composer pinned above the bottom of
-   the window — but not that the text stretches to the window's edges. A 2560px monitor
-   would give a 2200px line of prose, so the column stays capped and centred inside the
-   full-width shell; what goes edge to edge is the furniture, not the reading.
+   place you sit in, not a page you read down. Full bleed means the shell owns the
+   window — shelf as a left rail (full or collapsed to dots), transcript with its own
+   scroller, composer pinned above the bottom. Turn prose keeps its own 68ch measure.
 
    The shell itself — the window-owning, footer-hiding, banner-reflowing part — is
-   above, outside any media query, and shared with the phone. What is here is only what
-   is different about a desktop: a rail instead of a switcher, and a capped column.
-
-   Keyed the same way as the phone rules — on a game being open, not on the route. */
+   above, outside any media query, and shared with the phone. */
 @media (min-width: 801px) {
   .app:has(.studio-layout.is-game-open) > .content {
     max-width: none;
@@ -4974,6 +4939,7 @@ body.player-open {
      window, which is not something that needs a line drawn around it. */
   .app:has(.studio-layout.is-game-open) .studio-detail {
     max-width: none;
+    width: 100%;
     margin: 0;
     border: 0;
     border-radius: 0;
@@ -4982,29 +4948,13 @@ body.player-open {
     padding: 16px 24px 0;
   }
 
-  /* Where full bleed stops — only while the shelf is still the edge furniture.
-     Focus mode (5+ games) hides that rail; capping the column then just paints
-     gutters where the furniture used to be, which reads as the old floating card.
-     Turn prose already has its own measure (68ch), so readable line length does not
-     need a second cage around the whole work surface. */
-  .app:has(.studio-layout.is-game-open:not(.is-focus)) .studio-detail-head,
-  .app:has(.studio-layout.is-game-open:not(.is-focus)) .studio-workspace {
-    width: 100%;
-    max-width: 1080px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  /* Focus mode: the work surface is the furniture. Stretch it — the detail already
-     carries horizontal padding from the rule above, so no second gutter. */
-  .app:has(.studio-layout.is-game-open.is-focus) .studio-detail {
-    max-width: none;
-    width: 100%;
-    margin: 0;
-  }
-
   .app:has(.studio-layout.is-game-open) .studio-thread-foot {
     padding-bottom: 16px;
+  }
+
+  /* Expanding the shelf on a desktop happens in the grid — no modal veil over the thread. */
+  .studio-shelf-backdrop {
+    display: none;
   }
 }
 
@@ -7450,9 +7400,10 @@ body.player-open {
 
 .studio-shelf-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
+  width: 100%;
 }
 
 .studio-shelf-heading {
@@ -7684,130 +7635,112 @@ body.player-open {
   flex-shrink: 0;
 }
 
-.studio-game-switcher {
+/* Opens the phone drawer. Hidden on desktop — the left rail is already there. */
+.studio-shelf-open {
   display: none;
+  flex: none;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  text-align: left;
-  padding: 12px 14px;
-  border-radius: 12px;
+  justify-content: center;
+  gap: 6px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 10px;
+  border-radius: 10px;
   border: 1px solid var(--panel-border);
-  background: linear-gradient(180deg, rgba(0, 228, 172, 0.06), transparent 70%), rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text);
   cursor: pointer;
-  transition:
-    border-color 0.2s,
-    box-shadow 0.2s,
-    background 0.2s;
 }
 
-.studio-game-switcher:hover {
+.studio-shelf-open:hover {
   border-color: rgba(0, 228, 172, 0.45);
-  box-shadow: 0 0 18px rgba(0, 228, 172, 0.08);
-}
-
-.studio-game-switcher-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-  flex-shrink: 0;
-}
-
-.studio-game-switcher-label {
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.45px;
-  color: var(--muted);
-}
-
-.studio-game-switcher-count {
-  font-size: 0.72rem;
-  font-weight: 600;
   color: var(--turquoise);
-  white-space: nowrap;
 }
 
-.studio-game-switcher-title {
-  flex: 1;
-  min-width: 0;
-  font-size: 1.15rem;
+.studio-shelf-open-label {
+  font-size: 0.78rem;
   font-weight: 700;
-  letter-spacing: -0.2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.studio-game-switcher .studio-slug {
-  flex-shrink: 0;
-}
-
-/* 5+ games: collapse the shelf after selection so the selected game owns the page.
-   Do not re-cage the detail here — a centred max-width on the work surface is what
-   made focus mode look like a floating card after the desktop shell went full-bleed.
-   Width comes from the shell rules above (padding, no max-width). */
-.studio-layout.is-focus {
-  grid-template-columns: 1fr;
-}
-
-.studio-layout.is-focus > .studio-shelf {
+/* Expand/collapse on the shelf itself (desktop rail ↔ full list, phone drawer close). */
+.studio-shelf-edge-toggle {
   display: none;
-}
-
-.studio-layout.is-focus .studio-game-switcher {
-  display: flex;
-}
-
-.studio-layout.is-focus .studio-detail-title-row {
-  display: none;
-}
-
-.studio-picker-backdrop {
-  z-index: 1100;
-  align-items: flex-end;
-}
-
-.studio-picker {
-  position: relative;
-  width: min(440px, 100%);
-  max-height: min(85vh, 720px);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 18px 16px 20px;
-  border-radius: 16px 16px 0 0;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-left: auto;
+  padding: 0;
+  border-radius: 8px;
   border: 1px solid var(--panel-border);
-  border-bottom: 0;
-  background: var(--panel);
-  box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
-}
-
-.studio-picker-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding-right: 2rem;
-}
-
-.studio-picker-header h2 {
-  margin: 0 0 4px;
-  font-size: 1.15rem;
-}
-
-.studio-picker-header p {
-  margin: 0;
+  background: transparent;
   color: var(--muted);
-  font-size: 0.85rem;
+  cursor: pointer;
 }
 
-.studio-picker .studio-shelf-list {
-  max-height: none;
-  flex: 1;
+.studio-shelf-edge-toggle:hover {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.4);
+}
+
+.studio-shelf-backdrop {
+  z-index: 1100;
+}
+
+/* 5+ games on a desktop: collapse to a left-edge rail of dots after selection.
+   Not a "switch game" combo — the shelf stays the shelf, just skinny. */
+@media (min-width: 801px) {
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) {
+    grid-template-columns: 56px 1fr;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf {
+    align-items: center;
+    padding: 12px 8px;
+    gap: 10px;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-head {
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-heading,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-count,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-tools,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-new-label,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-title {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-edge-toggle {
+    display: inline-flex;
+    margin-left: 0;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-new {
+    justify-content: center;
+    padding: 8px;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item {
+    justify-content: center;
+    padding: 10px 8px;
+  }
+
+  .studio-layout.is-compact-shelf.is-shelf-open .studio-shelf-edge-toggle {
+    display: inline-flex;
+  }
 }
 
 /* Whether anyone else may play an unpublished game. One switch, because the link is
@@ -8344,32 +8277,55 @@ body.player-open {
     grid-template-columns: 1fr;
   }
 
-  /* Narrow viewports always focus after selection — even a short shelf costs scroll. */
+  /* Phone + game open: the shelf is a drawer, never a permanent column. Closed it sits
+     off the left edge; open it covers ~90% of the width over a backdrop — the usual
+     mobile nav pattern, not a second page of cards above the thread. */
   .studio-layout.is-game-open > .studio-shelf {
-    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 1101;
+    width: min(90vw, 360px);
+    max-height: none;
+    margin: 0;
+    border-radius: 0;
+    border: 0;
+    border-right: 1px solid var(--panel-border);
+    background: var(--panel);
+    padding: 16px 14px max(16px, env(safe-area-inset-bottom, 0px));
+    transform: translateX(-105%);
+    transition: transform 0.2s ease;
+    box-shadow: 12px 0 40px rgba(0, 0, 0, 0.45);
   }
 
-  .studio-layout.is-game-open .studio-game-switcher {
-    display: flex;
+  .studio-layout.is-game-open.is-shelf-open > .studio-shelf {
+    transform: translateX(0);
   }
 
-  /* The switcher above already names the game, so the title block goes — but the
-     actions beside it must not, or Playtest and Details become unreachable on a phone. */
-  .studio-layout.is-game-open .studio-detail-title-block {
-    display: none;
+  .studio-layout.is-game-open .studio-shelf-open {
+    display: inline-flex;
   }
 
-  .studio-layout.is-game-open .studio-detail-title-row {
-    justify-content: flex-end;
+  .studio-layout.is-game-open .studio-shelf-open-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .studio-layout.is-game-open.is-shelf-open .studio-shelf-edge-toggle {
+    display: inline-flex;
   }
 
   .studio-layout.is-game-open .studio-detail {
     max-width: none;
     margin: 0;
-  }
-
-  .studio-game-switcher-title {
-    font-size: 1rem;
   }
 
   .studio-shelf {
@@ -8383,21 +8339,6 @@ body.player-open {
 
   .studio-detail {
     padding: 18px 16px;
-  }
-
-  .studio-picker {
-    width: 100%;
-  }
-}
-
-@media (min-width: 801px) {
-  .studio-picker-backdrop {
-    align-items: center;
-  }
-
-  .studio-picker {
-    border-radius: 16px;
-    border-bottom: 1px solid var(--panel-border);
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4982,14 +4982,25 @@ body.player-open {
     padding: 16px 24px 0;
   }
 
-  /* Where full bleed stops. The shell is as wide as the window; the conversation is as
-     wide as a conversation should be, centred in it. */
-  .app:has(.studio-layout.is-game-open) .studio-detail-head,
-  .app:has(.studio-layout.is-game-open) .studio-workspace {
+  /* Where full bleed stops — only while the shelf is still the edge furniture.
+     Focus mode (5+ games) hides that rail; capping the column then just paints
+     gutters where the furniture used to be, which reads as the old floating card.
+     Turn prose already has its own measure (68ch), so readable line length does not
+     need a second cage around the whole work surface. */
+  .app:has(.studio-layout.is-game-open:not(.is-focus)) .studio-detail-head,
+  .app:has(.studio-layout.is-game-open:not(.is-focus)) .studio-workspace {
     width: 100%;
     max-width: 1080px;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  /* Focus mode: the work surface is the furniture. Stretch it — the detail already
+     carries horizontal padding from the rule above, so no second gutter. */
+  .app:has(.studio-layout.is-game-open.is-focus) .studio-detail {
+    max-width: none;
+    width: 100%;
+    margin: 0;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-thread-foot {
@@ -7734,7 +7745,10 @@ body.player-open {
   flex-shrink: 0;
 }
 
-/* 5+ games: collapse the shelf after selection so the selected game owns the page. */
+/* 5+ games: collapse the shelf after selection so the selected game owns the page.
+   Do not re-cage the detail here — a centred max-width on the work surface is what
+   made focus mode look like a floating card after the desktop shell went full-bleed.
+   Width comes from the shell rules above (padding, no max-width). */
 .studio-layout.is-focus {
   grid-template-columns: 1fr;
 }
@@ -7749,12 +7763,6 @@ body.player-open {
 
 .studio-layout.is-focus .studio-detail-title-row {
   display: none;
-}
-
-.studio-layout.is-focus .studio-detail {
-  max-width: 920px;
-  width: 100%;
-  margin: 0 auto;
 }
 
 .studio-picker-backdrop {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8299,10 +8299,16 @@ body.player-open {
     transform: translateX(-105%);
     transition: transform 0.2s ease;
     box-shadow: 12px 0 40px rgba(0, 0, 0, 0.45);
+    /* translateX alone leaves the drawer in the tab order. Visibility + pointer-events
+       match the inert/aria-hidden markup so a closed drawer cannot be reached. */
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .studio-layout.is-game-open.is-shelf-open > .studio-shelf {
     transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
   }
 
   .studio-layout.is-game-open .studio-shelf-open {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4633,6 +4633,16 @@ body.player-open {
   position: static;
 }
 
+/* A bordered card around two words of status, directly above a bordered composer, reads
+   as two controls stacked — and on a desktop its right edge was a stray vertical line
+   floating in the shell padding. It is a caption; it can look like one. Shared with the
+   phone rules for the same reason the rest of the shell is shared. */
+.app:has(.studio-layout.is-game-open) .studio-thread-context {
+  border: 0;
+  background: none;
+  padding: 0 2px;
+}
+
 /* The install nudge and the update bar are fixed to the bottom of the viewport at
    z-index 900, which is exactly where this shell pins the composer. On the old scrolling
    page a reader could push the composer up past them; here there is nothing to scroll,
@@ -4776,14 +4786,6 @@ body.player-open {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
-  }
-
-  /* A bordered card around two words of status, directly above a bordered composer, read
-     as two controls stacked. It is a caption; it can look like one. */
-  .app:has(.studio-layout.is-game-open) .studio-thread-context {
-    border: 0;
-    background: none;
-    padding: 0 2px;
   }
 
   /* 126px of page padding — 60 on the content, 48 on the panel, 18 on the detail — was


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With 5+ games, Creator Studio hid the shelf and replaced it with a “Switch game” combo. After the desktop shell went full-bleed (#391), that left empty gutters and no edge furniture — and the combo itself was the wrong control.

## Fix

- **Desktop (5+ games):** keep the shelf; collapse it to a **56px left-edge rail of dots**. Expand/collapse in place. No combo, no centred card.
- **Phone (game open, any shelf size):** shelf is **never a permanent column** — it is a **~90vw drawer** over a backdrop, opened from a folder control in the title row (standard mobile nav pattern).
- Work surface stays full-bleed beside the rail; turn prose still uses its own `68ch` measure.
- Removed the picker modal / switcher chrome; Escape still closes the open shelf without exiting playtest.

## Screenshots

Desktop — collapsed rail:

[Desktop collapsed shelf rail](https://cursor.com/agents/bc-9300e58f-f239-46ab-9681-112ebfeee399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-desktop-rail-collapsed.png)

Desktop — expanded shelf:

[Desktop expanded shelf](https://cursor.com/agents/bc-9300e58f-f239-46ab-9681-112ebfeee399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-desktop-rail-expanded.png)

Phone — thread (shelf closed):

[Phone studio thread with shelf closed](https://cursor.com/agents/bc-9300e58f-f239-46ab-9681-112ebfeee399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-mobile-thread.png)

Phone — drawer open (~90vw):

[Phone shelf drawer open](https://cursor.com/agents/bc-9300e58f-f239-46ab-9681-112ebfeee399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-mobile-drawer-open.png)

## Test plan

- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] Screenshot: desktop rail collapsed / expanded; phone thread / drawer
- [ ] Desktop, 5+ games: rail of dots on the left; expand shows full list; no “Switch game” bar
- [ ] Desktop, &lt;5 games: full shelf column as before
- [ ] Phone, game open: no permanent shelf; folder opens ~90% drawer; backdrop / Escape / pick closes it
- [ ] Phone, no game selected: shelf is the page content as before

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9300e58f-f239-46ab-9681-112ebfeee399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9300e58f-f239-46ab-9681-112ebfeee399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

