### PR TITLE
Unblock the deploy, and make a remix survive an instance change

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,7 +20,7 @@ import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
 import { VertexEditorAssistant, type EditorAssistant } from './editor-assist.js';
 import { VertexCodeLane } from './code-lane.js';
-import { registerRemixRoutes } from './remix.js';
+import { registerRemixRoutes, MAX_REMIX_ID_LENGTH } from './remix.js';
 import { createEditingGate } from './creation-limits.js';
 import { createGenerator } from './generator.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
@@ -132,7 +132,16 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // hop and takes the leftmost entry — letting any caller choose their own rate
   // limit bucket. Trusting exactly one hop resolves to the rightmost entry, which
   // is the only one Cloud Run itself wrote, so spoofed prefixes are ignored.
-  const app = Fastify({ logger: options.logger ?? false, trustProxy: 1 });
+  // maxParamLength: a remix id is a self-describing token (apps/api/src/remix.ts)
+  // that carries the game's slug, so it is longer than Fastify's 100-character
+  // default allows. Over the limit the router answers 414 before any handler runs
+  // — which would read as "every remix on a long-slugged game is broken" with
+  // nothing in the logs. MAX_REMIX_ID_LENGTH is the bound the minter respects.
+  const app = Fastify({
+    logger: options.logger ?? false,
+    trustProxy: 1,
+    routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH },
+  });
   const store = options.store ?? new InMemoryStore();
   const dailyGenerationQuota = options.dailyGenerationQuota ?? Number(process.env.DAILY_GENERATION_QUOTA ?? '20');
 

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
-import { registerRemixRoutes } from './remix.js';
+import { registerRemixRoutes, MAX_REMIX_ID_LENGTH, REMIX_TTL_MS } from './remix.js';
 import { InMemoryStore } from './store.js';
 import type { GamesStore } from './games-store.js';
 import type { GitHubClient } from './github-client.js';
@@ -62,7 +63,12 @@ function stubGitHubClient(seen: Array<Record<string, string> | undefined>): GitH
 }
 
 async function buildTestApp(
-  overrides: { assistant?: EditorAssistant; codeLane?: unknown; isAbandoned?: () => boolean } = {},
+  overrides: {
+    assistant?: EditorAssistant;
+    codeLane?: unknown;
+    isAbandoned?: () => boolean;
+    now?: () => number;
+  } = {},
 ) {
   const store = new InMemoryStore();
   await store.setPublication({
@@ -72,7 +78,10 @@ async function buildTestApp(
     publishedAt: new Date(0).toISOString(),
   });
   const seen: Array<Record<string, string> | undefined> = [];
-  const app = Fastify();
+  // Same router ceiling as buildApp: a remix id is longer than Fastify's
+  // 100-character default, and a harness that forgot it would pass while
+  // production answered 414.
+  const app = Fastify({ routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH } });
   app.decorateRequest('user', null);
   // Stands in for the auth plugin: `x-test-uid` becomes the session, absent
   // means signed out. Enough to exercise the gate without minting real cookies.
@@ -88,6 +97,7 @@ async function buildTestApp(
     ...(overrides.assistant ? { assistant: overrides.assistant } : {}),
     ...(overrides.codeLane ? { codeLane: overrides.codeLane as never } : {}),
     ...(overrides.isAbandoned ? { isAbandoned: overrides.isAbandoned } : {}),
+    ...(overrides.now ? { now: overrides.now } : {}),
   });
   await app.ready();
   return { app, seen };
@@ -398,7 +408,7 @@ describe('remix across the two catalog eras', () => {
   async function repoEraApp() {
     const store = new InMemoryStore();
     const seen: Array<Record<string, string> | undefined> = [];
-    const instance = Fastify();
+    const instance = Fastify({ routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH } });
     instance.decorateRequest('user', null);
     instance.addHook('onRequest', async (request) => {
       const uid = request.headers['x-test-uid'];
@@ -445,6 +455,102 @@ describe('remix across the two catalog eras', () => {
   it('404s a slug with no manifest — a real absence, not a swallowed failure', async () => {
     app = await repoEraApp();
     const response = await app.inject({ method: 'POST', url: '/api/games/not-a-game/remix', headers: alice });
+    expect(response.statusCode).toBe(404);
+  });
+});
+
+/*
+ * One instance is not the world. The app runs with --max-instances 4, so the
+ * request that starts a remix and the request that uses it routinely land on
+ * different containers. A remix that only exists in the memory of the first one
+ * would expire at random — the failure everyone would blame on their wifi.
+ */
+describe('remix survives an instance change', () => {
+  const apps: FastifyInstance[] = [];
+
+  beforeEach(() => {
+    process.env.EDITOR_ASSIST = 'true';
+  });
+
+  afterEach(async () => {
+    delete process.env.EDITOR_ASSIST;
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  /** A container. Two of these share nothing but the catalog, like production. */
+  async function instance(now?: () => number) {
+    const built = await buildTestApp({
+      assistant: {
+        assist: async () => ({ lane: 'params', patches: [{ key: 'dogScale', value: 2 }] }),
+      } as unknown as EditorAssistant,
+      ...(now ? { now } : {}),
+    });
+    apps.push(built.app);
+    return built.app;
+  }
+
+  it('answers on a container that never saw the remix start', async () => {
+    const first = await instance();
+    const second = await instance();
+    const { remixId } = (
+      await first.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })
+    ).json();
+
+    const response = await second.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/assist`,
+      headers: alice,
+      payload: { utterance: 'make the dog bigger', params: { dogScale: 1, tagline: 'go!' } },
+    });
+    expect(response.statusCode).toBe(200);
+    // Rebuilt from the catalog, so it is the same session: same declaration,
+    // same clamping, same answer the first container would have given.
+    expect(response.json().values.dogScale).toBe(2);
+  });
+
+  it("still 404s another player's remix after the hop — an id is not a bearer token", async () => {
+    const first = await instance();
+    const second = await instance();
+    const { remixId } = (
+      await first.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })
+    ).json();
+
+    const stolen = await second.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/assist`,
+      headers: { 'x-test-uid': 'g:mallory' },
+      payload: { utterance: 'make the dog bigger' },
+    });
+    expect(stolen.statusCode).toBe(404);
+  });
+
+  it('is reachable through the real app — the router ceiling matches the minter', () => {
+    // A remix id carries the slug, so it runs past Fastify's 100-character
+    // default and the router answers 414 before any handler. That failure would
+    // be invisible in these tests, which build their own instance, so the
+    // production wiring is asserted at the source.
+    const appSource = readFileSync(new URL('./app.ts', import.meta.url), 'utf8');
+    expect(appSource).toContain('routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH }');
+    // The bound has to cover the longest id the minter can produce: the format
+    // preamble plus a slug at its schema maximum.
+    expect(MAX_REMIX_ID_LENGTH).toBeGreaterThanOrEqual('1.'.length + 12 + 1 + 10 + 1 + 6 + 1 + 80);
+  });
+
+  it('honours the original expiry rather than restarting the clock', async () => {
+    const start = 1_000_000;
+    const first = await instance(() => start);
+    const { remixId } = (
+      await first.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })
+    ).json();
+
+    // A container whose clock is past the TTL must not resurrect it.
+    const later = await instance(() => start + REMIX_TTL_MS + 1);
+    const response = await later.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/assist`,
+      headers: alice,
+      payload: { utterance: 'make the dog bigger' },
+    });
     expect(response.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { PARAMS_KEY, parseEditorDefinition, type EditorDefinition } from './editor-contract.js';
@@ -41,12 +41,23 @@ import type { EditingGate } from './creation-limits.js';
  *    frame to swap in, built by the same assembler the play path uses.
  *
  * Sessions live in this instance's memory with a TTL. Deliberately not
- * Firestore: a remix is explicitly disposable, a document per tweak would be
- * write traffic for something nobody may ever look at again, and the failure
- * mode is mild — an instance change loses the code edits, the client re-creates
- * the session and re-applies its params, which it holds itself. If remixes ever
- * become durable (the "save this as yours" path growing teeth), that is the
- * moment to give them a real home.
+ * Firestore: a remix is explicitly disposable, and a document per tweak would be
+ * write traffic for something nobody may ever look at again.
+ *
+ * But the app service deploys with `--max-instances 4` (it is only pinned to 1
+ * while party rooms live here — see `infra/deploy-api.sh`), so "this instance"
+ * is not where the next request necessarily lands. Memory alone would mean a
+ * player starts a remix on one container, types, and is told their remix expired
+ * — intermittently, and therefore blamed on their wifi. So the *id* carries what
+ * a session needs to exist: a container that has never seen it rebuilds it from
+ * the id and serves the request. Memory is the cache; the id is the record.
+ *
+ * What survives a hop is everything the player can see: the game, its
+ * declaration, and the parameter values (which the client holds and re-pushes).
+ * What does not is the accumulated code edits, because those are the one thing
+ * too big to put in a URL — a rebuilt session starts from the published game.
+ * If remixes ever become durable (the "save this as yours" path growing teeth),
+ * that is the moment to give them a real home.
  */
 
 export const REMIX_TTL_MS = 60 * 60_000;
@@ -102,6 +113,48 @@ const AssistSchema = z.object({
 const ShareSchema = z.object({
   params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
+
+/**
+ * The id is the session's record, so any container can answer for it.
+ *
+ * It carries only facts that are already the player's: which game, until when,
+ * and a tag for whose it is. Everything authoritative — the engine ref, the
+ * sources, whether the game is store-era — is re-derived from the catalog when a
+ * session is rebuilt, never read out of the id, so a hand-edited id cannot point
+ * a rebuild at a ref or a file list of its author's choosing.
+ *
+ * The owner is a hash rather than the uid itself: it keeps "an id is not a
+ * bearer token" true across a hop without putting a real account id in a URL.
+ * It is not a signature and does not need to be — the only claim it makes is one
+ * the caller must already be able to make about themselves.
+ */
+function ownerTag(uid: string): string {
+  return createHash('sha256').update(uid).digest('base64url').slice(0, 12);
+}
+
+/**
+ * `1.<owner>.<expiry>.<nonce>.<slug>` — every part URL-safe, none containing a
+ * dot, so it travels as a path segment without escaping. Deliberately not
+ * base64url'd JSON: that ran to ~130 characters and Fastify's route parser
+ * rejects a parameter over `MAX_REMIX_ID_LENGTH` before any handler sees it.
+ */
+export const MAX_REMIX_ID_LENGTH = 128;
+const REMIX_ID_PATTERN = /^1\.([A-Za-z0-9_-]{12})\.([0-9a-z]{1,10})\.([A-Za-z0-9_-]{6})\.(.+)$/;
+
+function mintRemixId(uid: string, slug: string, expiresAt: number): string {
+  const nonce = randomBytes(6).toString('base64url').slice(0, 6);
+  return `1.${ownerTag(uid)}.${expiresAt.toString(36)}.${nonce}.${slug}`;
+}
+
+function readRemixId(id: string): { uidTag: string; slug: string; expiresAt: number } | null {
+  if (id.length > MAX_REMIX_ID_LENGTH) return null;
+  const match = REMIX_ID_PATTERN.exec(id);
+  if (!match) return null;
+  const expiresAt = parseInt(match[2], 36);
+  if (!Number.isFinite(expiresAt)) return null;
+  if (!StartSchema.shape.slug.safeParse(match[4]).success) return null;
+  return { uidTag: match[1], slug: match[4], expiresAt };
+}
 
 export interface RemixRoutesOptions {
   store?: Store;
@@ -174,15 +227,61 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     return true;
   }
 
-  function getSession(request: FastifyRequest): RemixSession | null {
+  async function getSession(request: FastifyRequest): Promise<RemixSession | null> {
     sweep();
     const id = (request.params as { id?: string }).id;
-    if (!id) return null;
+    const uid = request.user?.uid;
+    if (!id || !uid) return null;
     const session = sessions.get(id);
-    if (!session || session.expiresAt <= now()) return null;
-    // Someone else's remix is indistinguishable from an expired one, which is
-    // the honest answer as well as the safe one.
-    if (session.ownerUid !== request.user?.uid) return null;
+    if (session) {
+      if (session.expiresAt <= now()) return null;
+      // Someone else's remix is indistinguishable from an expired one, which is
+      // the honest answer as well as the safe one.
+      if (session.ownerUid !== uid) return null;
+      return session;
+    }
+    return rehydrate(id, uid);
+  }
+
+  /**
+   * This container has never seen this remix. Rebuild it, or say it is gone.
+   *
+   * Reached whenever the load balancer hands a follow-up request to a different
+   * instance than the one that minted the id — the common case under any real
+   * traffic, and the reason the id is self-describing. The game is re-read from
+   * the catalog exactly as `start` reads it, so a rebuilt session is a session:
+   * same declaration, same lanes, same ownership answer.
+   *
+   * Two things reset. Code edits are gone, because they only ever lived in the
+   * instance that made them; the player's params come back from the client, so
+   * what they see is what they had. And `codeEdits` restarts at zero, which
+   * loosens the per-session spend bound — deliberately accepted, because the
+   * per-route rate limit, the per-account daily cap and the platform breaker are
+   * the bounds that actually hold, and none of them live in this map.
+   */
+  async function rehydrate(id: string, uid: string): Promise<RemixSession | null> {
+    const claims = readRemixId(id);
+    if (!claims || claims.expiresAt <= now()) return null;
+    if (claims.uidTag !== ownerTag(uid)) return null;
+    const loaded = await loadSources(claims.slug);
+    if (!loaded) return null;
+    const editorJson = loaded.sources[EDITOR_FILE];
+    const session: RemixSession = {
+      id,
+      ownerUid: uid,
+      slug: claims.slug,
+      ref: loaded.ref,
+      sources: loaded.sources,
+      fromStore: loaded.fromStore,
+      overrides: {},
+      definition: editorJson ? parseEditorDefinition(editorJson).definition : null,
+      title: claims.slug,
+      codeEdits: 0,
+      codeInFlight: false,
+      expiresAt: claims.expiresAt,
+    };
+    sessions.set(id, session);
+    sweep();
     return session;
   }
 
@@ -266,7 +365,8 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
 
       const editorJson = loaded.sources[EDITOR_FILE];
       const definition = editorJson ? parseEditorDefinition(editorJson).definition : null;
-      const id = randomUUID();
+      const expiresAt = now() + REMIX_TTL_MS;
+      const id = mintRemixId(request.user!.uid, params.data.slug, expiresAt);
       sweep();
       sessions.set(id, {
         id,
@@ -280,7 +380,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         title: params.data.slug,
         codeEdits: 0,
         codeInFlight: false,
-        expiresAt: now() + REMIX_TTL_MS,
+        expiresAt,
       });
 
       return reply.send({
@@ -302,7 +402,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     { config: { rateLimit: { max: 20, timeWindow: 60_000 } } },
     async (request, reply) => {
       if (!requireUser(request, reply)) return;
-      const session = getSession(request);
+      const session = await getSession(request);
       if (!session) return reply.status(404).send({ error: 'this remix has expired — start a new one' });
       if (!options.assistant || !assistEnabled() || !session.definition?.params) {
         return reply.status(503).send({ error: 'tuning by request is not available here' });
@@ -361,7 +461,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     { config: { rateLimit: { max: 6, timeWindow: 60_000 } } },
     async (request, reply) => {
       if (!requireUser(request, reply)) return;
-      const session = getSession(request);
+      const session = await getSession(request);
       if (!session) return reply.status(404).send({ error: 'this remix has expired — start a new one' });
       if (!options.codeLane || !codeLaneEnabled()) {
         return reply.status(503).send({ error: 'code changes are not available here' });
@@ -479,7 +579,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     { config: { rateLimit: { max: 10, timeWindow: 60_000 } } },
     async (request, reply) => {
       if (!requireUser(request, reply)) return;
-      const session = getSession(request);
+      const session = await getSession(request);
       if (!session) return reply.status(404).send({ error: 'this remix has expired — start a new one' });
       const body = ShareSchema.safeParse(request.body);
       if (!body.success) return reply.status(400).send({ error: 'invalid request' });

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -187,6 +187,16 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
     const { slug } = singlePlayer();
     await visit(page, `/play/${slug}`, 5_000);
 
+    // The theater bar now auto-hides a few seconds into play, so the report path
+    // is reached the way a person reaches it: the peek pill is always on screen
+    // and brings the chrome back. Asserting the whole route rather than the
+    // element alone is the stronger guard — "accessible" under art. 16 is a claim
+    // about a path, and an auto-hide that swallowed the only route would pass a
+    // test that merely looked for the link.
+    const pill = page.locator('.theater-peek-pill');
+    await pill.waitFor({ state: 'visible', timeout: 15_000 });
+    await pill.click();
+
     // A mailto, not a button — the honest MVP per ReportGameButton.tsx. The four
     // headings are what makes a notice actionable under art. 16, so an empty mail
     // body would technically "have a report path" and still fail the obligation.

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -438,6 +438,10 @@ describe('GameTheater how-to-play visit telemetry', () => {
         pill!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       });
       expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+      // And the bar it brings back is the whole bar: the report path (DSA art.
+      // 16) lives in the More panel, so an auto-hide is only allowed to make it
+      // one tap deeper — never to make it unreachable.
+      expect(container.querySelector('a.report-btn')).not.toBeNull();
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Two things the merge of #467 surfaced. **Master is currently not deployed** — the first one is why.

## 1. The deploy gate failed, so nothing from #467 is live

The browser gate against the candidate revision failed the DSA art. 16 check (`a.report-btn`, 30s timeout) and the candidate was never promoted. Production is still running the previous revision: the prompt-only remix UI, the later sign-in wall, the reveal triggers and the chrome auto-hide are **not on the site**.

Cause is the auto-hide itself: it unmounts the whole theater bar three seconds into play, and the report link lives in that bar's More panel. The gate visited `/play/<slug>`, waited, and found nothing.

The path is not gone — the peek pill is always on screen and brings the bar back in one tap. So the guard now walks that route (reveal → read the link) rather than looking for the element in isolation. That is the stronger assertion: "accessible" under art. 16 is a claim about a path, and an auto-hide that swallowed the only route would have passed a test that merely found the link. A jsdom test in `GameTheater.test.tsx` pins the same thing in ordinary CI, so this class of regression stops at the PR next time instead of at the deploy.

## 2. Per-instance remix session loss was live, not scheduled

The app service deploys with `--max-instances 4` — the pin to 1 lifted when party rooms moved to the relay — so the request that starts a remix and the request that uses it routinely land on different containers. A session held only in the first one's memory would expire at random, worst at the very first prompt, and would read to the player as broken editing and to us as a mystery: "this remix has expired" is indistinguishable from an honest TTL.

The id now carries what a session needs to exist — `1.<owner>.<expiry>.<nonce>.<slug>` — and a container that has never seen it rebuilds the session from the catalog. Memory is the cache; the id is the record.

- Nothing authoritative is read out of the id. The engine ref, the sources and store-vs-repo are re-derived exactly as `start` derives them, so a hand-edited id cannot aim a rebuild at a ref or a file list of its author's choosing.
- Ownership survives as a hash rather than a uid: "an id is not a bearer token" stays true across the hop, without putting an account id in a URL.
- The expiry is the minted one, so a hop cannot extend a remix.
- Accepted losses on a hop, both deliberate: the accumulated code edits (they only ever lived in the instance that made them; the params come back from the client, so what the player *sees* survives) and the per-session code-edit counter — the weakest of the four spend bounds and the only one that lived in this map. The per-route limit, the per-account daily cap and the platform breaker all still hold.
- Fastify refuses a path parameter over 100 characters before any handler runs, which a slug-carrying id can exceed. The router ceiling now comes from the minter's own bound, and a test reads `app.ts` to keep the two together — that failure would otherwise be a 414 with nothing in the logs.

## Verification

- `npm run test` — API 1889, web 914, world 19, e2e-rules 23; all green
- `npm run lint`, `npm run type-check` — clean
- New: three tests for the hop (a second container answers; another player still gets 404; a container past the TTL does not resurrect), one for the router ceiling, one for the report path after reveal
- The DSA gate itself only runs against a deployed candidate, so it is proven on merge

Design record updated in the ops repo (§D.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_