### PR TITLE
byoca(BY-22): session playbook on MCP start + kickoff loop pointer

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -217,6 +217,16 @@ describe('POST /api/mcp (BY-05)', () => {
     const tools = listed.json().result.tools as Array<{ name: string; description: string }>;
     const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
+    // start advertises the returned workflow / inbox policy / refusal guidance.
+    expect(start?.description).toMatch(/workflow/i);
+
+    // The behavioural contract (on every tool description) now folds in the loop-critical
+    // rules: pendingMessages on write replies, one final read_inbox, no scheduled polling,
+    // and that a green verdict ends the round.
+    expect(start?.description).toMatch(/pendingMessages/);
+    expect(start?.description).toMatch(/one final read_inbox/i);
+    expect(start?.description).toMatch(/do not schedule background/i);
+    expect(start?.description).toMatch(/green gate verdict ends the round/i);
 
     const getKit = tools.find((t) => t.name === 'get_kit');
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
@@ -257,6 +267,96 @@ describe('POST /api/mcp (BY-05)', () => {
       slug: 'comet-courier',
       seedAvailable: true,
     });
+  });
+
+  it('start returns the session workflow in both structuredContent and the text body', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const res = await mcpCall(
+      app,
+      'tools/call',
+      { name: 'start', arguments: { key: roundKey() } },
+      {
+        'mcp-session-id': sessionId,
+      },
+    );
+    expect(res.statusCode).toBe(200);
+    const result = res.json().result as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent: {
+        workflow?: unknown;
+        inboxPolicy?: string;
+        whenRefused?: string;
+      };
+    };
+
+    // Structured: ordered workflow covering the full loop, plus the inbox policy and the
+    // retired-key etiquette an agent relays.
+    const workflow = result.structuredContent.workflow as string[];
+    expect(Array.isArray(workflow)).toBe(true);
+    expect(workflow.length).toBeGreaterThanOrEqual(6);
+    const joined = workflow.join('\n');
+    expect(joined).toMatch(/get_brief/);
+    expect(joined).toMatch(/get_seed/);
+    expect(joined).toMatch(/get_kit/);
+    expect(joined).toMatch(/send_screenshot/);
+    expect(joined).toMatch(/submit_sources/);
+    expect(joined).toMatch(/get_gate_verdict/);
+    // The stop condition is explicit: green means done, then end the session.
+    expect(joined).toMatch(/green: the round is complete/i);
+    expect(joined).toMatch(/END the session/i);
+    // Both failure branches are covered.
+    expect(joined).toMatch(/red:.*resubmit on the SAME key/i);
+    expect(joined).toMatch(/kit_outdated: re-run get_kit/i);
+
+    // Inbox policy: no scheduled polling; pendingMessages rides writes; one final read.
+    expect(result.structuredContent.inboxPolicy).toMatch(/do not schedule background or recurring inbox checks/i);
+    expect(result.structuredContent.inboxPolicy).toMatch(/pendingMessages/);
+    expect(result.structuredContent.inboxPolicy).toMatch(/one final read_inbox/i);
+    expect(result.structuredContent.inboxPolicy).toMatch(/fresh kickoff/i);
+
+    // The text body mirrors the loop so an agent reading either channel knows it.
+    const body = result.content.map((c) => c.text).join('\n');
+    expect(body).toMatch(/Session workflow/i);
+    expect(body).toMatch(/get_gate_verdict/);
+    expect(body).toMatch(/END the session/i);
+    expect(body).toMatch(/Inbox:/);
+    expect(body).toMatch(/If a call is refused:/i);
+  });
+
+  it('retired-key etiquette in start matches the error agents relay on a refused call', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    // The guidance start hands the agent: point the creator at the Studio thread, do not
+    // call it an outage, note the MCP connection is unchanged.
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const whenRefused = (started.structured as { whenRefused: string }).whenRefused;
+    expect(whenRefused).toMatch(/Studio thread/i);
+    expect(whenRefused).toMatch(/current kickoff prompt/i);
+    expect(whenRefused).toMatch(/MCP connection/i);
+    expect(whenRefused).toMatch(/do not retry|do not report an outage/i);
+
+    // The actual refusal an agent hits when the key is stale names the same fix (Studio
+    // thread + fresh prompt), so what the agent relays lines up with what the server says.
+    const stale = mintAgentToken(ISSUE, secret, { roundGeneration: 1, now: Date.parse('2020-01-01T00:00:00.000Z') });
+    const refused = await callTool(
+      app,
+      'get_brief',
+      {},
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${stale}` },
+    );
+    expect(refused.isError).toBe(true);
+    const errorText = JSON.stringify(refused.structured);
+    expect(errorText).toContain(STALE_AGENT_TOKEN_REASON);
+    expect(STALE_AGENT_TOKEN_REASON).toMatch(/finished/i);
+    expect(STALE_AGENT_TOKEN_REASON).toMatch(/Studio thread/i);
+    expect(STALE_AGENT_TOKEN_REASON).toMatch(/fresh prompt/i);
   });
 
   it('rejects a call bearing a valid Mcp-Session-Id but no or a forged sessionKey', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -221,12 +221,13 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(start?.description).toMatch(/workflow/i);
 
     // The behavioural contract (on every tool description) now folds in the loop-critical
-    // rules: pendingMessages on write replies, one final read_inbox, no scheduled polling,
-    // and that a green verdict ends the round.
+    // rules: pendingMessages as a non-empty array, no scheduled polling, and that a green
+    // verdict ends the round immediately (no post-green tools — key retires).
     expect(start?.description).toMatch(/pendingMessages/);
-    expect(start?.description).toMatch(/one final read_inbox/i);
+    expect(start?.description).toMatch(/array is non-empty/i);
     expect(start?.description).toMatch(/do not schedule background/i);
     expect(start?.description).toMatch(/green gate verdict ends the round/i);
+    expect(start?.description).toMatch(/END immediately/i);
 
     const getKit = tools.find((t) => t.name === 'get_kit');
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
@@ -305,17 +306,19 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/submit_sources/);
     expect(joined).toMatch(/get_gate_verdict/);
-    // The stop condition is explicit: green means done, then end the session.
+    // The stop condition is explicit: green means done — END immediately; no post-green
+    // tools (key retires; get_gate_verdict may still answer via terminal receipt).
     expect(joined).toMatch(/green: the round is complete/i);
-    expect(joined).toMatch(/END the session/i);
+    expect(joined).toMatch(/END the session immediately/i);
+    expect(joined).toMatch(/Do not report_progress, read_inbox, or ack after green/i);
+    expect(joined).toMatch(/terminal receipt/i);
     // Both failure branches are covered.
     expect(joined).toMatch(/red:.*resubmit on the SAME key/i);
     expect(joined).toMatch(/kit_outdated: re-run get_kit/i);
 
-    // Inbox policy: no scheduled polling; pendingMessages rides writes; one final read.
+    // Inbox policy: no scheduled polling; drain non-empty pendingMessages from write replies.
     expect(result.structuredContent.inboxPolicy).toMatch(/do not schedule background or recurring inbox checks/i);
-    expect(result.structuredContent.inboxPolicy).toMatch(/pendingMessages/);
-    expect(result.structuredContent.inboxPolicy).toMatch(/one final read_inbox/i);
+    expect(result.structuredContent.inboxPolicy).toMatch(/pendingMessages array is non-empty/i);
     expect(result.structuredContent.inboxPolicy).toMatch(/fresh kickoff/i);
 
     // The text body mirrors the loop so an agent reading either channel knows it.

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -171,7 +171,58 @@ const BEHAVIOURAL_CONTRACT = [
   'Run kit checks green (at least check:static) before submit_sources.',
   'Honour stop immediately — do not continue after stop:true.',
   'When get_brief.seedAvailable is true, continue the seed (get_seed) rather than scaffolding from scratch.',
+  'Every write reply carries pendingMessages — when it is non-empty, read_inbox and apply before continuing.',
+  'Do not schedule background or recurring inbox polls; do one final read_inbox before you end.',
+  'A green gate verdict ends the round — the key then retires and new work arrives as a fresh kickoff.',
 ].join(' ');
+
+/**
+ * The explicit session loop, start → done, returned by `start` so an agent never has to
+ * guess what happens after submit, whether to poll the inbox on a schedule, or what a
+ * refused key means. Kept short and ordered; the prose body of `start` renders these plus
+ * the inbox policy and the retired-key etiquette.
+ */
+const SESSION_WORKFLOW: readonly string[] = [
+  'get_brief — read the brief; if seedAvailable, get_seed and continue that draft rather than scaffolding from scratch.',
+  'get_kit — unpack the tarball, open entry (gamedevpl-creator-kit/SKILL.md), and follow it. Keep the engineRef it returns for submit_sources.',
+  'Build the game from the kit; report_progress before and after long steps.',
+  'send_screenshot as soon as the game draws anything playable.',
+  'Run the kit checks green (at least check:static) before delivering.',
+  'submit_sources with the kitEngineRef get_kit returned.',
+  'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated.',
+  'red: read the report, fix, and resubmit on the SAME key.',
+  'kit_outdated: re-run get_kit, rebuild against the new kit, and resubmit.',
+  'green: the round is complete — send a final report_progress, do one read_inbox and ack, then END the session.',
+];
+
+/**
+ * Inbox policy, stated flat so agents stop asking whether to poll: no scheduled checks;
+ * pendingMessages rides every write; one final read before ending; nothing to poll after close.
+ */
+const INBOX_POLICY =
+  'Do not schedule background or recurring inbox checks. While working, every mutating reply carries ' +
+  '{ stop, pendingMessages } — when pendingMessages > 0, read_inbox and apply the notes before continuing. ' +
+  'Do exactly one final read_inbox before you end the session. After the round closes there is nothing left ' +
+  'to poll — the next round arrives as a fresh kickoff prompt.';
+
+/**
+ * What to tell the creator when a call is refused because the build finished / the key is
+ * stale. Matches STALE_AGENT_TOKEN_REASON so the agent relays the same fix the error names.
+ */
+const RETIRED_KEY_ETIQUETTE =
+  'If a call is refused because the build is finished or the key is stale, do not retry and do not report an ' +
+  "outage. Tell the creator to open the game's Studio thread and copy the current kickoff prompt; the gamedev.pl " +
+  'MCP connection itself is unchanged.';
+
+/** Human-readable session loop for the text body of `start`. */
+const SESSION_WORKFLOW_TEXT = [
+  'Session workflow (start → done):',
+  ...SESSION_WORKFLOW.map((step, index) => `${index + 1}. ${step}`),
+  '',
+  `Inbox: ${INBOX_POLICY}`,
+  '',
+  `If a call is refused: ${RETIRED_KEY_ETIQUETTE}`,
+].join('\n');
 
 const SESSION_KEY_PROP = {
   type: 'string' as const,
@@ -361,7 +412,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     start: {
       description:
         "Bind this MCP client to a build round using the key from the creator's Studio kickoff prompt. " +
-        'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call. ' +
+        'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
+        '(the ordered start→done loop), an inbox policy, and what to relay if a later call is refused. ' +
         'Does not treat Mcp-Session-Id as authority. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -438,7 +490,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const cap = record.builder === 'self' ? selfBuildDeliveryCap() : null;
         const used = record.roundDeliveryCount ?? 0;
 
-        return toolOk({
+        const structured = {
           sessionKey,
           sessionId,
           jobId: claims.jobId,
@@ -449,7 +501,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           locales: record.locale ? [record.locale, 'en'] : ['en'],
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
           expiresAt: sessionClaims.exp,
-        });
+          workflow: SESSION_WORKFLOW,
+          inboxPolicy: INBOX_POLICY,
+          whenRefused: RETIRED_KEY_ETIQUETTE,
+        };
+        // Both the structured payload and a readable text body carry the loop — an agent
+        // reading either one knows the full start→done sequence, including when to stop.
+        return {
+          content: [
+            { type: 'text', text: JSON.stringify(structured) },
+            { type: 'text', text: SESSION_WORKFLOW_TEXT },
+          ],
+          structuredContent: structured,
+        };
       },
     },
 
@@ -1010,7 +1074,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           },
           instructions:
             "Install is URL-only. Start with the gamedevpl start tool using the key from the creator's Studio kickoff prompt; " +
-            'pass the returned sessionKey on every later tool call. Honour stop; screenshot early; kit-check before submit.',
+            'pass the returned sessionKey on every later tool call. start returns your workflow (the ordered start→done ' +
+            'loop) — follow it: honour stop; screenshot early; kit-check before submit; poll get_gate_verdict until green, ' +
+            'then finish. Do not poll the inbox on a schedule; a green verdict ends the round and the key retires.',
         }),
       );
     }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -171,9 +171,9 @@ const BEHAVIOURAL_CONTRACT = [
   'Run kit checks green (at least check:static) before submit_sources.',
   'Honour stop immediately — do not continue after stop:true.',
   'When get_brief.seedAvailable is true, continue the seed (get_seed) rather than scaffolding from scratch.',
-  'Every write reply carries pendingMessages — when it is non-empty, read_inbox and apply before continuing.',
-  'Do not schedule background or recurring inbox polls; do one final read_inbox before you end.',
-  'A green gate verdict ends the round — the key then retires and new work arrives as a fresh kickoff.',
+  'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
+  'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies as you go.',
+  'A green gate verdict ends the round — END immediately; the key retires and new work arrives as a fresh kickoff.',
 ].join(' ');
 
 /**
@@ -192,18 +192,21 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated.',
   'red: read the report, fix, and resubmit on the SAME key.',
   'kit_outdated: re-run get_kit, rebuild against the new kit, and resubmit.',
-  'green: the round is complete — send a final report_progress, do one read_inbox and ack, then END the session.',
+  // Green closes the round before the next tool call; writes and non-receipt reads then
+  // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
+  // happen on earlier write replies — do not instruct post-green tools (Codex P1).
+  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict may still answer via terminal receipt).',
 ];
 
 /**
  * Inbox policy, stated flat so agents stop asking whether to poll: no scheduled checks;
- * pendingMessages rides every write; one final read before ending; nothing to poll after close.
+ * pendingMessages (an array) rides every write; nothing to poll after close.
  */
 const INBOX_POLICY =
   'Do not schedule background or recurring inbox checks. While working, every mutating reply carries ' +
-  '{ stop, pendingMessages } — when pendingMessages > 0, read_inbox and apply the notes before continuing. ' +
-  'Do exactly one final read_inbox before you end the session. After the round closes there is nothing left ' +
-  'to poll — the next round arrives as a fresh kickoff prompt.';
+  '{ stop, pendingMessages } — when the pendingMessages array is non-empty, read_inbox and apply the notes ' +
+  'before continuing. After the round closes there is nothing left to poll — the next round arrives as a ' +
+  'fresh kickoff prompt.';
 
 /**
  * What to tell the creator when a call is refused because the build finished / the key is
@@ -505,14 +508,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           inboxPolicy: INBOX_POLICY,
           whenRefused: RETIRED_KEY_ETIQUETTE,
         };
-        // Both the structured payload and a readable text body carry the loop — an agent
-        // reading either one knows the full start→done sequence, including when to stop.
+        // Base shape via toolOk so we do not drift from other tools; append the human-
+        // readable loop so an agent reading either form knows when to stop.
+        const base = toolOk(structured);
         return {
-          content: [
-            { type: 'text', text: JSON.stringify(structured) },
-            { type: 'text', text: SESSION_WORKFLOW_TEXT },
-          ],
-          structuredContent: structured,
+          ...base,
+          content: [...base.content, { type: 'text', text: SESSION_WORKFLOW_TEXT }],
         };
       },
     },

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -89,18 +89,37 @@ describe('self-build-connect templates', () => {
     }
   });
 
-  it('builds a kickoff prompt with the round key and pending feedback', () => {
+  it('builds a kickoff prompt with the round key, a loop pointer, and pending feedback', () => {
     const bare = buildKickoffPrompt({ title: 'Asteroids', roundKey: 'round-key-abc' });
     expect(bare).toBe(
-      ['Build "Asteroids" for gamedev.pl.', 'Start with the gamedevpl tool, key: round-key-abc'].join('\n'),
+      [
+        'Build "Asteroids" for gamedev.pl.',
+        'Start with the gamedevpl tool, key: round-key-abc',
+        'start returns your workflow; after gate green you are done — this key retires with the round.',
+      ].join('\n'),
     );
     expect(bare).not.toMatch(/\btoken\b/i);
+
+    // Base paste stays within the 5-line cap, with the key line intact at line 2 and the
+    // single loop pointer at line 3.
+    const bareLines = bare.split('\n');
+    expect(bareLines.length).toBeLessThanOrEqual(5);
+    expect(bareLines).toHaveLength(3);
+    expect(bareLines[1]).toBe('Start with the gamedevpl tool, key: round-key-abc');
+    expect(bareLines[2]).toMatch(/after gate green you are done/);
+    // Exactly one loop pointer line — not one per tool call.
+    expect(bare.match(/your workflow/g)).toHaveLength(1);
 
     const withPending = buildKickoffPrompt({
       title: 'Asteroids',
       roundKey: 'round-key-abc',
       pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
     });
+    // The loop line survives; "also apply:" bullets still append below, in order.
+    const pendingLines = withPending.split('\n');
+    expect(pendingLines[1]).toBe('Start with the gamedevpl tool, key: round-key-abc');
+    expect(pendingLines[2]).toMatch(/after gate green you are done/);
+    expect(withPending.indexOf('- make the ship faster')).toBeLessThan(withPending.indexOf('- add a pause button'));
     expect(withPending).toContain('also apply:');
     expect(withPending).toContain('- make the ship faster');
     expect(withPending).toContain('- add a pause button');

--- a/apps/api/src/self-build-connect.ts
+++ b/apps/api/src/self-build-connect.ts
@@ -89,14 +89,20 @@ export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallS
 }
 
 /**
- * Paste-ready kickoff: build instruction + gamedevpl tool key line, and any queued
- * creator feedback as a short "also apply:" list so a regenerate never drops them.
+ * Paste-ready kickoff: build instruction + gamedevpl tool key line + one line pointing at
+ * the session loop (start returns the workflow; gate green is done; the key retires with the
+ * round), and any queued creator feedback as a short "also apply:" list so a regenerate never
+ * drops them. The base paste stays ≤ 5 lines with the key line intact at line 2.
  *
  * User-facing copy says "key", never "token".
  */
 export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
   const title = input.title.trim() || 'your game';
-  const lines = [`Build "${title}" for gamedev.pl.`, `Start with the gamedevpl tool, key: ${input.roundKey}`];
+  const lines = [
+    `Build "${title}" for gamedev.pl.`,
+    `Start with the gamedevpl tool, key: ${input.roundKey}`,
+    'start returns your workflow; after gate green you are done — this key retires with the round.',
+  ];
   const pending = (input.pendingMessages ?? []).map((message) => message.text.trim()).filter((text) => text.length > 0);
   if (pending.length > 0) {
     lines.push('');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coding agents only had the terse BEHAVIOURAL_CONTRACT and a 2-line kickoff, so they guessed whether to poll inbox, keep watching after submit, or schedule background checks. `start` now returns an explicit work loop; the kickoff points at it in one line.

## Changes

1. **`start` response** — `workflow` (ordered steps), `inboxPolicy`, `whenRefused` in structuredContent **and** text: brief/seed → kit → build/progress/screenshot → check:static → submit → poll gate (~30s) until green/red/kit_outdated → red fix+resubmit same key; kit_outdated re-get_kit; **green → END immediately** (no post-green `report_progress` / `read_inbox` / ack — key retires; `get_gate_verdict` may still answer via terminal receipt). Base shape via `toolOk(structured)` plus appended workflow text.
2. **Inbox** — no scheduled polling; drain a non-empty `pendingMessages` **array** from mutating write replies; after close, new work = fresh kickoff.
3. **Retired key** — don’t retry / don’t call outage; tell creator to copy current kickoff from Studio; MCP connection unchanged.
4. **Kickoff** — one appended loop line; paste ≤ 5 lines; key line intact; also-apply still below.
5. **BEHAVIOURAL_CONTRACT** — fold loop-critical bullets; stay terse.

## Review follow-up (`cde0e61c`)

Addressed Copilot + Codex on the draft: array wording for `pendingMessages`, `toolOk` for `start`, and removal of impossible post-green tool calls (Codex P1).

## Follow-up (out of scope)

Optional pointer from games-repo kit `SKILL.md` back to “start returns your workflow” — not in this PR.

## Tests

`npm test --workspace=@gamedevpl/api -- --run src/mcp-server.test.ts` — 22 green.

## Protocol

Draft for owner review before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

