### PR TITLE
Prevent mobile prompt autofocus

### DIFF
--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -15,6 +15,7 @@ describe('HeroPromptSection', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('renders prompt inputs and voice, upload, sketch buttons', async () => {
@@ -51,6 +52,42 @@ describe('HeroPromptSection', () => {
     expect(micBtn).not.toBeNull();
     expect(uploadBtn).not.toBeNull();
     expect(sketchBtn).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not autofocus the prompt on a narrow viewport', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: '',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+          mockStatus: 'idle',
+          mockError: null,
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(document.activeElement).not.toBe(container.querySelector('.big-prompt-input'));
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -113,6 +113,10 @@ export function HeroPromptSection({
   mockError,
 }: HeroPromptSectionProps) {
   const { t } = useTranslation();
+  // Focusing a text field during mobile page load opens the on-screen keyboard and hides
+  // most of the creation surface. Keep the desktop shortcut, where no virtual keyboard
+  // competes for viewport space.
+  const shouldAutoFocusPrompt = typeof matchMedia !== 'function' || !matchMedia('(max-width: 768px)').matches;
   const [promptText, setPromptText] = useState(initialPrompt);
   const [attachments, setAttachments] = useState<VisualAttachment[]>([]);
   const [isSketchOpen, setIsSketchOpen] = useState(false);
@@ -323,7 +327,7 @@ export function HeroPromptSection({
           <div className="prompt-textarea-wrapper">
             <textarea
               className="big-prompt-input"
-              autoFocus
+              autoFocus={shouldAutoFocusPrompt}
               value={promptText}
               onChange={(e) => {
                 // Intent, recorded once per visit: the top of the creation funnel is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- prevent the home prompt from receiving autofocus at the 768px-and-under mobile breakpoint, so loading the page does not open the virtual keyboard
- retain desktop autofocus
- cover the narrow-viewport focus behavior with a component test

## Instrumentation
This affects creator-funnel usability (question 4). No telemetry contract changes are needed: `prompt_started` remains emitted from actual text entry, which is the behavior this change preserves.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f33a6abc-297f-4c55-961d-8af3f51cb326?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f33a6abc-297f-4c55-961d-8af3f51cb326&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

