### PR TITLE
feat(sensing): hand aim + pinch shell spike (Phase 1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "^0.10.18",
     "i18next": "^23.14.0",
     "i18next-browser-languagedetector": "^8.0.0",
     "react": "^18.3.1",

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -592,7 +592,23 @@ export function GameTheater({
           <div className="theater-camera-indicator" role="status" aria-live="polite">
             <span className="theater-camera-dot" aria-hidden="true" />
             {t('sensing.cameraLive')}
+            {sensing.hand.engaged
+              ? sensing.hand.tracking
+                ? ` · ${t('sensing.handTracking')}`
+                : ` · ${t('sensing.handLoading')}`
+              : null}
           </div>
+        ) : null}
+        {/* Phase 1 spike: shell-side aim crosshair so we can judge tracking before GameKit consumes it. */}
+        {sensing.hand.engaged && sensing.hand.tracking && sensing.hand.aim ? (
+          <div
+            className="theater-hand-aim"
+            style={{
+              left: `${((sensing.hand.aim.x + 1) / 2) * 100}%`,
+              top: `${((1 - sensing.hand.aim.y) / 2) * 100}%`,
+            }}
+            aria-hidden="true"
+          />
         ) : null}
         {/* A nudge, not a gate: the game stays playable and running underneath, and
             the hint clears itself the moment the device is turned. */}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -509,8 +509,8 @@ export function GameTheater({
                 type="button"
                 className="secondary-btn camera-btn"
                 onClick={sensing.backdrop.start}
-                title={t('sensing.cameraExplain')}
-                aria-label={t('sensing.cameraStartAria')}
+                title={sensing.hand.engaged ? t('sensing.cameraHandExplain') : t('sensing.cameraExplain')}
+                aria-label={sensing.hand.engaged ? t('sensing.cameraHandStartAria') : t('sensing.cameraStartAria')}
               >
                 <PixelIcon name="phone" size={13} />
                 <span className="btn-label">{t('sensing.cameraStart')}</span>
@@ -598,17 +598,6 @@ export function GameTheater({
                 : ` · ${t('sensing.handLoading')}`
               : null}
           </div>
-        ) : null}
-        {/* Phase 1 spike: shell-side aim crosshair so we can judge tracking before GameKit consumes it. */}
-        {sensing.hand.engaged && sensing.hand.tracking && sensing.hand.aim ? (
-          <div
-            className="theater-hand-aim"
-            style={{
-              left: `${((sensing.hand.aim.x + 1) / 2) * 100}%`,
-              top: `${((1 - sensing.hand.aim.y) / 2) * 100}%`,
-            }}
-            aria-hidden="true"
-          />
         ) : null}
         {/* A nudge, not a gate: the game stays playable and running underneath, and
             the hint clears itself the moment the device is turned. */}

--- a/apps/web/src/handLandmarker.ts
+++ b/apps/web/src/handLandmarker.ts
@@ -1,14 +1,14 @@
 /**
  * Lazy MediaPipe Hand Landmarker loader for the sensing Phase 1 shell spike.
  *
- * The npm package is first-party code; the `.task` model still loads from Google
- * storage during the spike. Production must vendor wasm + model under our origin
- * before store submission (ops camera-verbs-plan §4.3 / §5).
+ * The package is loaded only inside `loadHandLandmarker()` so the always-mounted
+ * sensing bridge does not pull MediaPipe into the startup graph. The `.task` model
+ * still loads from Google storage during the spike. Production must vendor wasm +
+ * model under our origin before store submission (ops camera-verbs-plan §4.3 / §5).
  *
  * Failures are soft: the game keeps keyboard/pointer; hand simply stays unavailable.
  */
 
-import { FilesetResolver, HandLandmarker } from '@mediapipe/tasks-vision';
 import type { Landmark } from './handVerbs.js';
 
 const WASM_ROOT = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.18/wasm';
@@ -27,28 +27,27 @@ let loadPromise: Promise<HandLandmarkerHandle | null> | null = null;
 
 async function createLandmarker(): Promise<HandLandmarkerHandle | null> {
   try {
+    const { FilesetResolver, HandLandmarker } = await import('@mediapipe/tasks-vision');
     const fileset = await FilesetResolver.forVisionTasks(WASM_ROOT);
-    const landmarker = await HandLandmarker.createFromOptions(fileset, {
-      baseOptions: { modelAssetPath: MODEL_URL, delegate: 'GPU' },
-      runningMode: 'VIDEO',
-      numHands: 1,
-      minHandDetectionConfidence: 0.55,
-      minHandPresenceConfidence: 0.55,
-      minTrackingConfidence: 0.55,
-    });
-    return landmarker;
-  } catch {
-    // CPU fallback — some iOS WebViews reject the GPU delegate.
     try {
-      const fileset = await FilesetResolver.forVisionTasks(WASM_ROOT);
+      return await HandLandmarker.createFromOptions(fileset, {
+        baseOptions: { modelAssetPath: MODEL_URL, delegate: 'GPU' },
+        runningMode: 'VIDEO',
+        numHands: 1,
+        minHandDetectionConfidence: 0.55,
+        minHandPresenceConfidence: 0.55,
+        minTrackingConfidence: 0.55,
+      });
+    } catch {
+      // CPU fallback — some iOS WebViews reject the GPU delegate.
       return await HandLandmarker.createFromOptions(fileset, {
         baseOptions: { modelAssetPath: MODEL_URL, delegate: 'CPU' },
         runningMode: 'VIDEO',
         numHands: 1,
       });
-    } catch {
-      return null;
     }
+  } catch {
+    return null;
   }
 }
 

--- a/apps/web/src/handLandmarker.ts
+++ b/apps/web/src/handLandmarker.ts
@@ -1,0 +1,89 @@
+/**
+ * Lazy MediaPipe Hand Landmarker loader for the sensing Phase 1 shell spike.
+ *
+ * The npm package is first-party code; the `.task` model still loads from Google
+ * storage during the spike. Production must vendor wasm + model under our origin
+ * before store submission (ops camera-verbs-plan §4.3 / §5).
+ *
+ * Failures are soft: the game keeps keyboard/pointer; hand simply stays unavailable.
+ */
+
+import { FilesetResolver, HandLandmarker } from '@mediapipe/tasks-vision';
+import type { Landmark } from './handVerbs.js';
+
+const WASM_ROOT = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.18/wasm';
+const MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task';
+
+export type HandLandmarkerHandle = {
+  detectForVideo: (
+    video: HTMLVideoElement,
+    timestamp: number,
+  ) => { landmarks: Array<Array<{ x: number; y: number; z?: number }>> };
+  close: () => void;
+};
+
+let loadPromise: Promise<HandLandmarkerHandle | null> | null = null;
+
+async function createLandmarker(): Promise<HandLandmarkerHandle | null> {
+  try {
+    const fileset = await FilesetResolver.forVisionTasks(WASM_ROOT);
+    const landmarker = await HandLandmarker.createFromOptions(fileset, {
+      baseOptions: { modelAssetPath: MODEL_URL, delegate: 'GPU' },
+      runningMode: 'VIDEO',
+      numHands: 1,
+      minHandDetectionConfidence: 0.55,
+      minHandPresenceConfidence: 0.55,
+      minTrackingConfidence: 0.55,
+    });
+    return landmarker;
+  } catch {
+    // CPU fallback — some iOS WebViews reject the GPU delegate.
+    try {
+      const fileset = await FilesetResolver.forVisionTasks(WASM_ROOT);
+      return await HandLandmarker.createFromOptions(fileset, {
+        baseOptions: { modelAssetPath: MODEL_URL, delegate: 'CPU' },
+        runningMode: 'VIDEO',
+        numHands: 1,
+      });
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Shared loader — one model instance per page is enough for the theater. */
+export function loadHandLandmarker(): Promise<HandLandmarkerHandle | null> {
+  if (!loadPromise) loadPromise = createLandmarker();
+  return loadPromise;
+}
+
+/** Test seam: reset the memoized loader. */
+export function resetHandLandmarkerLoader(): void {
+  loadPromise = null;
+}
+
+export function landmarksFromVideo(
+  landmarker: HandLandmarkerHandle,
+  video: HTMLVideoElement,
+  timestampMs: number,
+): Landmark[] | null {
+  if (video.readyState < 2 || video.videoWidth === 0) return null;
+  try {
+    const result = landmarker.detectForVideo(video, timestampMs);
+    const hand = result.landmarks?.[0];
+    if (!hand || hand.length < 9) return null;
+    return hand.map((p) => ({ x: p.x, y: p.y, z: p.z }));
+  } catch {
+    return null;
+  }
+}
+
+/** Closed-beta spike: `?handSpike=1` on the theater URL forces the hand pipeline. */
+export function handSpikeEnabled(): boolean {
+  try {
+    return typeof location !== 'undefined' && new URLSearchParams(location.search).get('handSpike') === '1';
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/handLandmarker.ts
+++ b/apps/web/src/handLandmarker.ts
@@ -77,12 +77,3 @@ export function landmarksFromVideo(
     return null;
   }
 }
-
-/** Closed-beta spike: `?handSpike=1` on the theater URL forces the hand pipeline. */
-export function handSpikeEnabled(): boolean {
-  try {
-    return typeof location !== 'undefined' && new URLSearchParams(location.search).get('handSpike') === '1';
-  } catch {
-    return false;
-  }
-}

--- a/apps/web/src/handVerbs.test.ts
+++ b/apps/web/src/handVerbs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HAND_AIM_MIN_INTERVAL_MS,
+  PINCH_OFF,
+  PINCH_ON,
+  PINCH_REFRACTORY_MS,
+  aimFromIndexTip,
+  createHandVerbState,
+  pinchDistance,
+  sampleHandVerbs,
+  type Landmark,
+} from './handVerbs.js';
+
+function tips(thumb: Landmark, index: Landmark): Landmark[] {
+  const pts: Landmark[] = Array.from({ length: 21 }, () => ({ x: 0.5, y: 0.5 }));
+  pts[4] = thumb;
+  pts[8] = index;
+  return pts;
+}
+
+describe('aimFromIndexTip', () => {
+  it('maps image centre to stick zero', () => {
+    expect(aimFromIndexTip({ x: 0.5, y: 0.5 }, false)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('maps top-left of the image to up-left without mirror', () => {
+    expect(aimFromIndexTip({ x: 0, y: 0 }, false)).toEqual({ x: -1, y: 1 });
+  });
+
+  it('mirrors x for a user-facing camera', () => {
+    expect(aimFromIndexTip({ x: 0, y: 0.5 }, true)).toEqual({ x: 1, y: 0 });
+    expect(aimFromIndexTip({ x: 1, y: 0.5 }, true)).toEqual({ x: -1, y: 0 });
+  });
+});
+
+describe('sampleHandVerbs', () => {
+  it('emits a pinch rising edge once, then needs an open before re-arming', () => {
+    const state = createHandVerbState();
+    const close = tips({ x: 0.5, y: 0.5 }, { x: 0.5 + PINCH_ON * 0.5, y: 0.5 });
+    const open = tips({ x: 0.5, y: 0.5 }, { x: 0.5 + PINCH_OFF + 0.01, y: 0.5 });
+
+    expect(sampleHandVerbs(state, close, 1_000, { mirror: false }).pinchEdge).toBe(true);
+    expect(sampleHandVerbs(state, close, 1_050, { mirror: false }).pinchEdge).toBe(false);
+
+    // Still closed — no edge.
+    expect(sampleHandVerbs(state, close, 1_000 + PINCH_REFRACTORY_MS + 10, { mirror: false }).pinchEdge).toBe(false);
+
+    sampleHandVerbs(state, open, 2_000, { mirror: false });
+    expect(sampleHandVerbs(state, close, 2_100, { mirror: false }).pinchEdge).toBe(true);
+  });
+
+  it('throttles aim posts to the hand budget', () => {
+    const state = createHandVerbState();
+    const hand = tips({ x: 0.4, y: 0.4 }, { x: 0.6, y: 0.4 });
+    const first = sampleHandVerbs(state, hand, 5_000, { mirror: false });
+    expect(first.aim).toEqual(aimFromIndexTip(hand[8]!, false));
+    const second = sampleHandVerbs(state, hand, 5_000 + HAND_AIM_MIN_INTERVAL_MS - 1, { mirror: false });
+    expect(second.aim).toBeNull();
+    const third = sampleHandVerbs(state, hand, 5_000 + HAND_AIM_MIN_INTERVAL_MS, { mirror: false });
+    expect(third.aim).not.toBeNull();
+  });
+
+  it('treats a missing hand as no verbs', () => {
+    const state = createHandVerbState();
+    expect(sampleHandVerbs(state, null, 1, { mirror: true })).toEqual({ aim: null, pinchEdge: false });
+    expect(sampleHandVerbs(state, [], 1, { mirror: true })).toEqual({ aim: null, pinchEdge: false });
+  });
+});
+
+describe('pinchDistance', () => {
+  it('is zero for coincident tips', () => {
+    expect(pinchDistance({ x: 0.2, y: 0.3 }, { x: 0.2, y: 0.3 })).toBe(0);
+  });
+});

--- a/apps/web/src/handVerbs.ts
+++ b/apps/web/src/handVerbs.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure landmark → game-verb math for sensing Phase 1 (camera hand control).
+ *
+ * The shell runs MediaPipe (or a stub) and feeds 21 normalized hand landmarks
+ * here. Only the sanitized outputs — aim in [-1,1] and pinch rising edges —
+ * ever cross into the game iframe. Unit-tested without the model.
+ *
+ * Landmark indices match MediaPipe Hands:
+ *   4  thumb tip
+ *   8  index fingertip  (aim)
+ */
+
+export type Landmark = { x: number; y: number; z?: number };
+
+/** Max posts per second for aim — battery / bridge budget. */
+export const HAND_AIM_HZ = 15;
+export const HAND_AIM_MIN_INTERVAL_MS = Math.ceil(1000 / HAND_AIM_HZ);
+
+/** Pinch distance (normalized image space) below this = pinched. */
+export const PINCH_ON = 0.055;
+/** Must open past this before another pinch can fire (hysteresis). */
+export const PINCH_OFF = 0.09;
+/** Ignore pinch edges closer than this (ms). */
+export const PINCH_REFRACTORY_MS = 280;
+
+export type HandAim = { x: number; y: number };
+
+export type HandVerbState = {
+  /** Last emitted aim, or null before the first sample. */
+  aim: HandAim | null;
+  pinched: boolean;
+  lastAimAt: number;
+  lastPinchAt: number;
+};
+
+export function createHandVerbState(): HandVerbState {
+  return { aim: null, pinched: false, lastAimAt: 0, lastPinchAt: 0 };
+}
+
+function clamp1(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+/**
+ * Map index fingertip into a stick-like aim.
+ * MediaPipe x grows right, y grows down in image space.
+ * For a mirrored user-facing camera the shell already mirrors the <video>;
+ * landmarks from detectForVideo follow the unmirrored frame — flip x when
+ * `mirror` is true so "hand left of frame" aims left on screen.
+ */
+export function aimFromIndexTip(tip: Landmark, mirror: boolean): HandAim {
+  const nx = mirror ? 1 - tip.x : tip.x;
+  // Image y down → stick y up (same convention as tilt / WASD).
+  return {
+    x: clamp1(nx * 2 - 1),
+    y: clamp1(1 - tip.y * 2),
+  };
+}
+
+export function pinchDistance(thumb: Landmark, index: Landmark): number {
+  const dx = thumb.x - index.x;
+  const dy = thumb.y - index.y;
+  return Math.hypot(dx, dy);
+}
+
+export type HandVerbSample = {
+  aim: HandAim | null;
+  /** True exactly once per pinch press (rising edge after hysteresis). */
+  pinchEdge: boolean;
+};
+
+/**
+ * Fold one landmark frame into verb outputs. Returns null aim when throttled
+ * (caller should not post). Pinch edges always return even if aim is throttled.
+ */
+export function sampleHandVerbs(
+  state: HandVerbState,
+  landmarks: Landmark[] | null,
+  nowMs: number,
+  opts: { mirror: boolean },
+): HandVerbSample {
+  if (!landmarks || landmarks.length < 9) {
+    return { aim: null, pinchEdge: false };
+  }
+  const thumb = landmarks[4];
+  const index = landmarks[8];
+  if (!thumb || !index) return { aim: null, pinchEdge: false };
+
+  const dist = pinchDistance(thumb, index);
+  let pinchEdge = false;
+  if (!state.pinched && dist <= PINCH_ON) {
+    if (nowMs - state.lastPinchAt >= PINCH_REFRACTORY_MS) {
+      pinchEdge = true;
+      state.lastPinchAt = nowMs;
+    }
+    state.pinched = true;
+  } else if (state.pinched && dist >= PINCH_OFF) {
+    state.pinched = false;
+  }
+
+  let aim: HandAim | null = null;
+  if (nowMs - state.lastAimAt >= HAND_AIM_MIN_INTERVAL_MS) {
+    aim = aimFromIndexTip(index, opts.mirror);
+    state.aim = aim;
+    state.lastAimAt = nowMs;
+  }
+
+  return { aim, pinchEdge };
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -773,7 +773,9 @@
     "cameraStop": "Stop camera",
     "cameraLive": "Camera on",
     "cameraExplain": "Nothing is recorded or sent — the camera stays in your browser and only shows behind the game.",
-    "cameraStartAria": "Start camera backdrop — allow camera access. Nothing is recorded or sent."
+    "cameraStartAria": "Start camera backdrop — allow camera access. Nothing is recorded or sent.",
+    "handLoading": "Hand…",
+    "handTracking": "Hand"
   },
   "pageTitle": {
     "home": "Gamedev.pl — Describe a game, play it",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -774,6 +774,8 @@
     "cameraLive": "Camera on",
     "cameraExplain": "Nothing is recorded or sent — the camera stays in your browser and only shows behind the game.",
     "cameraStartAria": "Start camera backdrop — allow camera access. Nothing is recorded or sent.",
+    "cameraHandExplain": "Nothing is recorded or sent — hand position can steer the game; everything stays in your browser.",
+    "cameraHandStartAria": "Start camera for hand control — allow camera access. Nothing is recorded or sent.",
     "handLoading": "Hand…",
     "handTracking": "Hand"
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -778,6 +778,8 @@
     "cameraLive": "Kamera włączona",
     "cameraExplain": "Nic nie jest nagrywane ani wysyłane — kamera zostaje w przeglądarce i tylko widać ją pod grą.",
     "cameraStartAria": "Włącz tło z kamery — zezwól na dostęp do kamery. Nic nie jest nagrywane ani wysyłane.",
+    "cameraHandExplain": "Nic nie jest nagrywane ani wysyłane — pozycja dłoni może sterować grą; wszystko zostaje w przeglądarce.",
+    "cameraHandStartAria": "Włącz kamerę do sterowania dłonią — zezwól na dostęp. Nic nie jest nagrywane ani wysyłane.",
     "handLoading": "Dłoń…",
     "handTracking": "Dłoń"
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -777,7 +777,9 @@
     "cameraStop": "Wyłącz kamerę",
     "cameraLive": "Kamera włączona",
     "cameraExplain": "Nic nie jest nagrywane ani wysyłane — kamera zostaje w przeglądarce i tylko widać ją pod grą.",
-    "cameraStartAria": "Włącz tło z kamery — zezwól na dostęp do kamery. Nic nie jest nagrywane ani wysyłane."
+    "cameraStartAria": "Włącz tło z kamery — zezwól na dostęp do kamery. Nic nie jest nagrywane ani wysyłane.",
+    "handLoading": "Dłoń…",
+    "handTracking": "Dłoń"
   },
   "pageTitle": {
     "home": "Gamedev.pl — Opisz grę, zagraj w nią",

--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -168,9 +168,9 @@ export const privacyEn: LegalDocument = {
         {
           kind: 'p',
           text:
-            'Some games can show your device camera behind the play surface. That feed is displayed only in your ' +
-            'browser for the session; it is never recorded, never uploaded, and never included in the gameplay ' +
-            'statistics above.',
+            'Some games can show your device camera behind the play surface, and some can estimate hand position ' +
+            'for control. That processing happens only in your browser for the session; frames and landmarks are ' +
+            'never recorded, never uploaded, and never included in the gameplay statistics above.',
         },
       ],
     },

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -173,9 +173,9 @@ export const privacyPl: LegalDocument = {
         {
           kind: 'p',
           text:
-            'Niektóre gry mogą pokazać obraz z kamery urządzenia pod powierzchnią gry. Ten obraz jest wyświetlany ' +
-            'tylko w przeglądarce na czas sesji; nigdy nie jest nagrywany, nigdy nie jest przesyłany i nigdy nie ' +
-            'trafia do powyższych statystyk rozgrywki.',
+            'Niektóre gry mogą pokazać obraz z kamery urządzenia pod powierzchnią gry, a niektóre mogą oszacować ' +
+            'pozycję dłoni do sterowania. To przetwarzanie odbywa się tylko w przeglądarce na czas sesji; klatki ' +
+            'i punkty dłoni nigdy nie są nagrywane, przesyłane ani włączane do powyższych statystyk rozgrywki.',
         },
       ],
     },

--- a/apps/web/src/sensing.ts
+++ b/apps/web/src/sensing.ts
@@ -273,7 +273,11 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
       .then((stream) => {
         acquiringRef.current = false;
         // Theater closed, feature dropped, tab hidden, or a newer stop invalidated us.
-        if (gen !== acquireGenRef.current || !wantsBackdropRef.current || document.visibilityState === 'hidden') {
+        if (
+          gen !== acquireGenRef.current ||
+          (!wantsBackdropRef.current && !wantsHandRef.current) ||
+          document.visibilityState === 'hidden'
+        ) {
           for (const track of stream.getTracks()) track.stop();
           return;
         }
@@ -325,7 +329,9 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
       }
 
       wantsTiltRef.current = wantsTilt;
-      wantsBackdropRef.current = wantsBackdrop;
+      // Hand tracking needs the same camera stream; keep the "camera wanted" ref true
+      // for either backdrop or hand so getUserMedia resolve does not drop the tracks.
+      wantsBackdropRef.current = wantsBackdrop || wantsHand;
       wantsHandRef.current = wantsHand;
       setTiltEngaged(wantsTilt);
       setHandEngaged(wantsHand);
@@ -438,6 +444,9 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
 
     let cancelled = false;
     let raf = 0;
+    /** Sample the model ~30 Hz — verb posts are throttled further in handVerbs. */
+    const DETECT_MIN_MS = 33;
+    let lastDetectAt = 0;
     const verbState = createHandVerbState();
     const video = document.createElement('video');
     video.playsInline = true;
@@ -457,20 +466,23 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
       const tick = () => {
         if (cancelled) return;
         const now = performance.now();
-        const landmarks = landmarksFromVideo(landmarker, video, now);
-        const sample = sampleHandVerbs(verbState, landmarks, now, { mirror });
-        if (landmarks && !handReadyRef.current) {
-          handReadyRef.current = true;
-          setHandTracking(true);
-          postState();
-        }
-        if (sample.aim) {
-          setHandAim(sample.aim);
-          postToGame({ t: 'sensing:hand', x: sample.aim.x, y: sample.aim.y });
-        }
-        if (sample.pinchEdge) {
-          setHandLastPinchAt(now);
-          postToGame({ t: 'sensing:act', name: 'banish' });
+        if (now - lastDetectAt >= DETECT_MIN_MS) {
+          lastDetectAt = now;
+          const landmarks = landmarksFromVideo(landmarker, video, now);
+          const sample = sampleHandVerbs(verbState, landmarks, now, { mirror });
+          if (landmarks && !handReadyRef.current) {
+            handReadyRef.current = true;
+            setHandTracking(true);
+            postState();
+          }
+          if (sample.aim) {
+            setHandAim(sample.aim);
+            postToGame({ t: 'sensing:hand', x: sample.aim.x, y: sample.aim.y });
+          }
+          if (sample.pinchEdge) {
+            setHandLastPinchAt(now);
+            postToGame({ t: 'sensing:act', name: 'banish' });
+          }
         }
         raf = requestAnimationFrame(tick);
       };

--- a/apps/web/src/sensing.ts
+++ b/apps/web/src/sensing.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
-import { handSpikeEnabled, landmarksFromVideo, loadHandLandmarker } from './handLandmarker.js';
+import { landmarksFromVideo, loadHandLandmarker } from './handLandmarker.js';
 import { createHandVerbState, sampleHandVerbs, type HandAim } from './handVerbs.js';
 import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { tiltFromOrientation } from './useDeviceTilt.js';
@@ -18,9 +18,9 @@ import { tiltFromOrientation } from './useDeviceTilt.js';
  * clears transparent when true. Camera never auto-starts; a theater chrome tap is
  * required every session.
  *
- * Phase 1 (spike) — hand verbs: when a game asks for `hand` (or `?handSpike=1`), the
- * shell runs MediaPipe on that same camera stream and posts clamped `sensing:hand`
- * aim + `sensing:act` pinch edges. Landmarks never enter the iframe.
+ * Phase 1 — hand verbs: when a game asks for `hand`, the shell runs MediaPipe on that
+ * same camera stream and posts clamped `sensing:hand` aim + `sensing:act` pinch edges.
+ * Landmarks never enter the iframe.
  *
  * Shared properties of both phases:
  *
@@ -128,7 +128,7 @@ export type SensingBackdrop = {
 };
 
 export type SensingHand = {
-  /** Game asked for hand (or closed-beta `?handSpike=1`). */
+  /** Game asked for hand verbs. */
   engaged: boolean;
   /** Landmarker loaded and at least one hand frame decoded. */
   tracking: boolean;
@@ -313,8 +313,7 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
 
       const wantsTilt = message.features.includes('tilt');
       const wantsBackdrop = message.features.includes('backdrop');
-      // Spike: `?handSpike=1` opts the theater into hand verbs without a games-repo change.
-      const wantsHand = message.features.includes('hand') || handSpikeEnabled();
+      const wantsHand = message.features.includes('hand');
       // Unknown-only hellos are noise before any engagement. Once a game has said
       // hello, a later hello is authoritative — including one that drops features.
       if (

--- a/apps/web/src/sensing.ts
+++ b/apps/web/src/sensing.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { handSpikeEnabled, landmarksFromVideo, loadHandLandmarker } from './handLandmarker.js';
+import { createHandVerbState, sampleHandVerbs, type HandAim } from './handVerbs.js';
 import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { tiltFromOrientation } from './useDeviceTilt.js';
 
@@ -15,6 +17,10 @@ import { tiltFromOrientation } from './useDeviceTilt.js';
  * boolean `backdrop` on `sensing:state`. The game paints a stand-in when false and
  * clears transparent when true. Camera never auto-starts; a theater chrome tap is
  * required every session.
+ *
+ * Phase 1 (spike) — hand verbs: when a game asks for `hand` (or `?handSpike=1`), the
+ * shell runs MediaPipe on that same camera stream and posts clamped `sensing:hand`
+ * aim + `sensing:act` pinch edges. Landmarks never enter the iframe.
  *
  * Shared properties of both phases:
  *
@@ -121,6 +127,17 @@ export type SensingBackdrop = {
   stop: () => void;
 };
 
+export type SensingHand = {
+  /** Game asked for hand (or closed-beta `?handSpike=1`). */
+  engaged: boolean;
+  /** Landmarker loaded and at least one hand frame decoded. */
+  tracking: boolean;
+  /** Last aim posted to the game — theater debug overlay only. */
+  aim: HandAim | null;
+  /** Millis of the last pinch edge (0 if none). */
+  lastPinchAt: number;
+};
+
 export type SensingBridge = {
   /** A game in the frame has asked for tilt. Until then, render nothing tilt-related. */
   engaged: boolean;
@@ -134,6 +151,8 @@ export type SensingBridge = {
   request: () => void;
   /** Camera-backdrop half; `engaged` is false until a game asks for it. */
   backdrop: SensingBackdrop;
+  /** Hand-verb half (Phase 1 spike). */
+  hand: SensingHand;
 };
 
 function cameraSupported(): boolean {
@@ -161,6 +180,10 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
   const [backdropLive, setBackdropLive] = useState(false);
   const [backdropFacing, setBackdropFacing] = useState<BackdropFacing>('user');
   const [backdropStream, setBackdropStream] = useState<MediaStream | null>(null);
+  const [handEngaged, setHandEngaged] = useState(false);
+  const [handTracking, setHandTracking] = useState(false);
+  const [handAim, setHandAim] = useState<HandAim | null>(null);
+  const [handLastPinchAt, setHandLastPinchAt] = useState(0);
 
   const tiltActiveRef = useRef(false);
   const backdropLiveRef = useRef(false);
@@ -172,6 +195,8 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
   const acquireGenRef = useRef(0);
   const wantsTiltRef = useRef(false);
   const wantsBackdropRef = useRef(false);
+  const wantsHandRef = useRef(false);
+  const handReadyRef = useRef(false);
 
   useEffect(() => {
     const ctor = orientationCtor();
@@ -189,6 +214,7 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
         t: 'sensing:state',
         active: tiltActiveRef.current,
         backdrop: backdropLiveRef.current,
+        hand: handReadyRef.current,
       },
       '*',
     );
@@ -228,7 +254,8 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
   }, []);
 
   const startBackdrop = useCallback(() => {
-    if (!wantsBackdropRef.current || !cameraSupported()) return;
+    // Backdrop chrome and/or hand verbs both need the same camera stream.
+    if ((!wantsBackdropRef.current && !wantsHandRef.current) || !cameraSupported()) return;
     if (streamRef.current || acquiringRef.current) return;
     acquiringRef.current = true;
     const gen = acquireGenRef.current;
@@ -282,16 +309,28 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
 
       const wantsTilt = message.features.includes('tilt');
       const wantsBackdrop = message.features.includes('backdrop');
+      // Spike: `?handSpike=1` opts the theater into hand verbs without a games-repo change.
+      const wantsHand = message.features.includes('hand') || handSpikeEnabled();
       // Unknown-only hellos are noise before any engagement. Once a game has said
-      // hello, a later hello is authoritative — including one that drops tilt/backdrop.
-      if (!wantsTilt && !wantsBackdrop && !wantsTiltRef.current && !wantsBackdropRef.current) {
+      // hello, a later hello is authoritative — including one that drops features.
+      if (
+        !wantsTilt &&
+        !wantsBackdrop &&
+        !wantsHand &&
+        !wantsTiltRef.current &&
+        !wantsBackdropRef.current &&
+        !wantsHandRef.current
+      ) {
         return;
       }
 
       wantsTiltRef.current = wantsTilt;
       wantsBackdropRef.current = wantsBackdrop;
+      wantsHandRef.current = wantsHand;
       setTiltEngaged(wantsTilt);
-      if (wantsBackdrop) {
+      setHandEngaged(wantsHand);
+      // Hand control needs a camera stream; engage backdrop chrome when hand asks alone.
+      if (wantsBackdrop || wantsHand) {
         const facing = message.facing ?? 'user';
         backdropFacingRef.current = facing;
         setBackdropFacing(facing);
@@ -388,6 +427,68 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
     };
   }, [listening, frameRef, postState]);
 
+  // Phase 1 spike: Hand Landmarker on the live backdrop stream → aim + pinch verbs.
+  useEffect(() => {
+    if (!handEngaged || !backdropLive || !backdropStream) {
+      handReadyRef.current = false;
+      setHandTracking(false);
+      setHandAim(null);
+      return;
+    }
+
+    let cancelled = false;
+    let raf = 0;
+    const verbState = createHandVerbState();
+    const video = document.createElement('video');
+    video.playsInline = true;
+    video.muted = true;
+    video.setAttribute('playsinline', 'true');
+    video.srcObject = backdropStream;
+    void video.play().catch(() => undefined);
+
+    function postToGame(payload: Record<string, unknown>) {
+      frameRef.current?.contentWindow?.postMessage({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload }, '*');
+    }
+
+    void loadHandLandmarker().then((landmarker) => {
+      if (cancelled || !landmarker) return;
+      const mirror = backdropFacingRef.current === 'user';
+
+      const tick = () => {
+        if (cancelled) return;
+        const now = performance.now();
+        const landmarks = landmarksFromVideo(landmarker, video, now);
+        const sample = sampleHandVerbs(verbState, landmarks, now, { mirror });
+        if (landmarks && !handReadyRef.current) {
+          handReadyRef.current = true;
+          setHandTracking(true);
+          postState();
+        }
+        if (sample.aim) {
+          setHandAim(sample.aim);
+          postToGame({ t: 'sensing:hand', x: sample.aim.x, y: sample.aim.y });
+        }
+        if (sample.pinchEdge) {
+          setHandLastPinchAt(now);
+          postToGame({ t: 'sensing:act', name: 'banish' });
+        }
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      video.pause();
+      video.srcObject = null;
+      handReadyRef.current = false;
+      setHandTracking(false);
+      setHandAim(null);
+      postState();
+    };
+  }, [handEngaged, backdropLive, backdropStream, frameRef, postState]);
+
   return {
     engaged: tiltEngaged,
     supported,
@@ -402,6 +503,12 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
       stream: backdropStream,
       start: startBackdrop,
       stop: stopBackdrop,
+    },
+    hand: {
+      engaged: handEngaged,
+      tracking: handTracking,
+      aim: handAim,
+      lastPinchAt: handLastPinchAt,
     },
   };
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2114,6 +2114,41 @@ body.player-open {
   }
 }
 
+/* Phase 1 hand-verb spike — shell debug crosshair (not game chrome). */
+.theater-hand-aim {
+  position: absolute;
+  z-index: 3;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border: 2px solid #9ef7b8;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  transform: translate(0, 0);
+}
+
+.theater-hand-aim::before,
+.theater-hand-aim::after {
+  content: '';
+  position: absolute;
+  background: #9ef7b8;
+  left: 50%;
+  top: 50%;
+}
+
+.theater-hand-aim::before {
+  width: 2px;
+  height: 12px;
+  margin: -6px 0 0 -1px;
+}
+
+.theater-hand-aim::after {
+  width: 12px;
+  height: 2px;
+  margin: -1px 0 0 -6px;
+}
+
 .is-playing-full-viewport .game-frame {
   width: 100%;
   height: 100%;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2114,41 +2114,6 @@ body.player-open {
   }
 }
 
-/* Phase 1 hand-verb spike — shell debug crosshair (not game chrome). */
-.theater-hand-aim {
-  position: absolute;
-  z-index: 3;
-  width: 22px;
-  height: 22px;
-  margin: -11px 0 0 -11px;
-  border: 2px solid #9ef7b8;
-  border-radius: 50%;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45);
-  pointer-events: none;
-  transform: translate(0, 0);
-}
-
-.theater-hand-aim::before,
-.theater-hand-aim::after {
-  content: '';
-  position: absolute;
-  background: #9ef7b8;
-  left: 50%;
-  top: 50%;
-}
-
-.theater-hand-aim::before {
-  width: 2px;
-  height: 12px;
-  margin: -6px 0 0 -1px;
-}
-
-.theater-hand-aim::after {
-  width: 12px;
-  height: 2px;
-  margin: -1px 0 0 -6px;
-}
-
 .is-playing-full-viewport .game-frame {
   width: 100%;
   height: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
       "name": "@gamedevpl/web",
       "version": "0.0.0",
       "dependencies": {
+        "@mediapipe/tasks-vision": "^0.10.18",
         "i18next": "^23.14.0",
         "i18next-browser-languagedetector": "^8.0.0",
         "react": "^18.3.1",
@@ -1834,6 +1835,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.18.tgz",
+      "integrity": "sha512-NRIlyqhGUz1Jdgcs6YybwPRhLK6dgeGAqAMXepIczEQ7FmA/0ouFtgMO1g9SPf/HaDSO8pNVdP54dAb9s9wj/Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Shell half of **hand control** for sensing Phase 1 (no debug flag).

### Play (after merge + deploy, with games half)
1. Open **Ghost Mirror**
2. Tap **Start camera**
3. Point with your hand → aim ring; **pinch** → banish nearest ghost  
   (Space / tap still work)

### What’s in
- MediaPipe Hand Landmarker on the backdrop stream when hello asks for `hand`
- `sensing:hand` aim + `sensing:act` `{ name: 'banish' }`
- Lazy-load MediaPipe; ~30 Hz detect; hand-only camera keep-alive
- Privacy + camera button copy for hand control
- Sandbox / iframe `allow=` unchanged

Merge **website before games** (existing rule). Catalog players need both PRs + a games snapshot publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-420ac37a-bee1-4b3f-b681-945672dcaef7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-420ac37a-bee1-4b3f-b681-945672dcaef7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

