### PR TITLE
Add CODEOWNERS with @gtanczyk as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for all paths in this repository.
+* @gtanczyk
+

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -3001,8 +3001,9 @@ export class InMemoryStore implements Store {
   async finishAgentOpenRound(slug: string, at: string): Promise<void> {
     const existing = this.gameAgentKeys.get(slug);
     if (!existing?.agentOpenRoundPending) return;
-    const { agentOpenRoundPending: _pending, ...rest } = existing;
-    this.gameAgentKeys.set(slug, { ...rest, updatedAt: at });
+    const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
+    delete next.agentOpenRoundPending;
+    this.gameAgentKeys.set(slug, next);
   }
 
   // Test/inspection only — production reads go through `listWaitlistEntries`.
@@ -4828,8 +4829,9 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return;
       const existing = snap.data() as GameAgentKeyRecord;
       if (!existing.agentOpenRoundPending) return;
-      const { agentOpenRoundPending: _pending, ...rest } = existing;
-      tx.set(docRef, { ...rest, updatedAt: at });
+      const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
+      delete next.agentOpenRoundPending;
+      tx.set(docRef, next);
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.github/CODEOWNERS` so `@gtanczyk` is the default reviewer for all paths in this repository.

```
* @gtanczyk
```

Also fixes a pre-existing lint failure on `master` from #452: `finishAgentOpenRound` destructured `agentOpenRoundPending` into an unused `_pending` binding, which `@typescript-eslint/no-unused-vars` rejects (only `argsIgnorePattern` is configured). The field is now omitted via `delete` instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0a861b6-adba-4b20-825b-82e2d1461e3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a861b6-adba-4b20-825b-82e2d1461e3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

