### PR TITLE
Convert CreatorQA from inline panel to full-screen wizard

### DIFF
--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -130,9 +130,31 @@ async function submitIdea(container: HTMLElement) {
   });
 }
 
+/**
+ * The confirm wizard portals itself to document.body, so it is never under the
+ * container the app was mounted into — everything about it is queried document-wide.
+ */
+const inWizard = <T extends Element>(selector: string): T | null => document.querySelector<T>(selector);
+const wizardOptions = () => document.querySelectorAll<HTMLButtonElement>('.qa-option');
+
+/** One progress cell per stage: the name, one per question, the builder, the review. */
+const stageCount = () => document.querySelectorAll('.qa-wizard-progress span').length;
+
+/** Advance one stage with the footer's primary button. */
+async function advance() {
+  await act(async () => {
+    inWizard('.qa-next')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushEffects();
+  });
+}
+
+/** The wizard opens on the name stage; the questions are one step in. */
+const gotoFirstQuestion = advance;
+
 describe('the QA gate in App', () => {
   afterEach(() => {
     document.body.innerHTML = '';
+    document.body.style.overflow = '';
     localStorage.clear();
     window.history.pushState(null, '', '/');
     vi.restoreAllMocks();
@@ -147,13 +169,14 @@ describe('the QA gate in App', () => {
     const first = await renderApp();
     await submitIdea(first.container);
 
-    expect(first.container.querySelector('.qa-container')).not.toBeNull();
-    expect(first.container.querySelectorAll('.qa-card')).toHaveLength(2);
+    expect(inWizard('.qa-wizard')).not.toBeNull();
+    // Name, the two questions, the builder, the review.
+    expect(stageCount()).toBe(5);
 
     // Answer one question, then throw the whole app away — the reload.
-    const chips = first.container.querySelectorAll<HTMLButtonElement>('.qa-chip');
+    await gotoFirstQuestion();
     await act(async () => {
-      chips[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      wizardOptions()[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
     await act(async () => first.root.unmount());
@@ -162,9 +185,9 @@ describe('the QA gate in App', () => {
     const second = await renderApp();
 
     // Back with the questions *and* the answer, without a second refine call.
-    expect(second.container.querySelectorAll('.qa-card')).toHaveLength(2);
-    const restoredChips = second.container.querySelectorAll<HTMLButtonElement>('.qa-chip');
-    expect(restoredChips[0].getAttribute('aria-pressed')).toBe('true');
+    expect(stageCount()).toBe(5);
+    await gotoFirstQuestion();
+    expect(wizardOptions()[0].getAttribute('aria-pressed')).toBe('true');
     expect(refineCalls).toBe(1);
 
     await act(async () => second.root.unmount());
@@ -206,7 +229,7 @@ describe('the QA gate in App', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector('.qa-container')).not.toBeNull();
+    expect(inWizard('.qa-wizard')).not.toBeNull();
     expect(container.querySelector<HTMLButtonElement>('.build-btn')?.textContent).toContain('Build My Game');
     await act(async () => root.unmount());
   });
@@ -221,13 +244,11 @@ describe('the QA gate in App', () => {
     expect(localStorage.getItem('gamedev_pending_qa')).not.toBeNull();
 
     await act(async () => {
-      container
-        .querySelector('.qa-container .btn-secondary')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      inWizard('.qa-wizard-exit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
 
-    expect(container.querySelector('.qa-container')).toBeNull();
+    expect(inWizard('.qa-wizard')).toBeNull();
     // Left behind, it would resurrect the abandoned idea on the next visit.
     expect(localStorage.getItem('gamedev_pending_qa')).toBeNull();
 
@@ -246,11 +267,15 @@ describe('the QA gate in App', () => {
     // A clean concept used to go straight to the agent, and the name it was built
     // under was the prompt's first 40 characters. Now it waits here.
     expect(submitted).toHaveLength(0);
-    expect(container.querySelector('.qa-container')).not.toBeNull();
-    expect(container.querySelector<HTMLInputElement>('.qa-name-input')?.value).toBe('Castaway Craft');
+    expect(inWizard('.qa-wizard')).not.toBeNull();
+    expect(inWizard<HTMLInputElement>('.qa-name-input')?.value).toBe('Castaway Craft');
+    // Nothing to clarify, so the round is name, builder, review — no question stages.
+    expect(stageCount()).toBe(3);
 
+    await advance(); // builder
+    await advance(); // review
     await act(async () => {
-      container.querySelector('.btn-create-now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      inWizard('.btn-create-now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
       await flushEffects();
     });
@@ -273,9 +298,10 @@ describe('the QA gate in App', () => {
     // Failing open must not mean skipping the step — that is how truncated prompts
     // became titles in the first place. The suggestion degrades; the gate does not.
     expect(submitted).toHaveLength(0);
-    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
+    const name = inWizard<HTMLInputElement>('.qa-name-input');
     expect(name?.value).toBe('A survival game on a desert island with');
-    expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
+    // No questions came back, so there are no question stages to walk.
+    expect(stageCount()).toBe(3);
 
     await act(async () => root.unmount());
   });
@@ -302,16 +328,17 @@ describe('the QA gate in App', () => {
     const { container, root } = await renderApp();
     await submitIdea(container);
 
-    expect(container.querySelector('.qa-card__question')?.textContent).toContain('What visual style');
+    await gotoFirstQuestion();
+    expect(inWizard('.qa-title')?.textContent).toContain('What visual style');
     expect(locales).toEqual(['en']);
 
-    // Pick a chip so we can prove the language switch clears English selections —
+    // Pick an option so we can prove the language switch clears English selections —
     // those labels would no longer match the Polish options.
     await act(async () => {
-      container.querySelector('.qa-chip')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      wizardOptions()[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
-    expect(container.querySelector('.qa-chip')?.getAttribute('aria-pressed')).toBe('true');
+    expect(wizardOptions()[0].getAttribute('aria-pressed')).toBe('true');
 
     await act(async () => {
       await i18n.changeLanguage('pl');
@@ -321,10 +348,12 @@ describe('the QA gate in App', () => {
     });
 
     expect(locales).toEqual(['en', 'pl']);
-    expect(container.querySelector('.qa-card__question')?.textContent).toContain('Jaki styl wizualny');
-    expect(container.querySelectorAll('.qa-card')).toHaveLength(1);
-    // Old English selection must not linger under the new chips.
-    expect(container.querySelector('.qa-chip')?.getAttribute('aria-pressed')).toBe('false');
+    // New questions remount the wizard, which restarts it on the name stage.
+    expect(stageCount()).toBe(4);
+    await gotoFirstQuestion();
+    expect(inWizard('.qa-title')?.textContent).toContain('Jaki styl wizualny');
+    // Old English selection must not linger under the new options.
+    expect(wizardOptions()[0].getAttribute('aria-pressed')).toBe('false');
     expect(JSON.parse(localStorage.getItem('gamedev_pending_qa')!).locale).toBe('pl');
 
     await act(async () => root.unmount());
@@ -356,11 +385,9 @@ describe('the QA gate in App', () => {
     const { container, root } = await renderApp();
     await submitIdea(container);
 
-    const createBtn = container.querySelector<HTMLButtonElement>('.qa-container .btn-create-now')!;
-    const chipBtn = container.querySelector<HTMLButtonElement>('.qa-chip')!;
-    expect(createBtn).not.toBeNull();
-    expect(createBtn.disabled).toBe(false);
-    expect(chipBtn.disabled).toBe(false);
+    await gotoFirstQuestion();
+    expect(inWizard<HTMLButtonElement>('.qa-next')?.disabled).toBe(false);
+    expect(wizardOptions()[0].disabled).toBe(false);
 
     // Switch language to trigger relocalization (which is the 2nd refine call, paused on `gate.promise`)
     await act(async () => {
@@ -369,8 +396,9 @@ describe('the QA gate in App', () => {
     });
 
     // While relocalization is in flight, controls in CreatorQA must be disabled
-    expect(container.querySelector<HTMLButtonElement>('.qa-container .btn-create-now')?.disabled).toBe(true);
-    expect(container.querySelector<HTMLButtonElement>('.qa-chip')?.disabled).toBe(true);
+    expect(inWizard<HTMLButtonElement>('.qa-next')?.disabled).toBe(true);
+    expect(wizardOptions()[0].disabled).toBe(true);
+    expect(inWizard<HTMLButtonElement>('.qa-wizard-exit')?.disabled).toBe(true);
 
     // Resolve relocalization call
     await act(async () => {
@@ -379,8 +407,10 @@ describe('the QA gate in App', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector<HTMLButtonElement>('.btn-create-now')?.disabled).toBe(false);
-    expect(container.querySelector<HTMLButtonElement>('.qa-chip')?.disabled).toBe(false);
+    // The new questions remount the wizard back on the name stage, live again.
+    expect(inWizard<HTMLButtonElement>('.qa-next')?.disabled).toBe(false);
+    await gotoFirstQuestion();
+    expect(wizardOptions()[0].disabled).toBe(false);
     await act(async () => root.unmount());
   });
 
@@ -397,7 +427,7 @@ describe('the QA gate in App', () => {
     const { container, root } = await renderApp();
     await submitIdea(container);
 
-    expect(container.querySelectorAll('.qa-card')).toHaveLength(2);
+    expect(stageCount()).toBe(5);
 
     await act(async () => {
       await i18n.changeLanguage('pl');
@@ -405,9 +435,10 @@ describe('the QA gate in App', () => {
       await flushEffects();
     });
 
-    // The 2 English questions must be retained, not erased into a name-only panel
-    expect(container.querySelectorAll('.qa-card')).toHaveLength(2);
-    expect(container.querySelector('.qa-card__question')?.textContent).toContain('What visual style');
+    // The 2 English questions must be retained, not erased into a name-only round
+    expect(stageCount()).toBe(5);
+    await gotoFirstQuestion();
+    expect(inWizard('.qa-title')?.textContent).toContain('What visual style');
     await act(async () => root.unmount());
   });
 
@@ -431,7 +462,8 @@ describe('the QA gate in App', () => {
     const { container, root } = await renderApp();
     await submitIdea(container);
 
-    const customInput = container.querySelector<HTMLInputElement>('.qa-custom-input input')!;
+    await gotoFirstQuestion();
+    const customInput = inWizard<HTMLInputElement>('.qa-custom-input input')!;
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
       setter?.call(customInput, 'with Amiga palette');
@@ -447,8 +479,8 @@ describe('the QA gate in App', () => {
       await flushEffects();
     });
 
-    const plCustomInput = container.querySelector<HTMLInputElement>('.qa-custom-input input');
-    expect(plCustomInput?.value).toBe('with Amiga palette');
+    await gotoFirstQuestion();
+    expect(inWizard<HTMLInputElement>('.qa-custom-input input')?.value).toBe('with Amiga palette');
     await act(async () => root.unmount());
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -127,7 +127,6 @@ export function App() {
   // with empty answers — English chip labels must not survive as "selected" under
   // Polish options that no longer match.
   const [qaFormKey, setQaFormKey] = useState(0);
-  const qaRef = useRef<HTMLDivElement | null>(null);
   // Kept next to the QA state so the language-switch effect can clear it too.
   const latestAnswersRef = useRef<PendingQaAnswers>(restoredQa.current?.answers ?? { selected: {}, custom: {} });
 
@@ -333,14 +332,6 @@ export function App() {
       window.setTimeout(resolve, 450);
     });
   }, []);
-
-  // Bring the confirm panel into view when it opens. Keyed on the spec rather than on
-  // the questions: the panel now appears for a clean concept too, to be named.
-  useEffect(() => {
-    if (pendingSpec) {
-      qaRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
-    }
-  }, [pendingSpec]);
 
   // The static chrome follows the language switcher instantly; the AI questions do
   // not — they were authored in whatever language the refine call used. Re-ask when
@@ -908,26 +899,25 @@ export function App() {
               />
             </div>
 
-            {/* Gated on the pending spec alone: the panel is the naming step, which
-                always happens, and the questions are the part that is sometimes empty. */}
+            {/* Gated on the pending spec alone: the wizard is the naming step, which
+                always happens, and the questions are the part that is sometimes empty.
+                It portals itself to a full-screen overlay, so nothing here positions it. */}
             {pendingSpec && (
-              <div ref={qaRef}>
-                <CreatorQA
-                  key={qaFormKey}
-                  questions={qaQuestions}
-                  initialConcept={pendingSpec.concept}
-                  initialTitle={pendingSpec.title}
-                  onSubmitWithConcept={handleQaComplete}
-                  onTitleChange={handleQaTitleChange}
-                  onCancel={handleQaCancel}
-                  submitting={submissionStatus === 'loading' || submissionStatus === 'refining'}
-                  error={submissionError}
-                  initialAnswers={latestAnswersRef.current}
-                  onAnswersChange={handleQaAnswersChange}
-                  initialBuilder={qaBuilder}
-                  onBuilderChange={handleQaBuilderChange}
-                />
-              </div>
+              <CreatorQA
+                key={qaFormKey}
+                questions={qaQuestions}
+                initialConcept={pendingSpec.concept}
+                initialTitle={pendingSpec.title}
+                onSubmitWithConcept={handleQaComplete}
+                onTitleChange={handleQaTitleChange}
+                onCancel={handleQaCancel}
+                submitting={submissionStatus === 'loading' || submissionStatus === 'refining'}
+                error={submissionError}
+                initialAnswers={latestAnswersRef.current}
+                onAnswersChange={handleQaAnswersChange}
+                initialBuilder={qaBuilder}
+                onBuilderChange={handleQaBuilderChange}
+              />
             )}
 
             {stageContent?.type === 'party' && (

--- a/apps/web/src/BuilderChoice.test.tsx
+++ b/apps/web/src/BuilderChoice.test.tsx
@@ -45,7 +45,7 @@ describe('BuilderChoice', () => {
     const options = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option');
     expect(options).toHaveLength(2);
     expect(options[0].getAttribute('aria-checked')).toBe('true');
-    expect(options[0].textContent).toContain('Our AI dev team');
+    expect(options[0].textContent).toContain('Gamedev.pl coding agent');
     expect(options[1].textContent).toContain('My own coding agent');
 
     await act(async () => {
@@ -74,7 +74,7 @@ describe('BuilderChoice', () => {
     });
 
     const text = container.textContent ?? '';
-    expect(text).toMatch(/Nasz zespół AI|Mój własny agent/);
+    expect(text).toMatch(/Agent Gamedev.pl|Mój własny agent/);
     expect(text.toLowerCase()).not.toMatch(/\btoken\b/);
 
     await act(async () => root.unmount());

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -8,6 +8,12 @@ type BuilderChoiceProps = {
   disabled?: boolean;
   /** Quieter presentation for the thread composer; full for the confirm screen. */
   compact?: boolean;
+  /**
+   * Drops the legend visually where the surrounding screen already asks the question —
+   * the confirm wizard gives it a whole stage heading. It stays in the accessibility
+   * tree, because a fieldset without a legend is a group a screen reader can't name.
+   */
+  hideLegend?: boolean;
 };
 
 /**
@@ -16,7 +22,13 @@ type BuilderChoiceProps = {
  * Shown on the creation confirm screen and again whenever a new round is about to
  * start. Selection is a pair of pressed options, not a settings dig.
  */
-export function BuilderChoice({ value, onChange, disabled = false, compact = false }: BuilderChoiceProps) {
+export function BuilderChoice({
+  value,
+  onChange,
+  disabled = false,
+  compact = false,
+  hideLegend = false,
+}: BuilderChoiceProps) {
   const { t } = useTranslation();
 
   const select = (next: BuilderKind) => {
@@ -26,7 +38,9 @@ export function BuilderChoice({ value, onChange, disabled = false, compact = fal
 
   return (
     <fieldset className={`builder-choice${compact ? ' is-compact' : ''}`} disabled={disabled}>
-      <legend className="builder-choice-legend">{t('builder.legend')}</legend>
+      <legend className={`builder-choice-legend${hideLegend ? ' is-visually-hidden' : ''}`}>
+        {t('builder.legend')}
+      </legend>
       <div className="builder-choice-options" role="radiogroup" aria-label={t('builder.legend')}>
         <button
           type="button"

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -227,12 +227,12 @@ describe('CreatorQA', () => {
       await flushEffects();
     });
 
+    // One submit button, in the sticky action bar — a second copy above the questions
+    // used to read as the end of the panel, with the questions orphaned below it.
     const createBtns = container.querySelectorAll<HTMLButtonElement>('.btn-create-now');
-    expect(createBtns).toHaveLength(2);
-    for (const btn of createBtns) {
-      expect(btn.disabled).toBe(true);
-      expect(btn.textContent).toContain('Submitting');
-    }
+    expect(createBtns).toHaveLength(1);
+    expect(createBtns[0].disabled).toBe(true);
+    expect(createBtns[0].textContent).toContain('Submitting');
 
     // Walking away mid-flight would strand a submission the creator can't see.
     expect(container.querySelector<HTMLButtonElement>('.btn-secondary')?.disabled).toBe(true);
@@ -438,7 +438,8 @@ describe('CreatorQA', () => {
     expect(container.querySelector('.qa-title')?.textContent).toContain('Name your game');
     expect(container.querySelector('.qa-name-input')).not.toBeNull();
     expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
-    // One button, not two: the second exists to be reachable after a long list.
+    // Still exactly one button: the sticky bar is the same whether or not there
+    // was a question list to scroll past.
     expect(container.querySelectorAll('.btn-create-now')).toHaveLength(1);
 
     await act(async () => root.unmount());

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -465,6 +465,34 @@ describe('CreatorQA', () => {
     await act(async () => root.unmount());
   });
 
+  it('still holds focus when a submission has disabled every control', async () => {
+    // The trap listed the focusable controls and bailed when it found none. Mid-flight
+    // `submitting` disables all of them, so that bail was the one path where Tab was
+    // handed back to the browser and walked into the shell behind the overlay.
+    const behind = document.createElement('button');
+    document.body.appendChild(behind);
+
+    const root = await render({
+      ...baseProps,
+      onSubmitWithConcept: vi.fn(),
+      onCancel: vi.fn(),
+      submitting: true,
+    });
+
+    expect(findAll('.qa-wizard button:not([disabled]), .qa-wizard input:not([disabled])')).toHaveLength(0);
+
+    const wizard = find<HTMLElement>('.qa-wizard')!;
+    await act(async () => {
+      wizard.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(document.activeElement).toBe(wizard);
+    expect(document.activeElement).not.toBe(behind);
+
+    await act(async () => root.unmount());
+  });
+
   it('gives focus back to whatever opened it', async () => {
     const opener = document.createElement('button');
     document.body.appendChild(opener);

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -420,4 +420,60 @@ describe('CreatorQA', () => {
     await act(async () => root.unmount());
     expect(document.body.style.overflow).not.toBe('hidden');
   });
+
+  it('names the exit even when its label is hidden on a narrow screen', async () => {
+    // Below 560px the CSS hides the span, and the icon is decorative — without an
+    // explicit label that leaves a phone user with an unnamed button as the only
+    // way back to editing.
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn(), onCancel: vi.fn() });
+
+    expect(find('.qa-wizard-exit')?.getAttribute('aria-label')).toBe('Back to editing');
+
+    await act(async () => root.unmount());
+  });
+
+  it('keeps Tab inside the overlay', async () => {
+    // aria-modal tells assistive tech this is modal; it does not stop the browser
+    // tabbing on into the app shell, which is still focusable behind the overlay.
+    const outside = document.createElement('button');
+    outside.id = 'behind-the-wizard';
+    document.body.appendChild(outside);
+
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn(), onCancel: vi.fn() });
+
+    const focusable = findAll<HTMLElement>(
+      '.qa-wizard a[href], .qa-wizard button:not([disabled]), .qa-wizard input:not([disabled])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    // Forward off the end wraps to the top rather than escaping to the page behind.
+    last.focus();
+    await act(async () => {
+      last.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+      await flushEffects();
+    });
+    expect(document.activeElement).toBe(first);
+
+    // And backwards off the front wraps to the end.
+    await act(async () => {
+      first.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+      await flushEffects();
+    });
+    expect(document.activeElement).toBe(last);
+
+    await act(async () => root.unmount());
+  });
+
+  it('gives focus back to whatever opened it', async () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
+    expect(document.activeElement).not.toBe(opener);
+
+    await act(async () => root.unmount());
+    expect(document.activeElement).toBe(opener);
+  });
 });

--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, createElement } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
 import i18n from './i18n/index.js';
@@ -11,9 +11,52 @@ async function flushEffects() {
   await Promise.resolve();
 }
 
+/**
+ * The wizard portals itself to document.body, so nothing it renders is under the
+ * container the root was mounted into — every query here is document-wide.
+ */
+const find = <T extends Element>(selector: string): T | null => document.querySelector<T>(selector);
+const findAll = <T extends Element>(selector: string): NodeListOf<T> => document.querySelectorAll<T>(selector);
+
+async function click(element: Element | null | undefined) {
+  await act(async () => {
+    element?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushEffects();
+  });
+}
+
+async function type(input: HTMLInputElement | null, value: string) {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    setter?.call(input, value);
+    input?.dispatchEvent(new Event('input', { bubbles: true }));
+    await flushEffects();
+  });
+}
+
+/** Advance one stage via the footer's primary button (Continue / Next / Skip / Review). */
+const next = () => click(find('.qa-next'));
+
+const options = () => findAll<HTMLButtonElement>('.qa-option');
+const heading = () => find('.qa-title')?.textContent ?? '';
+
+async function render(props: Record<string, unknown>): Promise<Root> {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(CreatorQA, props as never));
+    await flushEffects();
+  });
+  return root;
+}
+
 describe('CreatorQA', () => {
   afterEach(() => {
     document.body.innerHTML = '';
+    document.body.style.overflow = '';
     vi.restoreAllMocks();
   });
 
@@ -29,49 +72,40 @@ describe('CreatorQA', () => {
     },
   ];
 
-  it('renders questions and allows selecting an option chip', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
+  const baseProps = {
+    questions: mockQuestions,
+    initialConcept: 'Dodge the falling rocks and survive as long as possible',
+    initialTitle: 'Rock Dodger',
+  };
 
+  it('opens on the name stage and walks to review before anything is submitted', async () => {
     let submittedConcept = '';
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: (concept) => {
-            submittedConcept = concept;
-          },
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      onSubmitWithConcept: (concept: string) => {
+        submittedConcept = concept;
+      },
     });
 
-    expect(container.querySelector('.qa-title')).not.toBeNull();
-    expect(container.querySelector('.qa-card__question')?.textContent).toContain('What visual style');
+    // Name first: it is the prerequisite the build waits on.
+    expect(find('.qa-name-input')).not.toBeNull();
+    expect(findAll('.qa-option')).toHaveLength(0);
+    // Three stages: name, the one question, builder, review.
+    expect(find('.qa-wizard-step')?.textContent).toBe('Step 1 of 4');
 
-    const chips = container.querySelectorAll<HTMLButtonElement>('.qa-chip');
-    expect(chips).toHaveLength(2);
+    await next();
+    expect(heading()).toContain('What visual style');
+    expect(options()).toHaveLength(2);
 
-    // Select 'Pixel Art' chip
-    await act(async () => {
-      chips[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await click(options()[0]);
+    expect(options()[0].classList.contains('qa-option--selected')).toBe(true);
 
-    expect(chips[0].classList.contains('qa-chip--selected')).toBe(true);
+    await next(); // builder
+    await next(); // review
 
-    // Click "Create Now" button
-    const createBtn = container.querySelector<HTMLButtonElement>('.btn-create-now');
-    await act(async () => {
-      createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    // Nothing is submitted until the creator presses the button on the review stage.
+    expect(submittedConcept).toBe('');
+    await click(find('.btn-create-now'));
 
     expect(submittedConcept).toContain('Dodge the falling rocks');
     expect(submittedConcept).toContain('## Creator clarifications');
@@ -80,64 +114,64 @@ describe('CreatorQA', () => {
     await act(async () => root.unmount());
   });
 
-  it('combines a chosen chip with free text instead of dropping the chip', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
+  it('does not advance when an option is chosen — moving on is always explicit', async () => {
+    // Auto-advancing on selection made a tap yank the screen away mid-thought, and it
+    // was inconsistent with multi-choice questions, where the same gesture must not.
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
 
+    await next();
+    const before = find('.qa-wizard-step')?.textContent;
+    await click(options()[0]);
+
+    expect(find('.qa-wizard-step')?.textContent).toBe(before);
+    expect(heading()).toContain('What visual style');
+
+    await act(async () => root.unmount());
+  });
+
+  it('offers Skip until a question is answered, then Next', async () => {
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
+    await next();
+
+    const skip = find<HTMLButtonElement>('.qa-next');
+    expect(skip?.textContent).toContain('Skip');
+    expect(skip?.classList.contains('qa-next--skip')).toBe(true);
+
+    await click(options()[1]);
+    expect(find<HTMLButtonElement>('.qa-next')?.textContent).toContain('Next');
+    expect(find<HTMLButtonElement>('.qa-next')?.classList.contains('qa-next--skip')).toBe(false);
+
+    await act(async () => root.unmount());
+  });
+
+  it('combines a chosen option with free text instead of dropping the option', async () => {
     let submittedConcept = '';
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: (concept) => {
-            submittedConcept = concept;
-          },
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      onSubmitWithConcept: (concept: string) => {
+        submittedConcept = concept;
+      },
     });
 
-    const chips = container.querySelectorAll<HTMLButtonElement>('.qa-chip');
-    await act(async () => {
-      chips[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await next();
+    await click(options()[0]);
+    await type(find<HTMLInputElement>('.qa-custom-input .input-text'), 'but with an Amiga palette');
 
-    const input = container.querySelector<HTMLInputElement>('.qa-custom-input .input-text');
-    await act(async () => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-      setter?.call(input, 'but with an Amiga palette');
-      input?.dispatchEvent(new Event('input', { bubbles: true }));
-      await flushEffects();
-    });
+    // The option stays lit — un-highlighting it is what made the old data loss invisible.
+    expect(options()[0].classList.contains('qa-option--selected')).toBe(true);
+    expect(options()[0].getAttribute('aria-pressed')).toBe('true');
+    expect(options()[1].getAttribute('aria-pressed')).toBe('false');
 
-    // The chip stays lit — un-highlighting it is what made the old data loss invisible.
-    expect(chips[0].classList.contains('qa-chip--selected')).toBe(true);
-    expect(chips[0].getAttribute('aria-pressed')).toBe('true');
-    expect(chips[1].getAttribute('aria-pressed')).toBe('false');
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.btn-create-now')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await next();
+    await next();
+    await click(find('.btn-create-now'));
 
     expect(submittedConcept).toContain('- What visual style fits best: Pixel Art — but with an Amiga palette');
 
     await act(async () => root.unmount());
   });
 
-  it('accumulates chips on a multi-choice question and restores saved answers', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
+  it('accumulates options on a multi-choice question and restores saved answers', async () => {
     const multiQuestion: QAQuestion[] = [
       {
         id: 'mechanics',
@@ -149,170 +183,136 @@ describe('CreatorQA', () => {
 
     let submittedConcept = '';
     const answerSnapshots: Array<{ selected: Record<string, string[]>; custom: Record<string, string> }> = [];
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: multiQuestion,
-          initialConcept: 'A trading game',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: (concept) => {
-            submittedConcept = concept;
-          },
-          // Restored from a previous visit — the reload case.
-          initialAnswers: { selected: { mechanics: ['Crafting'] }, custom: {} },
-          onAnswersChange: (answers) => answerSnapshots.push(answers),
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      questions: multiQuestion,
+      initialConcept: 'A trading game',
+      initialTitle: 'Rock Dodger',
+      onSubmitWithConcept: (concept: string) => {
+        submittedConcept = concept;
+      },
+      // Restored from a previous visit — the reload case.
+      initialAnswers: { selected: { mechanics: ['Crafting'] }, custom: {} },
+      onAnswersChange: (answers: { selected: Record<string, string[]>; custom: Record<string, string> }) =>
+        answerSnapshots.push(answers),
     });
 
-    const chips = container.querySelectorAll<HTMLButtonElement>('.qa-chip');
-    expect(chips[0].getAttribute('aria-pressed')).toBe('true');
+    await next();
+    expect(options()[0].getAttribute('aria-pressed')).toBe('true');
 
-    await act(async () => {
-      chips[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await click(options()[1]);
 
     // Single-choice would have replaced 'Crafting'; this one keeps both.
-    expect(chips[0].getAttribute('aria-pressed')).toBe('true');
-    expect(chips[1].getAttribute('aria-pressed')).toBe('true');
+    expect(options()[0].getAttribute('aria-pressed')).toBe('true');
+    expect(options()[1].getAttribute('aria-pressed')).toBe('true');
     expect(answerSnapshots.at(-1)?.selected.mechanics).toEqual(['Crafting', 'Trading']);
 
-    // Clicking a lit chip still clears it, so "no opinion" stays reachable.
-    await act(async () => {
-      chips[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
-    expect(chips[0].getAttribute('aria-pressed')).toBe('false');
+    // Clicking a lit option still clears it, so "no opinion" stays reachable.
+    await click(options()[0]);
+    expect(options()[0].getAttribute('aria-pressed')).toBe('false');
 
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.btn-create-now')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await next();
+    await next();
+    await click(find('.btn-create-now'));
 
     expect(submittedConcept).toContain('- Which mechanics should be in: Trading');
 
     await act(async () => root.unmount());
   });
 
-  it('stays up and says so while the submission is in flight', async () => {
-    // The panel used to unmount the instant you approved, leaving blank space for as
-    // long as the API took to create the issue. It now reports its own progress.
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
+  it('jumps straight to review from the shortcut, and shows what was left unanswered', async () => {
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
+    await click(find('.qa-shortcut'));
 
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: vi.fn(),
-          onCancel: vi.fn(),
-          submitting: true,
-          error: 'Daily quota exceeded',
-        }),
-      );
-      await flushEffects();
-    });
+    // The shortcut lands on the summary, not on a blind submission.
+    expect(find('.btn-create-now')).not.toBeNull();
+    const values = [...findAll('.qa-review-value')].map((row) => row.textContent ?? '');
+    expect(values[0]).toContain('Rock Dodger');
+    expect(values[1]).toContain('AI decides');
+    expect(find('.qa-review-unset')).not.toBeNull();
 
-    // One submit button, in the sticky action bar — a second copy above the questions
-    // used to read as the end of the panel, with the questions orphaned below it.
-    const createBtns = container.querySelectorAll<HTMLButtonElement>('.btn-create-now');
-    expect(createBtns).toHaveLength(1);
-    expect(createBtns[0].disabled).toBe(true);
-    expect(createBtns[0].textContent).toContain('Submitting');
-
-    // Walking away mid-flight would strand a submission the creator can't see.
-    expect(container.querySelector<HTMLButtonElement>('.btn-secondary')?.disabled).toBe(true);
-    // The error belongs where the creator is looking, not only up in the hero.
-    expect(container.querySelector('.qa-error')?.textContent).toBe('Daily quota exceeded');
+    // Edit goes back to the stage that sets that answer.
+    await click(findAll('.qa-review-edit')[1]);
+    expect(heading()).toContain('What visual style');
 
     await act(async () => root.unmount());
   });
 
-  it('labels the secondary action for what it does — dismiss, not submit', async () => {
-    // It used to read "Skip Clarifications", which promises the thing the primary
-    // button does. Whatever the wording becomes, it must not imply a submission.
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
-    let submitted = false;
-    let cancelled = false;
+  it('stays on the review stage and says so while the submission is in flight', async () => {
+    // The panel used to unmount the instant you approved, leaving blank space for as
+    // long as the API took to create the issue. It now reports its own progress —
+    // in place, on the stage the creator pressed the button from.
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    const props = { ...baseProps, onSubmitWithConcept: vi.fn(), onCancel: vi.fn() };
 
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
     await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: () => {
-            submitted = true;
-          },
-          onCancel: () => {
-            cancelled = true;
-          },
-        }),
-      );
+      root.render(createElement(CreatorQA, props as never));
       await flushEffects();
     });
 
-    const cancelBtn = container.querySelector<HTMLButtonElement>('.btn-secondary');
-    expect(cancelBtn?.textContent).toBe('Back to Editing');
+    await click(find('.qa-shortcut'));
+    expect(find('.btn-create-now')).not.toBeNull();
 
+    // The submission is now in flight, exactly as the caller re-renders it.
     await act(async () => {
-      cancelBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      root.render(createElement(CreatorQA, { ...props, submitting: true, error: 'Daily quota exceeded' } as never));
       await flushEffects();
     });
 
+    const createBtn = find<HTMLButtonElement>('.btn-create-now');
+    expect(createBtn?.disabled).toBe(true);
+    expect(createBtn?.textContent).toContain('Submitting');
+    // Walking away mid-flight would strand a submission the creator can't see.
+    expect(find<HTMLButtonElement>('.qa-wizard-exit')?.disabled).toBe(true);
+    expect(findAll<HTMLButtonElement>('.qa-review-edit')[0].disabled).toBe(true);
+    // The error belongs where the creator is looking, not only up in the hero.
+    expect(find('.qa-error')?.textContent).toBe('Daily quota exceeded');
+
+    await act(async () => root.unmount());
+  });
+
+  it('labels the exit for what it does — dismiss, not submit', async () => {
+    // It used to read "Skip Clarifications", which promises the thing the primary
+    // button does. Whatever the wording becomes, it must not imply a submission.
+    let submitted = false;
+    let cancelled = false;
+    const root = await render({
+      ...baseProps,
+      onSubmitWithConcept: () => {
+        submitted = true;
+      },
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+
+    const exit = find<HTMLButtonElement>('.qa-wizard-exit');
+    expect(exit?.textContent).toContain('Back to editing');
+
+    await click(exit);
     expect(cancelled).toBe(true);
     expect(submitted).toBe(false);
 
     await act(async () => root.unmount());
   });
 
-  it('submits initial concept unchanged when no chips or custom answers are selected', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
+  it('submits initial concept unchanged when every question is skipped', async () => {
     let submittedConcept = '';
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: (concept) => {
-            submittedConcept = concept;
-          },
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      onSubmitWithConcept: (concept: string) => {
+        submittedConcept = concept;
+      },
     });
 
-    const createBtn = container.querySelector<HTMLButtonElement>('.btn-create-now');
-    await act(async () => {
-      createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await next(); // question
+    await next(); // skip it
+    await next(); // builder
+    await click(find('.btn-create-now'));
 
     expect(submittedConcept).toBe('Dodge the falling rocks and survive as long as possible');
     expect(submittedConcept).not.toContain('## Creator clarifications');
@@ -321,174 +321,103 @@ describe('CreatorQA', () => {
   });
 
   it('carries the name the creator settled on, not the one that was suggested', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
     let submittedTitle = '';
     const onTitleChange = vi.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: mockQuestions,
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onTitleChange,
-          onSubmitWithConcept: (_concept, title) => {
-            submittedTitle = title;
-          },
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      onTitleChange,
+      onSubmitWithConcept: (_concept: string, title: string) => {
+        submittedTitle = title;
+      },
     });
 
-    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
+    const name = find<HTMLInputElement>('.qa-name-input');
     expect(name?.value).toBe('Rock Dodger');
 
-    await act(async () => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-      setter?.call(name, '  Boulder Panic  ');
-      name?.dispatchEvent(new Event('input', { bubbles: true }));
-      await flushEffects();
-    });
-
+    await type(name, '  Boulder Panic  ');
     // Reported as it is typed, so the caller can park it with the rest of the session.
     expect(onTitleChange).toHaveBeenLastCalledWith('  Boulder Panic  ');
 
-    await act(async () => {
-      container.querySelector('.btn-create-now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await click(find('.qa-shortcut'));
+    await click(find('.btn-create-now'));
 
     expect(submittedTitle).toBe('Boulder Panic');
 
     await act(async () => root.unmount());
   });
 
-  it('will not start a build on a name too short to submit', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
+  it('will not leave the name stage on a name too short to submit', async () => {
     const onSubmit = vi.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
     // The refiner had nothing to suggest and the concept yielded nothing either, so
     // the box starts empty and the creator has to name the thing themselves.
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: [],
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: '',
-          onSubmitWithConcept: onSubmit,
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      questions: [],
+      initialTitle: '',
+      onSubmitWithConcept: onSubmit,
     });
 
-    const createBtn = container.querySelector<HTMLButtonElement>('.btn-create-now');
-    expect(createBtn?.disabled).toBe(true);
-
-    await act(async () => {
-      createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    expect(find<HTMLButtonElement>('.qa-next')?.disabled).toBe(true);
+    await next();
+    expect(find('.qa-name-input')).not.toBeNull();
     expect(onSubmit).not.toHaveBeenCalled();
 
-    const name = container.querySelector<HTMLInputElement>('.qa-name-input');
-    await act(async () => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-      setter?.call(name, 'Rock Dodger');
-      name?.dispatchEvent(new Event('input', { bubbles: true }));
-      await flushEffects();
-    });
+    await type(find<HTMLInputElement>('.qa-name-input'), 'Rock Dodger');
+    expect(find<HTMLButtonElement>('.qa-next')?.disabled).toBe(false);
 
-    expect(container.querySelector<HTMLButtonElement>('.btn-create-now')?.disabled).toBe(false);
+    await next();
+    expect(find('.builder-choice')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
 
   it('is still the naming step when the refiner asked nothing', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
+    const root = await render({ ...baseProps, questions: [], onSubmitWithConcept: vi.fn() });
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: [],
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          onSubmitWithConcept: vi.fn(),
-        }),
-      );
-      await flushEffects();
-    });
-
-    // A heading about clarifying questions, over no questions, is a panel that looks
+    // A heading about clarifying questions, over no questions, is a wizard that looks
     // broken. With nothing to clarify it says what it is actually for.
-    expect(container.querySelector('.qa-title')?.textContent).toContain('Name your game');
-    expect(container.querySelector('.qa-name-input')).not.toBeNull();
-    expect(container.querySelectorAll('.qa-card')).toHaveLength(0);
-    // Still exactly one button: the sticky bar is the same whether or not there
-    // was a question list to scroll past.
-    expect(container.querySelectorAll('.btn-create-now')).toHaveLength(1);
+    expect(heading()).toContain('Name your game');
+    expect(find('.qa-name-input')).not.toBeNull();
+    // No question stages, and so nothing for the shortcut to skip past.
+    expect(find('.qa-wizard-step')?.textContent).toBe('Step 1 of 3');
+    expect(find('.qa-shortcut')).toBeNull();
 
     await act(async () => root.unmount());
   });
 
   it('lets the creator choose a builder and passes it on submit', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
     let submittedBuilder = '';
     const onBuilderChange = vi.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(CreatorQA, {
-          questions: [],
-          initialConcept: 'Dodge the falling rocks and survive as long as possible',
-          initialTitle: 'Rock Dodger',
-          initialBuilder: 'platform',
-          onBuilderChange,
-          onSubmitWithConcept: (_concept, _title, builder) => {
-            submittedBuilder = builder;
-          },
-        }),
-      );
-      await flushEffects();
+    const root = await render({
+      ...baseProps,
+      questions: [],
+      initialBuilder: 'platform',
+      onBuilderChange,
+      onSubmitWithConcept: (_concept: string, _title: string, builder: string) => {
+        submittedBuilder = builder;
+      },
     });
 
-    expect(container.querySelector('.builder-choice')).not.toBeNull();
-    const options = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option');
-    expect(options[0].getAttribute('aria-checked')).toBe('true');
+    await next();
+    expect(find('.builder-choice')).not.toBeNull();
+    const builderOptions = findAll<HTMLButtonElement>('.builder-choice-option');
+    expect(builderOptions[0].getAttribute('aria-checked')).toBe('true');
 
-    await act(async () => {
-      options[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await click(builderOptions[1]);
     expect(onBuilderChange).toHaveBeenCalledWith('self');
 
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.btn-create-now')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
+    await next();
+    await click(find('.btn-create-now'));
     expect(submittedBuilder).toBe('self');
 
     await act(async () => root.unmount());
+  });
+
+  it('locks the page behind it while it is open', async () => {
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
+    expect(document.body.style.overflow).toBe('hidden');
+
+    await act(async () => root.unmount());
+    expect(document.body.style.overflow).not.toBe('hidden');
   });
 });

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { BuilderChoice } from './BuilderChoice.js';
 import { isBuilderKind, type BuilderKind } from './builderKind.js';
@@ -32,7 +33,7 @@ interface CreatorQAProps {
   /** Fires on every edit so the caller can park the name with the rest of the session. */
   onTitleChange?: (title: string) => void;
   onCancel?: () => void;
-  /** The submission is in flight; the panel stays up rather than vanishing into a gap. */
+  /** The submission is in flight; the wizard stays up rather than vanishing into a gap. */
   submitting?: boolean;
   /** Shown here as well as in the hero, because this is where the creator is looking. */
   error?: string | null;
@@ -46,6 +47,26 @@ interface CreatorQAProps {
   onBuilderChange?: (builder: BuilderKind) => void;
 }
 
+/**
+ * One screen of the wizard. The questions come from the refiner, so how many there are
+ * — and whether there are any — is only known at render time.
+ */
+type Stage = { kind: 'name' } | { kind: 'question'; question: QAQuestion } | { kind: 'builder' } | { kind: 'review' };
+
+/**
+ * The confirm step, as a full-screen wizard: one decision per screen.
+ *
+ * It was a single long panel below the hero, which put four questions, a name field, a
+ * builder choice and a submit button on one page — and left the hero's own "Build my
+ * game" button live above it, so two green CTAs competed for the same click. A
+ * full-screen overlay is what removes that competition rather than restyling around it,
+ * and one-decision-per-screen is what a phone can show without the creator scrolling
+ * past the thing they were asked to answer.
+ *
+ * Nothing here advances on its own. Selecting an option selects it; moving on is always
+ * an explicit Next (or Skip), because a screen that changes under a tap costs more in
+ * second-guessing than it saves in clicks.
+ */
 export function CreatorQA({
   questions,
   initialConcept,
@@ -65,7 +86,46 @@ export function CreatorQA({
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string[]>>(initialAnswers?.selected ?? {});
   const [customText, setCustomText] = useState<Record<string, string>>(initialAnswers?.custom ?? {});
   const [builder, setBuilder] = useState<BuilderKind>(isBuilderKind(initialBuilder) ? initialBuilder : 'platform');
+  const [step, setStep] = useState(0);
   const titleReady = isSubmittableTitle(title);
+
+  const stages = useMemo<Stage[]>(
+    () => [
+      { kind: 'name' },
+      ...questions.map((question) => ({ kind: 'question' as const, question })),
+      { kind: 'builder' as const },
+      { kind: 'review' as const },
+    ],
+    [questions],
+  );
+
+  // Guards against a restored session pointing past the end of a shorter question list.
+  const stepIndex = Math.min(step, stages.length - 1);
+  const stage = stages[stepIndex];
+  const reviewIndex = stages.length - 1;
+
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
+
+  // The page behind the overlay must not scroll with it; same approach as the studio's
+  // sheet so there is one way this is done in the app.
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  // Every stage starts at its own top, and the new heading takes focus so a screen
+  // reader announces the question rather than leaving the caret on the button that
+  // moved us here. Escape is deliberately *not* bound to close: the only exit drops
+  // the pending spec, and that is too destructive for a stray keypress.
+  useEffect(() => {
+    if (scrollerRef.current) scrollerRef.current.scrollTop = 0;
+    headingRef.current?.focus?.();
+  }, [stepIndex]);
 
   const handleBuilderChange = (next: BuilderKind) => {
     setBuilder(next);
@@ -81,7 +141,7 @@ export function CreatorQA({
       const current = prev[question.id] ?? [];
       const isOn = current.includes(label);
       // Single-choice questions replace; multi-choice accumulate. Either way clicking
-      // a chosen chip clears it, so there is always a way back to "no opinion".
+      // a chosen option clears it, so there is always a way back to "no opinion".
       const next = question.multiple
         ? isOn
           ? current.filter((item) => item !== label)
@@ -104,10 +164,10 @@ export function CreatorQA({
   };
 
   /**
-   * A chip and free text are one answer, not two competing ones.
+   * An option and free text are one answer, not two competing ones.
    *
-   * Free text used to *replace* the chip, so clicking "Pixel Art" and then typing
-   * "but with an Amiga palette" threw the chip away and sent only the qualifier —
+   * Free text used to *replace* the selection, so choosing "Pixel Art" and then typing
+   * "but with an Amiga palette" threw the choice away and sent only the qualifier —
    * silently, since the creator had already seen their choice highlighted. Typing a
    * refinement is the commonest way to answer these questions, so the two combine.
    */
@@ -145,128 +205,278 @@ export function CreatorQA({
     onSubmitWithConcept(buildMergedConcept(), title.trim(), builder);
   };
 
-  return (
-    <div className="qa-container panel">
-      <div className="qa-header">
-        {/* Two jobs, two headings: naming the game is the one that always happens, and
-            the questions only exist when the refiner found something underspecified. */}
-        <h3 className="qa-title">{t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}</h3>
-        <p className="qa-subtitle">{t(questions.length > 0 ? 'qa.subtitle' : 'qa.subtitleNameOnly')}</p>
-      </div>
+  const goTo = (next: number) => {
+    if (submitting) return;
+    // The name gates the build, so it also gates leaving the screen that sets it.
+    if (stage.kind === 'name' && next > stepIndex && !titleReady) return;
+    setStep(Math.max(0, Math.min(next, reviewIndex)));
+  };
 
-      {/* The name goes first because it is the prerequisite, not a detail: nothing is
-          built until the creator has confirmed one, which is what stops a game being
-          named after the first 40 characters of the prompt that asked for it. */}
-      <div className="qa-name">
-        <label className="qa-name-label" htmlFor="qa-game-title">
-          {t('qa.nameLabel')}
-        </label>
-        <input
-          id="qa-game-title"
-          type="text"
-          className="input-text qa-name-input"
-          value={title}
-          maxLength={MAX_TITLE_LENGTH}
-          placeholder={t('qa.namePlaceholder')}
-          onChange={(e) => handleTitleChange(e.target.value)}
-          disabled={submitting}
-        />
-        <p className="qa-name-hint">{t('qa.nameHint')}</p>
-      </div>
+  const currentAnswer = stage.kind === 'question' ? answerFor(stage.question.id) : '';
+  // The shortcut only earns its place while there are questions left to skip; from the
+  // builder step onward Next already leads straight to review.
+  const showShortcut = questions.length > 0 && (stage.kind === 'name' || stage.kind === 'question');
 
-      {/* Questions directly under the header that announces them: the subtitle says
-          "click any proposed options", so the options must be the next thing on
-          screen — not parked below a green button that looks like the end of the
-          panel. The builder choice and the actions follow, in the order they are
-          decided: what the game is, who builds it, go. */}
-      {questions.length > 0 && (
-        <div className="qa-questions-list">
-          {questions.map((q) => {
-            const selected = selectedAnswers[q.id] ?? [];
-            const custom = customText[q.id] ?? '';
+  const nextLabel = () => {
+    if (stage.kind === 'name') return t('qa.continue');
+    if (stage.kind === 'question') return currentAnswer ? t('qa.next') : t('qa.skip');
+    return t('qa.reviewAction');
+  };
 
-            return (
-              <div key={q.id} className="qa-card">
-                <h4 className="qa-card__question">
-                  {q.question}
-                  {q.multiple && <span className="qa-card__hint"> {t('qa.pickSeveral')}</span>}
-                </h4>
-                <div className="qa-chips">
-                  {q.options.map((opt) => {
-                    // Stays lit while free text is typed: the two are now one answer,
-                    // and un-highlighting the chip was how the old behaviour hid itself.
-                    const isSelected = selected.includes(opt.label);
-                    return (
-                      <button
-                        key={opt.label}
-                        type="button"
-                        // Selection lived only in a class, so a screen reader announced
-                        // every chip identically whether or not it was chosen.
-                        aria-pressed={isSelected}
-                        className={`qa-chip ${isSelected ? 'qa-chip--selected' : ''}`}
-                        disabled={submitting}
-                        onClick={() => handleSelectOption(q, opt.label)}
-                      >
-                        <span className="qa-chip__label">{opt.label}</span>
-                        {opt.detail && <span className="qa-chip__detail">{opt.detail}</span>}
-                      </button>
-                    );
-                  })}
-                </div>
-
-                {q.allowFreeText !== false && (
-                  <div className="qa-custom-input">
-                    <input
-                      type="text"
-                      className="input-text"
-                      placeholder={t('qa.otherPlaceholder')}
-                      // The placeholder is the only visible cue, and placeholders are
-                      // not names — without this the field is announced unlabelled.
-                      aria-label={`${q.question} — ${t('qa.otherPlaceholder')}`}
-                      value={custom}
-                      disabled={submitting}
-                      onChange={(e) => handleCustomTextChange(q.id, e.target.value)}
-                    />
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {Object.values(selectedAnswers).some(Boolean) || Object.values(customText).some((s) => s.trim().length > 0) ? (
-        <div className="qa-preview">
-          <h5>{t('qa.clarificationsTitle')}</h5>
-          <pre className="qa-preview__code">{buildMergedConcept().slice(initialConcept.trim().length).trim()}</pre>
-        </div>
-      ) : null}
-
-      <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={submitting} />
-
-      {error && <p className="error qa-error">{error}</p>}
-
-      {/* One action bar, after everything it submits. It sticks to the bottom of the
-          viewport while the panel is taller than the screen, so "Create Now" is always
-          in reach without printing the same green button twice. */}
-      <div className="qa-actions">
-        <button
-          type="button"
-          className="btn btn-primary btn-create-now"
-          onClick={handleSubmit}
-          disabled={submitting || !titleReady}
-        >
-          <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
-        </button>
-        {/* This dismisses the panel and drops the pending spec — it does *not* submit.
-            It was labelled "skip clarifications", which reads as "create without
-            answering"; that is what the primary button next to it already does. */}
+  return createPortal(
+    <div
+      className="qa-wizard"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}
+    >
+      <header className="qa-wizard-header">
+        <p className="qa-wizard-step" aria-live="polite">
+          {t('qa.stepOf', { current: stepIndex + 1, total: stages.length })}
+        </p>
         {onCancel && (
-          <button type="button" className="btn btn-secondary" onClick={onCancel} disabled={submitting}>
-            {t('qa.backToEditing')}
+          // This dismisses the wizard and drops the pending spec — it does *not* submit.
+          <button type="button" className="btn-secondary qa-wizard-exit" onClick={onCancel} disabled={submitting}>
+            <PixelIcon name="close" size={12} />
+            <span>{t('qa.backToEditing')}</span>
           </button>
         )}
+      </header>
+
+      <div className="qa-wizard-progress" aria-hidden="true">
+        {stages.map((_, index) => (
+          <span key={index} className={index < stepIndex ? 'is-done' : index === stepIndex ? 'is-now' : undefined} />
+        ))}
       </div>
-    </div>
+
+      <div className="qa-wizard-scroller" ref={scrollerRef}>
+        <div className="qa-stage" key={stepIndex}>
+          {stage.kind === 'name' && (
+            <>
+              <p className="qa-stage-eyebrow">{t('qa.eyebrowIdea')}</p>
+              <h2 className="qa-title" ref={headingRef} tabIndex={-1}>
+                {t(questions.length > 0 ? 'qa.nameStageTitle' : 'qa.titleNameOnly')}
+              </h2>
+              {/* Grounding: the wizard opens on top of the idea they typed, so it shows
+                  the idea it is about to build rather than asking them to remember it. */}
+              <blockquote className="qa-idea-quote">{initialConcept.trim()}</blockquote>
+              <div className="qa-name">
+                <label className="qa-name-label" htmlFor="qa-game-title">
+                  {t('qa.nameLabel')}
+                </label>
+                <input
+                  id="qa-game-title"
+                  ref={nameInputRef}
+                  type="text"
+                  className="input-text qa-name-input"
+                  value={title}
+                  maxLength={MAX_TITLE_LENGTH}
+                  placeholder={t('qa.namePlaceholder')}
+                  onChange={(e) => handleTitleChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      goTo(stepIndex + 1);
+                    }
+                  }}
+                  disabled={submitting}
+                />
+                <p className="qa-name-hint">{t('qa.nameHint')}</p>
+              </div>
+            </>
+          )}
+
+          {stage.kind === 'question' && (
+            <>
+              <p className="qa-stage-eyebrow">
+                {t('qa.questionCount', { current: stepIndex, total: questions.length })}
+              </p>
+              <h2 className="qa-title" ref={headingRef} tabIndex={-1}>
+                {stage.question.question}
+              </h2>
+              <p className="qa-stage-lede">{stage.question.multiple ? t('qa.pickSeveral') : t('qa.pickOneOrSkip')}</p>
+
+              <div className="qa-options">
+                {stage.question.options.map((opt) => {
+                  // Stays lit while free text is typed: the two are now one answer,
+                  // and un-highlighting the option was how the old behaviour hid itself.
+                  const isSelected = (selectedAnswers[stage.question.id] ?? []).includes(opt.label);
+                  return (
+                    <button
+                      key={opt.label}
+                      type="button"
+                      // Selection lived only in a class, so a screen reader announced
+                      // every option identically whether or not it was chosen.
+                      aria-pressed={isSelected}
+                      className={`qa-option${isSelected ? ' qa-option--selected' : ''}${
+                        stage.question.multiple ? ' qa-option--multi' : ''
+                      }`}
+                      disabled={submitting}
+                      onClick={() => handleSelectOption(stage.question, opt.label)}
+                    >
+                      <span className="qa-option__tick" aria-hidden="true" />
+                      <span className="qa-option__text">
+                        <span className="qa-option__label">{opt.label}</span>
+                        {opt.detail && <span className="qa-option__detail">{opt.detail}</span>}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {stage.question.allowFreeText !== false && (
+                <div className="qa-custom-input">
+                  <input
+                    type="text"
+                    className="input-text"
+                    placeholder={t('qa.otherPlaceholder')}
+                    // The placeholder is the only visible cue, and placeholders are
+                    // not names — without this the field is announced unlabelled.
+                    aria-label={`${stage.question.question} — ${t('qa.otherPlaceholder')}`}
+                    value={customText[stage.question.id] ?? ''}
+                    disabled={submitting}
+                    onChange={(e) => handleCustomTextChange(stage.question.id, e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        goTo(stepIndex + 1);
+                      }
+                    }}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          {stage.kind === 'builder' && (
+            <>
+              <p className="qa-stage-eyebrow">{t('qa.eyebrowBuilder')}</p>
+              <h2 className="qa-title" ref={headingRef} tabIndex={-1}>
+                {t('builder.legend')}
+              </h2>
+              <p className="qa-stage-lede">{t('qa.builderLede')}</p>
+              <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={submitting} hideLegend />
+            </>
+          )}
+
+          {stage.kind === 'review' && (
+            <>
+              <p className="qa-stage-eyebrow">{t('qa.reviewEyebrow')}</p>
+              <h2 className="qa-title" ref={headingRef} tabIndex={-1}>
+                {t('qa.reviewTitle')}
+              </h2>
+              <p className="qa-stage-lede">{t('qa.reviewSubtitle')}</p>
+
+              <dl className="qa-review">
+                <div className="qa-review-row">
+                  <dt className="qa-review-label">{t('qa.nameLabel')}</dt>
+                  <dd className="qa-review-value">
+                    <span>{title.trim()}</span>
+                    <button
+                      type="button"
+                      className="qa-review-edit"
+                      disabled={submitting}
+                      onClick={() => goTo(0)}
+                      aria-label={`${t('qa.edit')}: ${t('qa.nameLabel')}`}
+                    >
+                      {t('qa.edit')}
+                    </button>
+                  </dd>
+                </div>
+
+                {questions.map((q, index) => {
+                  const answer = answerFor(q.id);
+                  return (
+                    <div className="qa-review-row" key={q.id}>
+                      <dt className="qa-review-label">{q.question}</dt>
+                      <dd className="qa-review-value">
+                        <span className={answer ? undefined : 'qa-review-unset'}>{answer || t('qa.aiDecides')}</span>
+                        <button
+                          type="button"
+                          className="qa-review-edit"
+                          disabled={submitting}
+                          onClick={() => goTo(index + 1)}
+                          aria-label={`${t('qa.edit')}: ${q.question}`}
+                        >
+                          {t('qa.edit')}
+                        </button>
+                      </dd>
+                    </div>
+                  );
+                })}
+
+                <div className="qa-review-row">
+                  <dt className="qa-review-label">{t('builder.legend')}</dt>
+                  <dd className="qa-review-value">
+                    <span>{t(builder === 'self' ? 'builder.self.title' : 'builder.platform.title')}</span>
+                    <button
+                      type="button"
+                      className="qa-review-edit"
+                      disabled={submitting}
+                      onClick={() => goTo(reviewIndex - 1)}
+                      aria-label={`${t('qa.edit')}: ${t('builder.legend')}`}
+                    >
+                      {t('qa.edit')}
+                    </button>
+                  </dd>
+                </div>
+              </dl>
+
+              {error && <p className="error qa-error">{error}</p>}
+            </>
+          )}
+        </div>
+      </div>
+
+      <footer className="qa-wizard-footer">
+        {stepIndex > 0 && (
+          <button
+            type="button"
+            className="btn btn-secondary qa-back"
+            onClick={() => goTo(stepIndex - 1)}
+            disabled={submitting}
+          >
+            <PixelIcon name="arrowLeft" size={12} /> {t('qa.back')}
+          </button>
+        )}
+
+        {showShortcut && (
+          // The impatience escape hatch: straight to review, where Create Now is. It
+          // lands on the summary rather than submitting blind, so skipping the rest
+          // still shows what is about to be built.
+          <button
+            type="button"
+            className="qa-shortcut"
+            onClick={() => goTo(reviewIndex)}
+            disabled={submitting || !titleReady}
+          >
+            {t('qa.startBuilding')}
+          </button>
+        )}
+
+        {stage.kind === 'review' ? (
+          <button
+            type="button"
+            className="btn btn-primary qa-primary btn-create-now"
+            onClick={handleSubmit}
+            disabled={submitting || !titleReady}
+          >
+            <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={`btn btn-primary qa-primary qa-next${
+              stage.kind === 'question' && !currentAnswer ? ' qa-next--skip' : ''
+            }`}
+            onClick={() => goTo(stepIndex + 1)}
+            disabled={submitting || (stage.kind === 'name' && !titleReady)}
+          >
+            {nextLabel()} <PixelIcon name="arrowRight" size={12} />
+          </button>
+        )}
+      </footer>
+    </div>,
+    document.body,
   );
 }

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -174,9 +174,82 @@ export function CreatorQA({
         <p className="qa-name-hint">{t('qa.nameHint')}</p>
       </div>
 
+      {/* Questions directly under the header that announces them: the subtitle says
+          "click any proposed options", so the options must be the next thing on
+          screen — not parked below a green button that looks like the end of the
+          panel. The builder choice and the actions follow, in the order they are
+          decided: what the game is, who builds it, go. */}
+      {questions.length > 0 && (
+        <div className="qa-questions-list">
+          {questions.map((q) => {
+            const selected = selectedAnswers[q.id] ?? [];
+            const custom = customText[q.id] ?? '';
+
+            return (
+              <div key={q.id} className="qa-card">
+                <h4 className="qa-card__question">
+                  {q.question}
+                  {q.multiple && <span className="qa-card__hint"> {t('qa.pickSeveral')}</span>}
+                </h4>
+                <div className="qa-chips">
+                  {q.options.map((opt) => {
+                    // Stays lit while free text is typed: the two are now one answer,
+                    // and un-highlighting the chip was how the old behaviour hid itself.
+                    const isSelected = selected.includes(opt.label);
+                    return (
+                      <button
+                        key={opt.label}
+                        type="button"
+                        // Selection lived only in a class, so a screen reader announced
+                        // every chip identically whether or not it was chosen.
+                        aria-pressed={isSelected}
+                        className={`qa-chip ${isSelected ? 'qa-chip--selected' : ''}`}
+                        disabled={submitting}
+                        onClick={() => handleSelectOption(q, opt.label)}
+                      >
+                        <span className="qa-chip__label">{opt.label}</span>
+                        {opt.detail && <span className="qa-chip__detail">{opt.detail}</span>}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {q.allowFreeText !== false && (
+                  <div className="qa-custom-input">
+                    <input
+                      type="text"
+                      className="input-text"
+                      placeholder={t('qa.otherPlaceholder')}
+                      // The placeholder is the only visible cue, and placeholders are
+                      // not names — without this the field is announced unlabelled.
+                      aria-label={`${q.question} — ${t('qa.otherPlaceholder')}`}
+                      value={custom}
+                      disabled={submitting}
+                      onChange={(e) => handleCustomTextChange(q.id, e.target.value)}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {Object.values(selectedAnswers).some(Boolean) || Object.values(customText).some((s) => s.trim().length > 0) ? (
+        <div className="qa-preview">
+          <h5>{t('qa.clarificationsTitle')}</h5>
+          <pre className="qa-preview__code">{buildMergedConcept().slice(initialConcept.trim().length).trim()}</pre>
+        </div>
+      ) : null}
+
       <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={submitting} />
 
-      <div className="qa-actions qa-actions--top">
+      {error && <p className="error qa-error">{error}</p>}
+
+      {/* One action bar, after everything it submits. It sticks to the bottom of the
+          viewport while the panel is taller than the screen, so "Create Now" is always
+          in reach without printing the same green button twice. */}
+      <div className="qa-actions">
         <button
           type="button"
           className="btn btn-primary btn-create-now"
@@ -194,83 +267,6 @@ export function CreatorQA({
           </button>
         )}
       </div>
-
-      <div className="qa-questions-list">
-        {questions.map((q) => {
-          const selected = selectedAnswers[q.id] ?? [];
-          const custom = customText[q.id] ?? '';
-
-          return (
-            <div key={q.id} className="qa-card">
-              <h4 className="qa-card__question">
-                {q.question}
-                {q.multiple && <span className="qa-card__hint"> {t('qa.pickSeveral')}</span>}
-              </h4>
-              <div className="qa-chips">
-                {q.options.map((opt) => {
-                  // Stays lit while free text is typed: the two are now one answer,
-                  // and un-highlighting the chip was how the old behaviour hid itself.
-                  const isSelected = selected.includes(opt.label);
-                  return (
-                    <button
-                      key={opt.label}
-                      type="button"
-                      // Selection lived only in a class, so a screen reader announced
-                      // every chip identically whether or not it was chosen.
-                      aria-pressed={isSelected}
-                      className={`qa-chip ${isSelected ? 'qa-chip--selected' : ''}`}
-                      disabled={submitting}
-                      onClick={() => handleSelectOption(q, opt.label)}
-                    >
-                      <span className="qa-chip__label">{opt.label}</span>
-                      {opt.detail && <span className="qa-chip__detail">{opt.detail}</span>}
-                    </button>
-                  );
-                })}
-              </div>
-
-              {q.allowFreeText !== false && (
-                <div className="qa-custom-input">
-                  <input
-                    type="text"
-                    className="input-text"
-                    placeholder={t('qa.otherPlaceholder')}
-                    // The placeholder is the only visible cue, and placeholders are
-                    // not names — without this the field is announced unlabelled.
-                    aria-label={`${q.question} — ${t('qa.otherPlaceholder')}`}
-                    value={custom}
-                    disabled={submitting}
-                    onChange={(e) => handleCustomTextChange(q.id, e.target.value)}
-                  />
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      {Object.values(selectedAnswers).some(Boolean) || Object.values(customText).some((s) => s.trim().length > 0) ? (
-        <div className="qa-preview">
-          <h5>{t('qa.clarificationsTitle')}</h5>
-          <pre className="qa-preview__code">{buildMergedConcept().slice(initialConcept.trim().length).trim()}</pre>
-        </div>
-      ) : null}
-
-      {error && <p className="error qa-error">{error}</p>}
-
-      {/* Only worth a second button when there is a list to have scrolled past. */}
-      {questions.length > 0 ? (
-        <div className="qa-actions qa-actions--bottom">
-          <button
-            type="button"
-            className="btn btn-primary btn-create-now"
-            onClick={handleSubmit}
-            disabled={submitting || !titleReady}
-          >
-            <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
-          </button>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -142,7 +142,17 @@ export function CreatorQA({
     const root = wizardRef.current;
     if (!root) return;
     const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
-    if (focusable.length === 0) return;
+
+    // While a submission or a relocalization is in flight every control here is
+    // disabled, so there is nothing left to cycle between — and simply returning would
+    // hand Tab back to the browser, which is the one case where it escapes into the
+    // shell behind. The overlay itself takes the focus and holds it until a control
+    // comes back. The root carries tabIndex -1 for exactly this.
+    if (focusable.length === 0) {
+      event.preventDefault();
+      root.focus?.();
+      return;
+    }
 
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
@@ -271,6 +281,8 @@ export function CreatorQA({
       aria-label={t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}
       ref={wizardRef}
       onKeyDown={handleTabKey}
+      // Somewhere for focus to rest when every control is disabled mid-submission.
+      tabIndex={-1}
     >
       <header className="qa-wizard-header">
         <p className="qa-wizard-step" aria-live="polite">

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -53,6 +53,9 @@ interface CreatorQAProps {
  */
 type Stage = { kind: 'name' } | { kind: 'question'; question: QAQuestion } | { kind: 'builder' } | { kind: 'review' };
 
+/** Tab stops the wizard is allowed to cycle between; the stage heading (tabindex -1) is not one. */
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 /**
  * The confirm step, as a full-screen wizard: one decision per screen.
  *
@@ -104,6 +107,7 @@ export function CreatorQA({
   const stage = stages[stepIndex];
   const reviewIndex = stages.length - 1;
 
+  const wizardRef = useRef<HTMLDivElement | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
@@ -117,6 +121,42 @@ export function CreatorQA({
       document.body.style.overflow = previous;
     };
   }, []);
+
+  // Whatever had focus when the wizard opened gets it back when the wizard closes,
+  // rather than dropping the caret at the top of a page the creator did not move to.
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    return () => opener?.focus?.();
+  }, []);
+
+  /**
+   * Keeps Tab inside the overlay.
+   *
+   * `aria-modal` tells assistive tech this is modal; it does not stop the browser
+   * tabbing on into the app shell underneath, which is still fully focusable behind a
+   * covering element. Without this, tabbing past the last control lands on the hero's
+   * own prompt box and build button — the ones this screen exists to take over from.
+   */
+  const handleTabKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return;
+    const root = wizardRef.current;
+    if (!root) return;
+    const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    const outside = !root.contains(active);
+
+    if (event.shiftKey && (active === first || outside)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && (active === last || outside)) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   // Every stage starts at its own top, and the new heading takes focus so a screen
   // reader announces the question rather than leaving the caret on the button that
@@ -229,6 +269,8 @@ export function CreatorQA({
       role="dialog"
       aria-modal="true"
       aria-label={t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}
+      ref={wizardRef}
+      onKeyDown={handleTabKey}
     >
       <header className="qa-wizard-header">
         <p className="qa-wizard-step" aria-live="polite">
@@ -236,7 +278,15 @@ export function CreatorQA({
         </p>
         {onCancel && (
           // This dismisses the wizard and drops the pending spec — it does *not* submit.
-          <button type="button" className="btn-secondary qa-wizard-exit" onClick={onCancel} disabled={submitting}>
+          <button
+            type="button"
+            className="btn-secondary qa-wizard-exit"
+            onClick={onCancel}
+            disabled={submitting}
+            // The label is hidden on narrow screens and the icon is decorative, which
+            // left the only way back to editing as an unnamed button on a phone.
+            aria-label={t('qa.backToEditing')}
+          >
             <PixelIcon name="close" size={12} />
             <span>{t('qa.backToEditing')}</span>
           </button>

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -512,7 +512,7 @@ export function CreatorQA({
             onClick={() => goTo(reviewIndex)}
             disabled={submitting || !titleReady}
           >
-            {t('qa.startBuilding')}
+            {t('qa.skipToReview')}
           </button>
         )}
 

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -530,7 +530,7 @@ describe('SubmissionStatusView', () => {
 
     // Routed from the state the server reported, not from a mode the creator picked.
     // Published starts a new round, so the builder choice travels with the request
-    // (default: platform — "Our AI dev team").
+    // (default: platform — the Gamedev.pl coding agent).
     expect(mockedSubmitImprovement).toHaveBeenCalledWith(
       'live-token',
       'The second level is far too hard, please add a checkpoint.',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -423,7 +423,7 @@
     "continue": "Continue",
     "next": "Next",
     "skip": "Skip — AI decides",
-    "startBuilding": "Skip the rest — start building",
+    "skipToReview": "Skip the rest — review & create",
     "reviewAction": "Review",
     "reviewEyebrow": "Ready when you are",
     "reviewTitle": "Review & create",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -402,19 +402,34 @@
     "demoHide": "Hide local mock generator"
   },
   "qa": {
-    "title": "Refine Your Game Idea (Optional)",
-    "subtitle": "Click any proposed options to clarify your spec, or hit 'Create Now' to submit immediately.",
+    "title": "Refine your game idea",
     "titleNameOnly": "Name your game",
-    "subtitleNameOnly": "Your idea is clear enough to build. Give it a name and we'll get started.",
+    "nameStageTitle": "First, name your game",
     "nameLabel": "Game name",
     "namePlaceholder": "e.g. TV Tycoon",
     "nameHint": "This is what your game will be called everywhere. You can change it now — not later.",
     "createNow": "Create Now",
     "analyzing": "Analyzing your idea…",
-    "otherPlaceholder": "Other / Custom answer…",
-    "clarificationsTitle": "Creator Clarifications",
-    "pickSeveral": "(pick any that apply)",
-    "backToEditing": "Back to Editing"
+    "otherPlaceholder": "Other — describe it your way…",
+    "pickSeveral": "Pick any that apply — these stack.",
+    "pickOneOrSkip": "Pick the one that matches what you imagined, or skip and we decide.",
+    "backToEditing": "Back to editing",
+    "stepOf": "Step {{current}} of {{total}}",
+    "questionCount": "Question {{current}} of {{total}}",
+    "eyebrowIdea": "Your idea",
+    "eyebrowBuilder": "Last choice",
+    "builderLede": "Either way you watch progress live in the studio.",
+    "back": "Back",
+    "continue": "Continue",
+    "next": "Next",
+    "skip": "Skip — AI decides",
+    "startBuilding": "Skip the rest — start building",
+    "reviewAction": "Review",
+    "reviewEyebrow": "Ready when you are",
+    "reviewTitle": "Review & create",
+    "reviewSubtitle": "Anything left unset is a creative call we make for you.",
+    "aiDecides": "AI decides",
+    "edit": "Edit"
   },
   "transparency": {
     "title": "Agent Stream & Transparency",
@@ -780,7 +795,7 @@
   "builder": {
     "legend": "Who builds this round?",
     "platform": {
-      "title": "Our AI dev team",
+      "title": "Gamedev.pl coding agent",
       "detail": "We assign a coding agent and you watch progress here."
     },
     "self": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -406,19 +406,34 @@
     "demoHide": "Ukryj podgląd demo"
   },
   "qa": {
-    "title": "Doprecyzuj swój pomysł (Opcjonalnie)",
-    "subtitle": "Kliknij sugerowane opcje, aby doprecyzować specyfikację, lub naciśnij 'Stwórz teraz', aby natychmiast wysłać.",
+    "title": "Doprecyzuj swój pomysł",
     "titleNameOnly": "Nazwij swoją grę",
-    "subtitleNameOnly": "Twój pomysł jest wystarczająco jasny. Nadaj mu nazwę, a zaczynamy.",
+    "nameStageTitle": "Najpierw nazwij swoją grę",
     "nameLabel": "Nazwa gry",
     "namePlaceholder": "np. Telewizyjny Potentat",
     "nameHint": "Tak Twoja gra będzie się nazywać wszędzie. Możesz to zmienić teraz — później już nie.",
     "createNow": "Stwórz teraz",
     "analyzing": "Analizuję Twój pomysł…",
-    "otherPlaceholder": "Inna / Własna odpowiedź…",
-    "clarificationsTitle": "Doprecyzowania Twórcy",
-    "pickSeveral": "(wybierz dowolne pasujące)",
-    "backToEditing": "Wróć do edycji"
+    "otherPlaceholder": "Inaczej — opisz to po swojemu…",
+    "pickSeveral": "Wybierz dowolne pasujące — mogą się łączyć.",
+    "pickOneOrSkip": "Wybierz to, co sobie wyobrażasz, albo pomiń — wtedy my zdecydujemy.",
+    "backToEditing": "Wróć do edycji",
+    "stepOf": "Krok {{current}} z {{total}}",
+    "questionCount": "Pytanie {{current}} z {{total}}",
+    "eyebrowIdea": "Twój pomysł",
+    "eyebrowBuilder": "Ostatni wybór",
+    "builderLede": "Tak czy inaczej postęp śledzisz na żywo w studiu.",
+    "back": "Wstecz",
+    "continue": "Dalej",
+    "next": "Dalej",
+    "skip": "Pomiń — AI zdecyduje",
+    "startBuilding": "Pomiń resztę — zacznij budowę",
+    "reviewAction": "Podsumowanie",
+    "reviewEyebrow": "Gotowe, gdy tylko zechcesz",
+    "reviewTitle": "Sprawdź i stwórz",
+    "reviewSubtitle": "Wszystko, czego nie ustawisz, jest decyzją twórczą, którą podejmiemy za Ciebie.",
+    "aiDecides": "AI zdecyduje",
+    "edit": "Zmień"
   },
   "transparency": {
     "title": "Strumień Agentów i Przejrzystość",
@@ -784,7 +799,7 @@
   "builder": {
     "legend": "Kto buduje tę rundę?",
     "platform": {
-      "title": "Nasz zespół AI",
+      "title": "Agent Gamedev.pl",
       "detail": "Przypisujemy agenta i postęp widać tutaj."
     },
     "self": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -427,7 +427,7 @@
     "continue": "Dalej",
     "next": "Dalej",
     "skip": "Pomiń — AI zdecyduje",
-    "startBuilding": "Pomiń resztę — zacznij budowę",
+    "skipToReview": "Pomiń resztę — sprawdź i stwórz",
     "reviewAction": "Podsumowanie",
     "reviewEyebrow": "Gotowe, gdy tylko zechcesz",
     "reviewTitle": "Sprawdź i stwórz",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4078,7 +4078,12 @@ body.player-open {
 .qa-wizard {
   position: fixed;
   inset: 0;
-  z-index: 90;
+  /* Above the sticky .app-header (100), which otherwise paints over this wizard's own
+     header and swallows its step label and exit control, and above the install and
+     update banners (900), which are fixed to the bottom and would cover the footer
+     navigation. Still below .modal-backdrop (10000), so a sign-in prompt can appear
+     over the wizard rather than under it. */
+  z-index: 1200;
   display: flex;
   flex-direction: column;
   background: var(--bg, #0d1117);
@@ -5435,8 +5440,10 @@ body.player-open {
 }
 
 .qa-wizard-footer .qa-primary {
-  /* Both auto margins: the shortcut sits centered between Back and the primary, and
-     with either neighbour absent the primary still lands hard right. */
+  /* This and .qa-shortcut both take an auto left margin, so flexbox splits the free
+     space equally between them: the shortcut lands midway between Back and the
+     primary rather than against either. With the shortcut absent — or Back, on the
+     first stage — the primary still ends up hard right. */
   margin-left: auto;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -816,6 +816,10 @@ a {
 .creation-badge {
   color: var(--accent-blue);
   font-size: 0.85rem;
+  /* This badge quotes the creator's whole prompt back at them; the uppercase the
+     other badges use turned that quote into a full line of shouting. */
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .creation-sub {
@@ -4072,7 +4076,11 @@ body.player-open {
 
 /* Creator Q&A Clarifications */
 .qa-container {
-  margin-top: 24px;
+  /* Same column as the hero card above it. Left free, this panel stretched to the
+     1280px main container while the prompt card capped at 820px — two widths, and
+     the refine step read as an unrelated page rather than step two of the same flow. */
+  max-width: 820px;
+  margin: 24px auto 0;
   padding: 24px;
   background: var(--panel-bg, #1d2123);
   border: 1px solid var(--panel-border, #33383d);
@@ -5239,10 +5247,20 @@ body.player-open {
   color: var(--muted, #94a3b8);
 }
 
+/* Sticks to the viewport bottom while the question list runs past the screen, so
+   the submit is reachable from anywhere in the panel without a duplicate button.
+   The negative margins let the bar sit flush with the panel's bottom edge. */
 .qa-actions {
+  position: sticky;
+  bottom: 0;
   display: flex;
   align-items: center;
   gap: 12px;
+  margin: 0 -24px -24px;
+  padding: 14px 24px;
+  background: var(--panel-bg, #1d2123);
+  border-top: 1px solid var(--panel-border, #33383d);
+  border-radius: 0 0 12px 12px;
 }
 
 .btn-create-now {
@@ -5258,11 +5276,9 @@ body.player-open {
   transition:
     transform 0.15s ease,
     box-shadow 0.15s ease;
-  /* Two instances of this exact button — same markup, same class, same computed
-     padding/font/line-height — render at different heights (52px vs 36px) depending
-     on which one is in the DOM. No CSS difference explains it; whatever the browser's
-     reason, this is the CTA that actually submits the spec, so it gets an explicit
-     floor rather than an inherited "normal" line-height nobody can rely on. */
+  /* This is the CTA that actually submits the spec: an explicit floor (also the
+     minimum comfortable tap target) rather than an inherited "normal" line-height
+     that has rendered this same markup at 52px in one spot and 36px in another. */
   min-height: 44px;
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4074,38 +4074,180 @@ body.player-open {
   }
 }
 
-/* Creator Q&A Clarifications */
-.qa-container {
-  /* Same column as the hero card above it. Left free, this panel stretched to the
-     1280px main container while the prompt card capped at 820px — two widths, and
-     the refine step read as an unrelated page rather than step two of the same flow. */
-  max-width: 820px;
-  margin: 24px auto 0;
-  padding: 24px;
-  background: var(--panel-bg, #1d2123);
-  border: 1px solid var(--panel-border, #33383d);
-  border-radius: 12px;
+/* Creator confirm wizard — see CreatorQA.tsx for why this is full-screen. */
+.qa-wizard {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  background: var(--bg, #0d1117);
 }
 
-.qa-header {
+.qa-wizard-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--panel-border, #33383d);
-  padding-bottom: 12px;
+}
+
+.qa-wizard-step {
+  flex: 1;
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted, #94a3b8);
+  font-variant-numeric: tabular-nums;
+}
+
+/* .btn-secondary carries no rules anywhere in this stylesheet, so anything relying on
+   it renders as a default UA button — a near-white slab, which is how leaving ended up
+   the brightest thing on a screen about starting. Both quiet controls are styled here. */
+.qa-wizard-exit,
+.qa-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 8px;
+  color: var(--muted, #94a3b8);
+  font: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.qa-wizard-exit:hover:not(:disabled),
+.qa-back:hover:not(:disabled) {
+  color: var(--text, #e2e8f0);
+  border-color: var(--muted, #94a3b8);
+}
+
+.qa-wizard-exit:disabled,
+.qa-back:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.qa-wizard-exit {
+  padding: 7px 12px;
+  font-size: 0.8rem;
+}
+
+/* One cell per stage, filled as it is passed: how far in, and how much is left, in
+   the one place a wizard has to answer it. */
+.qa-wizard-progress {
+  flex: none;
+  display: flex;
+  gap: 4px;
+  padding: 8px 20px 0;
+}
+
+.qa-wizard-progress span {
+  flex: 1;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--panel-border, #33383d);
+  transition: background 0.3s ease;
+}
+
+.qa-wizard-progress span.is-done {
+  background: var(--turquoise, #00e4ac);
+}
+
+.qa-wizard-progress span.is-now {
+  background: linear-gradient(90deg, var(--turquoise, #00e4ac) 50%, var(--panel-border, #33383d) 50%);
+}
+
+.qa-wizard-scroller {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+}
+
+/* One column, phone-width, centered on any screen: the questions are a single
+   sequence of decisions, and stretching them across a desktop would only put the
+   option text further from the question that asked for it. */
+.qa-stage {
+  width: 100%;
+  max-width: 600px;
+  padding: 32px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  animation: qa-stage-in 0.22s ease;
+}
+
+@keyframes qa-stage-in {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qa-stage {
+    animation: none;
+  }
+}
+
+.qa-stage-eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--turquoise, #00e4ac);
 }
 
 .qa-title {
-  font-size: 1.35rem;
-  font-weight: 700;
+  margin: 0;
+  font-size: clamp(1.4rem, 4.5vw, 1.9rem);
+  line-height: 1.2;
+  font-weight: 800;
   color: var(--text-heading, #fff);
-  margin: 0 0 6px 0;
+  text-wrap: balance;
 }
 
-.qa-subtitle {
-  font-size: 0.9rem;
+/* Focused programmatically on every stage change so the question is announced; it is
+   not a click target, so it must not look like one. */
+.qa-title:focus-visible {
+  outline: 2px solid var(--turquoise, #00e4ac);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.qa-stage-lede {
+  margin: -4px 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
   color: var(--muted, #94a3b8);
+  max-width: 46ch;
+}
+
+.qa-idea-quote {
   margin: 0;
+  border-left: 3px solid var(--turquoise, #00e4ac);
+  background: var(--panel, #171c20);
+  border-radius: 0 10px 10px 0;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--muted, #94a3b8);
+  /* A prompt can be a paragraph; this is a reminder of it, not a re-read of it. */
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /* With a game open the page title steps out of the way. A masthead and a strapline are
@@ -5000,6 +5142,20 @@ body.player-open {
   color: var(--text-heading, #fff);
 }
 
+/* Still announced, just not drawn twice — the confirm wizard's stage heading already
+   asks this question in full. */
+.builder-choice-legend.is-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .builder-choice-options {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -5235,10 +5391,28 @@ body.player-open {
   letter-spacing: 0.5px;
 }
 
+/* .input-text carries no rules either, so this field rendered as a bare UA input —
+   a white slab whose look depended on the viewer's browser theme rather than on the
+   page it sits in. It is the decision the whole build waits on; it gets a real style. */
 .qa-name-input {
+  width: 100%;
   font-size: 1.15rem;
   font-weight: 600;
-  padding: 12px 14px;
+  padding: 14px 16px;
+  color: var(--text-heading, #fff);
+  background: var(--panel, #171c20);
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 12px;
+}
+
+.qa-name-input:focus {
+  outline: none;
+  border-color: var(--turquoise, #00e4ac);
+  box-shadow: 0 0 0 3px rgba(0, 228, 172, 0.2);
+}
+
+.qa-name-input:disabled {
+  opacity: 0.6;
 }
 
 .qa-name-hint {
@@ -5247,20 +5421,88 @@ body.player-open {
   color: var(--muted, #94a3b8);
 }
 
-/* Sticks to the viewport bottom while the question list runs past the screen, so
-   the submit is reachable from anywhere in the panel without a duplicate button.
-   The negative margins let the bar sit flush with the panel's bottom edge. */
-.qa-actions {
-  position: sticky;
-  bottom: 0;
+/* The one navigation bar, pinned below the stage. env() keeps the buttons clear of
+   the iOS home indicator, which otherwise sits on top of the primary action. */
+.qa-wizard-footer {
+  flex: none;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
-  margin: 0 -24px -24px;
-  padding: 14px 24px;
-  background: var(--panel-bg, #1d2123);
+  padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
   border-top: 1px solid var(--panel-border, #33383d);
-  border-radius: 0 0 12px 12px;
+  background: var(--panel-bg, #1d2123);
+}
+
+.qa-wizard-footer .qa-primary {
+  /* Both auto margins: the shortcut sits centered between Back and the primary, and
+     with either neighbour absent the primary still lands hard right. */
+  margin-left: auto;
+}
+
+.qa-back {
+  min-height: 44px;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.qa-next {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  min-height: 44px;
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 700;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #00e4ac 0%, #00b887 100%);
+  color: #0a0e12;
+  box-shadow: 0 4px 14px rgba(0, 228, 172, 0.3);
+  cursor: pointer;
+}
+
+/* An unanswered question is a legitimate outcome, not a failure to proceed: the
+   button still moves you on, but it stops competing with the options for the eye. */
+.qa-next--skip {
+  background: none;
+  color: var(--muted, #94a3b8);
+  border: 1px solid var(--panel-border, #33383d);
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.qa-next--skip:hover:not(:disabled) {
+  color: var(--text, #e2e8f0);
+  border-color: var(--muted, #94a3b8);
+}
+
+/* A text link, not a third button: it must be findable without competing with the
+   two real actions on either side of it. */
+.qa-shortcut {
+  margin-left: auto;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--muted, #94a3b8);
+  cursor: pointer;
+  white-space: nowrap;
+  text-underline-offset: 3px;
+}
+
+.qa-shortcut:hover:not(:disabled) {
+  color: var(--turquoise, #00e4ac);
+  text-decoration: underline;
+}
+
+.qa-shortcut:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .btn-create-now {
@@ -5290,114 +5532,204 @@ body.player-open {
   box-shadow: 0 6px 20px rgba(0, 228, 172, 0.45);
 }
 
-.qa-questions-list {
+/* Full-width rows, not wrapped chips: the option detail is a sentence, and a row that
+   is as wide as its text is also the easiest thing to hit with a thumb. */
+.qa-options {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-}
-
-.qa-card {
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.qa-card__question {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #f1f5f9;
-  margin: 0;
-}
-
-.qa-chips {
-  display: flex;
-  flex-wrap: wrap;
   gap: 10px;
 }
 
-.qa-chip {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 8px;
-  padding: 8px 14px;
-  color: #cbd5e1;
-  cursor: pointer;
+.qa-option {
   display: flex;
-  flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
+  gap: 12px;
+  text-align: left;
+  padding: 14px 16px;
+  background: var(--panel, #171c20);
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 12px;
+  color: var(--text, #e2e8f0);
+  cursor: pointer;
   transition:
     background 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease;
+    border-color 0.15s ease;
 }
 
-.qa-chip:hover {
+.qa-option:hover:not(:disabled) {
   border-color: var(--turquoise, #00e4ac);
-  background: rgba(0, 228, 172, 0.08);
-  color: #fff;
 }
 
-.qa-chip--selected {
+.qa-option--selected {
   border-color: var(--turquoise, #00e4ac);
-  background: rgba(0, 228, 172, 0.2);
-  color: #ffffff;
-  font-weight: 600;
-  box-shadow: 0 0 10px rgba(0, 228, 172, 0.25);
+  background: rgba(0, 228, 172, 0.1);
 }
 
-.qa-chip__label {
-  font-size: 0.9rem;
+/* Round for "one of these", square for "any of these" — the same convention as a
+   radio versus a checkbox, which is the only cue that the two behave differently. */
+.qa-option__tick {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  border: 2px solid var(--panel-border, #33383d);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: #0a0e12;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
-.qa-chip__detail {
-  font-size: 0.75rem;
+.qa-option--multi .qa-option__tick {
+  border-radius: 6px;
+}
+
+.qa-option--selected .qa-option__tick {
+  background: var(--turquoise, #00e4ac);
+  border-color: var(--turquoise, #00e4ac);
+}
+
+.qa-option--selected .qa-option__tick::before {
+  content: '✓';
+}
+
+.qa-option__text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.qa-option__label {
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.qa-option__detail {
+  font-size: 0.85rem;
+  line-height: 1.45;
   color: var(--muted, #94a3b8);
 }
 
+/* Dashed until it has focus: it is the answer for people none of the options fit,
+   and it should read as an invitation rather than as one more empty required field. */
 .qa-custom-input input {
   width: 100%;
-  padding: 8px 12px;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 6px;
-  color: #fff;
-  font-size: 0.85rem;
+  padding: 13px 16px;
+  background: none;
+  border: 1px dashed var(--panel-border, #33383d);
+  border-radius: 12px;
+  color: var(--text, #e2e8f0);
+  font-size: 0.95rem;
+}
+
+.qa-custom-input input:focus {
+  border-style: solid;
+  border-color: var(--turquoise, #00e4ac);
+}
+
+/* Every decision on one screen before the irreversible one, each with a way back to
+   the stage that set it. Skipped rows say who decides instead, because "blank" reads
+   as a mistake and "AI decides" reads as the choice it actually is. */
+.qa-review {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+}
+
+.qa-review-row {
+  background: var(--panel, #171c20);
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.qa-review-label {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--muted, #94a3b8);
+}
+
+.qa-review-value {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.qa-review-unset {
+  color: var(--muted, #94a3b8);
+  font-style: italic;
+}
+
+.qa-review-edit {
+  flex: none;
+  padding: 2px 4px;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--turquoise, #00e4ac);
+  cursor: pointer;
+}
+
+.qa-review-edit:hover:not(:disabled) {
+  text-decoration: underline;
 }
 
 /* Kept beside the rule it overrides rather than with the other mobile input
-   sizes — that block sits earlier in the file and loses on source order. */
+   sizes — that block sits earlier in the file and loses on source order.
+   16px is the floor below which iOS Safari zooms the page on focus. */
 @media (max-width: 768px) {
-  .qa-custom-input input {
+  .qa-custom-input input,
+  .qa-name-input {
     font-size: 16px;
   }
 }
 
-.qa-preview {
-  background: #0f1317;
-  border: 1px solid rgba(0, 228, 172, 0.3);
-  border-radius: 8px;
-  padding: 14px;
-}
+@media (max-width: 560px) {
+  .qa-wizard-header,
+  .qa-wizard-progress,
+  .qa-wizard-footer {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
 
-.qa-preview h5 {
-  margin: 0 0 8px 0;
-  color: var(--turquoise, #00e4ac);
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
+  .qa-stage {
+    padding: 24px 14px 16px;
+  }
 
-.qa-preview__code {
-  margin: 0;
-  font-family: monospace;
-  font-size: 0.85rem;
-  color: #e2e8f0;
-  white-space: pre-wrap;
+  /* Three controls do not fit one phone row. The shortcut takes its own line above
+     the two real actions rather than shrinking all three into thumb-sized ambiguity. */
+  .qa-shortcut {
+    order: -1;
+    flex-basis: 100%;
+    margin: 0;
+    text-align: center;
+  }
+
+  .qa-wizard-footer .qa-primary,
+  .qa-next {
+    margin-left: auto;
+  }
+
+  /* The label is the escape hatch, not the action — it can shed its words first. */
+  .qa-wizard-exit span {
+    display: none;
+  }
+
+  .qa-wizard-exit {
+    padding: 7px 10px;
+  }
 }
 
 /* Progressive Disclosure Accordion for Transparency */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4078,12 +4078,13 @@ body.player-open {
 .qa-wizard {
   position: fixed;
   inset: 0;
-  /* Above the sticky .app-header (100), which otherwise paints over this wizard's own
-     header and swallows its step label and exit control, and above the install and
-     update banners (900), which are fixed to the bottom and would cover the footer
-     navigation. Still below .modal-backdrop (10000), so a sign-in prompt can appear
-     over the wizard rather than under it. */
-  z-index: 1200;
+  /* Wedged deliberately between two groups. Above the sticky .app-header (100), which
+     otherwise paints over this wizard's own header and swallows its step label and exit
+     control, and above the install/update banners (900), which are fixed to the bottom
+     and would cover the footer navigation. Below the 1000 tier — .modal-backdrop,
+     .howto-backdrop, .stage.is-playing-full-viewport — because a sign-in prompt or a
+     running game has to be able to appear *over* the wizard, never under it. */
+  z-index: 950;
   display: flex;
   flex-direction: column;
   background: var(--bg, #0d1117);
@@ -4095,6 +4096,11 @@ body.player-open {
   align-items: center;
   gap: 16px;
   padding: 12px 20px;
+  /* This overlay covers .app-header, so it inherits the header's obligation: installed
+     on iOS with viewport-fit=cover the app runs under a translucent status bar, and
+     without the inset the step label and the only exit control sit beneath the clock
+     and the notch, where taps are intercepted. Resolves to 0 in a browser tab. */
+  padding-top: max(12px, env(safe-area-inset-top));
   border-bottom: 1px solid var(--panel-border, #33383d);
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4077,7 +4077,16 @@ body.player-open {
 /* Creator confirm wizard — see CreatorQA.tsx for why this is full-screen. */
 .qa-wizard {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Not `inset: 0`. Two of these stages are a text field, so the keyboard is up for
+     much of this flow, and iOS resolves a bottom-anchored 100vh box against the LARGE
+     viewport — the one with the toolbars retracted — which puts the footer's Back and
+     Next behind Safari's own bar. dvh tracks the visible viewport. Kept as a second
+     declaration so browsers without dvh keep the vh line. */
+  height: 100vh;
+  height: 100dvh;
   /* Wedged deliberately between two groups. Above the sticky .app-header (100), which
      otherwise paints over this wizard's own header and swallows its step label and exit
      control, and above the install/update banners (900), which are fixed to the bottom

--- a/apps/web/src/styles.qaWizard.test.ts
+++ b/apps/web/src/styles.qaWizard.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+/**
+ * The declarations of the first block whose selector list includes `selector` — the
+ * desktop rule, before any media-query override. Matching the selector list rather than
+ * an exact `selector {` is what finds `.install-prompt`, which shares its block with
+ * `.app-update` and would otherwise resolve to a later override carrying no z-index.
+ */
+function rule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // The selector must be a whole entry in the list: preceded by the start of a block
+  // and followed either by the brace or by a comma and the rest of the group. Anchoring
+  // both ends is what keeps `.qa-wizard` off `.qa-wizard-header` and `.modal-backdrop`
+  // off `.sketch-modal-backdrop`.
+  const pattern = new RegExp(`(?:^|[},])\\s*${escaped}\\s*(?:,[^{}]*)?\\{`, 'm');
+  const match = pattern.exec(css);
+  expect(match, `no ${selector} rule in styles.css`).not.toBeNull();
+  const start = match!.index + match![0].length;
+  const end = css.indexOf('}', start);
+  expect(end, `${selector} rule is never closed`).toBeGreaterThan(start);
+  return css.slice(start, end);
+}
+
+/** Places a new overlay against the rest of the stack rather than against a guess. */
+function zIndexOf(selector: string): number {
+  const match = /z-index:\s*(\d+)/.exec(rule(selector));
+  expect(match, `${selector} declares no z-index`).not.toBeNull();
+  return Number(match![1]);
+}
+
+describe('the creator confirm wizard as a full-screen overlay', () => {
+  /**
+   * Regression: the wizard shipped at `z-index: 90`.
+   *
+   * A full-screen overlay that loses the stacking contest is worse than no overlay —
+   * the sticky app header painted over the wizard's own header, swallowing its step
+   * label and the only exit control, and the fixed install/update banners covered the
+   * footer navigation. These are the neighbours it has to outrank.
+   */
+  it('outranks the app chrome it covers', () => {
+    const wizard = zIndexOf('.qa-wizard');
+
+    expect(wizard).toBeGreaterThan(zIndexOf('.app-header'));
+    expect(wizard).toBeGreaterThan(zIndexOf('.install-prompt'));
+  });
+
+  /**
+   * ...but not the 1000 tier. Both portal to the body, so source order decides nothing
+   * and only the z-index keeps a sign-in prompt — or a running game — on top of the
+   * wizard instead of sealed behind it. The first fix for the bug above overshot to
+   * 1200 and buried the auth modal, which is the failure this pins down.
+   */
+  it('stays under the modal backdrop, so a sign-in prompt lands over it', () => {
+    const wizard = zIndexOf('.qa-wizard');
+
+    expect(wizard).toBeLessThan(zIndexOf('.modal-backdrop'));
+    expect(wizard).toBeLessThan(zIndexOf('.howto-backdrop'));
+  });
+
+  /**
+   * index.html sets viewport-fit=cover for the game theater, which makes the insets
+   * nonzero on a notched phone. Covering .app-header means inheriting the reason it
+   * pays the top inset: otherwise the step text and the exit button render under the
+   * status bar, where taps never reach them.
+   */
+  it('pays both safe-area insets, because it replaces the chrome that used to', () => {
+    expect(rule('.qa-wizard-header')).toMatch(/padding-top:\s*max\(12px, env\(safe-area-inset-top\)\)/);
+    expect(rule('.qa-wizard-footer')).toMatch(/env\(safe-area-inset-bottom\)/);
+  });
+});

--- a/apps/web/src/styles.qaWizard.test.ts
+++ b/apps/web/src/styles.qaWizard.test.ts
@@ -2,7 +2,16 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+/**
+ * Comments are stripped up front so these assertions read declarations rather than
+ * prose. The rules below are commented heavily, and a comment that *names* the thing
+ * it is explaining — "not `inset: 0`", "below the 1000 tier" — otherwise satisfies or
+ * defeats the very pattern meant to check the declaration underneath it.
+ */
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8').replace(
+  /\/\*[\s\S]*?\*\//g,
+  '',
+);
 
 /**
  * The declarations of the first block whose selector list includes `selector` — the
@@ -70,5 +79,19 @@ describe('the creator confirm wizard as a full-screen overlay', () => {
   it('pays both safe-area insets, because it replaces the chrome that used to', () => {
     expect(rule('.qa-wizard-header')).toMatch(/padding-top:\s*max\(12px, env\(safe-area-inset-top\)\)/);
     expect(rule('.qa-wizard-footer')).toMatch(/env\(safe-area-inset-bottom\)/);
+  });
+
+  /**
+   * Two stages are a text field, so the keyboard is up for much of this flow. A
+   * bottom-anchored `inset: 0` box resolves against iOS's large viewport and puts the
+   * footer — Back, Skip, Next — behind Safari's own bar. dvh tracks what is visible,
+   * with the vh line kept underneath it for browsers that lack dvh.
+   */
+  it('is sized against the visible viewport, not the large one', () => {
+    const wizard = rule('.qa-wizard');
+
+    expect(wizard).not.toMatch(/inset:\s*0/);
+    expect(wizard).toMatch(/height:\s*100vh/);
+    expect(wizard).toMatch(/height:\s*100dvh/);
   });
 });


### PR DESCRIPTION
Redesigns the game creation confirmation flow from an inline panel below the hero into a full-screen modal wizard with one decision per screen.

## Summary
The CreatorQA component has been restructured from a single-page form into a multi-stage wizard interface. This change improves UX on mobile devices by reducing cognitive load (one question per screen) and eliminates UI competition between the hero's "Build my game" button and the confirmation panel's submit button.

## Key Changes

- **Wizard Architecture**: Converted to a stage-based system with distinct screens for: name input → questions → builder choice → review summary
- **Full-Screen Modal**: Component now renders as a portal to `document.body` with fixed positioning, preventing scroll conflicts and ensuring consistent presentation across devices
- **One Decision Per Screen**: Each question/choice occupies its own dedicated screen; selections no longer auto-advance (explicit Next/Skip buttons required)
- **Review Stage**: Added a final review screen showing all answers with edit buttons to jump back to specific stages
- **Navigation**: 
  - Back button to return to previous stage (disabled on name stage)
  - Next/Skip button that changes label based on whether current question is answered
  - Shortcut button to jump directly to review (skipping remaining questions)
  - Progress indicator showing current stage and total stages
- **Accessibility**: 
  - Stage headings receive focus on navigation for screen reader announcement
  - Progress bar with visual and semantic indicators
  - Proper ARIA labels for modal dialog
  - Legend hiding in BuilderChoice when context already provides the question
- **Styling**: Complete redesign of `.qa-*` classes to support full-screen layout, modal header/footer, stage animations, and improved touch targets (44px minimum)
- **Test Updates**: Refactored test helpers to work with document-wide queries (wizard portals outside component container) and updated assertions to match new wizard structure

## Implementation Details

- Body overflow is locked while wizard is open to prevent background scrolling
- Scroller resets to top on each stage change
- Name field gates progression to subsequent stages
- Multi-choice questions accumulate selections; single-choice replace them
- Custom text input combines with selected options rather than replacing them
- Submission state persists on review stage rather than unmounting the component

https://claude.ai/code/session_015wgLLexRUKneRr6cCYAD8R