### PR TITLE
byoca(BY-18a): OAuth protected-resource metadata + MCP 401 challenge

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -58,7 +58,7 @@ import { peekQuota } from './quota-gate.js';
 import { registerRateLimit } from './rate-limit.js';
 import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 import { logModerationRejection } from './moderation-metrics.js';
-import { OAUTH_PROTECTED_RESOURCE_PATH, registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
+import { registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -547,7 +547,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // flow, and the waitlist — which by definition serves people who just failed sign-in).
   app.addHook('onRequest', async (request, reply) => {
     if (!privateBeta) return;
-    if (request.url === OAUTH_PROTECTED_RESOURCE_PATH) return;
+    // No entry here for the OAuth protected-resource document: it is served outside
+    // `/api/`, so the next line already passes it through. An exemption that never fires
+    // would imply this wall covers that route, and a bypass list has to be read as exact.
     if (!request.url.startsWith('/api/')) return; // static shell always passes through
     if (request.url === '/api/health' || request.url.startsWith('/api/auth')) return;
     if (request.url.startsWith('/api/waitlist')) return;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -58,6 +58,7 @@ import { peekQuota } from './quota-gate.js';
 import { registerRateLimit } from './rate-limit.js';
 import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 import { logModerationRejection } from './moderation-metrics.js';
+import { OAUTH_PROTECTED_RESOURCE_PATH, registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -518,6 +519,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   app.get('/api/version', async () => ({ name: 'gamedev-pl', version: '0.0.0' }));
 
+  // RFC 9728 protected-resource metadata for the MCP endpoint (BY-18a). Public,
+  // cacheable, no auth — advertises where an authorization server will live.
+  registerOAuthProtectedResourceRoutes(app);
+
   // Apex → www canonical-host redirect. Cloud Run domain mappings can't emit a
   // 301, and both www.gamedev.pl and gamedev.pl terminate at this same service,
   // so we canonicalize here. When CANONICAL_HOST=www.gamedev.pl, a request whose
@@ -542,6 +547,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // flow, and the waitlist — which by definition serves people who just failed sign-in).
   app.addHook('onRequest', async (request, reply) => {
     if (!privateBeta) return;
+    if (request.url === OAUTH_PROTECTED_RESOURCE_PATH) return;
     if (!request.url.startsWith('/api/')) return; // static shell always passes through
     if (request.url === '/api/health' || request.url.startsWith('/api/auth')) return;
     if (request.url.startsWith('/api/waitlist')) return;

--- a/apps/api/src/canonical-app-url.ts
+++ b/apps/api/src/canonical-app-url.ts
@@ -4,14 +4,36 @@
  * Never derive from the request Host header — a spoofed Host must not redirect clients
  * to attacker-controlled metadata or consent URLs.
  */
+const DEFAULT_ORIGIN = 'https://www.gamedev.pl';
+
+/**
+ * Reduce a configured value to a bare origin, or null when it is not a URL at all.
+ *
+ * Trimming trailing slashes is not enough: a `CANONICAL_HOST` or `APP_BASE_URL` carrying
+ * a path, query, or fragment would be concatenated with `/.well-known/...` and yield a
+ * metadata URL that resolves nowhere — and this value is handed to clients inside a
+ * `WWW-Authenticate` challenge, so a misconfiguration becomes their problem, not ours.
+ * `URL` also rejects outright garbage, which a regex would have passed through.
+ */
+function toOrigin(value: string): string | null {
+  const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  try {
+    return new URL(candidate).origin;
+  } catch {
+    return null;
+  }
+}
+
 export function canonicalAppBaseUrl(): string {
   const canonicalHost = process.env.CANONICAL_HOST?.trim();
   if (canonicalHost) {
-    return `https://${canonicalHost.replace(/^https?:\/\//, '').replace(/\/+$/, '')}`;
+    const origin = toOrigin(canonicalHost);
+    if (origin) return origin;
   }
   const appBase = process.env.APP_BASE_URL?.trim();
   if (appBase) {
-    return appBase.replace(/\/+$/, '');
+    const origin = toOrigin(appBase);
+    if (origin) return origin;
   }
-  return 'https://www.gamedev.pl';
+  return DEFAULT_ORIGIN;
 }

--- a/apps/api/src/canonical-app-url.ts
+++ b/apps/api/src/canonical-app-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical public origin for absolute URLs in outbound links and OAuth metadata.
+ *
+ * Never derive from the request Host header — a spoofed Host must not redirect clients
+ * to attacker-controlled metadata or consent URLs.
+ */
+export function canonicalAppBaseUrl(): string {
+  const canonicalHost = process.env.CANONICAL_HOST?.trim();
+  if (canonicalHost) {
+    return `https://${canonicalHost.replace(/^https?:\/\//, '').replace(/\/+$/, '')}`;
+  }
+  const appBase = process.env.APP_BASE_URL?.trim();
+  if (appBase) {
+    return appBase.replace(/\/+$/, '');
+  }
+  return 'https://www.gamedev.pl';
+}

--- a/apps/api/src/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/mcp-oauth-metadata.test.ts
@@ -1,0 +1,390 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import { mintGameAgentKey } from './agent-game-key.js';
+import {
+  buildMcpOAuthAuthenticateHeader,
+  buildOAuthProtectedResourceDocument,
+  OAUTH_PROTECTED_RESOURCE_PATH,
+  oauthProtectedResourceMetadataUrl,
+} from './mcp-oauth-metadata.js';
+import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+describe('canonicalAppBaseUrl / oauth metadata helpers', () => {
+  const envKeys = [
+    'CANONICAL_HOST',
+    'APP_BASE_URL',
+    'MCP_AUTHORIZATION_SERVERS',
+    'MCP_RESOURCE_DOCUMENTATION_URL',
+  ] as const;
+
+  afterEach(() => {
+    for (const key of envKeys) delete process.env[key];
+  });
+
+  it('prefers CANONICAL_HOST over APP_BASE_URL for metadata URLs', () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    process.env.APP_BASE_URL = 'https://evil.test';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://www.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
+    expect(buildMcpOAuthAuthenticateHeader()).toBe(
+      `Bearer resource_metadata="https://www.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}"`,
+    );
+  });
+
+  it('falls back to APP_BASE_URL when CANONICAL_HOST is unset', () => {
+    process.env.APP_BASE_URL = 'https://staging.gamedev.pl';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://staging.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
+  });
+
+  it('omits authorization_servers when MCP_AUTHORIZATION_SERVERS is unset', () => {
+    delete process.env.MCP_AUTHORIZATION_SERVERS;
+    const doc = buildOAuthProtectedResourceDocument();
+    expect(doc).toMatchObject({
+      resource: `https://www.gamedev.pl${MCP_ENDPOINT_PATH}`,
+      bearer_methods_supported: ['header'],
+      resource_documentation: 'https://www.gamedev.pl/studio',
+    });
+    expect(doc).not.toHaveProperty('authorization_servers');
+  });
+
+  it('includes authorization_servers when MCP_AUTHORIZATION_SERVERS is set', () => {
+    process.env.MCP_AUTHORIZATION_SERVERS = 'https://auth.example.com, https://auth2.example.com';
+    const doc = buildOAuthProtectedResourceDocument();
+    expect(doc.authorization_servers).toEqual(['https://auth.example.com', 'https://auth2.example.com']);
+  });
+});
+
+describe('GET /.well-known/oauth-protected-resource (BY-18a)', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    delete process.env.CANONICAL_HOST;
+    delete process.env.APP_BASE_URL;
+    delete process.env.MCP_AUTHORIZATION_SERVERS;
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  it('serves the metadata document unauthenticated with cache headers', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    app = await buildApp({ store: new InMemoryStore(), sessionSecret: 'dev-session-secret-change-me' });
+    const res = await app.inject({ method: 'GET', url: OAUTH_PROTECTED_RESOURCE_PATH });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toBe('public, max-age=3600');
+    expect(res.json()).toEqual({
+      resource: `https://www.gamedev.pl${MCP_ENDPOINT_PATH}`,
+      bearer_methods_supported: ['header'],
+      resource_documentation: 'https://www.gamedev.pl/studio',
+    });
+  });
+
+  it('ignores a spoofed Host header when building absolute URLs', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    app = await buildApp({ store: new InMemoryStore(), sessionSecret: 'dev-session-secret-change-me' });
+    const res = await app.inject({
+      method: 'GET',
+      url: OAUTH_PROTECTED_RESOURCE_PATH,
+      headers: { host: 'evil.test' },
+    });
+    expect(res.json().resource).toBe(`https://www.gamedev.pl${MCP_ENDPOINT_PATH}`);
+  });
+
+  it('reaches the metadata route through the private-beta wall without a site session', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    app = await buildApp({
+      store: new InMemoryStore(),
+      betaAllowedUids: 'g:anyone',
+      sessionSecret: 'dev-session-secret-change-me',
+    });
+    const res = await app.inject({ method: 'GET', url: OAUTH_PROTECTED_RESOURCE_PATH });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().resource).toBe(`https://www.gamedev.pl${MCP_ENDPOINT_PATH}`);
+  });
+});
+
+describe('MCP OAuth 401 challenge (BY-18a)', () => {
+  const secret = 'oauth-challenge-secret';
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    delete process.env.CANONICAL_HOST;
+    delete process.env.APP_BASE_URL;
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  async function buildMcpApp(store: InMemoryStore) {
+    return buildApp({
+      store,
+      sessionSecret: 'dev-session-secret-change-me',
+      submissionRoutes: {
+        githubClient: {
+          createIssue: async () => ({ number: 42 }),
+          getIssueState: async () => ({ state: 'open' as const }),
+          findLinkedPR: async () => null,
+          createIssueComment: async () => ({ id: 1 }),
+          updateIssueBody: async () => {},
+          closeIssue: async () => {},
+          closePullRequest: async () => {},
+          ensureOpenPullRequest: async () => ({ number: 1 }),
+          deleteBranch: async () => {},
+          getGameSources: async () => null,
+          getGameMedia: async () => null,
+          getCatalog: async () => [],
+          getProgressNotes: async () => null,
+        },
+        githubToken: 'gh-token',
+        submissionTokenSecret: secret,
+        translator: new NoopTranslator(),
+        agentChannel: {},
+      },
+    });
+  }
+
+  async function seedJob(store: InMemoryStore) {
+    await store.createSubmission(42, 'g:owner', 'Comet Courier');
+    await store.setSubmissionSlug(42, 'comet-courier');
+    await store.setSubmissionLocale(42, 'en');
+    await store.setRoundBuilder(42, 'self');
+    await store.setSubmissionBrief(42, { spec: 'Build it.', qa: [] });
+  }
+
+  it('returns 401 with a canonical resource_metadata URL for unauthenticated tools/call', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        host: 'evil.test',
+        'content-type': 'application/json',
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: {} },
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.headers['www-authenticate']).toBe(
+      `Bearer resource_metadata="https://www.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}"`,
+    );
+    expect(res.json()).toEqual({ error: 'authentication required' });
+  });
+
+  it('returns 401 for unauthenticated GET /api/mcp', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    app = await buildMcpApp(new InMemoryStore());
+    const res = await app.inject({ method: 'GET', url: MCP_ENDPOINT_PATH, headers: { host: 'evil.test' } });
+    expect(res.statusCode).toBe(401);
+    expect(res.headers['www-authenticate']).toContain('resource_metadata="https://www.gamedev.pl');
+    expect(res.headers['www-authenticate']).not.toContain('evil.test');
+  });
+
+  it('still allows initialize without credentials', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['www-authenticate']).toBeUndefined();
+  });
+});
+
+describe('MCP OAuth challenge regressions (BY-18a)', () => {
+  const secret = 'oauth-regression-secret';
+  const ISSUE = 77;
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  async function buildMcpApp(store: InMemoryStore) {
+    return buildApp({
+      store,
+      sessionSecret: 'dev-session-secret-change-me',
+      submissionRoutes: {
+        githubClient: {
+          createIssue: async () => ({ number: ISSUE }),
+          getIssueState: async () => ({ state: 'open' as const }),
+          findLinkedPR: async () => null,
+          createIssueComment: async () => ({ id: 1 }),
+          updateIssueBody: async () => {},
+          closeIssue: async () => {},
+          closePullRequest: async () => {},
+          ensureOpenPullRequest: async () => ({ number: 1 }),
+          deleteBranch: async () => {},
+          getGameSources: async () => null,
+          getGameMedia: async () => null,
+          getCatalog: async () => [],
+          getProgressNotes: async () => null,
+        },
+        githubToken: 'gh-token',
+        submissionTokenSecret: secret,
+        translator: new NoopTranslator(),
+        agentChannel: {},
+      },
+    });
+  }
+
+  async function seedJob(store: InMemoryStore) {
+    await store.createSubmission(ISSUE, 'g:owner', 'Comet Courier');
+    await store.setSubmissionSlug(ISSUE, 'comet-courier');
+    await store.setSubmissionLocale(ISSUE, 'en');
+    await store.setRoundBuilder(ISSUE, 'self');
+    await store.setSubmissionBrief(ISSUE, { spec: 'Build it.', qa: [] });
+    await store.recordJobTransition(ISSUE, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+  }
+
+  async function initialize(app: FastifyInstance) {
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        },
+      },
+    });
+    return String(res.headers['mcp-session-id']);
+  }
+
+  it('does not challenge valid Bearer round-key or stale-key tool calls', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+    const sessionId = await initialize(app);
+    const roundKey = mintAgentToken(ISSUE, secret, { roundGeneration: 1 });
+
+    const brief = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${roundKey}`,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: {} },
+      },
+    });
+    expect(brief.statusCode).toBe(200);
+    expect(brief.headers['www-authenticate']).toBeUndefined();
+    const briefBody = brief.json() as { result?: { isError?: boolean; structuredContent?: { title?: string } } };
+    expect(briefBody.result?.isError).not.toBe(true);
+    expect(briefBody.result?.structuredContent).toMatchObject({ title: 'Comet Courier' });
+
+    const stale = mintAgentToken(ISSUE, secret, { roundGeneration: 1, now: Date.parse('2020-01-01T00:00:00.000Z') });
+    const refused = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${stale}`,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: {} },
+      },
+    });
+    expect(refused.statusCode).toBe(200);
+    expect(refused.headers['www-authenticate']).toBeUndefined();
+    const refusedBody = refused.json() as { result?: { isError?: boolean; structuredContent?: { error?: string } } };
+    expect(refusedBody.result?.isError).toBe(true);
+    expect(refusedBody.result?.structuredContent?.error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('does not challenge start with a durable game key or sessionKey tool calls', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const at = new Date().toISOString();
+    await store.ensureGameAgentKey('comet-courier', 'g:owner', at);
+    app = await buildMcpApp(store);
+    const sessionId = await initialize(app);
+
+    const gameKey = mintGameAgentKey(secret, {
+      slug: 'comet-courier',
+      creatorUid: 'g:owner',
+      keyGeneration: 1,
+    });
+    const started = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'start', arguments: { key: gameKey } },
+      },
+    });
+    expect(started.statusCode).toBe(200);
+    expect(started.headers['www-authenticate']).toBeUndefined();
+    const startedBody = started.json() as { result?: { structuredContent?: { sessionKey?: string } } };
+    const sessionKey = startedBody.result?.structuredContent?.sessionKey;
+    expect(typeof sessionKey).toBe('string');
+
+    const brief = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: { sessionKey } },
+      },
+    });
+    expect(brief.statusCode).toBe(200);
+    expect(brief.headers['www-authenticate']).toBeUndefined();
+    const briefBody = brief.json() as { result?: { isError?: boolean; structuredContent?: { title?: string } } };
+    expect(briefBody.result?.isError).not.toBe(true);
+    expect(briefBody.result?.structuredContent).toMatchObject({ title: 'Comet Courier' });
+  });
+});

--- a/apps/api/src/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/mcp-oauth-metadata.test.ts
@@ -40,6 +40,29 @@ describe('canonicalAppBaseUrl / oauth metadata helpers', () => {
     expect(oauthProtectedResourceMetadataUrl()).toBe(`https://staging.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
   });
 
+  // These values reach clients inside a WWW-Authenticate challenge, so a misconfigured
+  // env must not turn into a metadata URL that resolves nowhere.
+  it('reduces a CANONICAL_HOST carrying a path to its origin', () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl/some/path';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://www.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
+  });
+
+  it('reduces an APP_BASE_URL carrying a path and query to its origin', () => {
+    process.env.APP_BASE_URL = 'https://staging.gamedev.pl/base?tenant=1#frag';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://staging.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
+  });
+
+  it('keeps an explicit port', () => {
+    process.env.CANONICAL_HOST = 'localhost:5173';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://localhost:5173${OAUTH_PROTECTED_RESOURCE_PATH}`);
+  });
+
+  it('falls through to the next source when a value is not a URL at all', () => {
+    process.env.CANONICAL_HOST = 'http://';
+    process.env.APP_BASE_URL = 'https://staging.gamedev.pl';
+    expect(oauthProtectedResourceMetadataUrl()).toBe(`https://staging.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}`);
+  });
+
   it('omits authorization_servers when MCP_AUTHORIZATION_SERVERS is unset', () => {
     delete process.env.MCP_AUTHORIZATION_SERVERS;
     const doc = buildOAuthProtectedResourceDocument();

--- a/apps/api/src/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/mcp-oauth-metadata.test.ts
@@ -6,6 +6,7 @@ import { mintGameAgentKey } from './agent-game-key.js';
 import {
   buildMcpOAuthAuthenticateHeader,
   buildOAuthProtectedResourceDocument,
+  MCP_MISSING_CREDENTIAL_HINT,
   OAUTH_PROTECTED_RESOURCE_PATH,
   oauthProtectedResourceMetadataUrl,
 } from './mcp-oauth-metadata.js';
@@ -177,7 +178,13 @@ describe('MCP OAuth 401 challenge (BY-18a)', () => {
     expect(res.headers['www-authenticate']).toBe(
       `Bearer resource_metadata="https://www.gamedev.pl${OAUTH_PROTECTED_RESOURCE_PATH}"`,
     );
-    expect(res.json()).toEqual({ error: 'authentication required' });
+    // The challenge replaced a tool error that told the agent what to do; a status code
+    // is not an instruction, so the sentence has to survive the change.
+    expect(res.json()).toEqual({
+      error: 'authentication required',
+      hint: MCP_MISSING_CREDENTIAL_HINT,
+    });
+    expect(MCP_MISSING_CREDENTIAL_HINT).toMatch(/sessionKey from start\(\)/);
   });
 
   it('returns 401 for unauthenticated GET /api/mcp', async () => {

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -97,11 +97,23 @@ export function shouldIssueMcpOAuthChallenge(request: FastifyRequest, message: J
   return mcpRequestLacksCredential(request, message);
 }
 
+/**
+ * What an agent must actually DO about a missing credential.
+ *
+ * The challenge replaced a tool-level error that carried this sentence, and a status
+ * code is not an instruction: an agent that drops `sessionKey` on one call needs to be
+ * told to re-send it, not pointed at an authorization server that does not exist yet.
+ * Exported so the tool-level refusal in `mcp-server.ts` and this HTTP challenge cannot
+ * drift into saying different things.
+ */
+export const MCP_MISSING_CREDENTIAL_HINT =
+  'missing credential: pass sessionKey from start(), or configure Authorization: Bearer <round key>';
+
 export function sendMcpOAuthChallenge(reply: FastifyReply): FastifyReply {
   return reply
     .status(401)
     .header('WWW-Authenticate', buildMcpOAuthAuthenticateHeader())
-    .send({ error: 'authentication required' });
+    .send({ error: 'authentication required', hint: MCP_MISSING_CREDENTIAL_HINT });
 }
 
 export function registerOAuthProtectedResourceRoutes(app: FastifyInstance): void {

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -1,0 +1,114 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { readBearerToken } from './bearer.js';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
+import { mcpEndpointUrl } from './self-build-connect.js';
+
+/** RFC 9728 protected-resource metadata document (BY-18a). */
+export const OAUTH_PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
+
+const METADATA_CACHE_CONTROL = 'public, max-age=3600';
+
+interface JsonRpcMessage {
+  method?: string;
+  params?: unknown;
+}
+
+function parseAuthorizationServers(): string[] | undefined {
+  const raw = process.env.MCP_AUTHORIZATION_SERVERS?.trim();
+  if (!raw) return undefined;
+  const servers = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return servers.length > 0 ? servers : undefined;
+}
+
+function resourceDocumentationUrl(): string {
+  const configured = process.env.MCP_RESOURCE_DOCUMENTATION_URL?.trim();
+  if (configured) return configured;
+  return `${canonicalAppBaseUrl()}/studio`;
+}
+
+/** Absolute URL of the PRM document — always from the canonical origin, never Host. */
+export function oauthProtectedResourceMetadataUrl(): string {
+  return `${canonicalAppBaseUrl()}${OAUTH_PROTECTED_RESOURCE_PATH}`;
+}
+
+export function buildOAuthProtectedResourceDocument(): Record<string, unknown> {
+  const document: Record<string, unknown> = {
+    resource: mcpEndpointUrl(canonicalAppBaseUrl()),
+    bearer_methods_supported: ['header'],
+    resource_documentation: resourceDocumentationUrl(),
+  };
+  const authorizationServers = parseAuthorizationServers();
+  if (authorizationServers) {
+    document.authorization_servers = authorizationServers;
+  }
+  return document;
+}
+
+export function buildMcpOAuthAuthenticateHeader(): string {
+  return `Bearer resource_metadata="${oauthProtectedResourceMetadataUrl()}"`;
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * True when the JSON-RPC message is one that requires a build credential and the
+ * request presents none at the HTTP or tool-argument layer.
+ */
+export function mcpRequestLacksCredential(request: FastifyRequest, message: JsonRpcMessage): boolean {
+  if (readBearerToken(request.headers.authorization)) return false;
+
+  if (message.method !== 'tools/call') return false;
+
+  const params = message.params;
+  if (!params || typeof params !== 'object') return true;
+
+  const toolParams = params as { name?: string; arguments?: Record<string, unknown> };
+  const args = toolParams.arguments;
+  if (!args || typeof args !== 'object') return true;
+
+  if (nonEmptyString(args.sessionKey)) return false;
+
+  const toolName = nonEmptyString(toolParams.name);
+  if ((toolName === 'start' || toolName === 'open_round') && nonEmptyString(args.key)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Protocol methods that never receive an OAuth challenge — existing clients handshake here. */
+export function mcpMethodAllowsAnonymousHandshake(method: string | undefined): boolean {
+  if (!method) return true;
+  if (method === 'initialize') return true;
+  if (method === 'ping') return true;
+  if (method === 'tools/list') return true;
+  if (method.startsWith('notifications/')) return true;
+  return false;
+}
+
+export function shouldIssueMcpOAuthChallenge(request: FastifyRequest, message: JsonRpcMessage): boolean {
+  if (mcpMethodAllowsAnonymousHandshake(message.method)) return false;
+  if (message.method !== 'tools/call') return false;
+  return mcpRequestLacksCredential(request, message);
+}
+
+export function sendMcpOAuthChallenge(reply: FastifyReply): FastifyReply {
+  return reply
+    .status(401)
+    .header('WWW-Authenticate', buildMcpOAuthAuthenticateHeader())
+    .send({ error: 'authentication required' });
+}
+
+export function registerOAuthProtectedResourceRoutes(app: FastifyInstance): void {
+  app.get(OAUTH_PROTECTED_RESOURCE_PATH, async (_request, reply) => {
+    return reply
+      .header('Cache-Control', METADATA_CACHE_CONTROL)
+      .type('application/json')
+      .send(buildOAuthProtectedResourceDocument());
+  });
+}

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -395,9 +395,22 @@ describe('POST /api/mcp (BY-05)', () => {
     const started = await callTool(app, 'start', { key }, { 'mcp-session-id': sessionId });
     const realKey = (started.structured as { sessionKey: string }).sessionKey;
 
-    const missing = await callTool(app, 'get_brief', {}, { 'mcp-session-id': sessionId });
-    expect(missing.isError).toBe(true);
-    expect(JSON.stringify(missing.structured)).toMatch(/missing credential|sessionKey/i);
+    const missing = await app.inject({
+      method: 'POST',
+      url: '/api/mcp',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: {} },
+      },
+    });
+    expect(missing.statusCode).toBe(401);
+    expect(missing.headers['www-authenticate']).toMatch(/resource_metadata="/);
 
     const forged = mintMcpSessionKey(secret, {
       sessionId,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -30,7 +30,11 @@ import {
   newMcpSessionId,
   verifyMcpSessionKey,
 } from './mcp-session-key.js';
-import { sendMcpOAuthChallenge, shouldIssueMcpOAuthChallenge } from './mcp-oauth-metadata.js';
+import {
+  MCP_MISSING_CREDENTIAL_HINT,
+  sendMcpOAuthChallenge,
+  shouldIssueMcpOAuthChallenge,
+} from './mcp-oauth-metadata.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { BUILD_STEPS, sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
@@ -389,9 +393,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       });
     } else {
       // Possession of Mcp-Session-Id alone authorizes nothing.
-      return toolErr(
-        'missing credential: pass sessionKey from start(), or configure Authorization: Bearer <round key>',
-      );
+      return toolErr(MCP_MISSING_CREDENTIAL_HINT);
     }
 
     const record = await store.getSubmission(claims.jobId);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -30,6 +30,7 @@ import {
   newMcpSessionId,
   verifyMcpSessionKey,
 } from './mcp-session-key.js';
+import { sendMcpOAuthChallenge, shouldIssueMcpOAuthChallenge } from './mcp-oauth-metadata.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { BUILD_STEPS, sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
@@ -1357,13 +1358,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       return reply.status(400).send(jsonRpcError(null, -32600, 'invalid JSON-RPC body'));
     }
 
+    const message = body as JsonRpcRequest;
+    if (shouldIssueMcpOAuthChallenge(request, message)) {
+      return sendMcpOAuthChallenge(reply);
+    }
+
     // Single message only (streamable HTTP 2025-11-25 dropped batching).
-    return handleJsonRpc(request, reply, body as JsonRpcRequest);
+    return handleJsonRpc(request, reply, message);
   });
 
   app.get(MCP_ENDPOINT_PATH, { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } }, async (request, reply) => {
     if (!originAllowed(request)) {
       return reply.status(403).send({ error: 'forbidden origin' });
+    }
+    if (!readBearerToken(request.headers.authorization)) {
+      return sendMcpOAuthChallenge(reply);
     }
     // No server-initiated SSE in v1 — clients drive via POST tools/call.
     return reply.status(405).send({ error: 'SSE listen not offered; use POST for JSON-RPC' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ship the discovery half of MCP authorization (RFC 9728): advertise protected-resource metadata and challenge unauthenticated MCP callers. **No authorization server in this PR.**

### Invariant (must hold)
**No client that works today may change behaviour.** `mcp-server.ts` authenticates on `Authorization: Bearer` (round key or durable game key) or a `sessionKey` / opener `key` argument — those paths short-circuit **before** any OAuth logic. The challenge is only what a credential-less caller gets. Expired/stale keys must keep returning their existing self-explaining reasons (`STALE_AGENT_TOKEN_REASON`, `ROTATED_GAME_KEY_REASON`, `NO_OPEN_ROUND_REASON`), not a generic 401 OAuth challenge — those messages teach the agent to ask for a fresh prompt, and OAuth is not live yet.

## Changes
- `GET /.well-known/oauth-protected-resource` — public, cacheable PRM for `MCP_ENDPOINT_PATH`
- Unauthenticated MCP → `401` + `WWW-Authenticate: Bearer resource_metadata="<canonical absolute URL>"` (from canonical host helper — never reflected `Host`)
- `authorization_servers` from `MCP_AUTHORIZATION_SERVERS` (comma-separated); **omitted when unset** (no dead AS advertised)
- Optional `MCP_RESOURCE_DOCUMENTATION_URL` (defaults to `{canonical}/studio`)

## Test plan
- [x] Metadata document shape + unauthenticated reachability
- [x] Unauthenticated MCP → 401 with absolute canonical `resource_metadata` URL
- [x] Spoofed `Host` does not change that URL
- [x] Regression: valid round key / durable game key / sessionKey / expired-stale key paths unchanged
- [x] Full `apps/api` suite green (1791)
- [ ] Supervisor: walk stale-key + credential-less paths against the invariant above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

