### PR TITLE
fix(zones): survive wake catch-up timeouts (A6 2026-08-02)

### DIFF
--- a/apps/world/src/app.ts
+++ b/apps/world/src/app.ts
@@ -83,7 +83,21 @@ export async function buildWorldApp(options: WorldAppOptions): Promise<WorldApp>
   // trusting exactly one hop resolves to the entry Cloud Run itself wrote. `true` would
   // take the leftmost and let any caller pick their own rate-limit bucket.
   const app = Fastify({ logger: options.logger ?? false, trustProxy: 1 });
-  const host = new ZoneHost({ ...options, secret });
+  const host = new ZoneHost({
+    ...options,
+    secret,
+    onWarn:
+      options.onWarn ??
+      ((event) => {
+        // Not an admission failure — the join proceeds on the last snapshot. Still worth
+        // a warn: skipped catch-up is how a world looks "frozen in time" after a cold
+        // start, and A6 used to fire before this path existed (2026-08-02).
+        app.log.warn(
+          { err: event.error, slug: event.slug, zoneId: event.zoneId, elapsedMs: event.elapsedMs },
+          'zone wake catch-up skipped after timeout',
+        );
+      }),
+  });
   const maxSocketsPerIp = options.maxSocketsPerIp ?? DEFAULT_MAX_SOCKETS_PER_IP;
   const socketsByIp = new Map<string, number>();
 

--- a/apps/world/src/host.ts
+++ b/apps/world/src/host.ts
@@ -64,6 +64,14 @@ export interface ZoneHostOptions {
   secret: string;
   now?: () => number;
   maxZones?: number;
+  /** Soft faults a zone chose to survive (e.g. wake catch-up skipped after a timeout). */
+  onWarn?: (event: {
+    kind: 'wake_catchup_skipped';
+    slug: string;
+    zoneId: string;
+    elapsedMs: number;
+    error: unknown;
+  }) => void;
 }
 
 interface Seated {
@@ -153,6 +161,7 @@ export class ZoneHost {
         broadcast: (frame) => this.broadcast(claims.zone, frame),
         sendTo: (slot, frame) => this.sendTo(claims.zone, slot, frame),
         now: this.now,
+        onWarn: this.options.onWarn,
       });
       this.zones.set(claims.zone, zone);
       this.members.set(claims.zone, new Set());

--- a/docs/runbooks/zones-down-triage.md
+++ b/docs/runbooks/zones-down-triage.md
@@ -2,7 +2,8 @@
 
 Entry point for alerts **A6** (zone admission failing) and **A7** (world service 5xx).
 
-**Last drilled: never.**
+**Last drilled: never.** (A6 wake-timeout path diagnosed from prod logs 2026-08-02; degrade
+fix covered by unit test, not a live drill.)
 
 Read this first, because it changes what "working" looks like: when the zone host refuses
 a join, the shell falls back to solo play **without telling the player**. That is correct
@@ -42,8 +43,16 @@ would otherwise tell someone holding a stolen ticket which part they got wrong. 
 cause is only in this log.** A6 fires on the line `zone admission failed`; the `err`
 attached to it is the diagnosis.
 
-Two causes have happened before and are worth checking by eye first:
+Three causes have happened before and are worth checking by eye first:
 
+- **`Script execution timed out` inside `wake` / `tick` / `terrainHeight`** — catch-up
+  after hibernation blew the isolate budget. Seen on a cold `gamedev-world` start with
+  `biplane-skirmish` (A6 `0.oayobzkv6oet`, 2026-08-02 10:36Z): instance AUTOSCALING →
+  first `/zone/ws` failed in ~3s → retry four seconds later succeeded. Since the
+  wake-timeout degrade path landed, this should log
+  `zone wake catch-up skipped after timeout` at warn and **still admit** the player on
+  the last snapshot. If A6 is still firing on this message, the degrade path is not
+  deployed or a non-timeout error is wrapping it — check the revision.
 - **`not a constructor` / anything about `Isolate`** — the isolate cage loaded but is not
   usable. The host boots, passes its own cage assertion, serves `/health`, and fails
   every join. Fixed once in `packages/zone-core/src/cage.ts`; a recurrence most likely

--- a/packages/zone-core/src/cage.test.ts
+++ b/packages/zone-core/src/cage.test.ts
@@ -3,6 +3,7 @@ import {
   assertProductionCage,
   createIsolatedVmCage,
   createNodeVmCage,
+  isSimTimeoutError,
   SimCageUnavailableError,
   unwrapNativeModule,
   type SimCage,
@@ -50,6 +51,14 @@ const CAGES: Array<[string, () => Promise<SimCage> | SimCage]> = [
 function load(cage: SimCage, bundleJs: string) {
   return cage.load({ bundleJs, simMathJs: TEST_SIM_MATH_JS, timeoutMs: 2000, memoryMb: 32 });
 }
+
+describe('isSimTimeoutError', () => {
+  it('recognises isolated-vm and node:vm timeout messages', () => {
+    expect(isSimTimeoutError(new Error('Script execution timed out.'))).toBe(true);
+    expect(isSimTimeoutError(new Error('Script execution timed out after 200ms'))).toBe(true);
+    expect(isSimTimeoutError(new Error('zone is closed'))).toBe(false);
+  });
+});
 
 describe.each(CAGES)('%s cage', (_name, make) => {
   it('runs a sim and keeps its world inside the realm', async () => {

--- a/packages/zone-core/src/cage.ts
+++ b/packages/zone-core/src/cage.ts
@@ -52,10 +52,26 @@ export interface LoadSimOptions {
   bundleJs: string;
   /** The games repo's `shared/sim-math.ts`, transpiled. Installed as `Math`. */
   simMathJs: string;
-  /** Wall-clock ceiling for one call into the sim. */
+  /** Wall-clock ceiling for one call into the sim (init / tick / restore / snapshot). */
   timeoutMs: number;
+  /**
+   * Wall-clock ceiling for `wake` alone. Defaults to `timeoutMs`.
+   *
+   * Wake is once per hibernation and may run many catch-up ticks; keeping it on the
+   * per-tick budget is how a cold Cloud Run isolate turns a healthy sim into
+   * `zone_unavailable` (A6 2026-08-02, biplane-skirmish). Tick stays short so one zone
+   * cannot eat the core; wake gets its own headroom.
+   */
+  wakeTimeoutMs?: number;
   /** Heap ceiling for the whole zone, in MiB. Ignored by the node:vm cage, which has none. */
   memoryMb: number;
+}
+
+/** True when a cage interrupted a call for exceeding its wall-clock ceiling. */
+export function isSimTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  // isolated-vm: "Script execution timed out."; node:vm: "Script execution timed out after Nms"
+  return /timed?\s*out/i.test(message);
 }
 
 export class SimCageUnavailableError extends Error {}
@@ -223,10 +239,11 @@ export async function createIsolatedVmCage(): Promise<SimCage> {
   return {
     kind: 'isolated-vm',
     preemptsRunawayTicks: true,
-    async load({ bundleJs, simMathJs, timeoutMs, memoryMb }) {
+    async load({ bundleJs, simMathJs, timeoutMs, wakeTimeoutMs, memoryMb }) {
       const isolate = new ivm.Isolate({ memoryLimit: memoryMb });
       isolates.push(isolate);
       const context = isolate.createContextSync();
+      const wakeBudget = wakeTimeoutMs ?? timeoutMs;
 
       try {
         // Order matters: sim-math captures the exact-by-spec natives it builds on, so it
@@ -248,10 +265,10 @@ export async function createIsolatedVmCage(): Promise<SimCage> {
         throw error instanceof SimLoadError ? error : new SimLoadError(describeRealmFailure(error));
       }
 
-      const call = <T>(name: string, args: unknown[]): T => {
+      const call = <T>(name: string, args: unknown[], budget = timeoutMs): T => {
         const fn = context.global.getSync(name, { reference: true });
         try {
-          return fn.applySync(undefined, args, { timeout: timeoutMs }) as T;
+          return fn.applySync(undefined, args, { timeout: budget }) as T;
         } finally {
           fn.release();
         }
@@ -261,7 +278,7 @@ export async function createIsolatedVmCage(): Promise<SimCage> {
         init: (seed) => void call<number>('__zoneInit', [seed]),
         restore: (seed, stateJson, draws) => void call('__zoneRestore', [seed, stateJson, draws]),
         tick: (events) => void call('__zoneTick', [JSON.stringify(events)]),
-        wake: (elapsedMs) => void call('__zoneWake', [elapsedMs]),
+        wake: (elapsedMs) => void call('__zoneWake', [elapsedMs], wakeBudget),
         snapshot: () => ({ state: call<string>('__zoneState', []), draws: call<number>('__zoneDraws', []) }),
         dispose: () => {
           if (!isolate.isDisposed) isolate.dispose();
@@ -294,8 +311,9 @@ export function createNodeVmCage(): SimCage {
   return {
     kind: 'node-vm',
     preemptsRunawayTicks: false,
-    async load({ bundleJs, simMathJs, timeoutMs }) {
+    async load({ bundleJs, simMathJs, timeoutMs, wakeTimeoutMs }) {
       const context = vm.createContext({}, { codeGeneration: { strings: false, wasm: false }, name: 'zone-sim-realm' });
+      const wakeBudget = wakeTimeoutMs ?? timeoutMs;
 
       try {
         vm.runInContext(simMathJs, context, { timeout: timeoutMs });
@@ -315,10 +333,10 @@ export function createNodeVmCage(): SimCage {
         throw error instanceof SimLoadError ? error : new SimLoadError(describeRealmFailure(error));
       }
 
-      const call = <T>(source: string, args: Record<string, unknown> = {}): T => {
+      const call = <T>(source: string, args: Record<string, unknown> = {}, budget = timeoutMs): T => {
         Object.assign(context as Record<string, unknown>, args);
         try {
-          return vm.runInContext(source, context, { timeout: timeoutMs }) as T;
+          return vm.runInContext(source, context, { timeout: budget }) as T;
         } finally {
           for (const key of Object.keys(args)) delete (context as Record<string, unknown>)[key];
         }
@@ -330,7 +348,7 @@ export function createNodeVmCage(): SimCage {
         restore: (seed, stateJson, draws) =>
           void call('__zoneRestore(__seed, __state, __draws)', { __seed: seed, __state: stateJson, __draws: draws }),
         tick: (events) => void call('__zoneTick(__events)', { __events: JSON.stringify(events) }),
-        wake: (elapsedMs) => void call('__zoneWake(__elapsed)', { __elapsed: elapsedMs }),
+        wake: (elapsedMs) => void call('__zoneWake(__elapsed)', { __elapsed: elapsedMs }, wakeBudget),
         snapshot: () => ({ state: call<string>('__zoneState()'), draws: call<number>('__zoneDraws()') }),
         dispose: () => {
           // Nothing to release: a node:vm context is ordinary garbage. The flag exists so

--- a/packages/zone-core/src/index.ts
+++ b/packages/zone-core/src/index.ts
@@ -40,6 +40,7 @@ export {
   assertProductionCage,
   createIsolatedVmCage,
   createNodeVmCage,
+  isSimTimeoutError,
   SimCageUnavailableError,
   SimLoadError,
   type LoadSimOptions,
@@ -78,4 +79,5 @@ export {
   type ZoneOutboundFrame,
   type ZoneSnapshotStore,
   type ZoneStatus,
+  type ZoneWarnEvent,
 } from './zone.js';

--- a/packages/zone-core/src/zone.test.ts
+++ b/packages/zone-core/src/zone.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createNodeVmCage } from './cage.js';
+import { createNodeVmCage, type SimCage, type SimInstance } from './cage.js';
 import { ZONE_SNAPSHOT_VERSION, type ZoneSnapshot } from './contract.js';
 import { parseZoneSchema, type ZoneSchema } from './schema.js';
-import { Zone, ZoneFullError, type SimSource, type ZoneOutboundFrame, type ZoneSnapshotStore } from './zone.js';
+import {
+  Zone,
+  ZoneFullError,
+  type SimSource,
+  type ZoneOutboundFrame,
+  type ZoneSnapshotStore,
+  type ZoneWarnEvent,
+} from './zone.js';
 import {
   BLOATED_SIM,
   COUNTER_SIM,
@@ -271,6 +278,69 @@ describe('hibernation', () => {
     await second.zone.hibernate('empty');
     expect(JSON.parse(second.store.saved.get('ember-watch')!.state).slept).toBeGreaterThan(0);
     void state;
+  });
+
+  it('opens on the last snapshot when wake catch-up times out, rather than refusing the join', async () => {
+    // A6 2026-08-02: cold gamedev-world + biplane-skirmish wake blew the isolate budget
+    // and the shell fell back to silent solo play. Surviving on the snapshot is the
+    // lesser wrong — the world is a few minutes behind, not a different mode of play.
+    const store = new FakeStore();
+    const first = harness({ store });
+    await first.zone.join('player-a');
+    first.runTicks(3);
+    await first.zone.hibernate('empty');
+    const slept = store.saved.get('ember-watch')!;
+
+    const warnings: ZoneWarnEvent[] = [];
+    let wakeCalls = 0;
+    const inner = createNodeVmCage();
+    const cage: SimCage = {
+      kind: 'node-vm',
+      preemptsRunawayTick: false,
+      async load(options) {
+        const instance = await inner.load(options);
+        const wrapped: SimInstance = {
+          init: (seed) => instance.init(seed),
+          restore: (seed, state, draws) => instance.restore(seed, state, draws),
+          tick: (events) => instance.tick(events),
+          wake: (elapsedMs) => {
+            wakeCalls += 1;
+            if (wakeCalls === 1) throw new Error('Script execution timed out.');
+            instance.wake(elapsedMs);
+          },
+          snapshot: () => instance.snapshot(),
+          dispose: () => instance.dispose(),
+        };
+        return wrapped;
+      },
+      dispose: () => inner.dispose(),
+    };
+
+    const zone = new Zone({
+      id: 'ember-watch',
+      slug: 'ember-watch',
+      schema: SCHEMA,
+      cage,
+      source: simSource(COUNTER_SIM),
+      store,
+      broadcast: () => undefined,
+      sendTo: () => undefined,
+      now: () => slept.savedAt + 60_000,
+      newSeed: () => 4242,
+      onWarn: (event) => warnings.push(event),
+    });
+
+    await expect(zone.join('player-a')).resolves.toBe(0);
+    expect(zone.state).toBe('live');
+    expect(wakeCalls).toBe(1);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        kind: 'wake_catchup_skipped',
+        slug: 'ember-watch',
+        zoneId: 'ember-watch',
+        elapsedMs: 60_000,
+      }),
+    ]);
   });
 
   it('loses what a sim kept outside its state, which is why the gate checks for it', async () => {

--- a/packages/zone-core/src/zone.ts
+++ b/packages/zone-core/src/zone.ts
@@ -3,12 +3,13 @@ import {
   checksumState,
   MAX_STATE_BYTES,
   MAX_TICK_MS,
+  MAX_WAKE_MS,
   ZONE_SNAPSHOT_VERSION,
   type TickHz,
   type ZoneEvent,
   type ZoneSnapshot,
 } from './contract.js';
-import type { SimCage, SimInstance } from './cage.js';
+import { isSimTimeoutError, type SimCage, type SimInstance } from './cage.js';
 import { validateZoneInput, type ZoneSchema } from './schema.js';
 
 /**
@@ -58,6 +59,22 @@ const OVERRUN_LIMIT = 20;
  *  a tick's event list is meant to be a handful of intents, not a queue to flush. */
 const MAX_PENDING_PER_SLOT = 8;
 
+/**
+ * Interrupt ceiling for init / tick / restore. Headroom over `MAX_TICK_MS` so one GC
+ * pause is not a zone death; still short enough that a runaway tick cannot eat the core.
+ */
+const SIM_CALL_TIMEOUT_MS = Math.max(MAX_TICK_MS * 8, 200);
+
+/**
+ * Interrupt ceiling for `wake` alone.
+ *
+ * Wake is once per hibernation and may catch up hundreds of ticks. Pinning it to the
+ * per-tick budget is what turned a cold `gamedev-world` start into A6 on 2026-08-02
+ * (`biplane-skirmish`, `Script execution timed out` inside `terrainHeight`/`sin`). A
+ * second join four seconds later succeeded — the sim was fine; the budget was not.
+ */
+const SIM_WAKE_TIMEOUT_MS = Math.max(MAX_WAKE_MS * 20, 1_000);
+
 export type ZoneStatus = 'sleeping' | 'live' | 'closed';
 
 export interface ZoneSnapshotStore {
@@ -74,6 +91,14 @@ export type ZoneOutboundFrame =
   | { t: 'snap'; tick: number; seed: number; draws: number; state: string }
   | { t: 'delta'; tick: number; ev: ZoneEvent[]; h?: string }
   | { t: 'closed'; reason: string };
+
+export type ZoneWarnEvent = {
+  kind: 'wake_catchup_skipped';
+  slug: string;
+  zoneId: string;
+  elapsedMs: number;
+  error: unknown;
+};
 
 export interface ZoneOptions {
   id: string;
@@ -100,6 +125,12 @@ export interface ZoneOptions {
   /** Seed for a zone that has never existed. Injected so a test can pin a world. */
   newSeed?: () => number;
   memoryMb?: number;
+  /**
+   * Soft faults the zone chose to survive. Wake catch-up that blows its budget is the
+   * current one: refusing the join would fall the shell back to solo play and fire A6,
+   * which is worse than opening on the last snapshot without the missed minutes.
+   */
+  onWarn?: (event: ZoneWarnEvent) => void;
 }
 
 export class ZoneFullError extends Error {}
@@ -376,13 +407,16 @@ export class Zone {
     const sources = await this.options.source.load(this.slug);
     if (!sources) throw new ZoneUnavailableError(`no simulation is published for ${this.slug}`);
 
-    const sim = await this.options.cage.load({
-      bundleJs: sources.bundleJs,
-      simMathJs: sources.simMathJs,
-      timeoutMs: Math.max(MAX_TICK_MS * 8, 200),
-      memoryMb: this.options.memoryMb ?? 64,
-    });
+    const loadSim = () =>
+      this.options.cage.load({
+        bundleJs: sources.bundleJs,
+        simMathJs: sources.simMathJs,
+        timeoutMs: SIM_CALL_TIMEOUT_MS,
+        wakeTimeoutMs: SIM_WAKE_TIMEOUT_MS,
+        memoryMb: this.options.memoryMb ?? 64,
+      });
 
+    let sim = await loadSim();
     const stored = await this.options.store.load(this.id);
     const now = this.now();
 
@@ -394,7 +428,26 @@ export class Zone {
       // of the elapsed time actually applies is the *game's* decision — the platform
       // hands over real milliseconds and bounds only how long deciding may take.
       const elapsed = Math.max(0, now - stored.savedAt);
-      if (elapsed > 0) sim.wake(elapsed);
+      if (elapsed > 0) {
+        try {
+          sim.wake(elapsed);
+        } catch (error) {
+          if (!isSimTimeoutError(error)) throw error;
+          // A timed-out wake may have left the isolate mid-mutation. Rebuild from the
+          // same snapshot and open without catch-up rather than refuse the join: the
+          // shell's fallback is silent solo play, which looks healthy and is wrong.
+          sim.dispose();
+          sim = await loadSim();
+          sim.restore(stored.seed, stored.state, stored.draws);
+          this.options.onWarn?.({
+            kind: 'wake_catchup_skipped',
+            slug: this.slug,
+            zoneId: this.id,
+            elapsedMs: elapsed,
+            error,
+          });
+        }
+      }
     } else {
       this.seed = (this.options.newSeed ?? defaultSeed)();
       this.tick = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Triaged [A6 alert `0.oayobzkv6oet`](https://console.cloud.google.com/monitoring/alerting/alerts/0.oayobzkv6oet?project=gamedevpl).

**What fired:** `A6 zone admission failing` at 10:37Z on `gamedev-world-00005-xqn`.

**Cause:** Cold start (AUTOSCALING) → first `biplane-skirmish` join ran isolate `wake` catch-up → `Script execution timed out.` inside `terrainHeight`/`sin`. Site `/api/health` stayed 200; the shell fell back to silent solo play. A retry four seconds later succeeded.

**Fix:**
- Give `wake` its own isolate timeout (`wakeTimeoutMs`, 1s), separate from the per-tick budget.
- If wake still times out, dispose the isolate, restore the same snapshot **without** catch-up, admit the player, and warn-log `zone wake catch-up skipped after timeout` (no A6).
- Runbook updated with this failure mode.

Rebased onto latest `master` (lint fix from this branch dropped — master already solved that with `ignoreRestSiblings`).

## Deploy note

Needs a **`gamedev-world`** redeploy after merge (`infra/deploy-world.sh`). The app service alone does not pick this up.

## Side finding (ops)

Live `gamedev-world` has `maxInstanceCount: 20` while `deploy-world.sh` pins `--max-instances 1`. Reconcile on the next world deploy — do not raise without the zone directory.

## Test plan

- [x] `npm test --workspace=@gamedevpl/zone-core` (includes new degrade-path test)
- [x] `npm test --workspace=@gamedevpl/world`
- [x] `npm run lint`
- [ ] Owner: deploy world service; confirm warn log path under a forced cold start if desired

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d0e63e-562c-455a-a8c5-e6f1aed7b1dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d0e63e-562c-455a-a8c5-e6f1aed7b1dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

