### PR TITLE
fix(BY-26): model Studio shelf as games, not jobs

### DIFF
--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -68,6 +68,42 @@ describe('GET /api/me/studio', () => {
     await app.close();
   });
 
+  it('lists all distinct games even when improvement rounds exceed the job ceiling', async () => {
+    for (let game = 0; game < 3; game++) {
+      const slug = `game-${game}`;
+      for (let tip = 0; tip < 20; tip++) {
+        const issueNumber = game * 100 + tip + 1;
+        await store.createSubmission(issueNumber, 'g:creator', `Game ${game} tip ${tip}`);
+        await store.setSubmissionSlug(issueNumber, slug);
+        if (tip === 0) {
+          await store.setSubmissionPublishedAt(issueNumber, `${today}T12:00:00.000Z`);
+        }
+        if (tip < 19) await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+    }
+
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      submissionRoutes: { submissionTokenSecret },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio',
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { games: CreatorStudioGame[]; truncated: boolean; totalGames: number };
+    expect(body.totalGames).toBe(3);
+    expect(body.truncated).toBe(false);
+    expect(body.games).toHaveLength(3);
+    expect(new Set(body.games.map((game) => game.slug))).toEqual(new Set(['game-0', 'game-1', 'game-2']));
+
+    await app.close();
+  });
+
   it('requires a session', async () => {
     const app = await buildApp({
       store,
@@ -199,7 +235,41 @@ describe('GET /api/me/studio/health', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ days: [], truncated: false, games: [] });
+    expect(res.json()).toEqual({ days: [], truncated: false, gamesTruncated: false, totalGames: 0, games: [] });
+    await app.close();
+  });
+
+  it('lists all distinct published games even when improvement rounds exceed the job ceiling', async () => {
+    for (let game = 0; game < 3; game++) {
+      const slug = `game-${game}`;
+      for (let tip = 0; tip < 20; tip++) {
+        const issueNumber = game * 100 + tip + 1;
+        await store.createSubmission(issueNumber, 'g:creator', `Game ${game} tip ${tip}`);
+        await store.setSubmissionSlug(issueNumber, slug);
+        if (tip === 0) {
+          await store.setSubmissionPublishedAt(issueNumber, `${today}T12:00:00.000Z`);
+        }
+        if (tip < 19) await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+    }
+
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      submissionRoutes: { submissionTokenSecret },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio/health?days=1',
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CreatorHealthResponse;
+    expect(body.totalGames).toBe(3);
+    expect(body.gamesTruncated).toBe(false);
+
     await app.close();
   });
 });

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { pageOwnerGames } from './owner-games.js';
 import { recentPartitions, summarizeGameHealth, type GameHealth } from './telemetry-health.js';
 import type { GamesStore } from './games-store.js';
 import type { Store, TelemetryEvent } from './store.js';
@@ -20,8 +21,6 @@ const MAX_DAYS = 30;
 const DEFAULT_DAYS = 7;
 const MAX_EVENTS_PER_DAY = 1000;
 const MAX_EVENTS_PER_REQUEST = 5_000;
-/** Studio list ceiling — a creator's shelf, not a catalog. */
-const MAX_STUDIO_GAMES = 50;
 
 const QuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(MAX_DAYS).optional(),
@@ -43,6 +42,11 @@ export interface CreatorStudioGame {
   lastKnownStatus: string | null;
   slug?: string;
   publishedAt?: string;
+  /**
+   * Catalog publish time when this row is an improvement tip — the game is still live
+   * but the open job has no `publishedAt` of its own.
+   */
+  livePublishedAt?: string;
   /** Whether the creator has turned on the shared link for this game's draft. */
   draftShared?: boolean;
   /**
@@ -56,7 +60,11 @@ export interface CreatorStudioGame {
 
 export interface CreatorHealthResponse {
   days: string[];
+  /** Telemetry scan hit the event budget. */
   truncated: boolean;
+  /** Published-game list hit the shelf ceiling. */
+  gamesTruncated: boolean;
+  totalGames: number;
   games: GameHealth[];
 }
 
@@ -89,6 +97,8 @@ export interface CreatorScorecardSummary {
 
 export interface CreatorScorecardsResponse {
   scorecards: CreatorScorecardSummary[];
+  truncated: boolean;
+  totalGames: number;
 }
 
 /**
@@ -170,11 +180,8 @@ export async function registerCreatorStudioRoutes(
       return reply.status(503).send({ error: 'submissions are not configured' });
     }
 
-    const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: MAX_STUDIO_GAMES });
-    const shelf = records
-      // `abandonedAt` is the shelf contract; also drop `canceled` so an operator
-      // reject that predated writing `abandonedAt` does not leave a zombie row.
-      .filter((record) => !record.abandonedAt && record.state !== 'canceled');
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const { games: shelf, truncated, total } = pageOwnerGames(records, 'shelf');
 
     // Which delivered versions ship an editor definition. One manifest read per
     // game with a delivery, best-effort: a read that fails only costs the Edit
@@ -183,28 +190,29 @@ export async function registerCreatorStudioRoutes(
     if (options.gamesStore) {
       await Promise.all(
         shelf
-          .filter((record) => record.slug && record.deliveredVersion)
-          .map(async (record) => {
+          .filter(({ tip }) => tip.slug && tip.deliveredVersion)
+          .map(async ({ tip }) => {
             const manifest = await options
-              .gamesStore!.getManifest(record.slug as string, record.deliveredVersion as string)
+              .gamesStore!.getManifest(tip.slug as string, tip.deliveredVersion as string)
               .catch(() => null);
-            if (manifest?.sourceFiles.includes('EDITOR.json')) editableSlugs.add(record.slug as string);
+            if (manifest?.sourceFiles.includes('EDITOR.json')) editableSlugs.add(tip.slug as string);
           }),
       );
     }
 
-    const games: CreatorStudioGame[] = shelf.map((record) => ({
-      token: options.mintStatusToken!(record.issueNumber),
-      title: record.title,
-      createdAt: record.createdAt,
-      lastKnownStatus: record.lastNotifiedStatus ?? null,
-      ...(record.slug ? { slug: record.slug } : {}),
-      ...(record.publishedAt ? { publishedAt: record.publishedAt } : {}),
-      ...(record.draftSharedAt ? { draftShared: true } : {}),
-      ...(record.slug && editableSlugs.has(record.slug) ? { editable: true } : {}),
+    const games: CreatorStudioGame[] = shelf.map(({ tip, catalogPublishedAt }) => ({
+      token: options.mintStatusToken!(tip.issueNumber),
+      title: tip.title,
+      createdAt: tip.createdAt,
+      lastKnownStatus: tip.lastNotifiedStatus ?? null,
+      ...(tip.slug ? { slug: tip.slug } : {}),
+      ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
+      ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),
+      ...(tip.draftSharedAt ? { draftShared: true } : {}),
+      ...(tip.slug && editableSlugs.has(tip.slug) ? { editable: true } : {}),
     }));
 
-    return reply.send({ games });
+    return reply.send({ games, truncated, totalGames: total });
   });
 
   /**
@@ -223,17 +231,18 @@ export async function registerCreatorStudioRoutes(
       return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
     }
 
-    const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: MAX_STUDIO_GAMES });
-    const slugs = [
-      ...new Set(
-        records
-          .filter((record) => !record.abandonedAt && record.slug && record.publishedAt)
-          .map((record) => record.slug as string),
-      ),
-    ];
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const { games: published, truncated: gamesTruncated, total } = pageOwnerGames(records, 'published');
+    const slugs = published.map(({ tip }) => tip.slug).filter((slug): slug is string => Boolean(slug));
 
     if (slugs.length === 0) {
-      const body: CreatorHealthResponse = { days: [], truncated: false, games: [] };
+      const body: CreatorHealthResponse = {
+        days: [],
+        truncated: false,
+        gamesTruncated: gamesTruncated,
+        totalGames: total,
+        games: [],
+      };
       return reply.send(body);
     }
 
@@ -242,7 +251,13 @@ export async function registerCreatorStudioRoutes(
     const owned = new Set(slugs);
     const games = summarizeGameHealth(events).filter((game) => owned.has(game.slug));
 
-    const body: CreatorHealthResponse = { days: scanned, truncated, games };
+    const body: CreatorHealthResponse = {
+      days: scanned,
+      truncated,
+      gamesTruncated,
+      totalGames: total,
+      games,
+    };
     return reply.send(body);
   });
 
@@ -262,14 +277,9 @@ export async function registerCreatorStudioRoutes(
   app.get('/api/me/studio/scorecards', async (request, reply) => {
     if (!requireUser(request, reply)) return;
 
-    const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: MAX_STUDIO_GAMES });
-    const slugs = [
-      ...new Set(
-        records
-          .filter((record) => !record.abandonedAt && record.slug && record.publishedAt)
-          .map((record) => record.slug as string),
-      ),
-    ];
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const { games: published, truncated, total } = pageOwnerGames(records, 'published');
+    const slugs = published.map(({ tip }) => tip.slug).filter((slug): slug is string => Boolean(slug));
 
     const cards = await Promise.all(slugs.map((slug) => store.getScorecard(slug)));
     const scorecards: CreatorScorecardSummary[] = cards
@@ -284,7 +294,7 @@ export async function registerCreatorStudioRoutes(
         untrustedThemes: card.untrusted.feedbackThemes ?? [],
       }));
 
-    const body: CreatorScorecardsResponse = { scorecards };
+    const body: CreatorScorecardsResponse = { scorecards, truncated, totalGames: total };
     return reply.send(body);
   });
 }

--- a/apps/api/src/owner-games.test.ts
+++ b/apps/api/src/owner-games.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { collapseJobsToOwnerGames, MAX_OWNER_GAMES, pageOwnerGames } from './owner-games.js';
+import type { SubmissionRecord } from './store.js';
+
+function job(
+  partial: Partial<SubmissionRecord> & Pick<SubmissionRecord, 'issueNumber' | 'createdAt'>,
+): SubmissionRecord {
+  return {
+    ownerUid: 'g:creator',
+    title: `Job ${partial.issueNumber}`,
+    ...partial,
+  } as SubmissionRecord;
+}
+
+describe('collapseJobsToOwnerGames', () => {
+  it('groups by slug and picks the newest job as tip', () => {
+    const jobs = [
+      job({ issueNumber: 1, createdAt: '2026-01-01T00:00:00.000Z', slug: 'sky-dodge' }),
+      job({ issueNumber: 2, createdAt: '2026-01-02T00:00:00.000Z', slug: 'sky-dodge' }),
+    ];
+
+    const collapsed = collapseJobsToOwnerGames(jobs, 'shelf');
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]!.tip.issueNumber).toBe(2);
+  });
+
+  it('treats slugless jobs as one game per issue', () => {
+    const jobs = [
+      job({ issueNumber: 10, createdAt: '2026-01-01T00:00:00.000Z' }),
+      job({ issueNumber: 11, createdAt: '2026-01-02T00:00:00.000Z' }),
+    ];
+
+    expect(collapseJobsToOwnerGames(jobs, 'shelf')).toHaveLength(2);
+  });
+
+  it('drops abandoned and canceled jobs from the shelf', () => {
+    const jobs = [
+      job({ issueNumber: 1, createdAt: '2026-01-01T00:00:00.000Z', abandonedAt: '2026-01-02T00:00:00.000Z' }),
+      job({ issueNumber: 2, createdAt: '2026-01-02T00:00:00.000Z', state: 'canceled' }),
+      job({ issueNumber: 3, createdAt: '2026-01-03T00:00:00.000Z', slug: 'keep' }),
+    ];
+
+    const collapsed = collapseJobsToOwnerGames(jobs, 'shelf');
+    expect(collapsed.map((entry) => entry.tip.issueNumber)).toEqual([3]);
+  });
+
+  it('stamps catalogPublishedAt on an improve tip without copying publishedAt onto the tip', () => {
+    const jobs = [
+      job({
+        issueNumber: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        slug: 'sky-dodge',
+        publishedAt: '2026-01-01T12:00:00.000Z',
+      }),
+      job({ issueNumber: 2, createdAt: '2026-01-02T00:00:00.000Z', slug: 'sky-dodge' }),
+    ];
+
+    const collapsed = collapseJobsToOwnerGames(jobs, 'shelf');
+    expect(collapsed[0]!.tip.issueNumber).toBe(2);
+    expect(collapsed[0]!.tip.publishedAt).toBeUndefined();
+    expect(collapsed[0]!.catalogPublishedAt).toBe('2026-01-01T12:00:00.000Z');
+  });
+
+  it('published mode keeps only games with a published sibling', () => {
+    const jobs = [
+      job({
+        issueNumber: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        slug: 'live',
+        publishedAt: '2026-01-01T12:00:00.000Z',
+      }),
+      job({ issueNumber: 2, createdAt: '2026-01-02T00:00:00.000Z', slug: 'draft-only' }),
+    ];
+
+    const collapsed = collapseJobsToOwnerGames(jobs, 'published');
+    expect(collapsed.map((entry) => entry.tip.slug)).toEqual(['live']);
+  });
+});
+
+describe('pageOwnerGames', () => {
+  it('truncates after MAX_OWNER_GAMES distinct games', () => {
+    const jobs = Array.from({ length: MAX_OWNER_GAMES + 5 }, (_, index) =>
+      job({
+        issueNumber: index + 1,
+        createdAt: new Date(Date.UTC(2026, 0, MAX_OWNER_GAMES + 5 - index)).toISOString(),
+        slug: `game-${index + 1}`,
+      }),
+    );
+
+    const page = pageOwnerGames(jobs, 'shelf');
+    expect(page.games).toHaveLength(MAX_OWNER_GAMES);
+    expect(page.total).toBe(MAX_OWNER_GAMES + 5);
+    expect(page.truncated).toBe(true);
+  });
+});

--- a/apps/api/src/owner-games.ts
+++ b/apps/api/src/owner-games.ts
@@ -1,0 +1,76 @@
+import type { SubmissionRecord } from './store.js';
+
+/** Studio shelf ceiling — distinct games, not raw jobs. */
+export const MAX_OWNER_GAMES = 50;
+
+export interface OwnerGame {
+  /** Newest job for this game — what the shelf shows and what tokens address. */
+  tip: SubmissionRecord;
+  /**
+   * Publish time from a sibling job when the tip is not published but the game is
+   * still live in the catalog. Never copied onto `tip.publishedAt`.
+   */
+  catalogPublishedAt?: string;
+}
+
+function groupKey(record: SubmissionRecord): string {
+  return record.slug ?? `issue:${record.issueNumber}`;
+}
+
+function isShelfEligible(record: SubmissionRecord): boolean {
+  return !record.abandonedAt && record.state !== 'canceled';
+}
+
+function isPublishedEligible(record: SubmissionRecord): boolean {
+  return !record.abandonedAt;
+}
+
+function hasPublishedAt(record: SubmissionRecord): boolean {
+  return Boolean(record.publishedAt);
+}
+
+/**
+ * Collapse a creator's jobs to one row per game (slug, or issue when slugless).
+ *
+ * The tip is the newest job in each group. Published mode keeps only groups with a
+ * published sibling; shelf mode drops abandoned and operator-canceled jobs.
+ */
+export function collapseJobsToOwnerGames(jobs: readonly SubmissionRecord[], mode: 'shelf' | 'published'): OwnerGame[] {
+  const filtered = jobs.filter(mode === 'shelf' ? isShelfEligible : isPublishedEligible);
+
+  const groups = new Map<string, SubmissionRecord[]>();
+  for (const job of filtered) {
+    const key = groupKey(job);
+    const group = groups.get(key);
+    if (group) group.push(job);
+    else groups.set(key, [job]);
+  }
+
+  const collapsed: OwnerGame[] = [];
+  for (const group of groups.values()) {
+    const sorted = [...group].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    const tip = sorted[0]!;
+
+    if (mode === 'published' && !group.some(hasPublishedAt)) continue;
+
+    const publishedSibling = sorted.find(hasPublishedAt);
+    const ownerGame: OwnerGame = { tip };
+    if (publishedSibling && !tip.publishedAt) {
+      ownerGame.catalogPublishedAt = publishedSibling.publishedAt;
+    }
+    collapsed.push(ownerGame);
+  }
+
+  return collapsed.sort((a, b) => b.tip.createdAt.localeCompare(a.tip.createdAt));
+}
+
+/** Apply the shelf ceiling after collapsing jobs to distinct games. */
+export function pageOwnerGames(
+  jobs: readonly SubmissionRecord[],
+  mode: 'shelf' | 'published',
+): { games: OwnerGame[]; total: number; truncated: boolean } {
+  const collapsed = collapseJobsToOwnerGames(jobs, mode);
+  const total = collapsed.length;
+  const truncated = total > MAX_OWNER_GAMES;
+  return { games: collapsed.slice(0, MAX_OWNER_GAMES), total, truncated };
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1405,6 +1405,9 @@ export interface Store {
    * Every submission a creator owns, newest first. Backs the "my games" rail, so a
    * creator finds their work-in-progress without having saved the tracking link
    * (and on a device that never had it in localStorage).
+   *
+   * Omit `limit` to read the full job history; shelf endpoints collapse to distinct
+   * games before applying their own ceiling — a raw job limit is not a game limit.
    */
   listSubmissionsByOwner(ownerUid: string, opts?: { limit?: number }): Promise<SubmissionRecord[]>;
   checkAndIncrementQuota(
@@ -2358,11 +2361,11 @@ export class InMemoryStore implements Store {
   }
 
   async listSubmissionsByOwner(ownerUid: string, opts?: { limit?: number }): Promise<SubmissionRecord[]> {
-    return Array.from(this.submissions.values())
+    const sorted = Array.from(this.submissions.values())
       .filter((s) => s.ownerUid === ownerUid)
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-      .slice(0, opts?.limit ?? 20)
       .map((s) => ({ ...s }));
+    return opts?.limit !== undefined ? sorted.slice(0, opts.limit) : sorted;
   }
 
   async checkAndIncrementQuota(
@@ -3798,10 +3801,10 @@ export class FirestoreStore implements Store {
     // Equality-only query (no orderBy) so Firestore needs no composite index; a
     // creator's submission count is small, so sorting here is cheap.
     const snap = await this.db.collection('submissions').where('ownerUid', '==', ownerUid).get();
-    return snap.docs
+    const sorted = snap.docs
       .map((d) => d.data() as SubmissionRecord)
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-      .slice(0, opts?.limit ?? 20);
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return opts?.limit !== undefined ? sorted.slice(0, opts.limit) : sorted;
   }
 
   async checkAndIncrementQuota(

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2593,6 +2593,41 @@ describe('GET /api/submissions/mine', () => {
 
     await app.close();
   });
+
+  it('lists all distinct games even when improvement rounds exceed the job ceiling', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const store = new InMemoryStore();
+    const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
+    const today = new Date().toISOString().slice(0, 10);
+
+    for (let game = 0; game < 3; game++) {
+      const slug = `game-${game}`;
+      for (let tip = 0; tip < 20; tip++) {
+        const issueNumber = game * 100 + tip + 1;
+        await store.createSubmission(issueNumber, 'g:test-user', `Game ${game} tip ${tip}`);
+        await store.setSubmissionSlug(issueNumber, slug);
+        if (tip === 0) {
+          await store.setSubmissionPublishedAt(issueNumber, `${today}T12:00:00.000Z`);
+        }
+        if (tip < 19) await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/api/submissions/mine', headers: authHeaders });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json() as {
+      submissions: Array<{ slug: string | null }>;
+      truncated: boolean;
+      totalGames: number;
+    };
+    expect(body.totalGames).toBe(3);
+    expect(body.truncated).toBe(false);
+    expect(body.submissions).toHaveLength(3);
+    expect(new Set(body.submissions.map((item) => item.slug))).toEqual(new Set(['game-0', 'game-1', 'game-2']));
+
+    await app.close();
+  });
 });
 
 describe('GET /api/drafts/:slug (shareable, read-only)', () => {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -54,6 +54,7 @@ import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { emitOperatorAlert, emitSubmissionNotification, notifyOnTransition, type EmitDeps } from './notify.js';
 import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
+import { pageOwnerGames } from './owner-games.js';
 import { isAdminSession } from './admin.js';
 import { peekQuota } from './quota-gate.js';
 import { mintGameSlug } from './slug.js';
@@ -2536,27 +2537,26 @@ export async function registerSubmissionRoutes(
       return reply.send({ submissions: [] });
     }
 
-    const records = await store.listSubmissionsByOwner(request.user!.uid, { limit: 50 });
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const { games: shelf, truncated, total } = pageOwnerGames(records, 'shelf');
     return reply.send({
-      // Abandoned / operator-canceled builds are gone as far as the creator is
-      // concerned — they don't belong in "your games". `state === 'canceled'` heals
-      // jobs canceled before the operator path wrote `abandonedAt`.
-      submissions: records
-        .filter((record) => !record.abandonedAt && record.state !== 'canceled')
-        .map((record) => ({
-          token: mintToken(record.issueNumber, submissionTokenSecret),
-          title: record.title,
-          createdAt: record.createdAt,
-          // The last derived status, kept current by the two-minute sweep. This is
-          // what the rail renders — it used to be a hint the rail immediately went
-          // and re-derived per card, six GitHub fan-outs every thirty seconds from
-          // one open tab, which is what was rate-limiting the whole token.
-          // lastNotifiedStatus is the fallback for records written before this.
-          lastKnownStatus: record.lastStatus ?? record.lastNotifiedStatus ?? null,
-          // So a published card can offer Play without deriving the slug itself.
-          slug: record.slug ?? null,
-          ...(record.publishedAt ? { publishedAt: record.publishedAt } : {}),
-        })),
+      submissions: shelf.map(({ tip, catalogPublishedAt }) => ({
+        token: mintToken(tip.issueNumber, submissionTokenSecret),
+        title: tip.title,
+        createdAt: tip.createdAt,
+        // The last derived status, kept current by the two-minute sweep. This is
+        // what the rail renders — it used to be a hint the rail immediately went
+        // and re-derived per card, six GitHub fan-outs every thirty seconds from
+        // one open tab, which is what was rate-limiting the whole token.
+        // lastNotifiedStatus is the fallback for records written before this.
+        lastKnownStatus: tip.lastStatus ?? tip.lastNotifiedStatus ?? null,
+        // So a published card can offer Play without deriving the slug itself.
+        slug: tip.slug ?? null,
+        ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
+        ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),
+      })),
+      truncated,
+      totalGames: total,
     });
   });
 

--- a/apps/web/src/CreatorStudioView.handoff.test.tsx
+++ b/apps/web/src/CreatorStudioView.handoff.test.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatorStudioView } from './CreatorStudioView.js';
 import i18n from './i18n/index.js';
-import type { StudioGame } from './studioApi.js';
+import type { StudioGame, StudioGamesResponse } from './studioApi.js';
 import { getSubmissionStatus } from './submissionApi.js';
 import { submitImprovement } from './studioApi.js';
 
@@ -59,6 +59,10 @@ vi.mock('./submissionApi', async () => {
 const mockedGetSubmissionStatus = vi.mocked(getSubmissionStatus);
 const mockedSubmitImprovement = vi.mocked(submitImprovement);
 
+function studioShelf(games: StudioGame[], truncated = false, totalGames?: number): StudioGamesResponse {
+  return { games, truncated, totalGames: totalGames ?? games.length };
+}
+
 async function flushEffects() {
   await Promise.resolve();
   await Promise.resolve();
@@ -103,16 +107,18 @@ describe('CreatorStudioView publish→improve handoff', () => {
     }));
     vi.stubGlobal('fetch', connectFetch);
 
-    fetchStudioGames.mockResolvedValue([
-      {
-        token: 'pub-self-shelf',
-        title: 'TV Tycoon',
-        createdAt: '2026-07-01T00:00:00.000Z',
-        lastKnownStatus: 'published',
-        slug: 'tv-tycoon',
-        publishedAt: '2026-07-01T00:00:00.000Z',
-      },
-    ] satisfies StudioGame[]);
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'pub-self-shelf',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-01T00:00:00.000Z',
+          lastKnownStatus: 'published',
+          slug: 'tv-tycoon',
+          publishedAt: '2026-07-01T00:00:00.000Z',
+        },
+      ]),
+    );
 
     // The published (terminal) thread is self-built; its improvement is a new self job
     // still waiting on the creator's own agent — the state that renders the connect card.

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatorStudioView } from './CreatorStudioView.js';
 import i18n from './i18n/index.js';
-import type { StudioGame, StudioScorecard } from './studioApi.js';
+import type { StudioGame, StudioGamesResponse, StudioScorecard } from './studioApi.js';
 
 const fetchStudioGames = vi.fn();
 const fetchStudioHealth = vi.fn();
@@ -38,6 +38,10 @@ vi.mock('./studioApi', async () => {
     submitImprovement: vi.fn(),
   };
 });
+
+function studioShelf(games: StudioGame[], truncated = false, totalGames?: number): StudioGamesResponse {
+  return { games, truncated, totalGames: totalGames ?? games.length };
+}
 
 function manyGames(count: number): StudioGame[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -121,9 +125,9 @@ describe('CreatorStudioView', () => {
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
 
-    let resolveGames!: (value: StudioGame[]) => void;
+    let resolveGames!: (value: StudioGamesResponse) => void;
     fetchStudioGames.mockReturnValue(
-      new Promise<StudioGame[]>((resolve) => {
+      new Promise<StudioGamesResponse>((resolve) => {
         resolveGames = resolve;
       }),
     );
@@ -153,7 +157,7 @@ describe('CreatorStudioView', () => {
     expect(app.querySelector('.studio-shell-pending')).toBeTruthy();
 
     await act(async () => {
-      resolveGames(manyGames(2));
+      resolveGames(studioShelf(manyGames(2)));
       await fetchStudioGames.mock.results[0]?.value;
       await fetchStudioHealth.mock.results[0]?.value;
     });
@@ -170,7 +174,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(10));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(10)));
 
     const { container, root } = await renderStudio();
 
@@ -200,7 +204,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(6));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(6)));
 
     const { container, root } = await renderStudio();
 
@@ -221,46 +225,48 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue([
-      {
-        token: 'live-mw',
-        title: 'Miniature Warfare 2D',
-        slug: 'miniature-warfare-2d',
-        createdAt: '2026-07-01T00:00:00.000Z',
-        lastKnownStatus: 'published',
-        publishedAt: '2026-07-01T00:00:00.000Z',
-      },
-      {
-        token: 'tip-mw',
-        title: 'Miniature Warfare 2D',
-        slug: 'miniature-warfare-2d',
-        createdAt: '2026-07-20T00:00:00.000Z',
-        lastKnownStatus: 'building',
-      },
-      {
-        token: 'live-gts',
-        title: 'Global Thermonuclear Strategy',
-        slug: 'global-thermonuclear-strategy',
-        createdAt: '2026-07-02T00:00:00.000Z',
-        lastKnownStatus: 'published',
-        publishedAt: '2026-07-02T00:00:00.000Z',
-      },
-      {
-        token: 'tip-gts',
-        title: 'Global Thermonuclear Strategy',
-        slug: 'global-thermonuclear-strategy',
-        createdAt: '2026-07-21T00:00:00.000Z',
-        lastKnownStatus: 'building',
-      },
-      {
-        token: 'live-tv',
-        title: 'A game tycoon like where I run a tv busi',
-        slug: 'tv-tycoon',
-        createdAt: '2026-07-03T00:00:00.000Z',
-        lastKnownStatus: 'published',
-        publishedAt: '2026-07-03T00:00:00.000Z',
-      },
-    ]);
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'live-mw',
+          title: 'Miniature Warfare 2D',
+          slug: 'miniature-warfare-2d',
+          createdAt: '2026-07-01T00:00:00.000Z',
+          lastKnownStatus: 'published',
+          publishedAt: '2026-07-01T00:00:00.000Z',
+        },
+        {
+          token: 'tip-mw',
+          title: 'Miniature Warfare 2D',
+          slug: 'miniature-warfare-2d',
+          createdAt: '2026-07-20T00:00:00.000Z',
+          lastKnownStatus: 'building',
+        },
+        {
+          token: 'live-gts',
+          title: 'Global Thermonuclear Strategy',
+          slug: 'global-thermonuclear-strategy',
+          createdAt: '2026-07-02T00:00:00.000Z',
+          lastKnownStatus: 'published',
+          publishedAt: '2026-07-02T00:00:00.000Z',
+        },
+        {
+          token: 'tip-gts',
+          title: 'Global Thermonuclear Strategy',
+          slug: 'global-thermonuclear-strategy',
+          createdAt: '2026-07-21T00:00:00.000Z',
+          lastKnownStatus: 'building',
+        },
+        {
+          token: 'live-tv',
+          title: 'A game tycoon like where I run a tv busi',
+          slug: 'tv-tycoon',
+          createdAt: '2026-07-03T00:00:00.000Z',
+          lastKnownStatus: 'published',
+          publishedAt: '2026-07-03T00:00:00.000Z',
+        },
+      ]),
+    );
 
     const width = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true });
@@ -288,7 +294,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(6));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(6)));
 
     const { container, root } = await renderStudio({ selectedGame: 'game-2', selectedTab: 'playtest' });
 
@@ -316,7 +322,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(10));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(10)));
 
     const { container, root } = await renderStudio();
 
@@ -332,7 +338,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(6));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(6)));
     // jsdom has no matchMedia; width is the same fallback the drawer uses in embedded
     // webviews. Narrow enough that the shelf is off-canvas, not the desktop rail.
     const width = window.innerWidth;
@@ -373,7 +379,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     window.history.replaceState(null, '', '/studio/token-0');
 
     const { container, root, onNavigate } = await renderStudio({ selectedGame: 'token-0' });
@@ -400,7 +406,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     window.history.replaceState(null, '', '/studio/token-0');
 
     const { container, root } = await renderStudio({ selectedGame: 'token-0' });
@@ -421,7 +427,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     window.history.replaceState(null, '', '/studio/token-0/playtest');
 
     const { container, root, onNavigate } = await renderStudio({
@@ -449,7 +455,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     // The shape of a link from before there were three surfaces. The router resolves
     // `stats` onto Details; what is asserted here is that the address follows.
     window.history.replaceState(null, '', '/studio/token-0/stats');
@@ -475,15 +481,17 @@ describe('CreatorStudioView', () => {
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
     setDraftShared.mockResolvedValue({ shared: true, slug: 'tv-tycoon' });
-    fetchStudioGames.mockResolvedValue([
-      {
-        token: 'token-draft',
-        title: 'TV Tycoon',
-        createdAt: '2026-07-30T09:00:00.000Z',
-        lastKnownStatus: 'building',
-        slug: 'tv-tycoon',
-      },
-    ] satisfies StudioGame[]);
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+        },
+      ]),
+    );
     window.history.replaceState(null, '', '/studio/tv-tycoon/overview');
 
     const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
@@ -511,15 +519,17 @@ describe('CreatorStudioView', () => {
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
     setDraftShared.mockRejectedValue(new Error('nope'));
-    fetchStudioGames.mockResolvedValue([
-      {
-        token: 'token-draft',
-        title: 'TV Tycoon',
-        createdAt: '2026-07-30T09:00:00.000Z',
-        lastKnownStatus: 'building',
-        slug: 'tv-tycoon',
-      },
-    ] satisfies StudioGame[]);
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+        },
+      ]),
+    );
 
     const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
 
@@ -539,7 +549,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     // jsdom has no matchMedia, which is also the fallback path in real embedded
     // webviews — the width is what decides when the query is unavailable.
     const width = window.innerWidth;
@@ -567,7 +577,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     const width = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true });
 
@@ -587,23 +597,25 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue([
-      {
-        token: 'token-shared',
-        title: 'TV Tycoon',
-        createdAt: '2026-07-30T09:00:00.000Z',
-        lastKnownStatus: 'building',
-        slug: 'tv-tycoon',
-        draftShared: true,
-      },
-      {
-        token: 'token-private',
-        title: 'Space Miner',
-        createdAt: '2026-07-30T09:30:00.000Z',
-        lastKnownStatus: 'building',
-        slug: 'space-miner',
-      },
-    ] satisfies StudioGame[]);
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-shared',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+          draftShared: true,
+        },
+        {
+          token: 'token-private',
+          title: 'Space Miner',
+          createdAt: '2026-07-30T09:30:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'space-miner',
+        },
+      ]),
+    );
 
     // Two `/details` URLs in a row — a browser Back, or a link. The panel stays mounted
     // across that, so anything it seeded from the first game would still be on screen.
@@ -626,7 +638,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(3));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(3)));
     window.history.replaceState(null, '', '/studio/game-2');
 
     const { container, root } = await renderStudio({ selectedGame: 'game-2' });
@@ -640,7 +652,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(3));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(3)));
     window.history.replaceState(null, '', '/studio/token-1');
 
     // The shape of a link from a months-old notification email, minted before games
@@ -660,7 +672,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(3));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(3)));
     window.history.replaceState(null, '', '/studio/somebody-elses-game');
 
     // Slugs are public — they are in every /play/ link — so the guard cannot be that
@@ -678,7 +690,7 @@ describe('CreatorStudioView', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
-    fetchStudioGames.mockResolvedValue(manyGames(2));
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(2)));
     window.history.replaceState(null, '', '/studio');
 
     const { container, root, onNavigate } = await renderStudio();
@@ -731,7 +743,7 @@ describe('CreatorStudioView — what players think', () => {
   beforeEach(() => {
     authUser = { uid: 'g:creator', name: 'Creator' };
     fetchStudioGames.mockReset();
-    fetchStudioGames.mockResolvedValue(published);
+    fetchStudioGames.mockResolvedValue(studioShelf(published));
     fetchStudioHealth.mockReset();
     fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
     fetchStudioScorecards.mockReset();

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -168,6 +168,8 @@ export function CreatorStudioView({
   const [scorecards, setScorecards] = useState<StudioScorecard[]>([]);
   const [healthDays, setHealthDays] = useState<string[]>([]);
   const [truncated, setTruncated] = useState(false);
+  const [shelfTruncated, setShelfTruncated] = useState(false);
+  const [totalGames, setTotalGames] = useState(0);
   const [days, setDays] = useState(7);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -231,9 +233,12 @@ export function CreatorStudioView({
     setError(null);
 
     Promise.all([fetchStudioGames(), fetchStudioHealth(days)])
-      .then(([shelf, health]) => {
+      .then(([shelfPage, health]) => {
         if (cancelled) return;
+        const shelf = shelfPage.games;
         setGames(shelf);
+        setShelfTruncated(shelfPage.truncated);
+        setTotalGames(shelfPage.totalGames);
         setHealthRows(health.games);
         setHealthDays(health.days);
         setTruncated(health.truncated);
@@ -579,7 +584,11 @@ export function CreatorStudioView({
           >
             <div className="studio-shelf-head">
               <h2 className="studio-shelf-heading">{t('studioPanel.shelf.heading')}</h2>
-              <span className="studio-shelf-count">{t('studioPanel.shelf.count', { count: shelfGames.length })}</span>
+              <span className="studio-shelf-count">
+                {shelfTruncated
+                  ? t('studioPanel.shelf.countTruncated', { shown: shelfGames.length, total: totalGames })
+                  : t('studioPanel.shelf.count', { count: shelfGames.length })}
+              </span>
               {activeGame ? (
                 <button
                   type="button"
@@ -611,6 +620,7 @@ export function CreatorStudioView({
               onQueryChange={setShelfQuery}
               onFilterChange={setShelfFilter}
             />
+            {shelfTruncated ? <p className="studio-shelf-truncated">{t('studioPanel.shelf.truncated')}</p> : null}
             {shelfList}
           </aside>
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -261,6 +261,8 @@
         "live": "Live"
       },
       "noMatches": "No games match that search.",
+      "countTruncated": "Showing {{shown}} of {{total}} games",
+      "truncated": "You have more games than we can show here. The newest fifty are listed.",
       "openShelf": "Your games",
       "expandShelf": "Expand games list",
       "collapseShelf": "Collapse games list"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -263,6 +263,8 @@
         "live": "Na żywo"
       },
       "noMatches": "Żadna gra nie pasuje do tego wyszukiwania.",
+      "countTruncated": "Wyświetlam {{shown}} z {{total}} gier",
+      "truncated": "Masz więcej gier, niż możemy tu pokazać. Widać pięćdziesiąt najnowszych.",
       "openShelf": "Twoje gry",
       "expandShelf": "Rozwiń listę gier",
       "collapseShelf": "Zwiń listę gier"

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -11,6 +11,11 @@ export type StudioGame = {
   slug?: string;
   publishedAt?: string;
   /**
+   * Catalog publish time when this row is an improvement tip — the game is still live
+   * but the open job has no `publishedAt` of its own.
+   */
+  livePublishedAt?: string;
+  /**
    * Whether anyone holding the link may play this game before it is published. Off
    * until the creator says otherwise; irrelevant once the game is live, when the
    * catalog is the answer instead.
@@ -133,6 +138,8 @@ export async function publishEditorContent(slug: string): Promise<{ version: str
 export type StudioHealthResponse = {
   days: string[];
   truncated: boolean;
+  gamesTruncated?: boolean;
+  totalGames?: number;
   games: GameHealth[];
 };
 
@@ -170,9 +177,13 @@ async function readJson(response: Response): Promise<unknown> {
 }
 
 async function throwResponseError(response: Response): Promise<never> {
-  const body = (await readJson(response)) as
-    | { error?: string; category?: string; problems?: unknown; revision?: unknown; retryAfterMs?: unknown }
-    | null;
+  const body = (await readJson(response)) as {
+    error?: string;
+    category?: string;
+    problems?: unknown;
+    revision?: unknown;
+    retryAfterMs?: unknown;
+  } | null;
   const error = new Error(body?.error ?? `Request failed (${response.status})`) as StudioApiError;
   error.status = response.status;
   error.category = body?.category;
@@ -187,13 +198,29 @@ async function throwResponseError(response: Response): Promise<never> {
 }
 
 /** The signed-in creator's control-panel shelf (slug + publish time when known). */
-export async function fetchStudioGames(): Promise<StudioGame[]> {
+export type StudioGamesResponse = {
+  games: StudioGame[];
+  truncated: boolean;
+  totalGames: number;
+};
+
+/** The signed-in creator's control-panel shelf (slug + publish time when known). */
+export async function fetchStudioGames(): Promise<StudioGamesResponse> {
   const response = await fetch(`${API_BASE}/api/me/studio`, { credentials: 'include' });
   if (!response.ok) {
     await throwResponseError(response);
   }
-  const body = (await response.json()) as { games?: StudioGame[] };
-  return body.games ?? [];
+  const body = (await response.json()) as {
+    games?: StudioGame[];
+    truncated?: boolean;
+    totalGames?: number;
+  };
+  const games = body.games ?? [];
+  return {
+    games,
+    truncated: body.truncated ?? false,
+    totalGames: body.totalGames ?? games.length,
+  };
 }
 
 /** Play-health aggregates for the creator's own published slugs only. */

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -44,6 +44,11 @@ export type MySubmission = {
   slug: string | null;
   /** Set when the game has published — optional on older API responses. */
   publishedAt?: string;
+  /**
+   * Catalog publish time when this row is an improvement tip — the game is still live
+   * but the open job has no `publishedAt` of its own.
+   */
+  livePublishedAt?: string;
 };
 
 /** The build steps an agent can report. Rendered from our own translated copy. */
@@ -252,15 +257,35 @@ export async function getSubmissionStatus(token: string, locale?: string): Promi
  * The signed-in creator's own games. Server-side ownership means this works on a
  * device that never saved the tracking link — the tokens come back with it.
  */
-export async function listMySubmissions(): Promise<MySubmission[]> {
+export type MySubmissionsPage = {
+  submissions: MySubmission[];
+  truncated: boolean;
+  totalGames: number;
+};
+
+export async function listMySubmissionsPage(): Promise<MySubmissionsPage> {
   const response = await fetch(`${API_BASE}/api/submissions/mine`, { credentials: 'include' });
 
   if (!response.ok) {
     await throwResponseError(response);
   }
 
-  const body = (await response.json()) as { submissions?: MySubmission[] };
-  return body.submissions ?? [];
+  const body = (await response.json()) as {
+    submissions?: MySubmission[];
+    truncated?: boolean;
+    totalGames?: number;
+  };
+  const submissions = body.submissions ?? [];
+  return {
+    submissions,
+    truncated: body.truncated ?? false,
+    totalGames: body.totalGames ?? submissions.length,
+  };
+}
+
+export async function listMySubmissions(): Promise<MySubmission[]> {
+  const page = await listMySubmissionsPage();
+  return page.submissions;
 }
 
 export async function getSubmissionPreview(token: string): Promise<SubmissionPreview> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`GET /mine` and the three Studio shelf routes fetched the newest **50 jobs**, then filtered. Improvement rounds allocate a new job each time, so that window measures how much a creator has been *working*, not how many games they have — three games and sixty rounds can leave every published game outside the window. The shelf rendered a short list with no error and no “showing N of M”, so it read as complete while silently lying.

Same root assumption BY-25 fixed for durable-key ownership: `listSubmissionsByOwner`’s “submission count is small” comment was false once rounds became jobs.

**Fix:** collapse to distinct games (by slug; slugless jobs stay one-per-job) *before* the ceiling. Raising 50 is not the fix. Truncation is visible (`truncated` + `totalGames`).

## Predicate preservation
- **Shelf** (`/mine`, `/api/me/studio`): still hides `abandonedAt` and `state === 'canceled'`.
- **Health / scorecards:** still require `slug && publishedAt` on a non-abandoned job in the group; still do **not** filter `canceled` (prior behaviour kept — call out if that should change later).
- Improve tips stay unpublished on the tip row (`publishedAt` not copied); catalog liveness travels as `livePublishedAt` / `catalogPublishedAt`.

## Changes
- `apps/api/src/owner-games.ts` — collapse + page helper
- Wire `/api/submissions/mine`, `/api/me/studio`, health, scorecards
- Web: shelf “Showing X of Y” + note when truncated (EN/PL)
- `listSubmissionsByOwner`: omit limit → full owner set; comment updated

## Test plan
- [x] `owner-games` unit tests
- [x] 3 games × 20 tips each → all 3 on `/mine` and each studio route
- [x] Abandoned / canceled hidden; all-abandoned game absent; draft off published routes
- [x] Web CreatorStudioView + studioShelf suites
- [ ] Supervisor: confirm tip/`livePublishedAt` still drives Live filter + composer improve vs feedback correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0fdc2f-be8a-48de-81cb-d2b23d54845d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

