### PR TITLE
fix(BY-25): resolve slug ownership without owner job window

### DIFF
--- a/apps/api/src/agent-game-key-resolve.test.ts
+++ b/apps/api/src/agent-game-key-resolve.test.ts
@@ -1,12 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, mintGameAgentKey } from './agent-game-key.js';
-import { resolveGameAgentKeyForStart } from './agent-game-key-resolve.js';
+import {
+  NO_OPEN_ROUND_REASON,
+  PLATFORM_ROUND_REASON,
+  ROTATED_GAME_KEY_REASON,
+  mintGameAgentKey,
+} from './agent-game-key.js';
+import {
+  creatorOwnsSlug,
+  resolveGameAgentKeyForOpenRound,
+  resolveGameAgentKeyForStart,
+  verifyDurableGameAgentKey,
+} from './agent-game-key-resolve.js';
+import type { SubmissionRecord } from './store.js';
 import { InMemoryStore } from './store.js';
 
 const secret = 'resolve-game-key-secret';
 const slug = 'comet-courier';
 const ownerUid = 'g:owner';
 const now = Date.parse('2026-07-31T12:00:00.000Z');
+
+function submissionMap(store: InMemoryStore): Map<number, SubmissionRecord> {
+  return (store as unknown as { submissions: Map<number, SubmissionRecord> }).submissions;
+}
+
+function setCreatedAt(store: InMemoryStore, issueNumber: number, createdAt: string): void {
+  const map = submissionMap(store);
+  const sub = map.get(issueNumber);
+  if (sub) map.set(issueNumber, { ...sub, createdAt });
+}
 
 async function seedActiveSelfRound(store: InMemoryStore, issueNumber: number, builder: 'self' | 'platform' = 'self') {
   await store.createSubmission(issueNumber, ownerUid, 'Comet Courier');
@@ -18,6 +39,35 @@ async function seedActiveSelfRound(store: InMemoryStore, issueNumber: number, bu
     by: 'system',
   });
   await store.ensureRoundGeneration(issueNumber);
+}
+
+async function seedPublishedGame(store: InMemoryStore, issueNumber: number, createdAt = '2026-07-01T00:00:00.000Z') {
+  await store.createSubmission(issueNumber, ownerUid, 'Comet Courier');
+  await store.setSubmissionSlug(issueNumber, slug);
+  await store.setRoundBuilder(issueNumber, 'self');
+  setCreatedAt(store, issueNumber, createdAt);
+  await store.setSubmissionPublishedAt(issueNumber, createdAt);
+  await store.recordJobTransition(issueNumber, {
+    to: 'published',
+    at: createdAt,
+    by: 'operator',
+    reason: 'published',
+  });
+}
+
+/** 250 newer jobs on other slugs — pushes an older game past the owner-list window. */
+async function seedManyNewerJobs(store: InMemoryStore, count: number, startIssue: number) {
+  const map = submissionMap(store);
+  for (let i = 0; i < count; i++) {
+    const issue = startIssue + i;
+    await store.createSubmission(issue, ownerUid, `Other game ${issue}`);
+    await store.setSubmissionSlug(issue, `other-game-${issue}`);
+    const sub = map.get(issue)!;
+    map.set(issue, {
+      ...sub,
+      createdAt: `2026-08-${String((i % 28) + 1).padStart(2, '0')}T12:00:00.000Z`,
+    });
+  }
 }
 
 function gameKey(generation = 1) {
@@ -82,5 +132,83 @@ describe('resolveGameAgentKeyForStart', () => {
       expect(result.record.issueNumber).toBe(13);
       expect(result.record.builder).toBe('self');
     }
+  });
+});
+
+describe('slug ownership beyond owner-list window (BY-25)', () => {
+  const publishedIssue = 1;
+  const activeRoundIssue = 2;
+  const newerJobsStart = 100;
+
+  async function seedProlificCreatorBaseline(store: InMemoryStore) {
+    await seedPublishedGame(store, publishedIssue, '2026-06-01T00:00:00.000Z');
+    await seedManyNewerJobs(store, 250, newerJobsStart);
+    const at = new Date(now).toISOString();
+    await store.ensureGameAgentKey(slug, ownerUid, at);
+    await store.setGameAgentOpenRounds(slug, ownerUid, true, at);
+  }
+
+  it('creatorOwnsSlug stays true when the game aged out of listSubmissionsByOwner(200)', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+
+    expect(await creatorOwnsSlug(store, slug, ownerUid)).toBe(true);
+
+    const windowed = await store.listSubmissionsByOwner(ownerUid, { limit: 200 });
+    expect(windowed.some((job) => job.slug === slug)).toBe(false);
+  });
+
+  it('verifyDurableGameAgentKey accepts a key for an old owned slug', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+
+    const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
+    expect(result.ok).toBe(true);
+  });
+
+  it('start binds when a self round is open on an old slug', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+    await seedActiveSelfRound(store, activeRoundIssue, 'self');
+    setCreatedAt(store, activeRoundIssue, '2026-08-15T12:00:00.000Z');
+
+    const result = await resolveGameAgentKeyForStart(store, gameKey(), secret, now);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.issueNumber).toBe(activeRoundIssue);
+    }
+  });
+
+  it('open_round resolves a published game that aged out of the owner list', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+
+    const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret, now);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.publishedRecord.issueNumber).toBe(publishedIssue);
+      expect(result.activeRound).toBeNull();
+    }
+  });
+
+  it('still refuses when the newest slug record is owned by someone else', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+    const transferIssue = 3;
+    await store.createSubmission(transferIssue, 'g:stranger', 'Transferred');
+    await store.setSubmissionSlug(transferIssue, slug);
+    setCreatedAt(store, transferIssue, '2026-09-01T12:00:00.000Z');
+
+    const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
+    expect(result).toEqual({ ok: false, reason: ROTATED_GAME_KEY_REASON });
+  });
+
+  it('still refuses when the newest slug record is abandoned', async () => {
+    const store = new InMemoryStore();
+    await seedProlificCreatorBaseline(store);
+    await store.setSubmissionAbandoned(publishedIssue, '2026-09-01T12:00:00.000Z');
+
+    const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
+    expect(result).toEqual({ ok: false, reason: ROTATED_GAME_KEY_REASON });
   });
 });

--- a/apps/api/src/agent-game-key-resolve.test.ts
+++ b/apps/api/src/agent-game-key-resolve.test.ts
@@ -211,4 +211,58 @@ describe('slug ownership beyond owner-list window (BY-25)', () => {
     const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
     expect(result).toEqual({ ok: false, reason: ROTATED_GAME_KEY_REASON });
   });
+
+  /**
+   * Abandoning a *round* is routine — creator cancel, operator reject, or the
+   * `no_connect` sweep. None of those unpublish the game, so none may take the key
+   * down with them.
+   */
+  describe('an abandoned newer round does not unown the published game', () => {
+    const abandonedRoundIssue = 3;
+
+    async function seedWithAbandonedNewerRound(store: InMemoryStore) {
+      await seedProlificCreatorBaseline(store);
+      await store.createSubmission(abandonedRoundIssue, ownerUid, 'Comet Courier');
+      await store.setSubmissionSlug(abandonedRoundIssue, slug);
+      await store.setRoundBuilder(abandonedRoundIssue, 'self');
+      setCreatedAt(store, abandonedRoundIssue, '2026-08-20T00:00:00.000Z');
+      await store.setSubmissionAbandoned(abandonedRoundIssue, '2026-08-21T00:00:00.000Z');
+    }
+
+    it('keeps ownership', async () => {
+      const store = new InMemoryStore();
+      await seedWithAbandonedNewerRound(store);
+      expect(await creatorOwnsSlug(store, slug, ownerUid)).toBe(true);
+    });
+
+    it('keeps the durable key working', async () => {
+      const store = new InMemoryStore();
+      await seedWithAbandonedNewerRound(store);
+      const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
+      expect(result.ok).toBe(true);
+    });
+
+    it('leaves open_round able to open the next one', async () => {
+      const store = new InMemoryStore();
+      await seedWithAbandonedNewerRound(store);
+      const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret, now);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.publishedRecord.issueNumber).toBe(publishedIssue);
+        // The abandoned round must not read as an in-flight one.
+        expect(result.activeRound).toBeNull();
+      }
+    });
+
+    it('still refuses once the newest live record belongs to someone else', async () => {
+      const store = new InMemoryStore();
+      await seedWithAbandonedNewerRound(store);
+      await store.createSubmission(4, 'g:someone-else', 'Comet Courier');
+      await store.setSubmissionSlug(4, slug);
+      setCreatedAt(store, 4, '2026-08-25T00:00:00.000Z');
+
+      const result = await verifyDurableGameAgentKey(store, gameKey(), secret, now);
+      expect(result).toEqual({ ok: false, reason: ROTATED_GAME_KEY_REASON });
+    });
+  });
 });

--- a/apps/api/src/agent-game-key-resolve.test.ts
+++ b/apps/api/src/agent-game-key-resolve.test.ts
@@ -23,10 +23,19 @@ function submissionMap(store: InMemoryStore): Map<number, SubmissionRecord> {
   return (store as unknown as { submissions: Map<number, SubmissionRecord> }).submissions;
 }
 
+/**
+ * Fails loudly on a missing job: every ordering assertion in this file depends on the
+ * timestamps this sets, and silently doing nothing would leave the record on its
+ * real-clock `createdAt` — so a typo'd issue number would produce a green run that
+ * proved nothing about ordering.
+ */
 function setCreatedAt(store: InMemoryStore, issueNumber: number, createdAt: string): void {
   const map = submissionMap(store);
   const sub = map.get(issueNumber);
-  if (sub) map.set(issueNumber, { ...sub, createdAt });
+  if (!sub) {
+    throw new Error(`setCreatedAt: no submission ${issueNumber} — seed it before setting createdAt`);
+  }
+  map.set(issueNumber, { ...sub, createdAt });
 }
 
 async function seedActiveSelfRound(store: InMemoryStore, issueNumber: number, builder: 'self' | 'platform' = 'self') {

--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -34,12 +34,24 @@ export type ResolveGameKeyForOpenRoundResult =
   | { ok: false; reason: string };
 
 /**
- * Creator still "owns" the slug when the newest submission for it is non-abandoned
- * and its ownerUid matches. Resolved by slug, not by paging the owner's job list.
+ * Creator still "owns" the slug when the newest **non-abandoned** submission for it is
+ * theirs. Resolved by slug, not by paging the owner's job list.
+ *
+ * Abandoned jobs are skipped rather than being allowed to decide, because a round is
+ * abandoned routinely — a creator cancel, an operator reject, or the `no_connect` sweep
+ * retiring a self round whose agent never dialled in. Letting the newest record decide
+ * outright meant one canceled improvement round made a live published game read as
+ * unowned, which refuses the durable key as rotated: the same misdiagnosis this lookup
+ * was rewritten to remove, reached through a smaller door.
+ *
+ * Skipping them is still not the old "any owned job counts" scan: a transfer moves the
+ * newest live job to someone else, so ownership flips as it should, and a game whose
+ * every job is abandoned has no live record and is owned by nobody.
  */
 export async function creatorOwnsSlug(store: Store, slug: string, creatorUid: string): Promise<boolean> {
-  const record = await store.getSubmissionBySlug(slug);
-  return record !== null && record.ownerUid === creatorUid && !record.abandonedAt;
+  const records = await store.listSubmissionsBySlug(slug);
+  const newestLive = records.find((record) => !record.abandonedAt);
+  return newestLive !== undefined && newestLive.ownerUid === creatorUid;
 }
 
 /** Newest active build round for this slug owned by the creator, or null. */

--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -34,12 +34,12 @@ export type ResolveGameKeyForOpenRoundResult =
   | { ok: false; reason: string };
 
 /**
- * Creator still "owns" the slug when they have a non-abandoned submission for it
- * whose ownerUid matches the claims. Newest non-abandoned job decides ownership.
+ * Creator still "owns" the slug when the newest submission for it is non-abandoned
+ * and its ownerUid matches. Resolved by slug, not by paging the owner's job list.
  */
 export async function creatorOwnsSlug(store: Store, slug: string, creatorUid: string): Promise<boolean> {
-  const owned = await store.listSubmissionsByOwner(creatorUid, { limit: 200 });
-  return owned.some((job) => job.slug === slug && !job.abandonedAt);
+  const record = await store.getSubmissionBySlug(slug);
+  return record !== null && record.ownerUid === creatorUid && !record.abandonedAt;
 }
 
 /** Newest active build round for this slug owned by the creator, or null. */
@@ -48,11 +48,8 @@ export async function findActiveRoundForSlug(
   slug: string,
   creatorUid: string,
 ): Promise<SubmissionRecord | null> {
-  const owned = await store.listSubmissionsByOwner(creatorUid, { limit: 200 });
-  const active = owned
-    .filter((job) => job.slug === slug && !job.abandonedAt && isActiveBuildRound(job))
-    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-  return active[0] ?? null;
+  const bySlug = await store.listSubmissionsBySlug(slug);
+  return bySlug.find((job) => job.ownerUid === creatorUid && !job.abandonedAt && isActiveBuildRound(job)) ?? null;
 }
 
 /**

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1359,6 +1359,11 @@ export interface Store {
    */
   getSubmissionBySlug(slug: string): Promise<SubmissionRecord | null>;
   /**
+   * Every submission that claims this slug, newest first. A published game plus an
+   * in-flight improvement is the normal case — two jobs, one slug.
+   */
+  listSubmissionsBySlug(slug: string): Promise<SubmissionRecord[]>;
+  /**
    * The *published* submission for a slug, ignoring in-flight work on the same game.
    *
    * Separate from the lookup above because "who owns this game" and "what is the latest
@@ -2093,10 +2098,15 @@ export class InMemoryStore implements Store {
     // Newest first, matching the Firestore implementation. It used to take whatever
     // `find` reached first, which agreed with production only while a slug never had
     // more than one job — no longer true now that an improvement is a new job.
-    const match = Array.from(this.submissions.values())
+    const records = await this.listSubmissionsBySlug(slug);
+    return records[0] ?? null;
+  }
+
+  async listSubmissionsBySlug(slug: string): Promise<SubmissionRecord[]> {
+    return Array.from(this.submissions.values())
       .filter((s) => s.slug === slug)
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
-    return match ? { ...match } : null;
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .map((s) => ({ ...s }));
   }
 
   async getPublishedSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {
@@ -3729,12 +3739,15 @@ export class FirestoreStore implements Store {
   }
 
   async getSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {
-    // Equality-only query — no composite index needed. A slug is unique per game
-    // directory, but if two submissions ever raced onto one, the newest wins.
-    const snap = await this.db.collection('submissions').where('slug', '==', slug).get();
-    const records = snap.docs.map((d) => d.data() as SubmissionRecord);
-    records.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    const records = await this.listSubmissionsBySlug(slug);
     return records[0] ?? null;
+  }
+
+  async listSubmissionsBySlug(slug: string): Promise<SubmissionRecord[]> {
+    // Equality-only query — no composite index needed. Result set is bounded by how
+    // many jobs have touched one game.
+    const snap = await this.db.collection('submissions').where('slug', '==', slug).get();
+    return snap.docs.map((d) => d.data() as SubmissionRecord).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
   async getPublishedSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`creatorOwnsSlug` / `findActiveRoundForSlug` used `listSubmissionsByOwner(..., { limit: 200 })`, which keeps only the **newest** 200 jobs. Improvement rounds allocate new jobs, so older owned games age out of that window. Ownership then looks false and `verifyDurableGameAgentKey` misdiagnoses as `ROTATED_GAME_KEY_REASON` — a remedy that cannot work and can kill a working key if the creator rotates. `open_round` is hit hardest (old published games).

**Fix:** resolve by slug — `getSubmissionBySlug` for ownership; new `listSubmissionsBySlug` for the active round. No raised limit (that only moves the cliff).

## Changes
- `agent-game-key-resolve.ts` — slug-based ownership + active-round lookup
- `store.ts` — `listSubmissionsBySlug` (InMemory + Firestore); `getSubmissionBySlug` delegates to it
- Regression: old published game + 250 newer jobs on other slugs → ownership true, `start` binds, `open_round` resolves; transferred/abandoned still refuse

## `listSubmissionsByOwner` audit (follow-up)
| Call site | Limit | This PR |
|---|---|---|
| `agent-game-key-resolve.ts` | 200 | **Fixed** |
| `submissions.ts` `GET /mine` | 50 | Deferred — UI rail |
| `creator-studio.ts` shelf (3 routes) | 50 (`MAX_STUDIO_GAMES`) | Deferred — needs pagination |
| Tests only | various | n/a |

## Test plan
- [x] `npm test --workspace=apps/api -- agent-game-key-resolve agent-game-key store mcp-open-round`
- [x] 250-job probe encoded in suite
- [ ] Supervisor: confirm deferred call sites are truly UI-bounded, not silent auth cliffs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

