### PR TITLE
feat(sensing): pinch closeness meter for hand aim

### DIFF
--- a/apps/web/src/handVerbs.test.ts
+++ b/apps/web/src/handVerbs.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   HAND_AIM_MIN_INTERVAL_MS,
+  PINCH_FAR,
   PINCH_OFF,
   PINCH_ON,
   PINCH_REFRACTORY_MS,
   aimFromIndexTip,
   createHandVerbState,
+  pinchCloseness,
   pinchDistance,
   sampleHandVerbs,
   type Landmark,
@@ -49,6 +51,19 @@ describe('sampleHandVerbs', () => {
     expect(sampleHandVerbs(state, close, 2_100, { mirror: false }).pinchEdge).toBe(true);
   });
 
+  it('reports pinch closeness for the aim-ring meter', () => {
+    const state = createHandVerbState();
+    const open = tips({ x: 0.5, y: 0.5 }, { x: 0.5 + PINCH_FAR + 0.01, y: 0.5 });
+    const mid = tips({ x: 0.5, y: 0.5 }, { x: 0.5 + (PINCH_ON + PINCH_FAR) / 2, y: 0.5 });
+    const close = tips({ x: 0.5, y: 0.5 }, { x: 0.5 + PINCH_ON * 0.5, y: 0.5 });
+
+    expect(sampleHandVerbs(state, open, 1_000, { mirror: false }).pinch).toBe(0);
+    const midSample = sampleHandVerbs(createHandVerbState(), mid, 1_000, { mirror: false });
+    expect(midSample.pinch).toBeGreaterThan(0.4);
+    expect(midSample.pinch).toBeLessThan(0.6);
+    expect(sampleHandVerbs(createHandVerbState(), close, 1_000, { mirror: false }).pinch).toBe(1);
+  });
+
   it('throttles aim posts to the hand budget', () => {
     const state = createHandVerbState();
     const hand = tips({ x: 0.4, y: 0.4 }, { x: 0.6, y: 0.4 });
@@ -56,19 +71,38 @@ describe('sampleHandVerbs', () => {
     expect(first.aim).toEqual(aimFromIndexTip(hand[8]!, false));
     const second = sampleHandVerbs(state, hand, 5_000 + HAND_AIM_MIN_INTERVAL_MS - 1, { mirror: false });
     expect(second.aim).toBeNull();
+    // Pinch meter still updates while aim is throttled.
+    expect(second.pinch).toBeGreaterThanOrEqual(0);
     const third = sampleHandVerbs(state, hand, 5_000 + HAND_AIM_MIN_INTERVAL_MS, { mirror: false });
     expect(third.aim).not.toBeNull();
   });
 
   it('treats a missing hand as no verbs', () => {
     const state = createHandVerbState();
-    expect(sampleHandVerbs(state, null, 1, { mirror: true })).toEqual({ aim: null, pinchEdge: false });
-    expect(sampleHandVerbs(state, [], 1, { mirror: true })).toEqual({ aim: null, pinchEdge: false });
+    expect(sampleHandVerbs(state, null, 1, { mirror: true })).toEqual({
+      aim: null,
+      pinch: 0,
+      pinchEdge: false,
+    });
+    expect(sampleHandVerbs(state, [], 1, { mirror: true })).toEqual({
+      aim: null,
+      pinch: 0,
+      pinchEdge: false,
+    });
   });
 });
 
 describe('pinchDistance', () => {
   it('is zero for coincident tips', () => {
     expect(pinchDistance({ x: 0.2, y: 0.3 }, { x: 0.2, y: 0.3 })).toBe(0);
+  });
+});
+
+describe('pinchCloseness', () => {
+  it('is 1 at/below ON and 0 at/above FAR', () => {
+    expect(pinchCloseness(PINCH_ON)).toBe(1);
+    expect(pinchCloseness(0)).toBe(1);
+    expect(pinchCloseness(PINCH_FAR)).toBe(0);
+    expect(pinchCloseness(PINCH_FAR + 0.1)).toBe(0);
   });
 });

--- a/apps/web/src/handVerbs.ts
+++ b/apps/web/src/handVerbs.ts
@@ -2,8 +2,9 @@
  * Pure landmark → game-verb math for sensing Phase 1 (camera hand control).
  *
  * The shell runs MediaPipe (or a stub) and feeds 21 normalized hand landmarks
- * here. Only the sanitized outputs — aim in [-1,1] and pinch rising edges —
- * ever cross into the game iframe. Unit-tested without the model.
+ * here. Only the sanitized outputs — aim in [-1,1], pinch closeness in [0,1],
+ * and pinch rising edges — ever cross into the game iframe. Unit-tested without
+ * the model.
  *
  * Landmark indices match MediaPipe Hands:
  *   4  thumb tip
@@ -16,10 +17,18 @@ export type Landmark = { x: number; y: number; z?: number };
 export const HAND_AIM_HZ = 15;
 export const HAND_AIM_MIN_INTERVAL_MS = Math.ceil(1000 / HAND_AIM_HZ);
 
-/** Pinch distance (normalized image space) below this = pinched. */
-export const PINCH_ON = 0.055;
+/**
+ * Pinch distance (normalized image space) at or below this = pinched.
+ * Slightly forgiving: phone foreshortening makes a real pinch look larger in 2D.
+ */
+export const PINCH_ON = 0.08;
 /** Must open past this before another pinch can fire (hysteresis). */
-export const PINCH_OFF = 0.09;
+export const PINCH_OFF = 0.13;
+/**
+ * Distances at or above this map to pinch closeness 0 on the meter.
+ * Between PINCH_FAR and PINCH_ON the meter ramps 0→1.
+ */
+export const PINCH_FAR = 0.22;
 /** Ignore pinch edges closer than this (ms). */
 export const PINCH_REFRACTORY_MS = 280;
 
@@ -40,6 +49,11 @@ export function createHandVerbState(): HandVerbState {
 function clamp1(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(-1, Math.min(1, value));
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
 }
 
 /**
@@ -64,15 +78,30 @@ export function pinchDistance(thumb: Landmark, index: Landmark): number {
   return Math.hypot(dx, dy);
 }
 
+/**
+ * How close the tips are to a pinch fire, in [0, 1].
+ * 0 = clearly open (at/above PINCH_FAR); 1 = at/below PINCH_ON (would fire).
+ */
+export function pinchCloseness(dist: number): number {
+  if (dist <= PINCH_ON) return 1;
+  if (dist >= PINCH_FAR) return 0;
+  const t = clamp01((PINCH_FAR - dist) / (PINCH_FAR - PINCH_ON));
+  // Collapse float dust so "open" reads as exactly 0 in the game meter.
+  return t < 1e-6 ? 0 : t;
+}
+
 export type HandVerbSample = {
   aim: HandAim | null;
+  /** Continuous pinch meter for the game aim ring — 0 open, 1 would-fire. */
+  pinch: number;
   /** True exactly once per pinch press (rising edge after hysteresis). */
   pinchEdge: boolean;
 };
 
 /**
  * Fold one landmark frame into verb outputs. Returns null aim when throttled
- * (caller should not post). Pinch edges always return even if aim is throttled.
+ * (caller should not post aim). Pinch closeness always returns when a hand is
+ * present so the meter can update on the same post cadence as aim.
  */
 export function sampleHandVerbs(
   state: HandVerbState,
@@ -81,11 +110,11 @@ export function sampleHandVerbs(
   opts: { mirror: boolean },
 ): HandVerbSample {
   if (!landmarks || landmarks.length < 9) {
-    return { aim: null, pinchEdge: false };
+    return { aim: null, pinch: 0, pinchEdge: false };
   }
   const thumb = landmarks[4];
   const index = landmarks[8];
-  if (!thumb || !index) return { aim: null, pinchEdge: false };
+  if (!thumb || !index) return { aim: null, pinch: 0, pinchEdge: false };
 
   const dist = pinchDistance(thumb, index);
   let pinchEdge = false;
@@ -99,6 +128,9 @@ export function sampleHandVerbs(
     state.pinched = false;
   }
 
+  // While held closed, keep the meter pegged so a refractory hold still reads "in".
+  const pinch = state.pinched ? 1 : pinchCloseness(dist);
+
   let aim: HandAim | null = null;
   if (nowMs - state.lastAimAt >= HAND_AIM_MIN_INTERVAL_MS) {
     aim = aimFromIndexTip(index, opts.mirror);
@@ -106,5 +138,5 @@ export function sampleHandVerbs(
     state.lastAimAt = nowMs;
   }
 
-  return { aim, pinchEdge };
+  return { aim, pinch, pinchEdge };
 }

--- a/apps/web/src/sensing.ts
+++ b/apps/web/src/sensing.ts
@@ -446,6 +446,8 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
     /** Sample the model ~30 Hz — verb posts are throttled further in handVerbs. */
     const DETECT_MIN_MS = 33;
     let lastDetectAt = 0;
+    /** Last pinch value posted — meter can refresh between aim ticks. */
+    let lastPostedPinch = -1;
     const verbState = createHandVerbState();
     const video = document.createElement('video');
     video.playsInline = true;
@@ -474,9 +476,18 @@ export function useSensingBridge(frameRef: MutableRefObject<HTMLIFrameElement | 
             setHandTracking(true);
             postState();
           }
-          if (sample.aim) {
-            setHandAim(sample.aim);
-            postToGame({ t: 'sensing:hand', x: sample.aim.x, y: sample.aim.y });
+          if (sample.aim) setHandAim(sample.aim);
+          const aim = sample.aim ?? verbState.aim;
+          const pinchDelta = Math.abs(sample.pinch - lastPostedPinch);
+          // Aim posts on the 15 Hz budget; pinch meter may refresh between them.
+          if (aim && (sample.aim || sample.pinchEdge || pinchDelta >= 0.04)) {
+            lastPostedPinch = sample.pinch;
+            postToGame({
+              t: 'sensing:hand',
+              x: aim.x,
+              y: aim.y,
+              pinch: sample.pinch,
+            });
           }
           if (sample.pinchEdge) {
             setHandLastPinchAt(now);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playtest feedback: aim tracks well, but pinch often fails silently — hard to tell **detector miss** from **aim miss**.

- `sensing:hand` frames now include `pinch ∈ [0, 1]` (thumb↔index closeness).
- Slightly looser pinch-on threshold for phone foreshortening (`0.055` → `0.08`).
- Meter can refresh between the 15 Hz aim ticks; act edge still posts `sensing:act`.

## Pair with

- Games: same branch name — `sense.pinch()` + ghost-mirror aim-ring fill/flash.
- Ops: protocol note only.

## Test plan

- [ ] Unit: `handVerbs` pinch closeness / edge tests
- [ ] Phone: Ghost Mirror → Start camera → squeeze fingers; ring fills before fire; flashes on registered pinch
- [ ] Merge **website before games** so old shells omitting `pinch` still read as 0 on the game side
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-420ac37a-bee1-4b3f-b681-945672dcaef7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-420ac37a-bee1-4b3f-b681-945672dcaef7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

