### PR TITLE
byoca(BY-27a): creator-wide MCP opener key via Authorization header

### DIFF
--- a/apps/api/src/agent-creator-key-resolve.test.ts
+++ b/apps/api/src/agent-creator-key-resolve.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { mintCreatorAgentKey } from './agent-creator-key.js';
+import { resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
+import { InMemoryStore } from './store.js';
+
+const secret = 'creator-resolve-test-secret';
+const owner = 'g:owner';
+const other = 'g:other';
+const slug = 'sky-dodge';
+
+async function seedSelfRound(
+  store: InMemoryStore,
+  issue: number,
+  uid: string,
+  gameSlug: string,
+  builder: 'self' | 'platform' = 'self',
+) {
+  await store.createSubmission(issue, uid, 'Sky Dodge');
+  await store.setSubmissionSlug(issue, gameSlug);
+  await store.setRoundBuilder(issue, builder);
+  await store.recordJobTransition(issue, {
+    to: 'dispatched',
+    at: new Date().toISOString(),
+    by: 'system',
+  });
+}
+
+describe('resolveCreatorAgentKeyForStart (BY-27a)', () => {
+  it('binds to an open self round the creator owns', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 1, owner, slug);
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const result = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.issueNumber).toBe(1);
+    }
+  });
+
+  it('refuses an unowned slug without suggesting rotate', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 1, other, slug);
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const result = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
+    expect(result).toEqual({ ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON });
+    expect(result.ok === false && result.reason).not.toMatch(/rotated/i);
+  });
+
+  it('refuses a missing slug with the same account-slug reason', async () => {
+    const store = new InMemoryStore();
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const result = await resolveCreatorAgentKeyForStart(store, key, secret, 'does-not-exist');
+    expect(result).toEqual({ ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON });
+  });
+
+  it('keeps no-open-round and platform-round distinct once ownership is confirmed', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(1, owner, 'Sky Dodge');
+    await store.setSubmissionSlug(1, slug);
+    await store.setSubmissionPublishedAt(1, '2026-07-01T00:00:00.000Z');
+    await store.recordJobTransition(1, {
+      to: 'published',
+      at: '2026-07-01T00:00:00.000Z',
+      by: 'operator',
+      reason: 'published',
+    });
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const noRound = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
+    expect(noRound).toEqual({ ok: false, reason: NO_OPEN_ROUND_REASON });
+
+    await store.createSubmission(2, owner, 'Sky Dodge');
+    await store.setSubmissionSlug(2, slug);
+    await store.setRoundBuilder(2, 'platform');
+    await store.recordJobTransition(2, { to: 'dispatched', at: new Date().toISOString(), by: 'system' });
+
+    const platform = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
+    expect(platform).toEqual({ ok: false, reason: PLATFORM_ROUND_REASON });
+  });
+});

--- a/apps/api/src/agent-creator-key-resolve.ts
+++ b/apps/api/src/agent-creator-key-resolve.ts
@@ -1,0 +1,137 @@
+/**
+ * Resolve a durable creator-wide opener into an active self-build round (BY-27a).
+ *
+ * Shared by MCP `start` (and BY-27b `open_round`) so verification cannot drift from
+ * the OAuth Bearer + slug path after uid resolution.
+ */
+
+import {
+  assertCreatorAgentKeyActive,
+  looksLikeCreatorAgentKey,
+  ROTATED_CREATOR_KEY_REASON,
+  verifyCreatorAgentKey,
+  type CreatorAgentKeyClaims,
+} from './agent-creator-key.js';
+import { GAME_NOT_PUBLISHED_REASON, NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON } from './agent-game-key.js';
+import { creatorOwnsSlug, findActiveRoundForSlug } from './agent-game-key-resolve.js';
+import { InvalidAgentTokenError } from './agent-token.js';
+import type { CreatorAgentKeyRecord, Store, SubmissionRecord } from './store.js';
+
+export type VerifyCreatorAgentKeyResult =
+  { ok: true; claims: CreatorAgentKeyClaims; keyRecord: CreatorAgentKeyRecord } | { ok: false; reason: string };
+
+export type ResolveCreatorKeyForStartResult =
+  { ok: true; claims: CreatorAgentKeyClaims; record: SubmissionRecord } | { ok: false; reason: string };
+
+export type ResolveCreatorKeyForOpenRoundResult =
+  | {
+      ok: true;
+      claims: CreatorAgentKeyClaims;
+      publishedRecord: SubmissionRecord;
+      activeRound: SubmissionRecord | null;
+      slug: string;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Signature, generation, and expiry — shared by `start` and `open_round`.
+ * Does not require an open round or a published game.
+ */
+export async function verifyDurableCreatorAgentKey(
+  store: Store,
+  key: string,
+  secret: string,
+  nowMs: number = Date.now(),
+): Promise<VerifyCreatorAgentKeyResult> {
+  if (!looksLikeCreatorAgentKey(key)) {
+    return { ok: false, reason: 'invalid key — mint a fresh creator key in Studio' };
+  }
+
+  let claims: CreatorAgentKeyClaims;
+  try {
+    claims = verifyCreatorAgentKey(key, secret);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: 'invalid key — mint a fresh creator key in Studio' };
+    }
+    throw error;
+  }
+
+  const keyRecord = await store.getCreatorAgentKey(claims.creatorUid);
+  if (!keyRecord) {
+    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
+  }
+
+  try {
+    assertCreatorAgentKeyActive(claims, keyRecord, nowMs);
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      return { ok: false, reason: error.message || ROTATED_CREATOR_KEY_REASON };
+    }
+    throw error;
+  }
+
+  if (keyRecord.ownerUid !== claims.creatorUid) {
+    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
+  }
+
+  return { ok: true, claims, keyRecord };
+}
+
+/**
+ * Creator-key verification for `start`: shared checks, then bind to the active
+ * self round for the given slug (same refusals as the OAuth branch).
+ */
+export async function resolveCreatorAgentKeyForStart(
+  store: Store,
+  key: string,
+  secret: string,
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveCreatorKeyForStartResult> {
+  const verified = await verifyDurableCreatorAgentKey(store, key, secret, nowMs);
+  if (!verified.ok) return verified;
+
+  if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
+    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
+  }
+
+  const active = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
+  if (!active) {
+    return { ok: false, reason: NO_OPEN_ROUND_REASON };
+  }
+
+  const builder = active.builder ?? 'platform';
+  if (builder !== 'self') {
+    return { ok: false, reason: PLATFORM_ROUND_REASON };
+  }
+
+  return { ok: true, claims: verified.claims, record: active };
+}
+
+/**
+ * Creator-key verification for `open_round`: published game owned by the creator,
+ * and idempotent binding when a round is already open. No per-game opt-in (BY-27b).
+ */
+export async function resolveCreatorAgentKeyForOpenRound(
+  store: Store,
+  key: string,
+  secret: string,
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveCreatorKeyForOpenRoundResult> {
+  const verified = await verifyDurableCreatorAgentKey(store, key, secret, nowMs);
+  if (!verified.ok) return verified;
+
+  if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
+    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
+  }
+
+  const publishedRecord = await store.getPublishedSubmissionBySlug(slug);
+  if (!publishedRecord) {
+    return { ok: false, reason: GAME_NOT_PUBLISHED_REASON };
+  }
+
+  const activeRound = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
+  return { ok: true, claims: verified.claims, publishedRecord, activeRound, slug };
+}

--- a/apps/api/src/agent-creator-key-resolve.ts
+++ b/apps/api/src/agent-creator-key-resolve.ts
@@ -1,8 +1,9 @@
 /**
  * Resolve a durable creator-wide opener into an active self-build round (BY-27a).
  *
- * Shared by MCP `start` (and BY-27b `open_round`) so verification cannot drift from
- * the OAuth Bearer + slug path after uid resolution.
+ * Shared by MCP `start` so verification cannot drift from the OAuth Bearer + slug
+ * path after uid resolution. `open_round` wiring lands with BY-27b — do not add an
+ * unreachable resolver here ahead of that work.
  */
 
 import {
@@ -12,7 +13,7 @@ import {
   verifyCreatorAgentKey,
   type CreatorAgentKeyClaims,
 } from './agent-creator-key.js';
-import { GAME_NOT_PUBLISHED_REASON, NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON } from './agent-game-key.js';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
 import { creatorOwnsSlug, findActiveRoundForSlug } from './agent-game-key-resolve.js';
 import { InvalidAgentTokenError } from './agent-token.js';
 import type { CreatorAgentKeyRecord, Store, SubmissionRecord } from './store.js';
@@ -23,18 +24,8 @@ export type VerifyCreatorAgentKeyResult =
 export type ResolveCreatorKeyForStartResult =
   { ok: true; claims: CreatorAgentKeyClaims; record: SubmissionRecord } | { ok: false; reason: string };
 
-export type ResolveCreatorKeyForOpenRoundResult =
-  | {
-      ok: true;
-      claims: CreatorAgentKeyClaims;
-      publishedRecord: SubmissionRecord;
-      activeRound: SubmissionRecord | null;
-      slug: string;
-    }
-  | { ok: false; reason: string };
-
 /**
- * Signature, generation, and expiry — shared by `start` and `open_round`.
+ * Signature, generation, and expiry — shared by `start`.
  * Does not require an open round or a published game.
  */
 export async function verifyDurableCreatorAgentKey(
@@ -93,7 +84,7 @@ export async function resolveCreatorAgentKeyForStart(
   if (!verified.ok) return verified;
 
   if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
-    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
+    return { ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON };
   }
 
   const active = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
@@ -107,31 +98,4 @@ export async function resolveCreatorAgentKeyForStart(
   }
 
   return { ok: true, claims: verified.claims, record: active };
-}
-
-/**
- * Creator-key verification for `open_round`: published game owned by the creator,
- * and idempotent binding when a round is already open. No per-game opt-in (BY-27b).
- */
-export async function resolveCreatorAgentKeyForOpenRound(
-  store: Store,
-  key: string,
-  secret: string,
-  slug: string,
-  nowMs: number = Date.now(),
-): Promise<ResolveCreatorKeyForOpenRoundResult> {
-  const verified = await verifyDurableCreatorAgentKey(store, key, secret, nowMs);
-  if (!verified.ok) return verified;
-
-  if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
-    return { ok: false, reason: ROTATED_CREATOR_KEY_REASON };
-  }
-
-  const publishedRecord = await store.getPublishedSubmissionBySlug(slug);
-  if (!publishedRecord) {
-    return { ok: false, reason: GAME_NOT_PUBLISHED_REASON };
-  }
-
-  const activeRound = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
-  return { ok: true, claims: verified.claims, publishedRecord, activeRound, slug };
 }

--- a/apps/api/src/agent-creator-key.test.ts
+++ b/apps/api/src/agent-creator-key.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertCreatorAgentKeyActive,
+  creatorAgentKeyFingerprint,
+  creatorAgentKeyTtlDays,
+  DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS,
+  InvalidAgentTokenError,
+  looksLikeCreatorAgentKey,
+  maskCreatorAgentKeyHeader,
+  mintCreatorAgentKey,
+  ROTATED_CREATOR_KEY_REASON,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
+import { mintGameAgentKey } from './agent-game-key.js';
+import { mintMcpSessionKey } from './mcp-session-key.js';
+
+describe('durable creator agent key (BY-27a)', () => {
+  const secret = 'creator-key-test-secret';
+  const now = Date.parse('2026-08-02T12:00:00.000Z');
+  const creatorUid = 'g:creator';
+
+  afterEach(() => {
+    delete process.env.CREATOR_AGENT_KEY_TTL_DAYS;
+  });
+
+  it('mints and verifies a round-trip key', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyCreatorAgentKey(key, secret)).toEqual({
+      creatorUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.startsWith('c1.')).toBe(true);
+  });
+
+  it('rejects tampered claims', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    const [prefix, kind, uid, generation, exp, signature] = decoded.split('.');
+    const tamperedGeneration = Buffer.from(
+      `${prefix}.${kind}.${uid}.${Number(generation) + 1}.${exp}.${signature}`,
+      'utf8',
+    ).toString('base64url');
+    const tamperedExp = Buffer.from(
+      `${prefix}.${kind}.${uid}.${generation}.${Number(exp) + 1}.${signature}`,
+      'utf8',
+    ).toString('base64url');
+    const flipped = signature.endsWith('0') ? '1' : '0';
+    const tamperedSig = Buffer.from(
+      `${prefix}.${kind}.${uid}.${generation}.${exp}.${signature.slice(0, -1)}${flipped}`,
+      'utf8',
+    ).toString('base64url');
+    expect(() => verifyCreatorAgentKey(tamperedGeneration, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey(tamperedExp, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey(tamperedSig, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyCreatorAgentKey('not-a-key', secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('rejects an expired key', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyCreatorAgentKey(key, secret);
+    const afterExpiry = now + 91 * 24 * 60 * 60 * 1000;
+    expect(() => assertCreatorAgentKeyActive(claims, { keyGeneration: 1 }, afterExpiry)).toThrow(
+      ROTATED_CREATOR_KEY_REASON,
+    );
+  });
+
+  it('rejects a stale keyGeneration', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const claims = verifyCreatorAgentKey(key, secret);
+    expect(() => assertCreatorAgentKeyActive(claims, { keyGeneration: 2 }, now)).toThrow(ROTATED_CREATOR_KEY_REASON);
+  });
+
+  it('rotate makes the old key fail and the new pass', () => {
+    const oldKey = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const newKey = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 2, now, ttlDays: 90 });
+    const oldClaims = verifyCreatorAgentKey(oldKey, secret);
+    const newClaims = verifyCreatorAgentKey(newKey, secret);
+    expect(() => assertCreatorAgentKeyActive(oldClaims, { keyGeneration: 2 }, now)).toThrow(ROTATED_CREATOR_KEY_REASON);
+    expect(() => assertCreatorAgentKeyActive(newClaims, { keyGeneration: 2 }, now)).not.toThrow();
+  });
+
+  it('round-trips Apple dotted subject identifiers', () => {
+    const appleUid = 'a:001234.abcdef.0000';
+    const key = mintCreatorAgentKey(secret, { creatorUid: appleUid, keyGeneration: 1, now, ttlDays: 90 });
+    expect(verifyCreatorAgentKey(key, secret)).toEqual({
+      creatorUid: appleUid,
+      keyGeneration: 1,
+      exp: Math.floor(now / 1000) + 90 * 24 * 60 * 60,
+    });
+    const decoded = Buffer.from(key, 'base64url').toString('utf8');
+    expect(decoded.split('.')[2]).not.toContain('.');
+  });
+
+  it('does not false-positive on per-game or session keys', () => {
+    const gameKey = mintGameAgentKey(secret, {
+      slug: 'sky-dodge',
+      creatorUid,
+      keyGeneration: 1,
+      now,
+    });
+    // Session ids are free-form; `c1` would collide if creator keys were also 5 fields.
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: 'c1',
+      jobId: 42,
+      roundGeneration: 1,
+      now,
+    });
+    expect(Buffer.from(sessionKey, 'base64url').toString('utf8').startsWith('c1.')).toBe(true);
+    expect(looksLikeCreatorAgentKey(gameKey)).toBe(false);
+    expect(looksLikeCreatorAgentKey(sessionKey)).toBe(false);
+  });
+
+  it('defaults TTL from CREATOR_AGENT_KEY_TTL_DAYS (90 days)', () => {
+    expect(creatorAgentKeyTtlDays()).toBe(DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS);
+    process.env.CREATOR_AGENT_KEY_TTL_DAYS = '30';
+    expect(creatorAgentKeyTtlDays()).toBe(30);
+
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now });
+    const claims = verifyCreatorAgentKey(key, secret);
+    expect(claims.exp).toBe(Math.floor(now / 1000) + 30 * 24 * 60 * 60);
+  });
+
+  it('masks the Authorization header to a fingerprint', () => {
+    const key = mintCreatorAgentKey(secret, { creatorUid, keyGeneration: 1, now, ttlDays: 90 });
+    const fingerprint = creatorAgentKeyFingerprint(key);
+    expect(fingerprint).toHaveLength(5);
+    expect(maskCreatorAgentKeyHeader(key)).toBe(`Authorization: Bearer ····${fingerprint}`);
+    expect(maskCreatorAgentKeyHeader(key)).not.toContain(key);
+  });
+});

--- a/apps/api/src/agent-creator-key.ts
+++ b/apps/api/src/agent-creator-key.ts
@@ -1,0 +1,201 @@
+/**
+ * Durable creator-wide agent opener keys (BY-27a).
+ *
+ * Distinct scope from round-scoped build keys (`agent-channel-v1`), MCP session
+ * keys (`mcp-session-v1`), and per-game openers (`agent-game-v1`). This key may
+ * only be exchanged at `start` (and `open_round`) — together with a `slug` —
+ * for a round-bound sessionKey. Never accepted where a sessionKey or round write
+ * capability is required.
+ *
+ * Revocation is `keyGeneration` on `creatorAgentKeys/{uid}`, bumped only by an
+ * explicit creator rotate/revoke. Round close does NOT bump it.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { InvalidAgentTokenError } from './agent-token.js';
+
+export { InvalidAgentTokenError } from './agent-token.js';
+
+const SCOPE = 'agent-creator-v1';
+/** Wire marker so this shape can never parse as a per-game or session key. */
+const WIRE_PREFIX = 'c1';
+/**
+ * Fixed segment after the prefix. Keeps the wire at 6 fields so a session key whose
+ * session id is literally `c1` (5 fields: id.job.gen.exp.sig) cannot false-positive
+ * {@link looksLikeCreatorAgentKey}.
+ */
+const WIRE_KIND = 'u';
+
+/** Default lifetime for a durable creator opener key, in days. */
+export const DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS = 90;
+
+/** Rotated or generation-mismatched creator key. */
+export const ROTATED_CREATOR_KEY_REASON =
+  'this creator key was rotated — mint a fresh one in Studio and update your agent config';
+
+export interface CreatorAgentKeyClaims {
+  creatorUid: string;
+  keyGeneration: number;
+  /** Unix seconds. */
+  exp: number;
+}
+
+export interface MintCreatorAgentKeyOptions {
+  creatorUid: string;
+  keyGeneration: number;
+  /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+  /** Override {@link creatorAgentKeyTtlDays}; useful in tests. */
+  ttlDays?: number;
+}
+
+export function creatorAgentKeyTtlDays(): number {
+  const parsed = Number(process.env.CREATOR_AGENT_KEY_TTL_DAYS ?? DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS;
+}
+
+function signCreatorKey(creatorUid: string, keyGeneration: number, exp: number, secret: string): string {
+  return createHmac('sha256', secret).update(`${SCOPE}:${creatorUid}:${keyGeneration}:${exp}`).digest('hex');
+}
+
+function safeEqualHex(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function assertCreatorUid(creatorUid: string): void {
+  if (!creatorUid || /\s/.test(creatorUid)) {
+    throw new InvalidAgentTokenError('invalid creator id');
+  }
+}
+
+function encodeCreatorUid(creatorUid: string): string {
+  assertCreatorUid(creatorUid);
+  return Buffer.from(creatorUid, 'utf8').toString('base64url');
+}
+
+function decodeCreatorUid(encoded: string): string {
+  try {
+    const creatorUid = Buffer.from(encoded, 'base64url').toString('utf8');
+    assertCreatorUid(creatorUid);
+    return creatorUid;
+  } catch {
+    throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Mints a durable creator-wide opener. HMAC covers
+ * `(agent-creator-v1, creatorUid, keyGeneration, exp)`.
+ */
+export function mintCreatorAgentKey(secret: string, options: MintCreatorAgentKeyOptions): string {
+  if (!Number.isSafeInteger(options.keyGeneration) || options.keyGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid key generation');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlDays = options.ttlDays ?? creatorAgentKeyTtlDays();
+  const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
+  const signature = signCreatorKey(options.creatorUid, options.keyGeneration, exp, secret);
+  const encodedUid = encodeCreatorUid(options.creatorUid);
+  const payload = `${WIRE_PREFIX}.${WIRE_KIND}.${encodedUid}.${options.keyGeneration}.${exp}.${signature}`;
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+/**
+ * True when the decoded wire form matches the full durable creator-key shape. Used to
+ * reject these keys at sessionKey/Bearer write paths without inventing a second error.
+ */
+export function looksLikeCreatorAgentKey(token: string): boolean {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 6) return false;
+    const [prefix, kind, encodedUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      kind !== WIRE_KIND ||
+      !encodedUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      return false;
+    }
+    decodeCreatorUid(encodedUid);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies HMAC and returns claims. Does **not** check keyGeneration against the store
+ * — callers do that once the creatorAgentKeys record is loaded.
+ */
+export function verifyCreatorAgentKey(token: string, secret: string): CreatorAgentKeyClaims {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 6) {
+      throw new InvalidAgentTokenError();
+    }
+    const [prefix, kind, encodedUid, generationRaw, expRaw, signature] = parts;
+    if (
+      prefix !== WIRE_PREFIX ||
+      kind !== WIRE_KIND ||
+      !encodedUid ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    const creatorUid = decodeCreatorUid(encodedUid);
+    const keyGeneration = Number.parseInt(generationRaw, 10);
+    const exp = Number.parseInt(expRaw, 10);
+    if (!Number.isSafeInteger(keyGeneration) || keyGeneration < 1 || !Number.isSafeInteger(exp) || exp <= 0) {
+      throw new InvalidAgentTokenError();
+    }
+    if (!safeEqualHex(signature, signCreatorKey(creatorUid, keyGeneration, exp, secret))) {
+      throw new InvalidAgentTokenError();
+    }
+    return { creatorUid, keyGeneration, exp };
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) {
+      throw error;
+    }
+    throw new InvalidAgentTokenError();
+  }
+}
+
+/**
+ * Checks expiry and keyGeneration against the creator's current record.
+ */
+export function assertCreatorAgentKeyActive(
+  claims: CreatorAgentKeyClaims,
+  record: { keyGeneration: number },
+  nowMs: number = Date.now(),
+): void {
+  if (claims.exp * 1000 <= nowMs) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
+  if (claims.keyGeneration !== record.keyGeneration) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
+}
+
+/** Last five characters of the wire key — enough to tell keys apart in Studio. */
+export function creatorAgentKeyFingerprint(key: string): string {
+  if (key.length <= 5) return key;
+  return key.slice(-5);
+}
+
+/** Masked Authorization header value for display (never the full secret). */
+export function maskCreatorAgentKeyHeader(key: string): string {
+  return `Authorization: Bearer ····${creatorAgentKeyFingerprint(key)}`;
+}

--- a/apps/api/src/agent-creator-key.ts
+++ b/apps/api/src/agent-creator-key.ts
@@ -174,13 +174,16 @@ export function verifyCreatorAgentKey(token: string, secret: string): CreatorAge
 }
 
 /**
- * Checks expiry and keyGeneration against the creator's current record.
+ * Checks expiry, revocation, and keyGeneration against the creator's current record.
  */
 export function assertCreatorAgentKeyActive(
   claims: CreatorAgentKeyClaims,
-  record: { keyGeneration: number },
+  record: { keyGeneration: number; revokedAt?: string },
   nowMs: number = Date.now(),
 ): void {
+  if (record.revokedAt) {
+    throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
+  }
   if (claims.exp * 1000 <= nowMs) {
     throw new InvalidAgentTokenError(ROTATED_CREATOR_KEY_REASON);
   }

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -33,6 +33,14 @@ export const NO_OPEN_ROUND_REASON =
 export const PLATFORM_ROUND_REASON =
   'the open round for this game is built by the platform, not your agent — ask the creator to switch to their own agent in Studio';
 
+/**
+ * Bearer + slug identity paths: the slug is not on this creator's account.
+ * Names the slug — never the key — so a mistype does not push a destructive rotate.
+ * Same wording for "does not exist" and "belongs to someone else" (games are public).
+ */
+export const SLUG_NOT_ON_ACCOUNT_REASON =
+  'no game with that slug on your account — check the slug in your Studio thread';
+
 /** Rotated or generation-mismatched durable key. */
 export const ROTATED_GAME_KEY_REASON =
   'this game key was rotated — get a fresh prompt from the Studio thread for this game';

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -64,6 +64,7 @@ import { isKnownSpaShellPath, looksLikeStaticAsset } from './spa-paths.js';
 import { logModerationRejection } from './moderation-metrics.js';
 import { registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
 import { registerOAuthAuthorizationServerRoutes } from './oauth-as.js';
+import { registerCreatorAgentKeyRoutes } from './creator-agent-key-routes.js';
 
 const GenerateRequestSchema = z.object({
   prompt: z.string().trim().min(1, 'prompt is required').max(500, 'prompt is too long'),
@@ -572,6 +573,15 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     sessionSecret: oauthSessionSecret,
     sessionSecretPrev: oauthSessionSecretPrev,
   });
+
+  // Creator-wide MCP opener (BY-27a). Needs the same HMAC secret as per-game keys.
+  if (submissionTokenSecret) {
+    registerCreatorAgentKeyRoutes(app, {
+      store,
+      submissionTokenSecret,
+      now: options.submissionRoutes?.now,
+    });
+  }
 
   // Apex → www canonical-host redirect. Cloud Run domain mappings can't emit a
   // 301, and both www.gamedev.pl and gamedev.pl terminate at this same service,

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -1,0 +1,297 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertCreatorAgentKeyActive, looksLikeCreatorAgentKey, verifyCreatorAgentKey } from './agent-creator-key.js';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON } from './agent-game-key.js';
+import { mintGameAgentKey } from './agent-game-key.js';
+import { mintAgentToken } from './agent-token.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { buildApp } from './app.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { mintMcpSessionKey } from './mcp-session-key.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'creator-agent-routes-secret';
+const sessionSecret = 'dev-session-secret-change-me';
+const OWNER = 'g:owner';
+const OTHER = 'g:other';
+const SLUG = 'jagged-alliance';
+const CONCEPT = 'A tactics game about careful timing and cover.';
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: 1 }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+async function createApp(store: InMemoryStore) {
+  await store.upsertUser({ uid: OWNER, email: 'o@example.com', betaStatus: 'approved' });
+  await store.upsertUser({ uid: OTHER, email: 'x@example.com', betaStatus: 'approved' });
+  return buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+    },
+  });
+}
+
+function authHeaders(uid = OWNER) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+async function mcpCall(app: FastifyInstance, method: string, params?: unknown, headers: Record<string, string> = {}) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/mcp',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    payload: { jsonrpc: '2.0', id: 1, method, ...(params !== undefined ? { params } : {}) },
+  });
+}
+
+async function callStart(app: FastifyInstance, args: Record<string, unknown>, headers: Record<string, string> = {}) {
+  const init = await mcpCall(app, 'initialize', {
+    protocolVersion: '2025-11-25',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '0' },
+  });
+  const sessionId = init.headers['mcp-session-id'] as string;
+  const res = await mcpCall(
+    app,
+    'tools/call',
+    { name: 'start', arguments: args },
+    { ...headers, 'mcp-session-id': sessionId },
+  );
+  const body = res.json() as {
+    result?: {
+      isError?: boolean;
+      structuredContent?: { sessionKey?: string; jobId?: number };
+      content?: Array<{ text: string }>;
+    };
+  };
+  const structured =
+    body.result?.structuredContent ??
+    (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
+  return { structured, isError: Boolean(body.result?.isError), sessionId };
+}
+
+describe('creator agent key routes + MCP start (BY-27a)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('mints, remints without bumping, rotates, and revokes', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const first = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    expect(first.statusCode).toBe(200);
+    expect(first.headers['cache-control']).toBe('no-store');
+    const body1 = first.json() as {
+      key: string;
+      keyGeneration: number;
+      expiresAt: number;
+      fingerprint: string;
+      authorizationHeader: string;
+      authorizationHeaderMasked: string;
+    };
+    expect(looksLikeCreatorAgentKey(body1.key)).toBe(true);
+    expect(body1.keyGeneration).toBe(1);
+    expect(body1.fingerprint).toHaveLength(5);
+    expect(body1.authorizationHeader).toBe(`Authorization: Bearer ${body1.key}`);
+    expect(body1.authorizationHeaderMasked).toBe(`Authorization: Bearer ····${body1.fingerprint}`);
+    expect(body1.authorizationHeaderMasked).not.toContain(body1.key);
+    const claims1 = verifyCreatorAgentKey(body1.key, secret);
+    expect(claims1.creatorUid).toBe(OWNER);
+    expect(body1.expiresAt).toBe(claims1.exp);
+
+    const second = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    expect(second.json().keyGeneration).toBe(1);
+    expect((await store.getCreatorAgentKey(OWNER))?.keyGeneration).toBe(1);
+
+    const rotated = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key/rotate',
+      headers: authHeaders(),
+    });
+    expect(rotated.statusCode).toBe(200);
+    expect(rotated.json().keyGeneration).toBe(2);
+    expect(rotated.json().rotated).toBe(true);
+    expect(() => assertCreatorAgentKeyActive(claims1, { keyGeneration: 2 })).toThrow(/rotated/i);
+
+    const revoked = await app.inject({
+      method: 'DELETE',
+      url: '/api/me/creator-agent-key',
+      headers: authHeaders(),
+    });
+    expect(revoked.statusCode).toBe(204);
+    expect(await store.getCreatorAgentKey(OWNER)).toBeNull();
+
+    const reminted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    expect(reminted.json().keyGeneration).toBe(1);
+  });
+
+  it('starts via Authorization Bearer + slug on the creator key', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Jagged Alliance', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const key = minted.json().key as string;
+
+    const { structured, isError } = await callStart(app, { slug: SLUG }, { authorization: `Bearer ${key}` });
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ jobId: record.issueNumber, slug: SLUG });
+    expect((structured as { sessionKey: string }).sessionKey).toBeTruthy();
+  });
+
+  it('refuses a slug the creator does not own', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    await store.createSubmission(10, OTHER, 'Other Game');
+    await store.setSubmissionSlug(10, 'other-game');
+    await store.setRoundBuilder(10, 'self');
+    await store.recordJobTransition(10, { to: 'dispatched', at: new Date().toISOString(), by: 'system' });
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const key = minted.json().key as string;
+
+    const { structured, isError } = await callStart(app, { slug: 'other-game' }, { authorization: `Bearer ${key}` });
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toMatch(/rotated/i);
+  });
+
+  it('reuses no-open-round and platform-round refusals', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    await store.createSubmission(20, OWNER, 'Published Only');
+    await store.setSubmissionSlug(20, SLUG);
+    await store.setSubmissionPublishedAt(20, '2026-07-01T00:00:00.000Z');
+    await store.recordJobTransition(20, {
+      to: 'published',
+      at: '2026-07-01T00:00:00.000Z',
+      by: 'operator',
+      reason: 'published',
+    });
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const key = minted.json().key as string;
+
+    const noRound = await callStart(app, { slug: SLUG }, { authorization: `Bearer ${key}` });
+    expect(noRound.isError).toBe(true);
+    expect(noRound.structured).toMatchObject({ error: NO_OPEN_ROUND_REASON });
+
+    await store.createSubmission(21, OWNER, 'Platform Round');
+    await store.setSubmissionSlug(21, SLUG);
+    await store.setRoundBuilder(21, 'platform');
+    await store.recordJobTransition(21, { to: 'dispatched', at: new Date().toISOString(), by: 'system' });
+
+    const platform = await callStart(app, { slug: SLUG }, { authorization: `Bearer ${key}` });
+    expect(platform.isError).toBe(true);
+    expect(platform.structured).toMatchObject({ error: PLATFORM_ROUND_REASON });
+  });
+
+  it('rejects the creator key on write tools', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Write Guard', concept: CONCEPT, builder: 'self' },
+    });
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const key = minted.json().key as string;
+
+    const init = await mcpCall(app, 'initialize', {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' },
+    });
+    const sessionId = init.headers['mcp-session-id'] as string;
+    const res = await mcpCall(
+      app,
+      'tools/call',
+      { name: 'report_progress', arguments: { step: 'scaffold', note: 'hi' } },
+      { authorization: `Bearer ${key}`, 'mcp-session-id': sessionId },
+    );
+    const body = res.json() as {
+      result?: { isError?: boolean; content?: Array<{ text: string }> };
+    };
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toMatch(/creator key only opens a session/i);
+  });
+
+  it('keeps legacy round keys and durable per-game keys working', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Legacy Keys', concept: CONCEPT, builder: 'self' },
+    });
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+    await store.ensureRoundGeneration(record.issueNumber);
+    await store.ensureGameAgentKey(SLUG, OWNER, new Date().toISOString());
+
+    const gameKey = mintGameAgentKey(secret, {
+      slug: SLUG,
+      creatorUid: OWNER,
+      keyGeneration: 1,
+    });
+    const gameStart = await callStart(app, { key: gameKey });
+    expect(gameStart.isError).toBe(false);
+
+    const roundKey = mintAgentToken(record.issueNumber, secret, { roundGeneration: 1 });
+    const roundStart = await callStart(app, { key: roundKey });
+    expect(roundStart.isError).toBe(false);
+
+    // sessionKey from game start still works as a write credential shape check
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: 'sess-legacy',
+      jobId: record.issueNumber,
+      roundGeneration: 1,
+    });
+    expect(sessionKey).toBeTruthy();
+  });
+});

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -234,6 +234,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
       headers: authHeaders(),
       payload: { title: 'Write Guard', concept: CONCEPT, builder: 'self' },
     });
+    expect(submit.statusCode).toBe(200);
     const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
     await store.setSubmissionSlug(record.issueNumber, SLUG);
 
@@ -269,6 +270,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
       headers: authHeaders(),
       payload: { title: 'Legacy Keys', concept: CONCEPT, builder: 'self' },
     });
+    expect(submit.statusCode).toBe(200);
     const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
     await store.setSubmissionSlug(record.issueNumber, SLUG);
     await store.ensureRoundGeneration(record.issueNumber);

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -103,7 +103,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     app = null;
   });
 
-  it('mints, remints without bumping, rotates, and revokes', async () => {
+  it('mints, remints without bumping, rotates, and revokes without resurrecting gen-1', async () => {
     const store = new InMemoryStore();
     app = await createApp(store);
 
@@ -148,10 +148,30 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
       headers: authHeaders(),
     });
     expect(revoked.statusCode).toBe(204);
-    expect(await store.getCreatorAgentKey(OWNER)).toBeNull();
+    const afterRevoke = await store.getCreatorAgentKey(OWNER);
+    expect(afterRevoke?.revokedAt).toBeTruthy();
+    expect(afterRevoke?.keyGeneration).toBe(3);
 
-    const reminted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
-    expect(reminted.json().keyGeneration).toBe(1);
+    const status = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    expect(status.statusCode).toBe(200);
+    expect(status.json()).toMatchObject({ revoked: true, keyGeneration: 3 });
+    expect(status.json().key).toBeUndefined();
+
+    const reminted = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key',
+      headers: authHeaders(),
+    });
+    expect(reminted.statusCode).toBe(200);
+    expect(reminted.json().keyGeneration).toBe(3);
+    expect(() => assertCreatorAgentKeyActive(claims1, { keyGeneration: reminted.json().keyGeneration })).toThrow(
+      /rotated/i,
+    );
+    const live = await store.getCreatorAgentKey(OWNER);
+    expect(live?.revokedAt).toBeUndefined();
+    expect(() =>
+      assertCreatorAgentKeyActive(verifyCreatorAgentKey(reminted.json().key as string, secret), live!),
+    ).not.toThrow();
   });
 
   it('starts via Authorization Bearer + slug on the creator key', async () => {
@@ -315,7 +335,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     expect(platform.structured).toMatchObject({ error: PLATFORM_ROUND_REASON });
   });
 
-  it('rejects the creator key on write tools', async () => {
+  it('rejects the creator key on write tools when no sessionKey is present', async () => {
     const store = new InMemoryStore();
     app = await createApp(store);
 
@@ -349,6 +369,43 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     };
     expect(body.result?.isError).toBe(true);
     expect(body.result?.content?.[0]?.text).toMatch(/creator key only opens a session/i);
+  });
+
+  it('honours sessionKey for write tools even when Authorization still carries the creator key', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Paste Once', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+    await store.ensureRoundGeneration(record.issueNumber);
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const creatorKey = minted.json().key as string;
+    const started = await callStart(app, { slug: SLUG }, { authorization: `Bearer ${creatorKey}` });
+    expect(started.isError).toBe(false);
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const progress = await mcpCall(
+      app,
+      'tools/call',
+      {
+        name: 'report_progress',
+        arguments: { sessionKey, step: 'planning', text: 'paste-once ok' },
+      },
+      {
+        authorization: `Bearer ${creatorKey}`,
+        'mcp-session-id': started.sessionId,
+      },
+    );
+    const body = progress.json() as { result?: { isError?: boolean } };
+    expect(body.result?.isError).not.toBe(true);
   });
 
   it('keeps legacy round keys and durable per-game keys working', async () => {

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -1,13 +1,14 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 import { assertCreatorAgentKeyActive, looksLikeCreatorAgentKey, verifyCreatorAgentKey } from './agent-creator-key.js';
-import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON } from './agent-game-key.js';
+import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
 import { mintGameAgentKey } from './agent-game-key.js';
 import { mintAgentToken } from './agent-token.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { buildApp } from './app.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import { mintMcpSessionKey } from './mcp-session-key.js';
+import { pkceChallengeS256 } from './oauth-pkce.js';
 import { InMemoryStore } from './store.js';
 import { NoopTranslator } from './translate.js';
 
@@ -176,7 +177,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     expect((structured as { sessionKey: string }).sessionKey).toBeTruthy();
   });
 
-  it('refuses a slug the creator does not own', async () => {
+  it('refuses a slug the creator does not own without blaming the key', async () => {
     const store = new InMemoryStore();
     app = await createApp(store);
 
@@ -190,7 +191,97 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
 
     const { structured, isError } = await callStart(app, { slug: 'other-game' }, { authorization: `Bearer ${key}` });
     expect(isError).toBe(true);
-    expect((structured as { error: string }).error).toMatch(/rotated/i);
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+    expect((structured as { error: string }).error).not.toMatch(/rotated/i);
+  });
+
+  it('refuses a slug that does not exist with the same account-slug reason', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const key = minted.json().key as string;
+
+    const { structured, isError } = await callStart(
+      app,
+      { slug: 'no-such-game-anywhere' },
+      { authorization: `Bearer ${key}` },
+    );
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+  });
+
+  it('creator-key and OAuth Bearer paths refuse the same unowned slug with the same reason', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    await store.createSubmission(10, OTHER, 'Other Game');
+    await store.setSubmissionSlug(10, 'other-game');
+    await store.setRoundBuilder(10, 'self');
+    await store.recordJobTransition(10, { to: 'dispatched', at: new Date().toISOString(), by: 'system' });
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const creatorKey = minted.json().key as string;
+    const viaCreator = await callStart(app, { slug: 'other-game' }, { authorization: `Bearer ${creatorKey}` });
+
+    const register = await app.inject({
+      method: 'POST',
+      url: '/oauth/register',
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        redirect_uris: ['http://127.0.0.1/callback'],
+        client_name: 'Parity Agent',
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(register.statusCode).toBe(201);
+    const clientId = register.json().client_id as string;
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = pkceChallengeS256(verifier);
+    const approve = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: {
+        cookie: authHeaders().cookie,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: clientId,
+        redirect_uri: 'http://127.0.0.1/callback',
+        scope: 'mcp',
+        state: 'xyz',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        action: 'approve',
+      }).toString(),
+    });
+    expect(approve.statusCode).toBe(302);
+    const location = new URL(approve.headers.location as string);
+    const code = location.searchParams.get('code');
+    expect(code).toBeTruthy();
+    const tokenRes = await app.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        redirect_uri: 'http://127.0.0.1/callback',
+        client_id: clientId,
+        code_verifier: verifier,
+      }).toString(),
+    });
+    expect(tokenRes.statusCode).toBe(200);
+    const accessToken = tokenRes.json().access_token as string;
+
+    const viaOAuth = await callStart(app, { slug: 'other-game' }, { authorization: `Bearer ${accessToken}` });
+
+    expect(viaCreator.isError).toBe(true);
+    expect(viaOAuth.isError).toBe(true);
+    expect((viaCreator.structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+    expect((viaOAuth.structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+    expect((viaCreator.structured as { error: string }).error).toBe((viaOAuth.structured as { error: string }).error);
   });
 
   it('reuses no-open-round and platform-round refusals', async () => {

--- a/apps/api/src/creator-agent-key-routes.ts
+++ b/apps/api/src/creator-agent-key-routes.ts
@@ -32,6 +32,7 @@ function mintPayload(
   fingerprint: string;
   authorizationHeader: string;
   authorizationHeaderMasked: string;
+  revoked: false;
 } {
   const key = mintCreatorAgentKey(secret, { creatorUid: ownerUid, keyGeneration, now: nowMs });
   const claims = verifyCreatorAgentKey(key, secret);
@@ -42,6 +43,7 @@ function mintPayload(
     fingerprint: creatorAgentKeyFingerprint(key),
     authorizationHeader: `Authorization: Bearer ${key}`,
     authorizationHeaderMasked: maskCreatorAgentKeyHeader(key),
+    revoked: false,
   };
 }
 
@@ -51,19 +53,46 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
 
   /**
    * GET remints at the current generation (fresh exp) without rotating.
-   * When no record exists yet, ensures generation 1.
+   * When no record exists yet, ensures generation 1. When revoked, returns status
+   * only — does not resurrect a key (call POST to mint again).
    */
   app.get('/api/me/creator-agent-key', async (request, reply) => {
     const uid = request.user?.uid;
     if (!uid) return reply.status(401).send({ error: 'unauthorized' });
 
     const at = new Date(now()).toISOString();
-    const record = await store.ensureCreatorAgentKey(uid, at);
+    const existing = await store.getCreatorAgentKey(uid);
+    if (existing?.revokedAt) {
+      return reply.header('Cache-Control', 'no-store').send({
+        keyGeneration: existing.keyGeneration,
+        revoked: true,
+      });
+    }
+
+    const record = existing ?? (await store.ensureCreatorAgentKey(uid, at));
     const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, now());
     return reply.header('Cache-Control', 'no-store').send(payload);
   });
 
-  /** POST bumps keyGeneration — any agent still holding the old key is cut off. */
+  /**
+   * POST mints (first time or after revoke). Clears `revokedAt` without resetting
+   * generation, so a leaked gen-1 key cannot come back after revoke.
+   */
+  app.post(
+    '/api/me/creator-agent-key',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const uid = request.user?.uid;
+      if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+      const at = new Date(now()).toISOString();
+      const record = await store.reactivateCreatorAgentKey(uid, at);
+      const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, now());
+      return reply.header('Cache-Control', 'no-store').send(payload);
+    },
+  );
+
+  /** POST rotate bumps keyGeneration — any agent still holding the old key is cut off. */
   app.post(
     '/api/me/creator-agent-key/rotate',
     { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
@@ -82,7 +111,10 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
     },
   );
 
-  /** DELETE revokes the key entirely. A later GET starts again at generation 1. */
+  /**
+   * DELETE revokes by bumping generation and setting revokedAt. The doc is kept so
+   * generation never resets to 1 (a leaked gen-1 key must stay dead).
+   */
   app.delete(
     '/api/me/creator-agent-key',
     { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
@@ -90,7 +122,13 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
       const uid = request.user?.uid;
       if (!uid) return reply.status(401).send({ error: 'unauthorized' });
 
-      const revoked = await store.revokeCreatorAgentKey(uid);
+      const existing = await store.getCreatorAgentKey(uid);
+      if (!existing || existing.revokedAt) {
+        return reply.status(404).send({ error: 'not_found' });
+      }
+
+      const at = new Date(now()).toISOString();
+      const revoked = await store.revokeCreatorAgentKey(uid, at);
       if (!revoked) return reply.status(404).send({ error: 'not_found' });
       return reply.status(204).send();
     },

--- a/apps/api/src/creator-agent-key-routes.ts
+++ b/apps/api/src/creator-agent-key-routes.ts
@@ -1,0 +1,98 @@
+/**
+ * Studio routes for the creator-wide MCP opener key (BY-27a).
+ *
+ * Sits with OAuth grants under `/api/me/*` — both answer "what can reach my account".
+ * UI copy never uses the word "token".
+ */
+
+import type { FastifyInstance } from 'fastify';
+import {
+  creatorAgentKeyFingerprint,
+  maskCreatorAgentKeyHeader,
+  mintCreatorAgentKey,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
+import type { Store } from './store.js';
+
+export interface CreatorAgentKeyRoutesOptions {
+  store: Store;
+  submissionTokenSecret: string;
+  now?: () => number;
+}
+
+function mintPayload(
+  secret: string,
+  ownerUid: string,
+  keyGeneration: number,
+  nowMs: number,
+): {
+  key: string;
+  keyGeneration: number;
+  expiresAt: number;
+  fingerprint: string;
+  authorizationHeader: string;
+  authorizationHeaderMasked: string;
+} {
+  const key = mintCreatorAgentKey(secret, { creatorUid: ownerUid, keyGeneration, now: nowMs });
+  const claims = verifyCreatorAgentKey(key, secret);
+  return {
+    key,
+    keyGeneration: claims.keyGeneration,
+    expiresAt: claims.exp,
+    fingerprint: creatorAgentKeyFingerprint(key),
+    authorizationHeader: `Authorization: Bearer ${key}`,
+    authorizationHeaderMasked: maskCreatorAgentKeyHeader(key),
+  };
+}
+
+export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: CreatorAgentKeyRoutesOptions): void {
+  const { store, submissionTokenSecret } = options;
+  const now = options.now ?? Date.now;
+
+  /**
+   * GET remints at the current generation (fresh exp) without rotating.
+   * When no record exists yet, ensures generation 1.
+   */
+  app.get('/api/me/creator-agent-key', async (request, reply) => {
+    const uid = request.user?.uid;
+    if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+    const at = new Date(now()).toISOString();
+    const record = await store.ensureCreatorAgentKey(uid, at);
+    const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, now());
+    return reply.header('Cache-Control', 'no-store').send(payload);
+  });
+
+  /** POST bumps keyGeneration — any agent still holding the old key is cut off. */
+  app.post(
+    '/api/me/creator-agent-key/rotate',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const uid = request.user?.uid;
+      if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+      const at = new Date(now()).toISOString();
+      await store.ensureCreatorAgentKey(uid, at);
+      const rotated = await store.rotateCreatorAgentKey(uid, at);
+      if (!rotated) {
+        return reply.status(500).send({ error: 'could not rotate creator key' });
+      }
+      const payload = mintPayload(submissionTokenSecret, uid, rotated.keyGeneration, now());
+      return reply.header('Cache-Control', 'no-store').send({ ...payload, rotated: true });
+    },
+  );
+
+  /** DELETE revokes the key entirely. A later GET starts again at generation 1. */
+  app.delete(
+    '/api/me/creator-agent-key',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const uid = request.user?.uid;
+      if (!uid) return reply.status(401).send({ error: 'unauthorized' });
+
+      const revoked = await store.revokeCreatorAgentKey(uid);
+      if (!revoked) return reply.status(404).send({ error: 'not_found' });
+      return reply.status(204).send();
+    },
+  );
+}

--- a/apps/api/src/credential-scan.test.ts
+++ b/apps/api/src/credential-scan.test.ts
@@ -54,4 +54,13 @@ describe('findCredentialLikeStrings', () => {
     expect(findings.length).toBeGreaterThan(0);
     expect(JSON.stringify(findings)).not.toContain(secret);
   });
+
+  it('detects a creator-wide agent key (base64url of c1.…)', () => {
+    const secret = Buffer.from(`c1.u.${'x'.repeat(20)}.1.9999999999.${'ab'.repeat(32)}`, 'utf8').toString('base64url');
+    expect(secret.startsWith('YzEu')).toBe(true);
+    const bundle = `const key = "${secret}";`;
+    expect(findCredentialLikeStrings(bundle)).toEqual([
+      { kind: 'gamedev-creator-agent-key', index: bundle.indexOf(secret) },
+    ]);
+  });
 });

--- a/apps/api/src/credential-scan.ts
+++ b/apps/api/src/credential-scan.ts
@@ -14,6 +14,9 @@ const CREDENTIAL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
   { kind: 'gamedev-access-token', pattern: /\bgdpl_pat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
   { kind: 'gamedev-oauth-access', pattern: /\bgdpl_oat_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
   { kind: 'gamedev-oauth-refresh', pattern: /\bgdpl_ort_[0-9a-f]{16}_[A-Za-z0-9_-]{43}\b/g },
+  // Creator-wide MCP opener (BY-27a). Wire form is base64url of `c1.…`; "c1." is a
+  // complete 3-byte chunk so every such key's encoding starts with `YzEu`.
+  { kind: 'gamedev-creator-agent-key', pattern: /\bYzEu[A-Za-z0-9_-]{80,}\b/g },
   { kind: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g },
   { kind: 'aws-access-key-id', pattern: /\bAKIA[0-9A-Z]{16}\b/g },
   { kind: 'pem-private-key', pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/g },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -349,23 +349,25 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     let claims: AgentTokenClaims;
     let channelToken: string;
 
-    if (bearer) {
-      if (looksLikeAsAccessToken(bearer)) {
-        return toolErr(
-          'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
-        );
-      }
-      // Durable openers are start-only — never a write capability via Bearer.
-      if (looksLikeGameAgentKey(bearer)) {
-        return toolErr(
-          'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
-        );
-      }
-      if (looksLikeCreatorAgentKey(bearer)) {
-        return toolErr(
-          'this creator key only opens a session via start() — pass the sessionKey start returned for later tools',
-        );
-      }
+    // Paste-once MCP config leaves Authorization: Bearer <opener> on every request.
+    // When the tool also passes sessionKey, prefer that — openers never authorize writes.
+    const bearerIsOpener = Boolean(bearer) && (looksLikeGameAgentKey(bearer!) || looksLikeCreatorAgentKey(bearer!));
+
+    if (bearer && looksLikeAsAccessToken(bearer)) {
+      return toolErr(
+        'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
+      );
+    }
+
+    if (bearerIsOpener && !sessionKeyArg) {
+      return toolErr(
+        looksLikeCreatorAgentKey(bearer!)
+          ? 'this creator key only opens a session via start() — pass the sessionKey start returned for later tools'
+          : 'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+      );
+    }
+
+    if (bearer && !bearerIsOpener) {
       try {
         claims = verifyAgentToken(bearer, agentTokenSecret);
       } catch (error) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -8,8 +8,10 @@ import {
   NO_OPEN_ROUND_REASON,
   OPEN_ROUND_IN_PROGRESS_REASON,
   PLATFORM_ROUND_REASON,
+  SLUG_NOT_ON_ACCOUNT_REASON,
 } from './agent-game-key.js';
 import {
+  creatorOwnsSlug,
   findActiveRoundForSlug,
   resolveGameAgentKeyForOpenRound,
   resolveGameAgentKeyForStart,
@@ -576,6 +578,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           }
           if (!slugArg) {
             return toolErr('slug is required when using OAuth — pass the game slug for your open build round');
+          }
+
+          if (!(await creatorOwnsSlug(store, slugArg, asAccess.ownerUid))) {
+            noteInvalidStart(ctx.request);
+            return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
           }
 
           const active = await findActiveRoundForSlug(store, slugArg, asAccess.ownerUid);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
+import { resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
 import {
   looksLikeGameAgentKey,
   IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
@@ -351,10 +353,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
         );
       }
-      // Durable per-game openers are start-only — never a write capability via Bearer.
+      // Durable openers are start-only — never a write capability via Bearer.
       if (looksLikeGameAgentKey(bearer)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
+      if (looksLikeCreatorAgentKey(bearer)) {
+        return toolErr(
+          'this creator key only opens a session via start() — pass the sessionKey start returned for later tools',
         );
       }
       try {
@@ -370,6 +377,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       if (looksLikeGameAgentKey(sessionKeyArg)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+        );
+      }
+      if (looksLikeCreatorAgentKey(sessionKeyArg)) {
+        return toolErr(
+          'this creator key only opens a session via start() — pass the sessionKey start returned for later tools',
         );
       }
       let sessionClaims;
@@ -464,12 +476,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   > = {
     start: {
       description:
-        "Bind this MCP client to a build round using the key from the creator's Studio kickoff prompt, " +
-        'or sign in with OAuth and pass your game slug. ' +
-        'Accepts a durable per-game key (preferred), a legacy round-scoped key, or OAuth Bearer + slug. ' +
+        'Bind this MCP client to a build round using a creator key in Authorization: Bearer plus a game slug, ' +
+        'a durable per-game key, a legacy round-scoped key, or OAuth Bearer + slug. ' +
         'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
         '(the ordered start→done loop), an inbox policy, and what to relay if a later call is refused. ' +
-        'The game key itself is an opener only — never a write capability. OAuth access is identity only. ' +
+        'Creator and game keys are openers only — never a write capability. OAuth access is identity only. ' +
         'Does not treat Mcp-Session-Id as authority. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -478,13 +489,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           key: {
             type: 'string',
             description:
-              'Game key (or legacy round key) from the Studio kickoff prompt (the line "key: …"). ' +
-              'Optional when using OAuth Bearer + slug.',
+              'Per-game key (or legacy round key) from a Studio kickoff prompt. ' +
+              'Optional when using Authorization Bearer (creator key or OAuth) + slug.',
           },
           slug: {
             type: 'string',
             description:
-              'Game slug for your open self-build round. Required with OAuth Bearer; ignored with a game key.',
+              'Game slug for your open self-build round. Required with creator-key or OAuth Bearer; ignored with a game key.',
           },
         },
         required: [],
@@ -504,27 +515,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const slugArg = typeof args.slug === 'string' ? args.slug.trim() : '';
         const bearer = ctx.bearerToken;
 
-        if (!key && bearer && looksLikeAsAccessToken(bearer)) {
-          const asAccess = await verifyAsAccessToken(store, bearer, now());
-          if (!asAccess) {
-            noteInvalidStart(ctx.request);
-            return toolErr('invalid OAuth access — sign in again from your coding agent');
-          }
-          if (!slugArg) {
-            return toolErr('slug is required when using OAuth — pass the game slug for your open build round');
-          }
-
-          const active = await findActiveRoundForSlug(store, slugArg, asAccess.ownerUid);
-          if (!active) {
-            noteInvalidStart(ctx.request);
-            return toolErr(NO_OPEN_ROUND_REASON);
-          }
-          const builder = active.builder ?? 'platform';
-          if (builder !== 'self') {
-            noteInvalidStart(ctx.request);
-            return toolErr(PLATFORM_ROUND_REASON);
-          }
-
+        const bindActiveRound = (active: SubmissionRecord): ToolResult => {
           pruneTransportSessions(now());
           pruneInvalidStartBuckets(now());
           const sessionId = ctx.sessionId && transportSessions.has(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
@@ -561,8 +552,44 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           const base = toolOk(structured);
           return {
             ...base,
-            content: [...base.content, { type: 'text', text: SESSION_WORKFLOW_TEXT }],
+            content: [...base.content, { type: 'text' as const, text: SESSION_WORKFLOW_TEXT }],
           };
+        };
+
+        if (!key && bearer && looksLikeCreatorAgentKey(bearer)) {
+          if (!slugArg) {
+            return toolErr('slug is required when using a creator key — pass the game slug for your open build round');
+          }
+          const resolved = await resolveCreatorAgentKeyForStart(store, bearer, agentTokenSecret, slugArg, now());
+          if (!resolved.ok) {
+            noteInvalidStart(ctx.request);
+            return toolErr(resolved.reason);
+          }
+          return bindActiveRound(resolved.record);
+        }
+
+        if (!key && bearer && looksLikeAsAccessToken(bearer)) {
+          const asAccess = await verifyAsAccessToken(store, bearer, now());
+          if (!asAccess) {
+            noteInvalidStart(ctx.request);
+            return toolErr('invalid OAuth access — sign in again from your coding agent');
+          }
+          if (!slugArg) {
+            return toolErr('slug is required when using OAuth — pass the game slug for your open build round');
+          }
+
+          const active = await findActiveRoundForSlug(store, slugArg, asAccess.ownerUid);
+          if (!active) {
+            noteInvalidStart(ctx.request);
+            return toolErr(NO_OPEN_ROUND_REASON);
+          }
+          const builder = active.builder ?? 'platform';
+          if (builder !== 'self') {
+            noteInvalidStart(ctx.request);
+            return toolErr(PLATFORM_ROUND_REASON);
+          }
+
+          return bindActiveRound(active);
         }
 
         if (key && looksLikeAsAccessToken(key)) {
@@ -570,10 +597,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('OAuth access must be sent as Authorization Bearer, not as the key argument');
         }
 
+        if (key && looksLikeCreatorAgentKey(key)) {
+          noteInvalidStart(ctx.request);
+          return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
+        }
+
         if (!key) {
           noteInvalidStart(ctx.request);
           return toolErr(
-            "key is required — paste the key from the creator's Studio kickoff prompt, or use OAuth Bearer + slug",
+            'key is required — paste a game key, or use Authorization Bearer (creator key or OAuth) + slug',
           );
         }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1119,7 +1119,7 @@ export interface AccessTokenRecord {
  *
  * The HMAC opener itself is never stored — only the generation that revokes it.
  * Round close does not bump `keyGeneration`; only an explicit creator rotate does.
- * `allowAgentOpenRounds` is reserved for BY-24 (default off).
+ * `allowAgentOpenRounds` was the BY-24 opt-in; BY-27b ignores it (no migration).
  */
 export interface GameAgentKeyRecord {
   slug: string;
@@ -1127,10 +1127,26 @@ export interface GameAgentKeyRecord {
   keyGeneration: number;
   createdAt: string;
   updatedAt: string;
-  /** BY-24: when true, the creator's agent may call `open_round`. Default false. */
+  /**
+   * Legacy BY-24 opt-in. Ignored by `open_round` after BY-27b — existing documents may
+   * still carry the field; readers must not require it.
+   */
   allowAgentOpenRounds?: boolean;
   /** BY-24: admission lock while `open_round` is creating a job — cleared in finally. */
   agentOpenRoundPending?: boolean;
+}
+
+/**
+ * Durable creator-wide agent opener state (BY-27a), stored at `creatorAgentKeys/{uid}`.
+ *
+ * The HMAC opener itself is never stored — only the generation that revokes it.
+ * Bumped only by an explicit creator rotate/revoke; never on round close or publish.
+ */
+export interface CreatorAgentKeyRecord {
+  ownerUid: string;
+  keyGeneration: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /** OAuth dynamic or CIMD-registered MCP client (BY-18b). */
@@ -1760,6 +1776,23 @@ export interface Store {
   beginAgentOpenRound(slug: string, at: string): Promise<boolean>;
   /** BY-24: release the admission lock after `open_round` completes or aborts. */
   finishAgentOpenRound(slug: string, at: string): Promise<void>;
+  /** Creator-wide opener record, or null when the creator has never minted one. */
+  getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null>;
+  /**
+   * Ensures a creatorAgentKeys doc exists for ownerUid, creating generation 1 when
+   * absent. Remint (fresh exp) reuses the current generation.
+   */
+  ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord>;
+  /**
+   * Transactionally bumps `keyGeneration`. Returns the new record, or null when the
+   * creator has no key yet (caller should ensure first).
+   */
+  rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
+  /**
+   * Deletes the creatorAgentKeys doc (revoke). Returns false when nothing to delete.
+   * A subsequent ensure starts again at generation 1.
+   */
+  revokeCreatorAgentKey(ownerUid: string): Promise<boolean>;
   /** Persist a dynamically registered or CIMD-cached OAuth client. */
   createOAuthClient(record: OAuthClientRecord): Promise<void>;
   getOAuthClient(clientId: string): Promise<OAuthClientRecord | null>;
@@ -1933,6 +1966,7 @@ export class InMemoryStore implements Store {
   private accessTokens = new Map<string, AccessTokenRecord>();
   // slug -> durable per-game agent opener state (BY-23)
   private gameAgentKeys = new Map<string, GameAgentKeyRecord>();
+  private creatorAgentKeys = new Map<string, CreatorAgentKeyRecord>();
   private oauthClients = new Map<string, OAuthClientRecord>();
   private oauthGrants = new Map<string, OAuthGrantRecord>();
   private oauthAccessTokens = new Map<string, OAuthAccessTokenRecord>();
@@ -3146,6 +3180,40 @@ export class InMemoryStore implements Store {
     const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
     delete next.agentOpenRoundPending;
     this.gameAgentKeys.set(slug, next);
+  }
+
+  async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {
+    const record = this.creatorAgentKeys.get(ownerUid);
+    return record ? { ...record } : null;
+  }
+
+  async ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (existing) return { ...existing };
+    const created: CreatorAgentKeyRecord = {
+      ownerUid,
+      keyGeneration: 1,
+      createdAt: at,
+      updatedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, created);
+    return { ...created };
+  }
+
+  async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing) return null;
+    const next: CreatorAgentKeyRecord = {
+      ...existing,
+      keyGeneration: existing.keyGeneration + 1,
+      updatedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, next);
+    return { ...next };
+  }
+
+  async revokeCreatorAgentKey(ownerUid: string): Promise<boolean> {
+    return this.creatorAgentKeys.delete(ownerUid);
   }
 
   async createOAuthClient(record: OAuthClientRecord): Promise<void> {
@@ -5136,6 +5204,54 @@ export class FirestoreStore implements Store {
       delete next.agentOpenRoundPending;
       tx.set(docRef, next);
     });
+  }
+
+  async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {
+    const snap = await this.db.collection('creatorAgentKeys').doc(ownerUid).get();
+    if (!snap.exists) return null;
+    return snap.data() as CreatorAgentKeyRecord;
+  }
+
+  async ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (snap.exists) {
+        return snap.data() as CreatorAgentKeyRecord;
+      }
+      const created: CreatorAgentKeyRecord = {
+        ownerUid,
+        keyGeneration: 1,
+        createdAt: at,
+        updatedAt: at,
+      };
+      tx.create(docRef, created);
+      return created;
+    });
+  }
+
+  async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      const next: CreatorAgentKeyRecord = {
+        ...existing,
+        keyGeneration: existing.keyGeneration + 1,
+        updatedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
+    });
+  }
+
+  async revokeCreatorAgentKey(ownerUid: string): Promise<boolean> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    const snap = await docRef.get();
+    if (!snap.exists) return false;
+    await docRef.delete();
+    return true;
   }
 
   async touchAccessToken(tokenId: string, at: string): Promise<void> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1141,12 +1141,16 @@ export interface GameAgentKeyRecord {
  *
  * The HMAC opener itself is never stored — only the generation that revokes it.
  * Bumped only by an explicit creator rotate/revoke; never on round close or publish.
+ * Revoke must NOT delete the doc: deleting would let the next mint restart at
+ * generation 1 and resurrect a previously leaked gen-1 key until its exp.
  */
 export interface CreatorAgentKeyRecord {
   ownerUid: string;
   keyGeneration: number;
   createdAt: string;
   updatedAt: string;
+  /** Set by revoke; cleared on the next explicit mint. */
+  revokedAt?: string;
 }
 
 /** OAuth dynamic or CIMD-registered MCP client (BY-18b). */
@@ -1780,19 +1784,24 @@ export interface Store {
   getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null>;
   /**
    * Ensures a creatorAgentKeys doc exists for ownerUid, creating generation 1 when
-   * absent. Remint (fresh exp) reuses the current generation.
+   * absent. Does not clear `revokedAt` — mint after revoke is an explicit reactivate.
    */
   ensureCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord>;
   /**
-   * Transactionally bumps `keyGeneration`. Returns the new record, or null when the
-   * creator has no key yet (caller should ensure first).
+   * Clears `revokedAt` so a post-revoke mint can issue at the current (already bumped)
+   * generation. Creates generation 1 when absent. Does not bump `keyGeneration`.
+   */
+  reactivateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord>;
+  /**
+   * Transactionally bumps `keyGeneration` and clears `revokedAt`. Returns the new
+   * record, or null when the creator has no key yet (caller should ensure first).
    */
   rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
   /**
-   * Deletes the creatorAgentKeys doc (revoke). Returns false when nothing to delete.
-   * A subsequent ensure starts again at generation 1.
+   * Transactionally bumps `keyGeneration` and sets `revokedAt`. Returns the new
+   * record, or null when missing. Keeps the doc so generation never resets to 1.
    */
-  revokeCreatorAgentKey(ownerUid: string): Promise<boolean>;
+  revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
   /** Persist a dynamically registered or CIMD-cached OAuth client. */
   createOAuthClient(record: OAuthClientRecord): Promise<void>;
   getOAuthClient(clientId: string): Promise<OAuthClientRecord | null>;
@@ -3200,20 +3209,47 @@ export class InMemoryStore implements Store {
     return { ...created };
   }
 
+  async reactivateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing) {
+      return this.ensureCreatorAgentKey(ownerUid, at);
+    }
+    if (!existing.revokedAt) return { ...existing };
+    const cleared: CreatorAgentKeyRecord = {
+      ownerUid: existing.ownerUid,
+      keyGeneration: existing.keyGeneration,
+      createdAt: existing.createdAt,
+      updatedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, cleared);
+    return { ...cleared };
+  }
+
   async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
     const existing = this.creatorAgentKeys.get(ownerUid);
     if (!existing) return null;
     const next: CreatorAgentKeyRecord = {
-      ...existing,
+      ownerUid: existing.ownerUid,
       keyGeneration: existing.keyGeneration + 1,
+      createdAt: existing.createdAt,
       updatedAt: at,
     };
     this.creatorAgentKeys.set(ownerUid, next);
     return { ...next };
   }
 
-  async revokeCreatorAgentKey(ownerUid: string): Promise<boolean> {
-    return this.creatorAgentKeys.delete(ownerUid);
+  async revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing) return null;
+    const next: CreatorAgentKeyRecord = {
+      ownerUid: existing.ownerUid,
+      keyGeneration: existing.keyGeneration + 1,
+      createdAt: existing.createdAt,
+      updatedAt: at,
+      revokedAt: at,
+    };
+    this.creatorAgentKeys.set(ownerUid, next);
+    return { ...next };
   }
 
   async createOAuthClient(record: OAuthClientRecord): Promise<void> {
@@ -5230,6 +5266,33 @@ export class FirestoreStore implements Store {
     });
   }
 
+  async reactivateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) {
+        const created: CreatorAgentKeyRecord = {
+          ownerUid,
+          keyGeneration: 1,
+          createdAt: at,
+          updatedAt: at,
+        };
+        tx.create(docRef, created);
+        return created;
+      }
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      if (!existing.revokedAt) return existing;
+      const cleared: CreatorAgentKeyRecord = {
+        ownerUid: existing.ownerUid,
+        keyGeneration: existing.keyGeneration,
+        createdAt: existing.createdAt,
+        updatedAt: at,
+      };
+      tx.set(docRef, cleared);
+      return cleared;
+    });
+  }
+
   async rotateCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
     const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
     return this.db.runTransaction(async (tx) => {
@@ -5237,8 +5300,9 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return null;
       const existing = snap.data() as CreatorAgentKeyRecord;
       const next: CreatorAgentKeyRecord = {
-        ...existing,
+        ownerUid: existing.ownerUid,
         keyGeneration: existing.keyGeneration + 1,
+        createdAt: existing.createdAt,
         updatedAt: at,
       };
       tx.set(docRef, next);
@@ -5246,12 +5310,22 @@ export class FirestoreStore implements Store {
     });
   }
 
-  async revokeCreatorAgentKey(ownerUid: string): Promise<boolean> {
+  async revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
     const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
-    const snap = await docRef.get();
-    if (!snap.exists) return false;
-    await docRef.delete();
-    return true;
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      const next: CreatorAgentKeyRecord = {
+        ownerUid: existing.ownerUid,
+        keyGeneration: existing.keyGeneration + 1,
+        createdAt: existing.createdAt,
+        updatedAt: at,
+        revokedAt: at,
+      };
+      tx.set(docRef, next);
+      return next;
+    });
   }
 
   async touchAccessToken(tokenId: string, at: string): Promise<void> {

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -21,6 +21,7 @@ import {
   type StudioShelfGame,
 } from './studioShelf.js';
 import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
+import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
@@ -1030,6 +1031,7 @@ function DetailsPanel({
 
       {game.slug && game.lastKnownStatus !== 'abandoned' ? <StudioAgentKeyPanel token={game.token} /> : null}
 
+      <StudioCreatorAgentKeyPanel />
       <StudioOAuthClientsPanel />
 
       {/* Only once there is play to report on. Before a game is live every one of these

--- a/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
@@ -2,9 +2,17 @@
 
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import './i18n/index.js';
 import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
+import { recordStudioStep } from './visitTelemetry.js';
+
+vi.mock('./visitTelemetry', async () => {
+  const actual = await vi.importActual<typeof import('./visitTelemetry')>('./visitTelemetry');
+  return { ...actual, recordStudioStep: vi.fn() };
+});
+
+const mockedRecordStudioStep = vi.mocked(recordStudioStep);
 
 const FULL_KEY = 'YzEu' + 'a'.repeat(100);
 
@@ -16,6 +24,14 @@ async function flush() {
 describe('StudioCreatorAgentKeyPanel', () => {
   let container: HTMLDivElement;
   let root: Root;
+
+  beforeEach(() => {
+    mockedRecordStudioStep.mockClear();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
 
   afterEach(() => {
     act(() => {
@@ -59,5 +75,15 @@ describe('StudioCreatorAgentKeyPanel', () => {
     expect(container.querySelector('[data-testid="creator-key-masked"]')?.textContent).toBe(
       'Authorization: Bearer ····9a10e',
     );
+
+    await act(async () => {
+      container.querySelectorAll('button').forEach((button) => {
+        if (button.textContent?.includes('Copy header') || button.textContent?.includes('Kopiuj')) {
+          button.click();
+        }
+      });
+      await flush();
+    });
+    expect(mockedRecordStudioStep).toHaveBeenCalledWith('connect_copied', 'self', 'header');
   });
 });

--- a/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import './i18n/index.js';
+import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
+
+const FULL_KEY = 'YzEu' + 'a'.repeat(100);
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('StudioCreatorAgentKeyPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a masked header and never puts the full key in the markup', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          key: FULL_KEY,
+          keyGeneration: 1,
+          expiresAt: Math.floor(Date.now() / 1000) + 86400,
+          fingerprint: '9a10e',
+          authorizationHeader: `Authorization: Bearer ${FULL_KEY}`,
+          authorizationHeaderMasked: 'Authorization: Bearer ····9a10e',
+        }),
+      })),
+    );
+
+    await act(async () => {
+      root.render(createElement(StudioCreatorAgentKeyPanel));
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    const markup = container.innerHTML;
+    expect(markup).toContain('Authorization: Bearer ····9a10e');
+    expect(markup).not.toContain(FULL_KEY);
+    expect(markup).not.toContain(`Bearer ${FULL_KEY}`);
+    expect(container.querySelector('[data-testid="creator-key-masked"]')?.textContent).toBe(
+      'Authorization: Bearer ····9a10e',
+    );
+  });
+});

--- a/apps/web/src/StudioCreatorAgentKeyPanel.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.tsx
@@ -2,11 +2,14 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   getCreatorAgentKey,
+  mintCreatorAgentKey,
   revokeCreatorAgentKey,
   rotateCreatorAgentKey,
   type CreatorAgentKeyPayload,
+  type CreatorAgentKeyStatus,
 } from './connectApi.js';
 import { PixelIcon } from './PixelIcon.js';
+import { recordStudioStep } from './visitTelemetry.js';
 
 /**
  * Creator-wide MCP opener controls (BY-27a). Sits with OAuth grants — both answer
@@ -21,32 +24,50 @@ export function StudioCreatorAgentKeyPanel() {
   const [fingerprint, setFingerprint] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [keyGeneration, setKeyGeneration] = useState<number | null>(null);
+  const [revoked, setRevoked] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [rotateArmed, setRotateArmed] = useState(false);
   const [revokeArmed, setRevokeArmed] = useState(false);
-  const [busy, setBusy] = useState<'rotate' | 'revoke' | null>(null);
+  const [busy, setBusy] = useState<'mint' | 'rotate' | 'revoke' | null>(null);
 
-  const applyPayload = (payload: CreatorAgentKeyPayload) => {
+  const applyPayload = useCallback((payload: CreatorAgentKeyPayload) => {
     keyRef.current = payload.key;
     setMaskedHeader(payload.authorizationHeaderMasked);
     setFingerprint(payload.fingerprint);
     setExpiresAt(payload.expiresAt);
     setKeyGeneration(payload.keyGeneration);
-  };
+    setRevoked(false);
+  }, []);
+
+  const applyStatus = useCallback(
+    (status: CreatorAgentKeyStatus) => {
+      if (status.revoked) {
+        keyRef.current = null;
+        setMaskedHeader(null);
+        setFingerprint(null);
+        setExpiresAt(null);
+        setKeyGeneration(status.keyGeneration);
+        setRevoked(true);
+        return;
+      }
+      applyPayload(status);
+    },
+    [applyPayload],
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      applyPayload(await getCreatorAgentKey());
+      applyStatus(await getCreatorAgentKey());
     } catch {
       setError(t('creatorKey.loadError'));
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [applyStatus, t]);
 
   useEffect(() => {
     void load();
@@ -68,6 +89,19 @@ export function StudioCreatorAgentKeyPanel() {
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
       // Masked line stays on screen; creator can mint again if copy fails.
+    }
+    recordStudioStep('connect_copied', 'self', 'header');
+  };
+
+  const handleMint = async () => {
+    setBusy('mint');
+    setError(null);
+    try {
+      applyPayload(await mintCreatorAgentKey());
+    } catch {
+      setError(t('creatorKey.mintError'));
+    } finally {
+      setBusy(null);
     }
   };
 
@@ -93,15 +127,17 @@ export function StudioCreatorAgentKeyPanel() {
       setMaskedHeader(null);
       setFingerprint(null);
       setExpiresAt(null);
-      setKeyGeneration(null);
+      setKeyGeneration((prev) => (prev == null ? 1 : prev + 1));
+      setRevoked(true);
       setRevokeArmed(false);
-      applyPayload(await getCreatorAgentKey());
     } catch {
       setError(t('creatorKey.revokeError'));
     } finally {
       setBusy(null);
     }
   };
+
+  const hasActiveKey = Boolean(maskedHeader) && !revoked;
 
   return (
     <section className="studio-oauth-clients" aria-labelledby={`${baseId}-title`}>
@@ -113,7 +149,16 @@ export function StudioCreatorAgentKeyPanel() {
       {loading ? <p className="studio-connect-state">{t('creatorKey.loading')}</p> : null}
       {error ? <p className="error">{error}</p> : null}
 
-      {!loading && maskedHeader ? (
+      {!loading && revoked ? (
+        <div className="studio-connect-actions">
+          <p className="studio-connect-state">{t('creatorKey.revoked')}</p>
+          <button type="button" className="button" disabled={busy === 'mint'} onClick={() => void handleMint()}>
+            {busy === 'mint' ? t('creatorKey.minting') : t('creatorKey.mint')}
+          </button>
+        </div>
+      ) : null}
+
+      {!loading && hasActiveKey ? (
         <>
           <pre className="studio-connect-snippet" tabIndex={0} data-testid="creator-key-masked">
             {maskedHeader}

--- a/apps/web/src/StudioCreatorAgentKeyPanel.tsx
+++ b/apps/web/src/StudioCreatorAgentKeyPanel.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  getCreatorAgentKey,
+  revokeCreatorAgentKey,
+  rotateCreatorAgentKey,
+  type CreatorAgentKeyPayload,
+} from './connectApi.js';
+import { PixelIcon } from './PixelIcon.js';
+
+/**
+ * Creator-wide MCP opener controls (BY-27a). Sits with OAuth grants — both answer
+ * "what can reach my account". The full key is held in memory for Copy and never
+ * rendered into the DOM (BY-27b leak hygiene).
+ */
+export function StudioCreatorAgentKeyPanel() {
+  const { t, i18n } = useTranslation();
+  const baseId = useId();
+  const keyRef = useRef<string | null>(null);
+  const [maskedHeader, setMaskedHeader] = useState<string | null>(null);
+  const [fingerprint, setFingerprint] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [keyGeneration, setKeyGeneration] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [rotateArmed, setRotateArmed] = useState(false);
+  const [revokeArmed, setRevokeArmed] = useState(false);
+  const [busy, setBusy] = useState<'rotate' | 'revoke' | null>(null);
+
+  const applyPayload = (payload: CreatorAgentKeyPayload) => {
+    keyRef.current = payload.key;
+    setMaskedHeader(payload.authorizationHeaderMasked);
+    setFingerprint(payload.fingerprint);
+    setExpiresAt(payload.expiresAt);
+    setKeyGeneration(payload.keyGeneration);
+  };
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      applyPayload(await getCreatorAgentKey());
+    } catch {
+      setError(t('creatorKey.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const expiresLabel =
+    expiresAt != null
+      ? new Intl.DateTimeFormat(i18n.language, { dateStyle: 'medium', timeStyle: 'short' }).format(
+          new Date(expiresAt * 1000),
+        )
+      : '';
+
+  const copyHeader = async () => {
+    const key = keyRef.current;
+    if (!key) return;
+    try {
+      await navigator.clipboard.writeText(`Authorization: Bearer ${key}`);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Masked line stays on screen; creator can mint again if copy fails.
+    }
+  };
+
+  const handleRotate = async () => {
+    setBusy('rotate');
+    setError(null);
+    try {
+      applyPayload(await rotateCreatorAgentKey());
+      setRotateArmed(false);
+    } catch {
+      setError(t('creatorKey.rotateError'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleRevoke = async () => {
+    setBusy('revoke');
+    setError(null);
+    try {
+      await revokeCreatorAgentKey();
+      keyRef.current = null;
+      setMaskedHeader(null);
+      setFingerprint(null);
+      setExpiresAt(null);
+      setKeyGeneration(null);
+      setRevokeArmed(false);
+      applyPayload(await getCreatorAgentKey());
+    } catch {
+      setError(t('creatorKey.revokeError'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <section className="studio-oauth-clients" aria-labelledby={`${baseId}-title`}>
+      <h3 id={`${baseId}-title`} className="studio-agent-key-title">
+        {t('creatorKey.title')}
+      </h3>
+      <p className="studio-share-hint">{t('creatorKey.hint')}</p>
+
+      {loading ? <p className="studio-connect-state">{t('creatorKey.loading')}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      {!loading && maskedHeader ? (
+        <>
+          <pre className="studio-connect-snippet" tabIndex={0} data-testid="creator-key-masked">
+            {maskedHeader}
+          </pre>
+          <p className="studio-connect-expiry">
+            {t('creatorKey.meta', {
+              fingerprint: fingerprint ?? '',
+              when: expiresLabel,
+              generation: keyGeneration ?? 1,
+            })}
+          </p>
+          <div className="studio-connect-actions">
+            <button type="button" className="status-share-copy" onClick={() => void copyHeader()}>
+              <PixelIcon name={copied ? 'check' : 'sparkle'} size={12} />{' '}
+              {copied ? t('creatorKey.copied') : t('creatorKey.copyHeader')}
+            </button>
+
+            {!rotateArmed ? (
+              <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                {t('creatorKey.rotate.start')}
+              </button>
+            ) : (
+              <span className="studio-connect-rotate-confirm">
+                <span>{t('creatorKey.rotate.confirm')}</span>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={busy !== null}
+                  onClick={() => void handleRotate()}
+                >
+                  {busy === 'rotate' ? t('creatorKey.rotate.sending') : t('creatorKey.rotate.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={busy !== null}
+                  onClick={() => setRotateArmed(false)}
+                >
+                  {t('creatorKey.rotate.no')}
+                </button>
+              </span>
+            )}
+
+            {!revokeArmed ? (
+              <button type="button" className="studio-connect-skip" onClick={() => setRevokeArmed(true)}>
+                {t('creatorKey.revoke.start')}
+              </button>
+            ) : (
+              <span className="studio-connect-rotate-confirm">
+                <span>{t('creatorKey.revoke.confirm')}</span>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={busy !== null}
+                  onClick={() => void handleRevoke()}
+                >
+                  {busy === 'revoke' ? t('creatorKey.revoke.sending') : t('creatorKey.revoke.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={busy !== null}
+                  onClick={() => setRevokeArmed(false)}
+                >
+                  {t('creatorKey.revoke.no')}
+                </button>
+              </span>
+            )}
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -142,3 +142,46 @@ export async function revokeOAuthGrant(grantId: string): Promise<void> {
     await throwResponseError(response);
   }
 }
+
+export type CreatorAgentKeyPayload = {
+  /** Full key — hold in memory for Copy; never render into the DOM. */
+  key: string;
+  keyGeneration: number;
+  expiresAt: number;
+  fingerprint: string;
+  authorizationHeader: string;
+  authorizationHeaderMasked: string;
+  rotated?: boolean;
+};
+
+/** Mint or remint the creator-wide MCP opener (BY-27a). Fresh exp; no rotate. */
+export async function getCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, { credentials: 'include' });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyPayload;
+}
+
+/** Bump keyGeneration — agents holding the old key are cut off. */
+export async function rotateCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key/rotate`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyPayload;
+}
+
+/** Revoke the creator-wide key. A later mint starts at generation 1. */
+export async function revokeCreatorAgentKey(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!response.ok && response.status !== 204) {
+    await throwResponseError(response);
+  }
+}

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -152,11 +152,32 @@ export type CreatorAgentKeyPayload = {
   authorizationHeader: string;
   authorizationHeaderMasked: string;
   rotated?: boolean;
+  revoked?: false;
 };
 
-/** Mint or remint the creator-wide MCP opener (BY-27a). Fresh exp; no rotate. */
-export async function getCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+/** Status when the key is revoked — no secret; mint again explicitly. */
+export type CreatorAgentKeyRevokedStatus = {
+  keyGeneration: number;
+  revoked: true;
+};
+
+export type CreatorAgentKeyStatus = CreatorAgentKeyPayload | CreatorAgentKeyRevokedStatus;
+
+/** Current creator-wide MCP opener (BY-27a). Remints at current gen, or reports revoked. */
+export async function getCreatorAgentKey(): Promise<CreatorAgentKeyStatus> {
   const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, { credentials: 'include' });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return (await response.json()) as CreatorAgentKeyStatus;
+}
+
+/** Mint after revoke (or first time). Does not reset generation. */
+export async function mintCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
+  const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, {
+    method: 'POST',
+    credentials: 'include',
+  });
   if (!response.ok) {
     await throwResponseError(response);
   }
@@ -175,7 +196,7 @@ export async function rotateCreatorAgentKey(): Promise<CreatorAgentKeyPayload> {
   return (await response.json()) as CreatorAgentKeyPayload;
 }
 
-/** Revoke the creator-wide key. A later mint starts at generation 1. */
+/** Revoke the creator-wide key. Generation is preserved; remint needs an explicit mint. */
 export async function revokeCreatorAgentKey(): Promise<void> {
   const response = await fetch(`${API_BASE}/api/me/creator-agent-key`, {
     method: 'DELETE',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -925,6 +925,32 @@
     "revoke": "Disconnect",
     "revoking": "Disconnecting…"
   },
+  "creatorKey": {
+    "title": "Coding-agent key",
+    "hint": "Paste this header once into your agent's MCP server settings. It opens sessions on any of your games — rotating stops every agent still using the old key.",
+    "loading": "Loading your coding-agent key…",
+    "loadError": "We couldn't load your coding-agent key right now.",
+    "copyHeader": "Copy header",
+    "copied": "Copied",
+    "meta": "Ends in {{fingerprint}} · generation {{generation}} · expires {{when}}",
+    "rotate": {
+      "start": "Rotate key",
+      "confirm": "Rotating stops any agent still using the old key. Continue?",
+      "yes": "Rotate",
+      "no": "Cancel",
+      "sending": "Rotating…",
+      "error": "We couldn't rotate the key right now. Try again in a moment."
+    },
+    "rotateError": "We couldn't rotate the key right now. Try again in a moment.",
+    "revoke": {
+      "start": "Revoke key",
+      "confirm": "Revoking stops every agent using this key. Continue?",
+      "yes": "Revoke",
+      "no": "Cancel",
+      "sending": "Revoking…"
+    },
+    "revokeError": "We couldn't revoke the key right now. Try again in a moment."
+  },
   "remix": {
     "title": "Remix",
     "close": "Close",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -933,13 +933,16 @@
     "copyHeader": "Copy header",
     "copied": "Copied",
     "meta": "Ends in {{fingerprint}} · generation {{generation}} · expires {{when}}",
+    "revoked": "Your coding-agent key was revoked. Create a new one when you are ready to reconnect.",
+    "mint": "Create key",
+    "minting": "Creating…",
+    "mintError": "We couldn't create a key right now. Try again in a moment.",
     "rotate": {
       "start": "Rotate key",
       "confirm": "Rotating stops any agent still using the old key. Continue?",
       "yes": "Rotate",
       "no": "Cancel",
-      "sending": "Rotating…",
-      "error": "We couldn't rotate the key right now. Try again in a moment."
+      "sending": "Rotating…"
     },
     "rotateError": "We couldn't rotate the key right now. Try again in a moment.",
     "revoke": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -937,13 +937,16 @@
     "copyHeader": "Kopiuj nagłówek",
     "copied": "Skopiowano",
     "meta": "Końcówka {{fingerprint}} · generacja {{generation}} · wygasa {{when}}",
+    "revoked": "Klucz agenta został unieważniony. Utwórz nowy, gdy będziesz gotów połączyć się ponownie.",
+    "mint": "Utwórz klucz",
+    "minting": "Tworzenie…",
+    "mintError": "Nie udało się utworzyć klucza. Spróbuj za chwilę.",
     "rotate": {
       "start": "Rotuj klucz",
       "confirm": "Rotacja zatrzymuje każdy agent wciąż używający starego klucza. Kontynuować?",
       "yes": "Rotuj",
       "no": "Anuluj",
-      "sending": "Rotowanie…",
-      "error": "Nie udało się obrócić klucza. Spróbuj za chwilę."
+      "sending": "Rotowanie…"
     },
     "rotateError": "Nie udało się obrócić klucza. Spróbuj za chwilę.",
     "revoke": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -929,6 +929,32 @@
     "revoke": "Odłącz",
     "revoking": "Odłączanie…"
   },
+  "creatorKey": {
+    "title": "Klucz agenta kodującego",
+    "hint": "Wklej ten nagłówek raz w ustawieniach serwera MCP swojego agenta. Otwiera sesje na każdej z Twoich gier — rotacja zatrzymuje każdy agent wciąż używający starego klucza.",
+    "loading": "Wczytywanie klucza agenta…",
+    "loadError": "Nie udało się wczytać klucza agenta.",
+    "copyHeader": "Kopiuj nagłówek",
+    "copied": "Skopiowano",
+    "meta": "Końcówka {{fingerprint}} · generacja {{generation}} · wygasa {{when}}",
+    "rotate": {
+      "start": "Rotuj klucz",
+      "confirm": "Rotacja zatrzymuje każdy agent wciąż używający starego klucza. Kontynuować?",
+      "yes": "Rotuj",
+      "no": "Anuluj",
+      "sending": "Rotowanie…",
+      "error": "Nie udało się obrócić klucza. Spróbuj za chwilę."
+    },
+    "rotateError": "Nie udało się obrócić klucza. Spróbuj za chwilę.",
+    "revoke": {
+      "start": "Unieważnij klucz",
+      "confirm": "Unieważnienie zatrzymuje każdy agent używający tego klucza. Kontynuować?",
+      "yes": "Unieważnij",
+      "no": "Anuluj",
+      "sending": "Unieważnianie…"
+    },
+    "revokeError": "Nie udało się unieważnić klucza. Spróbuj za chwilę."
+  },
   "remix": {
     "title": "Remiks",
     "close": "Zamknij",

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -132,10 +132,12 @@ export type StudioStep = 'builder_chosen' | 'connect_copied' | 'agent_signaled' 
 
 /**
  * Closed detail for studio steps that need one. `install` / `kickoff` are connect-card
- * copies; `green` / `red` / `kit_outdated` are gate verdicts. Absent on steps that
- * need none (builder choice, first agent signal).
+ * copies; `header` is the creator-wide MCP Authorization header (BY-27a);
+ * `green` / `red` / `kit_outdated` are gate verdicts. Absent on steps that need none
+ * (builder choice, first agent signal).
  */
-export type StudioStepDetail = 'install' | 'kickoff' | 'green' | 'red' | 'kit_outdated' | 'creator' | 'agent';
+export type StudioStepDetail =
+  'install' | 'kickoff' | 'header' | 'green' | 'red' | 'kit_outdated' | 'creator' | 'agent';
 
 /**
  * The content-editor funnel (EditorKit): did a creator who *can* edit actually


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a durable **creator-wide** MCP opener key so a creator pastes one `Authorization: Bearer` value once in MCP client config and starts rounds with only a game slug. Reuses the BY-18b OAuth `start` path after uid resolution — no parallel session/write path.

### What landed
- New credential shape: HMAC over `(agent-creator-v1, creatorUid, keyGeneration, exp)`, wire prefix `c1.` (distinct from per-game `g1.`)
- Store: `creatorAgentKeys/{uid}` with `keyGeneration` bumped only on explicit rotate/revoke
- MCP `start` accepts Bearer creator key + `slug`, then the same round-binding → sessionKey path as OAuth
- Opener-only: rejected on both arms of the shared auth helper wherever a sessionKey is required
- Studio mint / rotate / revoke panel next to OAuth grants (EN + PL; never says “token”)
- Credential-scan registration for assembled-game refusal; TTL via `CREATOR_AGENT_KEY_TTL_DAYS` (default 90)
- Legacy round keys and durable per-game keys unchanged

### Review follow-ups
- **Unowned / missing slug** → `SLUG_NOT_ON_ACCOUNT_REASON` on both Bearer identity paths (creator key and OAuth), via `creatorOwnsSlug` before `findActiveRoundForSlug`
- **sessionKey over opener Bearer:** paste-once MCP headers no longer shadow the sessionKey on write tools
- **Revoke tombstone:** bumps generation + `revokedAt` (never deletes / resets to gen 1); Studio stays revoked until explicit mint
- **`connect_copied`** emitted on Copy header; unused `creatorKey.rotate.error` i18n removed

### Threat model (T4)
A leaked creator key reaches **every game that creator owns**, until rotated or expired — wider than the per-game key it replaces. Compensating controls: opener-only, per-round delivery cap, the gate judging every delivery, the platform building the bundle (D7), TTL, one-click revoke. Config is not a vault — BY-12 observed Codex and mcp-remote storing credentials as plaintext JSON under `$HOME`. Better than a prompt, not safe.

Ops companion: https://github.com/gamedevpl/www.gamedev.pl-ops/pull/44

### Out of scope
Removing either existing key shape, OAuth changes, kickoff-prompt rewrite (BY-27b), marketplace listings.

### Test plan
- [x] `npm run lint` / type-check / api + web tests green
- [x] Unowned/missing slug → `SLUG_NOT_ON_ACCOUNT_REASON` (not rotated); path parity
- [x] sessionKey + pasted creator Bearer allows write tools
- [x] revoke does not resurrect gen-1; remint stays at advanced generation
- [x] opener-only without sessionKey; legacy round key + per-game key still work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4e5063-12f7-4e30-824d-d451ac26e577?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4e5063-12f7-4e30-824d-d451ac26e577&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

