### PR TITLE
Remix: fix "game not found" everywhere, prompt-only UI, reveal at pauses, chrome auto-hide

### DIFF
--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -79,6 +79,9 @@ const MAX_GAME_SOURCE_BYTES = 200 * 1024;
  *
  * Returns null when the specifier is not a relative TypeScript module path.
  */
+/** What `getGameFile` will read. Declarations and manifests, never source or media. */
+const GAME_FILE_READS = new Set(['GAME.json', 'SPEC.md', 'EDITOR.json']);
+
 export function resolveGameTypeScriptPath(resolveDir: string, specifier: string): string | null {
   if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
     return null;
@@ -415,6 +418,17 @@ export interface GitHubClient {
    * never looked at, because the bundler only ever asks for game-root paths.
    */
   getGameSources(ref: string, slug: string, overrides?: Record<string, string>): Promise<GameSources | null>;
+  /**
+   * One declared file out of a game's directory, or null when it is not there.
+   *
+   * Exists because "does this game exist, and what does it declare?" should not
+   * cost a full assembly. `getGameSources` fetches the engine, every module,
+   * every audio asset and then bundles — minutes of work in bytes for a question
+   * two reads answer. Errors are *not* swallowed: a 403 or a rate limit must not
+   * be indistinguishable from a missing file, which is exactly the confusion
+   * that made every remix answer "game not found".
+   */
+  getGameFile(ref: string, slug: string, path: string): Promise<string | null>;
   /**
    * Reads the agent's own progress journal for a game on `ref`
    * (`games/<slug>/PROGRESS.md`). This is how the coding agent narrates what it is
@@ -1095,6 +1109,14 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       const raw = await readRawFile(`games/${slug}/PROGRESS.md`, ref);
       // Cap the read: this is agent-authored and only its newest lines are shown.
       return raw === null ? null : raw.slice(0, 4096);
+    },
+
+    async getGameFile(ref, slug, path) {
+      // Same slug guard as getGameSources, plus a closed file list: this reads
+      // whatever a caller names, so the names are ours rather than theirs.
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) return null;
+      if (!GAME_FILE_READS.has(path)) return null;
+      return readRawFile(`games/${slug}/${path}`, ref);
     },
 
     async getGameSources(ref, slug, overrides) {

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -61,7 +61,9 @@ function stubGitHubClient(seen: Array<Record<string, string> | undefined>): GitH
   } as unknown as GitHubClient;
 }
 
-async function buildTestApp(overrides: { assistant?: EditorAssistant; codeLane?: unknown } = {}) {
+async function buildTestApp(
+  overrides: { assistant?: EditorAssistant; codeLane?: unknown; isAbandoned?: () => boolean } = {},
+) {
   const store = new InMemoryStore();
   await store.setPublication({
     slug: 'dog-dash',
@@ -85,6 +87,7 @@ async function buildTestApp(overrides: { assistant?: EditorAssistant; codeLane?:
     publishedRef: 'main',
     ...(overrides.assistant ? { assistant: overrides.assistant } : {}),
     ...(overrides.codeLane ? { codeLane: overrides.codeLane as never } : {}),
+    ...(overrides.isAbandoned ? { isAbandoned: overrides.isAbandoned } : {}),
   });
   await app.ready();
   return { app, seen };
@@ -213,6 +216,83 @@ describe('remix routes', () => {
     const last = built.seen.at(-1)!;
     expect(last['game/runtime.ts']).toContain('return 0.08;');
     expect(last['index.html']).toBe(SOURCES['index.html']);
+  });
+
+  it('discards an abandoned code edit rather than letting it land later', async () => {
+    // The client aborts at its own timeout and tells the player their game came
+    // back untouched. The rebuild finishes anyway; what must not happen is that
+    // edit quietly becoming the base for the next one.
+    const sourcesSeen: Array<Record<string, string>> = [];
+    const codeLane = {
+      run: async (
+        request: { sources: Record<string, string> },
+        build: (o: Record<string, string>) => Promise<{ ok: boolean }>,
+      ) => {
+        sourcesSeen.push(request.sources);
+        const good = { 'game/runtime.ts': 'export function startGame() {\n  return 0.08;\n}\n' };
+        await build(good);
+        return {
+          ok: true,
+          overrides: good,
+          region: { file: 'game/runtime.ts', name: 'startGame' },
+          rounds: 0,
+          tokens: { input: 1, output: 1 },
+        };
+      },
+    };
+    const built = await buildTestApp({ codeLane, isAbandoned: () => true });
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'make it faster' },
+    });
+
+    // The next edit must see the ORIGINAL source, not the abandoned one.
+    await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'again' },
+    });
+    expect(sourcesSeen).toHaveLength(2);
+    expect(sourcesSeen[1]['game/runtime.ts']).toContain('return 0.16;');
+  });
+
+  it('refuses a second rebuild while one is in flight', async () => {
+    let release: (() => void) | null = null;
+    const codeLane = {
+      run: async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { ok: false, reason: 'did_not_compile', tokens: { input: 1, output: 1 } };
+      },
+    };
+    const built = await buildTestApp({ codeLane });
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+
+    const first = app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'one' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'two' },
+    });
+    // A double-tap or a post-timeout retry is told to wait, not charged again.
+    expect(second.statusCode).toBe(409);
+    release?.();
+    await first;
   });
 
   it('reports a failed code edit without swapping anything', async () => {

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -48,6 +48,8 @@ function stubGamesStore(): GamesStore {
 /** Records what the assembler was asked to build, so overrides can be asserted. */
 function stubGitHubClient(seen: Array<Record<string, string> | undefined>): GitHubClient {
   return {
+    getGameFile: async (_ref: string, slug: string, path: string) =>
+      slug === 'dog-dash' || slug === 'repo-game' ? (SOURCES[path] ?? null) : null,
     getGameSources: async (_ref: string, slug: string, overrides?: Record<string, string>) => {
       // Like the real client: a slug with no game directory on the ref is null.
       if (slug !== 'dog-dash') return null;
@@ -287,5 +289,82 @@ describe('remix routes', () => {
     expect(JSON.stringify(body)).not.toContain('startGame');
     // The player is told their code edit is not travelling, rather than it silently vanishing.
     expect(body.codeEditsExcluded).toBe(true);
+  });
+});
+
+/*
+ * The two eras. Production answered "game not found" for every slug because the
+ * start route proved existence by assembling the whole game and swallowed any
+ * failure as an absence; these pin the replacement — a manifest read decides
+ * existence, a declaration read decides which lanes exist, and a repo-era game
+ * gets the params lane instead of nothing.
+ */
+describe('remix across the two catalog eras', () => {
+  let app: FastifyInstance | null = null;
+
+  beforeEach(() => {
+    process.env.EDITOR_ASSIST = 'true';
+    process.env.CODE_LANE = 'true';
+  });
+
+  afterEach(async () => {
+    delete process.env.EDITOR_ASSIST;
+    delete process.env.CODE_LANE;
+    if (app) await app.close();
+    app = null;
+  });
+
+  /** No publication record → the repo-era path, exactly like a catalog game. */
+  async function repoEraApp() {
+    const store = new InMemoryStore();
+    const seen: Array<Record<string, string> | undefined> = [];
+    const instance = Fastify();
+    instance.decorateRequest('user', null);
+    instance.addHook('onRequest', async (request) => {
+      const uid = request.headers['x-test-uid'];
+      (request as { user?: unknown }).user = typeof uid === 'string' ? { uid, tier: 'standard' } : null;
+    });
+    await registerRemixRoutes(instance, {
+      store,
+      gamesStore: stubGamesStore(),
+      githubClient: stubGitHubClient(seen),
+      publishedRef: 'main',
+      assistant: { assist: async () => ({ lane: 'params' }) } as EditorAssistant,
+      codeLane: { run: async () => ({ ok: true }) } as never,
+    });
+    await instance.ready();
+    return instance;
+  }
+
+  it('opens a repo-era game on its declaration alone, with the params lane live', async () => {
+    app = await repoEraApp();
+    const response = await app.inject({ method: 'POST', url: '/api/games/repo-game/remix', headers: alice });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    // The declaration came from a file read, not from an assembly.
+    expect(body.params.dogScale.max).toBe(3);
+    expect(body.canAssist).toBe(true);
+    // ...but its code is still on the ref, so the deep lane says so honestly.
+    expect(body.canCode).toBe(false);
+  });
+
+  it('refuses the code lane on a repo-era game rather than mapping nothing', async () => {
+    app = await repoEraApp();
+    const { remixId } = (
+      await app.inject({ method: 'POST', url: '/api/games/repo-game/remix', headers: alice })
+    ).json();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'add a double jump' },
+    });
+    expect(response.statusCode).toBe(409);
+  });
+
+  it('404s a slug with no manifest — a real absence, not a swallowed failure', async () => {
+    app = await repoEraApp();
+    const response = await app.inject({ method: 'POST', url: '/api/games/not-a-game/remix', headers: alice });
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -75,6 +75,16 @@ interface RemixSession {
   definition: EditorDefinition | null;
   title: string;
   codeEdits: number;
+  /**
+   * A code rebuild is running for this session.
+   *
+   * One at a time, deliberately: two concurrent rebuilds race on `overrides`,
+   * and the loser's edit silently lands on top of a base it never saw. The
+   * client only ever has one in flight, so a second arrival is either a
+   * double-tap or a retry after a client-side timeout — both of which want to
+   * be told "still working", not to start a second paid run.
+   */
+  codeInFlight: boolean;
   expiresAt: number;
 }
 
@@ -104,6 +114,13 @@ export interface RemixRoutesOptions {
   contentChecker?: ContentChecker;
   /** The platform-wide editing spend breaker — both model lanes ride it. */
   editingGate?: EditingGate;
+  /**
+   * Whether the caller has hung up mid-rebuild. Defaults to the socket state;
+   * injectable because that is the one thing a test cannot produce through
+   * `inject()`, and the behaviour it guards — an abandoned edit must not land —
+   * is worth pinning.
+   */
+  isAbandoned?: (request: FastifyRequest) => boolean;
   now?: () => number;
 }
 
@@ -262,6 +279,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         definition,
         title: params.data.slug,
         codeEdits: 0,
+        codeInFlight: false,
         expiresAt: now() + REMIX_TTL_MS,
       });
 
@@ -373,43 +391,76 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         }
       }
 
+      if (session.codeInFlight) {
+        return reply.status(409).send({ error: 'still working on your last change' });
+      }
       if (!(await spendEditSlot(request, reply))) return;
 
-      const current = { ...session.sources, ...session.overrides };
-      const outcome = await options.codeLane.run(
-        { slug: session.slug, sources: current, utterance: body.data.utterance, game: { title: session.title } },
-        async (candidate) => {
-          // "Does it build" is answered by building the real document — the same
-          // assembler, CSP and caps the play path applies — so a green answer here
-          // means the frame can actually run it.
-          try {
-            const html = await rebuild(session, candidate);
-            return html ? { ok: true } : { ok: false, errors: ['the game could not be assembled'] };
-          } catch (error) {
-            return { ok: false, errors: [error instanceof Error ? error.message : String(error)] };
-          }
-        },
-      );
+      /**
+       * Did the player walk away while we worked?
+       *
+       * The client aborts its fetch at its own timeout and tells the player
+       * their game came back untouched. Nothing about that reaches this
+       * handler, so without this check the rebuild would finish anyway and
+       * write itself into the session — and the *next* edit would silently
+       * build on a change the player was told had been discarded. The socket
+       * closing is the only signal we get, and it is enough: an abandoned run
+       * is discarded here, which makes the client's promise true.
+       */
+      const abandoned = () =>
+        options.isAbandoned ? options.isAbandoned(request) : request.raw.destroyed || request.socket.destroyed;
 
-      if (!outcome.ok) {
+      session.codeInFlight = true;
+      try {
+        const current = { ...session.sources, ...session.overrides };
+        const outcome = await options.codeLane.run(
+          { slug: session.slug, sources: current, utterance: body.data.utterance, game: { title: session.title } },
+          async (candidate) => {
+            // "Does it build" is answered by building the real document — the same
+            // assembler, CSP and caps the play path applies — so a green answer here
+            // means the frame can actually run it.
+            try {
+              const html = await rebuild(session, candidate);
+              return html ? { ok: true } : { ok: false, errors: ['the game could not be assembled'] };
+            } catch (error) {
+              return { ok: false, errors: [error instanceof Error ? error.message : String(error)] };
+            }
+          },
+        );
+
+        if (!outcome.ok) {
+          return reply.send({
+            ok: false,
+            reason: outcome.reason,
+            ...(outcome.summary ? { summary: outcome.summary } : {}),
+          });
+        }
+
+        if (abandoned()) {
+          // The spend already happened and is not refundable — but the *edit* is,
+          // and discarding it is what the player was promised. Logged because a
+          // pattern of these is the signal that the timeout is set too tight.
+          request.log.info(
+            { slug: session.slug, region: outcome.region },
+            'remix code edit abandoned before it landed',
+          );
+          return;
+        }
+
+        session.overrides = { ...session.overrides, ...outcome.overrides };
+        session.codeEdits += 1;
+        session.expiresAt = now() + REMIX_TTL_MS;
+        const html = await rebuild(session);
+        if (!html) return reply.status(500).send({ ok: false, reason: 'error' });
         return reply.send({
-          ok: false,
-          reason: outcome.reason,
+          ok: true,
+          html,
+          region: outcome.region,
           ...(outcome.summary ? { summary: outcome.summary } : {}),
         });
+      } finally {
+        session.codeInFlight = false;
       }
-
-      session.overrides = { ...session.overrides, ...outcome.overrides };
-      session.codeEdits += 1;
-      session.expiresAt = now() + REMIX_TTL_MS;
-      const html = await rebuild(session);
-      if (!html) return reply.status(500).send({ ok: false, reason: 'error' });
-      return reply.send({
-        ok: true,
-        html,
-        region: outcome.region,
-        ...(outcome.summary ? { summary: outcome.summary } : {}),
-      });
     },
   );
 

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -66,6 +66,12 @@ interface RemixSession {
   sources: Record<string, string>;
   /** Accumulated edits, newest wins. Applied over `sources` on every rebuild. */
   overrides: Record<string, string>;
+  /**
+   * Whether every source is in hand. Only a store-era delivery hands over its
+   * files, and the code lane needs them to map regions — a repo-era game gets
+   * the params lane and an honest "not that deep, here" for the rest.
+   */
+  fromStore: boolean;
   definition: EditorDefinition | null;
   title: string;
   codeEdits: number;
@@ -164,10 +170,20 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
   }
 
   /**
-   * Every source file of the published version, whichever side of the migration
-   * the game lives on. Store games are authoritative in GCS; repo games are read
-   * from the published ref by the assembler itself, so only their editor
-   * declaration is fetched here.
+   * What this game is, and what it lets a player change.
+   *
+   * Two eras, one answer. A store-era game is authoritative in GCS and hands
+   * over every source, so both lanes can work on it. A repo-era game keeps its
+   * sources on the ref, and only its *declaration* is read here — two cheap
+   * file reads rather than a full assembly.
+   *
+   * That split is deliberate and was learned the hard way: the first version
+   * used `getGameSources` as an existence probe, which fetches the engine,
+   * every module and every audio asset and then bundles — and wrapped it in a
+   * catch that turned any GitHub hiccup into "game not found". Every remix on
+   * the site answered that, with nothing in the logs to say why. Existence is
+   * now a question about a manifest, and a read that *fails* is reported as a
+   * failure rather than as an absence.
    */
   async function loadSources(
     slug: string,
@@ -186,18 +202,22 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       const sources = Object.fromEntries(entries.filter((entry): entry is [string, string] => entry !== null));
       return { sources, ref: manifest.engineRef ?? options.publishedRef ?? 'main', fromStore: true };
     }
+
     if (!options.githubClient || !options.publishedRef) return null;
-    // Prove the game exists before minting a session for it: without the store's
-    // publication record, "is this a real published game" is a question only the
-    // assembler can answer, and answering it here keeps a typo'd slug from
-    // becoming a remix that fails on its first action instead of at the door.
-    const probe = await options.githubClient.getGameSources(options.publishedRef, slug).catch(() => null);
-    if (!probe) return null;
-    // A repo game's sources stay on the ref and the assembler reads them there.
-    // Nothing is loaded up front: without the store's file list there is no way
-    // to map regions, so such a game gets the params lane only — and its
-    // declaration, if it has one, arrives with the sources at rebuild time.
-    return { sources: {}, ref: options.publishedRef, fromStore: false };
+    const ref = options.publishedRef;
+    // GAME.json is the proof of existence — every game has one, and a missing
+    // file is a real "no such game" rather than a swallowed error.
+    const manifest = await options.githubClient.getGameFile(ref, slug, 'GAME.json');
+    if (manifest === null) return null;
+    const editorJson = await options.githubClient.getGameFile(ref, slug, EDITOR_FILE);
+    // Declaration only: a repo game's code stays on the ref (the assembler reads
+    // it there), so the code lane has no file list to map and says so, while the
+    // params lane works on exactly the games that declare params.
+    return {
+      sources: editorJson === null ? {} : { [EDITOR_FILE]: editorJson },
+      ref,
+      fromStore: false,
+    };
   }
 
   /** Rebuild the whole document with the session's edits applied. */
@@ -205,8 +225,9 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     if (!options.githubClient) return null;
     const overrides = { ...session.overrides, ...extra };
     const sources = await options.githubClient.getGameSources(session.ref, session.slug, {
-      // Store games carry every file; repo games carry only what was edited.
-      ...session.sources,
+      // A store game's files replace the ref's entirely (its code lives in GCS);
+      // a repo game keeps the ref as its base and only carries the edit.
+      ...(session.fromStore ? session.sources : {}),
       ...overrides,
     });
     if (!sources) return null;
@@ -235,7 +256,8 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         ownerUid: request.user!.uid,
         slug: params.data.slug,
         ref: loaded.ref,
-        sources: loaded.fromStore ? loaded.sources : {},
+        sources: loaded.sources,
+        fromStore: loaded.fromStore,
         overrides: {},
         definition,
         title: params.data.slug,
@@ -326,9 +348,11 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       if (!options.codeLane || !codeLaneEnabled()) {
         return reply.status(503).send({ error: 'code changes are not available here' });
       }
-      if (Object.keys(session.sources).length === 0) {
-        // Repo-era games keep their sources on the ref; the lane needs them in hand
-        // to map regions, so this is honestly "not here", not a failure.
+      if (!session.fromStore) {
+        // Repo-era games keep their sources on the ref; the lane needs them in
+        // hand to map regions, so this is honestly "not here", not a failure.
+        // Checked on `fromStore` rather than on the source count, because such a
+        // session now legitimately carries one file — its declaration.
         return reply.status(409).send({ error: 'this game cannot be remixed that deeply yet' });
       }
       if (session.codeEdits >= MAX_CODE_EDITS) {

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -172,6 +172,12 @@ export type AssistStep = (typeof ASSIST_STEPS)[number];
  */
 export const REMIX_STEPS = [
   'opened',
+  // The wall triple. `typed → signed_in` is the number the product strategy
+  // turns on: desire created versus what the sign-in wall costs. `typed` fires
+  // on send regardless of auth, so the gap is measured rather than guessed.
+  'typed',
+  'wall_shown',
+  'signed_in',
   'tuned',
   'asked',
   'applied',

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -75,7 +75,19 @@ const EditorStepSchema = z.enum(['opened', 'draft_saved', 'previewed', 'publishe
 /** The NL tuning lane's outcomes — a dimension beside the editing funnel, not a rung in it. */
 const AssistStepSchema = z.enum(['asked', 'applied', 'handoff', 'rejected']);
 /** The player-side remix funnel — see visit-funnel's REMIX_STEPS for the order's meaning. */
-const RemixStepSchema = z.enum(['opened', 'tuned', 'asked', 'applied', 'handoff', 'refused', 'shared', 'keep_clicked']);
+const RemixStepSchema = z.enum([
+  'opened',
+  'typed',
+  'wall_shown',
+  'signed_in',
+  'tuned',
+  'asked',
+  'applied',
+  'handoff',
+  'refused',
+  'shared',
+  'keep_clicked',
+]);
 /**
  * Which chrome surface opened How to play. Optional so a tab still running the previous
  * client can record the open without `via` — the aggregate treats missing as unknown

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -417,6 +417,32 @@ describe('GameTheater how-to-play visit telemetry', () => {
     setVisitSessionForTesting(null);
   });
 
+  it('hides the bar during play and restores it from the peek pill by keyboard', async () => {
+    vi.useFakeTimers();
+    try {
+      await draw();
+      // The grace window: the bar is still there while the title registers.
+      expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+      await act(async () => {
+        vi.advanceTimersByTime(3100);
+      });
+      // Play owns the screen; the pill is the way back.
+      expect(container.querySelector('.game-theater-bar')).toBeNull();
+      const pill = container.querySelector('.theater-peek-pill') as HTMLButtonElement | null;
+      expect(pill).not.toBeNull();
+
+      // Enter/Space on a focused button emit `click` and no pointer events at
+      // all — a pointerdown-only pill would strand a keyboard-only player with
+      // no route back to mute or exit.
+      await act(async () => {
+        pill!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('records via and same-card reopen for a published play', async () => {
     await draw({ controls: 'Arrow keys to move' });
     await click(container.querySelector('.howto-btn'));

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -514,7 +514,12 @@ export function GameTheater({
           type="button"
           className="theater-peek-pill"
           aria-label={t('player.showControls')}
+          // Both: pointerdown for a touch that should not wait for the click,
+          // click for Enter/Space — which never emit pointer events, and this
+          // pill is the only way back to mute and exit once the bar is hidden.
+          // revealChrome is idempotent, so the pair firing together is a no-op.
           onPointerDown={() => revealChrome()}
+          onClick={() => revealChrome()}
         />
       )}
       {!fullscreen && !chromeHidden && (

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -198,6 +198,42 @@ export function GameTheater({
   // and swallows its own key events.
   const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore);
 
+  /**
+   * Chrome auto-hide (ops repo realtime plan §D.11.6): during play the screen is
+   * pure game; the bar returns at the natural pauses — a finished run, or the
+   * always-visible peek pill. One rule, shared with the remix reveal: chrome
+   * appears in the gaps, never mid-action. Hidden must never mean gone — the
+   * pill is one tap from mute and exit, and reveal fires on pointerdown so a
+   * phone gets it without the click delay.
+   */
+  const [chromeHidden, setChromeHidden] = useState(false);
+  const rehideTimerRef = useRef<number | null>(null);
+  const revealChrome = useCallback((rehideAfterMs?: number) => {
+    setChromeHidden(false);
+    if (rehideTimerRef.current !== null) window.clearTimeout(rehideTimerRef.current);
+    rehideTimerRef.current =
+      rehideAfterMs === undefined ? null : window.setTimeout(() => setChromeHidden(true), rehideAfterMs);
+  }, []);
+  useEffect(() => {
+    // Play start: a short grace so the title/author register, then the game owns
+    // the screen. A finished run hands the controls back for a while — the same
+    // beat the remix invitation uses — and then play takes over again.
+    const grace = window.setTimeout(() => setChromeHidden(true), 3000);
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== 'null') return;
+      const frame = frameRef.current;
+      if (!frame || event.source !== frame.contentWindow) return;
+      const data = event.data as { source?: string; type?: string } | null;
+      if (data?.source === 'gdpl-player' && data.type === 'end') revealChrome(8000);
+    }
+    window.addEventListener('message', onMessage);
+    return () => {
+      window.clearTimeout(grace);
+      window.removeEventListener('message', onMessage);
+      if (rehideTimerRef.current !== null) window.clearTimeout(rehideTimerRef.current);
+    };
+  }, [frameRef, revealChrome]);
+
   // What the game says about itself, falling back to what the catalog says about it.
   // Derived every render rather than memoized on first value, because both sources
   // arrive late and at different times: on a deep-linked /play/<slug> the catalog never
@@ -470,9 +506,18 @@ export function GameTheater({
       aria-label={displayTitle}
       ref={stageRef}
     >
-      {/* Fullscreen hides the bar so the game owns the screen. Votes stay on the
-          bar when it's visible; secondary actions stay in More. */}
-      {!fullscreen && (
+      {/* Fullscreen hides the bar so the game owns the screen; so does play
+          itself now (chromeHidden), with the peek pill as the way back. Votes
+          stay on the bar when it's visible; secondary actions stay in More. */}
+      {!fullscreen && chromeHidden && (
+        <button
+          type="button"
+          className="theater-peek-pill"
+          aria-label={t('player.showControls')}
+          onPointerDown={() => revealChrome()}
+        />
+      )}
+      {!fullscreen && !chromeHidden && (
         <div className="game-theater-bar">
           <div className="game-theater-meta">
             <span className="theater-badge" title={t('ai.generatedTooltip')}>

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -43,6 +43,13 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
    */
   const [remixHtml, setRemixHtml] = useState<string | null>(null);
   const [remixOpen, setRemixOpen] = useState(false);
+  /**
+   * Remix is an invitation, revealed in the gaps rather than at second zero:
+   * a finished run (the "aw" beat), a reached landmark, or — failing both — a
+   * one-time gentle pulse after a minute of play. All three ride telemetry
+   * signals the game already sends; nothing new crosses the bridge.
+   */
+  const [remixRevealed, setRemixRevealed] = useState(false);
   const localFrameRef = useRef<HTMLIFrameElement | null>(null);
   const activeFrameRef = frameRef ?? localFrameRef;
   // Present only when the player arrived on a shared link; read once.
@@ -100,6 +107,24 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
   // `embed` describes chrome, not ownership — the theater always embeds — so the
   // gate is the explicit prop plus "this frame is one player's", which a party
   // session (slots) is not.
+  useEffect(() => {
+    if (!remixable || slots !== undefined || remixRevealed) return;
+    const frame = activeFrameRef.current;
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== 'null') return;
+      if (!frame || event.source !== frame.contentWindow) return;
+      const data = event.data as { source?: string; type?: string } | null;
+      if (!data || data.source !== 'gdpl-player') return;
+      if (data.type === 'end' || data.type === 'progress') setRemixRevealed(true);
+    }
+    window.addEventListener('message', onMessage);
+    const pulse = window.setTimeout(() => setRemixRevealed(true), 60_000);
+    return () => {
+      window.removeEventListener('message', onMessage);
+      window.clearTimeout(pulse);
+    };
+  }, [remixable, slots, remixRevealed, activeFrameRef, html]);
+
   const showRemix = Boolean(remixable) && slots === undefined;
   const frame = <GameFrame title={gameTitle} html={remixHtml ?? html} frameRef={activeFrameRef} embed={embed} />;
   if (!showRemix) return frame;
@@ -115,11 +140,11 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
           onSwapDocument={setRemixHtml}
           onClose={() => setRemixOpen(false)}
         />
-      ) : (
-        <button type="button" className="remix-open" onClick={() => setRemixOpen(true)}>
+      ) : remixRevealed ? (
+        <button type="button" className="remix-open is-revealed" onClick={() => setRemixOpen(true)}>
           <PixelIcon name="wrench" size={13} /> {t('remix.button')}
         </button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -91,22 +91,6 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
     };
   }, [slug, title, loadAttempt]);
 
-  if (failed) {
-    return (
-      <div className="load-error" role="alert">
-        <p className="error">{t('catalog.gameLoadError')}</p>
-        <button type="button" className="secondary-btn" onClick={() => setLoadAttempt((n) => n + 1)}>
-          <PixelIcon name="undo" size={13} /> {t('catalog.retry')}
-        </button>
-      </div>
-    );
-  }
-  if (html === null) {
-    return <p className="catalog-state">{t('catalog.gameLoading')}</p>;
-  }
-  // `embed` describes chrome, not ownership — the theater always embeds — so the
-  // gate is the explicit prop plus "this frame is one player's", which a party
-  // session (slots) is not.
   useEffect(() => {
     if (!remixable || slots !== undefined || remixRevealed) return;
     const frame = activeFrameRef.current;
@@ -125,6 +109,22 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
     };
   }, [remixable, slots, remixRevealed, activeFrameRef, html]);
 
+  if (failed) {
+    return (
+      <div className="load-error" role="alert">
+        <p className="error">{t('catalog.gameLoadError')}</p>
+        <button type="button" className="secondary-btn" onClick={() => setLoadAttempt((n) => n + 1)}>
+          <PixelIcon name="undo" size={13} /> {t('catalog.retry')}
+        </button>
+      </div>
+    );
+  }
+  if (html === null) {
+    return <p className="catalog-state">{t('catalog.gameLoading')}</p>;
+  }
+  // `embed` describes chrome, not ownership — the theater always embeds — so the
+  // gate is the explicit prop plus "this frame is one player's", which a party
+  // session (slots) is not.
   const showRemix = Boolean(remixable) && slots === undefined;
   const frame = <GameFrame title={gameTitle} html={remixHtml ?? html} frameRef={activeFrameRef} embed={embed} />;
   if (!showRemix) return frame;

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -6,8 +6,6 @@ import { PixelIcon } from './PixelIcon.js';
 import { useGameTelemetry } from './gamePlayer.js';
 import { rememberRecentPlay } from './recentPlays.js';
 import { recordGamePlayed } from './recommendationsApi.js';
-import { AuthModal } from './AuthModal.js';
-import { useAuth } from './AuthContext.js';
 import { RemixPanel } from './RemixPanel.js';
 import { readSharedParams } from './remixApi.js';
 
@@ -32,7 +30,6 @@ type PublishedGameFrameProps = {
  */
 export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixable }: PublishedGameFrameProps) {
   const { t } = useTranslation();
-  const { user } = useAuth();
   const [html, setHtml] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
   const [gameTitle, setGameTitle] = useState<string>(title);
@@ -46,7 +43,6 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
    */
   const [remixHtml, setRemixHtml] = useState<string | null>(null);
   const [remixOpen, setRemixOpen] = useState(false);
-  const [remixAuthOpen, setRemixAuthOpen] = useState(false);
   const localFrameRef = useRef<HTMLIFrameElement | null>(null);
   const activeFrameRef = frameRef ?? localFrameRef;
   // Present only when the player arrived on a shared link; read once.
@@ -111,20 +107,7 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
   return (
     <div className="remix-host">
       {frame}
-      {/*
-       * Signed-in only for now (owner decision): a remix spends model calls on
-       * someone's behalf, and a session is what makes that attributable during
-       * the beta.
-       *
-       * That includes arriving on a shared link. The values are harmless on
-       * their own, but the panel is what applies them and the panel needs a
-       * session to exist — so a signed-out visitor gets the game as published
-       * plus a sign-in prompt, rather than a link that silently does nothing.
-       * Applying shared values without an account would need an ungated way to
-       * read a game's declaration, which is a surface worth adding on purpose
-       * rather than as a side effect of this gate.
-       */}
-      {user && (remixOpen || sharedParams) ? (
+      {remixOpen || sharedParams ? (
         <RemixPanel
           slug={slug}
           frameRef={activeFrameRef}
@@ -133,21 +116,10 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
           onClose={() => setRemixOpen(false)}
         />
       ) : (
-        <button
-          type="button"
-          className="remix-open"
-          title={user ? t('remix.button') : t('remix.signInToRemix')}
-          onClick={() => (user ? setRemixOpen(true) : setRemixAuthOpen(true))}
-        >
-          <PixelIcon name="wrench" size={13} /> {user ? t('remix.button') : t('remix.signInToRemix')}
+        <button type="button" className="remix-open" onClick={() => setRemixOpen(true)}>
+          <PixelIcon name="wrench" size={13} /> {t('remix.button')}
         </button>
       )}
-      <AuthModal
-        isOpen={remixAuthOpen}
-        onClose={() => setRemixAuthOpen(false)}
-        title={t('remix.signInTitle')}
-        subtitle={t('remix.signInSubtitle')}
-      />
     </div>
   );
 }

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { recordRemixStep } from './visitTelemetry.js';
+import { useAuth } from './AuthContext.js';
+import { AuthModal } from './AuthModal.js';
 import {
   coerceSharedParams,
   remixAssist,
@@ -16,7 +18,21 @@ import type { EditorLabel, EditorParamValue } from './studioApi.js';
 /**
  * Remix: a player bends a published game while playing it.
  *
- * Three speeds, deliberately visible as three different things:
+ * **Prompt-only** (owner decision, post-build session): the player sees ONE
+ * door — say what you want, it happens. Which lane satisfies the request
+ * (values or a rebuild) is an implementation detail the messaging never names.
+ * The sliders survive behind an expert mode (`?remixExpert=1`) for power users
+ * and for the owner when a request misfires — valves behind a panel, not the
+ * faucet.
+ *
+ * **The wall comes after the words.** A signed-out visitor can open the panel
+ * and type; sign-in drops at send, right before anything is spent, and the
+ * typed request is carried across login so it runs the second they're through.
+ * The stash lives in sessionStorage under this tab only and is cleared on use —
+ * it is player content (the same privacy class as an utterance) and never
+ * enters telemetry; the funnel records only that the wall was hit and crossed.
+ *
+ * Three speeds underneath, deliberately distinct in mechanism:
  *
  *  - **A slider** moves the running game over the `editor:content` bridge with
  *    no round trip. Under a frame, no rebuild, and the fallback whenever the
@@ -37,6 +53,9 @@ import type { EditorLabel, EditorParamValue } from './studioApi.js';
  * state — ops repo §D.8.1).
  */
 
+/** Tab-scoped stash for the request typed before the wall. Cleared on use. */
+const PENDING_KEY = 'gdpl-remix-pending';
+
 type Lane = 'idle' | 'asking' | 'building';
 
 type Note = { kind: 'ok' | 'info' | 'error'; text: string } | null;
@@ -51,7 +70,11 @@ export function RemixPanel(props: {
   initialParams?: Record<string, EditorParamValue> | null;
 }) {
   const { t, i18n } = useTranslation();
+  const { user } = useAuth();
   const [session, setSession] = useState<RemixSession | null>(null);
+  const [authOpen, setAuthOpen] = useState(false);
+  /** Sliders and share stay tucked away unless explicitly asked for. */
+  const expert = useMemo(() => new URLSearchParams(window.location.search).has('remixExpert'), []);
   const [values, setValues] = useState<Record<string, EditorParamValue>>({});
   const [utterance, setUtterance] = useState('');
   const [lane, setLane] = useState<Lane>('idle');
@@ -79,6 +102,9 @@ export function RemixPanel(props: {
   );
 
   useEffect(() => {
+    // No session without a session: the API 401s signed out, and the composer
+    // needs nothing from the server until send — so a visitor can type first.
+    if (!user) return;
     let cancelled = false;
     startRemix(props.slug)
       .then((started) => {
@@ -100,7 +126,22 @@ export function RemixPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [props.slug, props.initialParams, pushToGame]);
+  }, [props.slug, props.initialParams, pushToGame, user]);
+
+  // The reward lands the second they're through the wall: once the session
+  // exists and a stashed request is waiting, run it with no further taps.
+  const ranPendingRef = useRef(false);
+  useEffect(() => {
+    if (!session || ranPendingRef.current) return;
+    const pending = window.sessionStorage.getItem(PENDING_KEY);
+    if (pending === null) return;
+    ranPendingRef.current = true;
+    window.sessionStorage.removeItem(PENDING_KEY);
+    recordRemixStep('signed_in');
+    setUtterance(pending);
+    void ask(pending, session);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once per session arrival
+  }, [session]);
 
   function setParam(key: string, value: EditorParamValue) {
     const next = { ...valuesRef.current, [key]: value };
@@ -109,18 +150,30 @@ export function RemixPanel(props: {
     recordRemixStep('tuned');
   }
 
-  async function ask() {
-    const text = utterance.trim();
-    if (!session || text.length < 2 || lane !== 'idle') return;
+  async function ask(textOverride?: string, sessionOverride?: RemixSession) {
+    const active = sessionOverride ?? session;
+    const text = (textOverride ?? utterance).trim();
+    if (text.length < 2 || lane !== 'idle') return;
+    // Desire exists the moment they hit send, wall or no wall.
+    recordRemixStep('typed');
+    if (!user) {
+      // The wall, exactly one step before anything is spent. The words survive
+      // the trip: stashed for this tab only, cleared the moment they run.
+      recordRemixStep('wall_shown');
+      window.sessionStorage.setItem(PENDING_KEY, text);
+      setAuthOpen(true);
+      return;
+    }
+    if (!active) return; // session still starting — the send lands a beat later
     setNote(null);
     recordRemixStep('asked');
 
     // The tuning lane first: it is cheaper, faster, and covers most of what
     // people ask for. Only what it declines is worth a rebuild.
-    if (session.canAssist) {
+    if (active.canAssist) {
       setLane('asking');
       try {
-        const result = await remixAssist(session.remixId, text, valuesRef.current);
+        const result = await remixAssist(active.remixId, text, valuesRef.current);
         if (result.lane === 'params' && result.values) {
           const before = valuesRef.current;
           const next = result.values;
@@ -140,7 +193,7 @@ export function RemixPanel(props: {
           return;
         }
         // `code` or `content`: falls through to the code lane below.
-        if (!session.canCode) {
+        if (!active.canCode) {
           setLane('idle');
           recordRemixStep('handoff');
           setNote({ kind: 'info', text: label(result.summary) || t('remix.needsCode') });
@@ -154,7 +207,7 @@ export function RemixPanel(props: {
       }
     }
 
-    if (!session.canCode) {
+    if (!active.canCode) {
       recordRemixStep('handoff');
       setNote({ kind: 'info', text: t('remix.needsCode') });
       return;
@@ -164,7 +217,7 @@ export function RemixPanel(props: {
     setLane('building');
     props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'pause' }, '*');
     try {
-      const result = await remixCode(session.remixId, text);
+      const result = await remixCode(active.remixId, text);
       if (result.ok) {
         recordRemixStep('applied');
         setUtterance('');
@@ -227,10 +280,14 @@ export function RemixPanel(props: {
       </div>
     );
   }
-  if (!session) return <div className="remix-panel remix-panel-note">{t('remix.starting')}</div>;
+  // Signed in but the session is still being minted → a short starting state.
+  // Signed out there is nothing to wait for: the composer is the whole surface.
+  if (user && !session) return <div className="remix-panel remix-panel-note">{t('remix.starting')}</div>;
 
-  const specs = session.params;
-  const canType = session.canAssist || session.canCode;
+  const specs = session?.params ?? null;
+  // The composer is the door. Signed out we cannot know the lanes yet, and the
+  // honest answer is to accept the words and let the wall decide — so it types.
+  const canType = session ? session.canAssist || session.canCode : true;
 
   return (
     <div className="remix-panel">
@@ -286,7 +343,7 @@ export function RemixPanel(props: {
         </p>
       ) : null}
 
-      {specs ? (
+      {expert && specs ? (
         <div className="remix-sliders">
           {Object.entries(specs).map(([key, spec]) => {
             const value = values[key] ?? spec.default;
@@ -353,9 +410,7 @@ export function RemixPanel(props: {
             );
           })}
         </div>
-      ) : (
-        <p className="remix-panel-note">{t('remix.nothingTunable')}</p>
-      )}
+      ) : null}
 
       {/*
        * The two upgrade triggers, side by side and never a wall. "Make it yours"
@@ -363,7 +418,7 @@ export function RemixPanel(props: {
        * the honest version of keeping it, since a remix itself never publishes.
        */}
       <div className="remix-actions">
-        {specs ? (
+        {expert && specs ? (
           <button type="button" className="remix-action" onClick={() => void share()}>
             {t('remix.share')}
           </button>
@@ -377,6 +432,12 @@ export function RemixPanel(props: {
         </a>
       </div>
       {shareUrl ? <p className="remix-share-url">{shareUrl}</p> : null}
+      <AuthModal
+        isOpen={authOpen}
+        onClose={() => setAuthOpen(false)}
+        title={t('remix.signInTitle')}
+        subtitle={t('remix.wallSubtitle')}
+      />
     </div>
   );
 }

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -58,6 +58,16 @@ const PENDING_KEY = 'gdpl-remix-pending';
 
 type Lane = 'idle' | 'asking' | 'building';
 
+/** After this long the shimmer needs words, or it reads as broken. */
+const SLOW_AFTER_MS = 8_000;
+/**
+ * The hard ceiling on a rebuild round trip. Generous on purpose: a legitimate
+ * code-lane run with repair rounds can take half a minute, and aborting a call
+ * that was about to land is worse than a long beat with honest copy. Past this,
+ * the player gets their game back untouched.
+ */
+const CODE_TIMEOUT_MS = 45_000;
+
 type Note = { kind: 'ok' | 'info' | 'error'; text: string } | null;
 
 export function RemixPanel(props: {
@@ -79,6 +89,9 @@ export function RemixPanel(props: {
   const [utterance, setUtterance] = useState('');
   const [lane, setLane] = useState<Lane>('idle');
   const [note, setNote] = useState<Note>(null);
+  const [slow, setSlow] = useState(false);
+  /** Consecutive model-lane failures — two in a row reads as "editing is napping". */
+  const failStreakRef = useRef(0);
   const [undo, setUndo] = useState<Record<string, EditorParamValue> | null>(null);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
@@ -215,10 +228,15 @@ export function RemixPanel(props: {
 
     // The pause seam. Freeze first, so nothing can land mid-jump.
     setLane('building');
+    setSlow(false);
     props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'pause' }, '*');
+    const controller = new AbortController();
+    const slowTimer = window.setTimeout(() => setSlow(true), SLOW_AFTER_MS);
+    const hardTimer = window.setTimeout(() => controller.abort(), CODE_TIMEOUT_MS);
     try {
-      const result = await remixCode(active.remixId, text);
+      const result = await remixCode(active.remixId, text, controller.signal);
       if (result.ok) {
+        failStreakRef.current = 0;
         recordRemixStep('applied');
         setUtterance('');
         setNote({ kind: 'ok', text: `${label(result.summary) || t('remix.rebuilt')} ${t('remix.restarted')}` });
@@ -237,10 +255,26 @@ export function RemixPanel(props: {
         });
       }
     } catch (error) {
+      // Whatever went wrong — timeout, network, 5xx — the old document simply
+      // resumes; the player never pays for our slow afternoon with their run.
       props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'resume' }, '*');
+      failStreakRef.current += 1;
       const status = (error as RemixApiError).status;
-      setNote({ kind: 'error', text: status === 429 ? t('remix.quota') : t('remix.unavailable') });
+      const timedOut = controller.signal.aborted;
+      setNote({
+        kind: timedOut ? 'info' : 'error',
+        text: timedOut
+          ? t('remix.tookTooLong')
+          : status === 429
+            ? t('remix.quota')
+            : failStreakRef.current >= 2
+              ? t('remix.napping')
+              : t('remix.unavailable'),
+      });
     } finally {
+      window.clearTimeout(slowTimer);
+      window.clearTimeout(hardTimer);
+      setSlow(false);
       setLane('idle');
     }
   }
@@ -299,7 +333,7 @@ export function RemixPanel(props: {
       {lane === 'building' ? (
         <div className="remix-working" role="status">
           <span className="remix-shimmer" aria-hidden="true" />
-          {t('remix.building')}
+          {slow ? t('remix.buildingSlow') : t('remix.building')}
         </div>
       ) : null}
 

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -94,7 +94,7 @@ export function RemixPanel(props: {
   const failStreakRef = useRef(0);
   const [undo, setUndo] = useState<Record<string, EditorParamValue> | null>(null);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
+  const [failed, setFailed] = useState<'unsupported' | 'error' | null>(null);
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
@@ -133,8 +133,10 @@ export function RemixPanel(props: {
         // A shared link's values are live the moment the game is listening.
         if (props.initialParams) window.setTimeout(() => pushToGame(merged), 300);
       })
-      .catch(() => {
-        if (!cancelled) setFailed(true);
+      .catch((error: RemixApiError) => {
+        // 404 is a fact about this game (not remixable here), not a fault —
+        // the panel says the honest thing instead of "couldn't do that".
+        if (!cancelled) setFailed(error.status === 404 ? 'unsupported' : 'error');
       });
     return () => {
       cancelled = true;
@@ -307,7 +309,7 @@ export function RemixPanel(props: {
   if (failed) {
     return (
       <div className="remix-panel remix-panel-note" role="alert">
-        {t('remix.unavailable')}
+        {failed === 'unsupported' ? t('remix.notHere') : t('remix.unavailable')}
         <button type="button" className="secondary-btn" onClick={props.onClose}>
           {t('remix.close')}
         </button>

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -56,6 +56,66 @@ import type { EditorLabel, EditorParamValue } from './studioApi.js';
 /** Tab-scoped stash for the request typed before the wall. Cleared on use. */
 const PENDING_KEY = 'gdpl-remix-pending';
 
+/**
+ * The stash, guarded and scoped.
+ *
+ * Guarded because `sessionStorage` *throws* in Safari private mode and hardened
+ * configurations — and the throw landed inside the send handler, so the wall
+ * never opened and the tap did nothing at all. The in-memory fallback keeps the
+ * whole flow working where storage is unavailable; it only loses the words if
+ * the tab reloads during sign-in, which is the lesser failure by a mile.
+ *
+ * Scoped because the key is tab-global: type on game A, dismiss the wall, sign
+ * in later, open Remix on game B, and B would silently run A's request — a
+ * spend on a game nobody asked about. The slug travels with the text and a
+ * mismatch clears the stash rather than firing it.
+ */
+let memoryPending: string | null = null;
+
+function stashPending(slug: string, text: string): void {
+  const payload = JSON.stringify({ slug, text });
+  memoryPending = payload;
+  try {
+    window.sessionStorage.setItem(PENDING_KEY, payload);
+  } catch {
+    // Storage refused; the in-memory copy is the fallback.
+  }
+}
+
+/** Returns the pending text when it belongs to `slug`, clearing it either way. */
+function takePending(slug: string): string | null {
+  let raw = memoryPending;
+  if (raw === null) {
+    try {
+      raw = window.sessionStorage.getItem(PENDING_KEY);
+    } catch {
+      raw = null;
+    }
+  }
+  if (raw === null) return null;
+  const clear = () => {
+    memoryPending = null;
+    try {
+      window.sessionStorage.removeItem(PENDING_KEY);
+    } catch {
+      // Nothing to do — the in-memory copy is already gone.
+    }
+  };
+  try {
+    const parsed = JSON.parse(raw) as { slug?: string; text?: string };
+    if (typeof parsed.text !== 'string' || parsed.slug !== slug) {
+      // Another game's words. Dropped rather than replayed here.
+      clear();
+      return null;
+    }
+    clear();
+    return parsed.text;
+  } catch {
+    clear();
+    return null;
+  }
+}
+
 type Lane = 'idle' | 'asking' | 'building';
 
 /** After this long the shimmer needs words, or it reads as broken. */
@@ -114,6 +174,15 @@ export function RemixPanel(props: {
     [props.frameRef],
   );
 
+  // The panel is open the moment it renders, signed in or not. Recorded here
+  // rather than on a minted session: a signed-out visitor can reach `typed` and
+  // `wall_shown`, and counting those against a denominator that only signed-in
+  // opens increment would make every rung read as a share of the wrong total —
+  // exactly the wall experiment this funnel exists to measure.
+  useEffect(() => {
+    recordRemixStep('opened');
+  }, []);
+
   useEffect(() => {
     // No session without a session: the API 401s signed out, and the composer
     // needs nothing from the server until send — so a visitor can type first.
@@ -122,7 +191,6 @@ export function RemixPanel(props: {
     startRemix(props.slug)
       .then((started) => {
         if (cancelled) return;
-        recordRemixStep('opened');
         setSession(started);
         const base = started.values ?? {};
         const merged =
@@ -148,15 +216,14 @@ export function RemixPanel(props: {
   const ranPendingRef = useRef(false);
   useEffect(() => {
     if (!session || ranPendingRef.current) return;
-    const pending = window.sessionStorage.getItem(PENDING_KEY);
+    const pending = takePending(props.slug);
     if (pending === null) return;
     ranPendingRef.current = true;
-    window.sessionStorage.removeItem(PENDING_KEY);
     recordRemixStep('signed_in');
     setUtterance(pending);
     void ask(pending, session);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once per session arrival
-  }, [session]);
+  }, [session, props.slug]);
 
   function setParam(key: string, value: EditorParamValue) {
     const next = { ...valuesRef.current, [key]: value };
@@ -175,7 +242,7 @@ export function RemixPanel(props: {
       // The wall, exactly one step before anything is spent. The words survive
       // the trip: stashed for this tab only, cleared the moment they run.
       recordRemixStep('wall_shown');
-      window.sessionStorage.setItem(PENDING_KEY, text);
+      stashPending(props.slug, text);
       setAuthOpen(true);
       return;
     }

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -39,6 +39,9 @@ const EDITOR_LABELS: Record<string, string> = {
 
 const REMIX_LABELS: Record<string, string> = {
   opened: 'opened a remix',
+  typed: 'typed a request',
+  wall_shown: 'hit the sign-in wall',
+  signed_in: 'came through the wall',
   tuned: 'moved a slider',
   asked: 'typed a request',
   applied: 'got a change applied',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -954,6 +954,9 @@
     "signInToRemix": "Sign in to remix",
     "signInTitle": "Sign in to remix this game",
     "signInSubtitle": "Remixing is tied to your account while we're in closed beta.",
-    "wallSubtitle": "Your request is saved — it runs the moment you're in."
+    "wallSubtitle": "Your request is saved — it runs the moment you're in.",
+    "buildingSlow": "Still working — rebuilding your game…",
+    "tookTooLong": "That took too long — here's your game back, unchanged.",
+    "napping": "Editing is napping right now — the game still plays."
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -163,7 +163,8 @@
     "howToPlayDismiss": "Press Escape, or click or tap anywhere outside, to close",
     "howToPlayTouch": "Touch",
     "howToPlayTouchPad": "On-screen pad on touch screens",
-    "howToPlayOther": "Control"
+    "howToPlayOther": "Control",
+    "showControls": "Show controls"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -958,6 +958,7 @@
     "wallSubtitle": "Your request is saved — it runs the moment you're in.",
     "buildingSlow": "Still working — rebuilding your game…",
     "tookTooLong": "That took too long — here's your game back, unchanged.",
-    "napping": "Editing is napping right now — the game still plays."
+    "napping": "Editing is napping right now — the game still plays.",
+    "notHere": "This game can't be remixed yet — but it still plays."
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -938,7 +938,7 @@
     "applied": "Applied.",
     "undo": "Undo",
     "refused": "That request was refused.",
-    "needsCode": "That needs a real code change — make this game your own to go further.",
+    "needsCode": "That's a bigger change than a remix can do — make this game your own to go further.",
     "couldNotBuild": "That change didn't work out. Try saying it a different way.",
     "tooBig": "That's a bigger change than a remix can make.",
     "quota": "You've made a lot of changes — take a break and try later.",
@@ -953,6 +953,7 @@
     "button": "Remix",
     "signInToRemix": "Sign in to remix",
     "signInTitle": "Sign in to remix this game",
-    "signInSubtitle": "Remixing is tied to your account while we're in closed beta."
+    "signInSubtitle": "Remixing is tied to your account while we're in closed beta.",
+    "wallSubtitle": "Your request is saved — it runs the moment you're in."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -942,7 +942,7 @@
     "applied": "Zastosowano.",
     "undo": "Cofnij",
     "refused": "Ta prośba została odrzucona.",
-    "needsCode": "To wymaga zmiany w kodzie — stwórz własną wersję tej gry, żeby pójść dalej.",
+    "needsCode": "To większa zmiana, niż remiks potrafi — stwórz własną wersję tej gry, aby pójść dalej.",
     "couldNotBuild": "Ta zmiana się nie udała. Spróbuj powiedzieć to inaczej.",
     "tooBig": "To większa zmiana, niż remiks potrafi zrobić.",
     "quota": "Sporo już zmian — zrób przerwę i wróć później.",
@@ -957,6 +957,7 @@
     "button": "Remiks",
     "signInToRemix": "Zaloguj się, aby remiksować",
     "signInTitle": "Zaloguj się, aby zremiksować tę grę",
-    "signInSubtitle": "W czasie zamkniętej bety remiksowanie jest powiązane z kontem."
+    "signInSubtitle": "W czasie zamkniętej bety remiksowanie jest powiązane z kontem.",
+    "wallSubtitle": "Twoja prośba jest zapisana — wykona się zaraz po zalogowaniu."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -958,6 +958,9 @@
     "signInToRemix": "Zaloguj się, aby remiksować",
     "signInTitle": "Zaloguj się, aby zremiksować tę grę",
     "signInSubtitle": "W czasie zamkniętej bety remiksowanie jest powiązane z kontem.",
-    "wallSubtitle": "Twoja prośba jest zapisana — wykona się zaraz po zalogowaniu."
+    "wallSubtitle": "Twoja prośba jest zapisana — wykona się zaraz po zalogowaniu.",
+    "buildingSlow": "Wciąż pracuję — przebudowuję Twoją grę…",
+    "tookTooLong": "To trwało za długo — oddaję Ci grę bez zmian.",
+    "napping": "Edytowanie teraz odpoczywa — gra nadal działa."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -962,6 +962,7 @@
     "wallSubtitle": "Twoja prośba jest zapisana — wykona się zaraz po zalogowaniu.",
     "buildingSlow": "Wciąż pracuję — przebudowuję Twoją grę…",
     "tookTooLong": "To trwało za długo — oddaję Ci grę bez zmian.",
-    "napping": "Edytowanie teraz odpoczywa — gra nadal działa."
+    "napping": "Edytowanie teraz odpoczywa — gra nadal działa.",
+    "notHere": "Tej gry nie można jeszcze remiksować — ale nadal działa."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -163,7 +163,8 @@
     "howToPlayDismiss": "Naciśnij Escape lub kliknij obok, aby zamknąć",
     "howToPlayTouch": "Dotyk",
     "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych",
-    "howToPlayOther": "Sterowanie"
+    "howToPlayOther": "Sterowanie",
+    "showControls": "Pokaż sterowanie"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/remixApi.ts
+++ b/apps/web/src/remixApi.ts
@@ -40,12 +40,13 @@ export type RemixShare = {
 
 export type RemixApiError = Error & { status?: number };
 
-async function post<T>(path: string, body?: unknown): Promise<T> {
+async function post<T>(path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body ?? {}),
+    ...(signal ? { signal } : {}),
   });
   if (!response.ok) {
     const error = new Error(`request failed with ${response.status}`) as RemixApiError;
@@ -67,8 +68,8 @@ export function remixAssist(
   return post<RemixAssistResponse>(`/api/remixes/${encodeURIComponent(remixId)}/assist`, { utterance, params });
 }
 
-export function remixCode(remixId: string, utterance: string): Promise<RemixCodeResponse> {
-  return post<RemixCodeResponse>(`/api/remixes/${encodeURIComponent(remixId)}/code`, { utterance });
+export function remixCode(remixId: string, utterance: string, signal?: AbortSignal): Promise<RemixCodeResponse> {
+  return post<RemixCodeResponse>(`/api/remixes/${encodeURIComponent(remixId)}/code`, { utterance }, signal);
 }
 
 export function remixShare(remixId: string, params: Record<string, EditorParamValue>): Promise<RemixShare> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10468,3 +10468,26 @@ body.player-open {
   font-size: 0.82rem;
   cursor: pointer;
 }
+
+/* The invitation's arrival: two gentle pulses, then stillness. Never mid-action
+   by construction — the reveal only fires on end/progress signals or the 60s
+   one-time timer, and reduced-motion users get no pulse at all. */
+.remix-open.is-revealed {
+  animation: remix-invite 1.6s ease-in-out 2;
+}
+
+@keyframes remix-invite {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .remix-open.is-revealed {
+    animation: none;
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10491,3 +10491,26 @@ body.player-open {
     animation: none;
   }
 }
+
+/* The way back when play owns the screen: a thin, always-visible pill at the
+   top edge. Deliberately quiet, deliberately generous to a thumb — hidden
+   chrome must never mean gone chrome. */
+.theater-peek-pill {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 6;
+  width: 64px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 9px;
+  background: rgba(140, 170, 190, 0.28);
+  cursor: pointer;
+}
+
+.theater-peek-pill:hover,
+.theater-peek-pill:focus-visible {
+  background: rgba(140, 170, 190, 0.5);
+}

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -174,7 +174,18 @@ export type AssistStep = 'asked' | 'applied' | 'handoff' | 'rejected';
  * The tail (`shared`, `keep_clicked`) is where retention turns into either a
  * visitor or a creator.
  */
-export type RemixStep = 'opened' | 'tuned' | 'asked' | 'applied' | 'handoff' | 'refused' | 'shared' | 'keep_clicked';
+export type RemixStep =
+  | 'opened'
+  | 'typed' // wrote a request and hit send — desire exists, regardless of auth
+  | 'wall_shown' // the sign-in wall dropped between typing and spending
+  | 'signed_in' // came through the wall; the stashed request runs next
+  | 'tuned'
+  | 'asked'
+  | 'applied'
+  | 'handoff'
+  | 'refused'
+  | 'shared'
+  | 'keep_clicked';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;


### PR DESCRIPTION
Everything the first live test surfaced, plus the post-build UX decisions.

### The bug the hand test found

Every game on the site answered **"game not found"** when a remix started. The start route proved a game existed by calling `getGameSources` — which fetches the engine, every GameKit module and every audio asset and then bundles the whole game — wrapped in a `catch` that turned any failure into a null. A GitHub hiccup, a rate limit or a permission problem all arrived as "no such game", with nothing in the logs to say otherwise: the wrong question, asked the most expensive way, with errors laundered into absence.

Existence is now a `GAME.json` read and the declaration a second `EDITOR.json` read — two cheap calls through a new narrow `getGameFile` whose closed path list keeps the readable names ours rather than the caller's. A read that *fails* now fails rather than reporting nothing there. (The assembler itself was verified fine against a local checkout, so the underlying production failure was GitHub-side; this stops hiding it.)

**That also closes a product gap:** the entire repo-era catalog previously offered nothing, because only store-era deliveries hand over sources. A repo game's declaration is now read directly, so the params lane works on any game that declares params — Rock Blaster is remixable. The code lane still declines those games honestly (409, checked on `fromStore` rather than a source count, since such a session now legitimately carries one file).

Client-side, a 404 at start reads as "this game can't be remixed yet — but it still plays"; only a real fault says "couldn't do that". The generic message is what made a missing capability look like a broken feature.

### Post-build UX decisions

- **Prompt-only player UI.** One door: say what you want. Which lane satisfies it is never named. Sliders and share move behind `?remixExpert=1` — valves behind a panel, not the faucet.
- **The wall comes after the words.** A signed-out visitor opens the panel and types; sign-in drops at send, one step before anything is spent, and the request is stashed (tab-only `sessionStorage`, cleared on use, never in telemetry) so it runs the moment they're through. `REMIX_STEPS` gains `typed / wall_shown / signed_in` — the `typed → signed_in` gap is the number the strategy turns on.
- **Remix is an invitation.** The button is hidden until a natural pause: a finished run first, then a landmark, then a one-time pulse after a minute. Never mid-action; reduced-motion gets no pulse.
- **A slow-path story for the freeze.** 8s: the shimmer says it's still working. 45s: abort, resume the old document untouched, say so. Two consecutive failures: "editing is napping — the game still plays."
- **Chrome auto-hides during play.** Three seconds in, the theater bar slides away and the game owns the screen; it returns at the same beats as the remix invitation, plus an always-visible peek pill that reveals on `pointerdown`. Hidden never means gone — mute and exit stay one tap away.

Tests: API 1883, web 913, lint and typecheck clean. Three new tests pin the two-era behaviour, including that a missing manifest is a real absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_