### PR TITLE
BY-27a: creator-wide MCP opener key (header + slug)

### DIFF
--- a/apps/api/src/agent-creator-key.test.ts
+++ b/apps/api/src/agent-creator-key.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertCreatorAgentKeyActive,
+  CREATOR_AGENT_KEY_ENCODED_PREFIX,
+  creatorAgentKeyTtlDays,
+  DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS,
+  InvalidAgentTokenError,
+  looksLikeCreatorAgentKey,
+  mintCreatorAgentKey,
+  ROTATED_CREATOR_KEY_REASON,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
+import { findCredentialLikeStrings } from './credential-scan.js';
+import { mintGameAgentKey } from './agent-game-key.js';
+import { mintMcpSessionKey } from './mcp-session-key.js';
+
+describe('durable creator agent key (BY-27a)', () => {
+  const secret = 'creator-key-test-secret';
+  const now = Date.parse('2026-08-02T12:00:00.000Z');
+  const creatorUid = 'g:creator';
+
+  afterEach(() => {
+    delete process.env.CREATOR_AGENT_KEY_TTL_DAYS;
+  });
+
+  it('mints and verifies a round-trip key', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyCreatorAgentKey(key, secret)).toEqual({
+      creatorUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.startsWith('c1.')).toBe(true);
+    expect(key.startsWith(CREATOR_AGENT_KEY_ENCODED_PREFIX)).toBe(true);
+  });
+
+  it('rejects tampered claims', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    const [prefix, uid, generation, exp, signature] = decoded.split('.');
+    const tamperedGeneration = Buffer.from(
+      `${prefix}.${uid}.${Number(generation) + 1}.${exp}.${signature}`,
+      'utf8',
+    ).toString('base64url');
+    const tamperedExp = Buffer.from(`${prefix}.${uid}.${generation}.${Number(exp) + 1}.${signature}`, 'utf8').toString(
+      'base64url',
+    );
+    const flipped = signature.endsWith('0') ? 'f' : '0';
+    const tamperedSig = Buffer.from(
+      `${prefix}.${uid}.${generation}.${exp}.${signature.slice(0, -1)}${flipped}`,
+      'utf8',
+    ).toString('base64url');
+    expect(() => verifyCreatorAgentKey(tamperedGeneration, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey(tamperedExp, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey(tamperedSig, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey('not-a-key', secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('rejects an expired key', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyCreatorAgentKey(key, secret);
+    const afterExpiry = now + 91 * 24 * 60 * 60 * 1000;
+    expect(() => assertCreatorAgentKeyActive(claims, { keyGeneration: 1 }, afterExpiry)).toThrow(
+      ROTATED_CREATOR_KEY_REASON,
+    );
+  });
+
+  it('rejects a stale keyGeneration', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyCreatorAgentKey(key, secret);
+    expect(() => assertCreatorAgentKeyActive(claims, { keyGeneration: 2 }, now)).toThrow(ROTATED_CREATOR_KEY_REASON);
+  });
+
+  it('rejects a revoked record', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyCreatorAgentKey(key, secret);
+    expect(() =>
+      assertCreatorAgentKeyActive(claims, { keyGeneration: 1, revokedAt: '2026-08-02T13:00:00.000Z' }, now),
+    ).toThrow(ROTATED_CREATOR_KEY_REASON);
+  });
+
+  it('rotate makes the old key fail and the new pass', () => {
+    const oldKey = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const newKey = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const oldClaims = verifyCreatorAgentKey(oldKey, secret);
+    const newClaims = verifyCreatorAgentKey(newKey, secret);
+    expect(() => assertCreatorAgentKeyActive(oldClaims, { keyGeneration: 2 }, now)).toThrow(ROTATED_CREATOR_KEY_REASON);
+    expect(() => assertCreatorAgentKeyActive(newClaims, { keyGeneration: 2 }, now)).not.toThrow();
+  });
+
+  it('cannot be forged from a per-game key shape', () => {
+    const gameKey = mintGameAgentKey(secret, {
+      slug: 'sky-dodge',
+      creatorUid,
+      keyGeneration: 1,
+      now,
+      ttlDays: 90,
+    });
+    expect(looksLikeCreatorAgentKey(gameKey)).toBe(false);
+    expect(() => verifyCreatorAgentKey(gameKey, secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('round-trips Apple dotted subject identifiers', () => {
+    const appleUid = 'a:001234.abcdef.0000';
+    const key = mintCreatorAgentKey(secret, { creatorUid: appleUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyCreatorAgentKey(key, secret)).toEqual({
+      creatorUid: appleUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.split('.')[1]).not.toContain('.');
+  });
+
+  it('does not false-positive on MCP session keys whose session id is c1', () => {
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: 'c1',
+      jobId: 42,
+      roundGeneration: 1,
+      now,
+    });
+    const decoded = Buffer.from(sessionKey, 'base64url').toString('utf8');
+    expect(decoded.startsWith('c1.')).toBe(true);
+    expect(looksLikeCreatorAgentKey(sessionKey)).toBe(false);
+  });
+
+  it('defaults TTL from CREATOR_AGENT_KEY_TTL_DAYS (90 days)', () => {
+    expect(creatorAgentKeyTtlDays()).toBe(DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS);
+    process.env.CREATOR_AGENT_KEY_TTL_DAYS = '30';
+    expect(creatorAgentKeyTtlDays()).toBe(30);
+
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now });
+    const claims = verifyCreatorAgentKey(key, secret);
+    expect(claims.exp).toBe(Math.floor(now / 1000) + 30 * 24 * 60 * 60);
+  });
+
+  it('is caught by the generated-game credential scanner', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const findings = findCredentialLikeStrings(`const key = "${key}";`);
+    expect(findings.map((finding) => finding.kind)).toContain('gamedev-creator-agent-key');
+  });
+});

--- a/apps/api/src/agent-creator-key.ts
+++ b/apps/api/src/agent-creator-key.ts
@@ -1,0 +1,203 @@
+/**
+ * Durable creator-wide agent opener keys (BY-27a).
+ *
+ * Distinct scope from round-scoped build keys (`agent-channel-v1`), per-game openers
+ * (`agent-game-v1`), and MCP session keys (`mcp-session-v1`). This key may only be
+ * exchanged at `start` (Authorization Bearer + slug) for a round-bound sessionKey —
+ * never accepted where a sessionKey or round write capability is required.
+ *
+ * Revocation is `keyGeneration` on `creatorAgentKeys/{uid}`, bumped only by an
+ * explicit creator rotate or revoke. Round close and publish do NOT bump it.
+ *
+ * Blast radius (threat model): a leaked creator key reaches every game that creator
+ * owns, until rotated or expired — wider than the per-game key it replaces in MCP
+ * config. Compensating controls: opener-only, per-round delivery cap, gate on every
+ * delivery, platform builds the bundle (D7), TTL, one-click revoke. Config is not a
+ * vault (BY-12: Codex / mcp-remote store credentials as plaintext JSON under $HOME).
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { InvalidAgentTokenError } from './agent-token.js';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON } from './agent-game-key.js';
+
+export { InvalidAgentTokenError } from './agent-token.js';
+export { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON };
+
+const SCOPE = 'agent-creator-v1';
+/** Wire marker so this shape can never parse as a per-game (`g1`) or round key. */
+const WIRE_PREFIX = 'c1';
+
+/**
+ * Stable base64url of {@link WIRE_PREFIX} + `.` — on the wire the whole payload is
+ * base64url-encoded, so a generated game that embeds one starts with this prefix.
+ * Registered in `credential-scan.ts` (house rule; see `access-token.ts`).
+ */
+export const CREATOR_AGENT_KEY_ENCODED_PREFIX = Buffer.from(`${WIRE_PREFIX}.`, 'utf8').toString('base64url');
+
+/** Default lifetime for a durable creator opener key, in days. */
+export const DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS = 90;
+
+/** Rotated, revoked, or generation-mismatched creator key. */
+export const ROTATED_CREATOR_KEY_REASON =
+  'this creator key was rotated — mint a fresh key from Studio and put it in your MCP client headers';
+
+export interface CreatorAgentKeyClaims {
+  creatorUid: string;
+  keyGeneration: number;
+  /** Unix seconds. */
+  exp: number;
+}
+
+export interface MintCreatorAgentKeyOptions {
+  creatorUid: string;
+  keyGeneration: number;
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+  /** Override {@link creatorAgentKeyTtlDays}; useful in tests. */
+  ttlDays?: number;
+}
+
+export function creatorAgentKeyTtlDays(): number {
+  const parsed = Number(process.env.CREATOR_AGENT_KEY_TTL_DAYS ?? DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS;
+}
+
+function signCreatorKey(creatorUid: string, keyGeneration: number, exp: number, secret: string): string {
+  return createHmac('sha256', secret).update(`${SCOPE}:${creatorUid}:${keyGeneration}:${exp}`).digest('hex');
+}
+
+function safeEqualHex(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function assertCreatorUid(creatorUid: string): void {
+  // Provider-prefixed subjects (`g:…`, `a:…`). The colon is load-bearing for
+  // looksLike: MCP session keys are also five dotted fields, and a session id of
+  // `c1` would otherwise decode as a plausible creator-key shape (jobId as "uid").
+  if (!creatorUid || /\s/.test(creatorUid) || !/^[a-z][a-z0-9]*:/i.test(creatorUid)) {
+    throw new InvalidAgentTokenError('invalid creator id');
+  }
+}
+
+function encodeCreatorUid(creatorUid: string): string {
+  assertCreatorUid(creatorUid);
+  return Buffer.from(creatorUid, 'utf8').toString('base64url');
+}
+
+function decodeCreatorUid(encoded: string): string {
+  try {
+    const creatorUid = Buffer.from(encoded, 'base64url').toString('utf8');
+    assertCreatorUid(creatorUid);
+    return creatorUid;
+  } catch {
+    throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Mints a durable creator-wide opener. HMAC covers
+ * `(agent-creator-v1, creatorUid, keyGeneration, exp)`.
+ */
+export function mintCreatorAgentKey(secret: string, options: MintCreatorAgentKeyOptions): string {
+  if (!Number.isSafeInteger(options.keyGeneration) || options.keyGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid key generation');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlDays = options.ttlDays ?? creatorAgentKeyTtlDays();
+  const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
+  const signature = signCreatorKey(options.creatorUid, options.keyGeneration, exp, secret);
+  const encodedUid = encodeCreatorUid(options.creatorUid);
+  const payload = `${WIRE_PREFIX}.${encodedUid}.${options.keyGeneration}.${exp}.${signature}`;
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+/**
+ * True when the decoded wire form matches the full durable creator-key shape. Used to
+ * reject these keys at sessionKey/Bearer write paths without inventing a second error.
+ * Prefix-only checks false-positive on MCP session keys whose session id is `c1`.
+ */
+export function looksLikeCreatorAgentKey(token: string): boolean {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 5) return false;
+    const [prefix, encodedUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      !encodedUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      return false;
+    }
+    decodeCreatorUid(encodedUid);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies HMAC and returns claims. Does **not** check keyGeneration against the store
+ * — callers do that once the creatorAgentKeys record is loaded.
+ */
+export function verifyCreatorAgentKey(token: string, secret: string): CreatorAgentKeyClaims {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 5) {
+      throw new InvalidAgentTokenError();
+    }
+    const [prefix, encodedUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      !encodedUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    const creatorUid = decodeCreatorUid(encodedUid);
+    const keyGeneration = Number.parseInt(generationRaw, 10);
+    const exp = Number.parseInt(expRaw, 10);
+    if (!Number.isSafeInteger(keyGeneration) || keyGeneration < 1 || !Number.isSafeInteger(exp) || exp <= 0) {
+      throw new InvalidAgentTokenError();
+    }
+    if (!safeEqualHex(signature, signCreatorKey(creatorUid, keyGeneration, exp, secret))) {
+      throw new InvalidAgentTokenError();
+    }
+    return { creatorUid, keyGeneration, exp };
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      throw error;
+    }
+    throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Checks expiry, revocation, and keyGeneration against the creator's current record.
+ */
+export function assertCreatorAgentKeyActive(
+  claims: CreatorAgentKeyClaims,
+  record: { keyGeneration: number; revokedAt?: string },
+  nowMs: number = Date.now(),
+): void {
+  if (record.revokedAt) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
+  if (claims.exp * 1000 <= nowMs) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
+  if (claims.keyGeneration !== record.keyGeneration) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -64,6 +64,7 @@ import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 import { logModerationRejection } from './moderation-metrics.js';
 import { registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
 import { registerOAuthAuthorizationServerRoutes } from './oauth-as.js';
+import { registerCreatorAgentKeyRoutes } from './creator-agent-key-routes.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -504,6 +505,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     options.submissionRoutes?.submissionTokenSecret ??
     process.env.SUBMISSION_TOKEN_SECRET ??
     (localGames ? 'local-development-submission-secret' : undefined);
+
+  // Durable creator-wide MCP opener (BY-27a). Same secret MCP uses to verify game keys.
+  if (submissionTokenSecret) {
+    registerCreatorAgentKeyRoutes(app, { store, agentTokenSecret: submissionTokenSecret });
+  }
   await registerCreatorStudioRoutes(app, {
     store,
     gamesStore,

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -1,0 +1,378 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertCreatorAgentKeyActive,
+  mintCreatorAgentKey,
+  NO_OPEN_ROUND_REASON,
+  PLATFORM_ROUND_REASON,
+  ROTATED_CREATOR_KEY_REASON,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
+import { mintGameAgentKey } from './agent-game-key.js';
+import { mintAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+const SESSION_SECRET = 'dev-session-secret-change-me';
+const MCP_SECRET = 'creator-key-mcp-secret';
+
+function sessionCookie(uid: string): string {
+  return `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, SESSION_SECRET)}`;
+}
+
+async function buildTestApp(store: InMemoryStore) {
+  return buildApp({
+    store,
+    sessionSecret: SESSION_SECRET,
+    submissionRoutes: {
+      githubClient: {
+        createIssue: async () => ({ number: 42 }),
+        getIssueState: async () => ({ state: 'open' as const }),
+        findLinkedPR: async () => null,
+        createIssueComment: async () => ({ id: 1 }),
+        updateIssueBody: async () => {},
+        closeIssue: async () => {},
+        closePullRequest: async () => {},
+        ensureOpenPullRequest: async () => ({ number: 1 }),
+        deleteBranch: async () => {},
+        getGameSources: async () => null,
+        getGameMedia: async () => null,
+        getCatalog: async () => [],
+        getProgressNotes: async () => null,
+      },
+      githubToken: 'gh-token',
+      submissionTokenSecret: MCP_SECRET,
+      translator: new NoopTranslator(),
+      agentChannel: {},
+    },
+  });
+}
+
+async function seedSelfRound(store: InMemoryStore, issue = 42, owner = 'g:creator', slug = 'comet-courier') {
+  await store.createSubmission(issue, owner, 'Comet Courier');
+  await store.setSubmissionSlug(issue, slug);
+  await store.setSubmissionLocale(issue, 'en');
+  await store.setRoundBuilder(issue, 'self');
+  await store.setSubmissionBrief(issue, { spec: 'Build it.', qa: [] });
+  await store.recordJobTransition(issue, {
+    to: 'dispatched',
+    at: new Date().toISOString(),
+    by: 'system',
+  });
+}
+
+async function mcpInitialize(app: FastifyInstance): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: MCP_ENDPOINT_PATH,
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    payload: {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '0' },
+      },
+    },
+  });
+  expect(res.statusCode).toBe(200);
+  return String(res.headers['mcp-session-id']);
+}
+
+async function callTool(
+  app: FastifyInstance,
+  name: string,
+  args: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: MCP_ENDPOINT_PATH,
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    payload: { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name, arguments: args } },
+  });
+  expect(res.statusCode).toBe(200);
+  const body = res.json() as {
+    result?: { structuredContent?: Record<string, unknown>; isError?: boolean };
+  };
+  return { structured: body.result?.structuredContent, isError: Boolean(body.result?.isError) };
+}
+
+describe('creator agent key API (BY-27a)', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  it('mints, remints at same generation, rotate kills prior key, revoke blocks until remint', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    app = await buildTestApp(store);
+    const cookie = sessionCookie('g:creator');
+
+    const minted = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key',
+      headers: { cookie },
+    });
+    expect(minted.statusCode).toBe(200);
+    expect(minted.headers['cache-control']).toMatch(/no-store/i);
+    const first = minted.json() as { key: string; keyGeneration: number; expiresAt: number };
+    expect(first.keyGeneration).toBe(1);
+    expect(verifyCreatorAgentKey(first.key, MCP_SECRET).creatorUid).toBe('g:creator');
+
+    const status = await app.inject({
+      method: 'GET',
+      url: '/api/me/creator-agent-key',
+      headers: { cookie },
+    });
+    expect(status.statusCode).toBe(200);
+    const reminted = status.json() as { key: string; keyGeneration: number; revoked: boolean };
+    expect(reminted.keyGeneration).toBe(1);
+    expect(reminted.revoked).toBe(false);
+    expect(verifyCreatorAgentKey(reminted.key, MCP_SECRET).keyGeneration).toBe(1);
+
+    const rotated = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key/rotate',
+      headers: { cookie },
+    });
+    expect(rotated.statusCode).toBe(200);
+    const second = rotated.json() as { key: string; keyGeneration: number };
+    expect(second.keyGeneration).toBe(2);
+    const record = await store.getCreatorAgentKey('g:creator');
+    expect(record?.keyGeneration).toBe(2);
+    expect(() => assertCreatorAgentKeyActive(verifyCreatorAgentKey(first.key, MCP_SECRET), record!)).toThrow(
+      ROTATED_CREATOR_KEY_REASON,
+    );
+    expect(() => assertCreatorAgentKeyActive(verifyCreatorAgentKey(second.key, MCP_SECRET), record!)).not.toThrow();
+
+    const revoked = await app.inject({
+      method: 'DELETE',
+      url: '/api/me/creator-agent-key',
+      headers: { cookie },
+    });
+    expect(revoked.statusCode).toBe(204);
+    const afterRevoke = await store.getCreatorAgentKey('g:creator');
+    expect(afterRevoke?.revokedAt).toBeTruthy();
+    expect(afterRevoke?.keyGeneration).toBe(3);
+    expect(() => assertCreatorAgentKeyActive(verifyCreatorAgentKey(second.key, MCP_SECRET), afterRevoke!)).toThrow(
+      ROTATED_CREATOR_KEY_REASON,
+    );
+
+    const remintAfterRevoke = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key',
+      headers: { cookie },
+    });
+    expect(remintAfterRevoke.statusCode).toBe(200);
+    const third = remintAfterRevoke.json() as { key: string; keyGeneration: number };
+    expect(third.keyGeneration).toBe(3);
+    expect(verifyCreatorAgentKey(third.key, MCP_SECRET).keyGeneration).toBe(3);
+  });
+
+  it('requires a session', async () => {
+    const store = new InMemoryStore();
+    app = await buildTestApp(store);
+    const res = await app.inject({ method: 'POST', url: '/api/me/creator-agent-key' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('creator agent key MCP start (BY-27a)', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  it('start via Authorization Bearer + slug binds to the creator open self round', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store);
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+    const key = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+
+    const started = await callTool(
+      app,
+      'start',
+      { slug: 'comet-courier' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${key}` },
+    );
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({ jobId: 42, slug: 'comet-courier', title: 'Comet Courier' });
+    expect(typeof started.structured?.sessionKey).toBe('string');
+  });
+
+  it('refuses a slug the creator does not own', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 42, 'g:other', 'stranger-game');
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+    const key = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+
+    const started = await callTool(
+      app,
+      'start',
+      { slug: 'stranger-game' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${key}` },
+    );
+    expect(started.isError).toBe(true);
+    expect(started.structured?.error).toBe(NO_OPEN_ROUND_REASON);
+  });
+
+  it('reuses no-open-round and platform-round refusals', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+    const key = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+
+    const noRound = await callTool(
+      app,
+      'start',
+      { slug: 'missing-game' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${key}` },
+    );
+    expect(noRound.isError).toBe(true);
+    expect(noRound.structured?.error).toBe(NO_OPEN_ROUND_REASON);
+
+    await seedSelfRound(store, 99, 'g:creator', 'platform-game');
+    await store.setRoundBuilder(99, 'platform');
+    const platform = await callTool(
+      app,
+      'start',
+      { slug: 'platform-game' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${key}` },
+    );
+    expect(platform.isError).toBe(true);
+    expect(platform.structured?.error).toBe(PLATFORM_ROUND_REASON);
+  });
+
+  it('rejects the creator key on every write tool', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store);
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+    const key = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+
+    const viaSessionKey = await callTool(
+      app,
+      'report_progress',
+      { sessionKey: key, text: 'nope' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(viaSessionKey.isError).toBe(true);
+    expect(String(viaSessionKey.structured?.error)).toMatch(/only opens a session via start/i);
+
+    const viaBearer = await callTool(
+      app,
+      'report_progress',
+      { text: 'nope' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${key}` },
+    );
+    expect(viaBearer.isError).toBe(true);
+    expect(String(viaBearer.structured?.error)).toMatch(/only opens a session via start/i);
+  });
+
+  it('legacy round key and durable per-game key still work end to end', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 77, 'g:owner');
+    const at = new Date().toISOString();
+    await store.ensureGameAgentKey('comet-courier', 'g:owner', at);
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+
+    const roundKey = mintAgentToken(77, MCP_SECRET, { roundGeneration: 1 });
+    const briefRound = await callTool(
+      app,
+      'get_brief',
+      {},
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${roundKey}` },
+    );
+    expect(briefRound.isError).toBe(false);
+
+    const gameKey = mintGameAgentKey(MCP_SECRET, {
+      slug: 'comet-courier',
+      creatorUid: 'g:owner',
+      keyGeneration: 1,
+    });
+    const started = await callTool(app, 'start', { key: gameKey }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+    const sessionKey = started.structured?.sessionKey as string;
+    expect(typeof sessionKey).toBe('string');
+
+    const progress = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, text: 'still works' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(progress.isError).toBe(false);
+  });
+
+  it('refuses a creator key passed as the key argument', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store);
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+    const key = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+
+    const started = await callTool(app, 'start', { key, slug: 'comet-courier' }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(true);
+    expect(String(started.structured?.error)).toMatch(/Authorization Bearer/i);
+  });
+
+  it('refuses a wrong-creator signature and a stale generation', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store);
+    await store.ensureCreatorAgentKey('g:creator', new Date().toISOString());
+    await store.rotateCreatorAgentKey('g:creator', new Date().toISOString());
+    app = await buildTestApp(store);
+    const sessionId = await mcpInitialize(app);
+
+    const stale = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:creator', keyGeneration: 1 });
+    const staleStart = await callTool(
+      app,
+      'start',
+      { slug: 'comet-courier' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${stale}` },
+    );
+    expect(staleStart.isError).toBe(true);
+    expect(staleStart.structured?.error).toBe(ROTATED_CREATOR_KEY_REASON);
+
+    const wrongCreator = mintCreatorAgentKey(MCP_SECRET, { creatorUid: 'g:intruder', keyGeneration: 2 });
+    await store.ensureCreatorAgentKey('g:intruder', new Date().toISOString());
+    await store.rotateCreatorAgentKey('g:intruder', new Date().toISOString());
+    const wrongStart = await callTool(
+      app,
+      'start',
+      { slug: 'comet-courier' },
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${wrongCreator}` },
+    );
+    expect(wrongStart.isError).toBe(true);
+    expect(wrongStart.structured?.error).toBe(NO_OPEN_ROUND_REASON);
+  });
+});

--- a/apps/api/src/creator-agent-key-routes.ts
+++ b/apps/api/src/creator-agent-key-routes.ts
@@ -1,0 +1,165 @@
+/**
+ * Studio mint / rotate / revoke for durable creator-wide agent opener keys (BY-27a).
+ *
+ * Lives next to OAuth grants under `/api/me/…` — both answer "what can reach my account".
+ * UI copy must never say "token".
+ */
+
+import type { FastifyInstance } from 'fastify';
+import {
+  assertCreatorAgentKeyActive,
+  mintCreatorAgentKey,
+  verifyCreatorAgentKey,
+  type CreatorAgentKeyClaims,
+} from './agent-creator-key.js';
+import { InvalidAgentTokenError } from './agent-token.js';
+import type { CreatorAgentKeyRecord, Store } from './store.js';
+
+export interface CreatorAgentKeyRouteOptions {
+  store: Store;
+  /** Same secret MCP uses to verify openers (submission / agent channel secret). */
+  agentTokenSecret: string;
+  now?: () => number;
+}
+
+export type CreatorAgentKeyPayload = {
+  key: string;
+  keyGeneration: number;
+  /** Unix seconds — identical to the key's signed exp. */
+  expiresAt: number;
+  revoked: false;
+};
+
+export type CreatorAgentKeyStatusPayload = {
+  keyGeneration: number;
+  revoked: boolean;
+  /** Present when a key is active (not revoked); reminted at the current generation. */
+  key?: string;
+  expiresAt?: number;
+};
+
+function mintPayload(secret: string, record: CreatorAgentKeyRecord, nowMs: number): CreatorAgentKeyPayload {
+  const key = mintCreatorAgentKey(secret, {
+    creatorUid: record.ownerUid,
+    keyGeneration: record.keyGeneration,
+    now: nowMs,
+  });
+  const claims = verifyCreatorAgentKey(key, secret);
+  return {
+    key,
+    keyGeneration: record.keyGeneration,
+    expiresAt: claims.exp,
+    revoked: false,
+  };
+}
+
+/**
+ * Signature, generation, expiry, and revocation — shared by MCP `start`.
+ */
+export async function verifyDurableCreatorAgentKey(
+  store: Store,
+  key: string,
+  secret: string,
+  nowMs: number = Date.now(),
+): Promise<{ ok: true; claims: CreatorAgentKeyClaims } | { ok: false; reason: string }> {
+  let claims: CreatorAgentKeyClaims;
+  try {
+    claims = verifyCreatorAgentKey(key, secret);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: 'invalid creator key — mint a fresh key from Studio' };
+    }
+    throw error;
+  }
+
+  const record = await store.getCreatorAgentKey(claims.creatorUid);
+  if (!record) {
+    return { ok: false, reason: 'invalid creator key — mint a fresh key from Studio' };
+  }
+
+  try {
+    assertCreatorAgentKeyActive(claims, record, nowMs);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: error.message || 'invalid creator key — mint a fresh key from Studio' };
+    }
+    throw error;
+  }
+
+  return { ok: true, claims };
+}
+
+export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: CreatorAgentKeyRouteOptions): void {
+  const { store, agentTokenSecret } = options;
+  const now = options.now ?? Date.now;
+
+  app.get('/api/me/creator-agent-key', async (request, reply) => {
+    const uid = request.user?.uid;
+    if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+    const record = await store.getCreatorAgentKey(uid);
+    if (!record) {
+      return reply.header('cache-control', 'no-store').send({
+        keyGeneration: 0,
+        revoked: false,
+      } satisfies CreatorAgentKeyStatusPayload);
+    }
+
+    if (record.revokedAt) {
+      return reply.header('cache-control', 'no-store').send({
+        keyGeneration: record.keyGeneration,
+        revoked: true,
+      } satisfies CreatorAgentKeyStatusPayload);
+    }
+
+    const minted = mintPayload(agentTokenSecret, record, now());
+    return reply.header('cache-control', 'no-store').send({
+      keyGeneration: minted.keyGeneration,
+      revoked: false,
+      key: minted.key,
+      expiresAt: minted.expiresAt,
+    } satisfies CreatorAgentKeyStatusPayload);
+  });
+
+  /** Mint (first time or after revoke). Does not bump generation when already active. */
+  app.post('/api/me/creator-agent-key', async (request, reply) => {
+    const uid = request.user?.uid;
+    if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+    const at = new Date(now()).toISOString();
+    const record = await store.ensureCreatorAgentKey(uid, at);
+    const payload = mintPayload(agentTokenSecret, record, now());
+    return reply.header('cache-control', 'no-store').send(payload);
+  });
+
+  /** Rotate: bump generation and return a fresh key. Stops any agent holding the old one. */
+  app.post('/api/me/creator-agent-key/rotate', async (request, reply) => {
+    const uid = request.user?.uid;
+    if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+    const existing = await store.getCreatorAgentKey(uid);
+    if (!existing) return reply.status(404).send({ error: 'not_found' });
+
+    const at = new Date(now()).toISOString();
+    const rotated = await store.rotateCreatorAgentKey(uid, at);
+    if (!rotated) return reply.status(404).send({ error: 'not_found' });
+    const payload = mintPayload(agentTokenSecret, rotated, now());
+    return reply.header('cache-control', 'no-store').send(payload);
+  });
+
+  /** Revoke: bump generation, mark revoked, do not return a replacement. */
+  app.delete('/api/me/creator-agent-key', async (request, reply) => {
+    const uid = request.user?.uid;
+    if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+    const existing = await store.getCreatorAgentKey(uid);
+    if (!existing || existing.revokedAt) {
+      return reply.status(404).send({ error: 'not_found' });
+    }
+
+    const at = new Date(now()).toISOString();
+    const revoked = await store.revokeCreatorAgentKey(uid, at);
+    if (!revoked) return reply.status(404).send({ error: 'not_found' });
+    return reply.status(204).send();
+  });
+}

--- a/apps/api/src/credential-scan.ts
+++ b/apps/api/src/credential-scan.ts
@@ -14,6 +14,10 @@ const CREDENTIAL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
   { kind: 'gamedev-access-token', pattern: /\bgdpl_pat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
   { kind: 'gamedev-oauth-access', pattern: /\bgdpl_oat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
   { kind: 'gamedev-oauth-refresh', pattern: /\bgdpl_ort_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
+  // Durable creator agent opener (BY-27a). Wire form is base64url(`c1.…`); embeddings
+  // therefore start with the stable encoding of `c1.` (`YzEu`). Same house rule as
+  // access-token.ts — refuse assembled games that embed one.
+  { kind: 'gamedev-creator-agent-key', pattern: /\bYzEu[A-Za-z0-9_-]{80,}\b/g },
   { kind: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g },
   { kind: 'aws-access-key-id', pattern: /\bAKIA[0-9A-Z]{16}\b/g },
   { kind: 'pem-private-key', pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/g },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -12,6 +12,8 @@ import {
   resolveGameAgentKeyForOpenRound,
   resolveGameAgentKeyForStart,
 } from './agent-game-key-resolve.js';
+import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
+import { verifyDurableCreatorAgentKey } from './creator-agent-key-routes.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -351,10 +353,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
         );
       }
-      // Durable per-game openers are start-only — never a write capability via Bearer.
+      // Durable openers are start-only — never a write capability via Bearer.
       if (looksLikeGameAgentKey(bearer)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
+      if (looksLikeCreatorAgentKey(bearer)) {
+        return toolErr(
+          'this creator key only opens a session via start() — pass the sessionKey start returned for later tools',
         );
       }
       try {
@@ -370,6 +377,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       if (looksLikeGameAgentKey(sessionKeyArg)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
+      if (looksLikeCreatorAgentKey(sessionKeyArg)) {
+        return toolErr(
+          'this creator key only opens a session via start() — pass the sessionKey start returned for later tools',
         );
       }
       let sessionClaims;
@@ -465,11 +477,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     start: {
       description:
         "Bind this MCP client to a build round using the key from the creator's Studio kickoff prompt, " +
-        'or sign in with OAuth and pass your game slug. ' +
-        'Accepts a durable per-game key (preferred), a legacy round-scoped key, or OAuth Bearer + slug. ' +
+        'a creator key in Authorization Bearer with your game slug, or OAuth Bearer + slug. ' +
+        'Accepts a durable per-game key, a legacy round-scoped key, a creator-wide key (Bearer + slug), or OAuth Bearer + slug. ' +
         'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
         '(the ordered start→done loop), an inbox policy, and what to relay if a later call is refused. ' +
-        'The game key itself is an opener only — never a write capability. OAuth access is identity only. ' +
+        'Game keys and creator keys are openers only — never a write capability. OAuth access is identity only. ' +
         'Does not treat Mcp-Session-Id as authority. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -479,12 +491,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'string',
             description:
               'Game key (or legacy round key) from the Studio kickoff prompt (the line "key: …"). ' +
-              'Optional when using OAuth Bearer + slug.',
+              'Optional when using Authorization Bearer (creator key or OAuth) + slug.',
           },
           slug: {
             type: 'string',
             description:
-              'Game slug for your open self-build round. Required with OAuth Bearer; ignored with a game key.',
+              'Game slug for your open self-build round. Required with Authorization Bearer (creator key or OAuth); ignored with a game key.',
           },
         },
         required: [],
@@ -504,17 +516,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const slugArg = typeof args.slug === 'string' ? args.slug.trim() : '';
         const bearer = ctx.bearerToken;
 
-        if (!key && bearer && looksLikeAsAccessToken(bearer)) {
-          const asAccess = await verifyAsAccessToken(store, bearer, now());
-          if (!asAccess) {
-            noteInvalidStart(ctx.request);
-            return toolErr('invalid OAuth access — sign in again from your coding agent');
-          }
+        /**
+         * Shared identity→round→sessionKey path for OAuth and creator-key openers
+         * (BY-18b / BY-27a). Both only produce a uid; everything after is identical.
+         */
+        const startFromCreatorUid = async (ownerUid: string): Promise<ToolResult> => {
           if (!slugArg) {
-            return toolErr('slug is required when using OAuth — pass the game slug for your open build round');
+            return toolErr(
+              'slug is required when using Authorization Bearer — pass the game slug for your open build round',
+            );
           }
 
-          const active = await findActiveRoundForSlug(store, slugArg, asAccess.ownerUid);
+          const active = await findActiveRoundForSlug(store, slugArg, ownerUid);
           if (!active) {
             noteInvalidStart(ctx.request);
             return toolErr(NO_OPEN_ROUND_REASON);
@@ -563,6 +576,24 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             ...base,
             content: [...base.content, { type: 'text', text: SESSION_WORKFLOW_TEXT }],
           };
+        };
+
+        if (!key && bearer && looksLikeAsAccessToken(bearer)) {
+          const asAccess = await verifyAsAccessToken(store, bearer, now());
+          if (!asAccess) {
+            noteInvalidStart(ctx.request);
+            return toolErr('invalid OAuth access — sign in again from your coding agent');
+          }
+          return startFromCreatorUid(asAccess.ownerUid);
+        }
+
+        if (!key && bearer && looksLikeCreatorAgentKey(bearer)) {
+          const verified = await verifyDurableCreatorAgentKey(store, bearer, agentTokenSecret, now());
+          if (!verified.ok) {
+            noteInvalidStart(ctx.request);
+            return toolErr(verified.reason);
+          }
+          return startFromCreatorUid(verified.claims.creatorUid);
         }
 
         if (key && looksLikeAsAccessToken(key)) {
@@ -570,10 +601,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('OAuth access must be sent as Authorization Bearer, not as the key argument');
         }
 
+        if (key && looksLikeCreatorAgentKey(key)) {
+          noteInvalidStart(ctx.request);
+          return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
+        }
+
         if (!key) {
           noteInvalidStart(ctx.request);
           return toolErr(
-            "key is required — paste the key from the creator's Studio kickoff prompt, or use OAuth Bearer + slug",
+            "key is required — paste the key from the creator's Studio kickoff prompt, or use Authorization Bearer + slug",
           );
         }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1133,6 +1133,21 @@ export interface GameAgentKeyRecord {
   agentOpenRoundPending?: boolean;
 }
 
+/**
+ * Durable creator-wide agent opener state (BY-27a), stored at `creatorAgentKeys/{uid}`.
+ *
+ * The HMAC opener itself is never stored — only the generation that revokes it.
+ * Bumped ONLY on explicit rotate/revoke — never on round close or publish.
+ */
+export interface CreatorAgentKeyRecord {
+  ownerUid: string;
+  keyGeneration: number;
+  createdAt: string;
+  updatedAt: string;
+  /** Set by revoke; cleared on the next mint/rotate. */
+  revokedAt?: string;
+}
+
 /** OAuth dynamic or CIMD-registered MCP client (BY-18b). */
 export interface OAuthClientRecord {
   clientId: string;
@@ -1760,6 +1775,27 @@ export interface Store {
   beginAgentOpenRound(slug: string, at: string): Promise<boolean>;
   /** BY-24: release the admission lock after `open_round` completes or aborts. */
   finishAgentOpenRound(slug: string, at: string): Promise<void>;
+  /**
+   * Durable creator-wide opener state (BY-27a). Returns null when no key has been
+   * issued for this creator yet.
+   */
+  getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null>;
+  /**
+   * Ensures a creatorAgentKeys doc exists for ownerUid, creating generation 1 when
+   * absent. Clears `revokedAt` so a post-revoke mint can issue again at the current
+   * generation. Does not bump `keyGeneration`.
+   */
+  ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord>;
+  /**
+   * Transactionally bumps `keyGeneration` and clears `revokedAt`. Returns the new
+   * record, or null when missing.
+   */
+  rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
+  /**
+   * Transactionally bumps `keyGeneration` and sets `revokedAt`. Returns the new
+   * record, or null when missing. Does not mint a replacement key.
+   */
+  revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
   /** Persist a dynamically registered or CIMD-cached OAuth client. */
   createOAuthClient(record: OAuthClientRecord): Promise<void>;
   getOAuthClient(clientId: string): Promise<OAuthClientRecord | null>;
@@ -1933,6 +1969,8 @@ export class InMemoryStore implements Store {
   private accessTokens = new Map<string, AccessTokenRecord>();
   // slug -> durable per-game agent opener state (BY-23)
   private gameAgentKeys = new Map<string, GameAgentKeyRecord>();
+  // uid -> durable creator-wide agent opener state (BY-27a)
+  private creatorAgentKeys = new Map<string, CreatorAgentKeyRecord>();
   private oauthClients = new Map<string, OAuthClientRecord>();
   private oauthGrants = new Map<string, OAuthGrantRecord>();
   private oauthAccessTokens = new Map<string, OAuthAccessTokenRecord>();
@@ -3146,6 +3184,57 @@ export class InMemoryStore implements Store {
     const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
     delete next.agentOpenRoundPending;
     this.gameAgentKeys.set(slug, next);
+  }
+
+  async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {
+    const record = this.creatorAgentKeys.get(ownerUid);
+    return record ? { ...record } : null;
+  }
+
+  async ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (existing) {
+      if (!existing.revokedAt) return { ...existing };
+      const cleared: CreatorAgentKeyRecord = { ...existing, updatedAt: at };
+      delete cleared.revokedAt;
+      this.creatorAgentKeys.set(ownerUid, cleared);
+      return { ...cleared };
+    }
+    const created: CreatorAgentKeyRecord = {
+      ownerUid,
+      keyGeneration: 1,
+      createdAt: at,
+      updatedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, created);
+    return { ...created };
+  }
+
+  async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing) return null;
+    const next: CreatorAgentKeyRecord = {
+      ownerUid: existing.ownerUid,
+      keyGeneration: existing.keyGeneration + 1,
+      createdAt: existing.createdAt,
+      updatedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, next);
+    return { ...next };
+  }
+
+  async revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing) return null;
+    const next: CreatorAgentKeyRecord = {
+      ownerUid: existing.ownerUid,
+      keyGeneration: existing.keyGeneration + 1,
+      createdAt: existing.createdAt,
+      updatedAt: at,
+      revokedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, next);
+    return { ...next };
   }
 
   async createOAuthClient(record: OAuthClientRecord): Promise<void> {
@@ -5135,6 +5224,70 @@ export class FirestoreStore implements Store {
       const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
       delete next.agentOpenRoundPending;
       tx.set(docRef, next);
+    });
+  }
+
+  async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {
+    const snap = await this.db.collection('creatorAgentKeys').doc(ownerUid).get();
+    if (!snap.exists) return null;
+    return snap.data() as CreatorAgentKeyRecord;
+  }
+
+  async ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (snap.exists) {
+        const existing = snap.data() as CreatorAgentKeyRecord;
+        if (!existing.revokedAt) return existing;
+        const cleared: CreatorAgentKeyRecord = { ...existing, updatedAt: at };
+        delete cleared.revokedAt;
+        tx.set(docRef, cleared);
+        return cleared;
+      }
+      const created: CreatorAgentKeyRecord = {
+        ownerUid,
+        keyGeneration: 1,
+        createdAt: at,
+        updatedAt: at,
+      };
+      tx.create(docRef, created);
+      return created;
+    });
+  }
+
+  async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      const next: CreatorAgentKeyRecord = {
+        ownerUid: existing.ownerUid,
+        keyGeneration: existing.keyGeneration + 1,
+        createdAt: existing.createdAt,
+        updatedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
+    });
+  }
+
+  async revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      const next: CreatorAgentKeyRecord = {
+        ownerUid: existing.ownerUid,
+        keyGeneration: existing.keyGeneration + 1,
+        createdAt: existing.createdAt,
+        updatedAt: at,
+        revokedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
     });
   }
 

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -21,6 +21,7 @@ import {
   type StudioShelfGame,
 } from './studioShelf.js';
 import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
+import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
@@ -1030,6 +1031,7 @@ function DetailsPanel({
 
       {game.slug && game.lastKnownStatus !== 'abandoned' ? <StudioAgentKeyPanel token={game.token} /> : null}
 
+      <StudioCreatorAgentKeyPanel />
       <StudioOAuthClientsPanel />
 
       {/* Only once there is play to report on. Before a game is live every one of these

--- a/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('StudioCreatorAgentKeyPanel', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo, init?: RequestInit) => {
+        const url = String(input);
+        const method = (init?.method ?? 'GET').toUpperCase();
+        if (url.includes('/api/me/creator-agent-key/rotate') && method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              key: 'rotated-creator-key',
+              keyGeneration: 2,
+              expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
+              revoked: false,
+            }),
+          };
+        }
+        if (url.endsWith('/api/me/creator-agent-key') && method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              key: 'fresh-creator-key',
+              keyGeneration: 1,
+              expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
+              revoked: false,
+            }),
+          };
+        }
+        if (url.endsWith('/api/me/creator-agent-key') && method === 'DELETE') {
+          return { ok: true, status: 204, json: async () => null };
+        }
+        return {
+          ok: true,
+          json: async () => ({ keyGeneration: 0, revoked: false }),
+        };
+      }),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('mints a key and warns that rotate stops agents holding the old key', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioCreatorAgentKeyPanel));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.textContent).toMatch(/Create key/i);
+    expect(container.textContent?.toLowerCase()).not.toContain('token');
+
+    await act(async () => {
+      container.querySelectorAll('button').forEach((button) => {
+        if (button.textContent?.includes('Create key')) button.click();
+      });
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.textContent).toContain('fresh-creator-key');
+
+    await act(async () => {
+      container.querySelectorAll('button').forEach((button) => {
+        if (button.textContent?.includes('Rotate key')) button.click();
+      });
+      await flush();
+    });
+
+    expect(container.textContent).toMatch(/stops any agent still holding the old key/i);
+  });
+});

--- a/apps/web/src/StudioCreatorAgentKeyPanel.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  getCreatorAgentKey,
+  mintCreatorAgentKey,
+  revokeCreatorAgentKey,
+  rotateCreatorAgentKey,
+  type CreatorAgentKeyStatus,
+} from './connectApi.js';
+
+/**
+ * Creator-wide MCP opener key (BY-27a). Sits with the OAuth grants panel — both answer
+ * "what can reach my account". UI copy never uses the word "token".
+ */
+export function StudioCreatorAgentKeyPanel() {
+  const { t, i18n } = useTranslation();
+  const baseId = useId();
+  const [status, setStatus] = useState<CreatorAgentKeyStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<'mint' | 'rotate' | 'revoke' | null>(null);
+  const [rotateArmed, setRotateArmed] = useState(false);
+  const [revokeArmed, setRevokeArmed] = useState(false);
+  const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getCreatorAgentKey();
+      setStatus(next);
+      if (next.key) setRevealedKey(next.key);
+    } catch {
+      setError(t('creatorAgentKey.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const expiresLabel =
+    status?.expiresAt != null
+      ? new Intl.DateTimeFormat(i18n.language, { dateStyle: 'medium', timeStyle: 'short' }).format(
+          new Date(status.expiresAt * 1000),
+        )
+      : '';
+
+  const hasActiveKey = Boolean(status && !status.revoked && status.keyGeneration > 0);
+
+  const copyKey = async (key: string) => {
+    try {
+      await navigator.clipboard.writeText(key);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Key stays on screen to select by hand.
+    }
+  };
+
+  const handleMint = async () => {
+    setBusy('mint');
+    setError(null);
+    try {
+      const minted = await mintCreatorAgentKey();
+      setStatus({
+        keyGeneration: minted.keyGeneration,
+        revoked: false,
+        key: minted.key,
+        expiresAt: minted.expiresAt,
+      });
+      setRevealedKey(minted.key);
+    } catch {
+      setError(t('creatorAgentKey.mintError'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleRotate = async () => {
+    setBusy('rotate');
+    setError(null);
+    try {
+      const rotated = await rotateCreatorAgentKey();
+      setStatus({
+        keyGeneration: rotated.keyGeneration,
+        revoked: false,
+        key: rotated.key,
+        expiresAt: rotated.expiresAt,
+      });
+      setRevealedKey(rotated.key);
+      setRotateArmed(false);
+    } catch {
+      setError(t('creatorAgentKey.rotateError'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleRevoke = async () => {
+    setBusy('revoke');
+    setError(null);
+    try {
+      await revokeCreatorAgentKey();
+      setStatus((prev) =>
+        prev ? { keyGeneration: prev.keyGeneration + 1, revoked: true } : { keyGeneration: 1, revoked: true },
+      );
+      setRevealedKey(null);
+      setRevokeArmed(false);
+    } catch {
+      setError(t('creatorAgentKey.revokeError'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <section className="studio-creator-agent-key" aria-labelledby={`${baseId}-title`}>
+      <h3 id={`${baseId}-title`} className="studio-agent-key-title">
+        {t('creatorAgentKey.title')}
+      </h3>
+      <p className="studio-share-hint">{t('creatorAgentKey.hint')}</p>
+
+      {loading ? <p className="studio-connect-state">{t('creatorAgentKey.loading')}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      {!loading && !hasActiveKey ? (
+        <div className="studio-creator-agent-key-actions">
+          <p className="studio-connect-state">
+            {status?.revoked ? t('creatorAgentKey.revoked') : t('creatorAgentKey.empty')}
+          </p>
+          <button type="button" className="button" disabled={busy === 'mint'} onClick={() => void handleMint()}>
+            {busy === 'mint' ? t('creatorAgentKey.minting') : t('creatorAgentKey.mint')}
+          </button>
+        </div>
+      ) : null}
+
+      {!loading && hasActiveKey ? (
+        <>
+          {expiresLabel ? (
+            <p className="studio-connect-expiry">{t('creatorAgentKey.expiry', { when: expiresLabel })}</p>
+          ) : null}
+
+          {revealedKey ? (
+            <div className="studio-creator-agent-key-reveal">
+              <p className="studio-share-hint">{t('creatorAgentKey.headerHint')}</p>
+              <pre className="studio-creator-agent-key-value" tabIndex={0}>
+                {revealedKey}
+              </pre>
+              <button type="button" className="button" onClick={() => void copyKey(revealedKey)}>
+                {copied ? t('creatorAgentKey.copied') : t('creatorAgentKey.copy')}
+              </button>
+            </div>
+          ) : null}
+
+          <div className="studio-creator-agent-key-actions">
+            {rotateArmed ? (
+              <>
+                <p className="studio-share-hint">{t('creatorAgentKey.rotate.confirm')}</p>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={busy === 'rotate'}
+                  onClick={() => void handleRotate()}
+                >
+                  {busy === 'rotate' ? t('creatorAgentKey.rotate.sending') : t('creatorAgentKey.rotate.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={busy === 'rotate'}
+                  onClick={() => setRotateArmed(false)}
+                >
+                  {t('creatorAgentKey.rotate.no')}
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                className="studio-connect-skip is-danger"
+                disabled={busy !== null}
+                onClick={() => {
+                  setRotateArmed(true);
+                  setRevokeArmed(false);
+                }}
+              >
+                {t('creatorAgentKey.rotate.start')}
+              </button>
+            )}
+
+            {revokeArmed ? (
+              <>
+                <p className="studio-share-hint">{t('creatorAgentKey.revoke.confirm')}</p>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={busy === 'revoke'}
+                  onClick={() => void handleRevoke()}
+                >
+                  {busy === 'revoke' ? t('creatorAgentKey.revoke.sending') : t('creatorAgentKey.revoke.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={busy === 'revoke'}
+                  onClick={() => setRevokeArmed(false)}
+                >
+                  {t('creatorAgentKey.revoke.no')}
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                className="studio-connect-skip is-danger"
+                disabled={busy !== null}
+                onClick={() => {
+                  setRevokeArmed(true);
+                  setRotateArmed(false);
+                }}
+              >
+                {t('creatorAgentKey.revoke.start')}
+              </button>
+            )}
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -142,3 +142,58 @@ export async function revokeOAuthGrant(grantId: string): Promise<void> {
     await throwResponseError(response);
   }
 }
+
+/** Creator-wide MCP opener status (BY-27a). Never call this a "token" in UI copy. */
+export type CreatorAgentKeyStatus = {
+  keyGeneration: number;
+  revoked: boolean;
+  key?: string;
+  expiresAt?: number;
+};
+
+export type CreatorAgentKeyPayload = {
+  key: string;
+  keyGeneration: number;
+  expiresAt: number;
+  revoked: false;
+};
+
+export async function getCreatorAgentKey(): Promise<CreatorAgentKeyStatus> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, { credentials: 'include' });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyStatus;
+}
+
+export async function mintCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyPayload;
+}
+
+export async function rotateCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key/rotate`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyPayload;
+}
+
+export async function revokeCreatorAgentKey(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!response.ok && response.status !== 204) {
+    await throwResponseError(response);
+  }
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -925,6 +925,38 @@
     "revoke": "Disconnect",
     "revoking": "Disconnecting…"
   },
+  "creatorAgentKey": {
+    "title": "Agent connection key",
+    "hint": "Paste this key once into your coding agent's MCP server headers (Authorization: Bearer …). Then start each round with only the game's slug — nothing secret in the prompt.",
+    "loading": "Loading your agent connection key…",
+    "loadError": "We couldn't load your agent connection key right now.",
+    "empty": "No agent connection key yet. Create one to connect your coding agent once for every game you own.",
+    "revoked": "Your agent connection key was revoked. Create a new one when you are ready to reconnect.",
+    "mint": "Create key",
+    "minting": "Creating…",
+    "mintError": "We couldn't create a key right now. Try again in a moment.",
+    "expiry": "This key expires {{when}}.",
+    "headerHint": "Put this value in your MCP client's Authorization header as Bearer …",
+    "copy": "Copy key",
+    "copied": "Copied",
+    "rotate": {
+      "start": "Rotate key",
+      "confirm": "Rotating stops any agent still holding the old key. Continue?",
+      "yes": "Rotate",
+      "no": "Cancel",
+      "sending": "Rotating…",
+      "error": "We couldn't rotate the key right now. Try again in a moment."
+    },
+    "rotateError": "We couldn't rotate the key right now. Try again in a moment.",
+    "revoke": {
+      "start": "Revoke key",
+      "confirm": "Revoking stops any agent still holding this key. You can create a new one later.",
+      "yes": "Revoke",
+      "no": "Cancel",
+      "sending": "Revoking…"
+    },
+    "revokeError": "We couldn't revoke the key right now. Try again in a moment."
+  },
   "remix": {
     "title": "Remix",
     "close": "Close",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -929,6 +929,38 @@
     "revoke": "Odłącz",
     "revoking": "Odłączanie…"
   },
+  "creatorAgentKey": {
+    "title": "Klucz połączenia agenta",
+    "hint": "Wklej ten klucz raz w nagłówkach serwera MCP swojego agenta (Authorization: Bearer …). Potem każdą rundę zaczynaj samym slugiem gry — bez sekretów w prompcie.",
+    "loading": "Wczytywanie klucza połączenia agenta…",
+    "loadError": "Nie udało się wczytać klucza połączenia agenta.",
+    "empty": "Nie masz jeszcze klucza połączenia. Utwórz go, by raz podłączyć agenta do wszystkich swoich gier.",
+    "revoked": "Klucz połączenia został unieważniony. Utwórz nowy, gdy będziesz gotów połączyć się ponownie.",
+    "mint": "Utwórz klucz",
+    "minting": "Tworzenie…",
+    "mintError": "Nie udało się utworzyć klucza. Spróbuj za chwilę.",
+    "expiry": "Ten klucz wygasa {{when}}.",
+    "headerHint": "Wstaw tę wartość w nagłówku Authorization klienta MCP jako Bearer …",
+    "copy": "Kopiuj klucz",
+    "copied": "Skopiowano",
+    "rotate": {
+      "start": "Obróć klucz",
+      "confirm": "Obrót zatrzyma każdego agenta, który nadal trzyma stary klucz. Kontynuować?",
+      "yes": "Obróć",
+      "no": "Anuluj",
+      "sending": "Obracanie…",
+      "error": "Nie udało się obrócić klucza. Spróbuj za chwilę."
+    },
+    "rotateError": "Nie udało się obrócić klucza. Spróbuj za chwilę.",
+    "revoke": {
+      "start": "Unieważnij klucz",
+      "confirm": "Unieważnienie zatrzyma każdego agenta, który nadal trzyma ten klucz. Później możesz utworzyć nowy.",
+      "yes": "Unieważnij",
+      "no": "Anuluj",
+      "sending": "Unieważnianie…"
+    },
+    "revokeError": "Nie udało się unieważnić klucza. Spróbuj za chwilę."
+  },
   "remix": {
     "title": "Remiks",
     "close": "Zamknij",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8410,6 +8410,41 @@ body.player-open {
   color: var(--muted);
 }
 
+.studio-creator-agent-key {
+  margin-top: 20px;
+}
+
+.studio-creator-agent-key-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  margin-top: 10px;
+}
+
+.studio-creator-agent-key-reveal {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.studio-creator-agent-key-value {
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 10px 12px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  word-break: break-all;
+  white-space: pre-wrap;
+  color: var(--text, #e2e8f0);
+  background: var(--panel, #171c20);
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 8px;
+}
+
 .studio-share .status-share {
   margin: 12px 0 0;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a durable **creator-wide** MCP opener key so a creator pastes one `Authorization: Bearer` value once in MCP client config and starts rounds with only a game slug. Reuses the BY-18b OAuth `start` path after uid resolution — no parallel session/write path.

### What landed
- New credential shape: HMAC over `(agent-creator-v1, creatorUid, keyGeneration, exp)`, wire prefix `c1.` (distinct from per-game `g1.`)
- Store: `creatorAgentKeys/{uid}` with `keyGeneration` bumped only on explicit rotate/revoke
- MCP `start` accepts Bearer creator key + `slug`, then the same `findActiveRoundForSlug` → sessionKey binding as OAuth
- Opener-only: rejected on both arms of the shared auth helper wherever a sessionKey is required
- Studio mint / rotate / revoke panel next to OAuth grants (EN + PL; never says “token”)
- Credential-scan registration for assembled-game refusal; TTL via `CREATOR_AGENT_KEY_TTL_DAYS` (default 90)
- Legacy round keys and durable per-game keys unchanged

### Threat model (T4)
A leaked creator key reaches **every game that creator owns**, until rotated or expired — wider than the per-game key it replaces. Compensating controls: opener-only, per-round delivery cap, the gate judging every delivery, the platform building the bundle (D7), TTL, one-click revoke. Config is not a vault — BY-12 observed Codex and mcp-remote storing credentials as plaintext JSON under `$HOME`. Better than a prompt, not safe.

Ops companion: threat-section update on `www.gamedev.pl-ops` (`cursor/creator-agent-key-threat-266f`).

### Out of scope
Removing either existing key shape, OAuth changes, kickoff-prompt rewrite (BY-27b), marketplace listings.

### Test plan
- [x] `npm test` green in `apps/api` (1909) and `apps/web` (917)
- [x] mint/verify round trip; reject tampered claims, expiry, stale generation, revoke
- [x] rotate kills prior key; `start` via header + slug binds open self round
- [x] unowned slug / no-open-round / platform-round refusals
- [x] creator key rejected on write tools; legacy round key + per-game key still work E2E
- [x] credential scanner catches embedded creator keys

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4326944-e048-4d78-9866-927e3291266f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4326944-e048-4d78-9866-927e3291266f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

