### PR TITLE
fix(studio): one shelf row per game when an improve tip is running

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -166,6 +166,69 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('lists one picker row per game when a live title has an improve tip', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue([
+      {
+        token: 'live-mw',
+        title: 'Miniature Warfare 2D',
+        slug: 'miniature-warfare-2d',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+      },
+      {
+        token: 'tip-mw',
+        title: 'Miniature Warfare 2D',
+        slug: 'miniature-warfare-2d',
+        createdAt: '2026-07-20T00:00:00.000Z',
+        lastKnownStatus: 'building',
+      },
+      {
+        token: 'live-gts',
+        title: 'Global Thermonuclear Strategy',
+        slug: 'global-thermonuclear-strategy',
+        createdAt: '2026-07-02T00:00:00.000Z',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-07-02T00:00:00.000Z',
+      },
+      {
+        token: 'tip-gts',
+        title: 'Global Thermonuclear Strategy',
+        slug: 'global-thermonuclear-strategy',
+        createdAt: '2026-07-21T00:00:00.000Z',
+        lastKnownStatus: 'building',
+      },
+      {
+        token: 'live-tv',
+        title: 'A game tycoon like where I run a tv busi',
+        slug: 'tv-tycoon',
+        createdAt: '2026-07-03T00:00:00.000Z',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-07-03T00:00:00.000Z',
+      },
+    ]);
+
+    const { container, root } = await renderStudio({ selectedGame: 'miniature-warfare-2d' });
+
+    const switcher = container.querySelector('.studio-game-switcher');
+    expect(switcher?.textContent).toMatch(/3 games/i);
+
+    await act(async () => {
+      switcher!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const picker = container.querySelector('.studio-picker');
+    expect(picker?.textContent).toMatch(/3 games/i);
+    expect(picker?.querySelectorAll('.studio-shelf-item').length).toBe(3);
+    expect(picker?.textContent).toMatch(/Building\s*2/);
+    expect(picker?.textContent).toMatch(/Live\s*3/);
+
+    root.unmount();
+  });
+
   it('closes picker on Escape while in playtest tab without exiting playtest', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -9,11 +9,15 @@ import { playPath, studioPath, type StudioTab } from './router.js';
 import { abandonSubmission } from './submissionApi.js';
 import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import {
+  collapseStudioGames,
   filterStudioGames,
   isStudioGamePublished,
+  isStudioGameShelfLive,
+  sortStudioGames,
   STUDIO_LIVE_STATUSES,
   STUDIO_SHELF_TOOLS_AT,
   type StudioShelfFilter,
+  type StudioShelfGame,
 } from './studioShelf.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
@@ -48,7 +52,8 @@ import {
  *
  * Shelf scales past a handful of games: compact rows, search/filter once the list grows,
  * and on narrow viewports a game switcher (picker sheet) so the thread is not buried
- * under ten cards.
+ * under ten cards. A published game plus its improve tip share a slug — the shelf shows
+ * one row (the tip), not the same title twice.
  *
  * Selection + surface live in the URL (`/studio/<slug>/<surface>`) so a refresh or a
  * shared link reopens the same place. The five old tab names still resolve, onto
@@ -175,15 +180,22 @@ export function CreatorStudioView({
     requestedGameRef.current = selectedGame;
   }, [selectedGame]);
 
+  // One row per game for picking and counting. Raw `games` still holds every job so
+  // abandoning an improve tip can reveal the published sibling again without a refetch.
+  const shelfGames = useMemo(() => collapseStudioGames(games), [games]);
+
   // Resolve the URL's game segment against the shelf — by slug, or by capability token
   // for links minted before games were given slugs at submission. A value matching
   // neither selects nothing: the shelf holds only this creator's games, so a slug
   // belonging to someone else is indistinguishable from one that does not exist.
+  // Prefer the collapsed tip when a slug has both a live job and an improve job.
   useEffect(() => {
     if (!selectedGame) return;
     const match = games.find((game) => game.slug === selectedGame || game.token === selectedGame);
-    if (match) setSelected(match.token);
-  }, [selectedGame, games]);
+    if (!match) return;
+    const tip = match.slug ? shelfGames.find((game) => game.slug === match.slug) : match;
+    if (tip) setSelected(tip.token);
+  }, [selectedGame, games, shelfGames]);
 
   useEffect(() => {
     if (!user) {
@@ -206,16 +218,30 @@ export function CreatorStudioView({
         setHealthDays(health.days);
         setTruncated(health.truncated);
         setLoading(false);
+        const collapsed = collapseStudioGames(shelf);
         setSelected((current) => {
-          if (current && shelf.some((game) => game.token === current)) return current;
+          if (current) {
+            const stillOpen = collapsed.find((game) => game.token === current);
+            if (stillOpen) return stillOpen.token;
+            // Selected token was a published sibling now collapsed behind its tip.
+            const raw = shelf.find((game) => game.token === current);
+            if (raw?.slug) {
+              const tip = collapsed.find((game) => game.slug === raw.slug);
+              if (tip) return tip.token;
+            }
+          }
           // A URL naming a game picks that one, or none at all. Falling through to the
           // newest would answer "show me this game" with a different game, silently —
           // and since slugs are public, the request may well be for somebody else's.
           const requested = requestedGameRef.current;
           if (requested) {
-            return shelf.find((game) => game.slug === requested || game.token === requested)?.token ?? null;
+            const match = shelf.find((game) => game.slug === requested || game.token === requested);
+            if (!match) return null;
+            return (match.slug ? collapsed.find((game) => game.slug === match.slug)?.token : null) ?? match.token;
           }
-          return shelf[0]?.token ?? null;
+          // Same order the shelf paints: active tips first. Collapsed Map order alone
+          // would prefer whichever slugged job arrived first in the API payload.
+          return sortStudioGames(collapsed)[0]?.token ?? null;
         });
       })
       .catch(() => {
@@ -257,25 +283,25 @@ export function CreatorStudioView({
     };
   }, [user]);
 
-  const activeGame = useMemo(() => games.find((game) => game.token === selected) ?? null, [games, selected]);
+  const activeGame = useMemo(() => shelfGames.find((game) => game.token === selected) ?? null, [shelfGames, selected]);
   const selectedHealth = activeGame ? healthFor(activeGame, healthRows) : null;
   const selectedScorecard = activeGame?.slug
     ? (scorecards.find((card) => card.slug === activeGame.slug) ?? null)
     : null;
   const visibleGames = useMemo(
-    () => filterStudioGames(games, { filter: shelfFilter, query: shelfQuery }),
-    [games, shelfFilter, shelfQuery],
+    () => filterStudioGames(shelfGames, { filter: shelfFilter, query: shelfQuery }),
+    [shelfGames, shelfFilter, shelfQuery],
   );
-  const showShelfTools = games.length >= STUDIO_SHELF_TOOLS_AT;
+  const showShelfTools = shelfGames.length >= STUDIO_SHELF_TOOLS_AT;
   // The URL named a game and the shelf does not have it: a typo, a game since abandoned,
   // or somebody else's slug. Said plainly, because an unexplained shelf looks like the
   // link worked and the game vanished.
-  const missingGame = Boolean(selectedGame) && !loading && !error && games.length > 0 && !activeGame;
+  const missingGame = Boolean(selectedGame) && !loading && !error && shelfGames.length > 0 && !activeGame;
   const buildingCount = useMemo(
-    () => games.filter((game) => game.lastKnownStatus && STUDIO_LIVE_STATUSES.has(game.lastKnownStatus)).length,
-    [games],
+    () => shelfGames.filter((game) => game.lastKnownStatus && STUDIO_LIVE_STATUSES.has(game.lastKnownStatus)).length,
+    [shelfGames],
   );
-  const liveCount = useMemo(() => games.filter((game) => isStudioGamePublished(game)).length, [games]);
+  const liveCount = useMemo(() => shelfGames.filter((game) => isStudioGameShelfLive(game)).length, [shelfGames]);
 
   // Keep the visible tab aligned with the selected game, and the URL on the game's
   // current address. Only writes an address when the route already carried one (a deep
@@ -288,7 +314,7 @@ export function CreatorStudioView({
   // leaves a readable URL behind and takes the capability token out of history.
   useEffect(() => {
     if (!selected) return;
-    const game = games.find((entry) => entry.token === selected);
+    const game = shelfGames.find((entry) => entry.token === selected);
     if (!game) return;
     const next = resolveTab(game, selectedTab);
     setTab(next);
@@ -299,7 +325,7 @@ export function CreatorStudioView({
     if (window.location.pathname !== canonical) {
       onNavigate(canonical, { replace: true });
     }
-  }, [selected, selectedTab, selectedGame, games, onNavigate]);
+  }, [selected, selectedTab, selectedGame, shelfGames, onNavigate]);
 
   /**
    * Below the rail breakpoint the details panel is a sheet over the thread, and a sheet
@@ -359,7 +385,7 @@ export function CreatorStudioView({
   }, [pickerOpen]);
 
   function selectGame(token: string) {
-    const next = games.find((game) => game.token === token) ?? null;
+    const next = shelfGames.find((game) => game.token === token) ?? null;
     const nextTab = defaultTabFor();
     setSelected(token);
     setTab(nextTab);
@@ -424,7 +450,7 @@ export function CreatorStudioView({
       {loading ? <p className="studio-empty">{t('studioPanel.loading')}</p> : null}
       {error ? <p className="studio-empty studio-error">{error}</p> : null}
 
-      {!loading && !error && games.length === 0 ? (
+      {!loading && !error && shelfGames.length === 0 ? (
         <div className="studio-empty-state">
           <p>{t('studioPanel.empty')}</p>
           <button type="button" className="primary-btn" onClick={() => onNavigate('/')}>
@@ -433,7 +459,7 @@ export function CreatorStudioView({
         </div>
       ) : null}
 
-      {!loading && games.length > 0 ? (
+      {!loading && shelfGames.length > 0 ? (
         <div
           className={[
             'studio-layout',
@@ -448,7 +474,7 @@ export function CreatorStudioView({
           <aside className="studio-shelf" aria-label={t('studioPanel.shelfAria')}>
             <div className="studio-shelf-head">
               <h2 className="studio-shelf-heading">{t('studioPanel.shelf.heading')}</h2>
-              <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: games.length })}</span>
+              <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: shelfGames.length })}</span>
             </div>
             <button type="button" className="studio-shelf-new" onClick={() => onNavigate('/')}>
               <PixelIcon name="sparkle" size={12} /> {t('studioPanel.shelf.newGame')}
@@ -460,7 +486,7 @@ export function CreatorStudioView({
               showTools={showShelfTools}
               buildingCount={buildingCount}
               liveCount={liveCount}
-              totalCount={games.length}
+              totalCount={shelfGames.length}
               onQueryChange={setShelfQuery}
               onFilterChange={setShelfFilter}
             />
@@ -482,7 +508,7 @@ export function CreatorStudioView({
                   <span className="studio-game-switcher-meta">
                     <span className="studio-game-switcher-label">{t('studioPanel.shelf.switcher')}</span>
                     <span className="studio-game-switcher-count">
-                      {t('studioPanel.shelf.count', { count: games.length })}
+                      {t('studioPanel.shelf.count', { count: shelfGames.length })}
                     </span>
                   </span>
                   <span className="studio-game-switcher-title">{activeGame.title}</span>
@@ -640,7 +666,7 @@ export function CreatorStudioView({
             <header className="studio-picker-header">
               <div>
                 <h2>{t('studioPanel.shelf.pickerTitle')}</h2>
-                <p>{t('studioPanel.shelf.count', { count: games.length })}</p>
+                <p>{t('studioPanel.shelf.count', { count: shelfGames.length })}</p>
               </div>
               <button
                 type="button"
@@ -656,10 +682,10 @@ export function CreatorStudioView({
               searchRef={pickerSearchRef}
               query={shelfQuery}
               filter={shelfFilter}
-              showTools={showShelfTools || games.length > 1}
+              showTools={showShelfTools || shelfGames.length > 1}
               buildingCount={buildingCount}
               liveCount={liveCount}
-              totalCount={games.length}
+              totalCount={shelfGames.length}
               onQueryChange={setShelfQuery}
               onFilterChange={setShelfFilter}
             />
@@ -743,7 +769,7 @@ function StudioShelfList({
   emptyLabel,
   onSelect,
 }: {
-  games: StudioGame[];
+  games: StudioShelfGame[];
   selected: string | null;
   locale: string;
   emptyLabel: string;
@@ -761,12 +787,13 @@ function StudioShelfList({
         const active = game.token === selected;
         const status = game.lastKnownStatus;
         const building = Boolean(status && STUDIO_LIVE_STATUSES.has(status));
-        const published = isStudioGamePublished(game);
+        // Building wins the dot: a revise tip on a live game is still "moving".
+        const live = !building && isStudioGameShelfLive(game);
         return (
           <li key={game.token}>
             <button
               type="button"
-              className={`studio-shelf-item${active ? ' is-active' : ''}${building ? ' is-live' : ''}${published ? ' is-published' : ''}`}
+              className={`studio-shelf-item${active ? ' is-active' : ''}${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
               onClick={() => onSelect(game.token)}
               aria-current={active ? 'true' : undefined}
             >
@@ -776,7 +803,7 @@ function StudioShelfList({
                   order. The state that matters at a glance is "is this one moving", and a
                   dot says that without spending a line on it. */}
               <span
-                className={`studio-shelf-dot${building ? ' is-live' : ''}${published ? ' is-published' : ''}`}
+                className={`studio-shelf-dot${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
                 aria-hidden="true"
               />
               <span className="studio-shelf-title">{game.title}</span>
@@ -809,7 +836,7 @@ function DetailsPanel({
   onPlay,
   onRemoved,
 }: {
-  game: StudioGame;
+  game: StudioShelfGame;
   health: GameHealth | null;
   days: number;
   healthDays: string[];
@@ -821,7 +848,10 @@ function DetailsPanel({
   onRemoved: (token: string) => void;
 }) {
   const { t, i18n } = useTranslation();
-  const published = isStudioGamePublished(game);
+  // This *job* is published — composer/playtest routing. Distinct from catalog-live below.
+  const publishedJob = isStudioGamePublished(game);
+  const catalogLive = isStudioGameShelfLive(game);
+  const publishedAt = game.publishedAt ?? game.livePublishedAt;
   const [abandonArmed, setAbandonArmed] = useState(false);
   const [abandoning, setAbandoning] = useState(false);
 
@@ -847,9 +877,9 @@ function DetailsPanel({
           <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.createdAt), i18n.language)}</span>
           <span className="funnel-stat-label">{t('studioPanel.overview.created')}</span>
         </li>
-        {game.publishedAt ? (
+        {publishedAt ? (
           <li>
-            <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.publishedAt), i18n.language)}</span>
+            <span className="funnel-stat-value">{formatRelativeTime(Date.parse(publishedAt), i18n.language)}</span>
             <span className="funnel-stat-label">{t('studioPanel.overview.published')}</span>
           </li>
         ) : null}
@@ -870,7 +900,7 @@ function DetailsPanel({
         {/* Nothing here to reopen the build with: the thread is on the screen already,
             beside this panel. Playing a published game is the one action that is not
             simply "look left". */}
-        {published && game.slug ? (
+        {catalogLive && game.slug ? (
           <button type="button" className="primary-btn" onClick={onPlay}>
             <PixelIcon name="play" size={12} /> {t('myGames.play')}
           </button>
@@ -878,7 +908,7 @@ function DetailsPanel({
         <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
           <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
         </button>
-        {!published && game.lastKnownStatus !== 'abandoned' ? (
+        {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
           <button
             type="button"
             className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
@@ -890,12 +920,14 @@ function DetailsPanel({
         ) : null}
       </div>
 
-      {!published && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+      {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
+          public play link — offering a second "share the draft" switch would lie. */}
+      {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
 
       {/* Only once there is play to report on. Before a game is live every one of these
           numbers is zero, and a wall of zeroes reads as a verdict rather than as
           "nobody has played it yet, because nobody can". */}
-      {published ? (
+      {catalogLive ? (
         <StatsSection
           game={game}
           health={health}

--- a/apps/web/src/studioShelf.test.ts
+++ b/apps/web/src/studioShelf.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { StudioGame } from './studioApi.js';
-import { filterStudioGames, sortStudioGames, STUDIO_SHELF_TOOLS_AT } from './studioShelf.js';
+import {
+  collapseStudioGames,
+  filterStudioGames,
+  isStudioGameShelfLive,
+  sortStudioGames,
+  STUDIO_SHELF_TOOLS_AT,
+} from './studioShelf.js';
 
 function game(partial: Partial<StudioGame> & Pick<StudioGame, 'token' | 'title'>): StudioGame {
   return {
@@ -50,8 +56,42 @@ describe('studioShelf', () => {
     expect(sorted.map((item) => item.token)).toEqual(['new-build', 'older-build', 'new-live', 'old-live']);
   });
 
+  it('collapses a published game and its improve tip into one shelf row', () => {
+    const collapsed = collapseStudioGames([
+      game({
+        token: 'live',
+        title: 'Miniature Warfare 2D',
+        slug: 'miniature-warfare-2d',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-07-01T00:00:00.000Z',
+        createdAt: '2026-07-01T00:00:00.000Z',
+      }),
+      game({
+        token: 'tip',
+        title: 'Miniature Warfare 2D',
+        slug: 'miniature-warfare-2d',
+        lastKnownStatus: 'building',
+        createdAt: '2026-07-20T00:00:00.000Z',
+      }),
+      game({
+        token: 'solo',
+        title: 'TV Tycoon',
+        slug: 'tv-tycoon',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-07-10T00:00:00.000Z',
+        createdAt: '2026-07-10T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(collapsed.map((item) => item.token)).toEqual(['tip', 'solo']);
+    expect(collapsed[0]?.livePublishedAt).toBe('2026-07-01T00:00:00.000Z');
+    expect(isStudioGameShelfLive(collapsed[0]!)).toBe(true);
+    // Tip itself stays unpublished so composer/playtest keep using feedback, not improve.
+    expect(collapsed[0]?.publishedAt).toBeUndefined();
+  });
+
   it('filters by building / live and by title or slug query', () => {
-    const games = [
+    const games = collapseStudioGames([
       game({
         token: 'a',
         title: 'Sky Dodge',
@@ -61,11 +101,23 @@ describe('studioShelf', () => {
       }),
       game({ token: 'b', title: 'Arena Tag', lastKnownStatus: 'building' }),
       game({ token: 'c', title: 'Moon Run', lastKnownStatus: 'needs_changes' }),
-    ];
+      // Same slug as the live game — must not double-count under Live or All.
+      game({
+        token: 'a-tip',
+        title: 'Sky Dodge',
+        slug: 'sky-dodge',
+        lastKnownStatus: 'building',
+        createdAt: '2026-07-20T00:00:00.000Z',
+      }),
+    ]);
 
-    expect(filterStudioGames(games, { filter: 'building' }).map((item) => item.token)).toEqual(['b']);
-    expect(filterStudioGames(games, { filter: 'live' }).map((item) => item.token)).toEqual(['a']);
-    expect(filterStudioGames(games, { query: 'dodge' }).map((item) => item.token)).toEqual(['a']);
+    expect(
+      filterStudioGames(games, { filter: 'building' })
+        .map((item) => item.token)
+        .sort(),
+    ).toEqual(['a-tip', 'b']);
+    expect(filterStudioGames(games, { filter: 'live' }).map((item) => item.token)).toEqual(['a-tip']);
+    expect(filterStudioGames(games, { query: 'dodge' }).map((item) => item.token)).toEqual(['a-tip']);
     expect(filterStudioGames(games, { query: 'arena' }).map((item) => item.token)).toEqual(['b']);
     expect(filterStudioGames(games, { query: 'zzz' })).toEqual([]);
   });

--- a/apps/web/src/studioShelf.test.ts
+++ b/apps/web/src/studioShelf.test.ts
@@ -90,6 +90,33 @@ describe('studioShelf', () => {
     expect(collapsed[0]?.publishedAt).toBeUndefined();
   });
 
+  it('keeps an improve tip catalog-live when the sibling has no publish timestamp', () => {
+    // lastKnownStatus alone is enough for isStudioGamePublished; publishedAt is only
+    // present "when known". The tip must still pass the Live filter.
+    const collapsed = collapseStudioGames([
+      game({
+        token: 'legacy-live',
+        title: 'Sky Dodge',
+        slug: 'sky-dodge',
+        lastKnownStatus: 'published',
+        createdAt: '2026-06-01T00:00:00.000Z',
+      }),
+      game({
+        token: 'tip',
+        title: 'Sky Dodge',
+        slug: 'sky-dodge',
+        lastKnownStatus: 'building',
+        createdAt: '2026-07-20T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]?.token).toBe('tip');
+    expect(collapsed[0]?.livePublishedAt).toBe('');
+    expect(isStudioGameShelfLive(collapsed[0]!)).toBe(true);
+    expect(filterStudioGames(collapsed, { filter: 'live' }).map((item) => item.token)).toEqual(['tip']);
+  });
+
   it('filters by building / live and by title or slug query', () => {
     const games = collapseStudioGames([
       game({

--- a/apps/web/src/studioShelf.ts
+++ b/apps/web/src/studioShelf.ts
@@ -14,6 +14,8 @@ export type StudioShelfFilter = 'all' | 'building' | 'live';
  * talk to is the new job (no `publishedAt` of its own), but the game is still live in
  * the catalog, so Live filters / Play / stats need the sibling's publish time without
  * flipping the composer onto `improve()` (that path requires the published job's token).
+ * Empty string means “catalog-live, publish time unknown” (`lastKnownStatus` said
+ * published but no timestamp) — present for liveness, falsy so the UI skips the date.
  */
 export type StudioShelfGame = StudioGame & { livePublishedAt?: string };
 
@@ -26,7 +28,7 @@ export function isStudioGamePublished(game: StudioGame): boolean {
 
 /** Live in the catalog — this job, or a published sibling collapsed behind an improve tip. */
 export function isStudioGameShelfLive(game: StudioShelfGame): boolean {
-  return isStudioGamePublished(game) || Boolean(game.livePublishedAt);
+  return isStudioGamePublished(game) || game.livePublishedAt !== undefined;
 }
 
 function shelfRank(game: StudioShelfGame): number {
@@ -73,7 +75,7 @@ export function collapseStudioGames(games: readonly StudioGame[]): StudioShelfGa
       continue;
     }
     const liveSibling = group.find((game) => isStudioGamePublished(game));
-    collapsed.push(liveSibling?.publishedAt ? { ...newest, livePublishedAt: liveSibling.publishedAt } : newest);
+    collapsed.push(liveSibling ? { ...newest, livePublishedAt: liveSibling.publishedAt ?? '' } : newest);
   }
 
   return [...collapsed, ...unslugged];

--- a/apps/web/src/studioShelf.ts
+++ b/apps/web/src/studioShelf.ts
@@ -6,6 +6,17 @@ export const STUDIO_LIVE_STATUSES = new Set<SubmissionState>(['queued', 'buildin
 
 export type StudioShelfFilter = 'all' | 'building' | 'live';
 
+/**
+ * A shelf row. One game, even when the store still holds both the published job and an
+ * in-flight improvement on the same slug.
+ *
+ * `livePublishedAt` is stamped only when the open row is that improvement: the tip to
+ * talk to is the new job (no `publishedAt` of its own), but the game is still live in
+ * the catalog, so Live filters / Play / stats need the sibling's publish time without
+ * flipping the composer onto `improve()` (that path requires the published job's token).
+ */
+export type StudioShelfGame = StudioGame & { livePublishedAt?: string };
+
 /** Show search + filter chips once the shelf is no longer a glanceable handful. */
 export const STUDIO_SHELF_TOOLS_AT = 5;
 
@@ -13,15 +24,20 @@ export function isStudioGamePublished(game: StudioGame): boolean {
   return Boolean(game.publishedAt && game.slug) || game.lastKnownStatus === 'published';
 }
 
-function shelfRank(game: StudioGame): number {
+/** Live in the catalog — this job, or a published sibling collapsed behind an improve tip. */
+export function isStudioGameShelfLive(game: StudioShelfGame): boolean {
+  return isStudioGamePublished(game) || Boolean(game.livePublishedAt);
+}
+
+function shelfRank(game: StudioShelfGame): number {
   const status = game.lastKnownStatus;
   if (status && STUDIO_LIVE_STATUSES.has(status)) return 0;
-  if (isStudioGamePublished(game)) return 1;
+  if (isStudioGameShelfLive(game)) return 1;
   return 2;
 }
 
 /** Active builds first, then live games, then the rest — newest within each band. */
-export function sortStudioGames(games: readonly StudioGame[]): StudioGame[] {
+export function sortStudioGames(games: readonly StudioShelfGame[]): StudioShelfGame[] {
   return [...games].sort((a, b) => {
     const byRank = shelfRank(a) - shelfRank(b);
     if (byRank !== 0) return byRank;
@@ -29,24 +45,58 @@ export function sortStudioGames(games: readonly StudioGame[]): StudioGame[] {
   });
 }
 
-export function matchesStudioShelfFilter(game: StudioGame, filter: StudioShelfFilter): boolean {
+/**
+ * One row per game. An improvement is a new job on an existing slug — listing both the
+ * live game and the revise tip as separate picks is the same title twice in the switcher.
+ * Prefer the newest job (the tip); keep the sibling's publish time when the tip itself
+ * is not yet published.
+ */
+export function collapseStudioGames(games: readonly StudioGame[]): StudioShelfGame[] {
+  const bySlug = new Map<string, StudioGame[]>();
+  const unslugged: StudioShelfGame[] = [];
+
+  for (const game of games) {
+    if (!game.slug) {
+      unslugged.push(game);
+      continue;
+    }
+    const group = bySlug.get(game.slug);
+    if (group) group.push(game);
+    else bySlug.set(game.slug, [game]);
+  }
+
+  const collapsed: StudioShelfGame[] = [];
+  for (const group of bySlug.values()) {
+    const newest = [...group].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0]!;
+    if (isStudioGamePublished(newest)) {
+      collapsed.push(newest);
+      continue;
+    }
+    const liveSibling = group.find((game) => isStudioGamePublished(game));
+    collapsed.push(liveSibling?.publishedAt ? { ...newest, livePublishedAt: liveSibling.publishedAt } : newest);
+  }
+
+  return [...collapsed, ...unslugged];
+}
+
+export function matchesStudioShelfFilter(game: StudioShelfGame, filter: StudioShelfFilter): boolean {
   if (filter === 'all') return true;
   if (filter === 'building') {
     return Boolean(game.lastKnownStatus && STUDIO_LIVE_STATUSES.has(game.lastKnownStatus));
   }
-  return isStudioGamePublished(game);
+  return isStudioGameShelfLive(game);
 }
 
-export function matchesStudioShelfQuery(game: StudioGame, query: string): boolean {
+export function matchesStudioShelfQuery(game: StudioShelfGame, query: string): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
   return game.title.toLowerCase().includes(q) || (game.slug?.toLowerCase().includes(q) ?? false);
 }
 
 export function filterStudioGames(
-  games: readonly StudioGame[],
+  games: readonly StudioShelfGame[],
   opts: { filter?: StudioShelfFilter; query?: string } = {},
-): StudioGame[] {
+): StudioShelfGame[] {
   const filter = opts.filter ?? 'all';
   const query = opts.query ?? '';
   return sortStudioGames(games).filter(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The studio picker listed **jobs**, so a published game plus an in-flight improvement (same slug, same title) showed up twice — e.g. All 5 = Building 2 + Live 3 for only three games.

## What

- Collapse the shelf by slug to the newest tip (the job you talk to).
- Keep the published sibling’s timestamp as `livePublishedAt` so Live filters, Play, and stats still treat the game as live.
- If the sibling is published only via `lastKnownStatus` (no timestamp), stamp `livePublishedAt: ''` so it stays catalog-live without inventing a date.
- Leave composer/playtest routing on the tip’s own status (`feedback` while building, not `improve` on the tip token).
- Counts and the picker subtitle use unique games.

## Copilot review

Addressed the one inline comment: catalog-live without `publishedAt` (ee92a057).

## Merge

Rebased onto current `master` (includes #442 improve handoff). Conflict in `CreatorStudioView.tsx` was complementary: kept shelf collapse (`activeGame` from `shelfGames`) and the handoff tip (`threadToken` / `playtestGame`).

## Test plan

- [x] `studioShelf` unit tests for collapse + Live/Building filters with a tip
- [x] Unit test for tip + published sibling with no timestamp
- [x] Creator Studio picker test: 5 jobs → 3 rows, Building 2 / Live 3
- [x] Handoff tests still pass after merge
- [x] `npm run type-check` (web) + targeted vitest

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a5ea63-407c-49ba-8748-20839fc85bed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a5ea63-407c-49ba-8748-20839fc85bed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

