### PR TITLE
byoca(BY-23): durable per-game agent opener key

### DIFF
--- a/apps/api/src/agent-game-key-resolve.test.ts
+++ b/apps/api/src/agent-game-key-resolve.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, mintGameAgentKey } from './agent-game-key.js';
+import { resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
+import { InMemoryStore } from './store.js';
+
+const secret = 'resolve-game-key-secret';
+const slug = 'comet-courier';
+const ownerUid = 'g:owner';
+const now = Date.parse('2026-07-31T12:00:00.000Z');
+
+async function seedActiveSelfRound(store: InMemoryStore, issueNumber: number, builder: 'self' | 'platform' = 'self') {
+  await store.createSubmission(issueNumber, ownerUid, 'Comet Courier');
+  await store.setSubmissionSlug(issueNumber, slug);
+  await store.setRoundBuilder(issueNumber, builder);
+  await store.recordJobTransition(issueNumber, {
+    to: 'dispatched',
+    at: new Date(now).toISOString(),
+    by: 'system',
+  });
+  await store.ensureRoundGeneration(issueNumber);
+}
+
+function gameKey(generation = 1) {
+  return mintGameAgentKey(secret, { slug, creatorUid: ownerUid, keyGeneration: generation, now });
+}
+
+describe('resolveGameAgentKeyForStart', () => {
+  it('refuses when no open round exists', async () => {
+    const store = new InMemoryStore();
+    const at = new Date(now).toISOString();
+    await store.ensureGameAgentKey(slug, ownerUid, at);
+    await store.createSubmission(10, ownerUid, 'Comet Courier');
+    await store.setSubmissionSlug(10, slug);
+    await store.recordJobTransition(10, {
+      to: 'ready_for_review',
+      at: new Date(now).toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+
+    const result = await resolveGameAgentKeyForStart(store, gameKey(), secret, now);
+    expect(result).toEqual({ ok: false, reason: NO_OPEN_ROUND_REASON });
+  });
+
+  it('refuses when the open round is platform-built', async () => {
+    const store = new InMemoryStore();
+    const at = new Date(now).toISOString();
+    await store.ensureGameAgentKey(slug, ownerUid, at);
+    await seedActiveSelfRound(store, 11, 'platform');
+
+    const result = await resolveGameAgentKeyForStart(store, gameKey(), secret, now);
+    expect(result).toEqual({ ok: false, reason: PLATFORM_ROUND_REASON });
+  });
+
+  it('refuses when the key owner does not match the slug record', async () => {
+    const store = new InMemoryStore();
+    const at = new Date(now).toISOString();
+    await store.ensureGameAgentKey(slug, ownerUid, at);
+    await seedActiveSelfRound(store, 12, 'self');
+
+    const strangerKey = mintGameAgentKey(secret, {
+      slug,
+      creatorUid: 'g:stranger',
+      keyGeneration: 1,
+      now,
+    });
+    const result = await resolveGameAgentKeyForStart(store, strangerKey, secret, now);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toMatch(/rotated|invalid/i);
+  });
+
+  it('binds to the active self round on the happy path', async () => {
+    const store = new InMemoryStore();
+    const at = new Date(now).toISOString();
+    await store.ensureGameAgentKey(slug, ownerUid, at);
+    await seedActiveSelfRound(store, 13, 'self');
+
+    const result = await resolveGameAgentKeyForStart(store, gameKey(), secret, now);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims).toMatchObject({ slug, creatorUid: ownerUid, keyGeneration: 1 });
+      expect(result.record.issueNumber).toBe(13);
+      expect(result.record.builder).toBe('self');
+    }
+  });
+});

--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -1,0 +1,98 @@
+/**
+ * Resolve a durable per-game opener into an active self-build round (BY-23).
+ *
+ * Shared by MCP `start` (and later `open_round`) so verification + ownership +
+ * active-round selection cannot drift between callers.
+ */
+
+import {
+  assertGameAgentKeyActive,
+  NO_OPEN_ROUND_REASON,
+  PLATFORM_ROUND_REASON,
+  ROTATED_GAME_KEY_REASON,
+  verifyGameAgentKey,
+  type GameAgentKeyClaims,
+} from './agent-game-key.js';
+import { InvalidAgentTokenError } from './agent-token.js';
+import { isActiveBuildRound } from './builder.js';
+import type { Store, SubmissionRecord } from './store.js';
+
+export type ResolveGameKeyResult =
+  { ok: true; claims: GameAgentKeyClaims; record: SubmissionRecord } | { ok: false; reason: string };
+
+/**
+ * Creator still "owns" the slug when they have a non-abandoned submission for it
+ * whose ownerUid matches the claims. Newest non-abandoned job decides ownership.
+ */
+export async function creatorOwnsSlug(store: Store, slug: string, creatorUid: string): Promise<boolean> {
+  const owned = await store.listSubmissionsByOwner(creatorUid, { limit: 200 });
+  return owned.some((job) => job.slug === slug && !job.abandonedAt);
+}
+
+/** Newest active build round for this slug owned by the creator, or null. */
+export async function findActiveRoundForSlug(
+  store: Store,
+  slug: string,
+  creatorUid: string,
+): Promise<SubmissionRecord | null> {
+  const owned = await store.listSubmissionsByOwner(creatorUid, { limit: 200 });
+  const active = owned
+    .filter((job) => job.slug === slug && !job.abandonedAt && isActiveBuildRound(job))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return active[0] ?? null;
+}
+
+/**
+ * Full durable-key verification for `start`: signature, generation, expiry,
+ * ownership, then bind to the active self round (or refuse with a distinct reason).
+ */
+export async function resolveGameAgentKeyForStart(
+  store: Store,
+  key: string,
+  secret: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveGameKeyResult> {
+  let claims: GameAgentKeyClaims;
+  try {
+    claims = verifyGameAgentKey(key, secret);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: 'invalid key — ask the creator for the current prompt in their Studio thread' };
+    }
+    throw error;
+  }
+
+  const keyRecord = await store.getGameAgentKey(claims.slug);
+  if (!keyRecord) {
+    return { ok: false, reason: ROTATED_GAME_KEY_REASON };
+  }
+
+  try {
+    assertGameAgentKeyActive(claims, keyRecord, nowMs);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: error.message || ROTATED_GAME_KEY_REASON };
+    }
+    throw error;
+  }
+
+  if (keyRecord.ownerUid !== claims.creatorUid) {
+    return { ok: false, reason: ROTATED_GAME_KEY_REASON };
+  }
+
+  if (!(await creatorOwnsSlug(store, claims.slug, claims.creatorUid))) {
+    return { ok: false, reason: ROTATED_GAME_KEY_REASON };
+  }
+
+  const active = await findActiveRoundForSlug(store, claims.slug, claims.creatorUid);
+  if (!active) {
+    return { ok: false, reason: NO_OPEN_ROUND_REASON };
+  }
+
+  const builder = active.builder ?? 'platform';
+  if (builder !== 'self') {
+    return { ok: false, reason: PLATFORM_ROUND_REASON };
+  }
+
+  return { ok: true, claims, record: active };
+}

--- a/apps/api/src/agent-game-key.test.ts
+++ b/apps/api/src/agent-game-key.test.ts
@@ -4,10 +4,12 @@ import {
   DEFAULT_GAME_AGENT_KEY_TTL_DAYS,
   gameAgentKeyTtlDays,
   InvalidAgentTokenError,
+  looksLikeGameAgentKey,
   mintGameAgentKey,
   ROTATED_GAME_KEY_REASON,
   verifyGameAgentKey,
 } from './agent-game-key.js';
+import { mintMcpSessionKey } from './mcp-session-key.js';
 
 describe('durable per-game agent key (BY-23)', () => {
   const secret = 'game-key-test-secret';
@@ -74,6 +76,31 @@ describe('durable per-game agent key (BY-23)', () => {
     const newClaims = verifyGameAgentKey(newKey, secret);
     expect(() => assertGameAgentKeyActive(oldClaims, { keyGeneration: 2 }, now)).toThrow(ROTATED_GAME_KEY_REASON);
     expect(() => assertGameAgentKeyActive(newClaims, { keyGeneration: 2 }, now)).not.toThrow();
+  });
+
+  it('round-trips Apple dotted subject identifiers', () => {
+    const appleUid = 'a:001234.abcdef.0000';
+    const key = mintGameAgentKey(secret, { slug, creatorUid: appleUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyGameAgentKey(key, secret)).toEqual({
+      slug,
+      creatorUid: appleUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.split('.')[2]).not.toContain('.');
+  });
+
+  it('does not false-positive on MCP session keys whose session id is g1', () => {
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: 'g1',
+      jobId: 42,
+      roundGeneration: 1,
+      now,
+    });
+    const decoded = Buffer.from(sessionKey, 'base64url').toString('utf8');
+    expect(decoded.startsWith('g1.')).toBe(true);
+    expect(looksLikeGameAgentKey(sessionKey)).toBe(false);
   });
 
   it('defaults TTL from GAME_AGENT_KEY_TTL_DAYS (90 days)', () => {

--- a/apps/api/src/agent-game-key.test.ts
+++ b/apps/api/src/agent-game-key.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertGameAgentKeyActive,
+  DEFAULT_GAME_AGENT_KEY_TTL_DAYS,
+  gameAgentKeyTtlDays,
+  InvalidAgentTokenError,
+  mintGameAgentKey,
+  ROTATED_GAME_KEY_REASON,
+  verifyGameAgentKey,
+} from './agent-game-key.js';
+
+describe('durable per-game agent key (BY-23)', () => {
+  const secret = 'game-key-test-secret';
+  const now = Date.parse('2026-07-31T12:00:00.000Z');
+  const slug = 'sky-dodge';
+  const creatorUid = 'g:creator';
+
+  afterEach(() => {
+    delete process.env.GAME_AGENT_KEY_TTL_DAYS;
+  });
+
+  it('mints and verifies a round-trip key', () => {
+    const key = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyGameAgentKey(key, secret)).toEqual({
+      slug,
+      creatorUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.startsWith('g1.')).toBe(true);
+  });
+
+  it('rejects tampered claims', () => {
+    const key = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    const [prefix, slugPart, uid, generation, exp, signature] = decoded.split('.');
+    const tamperedGeneration = Buffer.from(
+      `${prefix}.${slugPart}.${uid}.${Number(generation) + 1}.${exp}.${signature}`,
+      'utf8',
+    ).toString('base64url');
+    const tamperedExp = Buffer.from(
+      `${prefix}.${slugPart}.${uid}.${generation}.${Number(exp) + 1}.${signature}`,
+      'utf8',
+    ).toString('base64url');
+    const tamperedSig = Buffer.from(
+      `${prefix}.${slugPart}.${uid}.${generation}.${exp}.${signature.slice(0, -1)}0`,
+      'utf8',
+    ).toString('base64url');
+    expect(() => verifyGameAgentKey(tamperedGeneration, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyGameAgentKey(tamperedExp, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyGameAgentKey(tamperedSig, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyGameAgentKey('not-a-key', secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('rejects an expired key', () => {
+    const key = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyGameAgentKey(key, secret);
+    const afterExpiry = now + 91 * 24 * 60 * 60 * 1000;
+    expect(() => assertGameAgentKeyActive(claims, { keyGeneration: 1 }, afterExpiry)).toThrow(ROTATED_GAME_KEY_REASON);
+  });
+
+  it('rejects a stale keyGeneration', () => {
+    const key = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyGameAgentKey(key, secret);
+    expect(() => assertGameAgentKeyActive(claims, { keyGeneration: 2 }, now)).toThrow(ROTATED_GAME_KEY_REASON);
+  });
+
+  it('rotate makes the old key fail and the new pass', () => {
+    const oldKey = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const newKey = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const oldClaims = verifyGameAgentKey(oldKey, secret);
+    const newClaims = verifyGameAgentKey(newKey, secret);
+    expect(() => assertGameAgentKeyActive(oldClaims, { keyGeneration: 2 }, now)).toThrow(ROTATED_GAME_KEY_REASON);
+    expect(() => assertGameAgentKeyActive(newClaims, { keyGeneration: 2 }, now)).not.toThrow();
+  });
+
+  it('defaults TTL from GAME_AGENT_KEY_TTL_DAYS (90 days)', () => {
+    expect(gameAgentKeyTtlDays()).toBe(DEFAULT_GAME_AGENT_KEY_TTL_DAYS);
+    process.env.GAME_AGENT_KEY_TTL_DAYS = '30';
+    expect(gameAgentKeyTtlDays()).toBe(30);
+
+    const key = mintGameAgentKey(secret, { slug, creatorUid, keyGeneration: 1, now });
+    const claims = verifyGameAgentKey(key, secret);
+    expect(claims.exp).toBe(Math.floor(now / 1000) + 30 * 24 * 60 * 60);
+  });
+});

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -13,6 +13,8 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { InvalidAgentTokenError } from './agent-token.js';
 
+export { InvalidAgentTokenError } from './agent-token.js';
+
 const SCOPE = 'agent-game-v1';
 /** Wire marker so this shape can never parse as a round-scoped key. */
 const WIRE_PREFIX = 'g1';
@@ -68,13 +70,31 @@ function safeEqualHex(actual: string, expected: string): boolean {
   return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
 }
 
-function assertSlugUid(slug: string, creatorUid: string): void {
-  // Slugs and Firebase UIDs are dot-free; the wire format relies on that.
+function assertSlug(slug: string): void {
+  // Slugs are dot-free; the wire format uses `.` as a field delimiter.
   if (!slug || slug.includes('.') || /\s/.test(slug)) {
     throw new InvalidAgentTokenError('invalid game slug');
   }
-  if (!creatorUid || creatorUid.includes('.') || /\s/.test(creatorUid)) {
+}
+
+function assertCreatorUid(creatorUid: string): void {
+  if (!creatorUid || /\s/.test(creatorUid)) {
     throw new InvalidAgentTokenError('invalid creator id');
+  }
+}
+
+function encodeCreatorUid(creatorUid: string): string {
+  assertCreatorUid(creatorUid);
+  return Buffer.from(creatorUid, 'utf8').toString('base64url');
+}
+
+function decodeCreatorUid(encoded: string): string {
+  try {
+    const creatorUid = Buffer.from(encoded, 'base64url').toString('utf8');
+    assertCreatorUid(creatorUid);
+    return creatorUid;
+  } catch {
+    throw new InvalidAgentTokenError();
   }
 }
 
@@ -83,7 +103,7 @@ function assertSlugUid(slug: string, creatorUid: string): void {
  * `(agent-game-v1, slug, creatorUid, keyGeneration, exp)`.
  */
 export function mintGameAgentKey(secret: string, options: MintGameAgentKeyOptions): string {
-  assertSlugUid(options.slug, options.creatorUid);
+  assertSlug(options.slug);
   if (!Number.isSafeInteger(options.keyGeneration) || options.keyGeneration < 1) {
     throw new InvalidAgentTokenError('invalid key generation');
   }
@@ -91,18 +111,37 @@ export function mintGameAgentKey(secret: string, options: MintGameAgentKeyOption
   const ttlDays = options.ttlDays ?? gameAgentKeyTtlDays();
   const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
   const signature = signGameKey(options.slug, options.creatorUid, options.keyGeneration, exp, secret);
-  const payload = `${WIRE_PREFIX}.${options.slug}.${options.creatorUid}.${options.keyGeneration}.${exp}.${signature}`;
+  const encodedUid = encodeCreatorUid(options.creatorUid);
+  const payload = `${WIRE_PREFIX}.${options.slug}.${encodedUid}.${options.keyGeneration}.${exp}.${signature}`;
   return Buffer.from(payload, 'utf8').toString('base64url');
 }
 
 /**
- * True when the decoded wire form looks like a game opener (prefix `g1.`). Used to
+ * True when the decoded wire form matches the full durable game-key shape. Used to
  * reject these keys at sessionKey/Bearer write paths without inventing a second error.
+ * Prefix-only checks false-positive on MCP session keys whose session id is `g1`.
  */
 export function looksLikeGameAgentKey(token: string): boolean {
   try {
-    const decoded = Buffer.from(token, 'base64url').toString('utf8');
-    return decoded.startsWith(`${WIRE_PREFIX}.`);
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 6) return false;
+    const [prefix, slug, encodedUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      !slug ||
+      !encodedUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      slug.includes('.') ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      return false;
+    }
+    decodeCreatorUid(encodedUid);
+    return true;
   } catch {
     return false;
   }
@@ -118,11 +157,11 @@ export function verifyGameAgentKey(token: string, secret: string): GameAgentKeyC
     if (parts.length !== 6) {
       throw new InvalidAgentTokenError();
     }
-    const [prefix, slug, creatorUid, generationRaw, expRaw, signature] = parts;
+    const [prefix, slug, encodedUid, generationRaw, expRaw, signature] = parts;
     if (
       prefix !== WIRE_PREFIX ||
       !slug ||
-      !creatorUid ||
+      !encodedUid ||
       !generationRaw ||
       !expRaw ||
       !signature ||
@@ -132,7 +171,8 @@ export function verifyGameAgentKey(token: string, secret: string): GameAgentKeyC
     ) {
       throw new InvalidAgentTokenError();
     }
-    assertSlugUid(slug, creatorUid);
+    assertSlug(slug);
+    const creatorUid = decodeCreatorUid(encodedUid);
     const keyGeneration = Number.parseInt(generationRaw, 10);
     const exp = Number.parseInt(expRaw, 10);
     if (!Number.isSafeInteger(keyGeneration) || keyGeneration < 1 || !Number.isSafeInteger(exp) || exp <= 0) {

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -1,0 +1,168 @@
+/**
+ * Durable per-game agent opener keys (BY-23).
+ *
+ * Distinct scope from round-scoped build keys (`agent-channel-v1`) and MCP session
+ * keys (`mcp-session-v1`). This key may only be exchanged at `start` (and later
+ * `open_round`) for a round-bound sessionKey — never accepted where a sessionKey or
+ * round write capability is required.
+ *
+ * Revocation is `keyGeneration` on `gameAgentKeys/{slug}`, bumped only by an explicit
+ * creator rotate. Round close does NOT bump it.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { InvalidAgentTokenError } from './agent-token.js';
+
+const SCOPE = 'agent-game-v1';
+/** Wire marker so this shape can never parse as a round-scoped key. */
+const WIRE_PREFIX = 'g1';
+
+/** Default lifetime for a durable per-game opener key, in days. */
+export const DEFAULT_GAME_AGENT_KEY_TTL_DAYS = 90;
+
+/**
+ * Distinct from {@link STALE_AGENT_TOKEN_REASON}: the durable key itself is fine;
+ * there is simply no self-build round open for the agent to join.
+ */
+export const NO_OPEN_ROUND_REASON =
+  'no build round is open for this game; ask the creator to request a change in their Studio thread';
+
+/** Active round exists but is platform-built — not the creator's agent's turn. */
+export const PLATFORM_ROUND_REASON =
+  'the open round for this game is built by the platform, not your agent — ask the creator to switch to their own agent in Studio';
+
+/** Rotated or generation-mismatched durable key. */
+export const ROTATED_GAME_KEY_REASON =
+  'this game key was rotated — get a fresh prompt from the Studio thread for this game';
+
+export interface GameAgentKeyClaims {
+  slug: string;
+  creatorUid: string;
+  keyGeneration: number;
+  /** Unix seconds. */
+  exp: number;
+}
+
+export interface MintGameAgentKeyOptions {
+  slug: string;
+  creatorUid: string;
+  keyGeneration: number;
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+  /** Override {@link gameAgentKeyTtlDays}; useful in tests. */
+  ttlDays?: number;
+}
+
+export function gameAgentKeyTtlDays(): number {
+  const parsed = Number(process.env.GAME_AGENT_KEY_TTL_DAYS ?? DEFAULT_GAME_AGENT_KEY_TTL_DAYS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_GAME_AGENT_KEY_TTL_DAYS;
+}
+
+function signGameKey(slug: string, creatorUid: string, keyGeneration: number, exp: number, secret: string): string {
+  return createHmac('sha256', secret).update(`${SCOPE}:${slug}:${creatorUid}:${keyGeneration}:${exp}`).digest('hex');
+}
+
+function safeEqualHex(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function assertSlugUid(slug: string, creatorUid: string): void {
+  // Slugs and Firebase UIDs are dot-free; the wire format relies on that.
+  if (!slug || slug.includes('.') || /\s/.test(slug)) {
+    throw new InvalidAgentTokenError('invalid game slug');
+  }
+  if (!creatorUid || creatorUid.includes('.') || /\s/.test(creatorUid)) {
+    throw new InvalidAgentTokenError('invalid creator id');
+  }
+}
+
+/**
+ * Mints a durable per-game opener. HMAC covers
+ * `(agent-game-v1, slug, creatorUid, keyGeneration, exp)`.
+ */
+export function mintGameAgentKey(secret: string, options: MintGameAgentKeyOptions): string {
+  assertSlugUid(options.slug, options.creatorUid);
+  if (!Number.isSafeInteger(options.keyGeneration) || options.keyGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid key generation');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlDays = options.ttlDays ?? gameAgentKeyTtlDays();
+  const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
+  const signature = signGameKey(options.slug, options.creatorUid, options.keyGeneration, exp, secret);
+  const payload = `${WIRE_PREFIX}.${options.slug}.${options.creatorUid}.${options.keyGeneration}.${exp}.${signature}`;
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+/**
+ * True when the decoded wire form looks like a game opener (prefix `g1.`). Used to
+ * reject these keys at sessionKey/Bearer write paths without inventing a second error.
+ */
+export function looksLikeGameAgentKey(token: string): boolean {
+  try {
+    const decoded = Buffer.from(token, 'base64url').toString('utf8');
+    return decoded.startsWith(`${WIRE_PREFIX}.`);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies HMAC and returns claims. Does **not** check keyGeneration against the store
+ * or ownership — callers do that once the gameAgentKeys record is loaded.
+ */
+export function verifyGameAgentKey(token: string, secret: string): GameAgentKeyClaims {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 6) {
+      throw new InvalidAgentTokenError();
+    }
+    const [prefix, slug, creatorUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      !slug ||
+      !creatorUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    assertSlugUid(slug, creatorUid);
+    const keyGeneration = Number.parseInt(generationRaw, 10);
+    const exp = Number.parseInt(expRaw, 10);
+    if (!Number.isSafeInteger(keyGeneration) || keyGeneration < 1 || !Number.isSafeInteger(exp) || exp <= 0) {
+      throw new InvalidAgentTokenError();
+    }
+    if (!safeEqualHex(signature, signGameKey(slug, creatorUid, keyGeneration, exp, secret))) {
+      throw new InvalidAgentTokenError();
+    }
+    return { slug, creatorUid, keyGeneration, exp };
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      throw error;
+    }
+    throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Checks expiry and keyGeneration against the game's current record. Ownership of the
+ * slug is a separate check (creator may have transferred / abandoned).
+ */
+export function assertGameAgentKeyActive(
+  claims: GameAgentKeyClaims,
+  record: { keyGeneration: number },
+  nowMs: number = Date.now(),
+): void {
+  if (claims.exp * 1000 <= nowMs) {
+    throw new InvalidAgentTokenError(ROTATED_GAME_KEY_REASON);
+  }
+  if (claims.keyGeneration !== record.keyGeneration) {
+    throw new InvalidAgentTokenError(ROTATED_GAME_KEY_REASON);
+  }
+}

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 import { classifyAgentTokenAccess, mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import { mintGameAgentKey } from './agent-game-key.js';
 import { buildApp } from './app.js';
 import type { GamesStore } from './games-store.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
@@ -110,8 +111,34 @@ async function seedJob(store: InMemoryStore) {
   });
 }
 
+async function seedActiveSelfJob(store: InMemoryStore) {
+  await seedJob(store);
+  await store.recordJobTransition(ISSUE, {
+    to: 'dispatched',
+    at: new Date().toISOString(),
+    by: 'system',
+  });
+}
+
 function roundKey(generation = 1, now?: number) {
   return mintAgentToken(ISSUE, secret, { roundGeneration: generation, ...(now !== undefined ? { now } : {}) });
+}
+
+async function ensureGameKey(store: InMemoryStore, generation = 1) {
+  const at = new Date().toISOString();
+  await store.ensureGameAgentKey('comet-courier', 'g:owner', at);
+  for (let i = 1; i < generation; i++) {
+    await store.rotateGameAgentKey('comet-courier', 'g:owner', at);
+  }
+}
+
+function gameKey(generation = 1, now?: number) {
+  return mintGameAgentKey(secret, {
+    slug: 'comet-courier',
+    creatorUid: 'g:owner',
+    keyGeneration: generation,
+    ...(now !== undefined ? { now } : {}),
+  });
 }
 
 async function mcpCall(
@@ -294,10 +321,7 @@ describe('POST /api/mcp (BY-05)', () => {
       };
     };
 
-    // Structured: ordered workflow covering the full loop, plus the inbox policy and the
-    // retired-key etiquette an agent relays.
     const workflow = result.structuredContent.workflow as string[];
-    expect(Array.isArray(workflow)).toBe(true);
     expect(workflow.length).toBeGreaterThanOrEqual(6);
     const joined = workflow.join('\n');
     expect(joined).toMatch(/get_brief/);
@@ -341,7 +365,7 @@ describe('POST /api/mcp (BY-05)', () => {
     const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
     const whenRefused = (started.structured as { whenRefused: string }).whenRefused;
     expect(whenRefused).toMatch(/Studio thread/i);
-    expect(whenRefused).toMatch(/current kickoff prompt/i);
+    expect(whenRefused).toMatch(/current kickoff/i);
     expect(whenRefused).toMatch(/MCP connection/i);
     expect(whenRefused).toMatch(/do not retry|do not report an outage/i);
 
@@ -840,5 +864,109 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(brief.isError).toBe(true);
+  });
+
+  it('start with a durable per-game key works', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    await ensureGameKey(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const started = await callTool(app, 'start', { key: gameKey() }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({
+      jobId: ISSUE,
+      slug: 'comet-courier',
+      title: 'Comet Courier',
+    });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+    const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(brief.isError).toBe(false);
+  });
+
+  it('durable key still starts a new active round after the previous round closes', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    await ensureGameKey(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const durable = gameKey();
+
+    const first = await callTool(app, 'start', { key: durable }, { 'mcp-session-id': sessionId });
+    expect(first.isError).toBe(false);
+
+    await store.recordJobTransition(ISSUE, {
+      to: 'ready_for_review',
+      at: '2026-08-01T12:00:00.000Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(2);
+
+    const NEXT_ISSUE = 56;
+    await store.createSubmission(NEXT_ISSUE, 'g:owner', 'Comet Courier v2');
+    await store.setSubmissionSlug(NEXT_ISSUE, 'comet-courier');
+    await store.setRoundBuilder(NEXT_ISSUE, 'self');
+    await store.recordJobTransition(NEXT_ISSUE, {
+      to: 'dispatched',
+      at: '2026-08-02T12:00:00.000Z',
+      by: 'system',
+    });
+    await store.ensureRoundGeneration(NEXT_ISSUE);
+
+    const keyRecord = await store.getGameAgentKey('comet-courier');
+    expect(keyRecord?.keyGeneration).toBe(1);
+
+    const second = await callTool(app, 'start', { key: durable }, { 'mcp-session-id': sessionId });
+    expect(second.isError).toBe(false);
+    expect(second.structured).toMatchObject({ jobId: NEXT_ISSUE, slug: 'comet-courier' });
+  });
+
+  it('rejects a durable game key on write tools', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    await ensureGameKey(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const durable = gameKey();
+
+    const viaSessionKey = await callTool(
+      app,
+      'report_progress',
+      { sessionKey: durable, text: 'nope' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(viaSessionKey.isError).toBe(true);
+    expect(JSON.stringify(viaSessionKey.structured)).toMatch(/only opens a session via start/i);
+
+    const viaBearer = await callTool(
+      app,
+      'report_progress',
+      { text: 'nope' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${durable}` },
+    );
+    expect(viaBearer.isError).toBe(true);
+    expect(JSON.stringify(viaBearer.structured)).toMatch(/only opens a session via start/i);
+  });
+
+  it('legacy round-scoped key still works end-to-end on start', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const legacy = roundKey();
+
+    const started = await callTool(app, 'start', { key: legacy }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({ jobId: ISSUE, slug: 'comet-courier' });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+    const progress = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, text: 'legacy path ok' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(progress.isError).toBe(false);
   });
 });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+import { looksLikeGameAgentKey } from './agent-game-key.js';
+import { resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -24,12 +26,13 @@ import { BUILD_STEPS } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
 
 /**
- * Streamable-HTTP MCP endpoint (BY-05).
+ * Streamable-HTTP MCP endpoint (BY-05 / BY-23).
  *
  * Job binding is prompt-first: install configures the URL alone; `start({ key })`
- * validates the round key and returns a short-lived `sessionKey`. Every later tool
- * authenticates on that argument (or on `Authorization: Bearer <round key>`). The
- * transport `Mcp-Session-Id` correlator authorizes nothing — MCP spec forbids it.
+ * validates a durable per-game opener **or** a legacy round-scoped key and returns a
+ * short-lived `sessionKey`. Every later tool authenticates on that argument (or on
+ * `Authorization: Bearer <round key>` — never the durable game key). The transport
+ * `Mcp-Session-Id` correlator authorizes nothing — MCP spec forbids it.
  *
  * Tools wrap the existing `/api/agent/build/*` channel. Mutating replies always
  * include `{ stop, pendingMessages }`.
@@ -213,9 +216,9 @@ const INBOX_POLICY =
  * stale. Matches STALE_AGENT_TOKEN_REASON so the agent relays the same fix the error names.
  */
 const RETIRED_KEY_ETIQUETTE =
-  'If a call is refused because the build is finished or the key is stale, do not retry and do not report an ' +
-  "outage. Tell the creator to open the game's Studio thread and copy the current kickoff prompt; the gamedev.pl " +
-  'MCP connection itself is unchanged.';
+  'If a call is refused because the round finished, no round is open, or the key was rotated, do not retry and do not ' +
+  "report an outage. Tell the creator to open the game's Studio thread — start a new round if none is open, or copy " +
+  'the current kickoff only if they rotated the key; the gamedev.pl MCP connection itself is unchanged.';
 
 /** Human-readable session loop for the text body of `start`. */
 const SESSION_WORKFLOW_TEXT = [
@@ -310,6 +313,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     let channelToken: string;
 
     if (bearer) {
+      // Durable per-game openers are start-only — never a write capability via Bearer.
+      if (looksLikeGameAgentKey(bearer)) {
+        return toolErr(
+          'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
       try {
         claims = verifyAgentToken(bearer, agentTokenSecret);
       } catch (error) {
@@ -320,6 +329,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       }
       channelToken = bearer;
     } else if (sessionKeyArg) {
+      if (looksLikeGameAgentKey(sessionKeyArg)) {
+        return toolErr(
+          'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
       let sessionClaims;
       try {
         sessionClaims = verifyMcpSessionKey(sessionKeyArg, agentTokenSecret);
@@ -415,8 +429,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     start: {
       description:
         "Bind this MCP client to a build round using the key from the creator's Studio kickoff prompt. " +
+        'Accepts a durable per-game key (preferred) or a legacy round-scoped key. ' +
         'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
         '(the ordered start→done loop), an inbox policy, and what to relay if a later call is refused. ' +
+        'The game key itself is an opener only — never a write capability. ' +
         'Does not treat Mcp-Session-Id as authority. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -424,7 +440,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: {
           key: {
             type: 'string',
-            description: 'Round key from the Studio kickoff prompt (the line "key: …").',
+            description: 'Game key (or legacy round key) from the Studio kickoff prompt (the line "key: …").',
           },
         },
         required: ['key'],
@@ -446,33 +462,52 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr("key is required — paste the key from the creator's Studio kickoff prompt");
         }
 
-        let claims: AgentTokenClaims;
-        try {
-          claims = verifyAgentToken(key, agentTokenSecret);
-        } catch {
-          noteInvalidStart(ctx.request);
-          return toolErr('invalid key — ask the creator for the current prompt in their Studio thread');
-        }
+        let record: SubmissionRecord;
+        let jobId: number;
+        let roundGeneration: number;
 
-        const record = await store.getSubmission(claims.jobId);
-        if (!record) {
-          noteInvalidStart(ctx.request);
-          return toolErr('unknown build — ask the creator for the current prompt in their Studio thread');
-        }
-
-        let access: AgentTokenAccess;
-        try {
-          access = classifyAgentTokenAccess(claims, record, now());
-        } catch (error) {
-          noteInvalidStart(ctx.request);
-          if (error instanceof InvalidAgentTokenError) {
-            return toolErr(error.message || FINISHED_REASON);
+        if (looksLikeGameAgentKey(key)) {
+          const resolved = await resolveGameAgentKeyForStart(store, key, agentTokenSecret, now());
+          if (!resolved.ok) {
+            noteInvalidStart(ctx.request);
+            return toolErr(resolved.reason);
           }
-          throw error;
-        }
-        if (access !== 'active') {
-          noteInvalidStart(ctx.request);
-          return toolErr(FINISHED_REASON);
+          record = resolved.record;
+          jobId = record.issueNumber;
+          roundGeneration = record.roundGeneration ?? 1;
+        } else {
+          // Legacy round-scoped key — still accepted for in-flight rounds.
+          let claims: AgentTokenClaims;
+          try {
+            claims = verifyAgentToken(key, agentTokenSecret);
+          } catch {
+            noteInvalidStart(ctx.request);
+            return toolErr('invalid key — ask the creator for the current prompt in their Studio thread');
+          }
+
+          const found = await store.getSubmission(claims.jobId);
+          if (!found) {
+            noteInvalidStart(ctx.request);
+            return toolErr('unknown build — ask the creator for the current prompt in their Studio thread');
+          }
+
+          let access: AgentTokenAccess;
+          try {
+            access = classifyAgentTokenAccess(claims, found, now());
+          } catch (error) {
+            noteInvalidStart(ctx.request);
+            if (error instanceof InvalidAgentTokenError) {
+              return toolErr(error.message || FINISHED_REASON);
+            }
+            throw error;
+          }
+          if (access !== 'active') {
+            noteInvalidStart(ctx.request);
+            return toolErr(FINISHED_REASON);
+          }
+          record = found;
+          jobId = claims.jobId;
+          roundGeneration = claims.roundGeneration ?? record.roundGeneration ?? 1;
         }
 
         // Prefer the transport session id when the client already has one; otherwise mint.
@@ -481,10 +516,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const sessionId = ctx.sessionId && transportSessions.has(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
         transportSessions.set(sessionId, { createdAt: now() });
 
-        const roundGeneration = claims.roundGeneration ?? record.roundGeneration ?? 1;
         const sessionKey = mintMcpSessionKey(agentTokenSecret, {
           sessionId,
-          jobId: claims.jobId,
+          jobId,
           roundGeneration,
           now: now(),
         });
@@ -496,7 +530,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const structured = {
           sessionKey,
           sessionId,
-          jobId: claims.jobId,
+          jobId,
           slug: record.slug ?? null,
           title: record.title,
           state: record.state ?? 'queued',

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import { assertAgentTokenActive, verifyAgentToken } from './agent-token.js';
+import { assertGameAgentKeyActive, DEFAULT_GAME_AGENT_KEY_TTL_DAYS, verifyGameAgentKey } from './agent-game-key.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
@@ -89,36 +89,39 @@ describe('self-build-connect templates', () => {
     }
   });
 
-  it('builds a kickoff prompt with the round key, a loop pointer, and pending feedback', () => {
-    const bare = buildKickoffPrompt({ title: 'Asteroids', roundKey: 'round-key-abc' });
+  it('builds a kickoff prompt with the game key, a loop pointer, and pending feedback', () => {
+    const bare = buildKickoffPrompt({ title: 'Asteroids', gameKey: 'game-key-abc' });
     expect(bare).toBe(
       [
         'Build "Asteroids" for gamedev.pl.',
-        'Start with the gamedevpl tool, key: round-key-abc',
-        'start returns your workflow; after gate green you are done — this key retires with the round.',
+        'Start with the gamedevpl tool, key: game-key-abc',
+        'start returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
       ].join('\n'),
     );
     expect(bare).not.toMatch(/\btoken\b/i);
 
-    // Base paste stays within the 5-line cap, with the key line intact at line 2 and the
-    // single loop pointer at line 3.
     const bareLines = bare.split('\n');
     expect(bareLines.length).toBeLessThanOrEqual(5);
     expect(bareLines).toHaveLength(3);
-    expect(bareLines[1]).toBe('Start with the gamedevpl tool, key: round-key-abc');
-    expect(bareLines[2]).toMatch(/after gate green you are done/);
-    // Exactly one loop pointer line — not one per tool call.
+    expect(bareLines[1]).toBe('Start with the gamedevpl tool, key: game-key-abc');
+    expect(bareLines[2]).toMatch(/keep this key for the next round/i);
     expect(bare.match(/your workflow/g)).toHaveLength(1);
+
+    const withReminder = buildKickoffPrompt({
+      title: 'Asteroids',
+      gameKey: 'game-key-abc',
+      sameKeyReminder: true,
+    });
+    expect(withReminder).toContain('Same key as before — nothing new to copy unless the creator rotated it.');
 
     const withPending = buildKickoffPrompt({
       title: 'Asteroids',
-      roundKey: 'round-key-abc',
+      gameKey: 'game-key-abc',
       pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
     });
-    // The loop line survives; "also apply:" bullets still append below, in order.
     const pendingLines = withPending.split('\n');
-    expect(pendingLines[1]).toBe('Start with the gamedevpl tool, key: round-key-abc');
-    expect(pendingLines[2]).toMatch(/after gate green you are done/);
+    expect(pendingLines[1]).toBe('Start with the gamedevpl tool, key: game-key-abc');
+    expect(pendingLines[2]).toMatch(/keep this key for the next round/i);
     expect(withPending.indexOf('- make the ship faster')).toBeLessThan(withPending.indexOf('- add a pause button'));
     expect(withPending).toContain('also apply:');
     expect(withPending).toContain('- make the ship faster');
@@ -128,21 +131,23 @@ describe('self-build-connect templates', () => {
   it('mints a payload whose expiresAt equals the key signed exp claim', () => {
     const now = Date.parse('2026-07-31T12:00:00Z');
     const payload = mintConnectPayload({
-      jobId: 42,
+      slug: 'nebula',
+      ownerUid: 'g:creator',
+      keyGeneration: 3,
       title: 'Nebula',
-      roundGeneration: 3,
       submissionTokenSecret: secret,
       appBaseUrl: APP_BASE,
       now,
     });
     const keyMatch = payload.kickoffPrompt.match(/key: (\S+)/);
     expect(keyMatch).toBeTruthy();
-    const roundKey = keyMatch![1]!;
-    const claims = verifyAgentToken(roundKey, secret);
-    expect(claims).toMatchObject({ jobId: 42, roundGeneration: 3 });
+    const gameKey = keyMatch![1]!;
+    const claims = verifyGameAgentKey(gameKey, secret);
+    expect(claims).toMatchObject({ slug: 'nebula', creatorUid: 'g:creator', keyGeneration: 3 });
     expect(payload.expiresAt).toBe(claims.exp);
-    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + 14 * 24 * 60 * 60);
-    expect(() => assertAgentTokenActive(claims, { roundGeneration: 3 }, now)).not.toThrow();
+    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + DEFAULT_GAME_AGENT_KEY_TTL_DAYS * 24 * 60 * 60);
+    expect(payload.keyGeneration).toBe(3);
+    expect(() => assertGameAgentKeyActive(claims, { keyGeneration: 3 }, now)).not.toThrow();
   });
 });
 
@@ -181,6 +186,7 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
       installSnippets: Record<string, string>;
       kickoffPrompt: string;
       expiresAt: number;
+      keyGeneration: number;
     };
 
     expect(Object.keys(body.installSnippets).sort()).toEqual(['claudeCode', 'cli', 'codex', 'cursor', 'kimi'].sort());
@@ -194,18 +200,16 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     expect(body.kickoffPrompt).toMatch(/Start with the gamedevpl tool, key: \S+/);
     expect(body.kickoffPrompt).not.toMatch(/\btoken\b/i);
 
-    const roundKey = body.kickoffPrompt.match(/key: (\S+)/)![1]!;
-    const claims = verifyAgentToken(roundKey, secret);
-    expect(claims.jobId).toBe(record.issueNumber);
-    expect(claims.roundGeneration).toBe(record.roundGeneration ?? 1);
+    expect(record.slug).toBeTruthy();
+    const gameKey = body.kickoffPrompt.match(/key: (\S+)/)![1]!;
+    const claims = verifyGameAgentKey(gameKey, secret);
+    expect(claims.slug).toBe(record.slug);
+    expect(claims.creatorUid).toBe(record.ownerUid);
+    const keyRecord = await store.getGameAgentKey(record.slug!);
+    expect(keyRecord).toBeTruthy();
+    expect(body.keyGeneration).toBe(keyRecord!.keyGeneration);
     expect(body.expiresAt).toBe(claims.exp);
-    expect(() =>
-      assertAgentTokenActive(
-        claims,
-        { roundGeneration: record.roundGeneration ?? 1 },
-        Date.parse('2026-07-31T12:00:00Z'),
-      ),
-    ).not.toThrow();
+    expect(() => assertGameAgentKeyActive(claims, keyRecord!, Date.parse('2026-07-31T12:00:00Z'))).not.toThrow();
   });
 
   it('rejects a stranger with 403', async () => {
@@ -368,12 +372,13 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     });
   });
 
-  it('binds the minted key to the job round generation', async () => {
+  it('binds the minted key to the game keyGeneration, not the round generation', async () => {
     const created = await createApp();
     app = created.app;
     const { store } = created;
 
     await store.createSubmission(77, 'g:creator', 'Bound Round');
+    await store.setSubmissionSlug(77, 'bound-round');
     await store.setRoundBuilder(77, 'self');
     await store.recordJobTransition(77, {
       to: 'dispatched',
@@ -381,7 +386,8 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
       by: 'system',
     });
     await store.ensureRoundGeneration(77);
-    // Simulate a later round: generation 2 is active.
+    await store.ensureGameAgentKey('bound-round', 'g:creator', new Date().toISOString());
+    // Simulate a later round: roundGeneration 2 is active; game keyGeneration stays 1.
     await store.bumpRoundGeneration(77);
     const afterBump = await store.getSubmission(77);
     expect(afterBump?.roundGeneration).toBe(2);
@@ -393,11 +399,11 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
       headers: authHeaders(),
     });
     expect(response.statusCode).toBe(200);
-    const roundKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
-    const claims = verifyAgentToken(roundKey, secret);
-    expect(claims).toMatchObject({ jobId: 77, roundGeneration: 2 });
-    expect(() => assertAgentTokenActive(claims, { roundGeneration: 1 })).toThrow();
-    expect(() => assertAgentTokenActive(claims, { roundGeneration: 2 })).not.toThrow();
+    const gameKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
+    const claims = verifyGameAgentKey(gameKey, secret);
+    expect(claims).toMatchObject({ slug: 'bound-round', creatorUid: 'g:creator', keyGeneration: 1 });
+    const keyRecord = await store.getGameAgentKey('bound-round');
+    expect(() => assertGameAgentKeyActive(claims, keyRecord!)).not.toThrow();
   });
 
   it('embeds pending unacknowledged creator inbox messages in the kickoff', async () => {
@@ -428,5 +434,161 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     expect(prompt).toContain('also apply:');
     expect(prompt).toContain('- add a pause button');
     expect(prompt).not.toContain('make the ship faster');
+  });
+});
+
+async function mcpStart(
+  app: FastifyInstance,
+  key: string,
+): Promise<{ ok: boolean; error?: string; sessionKey?: string }> {
+  const init = await app.inject({
+    method: 'POST',
+    url: '/api/mcp',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    payload: {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+    },
+  });
+  const sessionId = init.headers['mcp-session-id'] as string;
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/mcp',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'mcp-session-id': sessionId,
+    },
+    payload: {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'start', arguments: { key } },
+    },
+  });
+  const body = res.json() as {
+    result?: { isError?: boolean; structuredContent?: { sessionKey?: string }; content?: Array<{ text: string }> };
+  };
+  const structured =
+    body.result?.structuredContent ??
+    (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
+  if (body.result?.isError) {
+    return { ok: false, error: JSON.stringify(structured) };
+  }
+  return { ok: true, sessionKey: (structured as { sessionKey?: string })?.sessionKey };
+}
+
+function extractGameKey(kickoffPrompt: string): string {
+  return kickoffPrompt.match(/key: (\S+)/)![1]!;
+}
+
+describe('game agent key API (BY-23)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  async function submitSelfRound(store: InMemoryStore) {
+    const submit = await app!.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Key Game', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const id = submit.json().token as string;
+    const record = (await store.listSubmissionsByOwner('g:creator'))[0]!;
+    expect(record.slug).toBeTruthy();
+    return { id, record };
+  }
+
+  it('rotate bumps generation; old kickoff key fails start; new works', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+    const { id, record } = await submitSelfRound(store);
+
+    const connect = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    const oldKey = extractGameKey(connect.json().kickoffPrompt as string);
+
+    const rotated = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${id}/agent-key/rotate`,
+      headers: authHeaders(),
+    });
+    expect(rotated.statusCode).toBe(200);
+    expect(rotated.json().keyGeneration).toBe(2);
+    const newKey = extractGameKey(rotated.json().kickoffPrompt as string);
+
+    const oldStart = await mcpStart(app, oldKey);
+    expect(oldStart.ok).toBe(false);
+    expect(oldStart.error).toMatch(/rotated/i);
+
+    const newStart = await mcpStart(app, newKey);
+    expect(newStart.ok).toBe(true);
+    expect(newStart.sessionKey).toBeTruthy();
+    void record;
+  });
+
+  it('GET agent-key remint does NOT bump generation', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+    const { id } = await submitSelfRound(store);
+
+    const first = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/agent-key`,
+      headers: authHeaders(),
+    });
+    expect(first.statusCode).toBe(200);
+    const gen1 = first.json().keyGeneration as number;
+
+    const second = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/agent-key`,
+      headers: authHeaders(),
+    });
+    expect(second.statusCode).toBe(200);
+    expect(second.json().keyGeneration).toBe(gen1);
+
+    const keyRecord = await store.getGameAgentKey((await store.listSubmissionsByOwner('g:creator'))[0]!.slug!);
+    expect(keyRecord?.keyGeneration).toBe(gen1);
+  });
+
+  it('round close does not bump game keyGeneration', async () => {
+    const created = await createApp();
+    app = created.app;
+    const { store } = created;
+    const { id, record } = await submitSelfRound(store);
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    const beforeClose = await store.getGameAgentKey(record.slug!);
+    expect(beforeClose?.keyGeneration).toBe(1);
+
+    await store.recordJobTransition(record.issueNumber, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+
+    const afterClose = await store.getGameAgentKey(record.slug!);
+    expect(afterClose?.keyGeneration).toBe(1);
   });
 });

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -372,6 +372,36 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     });
   });
 
+  it('mints a slug on demand for a legacy self round missing one', async () => {
+    const created = await createApp({ now: () => Date.parse('2026-07-31T12:00:00Z') });
+    app = created.app;
+    const { store } = created;
+
+    await store.createSubmission(66, 'g:creator', 'Legacy Slugless');
+    await store.setRoundBuilder(66, 'self');
+    await store.recordJobTransition(66, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+    await store.ensureRoundGeneration(66);
+    const before = await store.getSubmission(66);
+    expect(before?.slug).toBeUndefined();
+
+    const id = mintToken(66, secret);
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${id}/connect`,
+      headers: authHeaders(),
+    });
+    expect(response.statusCode).toBe(200);
+    const after = await store.getSubmission(66);
+    expect(after?.slug).toBeTruthy();
+    const gameKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
+    const claims = verifyGameAgentKey(gameKey, secret);
+    expect(claims).toMatchObject({ slug: after!.slug, creatorUid: 'g:creator', keyGeneration: 1 });
+  });
+
   it('binds the minted key to the game keyGeneration, not the round generation', async () => {
     const created = await createApp();
     app = created.app;

--- a/apps/api/src/self-build-connect.ts
+++ b/apps/api/src/self-build-connect.ts
@@ -1,14 +1,15 @@
 /**
- * Connect payload for a self-build round (BY-03).
+ * Connect payload for a self-build round (BY-03 / BY-23).
  *
  * The Studio asks once for everything a creator needs to paste into their own coding
  * agent: per-client MCP install snippets (endpoint URL only — never a credential) and a
- * kickoff prompt that carries this round's key. Snippet templates live here so docs and
- * UI render from one source of truth; regenerating the prompt mints a fresh key with a
- * new signed `exp`, and any pending creator inbox lines ride along under "also apply:".
+ * kickoff prompt that carries this game's durable opener key. Snippet templates live here
+ * so docs and UI render from one source of truth. Regenerating the prompt remints a key
+ * with a fresh signed `exp` at the same keyGeneration — it does NOT rotate. Pending
+ * creator inbox lines ride along under "also apply:".
  */
 
-import { mintAgentToken, verifyAgentToken } from './agent-token.js';
+import { mintGameAgentKey, verifyGameAgentKey } from './agent-game-key.js';
 
 /** Path of the remote MCP endpoint (served by BY-05). Install snippets point here. */
 export const MCP_ENDPOINT_PATH = '/api/mcp';
@@ -29,6 +30,10 @@ export interface ConnectPayload {
    * display clock the UI could drift from.
    */
   expiresAt: number;
+  /** Current keyGeneration — display/rotate UI; not a secret. */
+  keyGeneration: number;
+  /** True when this kickoff is the same durable key the creator already pasted (BY-20 handoff). */
+  sameKeyAsBefore?: boolean;
 }
 
 export interface BuildInstallSnippetsInput {
@@ -38,19 +43,26 @@ export interface BuildInstallSnippetsInput {
 
 export interface BuildKickoffPromptInput {
   title: string;
-  /** Round-scoped build-channel key (embedded only in the kickoff, never in install). */
-  roundKey: string;
+  /** Durable per-game opener key (embedded only in the kickoff, never in install). */
+  gameKey: string;
   /** Undelivered creator inbox lines, oldest first. */
   pendingMessages?: readonly { text: string }[];
+  /**
+   * When true, append a line that nothing new needs pasting unless the creator rotated
+   * (post-publish improve handoff — BY-20 + BY-23).
+   */
+  sameKeyReminder?: boolean;
 }
 
 export interface MintConnectPayloadInput {
-  jobId: number;
+  slug: string;
+  ownerUid: string;
+  keyGeneration: number;
   title: string;
-  roundGeneration: number;
   submissionTokenSecret: string;
   appBaseUrl: string;
   pendingMessages?: readonly { text: string }[];
+  sameKeyReminder?: boolean;
   /** Epoch ms; defaults to `Date.now()`. */
   now?: number;
 }
@@ -62,7 +74,7 @@ export function mcpEndpointUrl(appBaseUrl: string): string {
 
 /**
  * Per-client install snippets. Every snippet configures the MCP endpoint URL and
- * nothing else — the round key rides the kickoff prompt, not the install.
+ * nothing else — the game key rides the kickoff prompt, not the install.
  */
 export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallSnippets {
   const url = mcpEndpointUrl(input.appBaseUrl);
@@ -90,9 +102,9 @@ export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallS
 
 /**
  * Paste-ready kickoff: build instruction + gamedevpl tool key line + one line pointing at
- * the session loop (start returns the workflow; gate green is done; the key retires with the
- * round), and any queued creator feedback as a short "also apply:" list so a regenerate never
- * drops them. The base paste stays ≤ 5 lines with the key line intact at line 2.
+ * the session loop (start returns the workflow; gate green ends the round — the game key
+ * stays valid for the next round unless rotated), and any queued creator feedback as a
+ * short "also apply:" list so a regenerate never drops them.
  *
  * User-facing copy says "key", never "token".
  */
@@ -100,9 +112,12 @@ export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
   const title = input.title.trim() || 'your game';
   const lines = [
     `Build "${title}" for gamedev.pl.`,
-    `Start with the gamedevpl tool, key: ${input.roundKey}`,
-    'start returns your workflow; after gate green you are done — this key retires with the round.',
+    `Start with the gamedevpl tool, key: ${input.gameKey}`,
+    'start returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
   ];
+  if (input.sameKeyReminder) {
+    lines.push('Same key as before — nothing new to copy unless the creator rotated it.');
+  }
   const pending = (input.pendingMessages ?? []).map((message) => message.text.trim()).filter((text) => text.length > 0);
   if (pending.length > 0) {
     lines.push('');
@@ -116,26 +131,27 @@ export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
 }
 
 /**
- * Mint a round-scoped key and assemble the connect payload. `expiresAt` is taken from
- * the key's verified `exp` claim so the UI's "expires" line cannot disagree with auth.
+ * Mint a durable per-game opener and assemble the connect payload. `expiresAt` is taken
+ * from the key's verified `exp` claim so the UI's "expires" line cannot disagree with auth.
  */
 export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPayload {
-  const roundKey = mintAgentToken(input.jobId, input.submissionTokenSecret, {
-    roundGeneration: input.roundGeneration,
+  const gameKey = mintGameAgentKey(input.submissionTokenSecret, {
+    slug: input.slug,
+    creatorUid: input.ownerUid,
+    keyGeneration: input.keyGeneration,
     now: input.now,
   });
-  const claims = verifyAgentToken(roundKey, input.submissionTokenSecret);
-  if (claims.exp === undefined) {
-    // Round-scoped mint always sets exp; a missing claim would mean mint/verify drifted.
-    throw new Error('minted connect key is missing exp claim');
-  }
+  const claims = verifyGameAgentKey(gameKey, input.submissionTokenSecret);
   return {
     installSnippets: buildInstallSnippets({ appBaseUrl: input.appBaseUrl }),
     kickoffPrompt: buildKickoffPrompt({
       title: input.title,
-      roundKey,
+      gameKey,
       pendingMessages: input.pendingMessages,
+      sameKeyReminder: input.sameKeyReminder,
     }),
     expiresAt: claims.exp,
+    keyGeneration: claims.keyGeneration,
+    sameKeyAsBefore: input.sameKeyReminder,
   };
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2973,7 +2973,10 @@ export class InMemoryStore implements Store {
   ): Promise<GameAgentKeyRecord | null> {
     const ensured = await this.ensureGameAgentKey(slug, ownerUid, at);
     if (!ensured) return null;
-    const next: GameAgentKeyRecord = { ...ensured, allowAgentOpenRounds: allow, updatedAt: at };
+    // Re-read after ensure: a concurrent rotate may have bumped keyGeneration.
+    const current = this.gameAgentKeys.get(slug);
+    if (!current || current.ownerUid !== ownerUid) return null;
+    const next: GameAgentKeyRecord = { ...current, allowAgentOpenRounds: allow, updatedAt: at };
     this.gameAgentKeys.set(slug, next);
     return { ...next };
   }
@@ -4754,11 +4757,31 @@ export class FirestoreStore implements Store {
     allow: boolean,
     at: string,
   ): Promise<GameAgentKeyRecord | null> {
-    const ensured = await this.ensureGameAgentKey(slug, ownerUid, at);
-    if (!ensured) return null;
-    const next: GameAgentKeyRecord = { ...ensured, allowAgentOpenRounds: allow, updatedAt: at };
-    await this.db.collection('gameAgentKeys').doc(slug).set(next);
-    return next;
+    const docRef = this.db.collection('gameAgentKeys').doc(slug);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) {
+        const created: GameAgentKeyRecord = {
+          slug,
+          ownerUid,
+          keyGeneration: 1,
+          createdAt: at,
+          updatedAt: at,
+          allowAgentOpenRounds: allow,
+        };
+        tx.create(docRef, created);
+        return created;
+      }
+      const existing = snap.data() as GameAgentKeyRecord;
+      if (existing.ownerUid !== ownerUid) return null;
+      const next: GameAgentKeyRecord = {
+        ...existing,
+        allowAgentOpenRounds: allow,
+        updatedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
+    });
   }
 
   async touchAccessToken(tokenId: string, at: string): Promise<void> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1101,6 +1101,23 @@ export interface AccessTokenRecord {
   lastUsedAt?: string;
 }
 
+/**
+ * Durable per-game agent opener state (BY-23), stored at `gameAgentKeys/{slug}`.
+ *
+ * The HMAC opener itself is never stored — only the generation that revokes it.
+ * Round close does not bump `keyGeneration`; only an explicit creator rotate does.
+ * `allowAgentOpenRounds` is reserved for BY-24 (default off).
+ */
+export interface GameAgentKeyRecord {
+  slug: string;
+  ownerUid: string;
+  keyGeneration: number;
+  createdAt: string;
+  updatedAt: string;
+  /** BY-24: when true, the creator's agent may call `open_round`. Default false. */
+  allowAgentOpenRounds?: boolean;
+}
+
 export interface Store {
   getUser(uid: string): Promise<User | null>;
   /**
@@ -1635,6 +1652,29 @@ export interface Store {
   deleteAccessToken(tokenId: string): Promise<boolean>;
   /** Best-effort last-use stamp; callers must not let a failure fail the request. */
   touchAccessToken(tokenId: string, at: string): Promise<void>;
+  /**
+   * Durable per-game opener state (BY-23). Returns null when no key has been issued
+   * for this slug yet.
+   */
+  getGameAgentKey(slug: string): Promise<GameAgentKeyRecord | null>;
+  /**
+   * Ensures a gameAgentKeys doc exists for (slug, ownerUid), creating generation 1
+   * when absent. If the doc exists for a different owner, returns null (caller must
+   * refuse — the slug is not theirs to key).
+   */
+  ensureGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null>;
+  /**
+   * Transactionally bumps `keyGeneration` for an owned slug. Returns the new record,
+   * or null when missing / not owned by `ownerUid`.
+   */
+  rotateGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null>;
+  /** BY-24: set whether the creator's agent may open improvement rounds. */
+  setGameAgentOpenRounds(
+    slug: string,
+    ownerUid: string,
+    allow: boolean,
+    at: string,
+  ): Promise<GameAgentKeyRecord | null>;
 }
 
 // Stable doc id for a subscription: a hash of its endpoint URL. Endpoints are long
@@ -1764,6 +1804,8 @@ export class InMemoryStore implements Store {
   private legacyGameSuggestions = new Set<string>();
   // tokenId -> personal access token record
   private accessTokens = new Map<string, AccessTokenRecord>();
+  // slug -> durable per-game agent opener state (BY-23)
+  private gameAgentKeys = new Map<string, GameAgentKeyRecord>();
 
   async getUser(uid: string): Promise<User | null> {
     const user = this.users.get(uid);
@@ -2886,6 +2928,54 @@ export class InMemoryStore implements Store {
   async touchAccessToken(tokenId: string, at: string): Promise<void> {
     const record = this.accessTokens.get(tokenId);
     if (record) this.accessTokens.set(tokenId, { ...record, lastUsedAt: at });
+  }
+
+  async getGameAgentKey(slug: string): Promise<GameAgentKeyRecord | null> {
+    const record = this.gameAgentKeys.get(slug);
+    return record ? { ...record } : null;
+  }
+
+  async ensureGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null> {
+    const existing = this.gameAgentKeys.get(slug);
+    if (existing) {
+      if (existing.ownerUid !== ownerUid) return null;
+      return { ...existing };
+    }
+    const created: GameAgentKeyRecord = {
+      slug,
+      ownerUid,
+      keyGeneration: 1,
+      createdAt: at,
+      updatedAt: at,
+      allowAgentOpenRounds: false,
+    };
+    this.gameAgentKeys.set(slug, created);
+    return { ...created };
+  }
+
+  async rotateGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null> {
+    const existing = this.gameAgentKeys.get(slug);
+    if (!existing || existing.ownerUid !== ownerUid) return null;
+    const next: GameAgentKeyRecord = {
+      ...existing,
+      keyGeneration: existing.keyGeneration + 1,
+      updatedAt: at,
+    };
+    this.gameAgentKeys.set(slug, next);
+    return { ...next };
+  }
+
+  async setGameAgentOpenRounds(
+    slug: string,
+    ownerUid: string,
+    allow: boolean,
+    at: string,
+  ): Promise<GameAgentKeyRecord | null> {
+    const ensured = await this.ensureGameAgentKey(slug, ownerUid, at);
+    if (!ensured) return null;
+    const next: GameAgentKeyRecord = { ...ensured, allowAgentOpenRounds: allow, updatedAt: at };
+    this.gameAgentKeys.set(slug, next);
+    return { ...next };
   }
 
   // Test/inspection only — production reads go through `listWaitlistEntries`.
@@ -4611,6 +4701,64 @@ export class FirestoreStore implements Store {
     if (!snap.exists) return false;
     await docRef.delete();
     return true;
+  }
+
+  async getGameAgentKey(slug: string): Promise<GameAgentKeyRecord | null> {
+    const snap = await this.db.collection('gameAgentKeys').doc(slug).get();
+    if (!snap.exists) return null;
+    return snap.data() as GameAgentKeyRecord;
+  }
+
+  async ensureGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null> {
+    const docRef = this.db.collection('gameAgentKeys').doc(slug);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (snap.exists) {
+        const existing = snap.data() as GameAgentKeyRecord;
+        if (existing.ownerUid !== ownerUid) return null;
+        return existing;
+      }
+      const created: GameAgentKeyRecord = {
+        slug,
+        ownerUid,
+        keyGeneration: 1,
+        createdAt: at,
+        updatedAt: at,
+        allowAgentOpenRounds: false,
+      };
+      tx.create(docRef, created);
+      return created;
+    });
+  }
+
+  async rotateGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null> {
+    const docRef = this.db.collection('gameAgentKeys').doc(slug);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as GameAgentKeyRecord;
+      if (existing.ownerUid !== ownerUid) return null;
+      const next: GameAgentKeyRecord = {
+        ...existing,
+        keyGeneration: existing.keyGeneration + 1,
+        updatedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
+    });
+  }
+
+  async setGameAgentOpenRounds(
+    slug: string,
+    ownerUid: string,
+    allow: boolean,
+    at: string,
+  ): Promise<GameAgentKeyRecord | null> {
+    const ensured = await this.ensureGameAgentKey(slug, ownerUid, at);
+    if (!ensured) return null;
+    const next: GameAgentKeyRecord = { ...ensured, allowAgentOpenRounds: allow, updatedAt: at };
+    await this.db.collection('gameAgentKeys').doc(slug).set(next);
+    return next;
   }
 
   async touchAccessToken(tokenId: string, at: string): Promise<void> {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1462,6 +1462,16 @@ export async function registerSubmissionRoutes(
   }
 
   /**
+   * Ensures a submission has a settled slug, minting one on demand for legacy rounds
+   * that predated slug-at-submission.
+   */
+  async function ensureSubmissionSlug(issueNumber: number, record: SubmissionRecord): Promise<string | null> {
+    if (record.slug) return record.slug;
+    const wanted = await mintGameSlug(record.title, async (candidate) => isSlugClaimed(candidate, issueNumber));
+    return confirmSlugClaim(issueNumber, wanted, record.title);
+  }
+
+  /**
    * Whether this request may play the unpublished game at `slug`.
    *
    * Two ways in, and no third: you made it, or its creator turned sharing on. There is
@@ -2157,7 +2167,9 @@ export async function registerSubmissionRoutes(
           builder: freshBuilder,
         });
       }
-      if (!fresh.slug) {
+
+      const slug = await ensureSubmissionSlug(issueNumber, fresh);
+      if (!slug) {
         return reply.status(409).send({
           error: 'connect_unavailable',
           reason: 'missing_slug',
@@ -2166,7 +2178,7 @@ export async function registerSubmissionRoutes(
       }
 
       const at = new Date(now()).toISOString();
-      const keyRecord = await store.ensureGameAgentKey(fresh.slug, fresh.ownerUid, at);
+      const keyRecord = await store.ensureGameAgentKey(slug, fresh.ownerUid, at);
       if (!keyRecord) {
         return reply.status(403).send({ error: 'only the creator can connect a build' });
       }
@@ -2176,7 +2188,7 @@ export async function registerSubmissionRoutes(
       // remind the creator there is nothing new to copy unless they rotated.
       const sameKeyReminder = (fresh.roundGeneration ?? 1) > 1 || Boolean(fresh.publishedAt);
       const payload = mintConnectPayload({
-        slug: fresh.slug,
+        slug,
         ownerUid: fresh.ownerUid,
         keyGeneration: keyRecord.keyGeneration,
         title: fresh.title,
@@ -2222,18 +2234,19 @@ export async function registerSubmissionRoutes(
       if (!record || record.ownerUid !== request.user!.uid) {
         return reply.status(403).send({ error: 'only the creator can manage this game key' });
       }
-      if (!record.slug) {
+      const slug = await ensureSubmissionSlug(issueNumber, record);
+      if (!slug) {
         return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
       }
 
       const at = new Date(now()).toISOString();
-      const keyRecord = await store.ensureGameAgentKey(record.slug, record.ownerUid, at);
+      const keyRecord = await store.ensureGameAgentKey(slug, record.ownerUid, at);
       if (!keyRecord) {
         return reply.status(403).send({ error: 'only the creator can manage this game key' });
       }
 
       const payload = mintConnectPayload({
-        slug: record.slug,
+        slug,
         ownerUid: record.ownerUid,
         keyGeneration: keyRecord.keyGeneration,
         title: record.title,
@@ -2243,7 +2256,7 @@ export async function registerSubmissionRoutes(
       });
 
       return reply.header('Cache-Control', 'no-store').send({
-        slug: record.slug,
+        slug,
         keyGeneration: keyRecord.keyGeneration,
         expiresAt: payload.expiresAt,
         allowAgentOpenRounds: keyRecord.allowAgentOpenRounds === true,
@@ -2277,23 +2290,24 @@ export async function registerSubmissionRoutes(
       if (!record || record.ownerUid !== request.user!.uid) {
         return reply.status(403).send({ error: 'only the creator can rotate this game key' });
       }
-      if (!record.slug) {
+      const slug = await ensureSubmissionSlug(issueNumber, record);
+      if (!slug) {
         return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
       }
 
       const at = new Date(now()).toISOString();
       // Ensure exists first so rotate has a generation to bump (first-time creators).
-      const ensured = await store.ensureGameAgentKey(record.slug, record.ownerUid, at);
+      const ensured = await store.ensureGameAgentKey(slug, record.ownerUid, at);
       if (!ensured) {
         return reply.status(403).send({ error: 'only the creator can rotate this game key' });
       }
-      const rotated = await store.rotateGameAgentKey(record.slug, record.ownerUid, at);
+      const rotated = await store.rotateGameAgentKey(slug, record.ownerUid, at);
       if (!rotated) {
         return reply.status(403).send({ error: 'only the creator can rotate this game key' });
       }
 
       const payload = mintConnectPayload({
-        slug: record.slug,
+        slug,
         ownerUid: record.ownerUid,
         keyGeneration: rotated.keyGeneration,
         title: record.title,
@@ -2303,7 +2317,7 @@ export async function registerSubmissionRoutes(
       });
 
       return reply.header('Cache-Control', 'no-store').send({
-        slug: record.slug,
+        slug,
         keyGeneration: rotated.keyGeneration,
         expiresAt: payload.expiresAt,
         allowAgentOpenRounds: rotated.allowAgentOpenRounds === true,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2096,10 +2096,11 @@ export async function registerSubmissionRoutes(
    * Everything a creator needs to connect their own coding agent to a self-build round.
    *
    * Creator-session auth, owner only. Valid only while the active round's builder is
-   * `self`. Install snippets configure the MCP URL alone; the round key rides the
-   * kickoff prompt (and regenerating mints a fresh key with a new signed `exp`).
-   * Pending, undelivered creator inbox lines are embedded under "also apply:" so a
-   * re-copy never drops queued feedback. See self-build-connect.ts for the templates.
+   * `self`. Install snippets configure the MCP URL alone; the durable per-game opener
+   * rides the kickoff prompt. Regenerating remints a key with a new signed `exp` at the
+   * same keyGeneration — it does NOT rotate. Pending, undelivered creator inbox lines
+   * are embedded under "also apply:" so a re-copy never drops queued feedback.
+   * See self-build-connect.ts for the templates.
    */
   app.get(
     '/api/submissions/:id/connect',
@@ -2143,11 +2144,10 @@ export async function registerSubmissionRoutes(
         });
       }
 
-      const roundGeneration = (await store.ensureRoundGeneration(issueNumber)) ?? 1;
+      await store.ensureRoundGeneration(issueNumber);
       // Re-read after ensureRoundGeneration: a closing transition can race between the
-      // first snapshot and minting. Without this we could mint generation N+1 for a
-      // round that just closed to ready_for_review (Codex P1) — channel auth only
-      // compares generations, and that state is not a stopReason.
+      // first snapshot and minting. Without this we could mint against a round that just
+      // closed to ready_for_review (Codex P1).
       const fresh = await store.getSubmission(issueNumber);
       const freshBuilder = fresh?.builder ?? 'platform';
       if (!fresh || freshBuilder !== 'self' || !isActiveBuildRound(fresh)) {
@@ -2157,19 +2157,160 @@ export async function registerSubmissionRoutes(
           builder: freshBuilder,
         });
       }
-      const activeGeneration = fresh.roundGeneration ?? roundGeneration;
+      if (!fresh.slug) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: 'missing_slug',
+          builder: freshBuilder,
+        });
+      }
+
+      const at = new Date(now()).toISOString();
+      const keyRecord = await store.ensureGameAgentKey(fresh.slug, fresh.ownerUid, at);
+      if (!keyRecord) {
+        return reply.status(403).send({ error: 'only the creator can connect a build' });
+      }
+
       const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
+      // Improve handoff (BY-20): a new job for the same slug shows the same durable key —
+      // remind the creator there is nothing new to copy unless they rotated.
+      const sameKeyReminder = (fresh.roundGeneration ?? 1) > 1 || Boolean(fresh.publishedAt);
       const payload = mintConnectPayload({
-        jobId: issueNumber,
+        slug: fresh.slug,
+        ownerUid: fresh.ownerUid,
+        keyGeneration: keyRecord.keyGeneration,
         title: fresh.title,
-        roundGeneration: activeGeneration,
         submissionTokenSecret,
         appBaseUrl: notifyAppBaseUrl,
         pendingMessages,
+        sameKeyReminder,
         now: now(),
       });
-      // Kickoff embeds a round key — never let intermediaries cache it.
+      // Kickoff embeds a capability — never let intermediaries cache it.
       return reply.header('Cache-Control', 'no-store').send(payload);
+    },
+  );
+
+  /**
+   * Durable per-game opener status + rotate (BY-23). Owner session only.
+   *
+   * GET returns whether a key is active, its generation, and a display kickoff (remint
+   * with fresh exp — does NOT rotate). POST bumps keyGeneration and returns a fresh
+   * kickoff; any agent still holding the old key is cut off.
+   */
+  app.get(
+    '/api/submissions/:id/agent-key',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret || !store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can manage this game key' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
+      }
+
+      const at = new Date(now()).toISOString();
+      const keyRecord = await store.ensureGameAgentKey(record.slug, record.ownerUid, at);
+      if (!keyRecord) {
+        return reply.status(403).send({ error: 'only the creator can manage this game key' });
+      }
+
+      const payload = mintConnectPayload({
+        slug: record.slug,
+        ownerUid: record.ownerUid,
+        keyGeneration: keyRecord.keyGeneration,
+        title: record.title,
+        submissionTokenSecret,
+        appBaseUrl: notifyAppBaseUrl,
+        now: now(),
+      });
+
+      return reply.header('Cache-Control', 'no-store').send({
+        slug: record.slug,
+        keyGeneration: keyRecord.keyGeneration,
+        expiresAt: payload.expiresAt,
+        allowAgentOpenRounds: keyRecord.allowAgentOpenRounds === true,
+        kickoffPrompt: payload.kickoffPrompt,
+        installSnippets: payload.installSnippets,
+      });
+    },
+  );
+
+  app.post(
+    '/api/submissions/:id/agent-key/rotate',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret || !store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can rotate this game key' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
+      }
+
+      const at = new Date(now()).toISOString();
+      // Ensure exists first so rotate has a generation to bump (first-time creators).
+      const ensured = await store.ensureGameAgentKey(record.slug, record.ownerUid, at);
+      if (!ensured) {
+        return reply.status(403).send({ error: 'only the creator can rotate this game key' });
+      }
+      const rotated = await store.rotateGameAgentKey(record.slug, record.ownerUid, at);
+      if (!rotated) {
+        return reply.status(403).send({ error: 'only the creator can rotate this game key' });
+      }
+
+      const payload = mintConnectPayload({
+        slug: record.slug,
+        ownerUid: record.ownerUid,
+        keyGeneration: rotated.keyGeneration,
+        title: record.title,
+        submissionTokenSecret,
+        appBaseUrl: notifyAppBaseUrl,
+        now: now(),
+      });
+
+      return reply.header('Cache-Control', 'no-store').send({
+        slug: record.slug,
+        keyGeneration: rotated.keyGeneration,
+        expiresAt: payload.expiresAt,
+        allowAgentOpenRounds: rotated.allowAgentOpenRounds === true,
+        kickoffPrompt: payload.kickoffPrompt,
+        installSnippets: payload.installSnippets,
+        rotated: true,
+      });
     },
   );
 

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -20,18 +20,34 @@ const payload = {
     kimi: 'npx -y mcp-remote https://www.gamedev.pl/api/mcp',
     cli: 'curl -sS -X POST https://www.gamedev.pl/api/mcp',
   },
-  kickoffPrompt: 'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def',
-  expiresAt: Math.floor(Date.now() / 1000) + 14 * 24 * 60 * 60,
+  kickoffPrompt:
+    'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def\nstart returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
+  expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
+  keyGeneration: 1,
 };
 
 describe('StudioConnectCard', () => {
   beforeEach(() => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => payload,
-      })),
+      vi.fn(async (input: RequestInfo) => {
+        const url = String(input);
+        if (url.includes('/agent-key/rotate')) {
+          return {
+            ok: true,
+            json: async () => ({
+              ...payload,
+              keyGeneration: 2,
+              kickoffPrompt: payload.kickoffPrompt.replace('abc.def', 'rotated.key'),
+              rotated: true,
+            }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => payload,
+        };
+      }),
     );
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -45,7 +61,7 @@ describe('StudioConnectCard', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders install tabs, kickoff, and waiting state', async () => {
+  it('renders install tabs, kickoff, expiry, and waiting state', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -70,9 +86,11 @@ describe('StudioConnectCard', () => {
     expect(container.textContent).toContain('Add gamedev.pl to your agent');
     expect(container.textContent).toContain('Tell your agent what to build');
     expect(container.textContent).toContain(payload.kickoffPrompt.split('\n')[0]);
-    expect(container.textContent).toMatch(/key works only for this game/i);
+    expect(container.textContent).toMatch(/works for this game/i);
+    expect(container.textContent).toMatch(/stays too unless you rotate/i);
     expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
     expect(container.querySelector('.studio-connect-waiting')).not.toBeNull();
+    expect(container.textContent).toContain('Rotate key');
 
     const cursorTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
       tab.textContent?.includes('Cursor'),
@@ -90,6 +108,78 @@ describe('StudioConnectCard', () => {
       await flush();
     });
     expect(container.textContent).toContain('Skipped');
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows sameKeyAsBefore reminder when the payload says so', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ ...payload, sameKeyAsBefore: true }),
+      })),
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.textContent).toMatch(/Same key as before/i);
+    await act(async () => root.unmount());
+  });
+
+  it('rotate flow confirms then refreshes the kickoff', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    const rotateStart = [...container.querySelectorAll<HTMLButtonElement>('button')].find((btn) =>
+      btn.textContent?.includes('Rotate key'),
+    );
+    await act(async () => {
+      rotateStart?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(container.textContent).toMatch(/Rotating stops any agent still using the old key/i);
+
+    const confirm = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (btn) => btn.textContent?.includes('Rotate') && !btn.textContent?.includes('Rotate key'),
+    );
+    await act(async () => {
+      confirm?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/submissions/status-tok/agent-key/rotate'),
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    );
+    expect(container.textContent).toContain('rotated.key');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
-import { CONNECT_CLIENTS, getConnectPayload, type ConnectClient, type ConnectPayload } from './connectApi.js';
+import {
+  CONNECT_CLIENTS,
+  getConnectPayload,
+  rotateAgentKey,
+  type ConnectClient,
+  type ConnectPayload,
+} from './connectApi.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
@@ -26,7 +32,7 @@ type StudioConnectCardProps = {
  * Connect card for a self-build round waiting on the creator's own coding agent.
  *
  * Step 1: add gamedev.pl to the agent (install snippets, skip if already done).
- * Step 2: paste the kickoff prompt (round key embedded). Live waiting flips away on
+ * Step 2: paste the kickoff prompt (durable game key embedded). Live waiting flips away on
  * the first agent signal — the parent hides this when `stall` leaves `no_agent_yet`.
  */
 export function StudioConnectCard({ token, agentConnected = false }: StudioConnectCardProps) {
@@ -38,6 +44,9 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
   const [client, setClient] = useState<ConnectClient>('claudeCode');
   const [step1Skipped, setStep1Skipped] = useState(false);
   const [copied, setCopied] = useState<'install' | 'kickoff' | null>(null);
+  const [rotateArmed, setRotateArmed] = useState(false);
+  const [rotating, setRotating] = useState(false);
+  const [rotateError, setRotateError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,8 +82,21 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     } catch {
       // Snippet stays on screen to select by hand.
     }
-    // Count the click either way — clipboard denial still means they meant to connect.
     recordStudioStep('connect_copied', 'self', which);
+  };
+
+  const handleRotate = async () => {
+    setRotating(true);
+    setRotateError(null);
+    try {
+      const next = await rotateAgentKey(token);
+      setPayload(next);
+      setRotateArmed(false);
+    } catch {
+      setRotateError(t('connect.rotate.error'));
+    } finally {
+      setRotating(false);
+    }
   };
 
   const expiresLabel = payload
@@ -149,12 +171,10 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
               </span>
               <h4 className="studio-connect-step-title">{t('connect.step2.title')}</h4>
             </div>
-            {/* The split creators miss at a round boundary: the gamedev.pl connection in
-                their agent's config is set up once (step 1) and stays put; what changes
-                every round is the key inside the prompt below. Without this line, a
-                creator handed a new build thread re-runs step 1 or edits config that was
-                never stale. */}
             <p className="studio-connect-same">{t('connect.step2.sameConnection')}</p>
+            {payload.sameKeyAsBefore ? (
+              <p className="studio-connect-same-key">{t('connect.step2.sameKeyAsBefore')}</p>
+            ) : null}
             <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
               {payload.kickoffPrompt}
             </pre>
@@ -167,7 +187,33 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
                 <PixelIcon name={copied === 'kickoff' ? 'check' : 'sparkle'} size={12} />{' '}
                 {copied === 'kickoff' ? t('connect.copied') : t('connect.copyKickoff')}
               </button>
+              {!rotateArmed ? (
+                <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                  {t('connect.rotate.start')}
+                </button>
+              ) : (
+                <span className="studio-connect-rotate-confirm">
+                  <span>{t('connect.rotate.confirm')}</span>
+                  <button
+                    type="button"
+                    className="studio-connect-skip is-danger"
+                    disabled={rotating}
+                    onClick={() => void handleRotate()}
+                  >
+                    {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
+                  </button>
+                  <button
+                    type="button"
+                    className="studio-connect-skip"
+                    disabled={rotating}
+                    onClick={() => setRotateArmed(false)}
+                  >
+                    {t('connect.rotate.no')}
+                  </button>
+                </span>
+              )}
             </div>
+            {rotateError ? <p className="error">{rotateError}</p> : null}
             <p className="studio-connect-expiry">{t('connect.step2.expiry', { when: expiresLabel })}</p>
           </div>
 

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -1,8 +1,8 @@
 /**
- * Client for GET /api/submissions/:id/connect (BY-03).
+ * Client for GET /api/submissions/:id/connect and durable game key management (BY-03 / BY-23).
  *
  * Returns everything the Studio connect card needs: per-client install snippets
- * (MCP URL only) and the kickoff prompt that carries this round's key.
+ * (MCP URL only) and the kickoff prompt that carries this game's durable key.
  */
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
@@ -15,8 +15,19 @@ export type InstallSnippets = Record<ConnectClient, string>;
 export type ConnectPayload = {
   installSnippets: InstallSnippets;
   kickoffPrompt: string;
-  /** Unix seconds — identical to the round key's signed exp. */
+  /** Unix seconds — identical to the game key's signed exp. */
   expiresAt: number;
+  /** Current keyGeneration — display/rotate UI; not a secret. */
+  keyGeneration?: number;
+  /** True when this kickoff is the same durable key the creator already pasted. */
+  sameKeyAsBefore?: boolean;
+};
+
+export type AgentKeyPayload = ConnectPayload & {
+  slug: string;
+  keyGeneration: number;
+  allowAgentOpenRounds: boolean;
+  rotated?: boolean;
 };
 
 export type ConnectApiError = Error & {
@@ -59,4 +70,31 @@ export async function getConnectPayload(token: string): Promise<ConnectPayload> 
 
   const body = (await response.json()) as ConnectPayload;
   return body;
+}
+
+/** Remint the durable game key at the current generation (fresh exp, no rotate). */
+export async function getAgentKey(token: string): Promise<AgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+
+  return (await response.json()) as AgentKeyPayload;
+}
+
+/** Bump keyGeneration and return a fresh kickoff — agents holding the old key are cut off. */
+export async function rotateAgentKey(token: string): Promise<AgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key/rotate`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+
+  return (await response.json()) as AgentKeyPayload;
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -860,8 +860,9 @@
     },
     "step2": {
       "title": "Tell your agent what to build",
-      "sameConnection": "Your gamedev.pl connection stays the same — only this round's key, inside the prompt below, is new. No need to change your agent's config.",
-      "expiry": "This key works only for this game and expires {{when}}."
+      "sameConnection": "Your gamedev.pl connection stays the same — this game's key in the prompt below stays too unless you rotate it. No need to change your agent's config between rounds.",
+      "sameKeyAsBefore": "Same key as before — nothing new to copy unless you rotated it.",
+      "expiry": "This key works for this game and expires {{when}}."
     },
     "clients": {
       "claudeCode": "Claude Code",
@@ -869,6 +870,14 @@
       "cursor": "Cursor",
       "kimi": "Kimi",
       "cli": "CLI"
+    },
+    "rotate": {
+      "start": "Rotate key",
+      "confirm": "Rotating stops any agent still using the old key. Continue?",
+      "yes": "Rotate",
+      "no": "Cancel",
+      "sending": "Rotating…",
+      "error": "We couldn't rotate the key right now. Try again in a moment."
     }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -864,8 +864,9 @@
     },
     "step2": {
       "title": "Powiedz agentowi, co zbudować",
-      "sameConnection": "Połączenie z gamedev.pl pozostaje bez zmian — nowy jest tylko klucz tej rundy, w prompcie poniżej. Nie musisz zmieniać konfiguracji agenta.",
-      "expiry": "Ten klucz działa tylko dla tej gry i wygasa {{when}}."
+      "sameConnection": "Połączenie z gamedev.pl pozostaje bez zmian — klucz tej gry w prompcie poniżej też zostaje, dopóki go nie obrócisz. Nie musisz zmieniać konfiguracji agenta między rundami.",
+      "sameKeyAsBefore": "Ten sam klucz co wcześniej — nic nowego do skopiowania, chyba że go obróciłeś.",
+      "expiry": "Ten klucz działa dla tej gry i wygasa {{when}}."
     },
     "clients": {
       "claudeCode": "Claude Code",
@@ -873,6 +874,14 @@
       "cursor": "Cursor",
       "kimi": "Kimi",
       "cli": "CLI"
+    },
+    "rotate": {
+      "start": "Obróć klucz",
+      "confirm": "Obrócenie zatrzyma każdego agenta, który nadal używa starego klucza. Kontynuować?",
+      "yes": "Obróć",
+      "no": "Anuluj",
+      "sending": "Obracanie…",
+      "error": "Nie udało się teraz obrócić klucza. Spróbuj za chwilę."
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creators paste one kickoff per **game** and keep prompting across rounds. The durable key is an **opener only** — exchanged at `start` for a round-scoped `sessionKey`; every write still requires that sessionKey.

## Invariant (must survive)

The durable key (`agent-game-v1`) is never a write capability. It can only be exchanged at `start` for a round-bound `sessionKey`. `submit_sources` / `report_progress` / `send_screenshot` / `ack_inbox` still require the short-lived sessionKey. Legacy round-scoped keys (`agent-channel-v1`) remain valid for in-flight rounds.

## Changes

1. **New token shape** — HMAC over `(agent-game-v1, slug, creatorUid, keyGeneration, exp)`; wire prefix `g1.` so it cannot forge/parse as a round key.
2. **Revocation** — `gameAgentKeys/{slug}` holds `keyGeneration`, bumped **only** on explicit rotate (not on round close).
3. **`start`** — accepts durable **or** legacy round key; durable path verifies generation, expiry, ownership, binds to the active `self` round; distinct refusals for no-open-round and platform-round.
4. **TTL** — `GAME_AGENT_KEY_TTL_DAYS` (default 90).
5. **Studio** — connect kickoff carries the game key; EN/PL copy; Rotate control with confirm; regenerating display remints `exp` without rotating; improve handoff reminds “same key — nothing new to copy unless rotated.”
6. **Install snippets** — still URL-only.

## Threat model (T4 widened)

A leaked durable key lets an attacker open sessions and deliver to **one game** until expiry or rotate — wider than today’s round scope. Compensating controls: per-round delivery cap, gate on every delivery, platform builds the bundle (D7), one-click rotate. Exposure is **not** unchanged.

## Tests

- api: **1746** green (incl. agent-game-key, resolve, connect, mcp-server)
- web: **903** green (incl. StudioConnectCard)

## Protocol

Draft for owner review. **BY-24** (`open_round`) branches from this after merge/approval.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

