### PR TITLE
byoca(BY-20): hand off to new job thread after post-publish improve

### DIFF
--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -7,7 +7,7 @@ import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import type { ContentChecker } from './moderation.js';
 import { InMemoryStore, type Store } from './store.js';
-import { mintToken } from './submission-token.js';
+import { mintToken, verifyToken } from './submission-token.js';
 import { canTransition } from './job-state.js';
 import type { AgentBackend, BuildBrief } from './agent-backend.js';
 import type { GamesStore } from './games-store.js';
@@ -3100,6 +3100,43 @@ describe('POST /api/submissions/:token/improve', () => {
     expect(improvement?.defaultBuilder).toBe('platform');
     expect(improvement?.dispatch?.backend).toBe('stub');
     expect(briefs.at(-1)?.issueNumber).toBe(jobId);
+    await app.close();
+  });
+
+  it('returns the new job’s own token so the creator’s thread can move onto it', async () => {
+    // Publishing is terminal: the improvement is a new job, and the published token
+    // cannot address it (its round key is dead). The response has to carry the new
+    // job's own capability, minted exactly like the shelf mints one per record.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const published = await store.allocateJobId();
+    await store.createSubmission(published, 'g:test-user', 'Handoff Game');
+    await store.setSubmissionSlug(published, 'handoff-game');
+    await store.setSubmissionPublishedAt(published, '2026-07-01T00:00:00.000Z');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(published, secret)}/improve`,
+      headers: authHeaders,
+      payload: { feedback: 'Please add a checkpoint before the hard second level jump.' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { ok: boolean; jobId: number; token: string; slug: string };
+    // The wire name stays `jobId` (the client type was the thing out of step, not this).
+    expect(body.jobId).toBeTypeOf('number');
+    expect(body.jobId).not.toBe(published);
+    expect(body.slug).toBe('handoff-game');
+    // The token addresses the *new* job, not the published one it was minted from.
+    expect(body.token).toBeTypeOf('string');
+    expect(verifyToken(body.token, secret)).toBe(body.jobId);
+    expect(verifyToken(body.token, secret)).not.toBe(published);
     await app.close();
   });
 });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2726,7 +2726,19 @@ export async function registerSubmissionRoutes(
       if (!started) {
         return reply.status(502).send({ error: 'failed to submit improvement request' });
       }
-      return reply.send({ ok: true, jobId: started.jobId, slug: record.slug, ...(shotId ? { shotId } : {}) });
+      // Publishing is terminal, so this is a *new* job with its own capability. The
+      // creator's thread has to move onto it — the old (published) token cannot address
+      // the new round, and its round key is dead. Minted exactly as GET
+      // /api/submissions/mine mints one per shelf record: owner-session-authed, same
+      // exposure class as the shelf the creator already reads.
+      const jobToken = mintToken(started.jobId, submissionTokenSecret);
+      return reply.send({
+        ok: true,
+        jobId: started.jobId,
+        token: jobToken,
+        slug: record.slug,
+        ...(shotId ? { shotId } : {}),
+      });
     },
   );
 

--- a/apps/web/src/CreatorStudioView.handoff.test.tsx
+++ b/apps/web/src/CreatorStudioView.handoff.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreatorStudioView } from './CreatorStudioView.js';
+import i18n from './i18n/index.js';
+import type { StudioGame } from './studioApi.js';
+import { getSubmissionStatus } from './submissionApi.js';
+import { submitImprovement } from './studioApi.js';
+
+/**
+ * The studio-side half of the publish→improve handoff (BY-20): when the embedded build
+ * thread reports that a published-game improvement opened a new job, CreatorStudioView
+ * must move the open thread onto that new job — even though it is not on the shelf yet —
+ * rather than leaving the creator on the published (terminal) thread.
+ *
+ * Isolated in its own file because it mocks submissionApi and stubs global fetch, which
+ * the broad CreatorStudioView.test.tsx deliberately does not.
+ */
+
+const fetchStudioGames = vi.fn();
+const fetchStudioHealth = vi.fn();
+const fetchStudioScorecards = vi.fn();
+const fetchStudioSuggestions = vi.fn();
+let authUser: { uid: string; name: string } | null = null;
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: authUser, logout: vi.fn() }),
+}));
+
+vi.mock('./studioApi', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi.js')>('./studioApi.js');
+  return {
+    ...actual,
+    fetchStudioGames: (...args: unknown[]) => fetchStudioGames(...args),
+    fetchStudioHealth: (...args: unknown[]) => fetchStudioHealth(...args),
+    fetchStudioScorecards: (...args: unknown[]) => fetchStudioScorecards(...args),
+    fetchStudioSuggestions: (...args: unknown[]) => fetchStudioSuggestions(...args),
+    submitImprovement: vi.fn(),
+  };
+});
+
+vi.mock('./submissionApi', async () => {
+  const actual = await vi.importActual<typeof import('./submissionApi.js')>('./submissionApi.js');
+  return {
+    ...actual,
+    getSubmissionStatus: vi.fn(),
+    getSubmissionPreview: vi.fn(async () => {
+      throw Object.assign(new Error('no preview'), { status: 409 });
+    }),
+    getChannelPlayable: vi.fn(async () => {
+      throw Object.assign(new Error('no channel'), { status: 409 });
+    }),
+    abandonSubmission: vi.fn(),
+  };
+});
+
+const mockedGetSubmissionStatus = vi.mocked(getSubmissionStatus);
+const mockedSubmitImprovement = vi.mocked(submitImprovement);
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('CreatorStudioView publish→improve handoff', () => {
+  beforeEach(() => {
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockReset();
+    fetchStudioHealth.mockReset().mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset().mockResolvedValue([]);
+    fetchStudioSuggestions.mockReset().mockResolvedValue([]);
+    mockedGetSubmissionStatus.mockReset();
+    mockedSubmitImprovement.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    window.history.pushState(null, '', '/');
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('moves the open thread onto the new self job and shows its connect card', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const connectFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        installSnippets: {
+          claudeCode: 'claude mcp add gamedevpl https://example.test/api/mcp',
+          codex: 'url = "https://example.test/api/mcp"',
+          cursor: '{"mcpServers":{}}',
+          kimi: 'npx mcp-remote https://example.test/api/mcp',
+          cli: 'curl https://example.test/api/mcp',
+        },
+        kickoffPrompt: 'Build "TV Tycoon" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    }));
+    vi.stubGlobal('fetch', connectFetch);
+
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'pub-self-shelf',
+        title: 'TV Tycoon',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        lastKnownStatus: 'published',
+        slug: 'tv-tycoon',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      },
+    ] satisfies StudioGame[]);
+
+    // The published (terminal) thread is self-built; its improvement is a new self job
+    // still waiting on the creator's own agent — the state that renders the connect card.
+    mockedGetSubmissionStatus.mockImplementation(async (token: string) =>
+      token === 'new-self-job'
+        ? { status: 'queued', stall: 'no_agent_yet', builder: 'self' }
+        : { status: 'published', slug: 'tv-tycoon', defaultBuilder: 'self' },
+    );
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, jobId: 77, token: 'new-self-job', slug: 'tv-tycoon' });
+
+    window.history.replaceState(null, '', '/studio/tv-tycoon');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(CreatorStudioView, {
+            selectedGame: 'tv-tycoon',
+            onNavigate: vi.fn(),
+            onPlay: vi.fn(),
+          }),
+        );
+      });
+      await act(async () => {
+        await fetchStudioGames.mock.results[0]?.value;
+        await flushEffects();
+        await flushEffects();
+      });
+
+      // Terminal published thread: no connect card of its own.
+      expect(container.querySelector('.studio-build')).not.toBeNull();
+      expect(container.querySelector('.studio-connect')).toBeNull();
+
+      const box = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+      expect(box).not.toBeNull();
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+        setter?.call(box, 'Give the second level a checkpoint so it is not so punishing.');
+        box!.dispatchEvent(new Event('input', { bubbles: true }));
+        await flushEffects();
+      });
+      await act(async () => {
+        container.querySelector('.status-composer-send')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+        await flushEffects();
+        await flushEffects();
+      });
+
+      // The improvement was filed against the published job's token, defaulting to the
+      // status payload's builder (self) rather than empty local memory.
+      expect(mockedSubmitImprovement).toHaveBeenCalledWith('pub-self-shelf', expect.any(String), undefined, 'self');
+      // The thread is now the new job's: it announces the handoff and shows that round's
+      // connect card. The published thread never surfaced either.
+      expect(container.querySelector('.status-handoff-notice')?.textContent).toContain('new build thread');
+      expect(container.querySelector('.studio-connect')).not.toBeNull();
+      expect(connectFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/submissions/new-self-job/connect'),
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+  });
+});

--- a/apps/web/src/CreatorStudioView.handoff.test.tsx
+++ b/apps/web/src/CreatorStudioView.handoff.test.tsx
@@ -174,6 +174,21 @@ describe('CreatorStudioView publish→improve handoff', () => {
         expect.stringContaining('/api/submissions/new-self-job/connect'),
         expect.objectContaining({ credentials: 'include' }),
       );
+
+      // Playtest must follow the handoff token too — otherwise pause-feedback would
+      // call submitImprovement on the published job and open a second concurrent round.
+      await act(async () => {
+        const playtestTab = Array.from(container.querySelectorAll('button')).find((btn) =>
+          /playtest/i.test(btn.textContent ?? ''),
+        );
+        expect(playtestTab).toBeTruthy();
+        playtestTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+        await flushEffects();
+      });
+      // Unpublished preview path uses the new job's token (not the published slug fetch).
+      const { getSubmissionPreview } = await import('./submissionApi.js');
+      expect(vi.mocked(getSubmissionPreview)).toHaveBeenCalledWith('new-self-job');
     } finally {
       await act(async () => {
         root.unmount();

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -162,6 +162,12 @@ export function CreatorStudioView({
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Publishing is terminal, so an improvement on a live game opens a *new* job with its
+  // own token — one not on the shelf yet. When that happens the open thread moves onto
+  // it while the shelf selection stays on the source game (the new job inherits its slug,
+  // so the chrome beside the thread is still right). Cleared whenever the selected game
+  // changes, so switching games or following a link always lands on that game's own tip.
+  const [handoffToken, setHandoffToken] = useState<string | null>(null);
   const shelfSearchId = useId();
   const pickerSearchId = useId();
   const pickerSearchRef = useRef<HTMLInputElement>(null!);
@@ -257,7 +263,18 @@ export function CreatorStudioView({
     };
   }, [user]);
 
+  // A handoff belongs to the game the creator was on when they asked for the improvement.
+  // The moment the selected game changes — a shelf pick, a deep link, an Up — that thread
+  // is no longer on screen, so drop the override and let the newly selected game show its
+  // own current tip.
+  useEffect(() => {
+    setHandoffToken(null);
+  }, [selected]);
+
   const activeGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
+  // The token the thread is actually showing: the new job's after an improvement handoff,
+  // otherwise the selected game's own.
+  const threadToken = handoffToken ?? activeGame?.token ?? null;
   const selectedHealth = activeGame ? healthFor(activeGame, healthRows) : null;
   const selectedScorecard = activeGame?.slug
     ? (scorecards.find((card) => card.slug === activeGame.slug) ?? null)
@@ -538,9 +555,11 @@ export function CreatorStudioView({
                 {tab !== 'playtest' ? (
                   <div className="studio-build">
                     <SubmissionStatusView
-                      key={activeGame.token}
-                      token={activeGame.token}
+                      key={threadToken ?? activeGame.token}
+                      token={threadToken ?? activeGame.token}
                       embedded
+                      justHandedOff={handoffToken != null}
+                      onImproved={(newToken) => setHandoffToken(newToken)}
                       onPlaytest={() => openTab('playtest')}
                       onRetry={
                         onRetryConcept

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -275,6 +275,20 @@ export function CreatorStudioView({
   // The token the thread is actually showing: the new job's after an improvement handoff,
   // otherwise the selected game's own.
   const threadToken = handoffToken ?? activeGame?.token ?? null;
+  // Playtest must follow the same handoff: if it kept the published shelf record, pause
+  // feedback would call submitImprovement on the old token and open a second concurrent
+  // round (Codex P1). While a handoff is live, treat the surface as the unpublished new job.
+  const playtestGame = useMemo((): StudioGame | null => {
+    if (!activeGame) return null;
+    if (!handoffToken || handoffToken === activeGame.token) return activeGame;
+    return {
+      ...activeGame,
+      token: handoffToken,
+      lastKnownStatus: 'building',
+      publishedAt: undefined,
+    };
+  }, [activeGame, handoffToken]);
+  const playtestPublished = Boolean(playtestGame && isStudioGamePublished(playtestGame) && !handoffToken);
   const selectedHealth = activeGame ? healthFor(activeGame, healthRows) : null;
   const selectedScorecard = activeGame?.slug
     ? (scorecards.find((card) => card.slug === activeGame.slug) ?? null)
@@ -573,10 +587,10 @@ export function CreatorStudioView({
                   </div>
                 ) : null}
 
-                {tab === 'playtest' ? (
+                {tab === 'playtest' && playtestGame ? (
                   <StudioPlaytestPanel
-                    game={activeGame}
-                    published={isStudioGamePublished(activeGame)}
+                    game={playtestGame}
+                    published={playtestPublished}
                     onExit={() => openTab('thread')}
                     pickerOpen={pickerOpen}
                   />

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -149,6 +149,12 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
               </span>
               <h4 className="studio-connect-step-title">{t('connect.step2.title')}</h4>
             </div>
+            {/* The split creators miss at a round boundary: the gamedev.pl connection in
+                their agent's config is set up once (step 1) and stays put; what changes
+                every round is the key inside the prompt below. Without this line, a
+                creator handed a new build thread re-runs step 1 or edits config that was
+                never stale. */}
+            <p className="studio-connect-same">{t('connect.step2.sameConnection')}</p>
             <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
               {payload.kickoffPrompt}
             </pre>

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from 'react';
+import { act, createElement, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
+import { statusPath } from './router.js';
 import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView.js';
 import {
   abandonSubmission,
@@ -1704,5 +1705,238 @@ describe('SubmissionStatusView stop & retry', () => {
       liveRoot.unmount();
     });
     vi.useRealTimers();
+  });
+
+  /**
+   * Publishing is terminal: a post-publish improvement opens a *new* job on its own
+   * thread. These lock the handoff — the creator moving onto the new build thread rather
+   * than being left on the published (dead) one while its connect card sits unnoticed.
+   *
+   * The harness stands in for CreatorStudioView: it owns which thread is on screen and
+   * switches it to the new token when the child reports the improvement, marking the new
+   * mount as the handoff destination — exactly what the studio does via `onImproved`.
+   */
+  function HandoffHarness({ initialToken }: { initialToken: string }) {
+    const [threadToken, setThreadToken] = useState(initialToken);
+    const [handedOff, setHandedOff] = useState(false);
+    return createElement(SubmissionStatusView, {
+      key: threadToken,
+      token: threadToken,
+      embedded: true,
+      justHandedOff: handedOff,
+      onImproved: (next: string) => {
+        setThreadToken(next);
+        setHandedOff(true);
+      },
+    });
+  }
+
+  const CONNECT_PAYLOAD = {
+    installSnippets: {
+      claudeCode: 'claude mcp add gamedevpl https://example.test/api/mcp',
+      codex: 'url = "https://example.test/api/mcp"',
+      cursor: '{"mcpServers":{}}',
+      kimi: 'npx mcp-remote https://example.test/api/mcp',
+      cli: 'curl https://example.test/api/mcp',
+    },
+    kickoffPrompt: 'Build "Handoff Game" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+  };
+
+  it('standalone: a published improve navigates the browser to the new job’s thread', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'published', slug: 'tv-tycoon' });
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, jobId: 42, token: 'new-standalone-job', slug: 'tv-tycoon' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/status/live-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      // Standalone: no `embedded`, no `onImproved` — the view drives the browser itself.
+      root.render(createElement(SubmissionStatusView, { token: 'live-token' }));
+      await flushEffects();
+    });
+
+    const box = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(box, 'Please add a checkpoint before the hard second level jump.');
+      box!.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+    await act(async () => {
+      container
+        .querySelector('.status-feedback .primary-btn')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(mockedSubmitImprovement).toHaveBeenCalled();
+    // The old (published) token cannot address the new round — the browser is on the new one.
+    expect(window.location.pathname).toBe(statusPath('new-standalone-job'));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('embedded: a published self-improve switches the thread and surfaces the new round’s connect card', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const connectFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ...CONNECT_PAYLOAD, expiresAt: Math.floor(Date.now() / 1000) + 3600 }),
+    }));
+    vi.stubGlobal('fetch', connectFetch);
+
+    // The published job is self-built; its improvement is a new self job still waiting
+    // on the creator's own agent — the state that renders the connect card.
+    mockedGetSubmissionStatus.mockImplementation(async (token: string) =>
+      token === 'new-self-job'
+        ? { status: 'queued', stall: 'no_agent_yet', builder: 'self' }
+        : { status: 'published', slug: 'tv-tycoon', defaultBuilder: 'self' },
+    );
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, jobId: 77, token: 'new-self-job', slug: 'tv-tycoon' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/pub-self');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(HandoffHarness, { initialToken: 'pub-self' }));
+        await flushEffects();
+        await flushEffects();
+      });
+
+      // The published thread has no connect card of its own — it is terminal.
+      expect(container.querySelector('.studio-connect')).toBeNull();
+
+      const box = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+        setter?.call(box, 'Give the second level a checkpoint so it is not so punishing.');
+        box!.dispatchEvent(new Event('input', { bubbles: true }));
+        await flushEffects();
+      });
+      await act(async () => {
+        container.querySelector('.status-composer-send')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+        await flushEffects();
+        await flushEffects();
+      });
+
+      // The default builder came from the status payload (self), so the new round is self.
+      expect(mockedSubmitImprovement).toHaveBeenCalledWith('pub-self', expect.any(String), undefined, 'self');
+      // The thread moved onto the new job, announced itself, and shows that job's connect card.
+      expect(container.querySelector('.status-handoff-notice')?.textContent).toContain('new build thread');
+      expect(container.querySelector('.studio-connect')).not.toBeNull();
+      expect(container.textContent).toContain('Connect your coding agent');
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('embedded: a published platform-improve hands off with no connect card', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockImplementation(async (token: string) =>
+      token === 'new-plat-job'
+        ? { status: 'building', builder: 'platform', events: [] }
+        : { status: 'published', slug: 'tv-tycoon', defaultBuilder: 'platform' },
+    );
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, jobId: 88, token: 'new-plat-job', slug: 'tv-tycoon' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/pub-plat');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(HandoffHarness, { initialToken: 'pub-plat' }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const box = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(box, 'Please tune the difficulty curve on the later levels.');
+      box!.dispatchEvent(new Event('input', { bubbles: true }));
+      await flushEffects();
+    });
+    await act(async () => {
+      container.querySelector('.status-composer-send')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    // Handed over to the new build thread, but a platform round connects nothing.
+    expect(container.querySelector('.status-handoff-notice')?.textContent).toContain('new build thread');
+    expect(container.querySelector('.studio-connect')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('published composer defaults its builder chooser to the status defaultBuilder, over stale local memory', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    // Memory is keyed by token in localStorage, and a new job has a new token — so the
+    // remembered choice is gone at exactly this boundary. The status payload's
+    // defaultBuilder is the continuity, and it wins even over a stale local value.
+    localStorage.setItem('gamedev_last_builder:pub-def', 'platform');
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'published', slug: 'tv-tycoon', defaultBuilder: 'self' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/pub-def');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'pub-def', embedded: true }));
+      await flushEffects();
+    });
+
+    const selected = container.querySelector('.builder-choice-option[aria-checked="true"]');
+    expect(selected?.textContent).toContain(i18n.t('builder.self.title'));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it.each(['en', 'pl'])('announces the handoff on the destination thread (%s)', async (lang) => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({ status: 'building', builder: 'platform', events: [] });
+    await i18n.changeLanguage(lang);
+    window.history.pushState(null, '', '/studio/handed-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'handed-token', embedded: true, justHandedOff: true }));
+      await flushEffects();
+    });
+
+    const notice = container.querySelector('.status-handoff-notice');
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain(i18n.t('statusView.handoff.notice'));
+    // The copy carries a real sentence in each locale, not a leaked key.
+    expect(notice?.textContent).not.toContain('statusView.handoff');
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -496,7 +496,7 @@ describe('SubmissionStatusView', () => {
   it('offers the same one box on a published game, and sends it somewhere else', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({ status: 'published', slug: 'tv-tycoon' });
-    mockedSubmitImprovement.mockResolvedValue({ ok: true, issueNumber: 5, slug: 'tv-tycoon' });
+    mockedSubmitImprovement.mockResolvedValue({ ok: true, jobId: 5, token: 'improve-token', slug: 'tv-tycoon' });
     await i18n.changeLanguage('en');
     window.history.pushState(null, '', '/status/live-token');
 

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -286,7 +286,9 @@ export function SubmissionStatusView({
    * Move the creator onto the new job an improvement just opened. Embedded, the parent
    * owns which thread is on screen, so it does the switch (and re-mounts us on the new
    * token with `justHandedOff`). Standalone, we drive the browser there ourselves — the
-   * same programmatic push App uses, announced on NAVIGATE_EVENT so the route re-reads.
+   * same programmatic push App uses. App only re-reads the route on popstate/hashchange
+   * (pushState is silent), so we fire PopStateEvent after the push; NAVIGATE_EVENT still
+   * announces for telemetry listeners.
    */
   const handleImproved = (newToken: string) => {
     if (onImproved) {
@@ -295,6 +297,7 @@ export function SubmissionStatusView({
     }
     const path = statusPath(newToken);
     window.history.pushState(null, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
     window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT, { detail: { path } }));
   };
 

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -20,7 +20,7 @@ import {
   type SubmissionPreview,
   type SubmissionStatus,
 } from './submissionApi.js';
-import { statusPath, studioPath } from './router.js';
+import { NAVIGATE_EVENT, statusPath, studioPath } from './router.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
@@ -220,6 +220,20 @@ type SubmissionStatusViewProps = {
    * save-link lecture and point share URLs at `/studio/:token`.
    */
   embedded?: boolean;
+  /**
+   * Publishing is terminal: an improvement on a live game opens a *new* job with its
+   * own token, and the creator's thread must move onto it. Embedded in Studio the
+   * parent owns the open thread, so it does the switch (see CreatorStudioView). When
+   * absent — the standalone `/status/:token` view — this component navigates the
+   * browser to the new token itself.
+   */
+  onImproved?: (token: string) => void;
+  /**
+   * Marks this mount as the destination of an improvement handoff, so the new build
+   * thread announces itself rather than appearing out of nowhere. Set by the parent
+   * that performed the switch.
+   */
+  justHandedOff?: boolean;
 };
 
 export function SubmissionStatusView({
@@ -230,6 +244,8 @@ export function SubmissionStatusView({
   onRetry,
   onPlaytest,
   embedded = false,
+  onImproved,
+  justHandedOff = false,
 }: SubmissionStatusViewProps) {
   const { t, i18n } = useTranslation();
   const [status, setStatus] = useState<SubmissionStatus | null>(null);
@@ -265,6 +281,22 @@ export function SubmissionStatusView({
     () => trackingUrl ?? new URL(embedded ? studioPath(token) : statusPath(token), window.location.href).toString(),
     [token, trackingUrl, embedded],
   );
+
+  /**
+   * Move the creator onto the new job an improvement just opened. Embedded, the parent
+   * owns which thread is on screen, so it does the switch (and re-mounts us on the new
+   * token with `justHandedOff`). Standalone, we drive the browser there ourselves — the
+   * same programmatic push App uses, announced on NAVIGATE_EVENT so the route re-reads.
+   */
+  const handleImproved = (newToken: string) => {
+    if (onImproved) {
+      onImproved(newToken);
+      return;
+    }
+    const path = statusPath(newToken);
+    window.history.pushState(null, '', path);
+    window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT, { detail: { path } }));
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -567,6 +599,11 @@ export function SubmissionStatusView({
     return (
       <>
         <div className="studio-thread">
+          {justHandedOff ? (
+            <p className="status-handoff-notice" role="status">
+              <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.notice')}
+            </p>
+          ) : null}
           {loading ? (
             <p className="catalog-state studio-thread-empty">{t('statusView.loading')}</p>
           ) : errorMessage ? (
@@ -652,6 +689,7 @@ export function SubmissionStatusView({
                     stall={status.stall}
                     failureReason={status.failure?.reason}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+                    onPublishedImprove={handleImproved}
                   />
                 ) : null}
               </div>
@@ -666,6 +704,11 @@ export function SubmissionStatusView({
   return (
     <>
       <section className="panel status-panel">
+        {justHandedOff ? (
+          <p className="status-handoff-notice" role="status">
+            <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.notice')}
+          </p>
+        ) : null}
         {
           <>
             <div className="status-heading">
@@ -818,6 +861,7 @@ export function SubmissionStatusView({
                 stall={status.stall}
                 failureReason={status.failure?.reason}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+                onPublishedImprove={handleImproved}
               />
             ) : null}
 
@@ -1006,6 +1050,7 @@ function FeedbackPanel({
   stall,
   failureReason,
   onSent,
+  onPublishedImprove,
 }: {
   token: string;
   /** Routes the message: an improvement on the live game, or a change on the build. */
@@ -1021,6 +1066,12 @@ function FeedbackPanel({
   stall?: SubmissionStatus['stall'];
   failureReason?: string;
   onSent: (text: string) => void;
+  /**
+   * A published-game improvement opened a new job; called with its token so the view
+   * can move the creator onto the new build thread. Only fires on the `published`
+   * path — a draft revision continues the current round and stays on this thread.
+   */
+  onPublishedImprove?: (token: string) => void;
 }) {
   const { t } = useTranslation();
   const [text, setText] = useState('');
@@ -1084,16 +1135,21 @@ function FeedbackPanel({
     // client bounds the server call; this button stays disabled until that answer lands.
     try {
       const roundBuilder = chooseBuilder ? builder : undefined;
+      // The new job an improvement opened, if this send was one — the thread hands over
+      // to it once the local echo and receipt are in place, below.
+      let handoffToken: string | undefined;
       // Same box, same act, different destination — decided here from the state the
       // server reported rather than by asking the creator which one they meant.
       // Only pass builder when a new round is being chosen — keeps the 2-arg call
       // shape for ordinary mid-round messages (and the tests that assert it).
       if (published) {
-        if (roundBuilder) {
-          await submitImprovement(token, trimmed, undefined, roundBuilder);
-        } else {
-          await submitImprovement(token, trimmed);
-        }
+        const improved = roundBuilder
+          ? await submitImprovement(token, trimmed, undefined, roundBuilder)
+          : await submitImprovement(token, trimmed);
+        // Publishing is terminal: the improvement is a new job with its own token. The
+        // builder memory is keyed by token in localStorage, so persist the choice under
+        // the *new* token as well — the old token's memory dies with its round.
+        handoffToken = improved.token;
       } else {
         const result = roundBuilder
           ? await submitFeedback(token, trimmed, undefined, roundBuilder)
@@ -1105,7 +1161,9 @@ function FeedbackPanel({
         }
       }
       if (roundBuilder) {
-        saveLastBuilder(token, roundBuilder);
+        // A published improve moved to a new token; save the choice there too so the new
+        // build thread's composer/connect defaults to it before its status echoes back.
+        saveLastBuilder(handoffToken ?? token, roundBuilder);
         recordStudioStep('builder_chosen', roundBuilder);
       }
       setState('sent');
@@ -1116,6 +1174,9 @@ function FeedbackPanel({
       // Echo it into the activity feed straight away: the API only sees it once the
       // comment round-trips through GitHub, which is a poll or two away.
       onSent(trimmed);
+      // Then move the creator onto the new build thread. Last, so the receipt and the
+      // local echo are already committed before the thread this box lives in is swapped.
+      if (handoffToken) onPublishedImprove?.(handoffToken);
     } catch (err) {
       const message = err instanceof Error ? err.message : '';
       if (message === 'content_rejected') {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -492,6 +492,9 @@
       "quota": "You've sent a lot of feedback today — please try again tomorrow.",
       "published": "This game is already published. Submit a new idea to make another version."
     },
+    "handoff": {
+      "notice": "Improvement round started — this is the new build thread."
+    },
     "progress": {
       "checklistTitle": "What the agent is doing",
       "activityTitle": "Build activity",
@@ -801,6 +804,7 @@
     },
     "step2": {
       "title": "Tell your agent what to build",
+      "sameConnection": "Your gamedev.pl connection stays the same — only this round's key, inside the prompt below, is new. No need to change your agent's config.",
       "expiry": "This key works only for this game and expires {{when}}."
     },
     "clients": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -496,6 +496,9 @@
       "quota": "Wysłałeś dziś dużo uwag — spróbuj ponownie jutro.",
       "published": "Ta gra jest już opublikowana. Prześlij nowy pomysł, aby stworzyć kolejną wersję."
     },
+    "handoff": {
+      "notice": "Runda ulepszeń rozpoczęta — to jest wątek nowej wersji."
+    },
     "progress": {
       "checklistTitle": "Nad czym pracuje agent",
       "activityTitle": "Przebieg prac",
@@ -805,6 +808,7 @@
     },
     "step2": {
       "title": "Powiedz agentowi, co zbudować",
+      "sameConnection": "Połączenie z gamedev.pl pozostaje bez zmian — nowy jest tylko klucz tej rundy, w prompcie poniżej. Nie musisz zmieniać konfiguracji agenta.",
       "expiry": "Ten klucz działa tylko dla tej gry i wygasa {{when}}."
     },
     "clients": {

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -111,13 +111,19 @@ export async function setDraftShared(token: string, shared: boolean): Promise<{ 
  * Files a post-publish improvement issue. Draft revisions still use
  * {@link submitFeedback} on the open PR. Optional playtest context attaches a
  * paused-frame screenshot + instrumentation digest (Creator Studio Playtest).
+ *
+ * Publishing is terminal, so this opens a *new* job: the response carries that job's
+ * own `jobId` and a fresh `token` addressing it, and the caller hands the creator's
+ * thread over to it. The field was declared `issueNumber` here while the server has
+ * always sent `jobId` — a mismatch that only ever read as `undefined`; keep the wire
+ * name (`jobId`) and correct the type.
  */
 export async function submitImprovement(
   token: string,
   feedback: string,
   context?: FeedbackContext,
   builder?: 'platform' | 'self',
-): Promise<{ ok: boolean; issueNumber: number; slug: string; shotId?: string }> {
+): Promise<{ ok: boolean; jobId: number; token: string; slug: string; shotId?: string }> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/improve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -131,7 +137,7 @@ export async function submitImprovement(
   if (!response.ok) {
     await throwResponseError(response);
   }
-  return (await response.json()) as { ok: boolean; issueNumber: number; slug: string; shotId?: string };
+  return (await response.json()) as { ok: boolean; jobId: number; token: string; slug: string; shotId?: string };
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a post-publish improvement, the creator was left on the published (terminal) job’s thread while the new round’s connect card and kickoff sat on the shelf. Agents kept a dead key and failed with “this build is finished…”.

## Cause

Publishing is terminal; improve allocates a **new** job. `POST …/improve` returned `{ ok, jobId, slug }` with no submission token for that job, and the web composer only echoed into the current thread. Client type also declared `issueNumber` while the server sends `jobId`.

## Fix

1. **API** — improve success also returns `token` (minted like `/mine`). Keep `jobId` name; fix client type.
2. **Web handoff** — on successful published improve: embedded Studio switches thread via callback; standalone navigates to the new token. Visible transition notice (EN+PL). Self connect card via existing mechanism.
3. **Builder default** — published composer defaults from `status.defaultBuilder`; explicit selection wins.
4. **Copy** — one line: MCP connection unchanged; only this round’s key in the kickoff is new. One copy button.

## Tests

API + web green (agent report: api 1711, web 863). Covers token+jobId, embedded self handoff + connect card, standalone nav, platform handoff without connect, builder default, locales.

## Protocol

Draft for owner review before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

