### PR TITLE
Size the confirm wizard to the keyboard, not just the browser chrome

### DIFF
--- a/apps/web/src/CreatorQA.test.tsx
+++ b/apps/web/src/CreatorQA.test.tsx
@@ -421,6 +421,76 @@ describe('CreatorQA', () => {
     expect(document.body.style.overflow).not.toBe('hidden');
   });
 
+  /**
+   * jsdom has no visual viewport, so this is the keyboard as the browser reports it:
+   * an object whose height shrinks and whose offsetTop moves, emitting resize/scroll.
+   */
+  function stubVisualViewport(height: number, offsetTop = 0) {
+    const listeners = new Map<string, Set<() => void>>();
+    const viewport = {
+      height,
+      offsetTop,
+      addEventListener: (type: string, fn: () => void) => {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(fn);
+      },
+      removeEventListener: (type: string, fn: () => void) => listeners.get(type)?.delete(fn),
+    };
+    Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true, writable: true });
+    return {
+      viewport,
+      /** The keyboard opening: the visible area shrinks and everything is told. */
+      async emit(type: 'resize' | 'scroll', next: { height?: number; offsetTop?: number }) {
+        if (next.height !== undefined) viewport.height = next.height;
+        if (next.offsetTop !== undefined) viewport.offsetTop = next.offsetTop;
+        await act(async () => {
+          listeners.get(type)?.forEach((fn) => fn());
+          await flushEffects();
+        });
+      },
+      listenerCount: () => (listeners.get('resize')?.size ?? 0) + (listeners.get('scroll')?.size ?? 0),
+      restore: () => Reflect.deleteProperty(window, 'visualViewport'),
+    };
+  }
+
+  it('sizes itself to the visual viewport, so the keyboard cannot bury the footer', async () => {
+    // dvh tracks the address bar and stops there: iOS shrinks only the visual viewport
+    // for the keyboard, leaving the layout viewport — what a fixed box is sized
+    // against — at full height, with Back and Next underneath the keys.
+    const vv = stubVisualViewport(844);
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
+
+    const wizard = find<HTMLElement>('.qa-wizard')!;
+    expect(wizard.classList.contains('is-viewport-tracked')).toBe(true);
+    expect(wizard.style.getPropertyValue('--qa-viewport-height')).toBe('844px');
+
+    // Keyboard up: the shell follows the visible area rather than the layout viewport.
+    await vv.emit('resize', { height: 508 });
+    expect(wizard.style.getPropertyValue('--qa-viewport-height')).toBe('508px');
+
+    // ...and iOS scrolling the visual viewport to reveal an input drags the shell with
+    // it, which a position:fixed box does not do on its own.
+    await vv.emit('scroll', { offsetTop: 62 });
+    expect(wizard.style.getPropertyValue('--qa-viewport-offset')).toBe('62px');
+
+    await act(async () => root.unmount());
+    expect(vv.listenerCount()).toBe(0);
+    vv.restore();
+  });
+
+  it('falls back to the stylesheet when the browser has no visual viewport', async () => {
+    // The class is what opts into the custom properties. Without the API there is
+    // nothing to write into them, so it must stay off and leave dvh in charge.
+    Reflect.deleteProperty(window, 'visualViewport');
+    const root = await render({ ...baseProps, onSubmitWithConcept: vi.fn() });
+
+    const wizard = find<HTMLElement>('.qa-wizard')!;
+    expect(wizard.classList.contains('is-viewport-tracked')).toBe(false);
+    expect(wizard.style.getPropertyValue('--qa-viewport-height')).toBe('');
+
+    await act(async () => root.unmount());
+  });
+
   it('names the exit even when its label is hidden on a narrow screen', async () => {
     // Below 560px the CSS hides the span, and the icon is decorative — without an
     // explicit label that leaves a phone user with an unnamed button as the only

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -130,6 +130,46 @@ export function CreatorQA({
   }, []);
 
   /**
+   * Size the shell against the visual viewport, the only one that knows about the
+   * on-screen keyboard.
+   *
+   * The `100dvh` in the stylesheet tracks browser chrome — the retracting address bar —
+   * and stops there. iOS shrinks only the *visual* viewport for the keyboard and leaves
+   * the layout viewport, which is what a `position: fixed` box is sized against, at full
+   * height. Two of these stages are a text field, so without this the footer carrying
+   * Back and Next sits behind the keyboard for much of the flow, and the creator has to
+   * dismiss it to move on.
+   *
+   * `offsetTop` matters as much as height: iOS scrolls the visual viewport to reveal a
+   * focused input even with the body locked, and a fixed box does not follow it.
+   *
+   * Written straight to the node rather than through state — `scroll` fires per frame
+   * while the keyboard animates, and re-rendering the whole wizard on each one would
+   * trade a layout bug for a jank bug. dvh stays in the stylesheet as the fallback for
+   * browsers without the API.
+   */
+  const [tracksViewport, setTracksViewport] = useState(false);
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    const root = wizardRef.current;
+    if (!viewport || !root) return;
+
+    const sync = () => {
+      root.style.setProperty('--qa-viewport-height', `${viewport.height}px`);
+      root.style.setProperty('--qa-viewport-offset', `${viewport.offsetTop}px`);
+    };
+
+    sync();
+    setTracksViewport(true);
+    viewport.addEventListener('resize', sync);
+    viewport.addEventListener('scroll', sync);
+    return () => {
+      viewport.removeEventListener('resize', sync);
+      viewport.removeEventListener('scroll', sync);
+    };
+  }, []);
+
+  /**
    * Keeps Tab inside the overlay.
    *
    * `aria-modal` tells assistive tech this is modal; it does not stop the browser
@@ -275,7 +315,7 @@ export function CreatorQA({
 
   return createPortal(
     <div
-      className="qa-wizard"
+      className={`qa-wizard${tracksViewport ? ' is-viewport-tracked' : ''}`}
       role="dialog"
       aria-modal="true"
       aria-label={t(questions.length > 0 ? 'qa.title' : 'qa.titleNameOnly')}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4099,6 +4099,18 @@ body.player-open {
   background: var(--bg, #0d1117);
 }
 
+/* Added by CreatorQA once it finds `window.visualViewport`, which is the only thing
+   that measures the on-screen keyboard — dvh above tracks the address bar and stops
+   there. The custom properties are written straight to the node on every viewport
+   event; the fallbacks in `var()` keep this rule harmless if one has yet to land. */
+.qa-wizard.is-viewport-tracked {
+  height: var(--qa-viewport-height, 100dvh);
+  /* iOS scrolls the visual viewport to reveal a focused input even with the body
+     locked, and a fixed box does not follow it. This puts the shell back over the part
+     of the screen the creator can actually see. */
+  transform: translateY(var(--qa-viewport-offset, 0px));
+}
+
 .qa-wizard-header {
   flex: none;
   display: flex;

--- a/apps/web/src/styles.qaWizard.test.ts
+++ b/apps/web/src/styles.qaWizard.test.ts
@@ -94,4 +94,18 @@ describe('the creator confirm wizard as a full-screen overlay', () => {
     expect(wizard).toMatch(/height:\s*100vh/);
     expect(wizard).toMatch(/height:\s*100dvh/);
   });
+
+  /**
+   * dvh above covers the address bar; it does not cover the on-screen keyboard, which
+   * shrinks only the visual viewport. CreatorQA adds this class when the browser
+   * exposes that API and writes the measurements in. The `var()` fallbacks are the
+   * contract with the effect: the rule has to be inert until values arrive, or the
+   * first paint collapses the overlay to nothing.
+   */
+  it('hands over to the measured viewport when the browser reports one', () => {
+    const tracked = rule('.qa-wizard.is-viewport-tracked');
+
+    expect(tracked).toMatch(/height:\s*var\(--qa-viewport-height,\s*100dvh\)/);
+    expect(tracked).toMatch(/transform:\s*translateY\(var\(--qa-viewport-offset,\s*0px\)\)/);
+  });
 });


### PR DESCRIPTION
Follow-up to #447, which named this limitation but left it unsolved.

## The problem

`100dvh` tracks the retracting address bar and stops there. iOS shrinks only the **visual** viewport for the on-screen keyboard and leaves the layout viewport — which is what a `position: fixed` box is sized against — at full height.

Two of the wizard's stages are a text field, so the footer carrying Back and Next spent much of the flow behind the keys, and the creator had to dismiss the keyboard to move on.

## The change

`CreatorQA` measures `window.visualViewport` and writes its height and offset to the overlay as custom properties, which a new `.qa-wizard.is-viewport-tracked` rule consumes.

`offsetTop` is tracked as well as height: iOS scrolls the visual viewport to reveal a focused input even with the body locked, and a fixed box does not follow it. Height alone would correct the size but leave the shell misaligned.

Two deliberate calls:

- **Values are written straight to the node, not through React state.** `scroll` fires per frame while the keyboard animates; re-rendering the wizard on each one would trade a layout bug for a jank bug. Only the class toggle is stateful, and it is set once.
- **The `dvh` pair stays in the stylesheet.** The `var()` fallbacks keep the new rule inert until values arrive, so browsers without the API get exactly today's behaviour and there is no collapsed-overlay flash on first paint.

## Verification

Measured in Chromium at 390×844 rather than assumed: driving the visible area to 508px moves the footer's bottom edge from **844 → 508**, inside the visible area instead of under the keys.

Tests added:
- a stubbed visual viewport emitting `resize`/`scroll`, asserting the shell follows both height and offset
- listener cleanup on unmount
- the no-API path, asserting the class stays off so `dvh` remains in charge
- a stylesheet test pinning the `var()` fallback contract, which is what keeps the rule inert before the first measurement

884 tests pass; type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wgLLexRUKneRr6cCYAD8R

---
_Generated by [Claude Code](https://claude.ai/code/session_015wgLLexRUKneRr6cCYAD8R)_