### PR TITLE
Mark how-to-play plan phases 2–5 done

### DIFF
--- a/docs/how-to-play-plan.md
+++ b/docs/how-to-play-plan.md
@@ -10,15 +10,16 @@
 
 Richer content lives in the game's `.legend-keys` markup — already scraped by the player
 bridge, already localized, **zero GameKit bytes**. Do not put goal/scoring into
-`controlsManifest()` (input facts only; kit budget is tight).
+`controlsManifest()` (input facts only; kit budget is tight). Legend CSS lives in the
+games-repo `shared/game-shell.css` (not copied per game).
 
 Reserved `dt` labels (English canonical + Polish twin):
 
-| Role    | `data-i18n-en` | `data-i18n-pl` | Required?                              |
-| ------- | -------------- | -------------- | -------------------------------------- |
-| Goal    | `Goal`         | `Cel`          | **Yes** once a game has `.legend-keys` |
-| Scoring | `Scoring`      | `Punkty`       | Optional                               |
-| Mode    | `Mode: …`      | `Tryb: …`      | Optional, repeatable                   |
+| Role    | `data-i18n-en` | `data-i18n-pl` | Required?             |
+| ------- | -------------- | -------------- | --------------------- |
+| Goal    | `Goal`         | `Cel`          | **Yes** on every game |
+| Scoring | `Scoring`      | `Punkty`       | Optional              |
+| Mode    | `Mode: …`      | `Tryb: …`      | Optional, repeatable  |
 
 Key rows stay as today (`← →` → Move — only keys the game actually binds). SPEC `controls:`
 remains the short English catalog / LLM string — keep it in sync with the legend, do not
@@ -32,17 +33,14 @@ as fake keys. No slug on `how_to_play_opened`; streams stay unjoinable.
 
 ## Rollout
 
-| Phase                | What                                                                                                                                                                                                                                                                                 | Seal                                     |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| **0 — Convention**   | This doc; skill + copilot rule in games repo                                                                                                                                                                                                                                         | Agents know the shape                    |
-| **1 — Soft seal**    | Validate Check 32: _if_ `.legend-keys` exists, Goal + i18n required                                                                                                                                                                                                                  | Pilots cannot ship a legend without Goal |
-| **2 — Templates**    | Land / extend [games#172](https://github.com/gamedevpl/www.gamedev.pl-games/pull/172) so `npm run create` scaffolds legend + Goal                                                                                                                                                    | New catalog games start rich             |
-| **3 — Catalog**      | Agent batch: add `.legend-keys` + Goal (+ Scoring where natural) to existing games                                                                                                                                                                                                   | Coverage grows                           |
-| **4 — Hard seal**    | Check 32 requires `.legend-keys` (and thus Goal) on every published game                                                                                                                                                                                                             | Missing how-to-play fails the gate       |
-| **5 — Creator path** | Keep games-repo `npm run create` / pack-kit templates and the agent contract (skills, game-builder) emitting `.legend-keys` + Goal — that is the production path for creator specs. Do **not** treat public-repo `packages/game-generator` (mock / local preview only) as this seal. | Creator deliveries match catalog         |
-
-Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fails CI for
-~90 games at once.
+| Phase                | What                                                                                                                                 | Status                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| **0 — Convention**   | This doc; skill + copilot rule in games repo                                                                                         | ✅                    |
+| **1 — Soft seal**    | Validate Check 32: _if_ `.legend-keys` exists, Goal + i18n required                                                                  | ✅ games #398         |
+| **2 — Templates**    | `npm run create` scaffolds legend + Goal ([games#421](https://github.com/gamedevpl/www.gamedev.pl-games/pull/421), forked from #172) | ✅                    |
+| **3 — Catalog**      | `npm run howto:migrate` — Goal from `#game-desc`, rows from `.hint`; media hashes refreshed                                          | ✅ companion games PR |
+| **4 — Hard seal**    | Check 32 requires `.legend-keys` (and thus Goal) on every published game                                                             | ✅ companion games PR |
+| **5 — Creator path** | Templates + pack-kit + `game-builder` / §12a emit and require the same markup                                                        | ✅ companion games PR |
 
 ## Out of scope
 
@@ -50,6 +48,7 @@ Phase 4 waits until Phase 3 is near-complete — flipping the hard seal early fa
 - Kit protocol changes for prose
 - Per-game open-rate joins (privacy)
 - Wiring Goal into `packages/game-generator` mock templates (dev preview only; not production)
+- Hand-polishing every migrated key row (agents can tighten Scoring/Mode later)
 
 ## Done when
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `docs/how-to-play-plan.md` after the games-repo catalog migrate / hard seal / creator-path work.

Companion: https://github.com/gamedevpl/www.gamedev.pl-games/pull/423

Phases 0–5 marked done; notes shared legend CSS and that key-row polish (Scoring/Mode) can continue opportunistically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6c8a180-8993-4412-bff7-f0f7762545eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6c8a180-8993-4412-bff7-f0f7762545eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

