### PR TITLE
byoca(BY-24): agent-opened improvement rounds via open_round

### DIFF
--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -1,12 +1,15 @@
 /**
- * Resolve a durable per-game opener into an active self-build round (BY-23).
+ * Resolve a durable per-game opener into an active self-build round (BY-23) or an
+ * agent-opened improvement round (BY-24).
  *
- * Shared by MCP `start` (and later `open_round`) so verification + ownership +
- * active-round selection cannot drift between callers.
+ * Shared by MCP `start` and `open_round` so verification + ownership cannot drift.
  */
 
 import {
+  AGENT_OPEN_ROUNDS_DISABLED_REASON,
   assertGameAgentKeyActive,
+  GAME_NOT_PUBLISHED_REASON,
+  looksLikeGameAgentKey,
   NO_OPEN_ROUND_REASON,
   PLATFORM_ROUND_REASON,
   ROTATED_GAME_KEY_REASON,
@@ -15,10 +18,20 @@ import {
 } from './agent-game-key.js';
 import { InvalidAgentTokenError } from './agent-token.js';
 import { isActiveBuildRound } from './builder.js';
-import type { Store, SubmissionRecord } from './store.js';
+import type { GameAgentKeyRecord, Store, SubmissionRecord } from './store.js';
 
 export type ResolveGameKeyResult =
   { ok: true; claims: GameAgentKeyClaims; record: SubmissionRecord } | { ok: false; reason: string };
+
+export type ResolveGameKeyForOpenRoundResult =
+  | {
+      ok: true;
+      claims: GameAgentKeyClaims;
+      publishedRecord: SubmissionRecord;
+      /** When set, a round is already open — callers must not stack another. */
+      activeRound: SubmissionRecord | null;
+    }
+  | { ok: false; reason: string };
 
 /**
  * Creator still "owns" the slug when they have a non-abandoned submission for it
@@ -43,15 +56,19 @@ export async function findActiveRoundForSlug(
 }
 
 /**
- * Full durable-key verification for `start`: signature, generation, expiry,
- * ownership, then bind to the active self round (or refuse with a distinct reason).
+ * Signature, generation, expiry, and slug ownership — shared by `start` and `open_round`.
+ * Does not require an open round or a published game.
  */
-export async function resolveGameAgentKeyForStart(
+export async function verifyDurableGameAgentKey(
   store: Store,
   key: string,
   secret: string,
   nowMs: number = Date.now(),
-): Promise<ResolveGameKeyResult> {
+): Promise<{ ok: true; claims: GameAgentKeyClaims; keyRecord: GameAgentKeyRecord } | { ok: false; reason: string }> {
+  if (!looksLikeGameAgentKey(key)) {
+    return { ok: false, reason: 'invalid key — ask the creator for the current prompt in their Studio thread' };
+  }
+
   let claims: GameAgentKeyClaims;
   try {
     claims = verifyGameAgentKey(key, secret);
@@ -84,7 +101,23 @@ export async function resolveGameAgentKeyForStart(
     return { ok: false, reason: ROTATED_GAME_KEY_REASON };
   }
 
-  const active = await findActiveRoundForSlug(store, claims.slug, claims.creatorUid);
+  return { ok: true, claims, keyRecord };
+}
+
+/**
+ * Full durable-key verification for `start`: shared checks, then bind to the active
+ * self round (or refuse with a distinct reason).
+ */
+export async function resolveGameAgentKeyForStart(
+  store: Store,
+  key: string,
+  secret: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveGameKeyResult> {
+  const verified = await verifyDurableGameAgentKey(store, key, secret, nowMs);
+  if (!verified.ok) return verified;
+
+  const active = await findActiveRoundForSlug(store, verified.claims.slug, verified.claims.creatorUid);
   if (!active) {
     return { ok: false, reason: NO_OPEN_ROUND_REASON };
   }
@@ -94,5 +127,31 @@ export async function resolveGameAgentKeyForStart(
     return { ok: false, reason: PLATFORM_ROUND_REASON };
   }
 
-  return { ok: true, claims, record: active };
+  return { ok: true, claims: verified.claims, record: active };
+}
+
+/**
+ * Durable-key verification for `open_round`: published game, opt-in, and idempotent
+ * binding when a round is already open.
+ */
+export async function resolveGameAgentKeyForOpenRound(
+  store: Store,
+  key: string,
+  secret: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveGameKeyForOpenRoundResult> {
+  const verified = await verifyDurableGameAgentKey(store, key, secret, nowMs);
+  if (!verified.ok) return verified;
+
+  if (verified.keyRecord.allowAgentOpenRounds !== true) {
+    return { ok: false, reason: AGENT_OPEN_ROUNDS_DISABLED_REASON };
+  }
+
+  const publishedRecord = await store.getPublishedSubmissionBySlug(verified.claims.slug);
+  if (!publishedRecord) {
+    return { ok: false, reason: GAME_NOT_PUBLISHED_REASON };
+  }
+
+  const activeRound = await findActiveRoundForSlug(store, verified.claims.slug, verified.claims.creatorUid);
+  return { ok: true, claims: verified.claims, publishedRecord, activeRound };
 }

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -48,6 +48,10 @@ export const GAME_NOT_PUBLISHED_REASON = 'this game is not published yet — imp
 export const IMPROVEMENT_QUOTA_EXHAUSTED_REASON =
   "today's improvement limit is used up — the creator can start another round tomorrow, or from the Studio";
 
+/** Another `open_round` is already creating a job for this slug — retry shortly. */
+export const OPEN_ROUND_IN_PROGRESS_REASON =
+  'an improvement round is already being opened for this game — wait a moment and try again';
+
 export interface GameAgentKeyClaims {
   slug: string;
   creatorUid: string;

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -37,6 +37,17 @@ export const PLATFORM_ROUND_REASON =
 export const ROTATED_GAME_KEY_REASON =
   'this game key was rotated — get a fresh prompt from the Studio thread for this game';
 
+/** Per-game opt-in for MCP `open_round` is off (BY-24). */
+export const AGENT_OPEN_ROUNDS_DISABLED_REASON =
+  'the creator has not allowed their agent to start new rounds for this game — ask them to enable it in Studio';
+
+/** `open_round` only applies after the game has shipped. */
+export const GAME_NOT_PUBLISHED_REASON = 'this game is not published yet — improvement rounds open only after publish';
+
+/** Creator daily improvement quota exhausted on the agent-open path. */
+export const IMPROVEMENT_QUOTA_EXHAUSTED_REASON =
+  "today's improvement limit is used up — the creator can start another round tomorrow, or from the Studio";
+
 export interface GameAgentKeyClaims {
   slug: string;
   creatorUid: string;

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -1,0 +1,312 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  AGENT_OPEN_ROUNDS_DISABLED_REASON,
+  GAME_NOT_PUBLISHED_REASON,
+  IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
+  mintGameAgentKey,
+} from './agent-game-key.js';
+import { resolveGameAgentKeyForOpenRound } from './agent-game-key-resolve.js';
+import { mintAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import type { ContentChecker } from './moderation.js';
+import type { GamesStore } from './games-store.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { mintMcpSessionKey } from './mcp-session-key.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'open-round-test-secret';
+const OWNER = 'g:owner';
+const SLUG = 'comet-courier';
+const PUBLISHED_ISSUE = 10;
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: PUBLISHED_ISSUE }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+function rejectingChecker(): ContentChecker {
+  return {
+    check: async () => ({ allowed: false, category: 'hate' }),
+    checkFields: async () => ({ allowed: false, category: 'hate' }),
+  };
+}
+
+async function createApp(store: InMemoryStore, contentChecker?: ContentChecker) {
+  return buildApp({
+    store,
+    sessionSecret: 'dev-session-secret-change-me',
+    ...(contentChecker ? { contentChecker } : {}),
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh-token',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      dailyImprovementQuota: 2,
+      agentChannel: {} as { gamesStore?: GamesStore },
+    },
+  });
+}
+
+async function seedPublishedGame(store: InMemoryStore) {
+  await store.createSubmission(PUBLISHED_ISSUE, OWNER, 'Comet Courier');
+  await store.setSubmissionSlug(PUBLISHED_ISSUE, SLUG);
+  await store.setRoundBuilder(PUBLISHED_ISSUE, 'self');
+  await store.setSubmissionPublishedAt(PUBLISHED_ISSUE, '2026-07-01T00:00:00.000Z');
+  await store.recordJobTransition(PUBLISHED_ISSUE, {
+    to: 'published',
+    at: '2026-07-01T00:00:00.000Z',
+    by: 'operator',
+    reason: 'published',
+  });
+}
+
+function gameKey(generation = 1) {
+  return mintGameAgentKey(secret, {
+    slug: SLUG,
+    creatorUid: OWNER,
+    keyGeneration: generation,
+    now: Date.parse('2026-08-01T12:00:00.000Z'),
+  });
+}
+
+async function mcpCall(
+  app: FastifyInstance,
+  method: string,
+  params?: unknown,
+  headers: Record<string, string> = {},
+  id: string | number = 1,
+) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/mcp',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    payload: { jsonrpc: '2.0', id, method, ...(params !== undefined ? { params } : {}) },
+  });
+}
+
+async function callOpenRound(
+  app: FastifyInstance,
+  args: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const res = await mcpCall(app, 'tools/call', { name: 'open_round', arguments: args }, headers);
+  expect(res.statusCode).toBe(200);
+  const body = res.json() as {
+    result?: { content?: Array<{ text: string }>; structuredContent?: unknown; isError?: boolean };
+  };
+  const structured =
+    body.result?.structuredContent ??
+    (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
+  return { structured, isError: Boolean(body.result?.isError) };
+}
+
+describe('resolveGameAgentKeyForOpenRound', () => {
+  it('refuses when opt-in is off', async () => {
+    const store = new InMemoryStore();
+    const at = '2026-08-01T12:00:00.000Z';
+    await store.ensureGameAgentKey(SLUG, OWNER, at);
+    await seedPublishedGame(store);
+
+    const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret);
+    expect(result).toEqual({ ok: false, reason: AGENT_OPEN_ROUNDS_DISABLED_REASON });
+  });
+
+  it('refuses when the game is not published', async () => {
+    const store = new InMemoryStore();
+    const at = '2026-08-01T12:00:00.000Z';
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await store.createSubmission(20, OWNER, 'Draft');
+    await store.setSubmissionSlug(20, SLUG);
+
+    const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret);
+    expect(result).toEqual({ ok: false, reason: GAME_NOT_PUBLISHED_REASON });
+  });
+});
+
+describe('MCP open_round (BY-24)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('refuses when opt-in is off', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    await store.ensureGameAgentKey(SLUG, OWNER, new Date().toISOString());
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'Add a checkpoint.',
+    });
+    expect(isError).toBe(true);
+    expect(structured).toMatchObject({ error: AGENT_OPEN_ROUNDS_DISABLED_REASON });
+  });
+
+  it('opens exactly one self improvement round when opt-in is on', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    const at = new Date().toISOString();
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'Add a checkpoint after level one.',
+    });
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ slug: SLUG, alreadyOpen: false });
+    const jobId = (structured as { jobId: number }).jobId;
+    expect(jobId).not.toBe(PUBLISHED_ISSUE);
+
+    const job = await store.getSubmission(jobId);
+    expect(job?.builder).toBe('self');
+    expect(job?.transitions?.[0]).toMatchObject({ to: 'queued', by: 'agent', reason: 'agent_open_round' });
+  });
+
+  it('is idempotent while a round is open and does not stack', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    const at = new Date().toISOString();
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    app = await createApp(store);
+
+    const first = await callOpenRound(app, { key: gameKey(), feedback: 'First change.' });
+    expect(first.isError).toBe(false);
+    const jobId = (first.structured as { jobId: number }).jobId;
+
+    const second = await callOpenRound(app, { key: gameKey(), feedback: 'Second change.' });
+    expect(second.isError).toBe(false);
+    expect(second.structured).toMatchObject({ jobId, alreadyOpen: true });
+
+    const owned = await store.listSubmissionsByOwner(OWNER, { limit: 50 });
+    const active = owned.filter((job) => job.slug === SLUG && job.issueNumber !== PUBLISHED_ISSUE);
+    expect(active).toHaveLength(1);
+  });
+
+  it('refuses when improvement quota is exhausted', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    const at = new Date().toISOString();
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    const dateStr = new Date().toISOString().slice(0, 10);
+    await store.checkAndIncrementQuota(OWNER, dateStr, 2, 'improvements');
+    await store.checkAndIncrementQuota(OWNER, dateStr, 2, 'improvements');
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'One more try.',
+    });
+    expect(isError).toBe(true);
+    expect(structured).toMatchObject({ error: IMPROVEMENT_QUOTA_EXHAUSTED_REASON });
+  });
+
+  it('moderates feedback on this path', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
+    app = await createApp(store, rejectingChecker());
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'bad words',
+    });
+    expect(isError).toBe(true);
+    expect(structured).toMatchObject({ error: 'content_rejected' });
+  });
+
+  it('rejects a round key where the durable key is required', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
+    app = await createApp(store);
+
+    const roundKey = mintAgentToken(PUBLISHED_ISSUE, secret, { roundGeneration: 1 });
+    const { structured, isError } = await callOpenRound(app, {
+      key: roundKey,
+      feedback: 'Nope.',
+    });
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toMatch(/durable per-game key/i);
+  });
+
+  it('rejects a sessionKey where the durable key is required', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
+    app = await createApp(store);
+
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: 'sess-1',
+      jobId: PUBLISHED_ISSUE,
+      roundGeneration: 1,
+    });
+    const { structured, isError } = await callOpenRound(app, {
+      key: sessionKey,
+      feedback: 'Nope.',
+    });
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toMatch(/durable per-game key/i);
+  });
+
+  it('refuses an unpublished game', async () => {
+    const store = new InMemoryStore();
+    const at = new Date().toISOString();
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await store.createSubmission(30, OWNER, 'Unpublished');
+    await store.setSubmissionSlug(30, SLUG);
+    await store.ensureGameAgentKey(SLUG, OWNER, at);
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'Too early.',
+    });
+    expect(isError).toBe(true);
+    expect(structured).toMatchObject({ error: GAME_NOT_PUBLISHED_REASON });
+  });
+
+  it('cannot open a round when the key slug has no published game', async () => {
+    const store = new InMemoryStore();
+    const at = new Date().toISOString();
+    await store.createSubmission(35, OWNER, 'Unpublished comet');
+    await store.setSubmissionSlug(35, SLUG);
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+
+    const otherSlug = 'other-game';
+    await store.createSubmission(40, OWNER, 'Other');
+    await store.setSubmissionSlug(40, otherSlug);
+    await store.setSubmissionPublishedAt(40, '2026-07-02T00:00:00.000Z');
+
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(app, {
+      key: gameKey(),
+      feedback: 'Wrong slug published.',
+    });
+    expect(isError).toBe(true);
+    expect(structured).toMatchObject({ error: GAME_NOT_PUBLISHED_REASON });
+  });
+});

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -185,6 +185,33 @@ describe('MCP open_round (BY-24)', () => {
     expect(job?.transitions?.[0]).toMatchObject({ to: 'queued', by: 'agent', reason: 'agent_open_round' });
   });
 
+  it('admits only one concurrent open_round per slug', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    const at = new Date().toISOString();
+    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    app = await createApp(store);
+
+    const results = await Promise.all([
+      callOpenRound(app, { key: gameKey(), feedback: 'Concurrent A.' }),
+      callOpenRound(app, { key: gameKey(), feedback: 'Concurrent B.' }),
+      callOpenRound(app, { key: gameKey(), feedback: 'Concurrent C.' }),
+    ]);
+
+    const newOpens = results.filter(
+      (result) => !result.isError && !(result.structured as { alreadyOpen?: boolean }).alreadyOpen,
+    );
+    expect(newOpens).toHaveLength(1);
+
+    const owned = await store.listSubmissionsByOwner(OWNER, { limit: 50 });
+    const active = owned.filter((job) => job.slug === SLUG && job.issueNumber !== PUBLISHED_ISSUE);
+    expect(active).toHaveLength(1);
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const usage = await store.getUsage(OWNER, dateStr);
+    expect(usage.improvements).toBe(1);
+  });
+
   it('is idempotent while a round is open and does not stack', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,7 +1,15 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { looksLikeGameAgentKey, IMPROVEMENT_QUOTA_EXHAUSTED_REASON } from './agent-game-key.js';
-import { resolveGameAgentKeyForOpenRound, resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
+import {
+  looksLikeGameAgentKey,
+  IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
+  OPEN_ROUND_IN_PROGRESS_REASON,
+} from './agent-game-key.js';
+import {
+  findActiveRoundForSlug,
+  resolveGameAgentKeyForOpenRound,
+  resolveGameAgentKeyForStart,
+} from './agent-game-key-resolve.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -617,7 +625,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr(resolved.reason);
         }
 
+        const at = new Date(now()).toISOString();
         if (resolved.activeRound) {
+          await store.finishAgentOpenRound(resolved.claims.slug, at);
           return toolOk({
             jobId: resolved.activeRound.issueNumber,
             slug: resolved.claims.slug,
@@ -635,42 +645,68 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('content_rejected', { category: moderation.category ?? 'other' });
         }
 
-        const dateStr = new Date(now()).toISOString().slice(0, 10);
-        const quota = await store.checkAndIncrementQuota(
-          resolved.claims.creatorUid,
-          dateStr,
-          dailyImprovementQuota,
-          'improvements',
-        );
-        if (!quota.allowed) {
-          if (quota.tier === 'blocked') {
-            return toolErr('account is blocked');
+        const admitted = await store.beginAgentOpenRound(resolved.claims.slug, at);
+        if (!admitted) {
+          const again = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
+          if (again.ok && again.activeRound) {
+            return toolOk({
+              jobId: again.activeRound.issueNumber,
+              slug: again.claims.slug,
+              alreadyOpen: true,
+            });
           }
-          return toolErr(IMPROVEMENT_QUOTA_EXHAUSTED_REASON);
+          return toolErr(OPEN_ROUND_IN_PROGRESS_REASON);
         }
 
-        const sanitizedFeedback = sanitizeCreatorText(feedbackRaw, { singleLine: false });
-        const sanitizedTitle = sanitizeCreatorText(`Improve ${resolved.publishedRecord.title}`, {
-          singleLine: true,
-        });
-        const started = await startImprovementRound({
-          issueNumber: resolved.publishedRecord.issueNumber,
-          text: sanitizedFeedback,
-          title: sanitizedTitle,
-          locale: resolved.publishedRecord.locale ?? 'en',
-          log: ctx.request.log,
-          builder: 'self',
-          openedBy: 'agent',
-        });
-        if (!started) {
-          return toolErr('could not open an improvement round for this game');
-        }
+        try {
+          const racingRound = await findActiveRoundForSlug(store, resolved.claims.slug, resolved.claims.creatorUid);
+          if (racingRound) {
+            return toolOk({
+              jobId: racingRound.issueNumber,
+              slug: resolved.claims.slug,
+              alreadyOpen: true,
+            });
+          }
 
-        return toolOk({
-          jobId: started.jobId,
-          slug: resolved.claims.slug,
-          alreadyOpen: false,
-        });
+          const dateStr = at.slice(0, 10);
+          const quota = await store.checkAndIncrementQuota(
+            resolved.claims.creatorUid,
+            dateStr,
+            dailyImprovementQuota,
+            'improvements',
+          );
+          if (!quota.allowed) {
+            if (quota.tier === 'blocked') {
+              return toolErr('account is blocked');
+            }
+            return toolErr(IMPROVEMENT_QUOTA_EXHAUSTED_REASON);
+          }
+
+          const sanitizedFeedback = sanitizeCreatorText(feedbackRaw, { singleLine: false });
+          const sanitizedTitle = sanitizeCreatorText(`Improve ${resolved.publishedRecord.title}`, {
+            singleLine: true,
+          });
+          const started = await startImprovementRound({
+            issueNumber: resolved.publishedRecord.issueNumber,
+            text: sanitizedFeedback,
+            title: sanitizedTitle,
+            locale: resolved.publishedRecord.locale ?? 'en',
+            log: ctx.request.log,
+            builder: 'self',
+            openedBy: 'agent',
+          });
+          if (!started) {
+            return toolErr('could not open an improvement round for this game');
+          }
+
+          return toolOk({
+            jobId: started.jobId,
+            slug: resolved.claims.slug,
+            alreadyOpen: false,
+          });
+        } finally {
+          await store.finishAgentOpenRound(resolved.claims.slug, at);
+        }
       },
     },
 

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { looksLikeGameAgentKey } from './agent-game-key.js';
-import { resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
+import { looksLikeGameAgentKey, IMPROVEMENT_QUOTA_EXHAUSTED_REASON } from './agent-game-key.js';
+import { resolveGameAgentKeyForOpenRound, resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -13,6 +13,7 @@ import {
   type AgentTokenClaims,
 } from './agent-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
+import type { BuilderKind } from './builder.js';
 import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import {
@@ -22,8 +23,10 @@ import {
   verifyMcpSessionKey,
 } from './mcp-session-key.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
-import { BUILD_STEPS } from './submission-status.js';
+import { BUILD_STEPS, sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
+import type { ContentChecker } from './moderation.js';
+import { logModerationRejection } from './moderation-metrics.js';
 
 /**
  * Streamable-HTTP MCP endpoint (BY-05 / BY-23).
@@ -71,6 +74,17 @@ export interface McpServerOptions {
    * mitigation). Absent Origin is allowed — coding agents are not browsers.
    */
   allowedOrigins?: string[];
+  startImprovementRound?: (input: {
+    issueNumber: number;
+    text: string;
+    title: string;
+    locale: string;
+    log: { error: (context: object, message: string) => void };
+    builder?: BuilderKind;
+    openedBy?: 'creator' | 'agent';
+  }) => Promise<{ route: 'job'; jobId: number } | null>;
+  contentChecker?: ContentChecker;
+  dailyImprovementQuota?: number;
 }
 
 interface JsonRpcRequest {
@@ -241,6 +255,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   const agentTokenSecret = options.agentTokenSecret ?? process.env.SUBMISSION_TOKEN_SECRET;
   const now = options.now ?? Date.now;
   const allowedOrigins = options.allowedOrigins ?? parseAllowedOrigins();
+  const startImprovementRound = options.startImprovementRound;
+  const contentChecker = options.contentChecker;
+  const dailyImprovementQuota = options.dailyImprovementQuota ?? Number(process.env.DAILY_IMPROVEMENT_QUOTA ?? '2');
 
   /** Transport sessions only — never consulted for authorization. */
   const transportSessions = new Map<string, { createdAt: number }>();
@@ -549,6 +566,111 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...base,
           content: [...base.content, { type: 'text', text: SESSION_WORKFLOW_TEXT }],
         };
+      },
+    },
+
+    open_round: {
+      description:
+        'Open a new post-publish improvement round on a published game using the durable per-game key. ' +
+        'Requires the creator to have opted in per game. Spends the same daily improvement quota as Studio. ' +
+        'Returns jobId only — call start() next for a sessionKey. Idempotent while a round is already open.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: {
+            type: 'string',
+            description: 'Durable per-game key from the Studio kickoff prompt — not a sessionKey or round key.',
+          },
+          feedback: {
+            type: 'string',
+            description:
+              'Creator change request for this improvement round (≤2000 chars). Treated as untrusted creator text.',
+          },
+        },
+        required: ['key', 'feedback'],
+      },
+      handler: async (args, ctx) => {
+        if (!store || !agentTokenSecret || !startImprovementRound || !contentChecker) {
+          return toolErr('the MCP build endpoint is not configured');
+        }
+
+        const key = typeof args.key === 'string' ? args.key.trim() : '';
+        if (!key) {
+          return toolErr('key is required — pass the durable per-game key from the Studio kickoff prompt');
+        }
+        if (!looksLikeGameAgentKey(key)) {
+          return toolErr(
+            'open_round requires the durable per-game key — session keys and round keys cannot open a new round',
+          );
+        }
+
+        const feedbackRaw = typeof args.feedback === 'string' ? args.feedback.trim() : '';
+        if (!feedbackRaw) {
+          return toolErr('feedback is required — relay what the creator wants changed');
+        }
+        if (feedbackRaw.length > 2000) {
+          return toolErr('feedback is too long (max 2000 characters)');
+        }
+
+        const resolved = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
+        if (!resolved.ok) {
+          return toolErr(resolved.reason);
+        }
+
+        if (resolved.activeRound) {
+          return toolOk({
+            jobId: resolved.activeRound.issueNumber,
+            slug: resolved.claims.slug,
+            alreadyOpen: true,
+          });
+        }
+
+        const moderation = await contentChecker.checkFields([feedbackRaw]);
+        if (!moderation.allowed) {
+          logModerationRejection(ctx.request.log, {
+            surface: 'creator_feedback',
+            uid: resolved.claims.creatorUid,
+            category: moderation.category,
+          });
+          return toolErr('content_rejected', { category: moderation.category ?? 'other' });
+        }
+
+        const dateStr = new Date(now()).toISOString().slice(0, 10);
+        const quota = await store.checkAndIncrementQuota(
+          resolved.claims.creatorUid,
+          dateStr,
+          dailyImprovementQuota,
+          'improvements',
+        );
+        if (!quota.allowed) {
+          if (quota.tier === 'blocked') {
+            return toolErr('account is blocked');
+          }
+          return toolErr(IMPROVEMENT_QUOTA_EXHAUSTED_REASON);
+        }
+
+        const sanitizedFeedback = sanitizeCreatorText(feedbackRaw, { singleLine: false });
+        const sanitizedTitle = sanitizeCreatorText(`Improve ${resolved.publishedRecord.title}`, {
+          singleLine: true,
+        });
+        const started = await startImprovementRound({
+          issueNumber: resolved.publishedRecord.issueNumber,
+          text: sanitizedFeedback,
+          title: sanitizedTitle,
+          locale: resolved.publishedRecord.locale ?? 'en',
+          log: ctx.request.log,
+          builder: 'self',
+          openedBy: 'agent',
+        });
+        if (!started) {
+          return toolErr('could not open an improvement round for this game');
+        }
+
+        return toolOk({
+          jobId: started.jobId,
+          slug: resolved.claims.slug,
+          alreadyOpen: false,
+        });
       },
     },
 

--- a/apps/api/src/moderation-metrics.test.ts
+++ b/apps/api/src/moderation-metrics.test.ts
@@ -99,6 +99,7 @@ describe('every moderating module reports its rejections', () => {
       'app.ts',
       'contact.ts',
       'editor-drafts.ts',
+      'mcp-server.ts',
       'player-feedback.ts',
       'refine.ts',
       'submissions.ts',

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1117,6 +1117,8 @@ export interface GameAgentKeyRecord {
   updatedAt: string;
   /** BY-24: when true, the creator's agent may call `open_round`. Default false. */
   allowAgentOpenRounds?: boolean;
+  /** BY-24: admission lock while `open_round` is creating a job — cleared in finally. */
+  agentOpenRoundPending?: boolean;
 }
 
 export interface Store {
@@ -1676,6 +1678,13 @@ export interface Store {
     allow: boolean,
     at: string,
   ): Promise<GameAgentKeyRecord | null>;
+  /**
+   * BY-24: admit at most one in-flight `open_round` per slug. Returns false when another
+   * caller already holds the lock.
+   */
+  beginAgentOpenRound(slug: string, at: string): Promise<boolean>;
+  /** BY-24: release the admission lock after `open_round` completes or aborts. */
+  finishAgentOpenRound(slug: string, at: string): Promise<void>;
 }
 
 // Stable doc id for a subscription: a hash of its endpoint URL. Endpoints are long
@@ -2980,6 +2989,20 @@ export class InMemoryStore implements Store {
     const next: GameAgentKeyRecord = { ...current, allowAgentOpenRounds: allow, updatedAt: at };
     this.gameAgentKeys.set(slug, next);
     return { ...next };
+  }
+
+  async beginAgentOpenRound(slug: string, at: string): Promise<boolean> {
+    const existing = this.gameAgentKeys.get(slug);
+    if (!existing || existing.agentOpenRoundPending) return false;
+    this.gameAgentKeys.set(slug, { ...existing, agentOpenRoundPending: true, updatedAt: at });
+    return true;
+  }
+
+  async finishAgentOpenRound(slug: string, at: string): Promise<void> {
+    const existing = this.gameAgentKeys.get(slug);
+    if (!existing?.agentOpenRoundPending) return;
+    const { agentOpenRoundPending: _pending, ...rest } = existing;
+    this.gameAgentKeys.set(slug, { ...rest, updatedAt: at });
   }
 
   // Test/inspection only — production reads go through `listWaitlistEntries`.
@@ -4782,6 +4805,31 @@ export class FirestoreStore implements Store {
       };
       tx.set(docRef, next);
       return next;
+    });
+  }
+
+  async beginAgentOpenRound(slug: string, at: string): Promise<boolean> {
+    const docRef = this.db.collection('gameAgentKeys').doc(slug);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return false;
+      const existing = snap.data() as GameAgentKeyRecord;
+      if (existing.agentOpenRoundPending) return false;
+      const next: GameAgentKeyRecord = { ...existing, agentOpenRoundPending: true, updatedAt: at };
+      tx.set(docRef, next);
+      return true;
+    });
+  }
+
+  async finishAgentOpenRound(slug: string, at: string): Promise<void> {
+    const docRef = this.db.collection('gameAgentKeys').doc(slug);
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return;
+      const existing = snap.data() as GameAgentKeyRecord;
+      if (!existing.agentOpenRoundPending) return;
+      const { agentOpenRoundPending: _pending, ...rest } = existing;
+      tx.set(docRef, { ...rest, updatedAt: at });
     });
   }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -575,7 +575,8 @@ export interface VisitEvent {
    */
   builder?: string;
   /**
-   * `studio_step`: closed detail (`install` | `kickoff` | `green` | `red` | `kit_outdated`).
+   * `studio_step`: closed detail (`install` | `kickoff` | `green` | `red` | `kit_outdated` |
+   * `creator` | `agent` for `round_opened`).
    * Never free text, never a game identity.
    */
   detail?: string;

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -211,6 +211,12 @@ export interface SubmissionStatusResponseBase {
    * `stall`: the UI renders its own translated copy, not this string.
    */
   failure?: { reason: string };
+  /**
+   * Who opened this improvement round, when it is one. Absent on first-time builds and
+   * legacy jobs. Lets Studio distinguish a creator-started handoff from an agent-opened
+   * round the creator did not initiate in the UI (BY-24).
+   */
+  openedBy?: 'creator' | 'agent';
 }
 
 /**

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -387,6 +387,8 @@ export interface SubmissionRoutesHandle {
      * builder (`builder` / `defaultBuilder`), then `platform`.
      */
     builder?: BuilderKind;
+    /** Who opened this improvement — drives the queued transition and status.openedBy. */
+    openedBy?: 'creator' | 'agent';
   }) => Promise<{ route: 'job'; jobId: number } | null>;
 }
 
@@ -1014,6 +1016,8 @@ export async function registerSubmissionRoutes(
      * so omitting this used to silently route every post-publish improve to `platform`.
      */
     builder?: BuilderKind;
+    /** Who opened this improvement — drives the queued transition and status.openedBy. */
+    openedBy?: 'creator' | 'agent';
   }): Promise<{ route: 'job'; jobId: number } | null> {
     if (!store) return null;
     const source = await store.getSubmission(input.issueNumber);
@@ -1035,8 +1039,8 @@ export async function registerSubmissionRoutes(
     await store.recordJobTransition(jobId, {
       to: 'queued',
       at: new Date(now()).toISOString(),
-      by: 'creator',
-      reason: 'improvement_requested',
+      by: input.openedBy === 'agent' ? 'agent' : 'creator',
+      reason: input.openedBy === 'agent' ? 'agent_open_round' : 'improvement_requested',
     });
 
     const dispatched = await dispatchBuild({
@@ -1627,6 +1631,12 @@ export async function registerSubmissionRoutes(
     // stronger (gate_red, task_failed, …) already explains the stop.
     if (builderOf(record) === 'self' && !status.failure && (record.roundDeliveryCount ?? 0) >= selfBuildDeliveryCap()) {
       status.failure = { reason: 'self_build_delivery_cap' };
+    }
+    const queuedTransition = (record.transitions ?? []).find((transition) => transition.to === 'queued');
+    if (queuedTransition?.reason === 'agent_open_round') {
+      status.openedBy = 'agent';
+    } else if (queuedTransition?.reason === 'improvement_requested') {
+      status.openedBy = 'creator';
     }
     return status;
   }
@@ -2324,6 +2334,52 @@ export async function registerSubmissionRoutes(
         kickoffPrompt: payload.kickoffPrompt,
         installSnippets: payload.installSnippets,
         rotated: true,
+      });
+    },
+  );
+
+  app.post(
+    '/api/submissions/:id/agent-key/open-rounds',
+    { config: { rateLimit: { max: 30, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret || !store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+
+      const parsedBody = z.object({ allow: z.boolean() }).safeParse(request.body ?? {});
+      if (!parsedBody.success) {
+        return reply.status(400).send({ error: 'allow must be true or false' });
+      }
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can manage this game key' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
+      }
+
+      const at = new Date(now()).toISOString();
+      const updated = await store.setGameAgentOpenRounds(record.slug, record.ownerUid, parsedBody.data.allow, at);
+      if (!updated) {
+        return reply.status(403).send({ error: 'only the creator can manage this game key' });
+      }
+
+      return reply.send({
+        slug: record.slug,
+        allowAgentOpenRounds: updated.allowAgentOpenRounds === true,
       });
     },
   );
@@ -4110,6 +4166,9 @@ export async function registerSubmissionRoutes(
     now,
     gamesStore: options.agentChannel?.gamesStore,
     objectStore: options.agentChannel?.objectStore,
+    startImprovementRound,
+    contentChecker,
+    dailyImprovementQuota,
   });
 
   return { githubClient, startImprovementRound };

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -62,14 +62,14 @@ const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
  * Studio / self-build funnel (BY-08). Sibling to create steps — not ordered with them.
  * Reaches a grouping key; closed enum on an open endpoint.
  */
-const StudioStepSchema = z.enum(['builder_chosen', 'connect_copied', 'agent_signaled', 'gate_verdict']);
+const StudioStepSchema = z.enum(['builder_chosen', 'connect_copied', 'agent_signaled', 'gate_verdict', 'round_opened']);
 /** Platform vs creator's own agent. Optional on create_step; required on studio_step. */
 const BuilderDimensionSchema = z.enum(['platform', 'self']);
 /**
  * Closed detail for studio steps that carry one. Optional so steps without a detail
  * (builder choice, first agent signal) stay valid.
  */
-const StudioStepDetailSchema = z.enum(['install', 'kickoff', 'green', 'red', 'kit_outdated']);
+const StudioStepDetailSchema = z.enum(['install', 'kickoff', 'green', 'red', 'kit_outdated', 'creator', 'agent']);
 /** EditorKit's revision funnel. No slug: the visit stream stays unjoinable. */
 const EditorStepSchema = z.enum(['opened', 'draft_saved', 'previewed', 'published']);
 /**

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -20,6 +20,7 @@ import {
   type StudioShelfFilter,
   type StudioShelfGame,
 } from './studioShelf.js';
+import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
   approveSuggestion,
@@ -1015,6 +1016,8 @@ function DetailsPanel({
       {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
           public play link — offering a second "share the draft" switch would lie. */}
       {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+
+      {game.slug && game.lastKnownStatus !== 'abandoned' ? <StudioAgentKeyPanel token={game.token} /> : null}
 
       {/* Only once there is play to report on. Before a game is live every one of these
           numbers is zero, and a wall of zeroes reads as a verdict rather than as

--- a/apps/web/src/StudioAgentKeyPanel.test.tsx
+++ b/apps/web/src/StudioAgentKeyPanel.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
+import { recordStudioStep } from './visitTelemetry.js';
+
+vi.mock('./visitTelemetry', async () => {
+  const actual = await vi.importActual<typeof import('./visitTelemetry')>('./visitTelemetry');
+  return { ...actual, recordStudioStep: vi.fn() };
+});
+
+const mockedRecordStudioStep = vi.mocked(recordStudioStep);
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const agentKeyPayload = {
+  slug: 'sky-dodge',
+  keyGeneration: 1,
+  allowAgentOpenRounds: false,
+  expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
+  kickoffPrompt:
+    'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def\nstart returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
+  installSnippets: {
+    claudeCode: 'claude mcp add --transport http gamedevpl https://www.gamedev.pl/api/mcp',
+    codex: '[mcp_servers.gamedevpl]\nurl = "https://www.gamedev.pl/api/mcp"',
+    cursor: '{\n  "mcpServers": {\n    "gamedevpl": {\n      "url": "https://www.gamedev.pl/api/mcp"\n    }\n  }\n}',
+    kimi: 'npx -y mcp-remote https://www.gamedev.pl/api/mcp',
+    cli: 'curl -sS -X POST https://www.gamedev.pl/api/mcp',
+  },
+};
+
+describe('StudioAgentKeyPanel', () => {
+  beforeEach(() => {
+    mockedRecordStudioStep.mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo) => {
+        const url = String(input);
+        if (url.includes('/agent-key/rotate')) {
+          return {
+            ok: true,
+            json: async () => ({
+              ...agentKeyPayload,
+              keyGeneration: 2,
+              kickoffPrompt: agentKeyPayload.kickoffPrompt.replace('abc.def', 'rotated.key'),
+              rotated: true,
+            }),
+          };
+        }
+        if (url.includes('/agent-key/open-rounds')) {
+          return {
+            ok: true,
+            json: async () => ({ allowAgentOpenRounds: true }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => agentKeyPayload,
+        };
+      }),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('shows kickoff after rotate and emits connect_copied only on copy', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioAgentKeyPanel, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.textContent).not.toContain('rotated.key');
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.studio-connect-skip')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.studio-connect-skip.is-danger')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+      await flush();
+    });
+
+    expect(container.textContent).toContain('rotated.key');
+    expect(mockedRecordStudioStep).not.toHaveBeenCalledWith('connect_copied', expect.anything(), expect.anything());
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-share-copy')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(mockedRecordStudioStep).toHaveBeenCalledWith('connect_copied', 'self', 'kickoff');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/StudioAgentKeyPanel.tsx
+++ b/apps/web/src/StudioAgentKeyPanel.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getAgentKey, rotateAgentKey, setAgentOpenRounds } from './connectApi.js';
+import { recordStudioStep } from './visitTelemetry.js';
+
+type StudioAgentKeyPanelProps = {
+  token: string;
+  /** Compact mode hides rotate and extra copy — for the connect card. */
+  compact?: boolean;
+};
+
+/**
+ * Durable per-game key controls (BY-23 / BY-24): opt-in for agent-opened rounds and
+ * rotate. Never uses the word "token" in UI copy.
+ */
+export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPanelProps) {
+  const { t, i18n } = useTranslation();
+  const baseId = useId();
+  const [allowAgentOpenRounds, setAllowAgentOpenRounds] = useState(false);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [rotateArmed, setRotateArmed] = useState(false);
+  const [rotating, setRotating] = useState(false);
+  const [rotateError, setRotateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getAgentKey(token)
+      .then((payload) => {
+        if (!cancelled) {
+          setAllowAgentOpenRounds(payload.allowAgentOpenRounds);
+          setExpiresAt(payload.expiresAt);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError(t('agentKey.loadError'));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, t]);
+
+  const expiresLabel =
+    expiresAt != null
+      ? new Intl.DateTimeFormat(i18n.language, { dateStyle: 'medium', timeStyle: 'short' }).format(
+          new Date(expiresAt * 1000),
+        )
+      : '';
+
+  const handleToggle = async () => {
+    const next = !allowAgentOpenRounds;
+    setToggleBusy(true);
+    setError(null);
+    setAllowAgentOpenRounds(next);
+    try {
+      const result = await setAgentOpenRounds(token, next);
+      setAllowAgentOpenRounds(result.allowAgentOpenRounds);
+    } catch {
+      setAllowAgentOpenRounds(!next);
+      setError(t('agentKey.toggleError'));
+    } finally {
+      setToggleBusy(false);
+    }
+  };
+
+  const handleRotate = async () => {
+    setRotating(true);
+    setRotateError(null);
+    try {
+      const next = await rotateAgentKey(token);
+      setExpiresAt(next.expiresAt);
+      setAllowAgentOpenRounds(next.allowAgentOpenRounds);
+      setRotateArmed(false);
+      recordStudioStep('connect_copied', 'self', 'kickoff');
+    } catch {
+      setRotateError(t('connect.rotate.error'));
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  return (
+    <section className="studio-agent-key" aria-labelledby={`${baseId}-title`}>
+      {!compact ? (
+        <h3 id={`${baseId}-title`} className="studio-agent-key-title">
+          {t('agentKey.title')}
+        </h3>
+      ) : null}
+
+      {loading ? <p className="studio-connect-state">{t('agentKey.loading')}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      {!loading ? (
+        <>
+          <div className="studio-share-head">
+            <h4 className="studio-share-title">{t('agentKey.openRounds.title')}</h4>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={allowAgentOpenRounds}
+              className={`studio-share-toggle${allowAgentOpenRounds ? ' is-on' : ''}`}
+              onClick={() => void handleToggle()}
+              disabled={toggleBusy}
+            >
+              <span className="studio-share-toggle-track" aria-hidden="true" />
+              {allowAgentOpenRounds ? t('agentKey.openRounds.on') : t('agentKey.openRounds.off')}
+            </button>
+          </div>
+          <p className="studio-share-hint">{t('agentKey.openRounds.hint')}</p>
+
+          {!compact ? (
+            <>
+              {expiresLabel ? (
+                <p className="studio-connect-expiry">{t('agentKey.expiry', { when: expiresLabel })}</p>
+              ) : null}
+              <div className="studio-connect-actions">
+                {!rotateArmed ? (
+                  <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                    {t('connect.rotate.start')}
+                  </button>
+                ) : (
+                  <span className="studio-connect-rotate-confirm">
+                    <span>{t('connect.rotate.confirm')}</span>
+                    <button
+                      type="button"
+                      className="studio-connect-skip is-danger"
+                      disabled={rotating}
+                      onClick={() => void handleRotate()}
+                    >
+                      {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
+                    </button>
+                    <button
+                      type="button"
+                      className="studio-connect-skip"
+                      disabled={rotating}
+                      onClick={() => setRotateArmed(false)}
+                    >
+                      {t('connect.rotate.no')}
+                    </button>
+                  </span>
+                )}
+              </div>
+              {rotateError ? <p className="error">{rotateError}</p> : null}
+            </>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+/** Agent-open-rounds toggle only — shared by the connect card. */
+export function AgentOpenRoundsToggle({ token }: { token: string }) {
+  return <StudioAgentKeyPanel token={token} compact />;
+}

--- a/apps/web/src/StudioAgentKeyPanel.tsx
+++ b/apps/web/src/StudioAgentKeyPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getAgentKey, rotateAgentKey, setAgentOpenRounds } from './connectApi.js';
+import { PixelIcon } from './PixelIcon.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 type StudioAgentKeyPanelProps = {
@@ -18,12 +19,14 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
   const baseId = useId();
   const [allowAgentOpenRounds, setAllowAgentOpenRounds] = useState(false);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [kickoffPrompt, setKickoffPrompt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toggleBusy, setToggleBusy] = useState(false);
   const [rotateArmed, setRotateArmed] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
+  const [copiedKickoff, setCopiedKickoff] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -71,6 +74,17 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
     }
   };
 
+  const copyKickoff = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKickoff(true);
+      window.setTimeout(() => setCopiedKickoff(false), 2000);
+    } catch {
+      // Snippet stays on screen to select by hand.
+    }
+    recordStudioStep('connect_copied', 'self', 'kickoff');
+  };
+
   const handleRotate = async () => {
     setRotating(true);
     setRotateError(null);
@@ -78,8 +92,8 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
       const next = await rotateAgentKey(token);
       setExpiresAt(next.expiresAt);
       setAllowAgentOpenRounds(next.allowAgentOpenRounds);
+      setKickoffPrompt(next.kickoffPrompt);
       setRotateArmed(false);
-      recordStudioStep('connect_copied', 'self', 'kickoff');
     } catch {
       setRotateError(t('connect.rotate.error'));
     } finally {
@@ -120,6 +134,20 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
             <>
               {expiresLabel ? (
                 <p className="studio-connect-expiry">{t('agentKey.expiry', { when: expiresLabel })}</p>
+              ) : null}
+              {kickoffPrompt ? (
+                <div className="studio-connect-step">
+                  <p className="studio-connect-same">{t('agentKey.rotatedKickoff')}</p>
+                  <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
+                    {kickoffPrompt}
+                  </pre>
+                  <div className="studio-connect-actions">
+                    <button type="button" className="status-share-copy" onClick={() => void copyKickoff(kickoffPrompt)}>
+                      <PixelIcon name={copiedKickoff ? 'check' : 'sparkle'} size={12} />{' '}
+                      {copiedKickoff ? t('connect.copied') : t('connect.copyKickoff')}
+                    </button>
+                  </div>
+                </div>
               ) : null}
               <div className="studio-connect-actions">
                 {!rotateArmed ? (

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -8,6 +8,7 @@ import {
   type ConnectClient,
   type ConnectPayload,
 } from './connectApi.js';
+import { AgentOpenRoundsToggle } from './StudioAgentKeyPanel.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
@@ -215,6 +216,7 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
             </div>
             {rotateError ? <p className="error">{rotateError}</p> : null}
             <p className="studio-connect-expiry">{t('connect.step2.expiry', { when: expiresLabel })}</p>
+            <AgentOpenRoundsToggle token={token} />
           </div>
 
           <p className="studio-connect-waiting" aria-live="polite">

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1836,6 +1836,32 @@ describe('SubmissionStatusView stop & retry', () => {
     vi.useRealTimers();
   });
 
+  it('emits round_opened on the first status snapshot when openedBy is set', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'queued',
+      builder: 'self',
+      openedBy: 'agent',
+    });
+    window.history.pushState(null, '', '/status/round-opened-first');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'round-opened-first', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+    expect(mockedRecordStudioStep).toHaveBeenCalledWith('round_opened', 'self', 'agent');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   /**
    * Publishing is terminal: a post-publish improvement opens a *new* job on its own
    * thread. These lock the handoff — the creator moving onto the new build thread rather

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -401,6 +401,7 @@ export function SubmissionStatusView({
   // finished submission must not mint a fresh gate_verdict (visit stream is per-tab).
   const prevStallRef = useRef<SubmissionStatus['stall'] | undefined>(undefined);
   const prevVerdictRef = useRef<StudioStepDetail | null | undefined>(undefined);
+  const prevOpenedByRef = useRef<SubmissionStatus['openedBy'] | undefined>(undefined);
   const hasSeenStatusRef = useRef(false);
   useEffect(() => {
     if (!status) return;
@@ -426,10 +427,14 @@ export function SubmissionStatusView({
       if (hasSeenStatusRef.current && verdict && prevVerdictRef.current !== verdict) {
         recordStudioStep('gate_verdict', builder, verdict);
       }
+      if (hasSeenStatusRef.current && status.openedBy && prevOpenedByRef.current !== status.openedBy) {
+        recordStudioStep('round_opened', builder, status.openedBy);
+      }
     }
 
     prevStallRef.current = status.stall;
     prevVerdictRef.current = verdict;
+    prevOpenedByRef.current = status.openedBy;
     hasSeenStatusRef.current = true;
   }, [status]);
 
@@ -608,6 +613,10 @@ export function SubmissionStatusView({
             <p className="status-handoff-notice" role="status">
               <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.notice')}
             </p>
+          ) : status?.openedBy === 'agent' ? (
+            <p className="status-handoff-notice" role="status">
+              <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.agentOpened')}
+            </p>
           ) : null}
           {loading ? (
             <p className="catalog-state studio-thread-empty">{t('statusView.loading')}</p>
@@ -714,6 +723,10 @@ export function SubmissionStatusView({
         {justHandedOff ? (
           <p className="status-handoff-notice" role="status">
             <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.notice')}
+          </p>
+        ) : status?.openedBy === 'agent' ? (
+          <p className="status-handoff-notice" role="status">
+            <PixelIcon name="sparkle" size={13} /> {t('statusView.handoff.agentOpened')}
           </p>
         ) : null}
         {

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -427,8 +427,12 @@ export function SubmissionStatusView({
       if (hasSeenStatusRef.current && verdict && prevVerdictRef.current !== verdict) {
         recordStudioStep('gate_verdict', builder, verdict);
       }
-      if (hasSeenStatusRef.current && status.openedBy && prevOpenedByRef.current !== status.openedBy) {
-        recordStudioStep('round_opened', builder, status.openedBy);
+      if (status.openedBy) {
+        if (!hasSeenStatusRef.current) {
+          recordStudioStep('round_opened', builder, status.openedBy);
+        } else if (prevOpenedByRef.current !== status.openedBy) {
+          recordStudioStep('round_opened', builder, status.openedBy);
+        }
       }
     }
 

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -98,3 +98,19 @@ export async function rotateAgentKey(token: string): Promise<AgentKeyPayload> {
 
   return (await response.json()) as AgentKeyPayload;
 }
+
+/** Opt in or out of agent-opened improvement rounds for this game (BY-24). */
+export async function setAgentOpenRounds(token: string, allow: boolean): Promise<{ allowAgentOpenRounds: boolean }> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key/open-rounds`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ allow }),
+  });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+
+  return (await response.json()) as { allowAgentOpenRounds: boolean };
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -887,6 +887,7 @@
     "loadError": "We couldn't load agent settings right now.",
     "toggleError": "We couldn't update that setting. Try again in a moment.",
     "expiry": "This game's key expires {{when}}.",
+    "rotatedKickoff": "Your key was rotated — copy this fresh kickoff for your agent:",
     "openRounds": {
       "title": "Let my agent start new rounds",
       "on": "On",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -543,7 +543,8 @@
       "published": "This game is already published. Submit a new idea to make another version."
     },
     "handoff": {
-      "notice": "Improvement round started — this is the new build thread."
+      "notice": "Improvement round started — this is the new build thread.",
+      "agentOpened": "Your agent opened this improvement round — same daily limit as starting one in Studio."
     },
     "progress": {
       "checklistTitle": "What the agent is doing",
@@ -878,6 +879,19 @@
       "no": "Cancel",
       "sending": "Rotating…",
       "error": "We couldn't rotate the key right now. Try again in a moment."
+    }
+  },
+  "agentKey": {
+    "title": "Agent connection",
+    "loading": "Loading agent settings…",
+    "loadError": "We couldn't load agent settings right now.",
+    "toggleError": "We couldn't update that setting. Try again in a moment.",
+    "expiry": "This game's key expires {{when}}.",
+    "openRounds": {
+      "title": "Let my agent start new rounds",
+      "on": "On",
+      "off": "Off",
+      "hint": "When on, your coding agent can open post-publish improvement rounds with this game's key. Uses the same daily improvement limit as starting a round here."
     }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -891,6 +891,7 @@
     "loadError": "Nie udało się wczytać ustawień agenta.",
     "toggleError": "Nie udało się zapisać tego ustawienia. Spróbuj za chwilę.",
     "expiry": "Klucz tej gry wygasa {{when}}.",
+    "rotatedKickoff": "Klucz został obrócony — skopiuj ten nowy kickoff dla agenta:",
     "openRounds": {
       "title": "Niech mój agent otwiera nowe rundy",
       "on": "Wł.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -547,7 +547,8 @@
       "published": "Ta gra jest już opublikowana. Prześlij nowy pomysł, aby stworzyć kolejną wersję."
     },
     "handoff": {
-      "notice": "Runda ulepszeń rozpoczęta — to jest wątek nowej wersji."
+      "notice": "Runda ulepszeń rozpoczęta — to jest wątek nowej wersji.",
+      "agentOpened": "Twój agent otworzył tę rundę ulepszeń — ten sam dzienny limit co przy starcie w Studio."
     },
     "progress": {
       "checklistTitle": "Nad czym pracuje agent",
@@ -882,6 +883,19 @@
       "no": "Anuluj",
       "sending": "Obracanie…",
       "error": "Nie udało się teraz obrócić klucza. Spróbuj za chwilę."
+    }
+  },
+  "agentKey": {
+    "title": "Połączenie z agentem",
+    "loading": "Wczytywanie ustawień agenta…",
+    "loadError": "Nie udało się wczytać ustawień agenta.",
+    "toggleError": "Nie udało się zapisać tego ustawienia. Spróbuj za chwilę.",
+    "expiry": "Klucz tej gry wygasa {{when}}.",
+    "openRounds": {
+      "title": "Niech mój agent otwiera nowe rundy",
+      "on": "Wł.",
+      "off": "Wył.",
+      "hint": "Gdy włączone, Twój agent może otwierać rundy ulepszeń po publikacji tym kluczem gry. Zużywa ten sam dzienny limit ulepszeń co start rundy w Studio."
     }
   }
 }

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -132,6 +132,8 @@ export type SubmissionStatus = {
    * itself. Sending feedback starts a new round.
    */
   failure?: { reason: string };
+  /** Who opened this improvement round, when reported (BY-24). */
+  openedBy?: 'creator' | 'agent';
 };
 
 export type BuildPlayableItem = {

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -126,14 +126,14 @@ export type BuilderDimension = 'platform' | 'self';
  * that ordered funnel — these answer builder choice, connect friction, time to first
  * agent signal (`msSinceStart` on `agent_signaled`), and gate verdict per visit.
  */
-export type StudioStep = 'builder_chosen' | 'connect_copied' | 'agent_signaled' | 'gate_verdict';
+export type StudioStep = 'builder_chosen' | 'connect_copied' | 'agent_signaled' | 'gate_verdict' | 'round_opened';
 
 /**
  * Closed detail for studio steps that need one. `install` / `kickoff` are connect-card
  * copies; `green` / `red` / `kit_outdated` are gate verdicts. Absent on steps that
  * need none (builder choice, first agent signal).
  */
-export type StudioStepDetail = 'install' | 'kickoff' | 'green' | 'red' | 'kit_outdated';
+export type StudioStepDetail = 'install' | 'kickoff' | 'green' | 'red' | 'kit_outdated' | 'creator' | 'agent';
 
 /**
  * The content-editor funnel (EditorKit): did a creator who *can* edit actually


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
BY-24: MCP `open_round` for agent-opened post-publish improvement rounds (opt-in, durable game key, same daily improvement quota as Studio).

### Review follow-ups (`1cc3cb0f`)
- **Atomic admission:** `gameAgentKeys.agentOpenRoundPending` + `beginAgentOpenRound` / `finishAgentOpenRound` so concurrent `open_round` cannot double-create jobs or double-spend quota
- **Transactional opt-in:** merged BY-23 tip — `setGameAgentOpenRounds` is one Firestore transaction
- **Studio rotate:** show/copy fresh kickoff after rotate; `connect_copied` only on actual copy
- **Telemetry:** `round_opened` on first status snapshot when `openedBy` is already set

Stacked on #450 (`byoca/per-game-agent-key`).

## Test plan
- [x] `npm test --workspace=apps/api -- mcp-open-round`
- [x] `npm test --workspace=apps/web -- StudioAgentKeyPanel SubmissionStatusView`
- [x] Concurrent `open_round` admits one job / one quota spend

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

