### PR TITLE
fix(web): stop footer flash while Creator Studio loads

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -92,11 +92,13 @@ for driving the same setup by hand.
 
 `src/studio-shell.test.ts` checks that an open Creator Studio thread owns the window
 (no page scroll, transcript scroller of its own, bottom bars never cover the composer)
-at every CSS band. It **stubs** `/api/me/studio` and the fixture game's status response
-rather than borrowing whatever happens to sit on `bot:e2e`'s shelf: an empty shelf used
-to make all four widths skip while the deploy still went green (#392). The real React
-tree and stylesheet still run; only the JSON is replaced, so the suite stays read-only
-against production.
+at every CSS band — and that the same window claim holds **while the shelf is still
+loading**, so the marketing footer cannot flash before a game opens. It **stubs**
+`/api/me/studio` and the fixture game's status response rather than borrowing whatever
+happens to sit on `bot:e2e`'s shelf: an empty shelf used to make all four widths skip
+while the deploy still went green (#392). The loading-state cases hold the shelf JSON
+deliberately. The real React tree and stylesheet still run; only the JSON is replaced,
+so the suite stays read-only against production.
 
 ## Adding a test
 

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { APIRequestContext, Browser, Page, Route } from 'playwright-core';
 import {
+  BASE_URL,
   collectProblems,
   describeProblems,
   e2ePrerequisites,
@@ -237,6 +238,124 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       }
 
       expect(describeProblems(watcher.drain())).toBe('');
+    });
+  }
+
+  /**
+   * The open-game tests above wait until a composer is on screen, so they never see the
+   * shelf-fetch window — which is exactly where the marketing footer used to paint and
+   * then vanish. Hold `/api/me/studio` and assert the pending shell claim itself: footer
+   * and lid gone, page scroll gone, bottom bars joined to the column (there is no
+   * composer yet, so "covers the composer" is the wrong question — `position: static` is
+   * the CSS contract that keeps them from floating over whatever comes next).
+   */
+  for (const viewport of VIEWPORTS) {
+    it(`claims the window while the shelf loads on a ${viewport.label}`, async () => {
+      const watcher = collectProblems(page);
+
+      let releaseShelf!: () => void;
+      const shelfHeld = new Promise<void>((resolve) => {
+        releaseShelf = resolve;
+      });
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        releaseShelf();
+      };
+
+      const holdShelf: Parameters<Page['route']>[1] = async (route) => {
+        const path = new URL(route.request().url()).pathname.replace(/\/$/, '');
+        if (path.endsWith('/api/me/studio/health')) {
+          await fulfillJson(route, { days: [], truncated: false, games: [] });
+          return;
+        }
+        if (path.endsWith('/api/me/studio/scorecards')) {
+          await fulfillJson(route, { scorecards: [] });
+          return;
+        }
+        if (path.endsWith('/api/me/studio')) {
+          await shelfHeld;
+          await fulfillJson(route, {
+            games: [
+              {
+                token: FIXTURE_TOKEN,
+                title: 'E2E Studio Shell Fixture',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                lastKnownStatus: 'published',
+                slug: FIXTURE_SLUG,
+                publishedAt: '2026-01-02T00:00:00.000Z',
+              },
+            ],
+          });
+          return;
+        }
+        await route.fallback();
+      };
+
+      await page.route('**/api/me/studio**', holdShelf);
+      try {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        // Short settle only: the shelf is held on purpose, so a long wait would just sit
+        // on the pending marker. Goto + marker is the signal the shell CSS under test ran.
+        await page.goto(`${BASE_URL}/studio`, { waitUntil: 'domcontentloaded' });
+        try {
+          await page.waitForSelector('.studio-shell-pending', { state: 'attached', timeout: 15_000 });
+        } catch {
+          expect.fail(
+            'studio shell did not mount .studio-shell-pending while the shelf was held — the loading-state gate would assert nothing',
+          );
+        }
+
+        const pending = await page.evaluate(() => {
+          const footer = document.querySelector('.site-footer');
+          const header = document.querySelector('.studio-panel-header');
+          const app = document.querySelector('.app');
+          return {
+            footerDisplay: footer ? getComputedStyle(footer).display : null,
+            headerDisplay: header ? getComputedStyle(header).display : null,
+            appOverflow: app ? getComputedStyle(app).overflow : null,
+            pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+            gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
+          };
+        });
+
+        expect(pending.gameOpen, 'a game must not open while the shelf response is held').toBe(false);
+        expect(pending.footerDisplay, 'the marketing footer must stay hidden during the fetch').toBe('none');
+        expect(pending.headerDisplay, 'the Creator Studio lid must stay hidden during the fetch').toBe('none');
+        expect(pending.appOverflow, 'the pending shell must take the page scroll away').toBe('hidden');
+        expect(pending.pageScroll, 'the pending shell should own the window').toBeLessThanOrEqual(2);
+
+        for (const bar of BOTTOM_BARS) {
+          const position = await page.evaluate((className) => {
+            const app = document.querySelector('.app');
+            const injected = document.createElement('div');
+            injected.className = className;
+            injected.dataset.e2eInjected = 'true';
+            app?.appendChild(injected);
+            const computed = getComputedStyle(injected).position;
+            injected.remove();
+            return computed;
+          }, bar);
+          expect(position, `.${bar} should join the column while the shell is pending`).toBe('static');
+        }
+
+        release();
+        try {
+          await page.waitForSelector('.studio-layout.is-game-open', { state: 'attached', timeout: 15_000 });
+        } catch {
+          expect.fail('releasing the shelf did not open a game — pending→open handoff broke');
+        }
+        expect(
+          await page.locator('.studio-shell-pending').count(),
+          'the pending marker must leave once a game is open',
+        ).toBe(0);
+
+        expect(describeProblems(watcher.drain())).toBe('');
+      } finally {
+        release();
+        await page.unroute('**/api/me/studio**', holdShelf);
+      }
     });
   }
 });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -116,6 +116,56 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('claims the app shell while the shelf loads so the footer does not flash', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+
+    let resolveGames!: (value: StudioGame[]) => void;
+    fetchStudioGames.mockReturnValue(
+      new Promise<StudioGame[]>((resolve) => {
+        resolveGames = resolve;
+      }),
+    );
+
+    const container = document.createElement('div');
+    // The shell CSS is keyed off `.app:has(...)`, so the marker has to sit under an
+    // `.app` that also holds a footer — the real tree App mounts.
+    const app = document.createElement('div');
+    app.className = 'app';
+    const content = document.createElement('div');
+    content.className = 'content';
+    const footer = document.createElement('footer');
+    footer.className = 'site-footer';
+    app.append(content, footer);
+    document.body.appendChild(app);
+    content.appendChild(container);
+
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(CreatorStudioView, { onNavigate: vi.fn(), onPlay: vi.fn() }));
+    });
+
+    expect(container.querySelector('.studio-shell-pending')).toBeTruthy();
+    expect(container.textContent).toContain('Loading your games…');
+    // jsdom does not apply stylesheets, so assert the marker the `:has()` rule keys on
+    // rather than computed footer display — that is what keeps the flash from painting.
+    expect(app.querySelector('.studio-shell-pending')).toBeTruthy();
+
+    await act(async () => {
+      resolveGames(manyGames(2));
+      await fetchStudioGames.mock.results[0]?.value;
+      await fetchStudioHealth.mock.results[0]?.value;
+    });
+
+    expect(container.querySelector('.studio-shell-pending')).toBeFalsy();
+    expect(container.querySelector('.studio-layout.is-game-open')).toBeTruthy();
+
+    root.unmount();
+    app.remove();
+    authUser = null;
+  });
+
   it('adds search and filters once the shelf has many games', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -421,7 +421,15 @@ export function CreatorStudioView({
         </button>
       </header>
 
-      {loading ? <p className="studio-empty">{t('studioPanel.loading')}</p> : null}
+      {loading ? (
+        <>
+          {/* Claims the app shell for the length of the shelf fetch so the marketing
+              footer (and this panel's lid) do not paint and then vanish the moment a
+              game opens — bare /studio auto-picks one without naming it in the URL. */}
+          <div className="studio-shell-pending" hidden />
+          <p className="studio-empty">{t('studioPanel.loading')}</p>
+        </>
+      ) : null}
       {error ? <p className="studio-empty studio-error">{error}</p> : null}
 
       {!loading && !error && games.length === 0 ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4580,15 +4580,20 @@ body.player-open {
    it in the URL, so a URL-driven class left exactly that case on the old broken shape.
    What matters is whether a game is open on screen, which is what this asks. Browsers
    without `:has()` drop the block and get the old scrolling page — the degradation is
-   yesterday's layout, not a broken one. */
-.app:has(.studio-layout.is-game-open) {
+   yesterday's layout, not a broken one.
+
+   `.studio-shell-pending` is the same claim during the shelf fetch. Without it, loading
+   paints the marketing footer (and the Creator Studio lid) for the length of the
+   request, then snatches both away the moment a game opens — a flash that is exactly
+   as long as the network. */
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) {
   height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-.app:has(.studio-layout.is-game-open) > .content {
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) > .content {
   flex: 1;
   min-height: 0;
   display: flex;
@@ -4602,13 +4607,13 @@ body.player-open {
 
 /* Legal links and a strapline do not belong under a live conversation, and with the page
    no longer scrolling there is nothing that could reach them anyway. */
-.app:has(.studio-layout.is-game-open) .site-footer {
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) .site-footer {
   display: none;
 }
 
 /* A kicker, a page title, a strapline and a way home, above a screen whose header
    already offers the way home. On a page it introduces; in an app it is a lid. */
-.app:has(.studio-layout.is-game-open) .studio-panel-header {
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) .studio-panel-header {
   display: none;
 }
 
@@ -4644,12 +4649,22 @@ body.player-open {
    control that matters. Suppressing them was the other option and a worse one: the
    update bar is how a browser finds out there is a new shell, and the studio is a screen
    people sit on for a long time. */
-.app:has(.studio-layout.is-game-open) .install-prompt,
-.app:has(.studio-layout.is-game-open) .app-update {
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) .install-prompt,
+.app:has(:is(.studio-layout.is-game-open, .studio-shell-pending)) .app-update {
   position: static;
   flex: none;
   margin: 0 12px max(12px, env(safe-area-inset-bottom, 0px));
   animation: none;
+}
+
+/* The lid is gone for the fetch, so the loading line sits in the middle of the window
+   rather than under an invisible header's leftover gap. */
+.app:has(.studio-shell-pending) .studio-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 /* On a narrow screen the thread does not get a scroller of its own.

--- a/apps/web/src/styles.studioShell.test.ts
+++ b/apps/web/src/styles.studioShell.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+/**
+ * The studio shell claim is keyed off `:has(...)`, and the loading flash was a missing
+ * second key. A unit suite cannot evaluate computed layout, but it can refuse a revert
+ * that drops `.studio-shell-pending` from the selectors the browser e2e exercises.
+ */
+describe('studio shell claim selectors', () => {
+  it('claims the window for both an open game and a pending shelf fetch', () => {
+    expect(css).toMatch(/\.app:has\(:is\(\.studio-layout\.is-game-open,\s*\.studio-shell-pending\)\)\s*\{/);
+    expect(css).toMatch(
+      /\.app:has\(:is\(\.studio-layout\.is-game-open,\s*\.studio-shell-pending\)\)\s*\.site-footer\s*\{/,
+    );
+    expect(css).toMatch(
+      /\.app:has\(:is\(\.studio-layout\.is-game-open,\s*\.studio-shell-pending\)\)\s*\.studio-panel-header\s*\{/,
+    );
+    expect(css).toMatch(
+      /\.app:has\(:is\(\.studio-layout\.is-game-open,\s*\.studio-shell-pending\)\)\s*\.install-prompt/,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening Creator Studio painted the marketing footer (and the “Creator Studio” lid) for the length of the shelf fetch, then hid both the moment a game auto-opened. Bare `/studio` picks a game without naming it in the URL, so the flash was the common path.

## Fix

Mount a `studio-shell-pending` marker while the shelf loads, and key the existing window-claim / footer-hide / lid-hide CSS off `:is(.studio-layout.is-game-open, .studio-shell-pending)`. The thread layout chain still waits for a real open game; only the shell claim applies during the fetch.

## Tests

- Unit: pending marker during shelf fetch → replaced by `is-game-open`
- CSS contract: shell-claim selectors include `.studio-shell-pending` (PR CI)
- E2E (`studio-shell.test.ts`): hold `/api/me/studio` and assert pending shell (footer/lid hidden, window owned, bottom bars `position: static`) on every viewport band, then handoff to open game

## Reviewer feedback

- Copilot: no comments
- Codex P1: addressed — browser layout coverage for the pending state, not only the React marker

## Test plan

- [x] Unit + CSS contract tests
- [x] `npm run type-check && npm run lint && npm test && npm run build` (pre-e2e commit)
- [ ] Deploy-candidate e2e: `GAMEDEV_ACCESS_TOKEN=… npm run e2e -w @gamedevpl/e2e`
- [ ] Manual: signed-in `/studio` with games — no footer flash
- [ ] Manual: empty shelf — footer returns after load
- [ ] Manual: unsigned `/studio` — sign-in + footer unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9454c88b-d241-48f5-8a0b-14b8e9c56c82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9454c88b-d241-48f5-8a0b-14b8e9c56c82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

