### PR TITLE
byoca(BY-27b): keyless connect card and open_round without opt-in

### DIFF
--- a/apps/api/src/agent-creator-key-resolve.test.ts
+++ b/apps/api/src/agent-creator-key-resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mintCreatorAgentKey } from './agent-creator-key.js';
-import { resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
+import { resolveCreatorAgentKeyForOpenRound, resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
 import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
 import { InMemoryStore } from './store.js';
 
@@ -84,5 +84,30 @@ describe('resolveCreatorAgentKeyForStart (BY-27a)', () => {
 
     const platform = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
     expect(platform).toEqual({ ok: false, reason: PLATFORM_ROUND_REASON });
+  });
+});
+
+describe('resolveCreatorAgentKeyForOpenRound (BY-27b)', () => {
+  it('refuses an unowned slug with the same account-slug reason as start', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 1, other, slug);
+    await store.setSubmissionPublishedAt(1, '2026-07-01T00:00:00.000Z');
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const forStart = await resolveCreatorAgentKeyForStart(store, key, secret, slug);
+    const forOpen = await resolveCreatorAgentKeyForOpenRound(store, key, secret, slug);
+    expect(forStart).toEqual({ ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON });
+    expect(forOpen).toEqual({ ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON });
+    expect(forOpen.ok === false && forOpen.reason).not.toMatch(/rotated/i);
+  });
+
+  it('refuses a missing slug without blaming the key', async () => {
+    const store = new InMemoryStore();
+    await store.ensureCreatorAgentKey(owner, new Date().toISOString());
+    const key = mintCreatorAgentKey(secret, { creatorUid: owner, keyGeneration: 1 });
+
+    const result = await resolveCreatorAgentKeyForOpenRound(store, key, secret, 'does-not-exist');
+    expect(result).toEqual({ ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON });
   });
 });

--- a/apps/api/src/agent-creator-key-resolve.ts
+++ b/apps/api/src/agent-creator-key-resolve.ts
@@ -1,9 +1,8 @@
 /**
  * Resolve a durable creator-wide opener into an active self-build round (BY-27a).
  *
- * Shared by MCP `start` so verification cannot drift from the OAuth Bearer + slug
- * path after uid resolution. `open_round` wiring lands with BY-27b — do not add an
- * unreachable resolver here ahead of that work.
+ * Shared by MCP `start` and BY-27b `open_round` so verification cannot drift from
+ * the OAuth Bearer + slug path after uid resolution.
  */
 
 import {
@@ -13,7 +12,12 @@ import {
   verifyCreatorAgentKey,
   type CreatorAgentKeyClaims,
 } from './agent-creator-key.js';
-import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
+import {
+  GAME_NOT_PUBLISHED_REASON,
+  NO_OPEN_ROUND_REASON,
+  PLATFORM_ROUND_REASON,
+  SLUG_NOT_ON_ACCOUNT_REASON,
+} from './agent-game-key.js';
 import { creatorOwnsSlug, findActiveRoundForSlug } from './agent-game-key-resolve.js';
 import { InvalidAgentTokenError } from './agent-token.js';
 import type { CreatorAgentKeyRecord, Store, SubmissionRecord } from './store.js';
@@ -24,8 +28,18 @@ export type VerifyCreatorAgentKeyResult =
 export type ResolveCreatorKeyForStartResult =
   { ok: true; claims: CreatorAgentKeyClaims; record: SubmissionRecord } | { ok: false; reason: string };
 
+export type ResolveCreatorKeyForOpenRoundResult =
+  | {
+      ok: true;
+      claims: CreatorAgentKeyClaims;
+      publishedRecord: SubmissionRecord;
+      activeRound: SubmissionRecord | null;
+      slug: string;
+    }
+  | { ok: false; reason: string };
+
 /**
- * Signature, generation, and expiry — shared by `start`.
+ * Signature, generation, and expiry — shared by `start` and `open_round`.
  * Does not require an open round or a published game.
  */
 export async function verifyDurableCreatorAgentKey(
@@ -98,4 +112,31 @@ export async function resolveCreatorAgentKeyForStart(
   }
 
   return { ok: true, claims: verified.claims, record: active };
+}
+
+/**
+ * Creator-key verification for `open_round`: published game owned by the creator,
+ * and idempotent binding when a round is already open. No per-game opt-in (BY-27b).
+ */
+export async function resolveCreatorAgentKeyForOpenRound(
+  store: Store,
+  key: string,
+  secret: string,
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<ResolveCreatorKeyForOpenRoundResult> {
+  const verified = await verifyDurableCreatorAgentKey(store, key, secret, nowMs);
+  if (!verified.ok) return verified;
+
+  if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
+    return { ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON };
+  }
+
+  const publishedRecord = await store.getPublishedSubmissionBySlug(slug);
+  if (!publishedRecord) {
+    return { ok: false, reason: GAME_NOT_PUBLISHED_REASON };
+  }
+
+  const activeRound = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
+  return { ok: true, claims: verified.claims, publishedRecord, activeRound, slug };
 }

--- a/apps/api/src/agent-game-key-resolve.test.ts
+++ b/apps/api/src/agent-game-key-resolve.test.ts
@@ -154,7 +154,6 @@ describe('slug ownership beyond owner-list window (BY-25)', () => {
     await seedManyNewerJobs(store, 250, newerJobsStart);
     const at = new Date(now).toISOString();
     await store.ensureGameAgentKey(slug, ownerUid, at);
-    await store.setGameAgentOpenRounds(slug, ownerUid, true, at);
   }
 
   it('creatorOwnsSlug stays true when the game aged out of listSubmissionsByOwner(200)', async () => {

--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  AGENT_OPEN_ROUNDS_DISABLED_REASON,
   assertGameAgentKeyActive,
   GAME_NOT_PUBLISHED_REASON,
   looksLikeGameAgentKey,
@@ -140,8 +139,9 @@ export async function resolveGameAgentKeyForStart(
 }
 
 /**
- * Durable-key verification for `open_round`: published game, opt-in, and idempotent
- * binding when a round is already open.
+ * Durable-key verification for `open_round`: published game and idempotent binding
+ * when a round is already open. The BY-24 per-game opt-in is withdrawn (BY-27b) —
+ * `allowAgentOpenRounds` on existing records is ignored.
  */
 export async function resolveGameAgentKeyForOpenRound(
   store: Store,
@@ -151,10 +151,6 @@ export async function resolveGameAgentKeyForOpenRound(
 ): Promise<ResolveGameKeyForOpenRoundResult> {
   const verified = await verifyDurableGameAgentKey(store, key, secret, nowMs);
   if (!verified.ok) return verified;
-
-  if (verified.keyRecord.allowAgentOpenRounds !== true) {
-    return { ok: false, reason: AGENT_OPEN_ROUNDS_DISABLED_REASON };
-  }
 
   const publishedRecord = await store.getPublishedSubmissionBySlug(verified.claims.slug);
   if (!publishedRecord) {

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -45,10 +45,6 @@ export const SLUG_NOT_ON_ACCOUNT_REASON =
 export const ROTATED_GAME_KEY_REASON =
   'this game key was rotated — get a fresh prompt from the Studio thread for this game';
 
-/** Per-game opt-in for MCP `open_round` is off (BY-24). */
-export const AGENT_OPEN_ROUNDS_DISABLED_REASON =
-  'the creator has not allowed their agent to start new rounds for this game — ask them to enable it in Studio';
-
 /** `open_round` only applies after the game has shipped. */
 export const GAME_NOT_PUBLISHED_REASON = 'this game is not published yet — improvement rounds open only after publish';
 

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -1,7 +1,12 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mintCreatorAgentKey } from './agent-creator-key.js';
-import { GAME_NOT_PUBLISHED_REASON, IMPROVEMENT_QUOTA_EXHAUSTED_REASON, mintGameAgentKey } from './agent-game-key.js';
+import {
+  GAME_NOT_PUBLISHED_REASON,
+  IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
+  mintGameAgentKey,
+  SLUG_NOT_ON_ACCOUNT_REASON,
+} from './agent-game-key.js';
 import { resolveGameAgentKeyForOpenRound } from './agent-game-key-resolve.js';
 import { mintAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
@@ -206,6 +211,36 @@ describe('MCP open_round (BY-24 / BY-27b)', () => {
     });
     expect(statusRes.statusCode).toBe(200);
     expect(statusRes.json()).toMatchObject({ openedBy: 'agent' });
+  });
+
+  it('refuses creator-key open_round for an unowned slug without blaming the key', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(PUBLISHED_ISSUE, 'g:other', 'Other Game');
+    await store.setSubmissionSlug(PUBLISHED_ISSUE, 'other-game');
+    await store.setSubmissionPublishedAt(PUBLISHED_ISSUE, '2026-07-01T00:00:00.000Z');
+    await store.recordJobTransition(PUBLISHED_ISSUE, {
+      to: 'published',
+      at: '2026-07-01T00:00:00.000Z',
+      by: 'operator',
+      reason: 'published',
+    });
+    const at = new Date().toISOString();
+    await store.ensureCreatorAgentKey(OWNER, at);
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: 'other-game', feedback: 'Do not rotate for a typo.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+    expect((structured as { error: string }).error).not.toMatch(/rotated/i);
   });
 
   it('admits only one concurrent open_round per slug', async () => {

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -243,6 +243,70 @@ describe('MCP open_round (BY-24 / BY-27b)', () => {
     expect((structured as { error: string }).error).not.toMatch(/rotated/i);
   });
 
+  it('refuses open_round when gameAgentKeys/{slug} is owned by someone else', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    // Lock doc belongs to another account — ensure for OWNER must return null.
+    await store.ensureGameAgentKey(SLUG, 'g:other', '2026-07-01T00:00:00.000Z');
+    const at = new Date().toISOString();
+    await store.ensureCreatorAgentKey(OWNER, at);
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: SLUG, feedback: 'Do not touch another account lock.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+  });
+
+  it('assigns an agent-opened round to the authorized creator after a slug transfer', async () => {
+    const store = new InMemoryStore();
+    // Previous owner published; current owner has a newer live (non-active) job.
+    await store.createSubmission(PUBLISHED_ISSUE, 'g:previous', 'Comet Courier');
+    await store.setSubmissionSlug(PUBLISHED_ISSUE, SLUG);
+    await store.setSubmissionPublishedAt(PUBLISHED_ISSUE, '2026-07-01T00:00:00.000Z');
+    await store.recordJobTransition(PUBLISHED_ISSUE, {
+      to: 'published',
+      at: '2026-07-01T00:00:00.000Z',
+      by: 'operator',
+      reason: 'published',
+    });
+    await store.createSubmission(11, OWNER, 'Comet Courier');
+    await store.setSubmissionSlug(11, SLUG);
+    const map = (store as unknown as { submissions: Map<number, { createdAt: string }> }).submissions;
+    const published = map.get(PUBLISHED_ISSUE)!;
+    const live = map.get(11)!;
+    map.set(PUBLISHED_ISSUE, { ...published, createdAt: '2026-07-01T00:00:00.000Z' });
+    map.set(11, { ...live, createdAt: '2026-09-01T12:00:00.000Z' });
+
+    const at = new Date().toISOString();
+    await store.ensureCreatorAgentKey(OWNER, at);
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: SLUG, feedback: 'Keep the round on the new owner.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(false);
+    const jobId = (structured as { jobId: number }).jobId;
+    const job = await store.getSubmission(jobId);
+    expect(job?.ownerUid).toBe(OWNER);
+    expect(job?.ownerUid).not.toBe('g:previous');
+  });
+
   it('admits only one concurrent open_round per slug', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -1,11 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  AGENT_OPEN_ROUNDS_DISABLED_REASON,
-  GAME_NOT_PUBLISHED_REASON,
-  IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
-  mintGameAgentKey,
-} from './agent-game-key.js';
+import { mintCreatorAgentKey } from './agent-creator-key.js';
+import { GAME_NOT_PUBLISHED_REASON, IMPROVEMENT_QUOTA_EXHAUSTED_REASON, mintGameAgentKey } from './agent-game-key.js';
 import { resolveGameAgentKeyForOpenRound } from './agent-game-key-resolve.js';
 import { mintAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
@@ -14,6 +10,7 @@ import type { GamesStore } from './games-store.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import { mintMcpSessionKey } from './mcp-session-key.js';
 import { InMemoryStore } from './store.js';
+import { mintToken } from './submission-token.js';
 import { NoopTranslator } from './translate.js';
 
 const secret = 'open-round-test-secret';
@@ -84,6 +81,10 @@ function gameKey(generation = 1) {
   });
 }
 
+async function ensureGameKey(store: InMemoryStore) {
+  await store.ensureGameAgentKey(SLUG, OWNER, new Date().toISOString());
+}
+
 async function mcpCall(
   app: FastifyInstance,
   method: string,
@@ -120,29 +121,33 @@ async function callOpenRound(
 }
 
 describe('resolveGameAgentKeyForOpenRound', () => {
-  it('refuses when opt-in is off', async () => {
-    const store = new InMemoryStore();
-    const at = '2026-08-01T12:00:00.000Z';
-    await store.ensureGameAgentKey(SLUG, OWNER, at);
-    await seedPublishedGame(store);
-
-    const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret);
-    expect(result).toEqual({ ok: false, reason: AGENT_OPEN_ROUNDS_DISABLED_REASON });
-  });
-
   it('refuses when the game is not published', async () => {
     const store = new InMemoryStore();
     const at = '2026-08-01T12:00:00.000Z';
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await store.ensureGameAgentKey(SLUG, OWNER, at);
     await store.createSubmission(20, OWNER, 'Draft');
     await store.setSubmissionSlug(20, SLUG);
 
     const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret);
     expect(result).toEqual({ ok: false, reason: GAME_NOT_PUBLISHED_REASON });
   });
+
+  it('succeeds for a published game with no opt-in flag', async () => {
+    const store = new InMemoryStore();
+    const at = '2026-08-01T12:00:00.000Z';
+    await store.ensureGameAgentKey(SLUG, OWNER, at);
+    await seedPublishedGame(store);
+
+    const result = await resolveGameAgentKeyForOpenRound(store, gameKey(), secret);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.publishedRecord.issueNumber).toBe(PUBLISHED_ISSUE);
+      expect(result.activeRound).toBeNull();
+    }
+  });
 });
 
-describe('MCP open_round (BY-24)', () => {
+describe('MCP open_round (BY-24 / BY-27b)', () => {
   let app: FastifyInstance | null = null;
 
   afterEach(async () => {
@@ -150,25 +155,10 @@ describe('MCP open_round (BY-24)', () => {
     app = null;
   });
 
-  it('refuses when opt-in is off', async () => {
+  it('opens exactly one self improvement round with no flag set', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    await store.ensureGameAgentKey(SLUG, OWNER, new Date().toISOString());
-    app = await createApp(store);
-
-    const { structured, isError } = await callOpenRound(app, {
-      key: gameKey(),
-      feedback: 'Add a checkpoint.',
-    });
-    expect(isError).toBe(true);
-    expect(structured).toMatchObject({ error: AGENT_OPEN_ROUNDS_DISABLED_REASON });
-  });
-
-  it('opens exactly one self improvement round when opt-in is on', async () => {
-    const store = new InMemoryStore();
-    await seedPublishedGame(store);
-    const at = new Date().toISOString();
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await ensureGameKey(store);
     app = await createApp(store);
 
     const { structured, isError } = await callOpenRound(app, {
@@ -185,11 +175,43 @@ describe('MCP open_round (BY-24)', () => {
     expect(job?.transitions?.[0]).toMatchObject({ to: 'queued', by: 'agent', reason: 'agent_open_round' });
   });
 
-  it('admits only one concurrent open_round per slug', async () => {
+  it('opens a round via creator key Bearer + slug and surfaces openedBy agent on status', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
     const at = new Date().toISOString();
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await store.ensureCreatorAgentKey(OWNER, at);
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: SLUG, feedback: 'Tighten the jump arc.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ slug: SLUG, alreadyOpen: false });
+    const jobId = (structured as { jobId: number }).jobId;
+    expect(jobId).not.toBe(PUBLISHED_ISSUE);
+
+    const job = await store.getSubmission(jobId);
+    expect(job?.transitions?.[0]).toMatchObject({ to: 'queued', by: 'agent', reason: 'agent_open_round' });
+
+    const statusRes = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(jobId, secret)}`,
+    });
+    expect(statusRes.statusCode).toBe(200);
+    expect(statusRes.json()).toMatchObject({ openedBy: 'agent' });
+  });
+
+  it('admits only one concurrent open_round per slug', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    await ensureGameKey(store);
     app = await createApp(store);
 
     const results = await Promise.all([
@@ -215,8 +237,7 @@ describe('MCP open_round (BY-24)', () => {
   it('is idempotent while a round is open and does not stack', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    const at = new Date().toISOString();
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await ensureGameKey(store);
     app = await createApp(store);
 
     const first = await callOpenRound(app, { key: gameKey(), feedback: 'First change.' });
@@ -235,8 +256,7 @@ describe('MCP open_round (BY-24)', () => {
   it('refuses when improvement quota is exhausted', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    const at = new Date().toISOString();
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await ensureGameKey(store);
     const dateStr = new Date().toISOString().slice(0, 10);
     await store.checkAndIncrementQuota(OWNER, dateStr, 2, 'improvements');
     await store.checkAndIncrementQuota(OWNER, dateStr, 2, 'improvements');
@@ -253,7 +273,7 @@ describe('MCP open_round (BY-24)', () => {
   it('moderates feedback on this path', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
+    await ensureGameKey(store);
     app = await createApp(store, rejectingChecker());
 
     const { structured, isError } = await callOpenRound(app, {
@@ -267,7 +287,6 @@ describe('MCP open_round (BY-24)', () => {
   it('rejects a round key where the durable key is required', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
     app = await createApp(store);
 
     const roundKey = mintAgentToken(PUBLISHED_ISSUE, secret, { roundGeneration: 1 });
@@ -282,7 +301,6 @@ describe('MCP open_round (BY-24)', () => {
   it('rejects a sessionKey where the durable key is required', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, new Date().toISOString());
     app = await createApp(store);
 
     const sessionKey = mintMcpSessionKey(secret, {
@@ -301,7 +319,6 @@ describe('MCP open_round (BY-24)', () => {
   it('refuses an unpublished game', async () => {
     const store = new InMemoryStore();
     const at = new Date().toISOString();
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
     await store.createSubmission(30, OWNER, 'Unpublished');
     await store.setSubmissionSlug(30, SLUG);
     await store.ensureGameAgentKey(SLUG, OWNER, at);
@@ -320,7 +337,7 @@ describe('MCP open_round (BY-24)', () => {
     const at = new Date().toISOString();
     await store.createSubmission(35, OWNER, 'Unpublished comet');
     await store.setSubmissionSlug(35, SLUG);
-    await store.setGameAgentOpenRounds(SLUG, OWNER, true, at);
+    await store.ensureGameAgentKey(SLUG, OWNER, at);
 
     const otherSlug = 'other-game';
     await store.createSubmission(40, OWNER, 'Other');

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -102,6 +102,8 @@ export interface McpServerOptions {
     log: { error: (context: object, message: string) => void };
     builder?: BuilderKind;
     openedBy?: 'creator' | 'agent';
+    /** When set, the new job is owned by this uid (slug-transfer safe). */
+    ownerUid?: string;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
   contentChecker?: ContentChecker;
   dailyImprovementQuota?: number;
@@ -802,7 +804,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
         const at = new Date(now()).toISOString();
         // Admission lock lives on gameAgentKeys/{slug}; ensure the doc exists for creator-key path.
-        await store.ensureGameAgentKey(resolved.slug, resolved.creatorUid, at);
+        const lockRecord = await store.ensureGameAgentKey(resolved.slug, resolved.creatorUid, at);
+        if (!lockRecord) {
+          // Existing doc owned by someone else — do not touch their admission lock.
+          return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+        }
 
         if (resolved.activeRound) {
           await store.finishAgentOpenRound(resolved.slug, at);
@@ -872,6 +878,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             log: ctx.request.log,
             builder: 'self',
             openedBy: 'agent',
+            // Authorized creator wins over the published record's owner after a transfer.
+            ownerUid: resolved.creatorUid,
           });
           if (!started) {
             return toolErr('could not open an improvement round for this game');

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
-import { resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
+import { resolveCreatorAgentKeyForOpenRound, resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
 import {
   looksLikeGameAgentKey,
   IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
@@ -710,15 +710,20 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     open_round: {
       description:
-        'Open a new post-publish improvement round on a published game using the durable per-game key. ' +
-        'Requires the creator to have opted in per game. Spends the same daily improvement quota as Studio. ' +
+        'Open a new post-publish improvement round on a published game. ' +
+        'Accepts a durable per-game key, or Authorization: Bearer <creator key> + slug. ' +
+        'Spends the same daily improvement quota as Studio. ' +
         'Returns jobId only — call start() next for a sessionKey. Idempotent while a round is already open.',
       inputSchema: {
         type: 'object',
         properties: {
           key: {
             type: 'string',
-            description: 'Durable per-game key from the Studio kickoff prompt — not a sessionKey or round key.',
+            description: 'Durable per-game key. Optional when using Authorization Bearer with a creator key + slug.',
+          },
+          slug: {
+            type: 'string',
+            description: 'Game slug. Required with a creator-key Bearer; ignored with a per-game key.',
           },
           feedback: {
             type: 'string',
@@ -726,7 +731,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'Creator change request for this improvement round (≤2000 chars). Treated as untrusted creator text.',
           },
         },
-        required: ['key', 'feedback'],
+        required: ['feedback'],
       },
       handler: async (args, ctx) => {
         if (!store || !agentTokenSecret || !startImprovementRound || !contentChecker) {
@@ -734,14 +739,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         }
 
         const key = typeof args.key === 'string' ? args.key.trim() : '';
-        if (!key) {
-          return toolErr('key is required — pass the durable per-game key from the Studio kickoff prompt');
-        }
-        if (!looksLikeGameAgentKey(key)) {
-          return toolErr(
-            'open_round requires the durable per-game key — session keys and round keys cannot open a new round',
-          );
-        }
+        const slugArg = typeof args.slug === 'string' ? args.slug.trim() : '';
+        const bearer = ctx.bearerToken;
 
         const feedbackRaw = typeof args.feedback === 'string' ? args.feedback.trim() : '';
         if (!feedbackRaw) {
@@ -751,17 +750,65 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('feedback is too long (max 2000 characters)');
         }
 
-        const resolved = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
-        if (!resolved.ok) {
-          return toolErr(resolved.reason);
+        type OpenResolved = {
+          creatorUid: string;
+          slug: string;
+          publishedRecord: SubmissionRecord;
+          activeRound: SubmissionRecord | null;
+        };
+
+        let resolved: OpenResolved;
+
+        if (!key && bearer && looksLikeCreatorAgentKey(bearer)) {
+          if (!slugArg) {
+            return toolErr('slug is required when using a creator key — pass the game slug to improve');
+          }
+          const creatorResolved = await resolveCreatorAgentKeyForOpenRound(
+            store,
+            bearer,
+            agentTokenSecret,
+            slugArg,
+            now(),
+          );
+          if (!creatorResolved.ok) {
+            return toolErr(creatorResolved.reason);
+          }
+          resolved = {
+            creatorUid: creatorResolved.claims.creatorUid,
+            slug: creatorResolved.slug,
+            publishedRecord: creatorResolved.publishedRecord,
+            activeRound: creatorResolved.activeRound,
+          };
+        } else if (key && looksLikeGameAgentKey(key)) {
+          const gameResolved = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
+          if (!gameResolved.ok) {
+            return toolErr(gameResolved.reason);
+          }
+          resolved = {
+            creatorUid: gameResolved.claims.creatorUid,
+            slug: gameResolved.claims.slug,
+            publishedRecord: gameResolved.publishedRecord,
+            activeRound: gameResolved.activeRound,
+          };
+        } else if (key && looksLikeCreatorAgentKey(key)) {
+          return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
+        } else if (key) {
+          return toolErr(
+            'open_round requires a durable per-game key or Authorization Bearer with a creator key + slug',
+          );
+        } else {
+          return toolErr('pass a durable per-game key, or Authorization Bearer with a creator key + slug');
         }
 
         const at = new Date(now()).toISOString();
+        // Admission lock lives on gameAgentKeys/{slug}; ensure the doc exists for creator-key path.
+        await store.ensureGameAgentKey(resolved.slug, resolved.creatorUid, at);
+
         if (resolved.activeRound) {
-          await store.finishAgentOpenRound(resolved.claims.slug, at);
+          await store.finishAgentOpenRound(resolved.slug, at);
           return toolOk({
             jobId: resolved.activeRound.issueNumber,
-            slug: resolved.claims.slug,
+            slug: resolved.slug,
             alreadyOpen: true,
           });
         }
@@ -770,19 +817,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (!moderation.allowed) {
           logModerationRejection(ctx.request.log, {
             surface: 'creator_feedback',
-            uid: resolved.claims.creatorUid,
+            uid: resolved.creatorUid,
             category: moderation.category,
           });
           return toolErr('content_rejected', { category: moderation.category ?? 'other' });
         }
 
-        const admitted = await store.beginAgentOpenRound(resolved.claims.slug, at);
+        const admitted = await store.beginAgentOpenRound(resolved.slug, at);
         if (!admitted) {
-          const again = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
-          if (again.ok && again.activeRound) {
+          const again = await findActiveRoundForSlug(store, resolved.slug, resolved.creatorUid);
+          if (again) {
             return toolOk({
-              jobId: again.activeRound.issueNumber,
-              slug: again.claims.slug,
+              jobId: again.issueNumber,
+              slug: resolved.slug,
               alreadyOpen: true,
             });
           }
@@ -790,18 +837,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         }
 
         try {
-          const racingRound = await findActiveRoundForSlug(store, resolved.claims.slug, resolved.claims.creatorUid);
+          const racingRound = await findActiveRoundForSlug(store, resolved.slug, resolved.creatorUid);
           if (racingRound) {
             return toolOk({
               jobId: racingRound.issueNumber,
-              slug: resolved.claims.slug,
+              slug: resolved.slug,
               alreadyOpen: true,
             });
           }
 
           const dateStr = at.slice(0, 10);
           const quota = await store.checkAndIncrementQuota(
-            resolved.claims.creatorUid,
+            resolved.creatorUid,
             dateStr,
             dailyImprovementQuota,
             'improvements',
@@ -832,11 +879,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
           return toolOk({
             jobId: started.jobId,
-            slug: resolved.claims.slug,
+            slug: resolved.slug,
             alreadyOpen: false,
           });
         } finally {
-          await store.finishAgentOpenRound(resolved.claims.slug, at);
+          await store.finishAgentOpenRound(resolved.slug, at);
         }
       },
     },

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import { assertGameAgentKeyActive, DEFAULT_GAME_AGENT_KEY_TTL_DAYS, verifyGameAgentKey } from './agent-game-key.js';
+import {
+  assertCreatorAgentKeyActive,
+  DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
+import { assertGameAgentKeyActive, verifyGameAgentKey } from './agent-game-key.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
@@ -9,6 +14,7 @@ import {
   buildKickoffPrompt,
   mcpEndpointUrl,
   mintConnectPayload,
+  mintGameKeyKickoff,
   MCP_ENDPOINT_PATH,
 } from './self-build-connect.js';
 import { InMemoryStore } from './store.js';
@@ -19,6 +25,7 @@ const secret = 'self-build-connect-test-secret';
 const sessionSecret = 'dev-session-secret-change-me';
 const CONCEPT = 'A squad tactics game about clearing rooms with careful timing and cover.';
 const APP_BASE = 'https://www.gamedev.pl';
+const MASKED_AUTH = 'Authorization: Bearer ····9a10e';
 
 function stubGitHub(): GitHubClient {
   return {
@@ -62,8 +69,11 @@ function authHeaders(uid = 'g:creator') {
 }
 
 describe('self-build-connect templates', () => {
-  it('builds install snippets that configure only the MCP URL', () => {
-    const snippets = buildInstallSnippets({ appBaseUrl: APP_BASE });
+  it('builds install snippets that embed the Authorization header with the MCP URL', () => {
+    const snippets = buildInstallSnippets({
+      appBaseUrl: APP_BASE,
+      authorizationBearer: MASKED_AUTH,
+    });
     const url = mcpEndpointUrl(APP_BASE);
     expect(url).toBe(`${APP_BASE}${MCP_ENDPOINT_PATH}`);
 
@@ -75,21 +85,62 @@ describe('self-build-connect templates', () => {
       cli: expect.stringContaining(url),
     });
     expect(snippets.claudeCode).toMatch(/^claude mcp add --transport http gamedevpl /);
+    expect(snippets.claudeCode).toContain(MASKED_AUTH);
     expect(snippets.codex).toContain('[mcp_servers.gamedevpl]');
+    expect(snippets.codex).toContain('Bearer ····9a10e');
     expect(JSON.parse(snippets.cursor)).toEqual({
-      mcpServers: { gamedevpl: { url } },
+      mcpServers: {
+        gamedevpl: {
+          url,
+          headers: { Authorization: 'Bearer ····9a10e' },
+        },
+      },
     });
     expect(snippets.kimi).toMatch(/^npx -y mcp-remote /);
+    expect(snippets.kimi).toContain(MASKED_AUTH);
     expect(snippets.cli).toMatch(/^curl -sS -X POST /);
+    expect(snippets.cli).toContain(MASKED_AUTH);
 
-    // No credential in any install snippet — only the URL.
+    // Masked Authorization is expected; full raw secrets / kickoff-style key: lines are not.
     for (const value of Object.values(snippets)) {
-      expect(value).not.toMatch(/key:|Bearer|token|Authorization/i);
+      expect(value).toMatch(/Authorization|Bearer/i);
+      expect(value).not.toMatch(/\bkey:\s*\S+/);
       expect(value).toContain(url);
     }
   });
 
-  it('builds a kickoff prompt with the game key, a loop pointer, and pending feedback', () => {
+  it('builds a keyless kickoff prompt with the game slug', () => {
+    const bare = buildKickoffPrompt({ title: 'Asteroids', slug: 'asteroids' });
+    expect(bare).toBe(
+      [
+        'Build "Asteroids" for gamedev.pl.',
+        'Start with the gamedevpl tool, slug: asteroids',
+        'start returns your workflow; after gate green the round is done.',
+      ].join('\n'),
+    );
+    expect(bare).not.toMatch(/\bkey:/);
+    expect(bare).not.toMatch(/\btoken\b/i);
+
+    const bareLines = bare.split('\n');
+    expect(bareLines.length).toBeLessThanOrEqual(5);
+    expect(bareLines).toHaveLength(3);
+    expect(bareLines[1]).toBe('Start with the gamedevpl tool, slug: asteroids');
+    expect(bare.match(/your workflow/g)).toHaveLength(1);
+
+    const withPending = buildKickoffPrompt({
+      title: 'Asteroids',
+      slug: 'asteroids',
+      pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
+    });
+    const pendingLines = withPending.split('\n');
+    expect(pendingLines[1]).toBe('Start with the gamedevpl tool, slug: asteroids');
+    expect(withPending.indexOf('- make the ship faster')).toBeLessThan(withPending.indexOf('- add a pause button'));
+    expect(withPending).toContain('also apply:');
+    expect(withPending).toContain('- make the ship faster');
+    expect(withPending).toContain('- add a pause button');
+  });
+
+  it('builds a keyed kickoff prompt with the game key (legacy / per-game path)', () => {
     const bare = buildKickoffPrompt({ title: 'Asteroids', gameKey: 'game-key-abc' });
     expect(bare).toBe(
       [
@@ -99,13 +150,7 @@ describe('self-build-connect templates', () => {
       ].join('\n'),
     );
     expect(bare).not.toMatch(/\btoken\b/i);
-
-    const bareLines = bare.split('\n');
-    expect(bareLines.length).toBeLessThanOrEqual(5);
-    expect(bareLines).toHaveLength(3);
-    expect(bareLines[1]).toBe('Start with the gamedevpl tool, key: game-key-abc');
-    expect(bareLines[2]).toMatch(/keep this key for the next round/i);
-    expect(bare.match(/your workflow/g)).toHaveLength(1);
+    expect(bare).not.toMatch(/\bslug:/);
 
     const withReminder = buildKickoffPrompt({
       title: 'Asteroids',
@@ -114,21 +159,13 @@ describe('self-build-connect templates', () => {
     });
     expect(withReminder).toContain('Same key as before — nothing new to copy unless the creator rotated it.');
 
-    const withPending = buildKickoffPrompt({
-      title: 'Asteroids',
-      gameKey: 'game-key-abc',
-      pendingMessages: [{ text: 'make the ship faster' }, { text: 'add a pause button' }],
-    });
-    const pendingLines = withPending.split('\n');
-    expect(pendingLines[1]).toBe('Start with the gamedevpl tool, key: game-key-abc');
-    expect(pendingLines[2]).toMatch(/keep this key for the next round/i);
-    expect(withPending.indexOf('- make the ship faster')).toBeLessThan(withPending.indexOf('- add a pause button'));
-    expect(withPending).toContain('also apply:');
-    expect(withPending).toContain('- make the ship faster');
-    expect(withPending).toContain('- add a pause button');
+    expect(() => buildKickoffPrompt({ title: 'Asteroids' })).toThrow(/exactly one of gameKey or slug/);
+    expect(() => buildKickoffPrompt({ title: 'Asteroids', gameKey: 'k', slug: 's' })).toThrow(
+      /exactly one of gameKey or slug/,
+    );
   });
 
-  it('mints a payload whose expiresAt equals the key signed exp claim', () => {
+  it('mints a keyless payload whose expiresAt equals the creator key signed exp claim', () => {
     const now = Date.parse('2026-07-31T12:00:00Z');
     const payload = mintConnectPayload({
       slug: 'nebula',
@@ -139,19 +176,53 @@ describe('self-build-connect templates', () => {
       appBaseUrl: APP_BASE,
       now,
     });
+
+    expect(payload.slug).toBe('nebula');
+    expect(payload.kickoffPrompt).toContain('slug: nebula');
+    expect(payload.kickoffPrompt).not.toMatch(/\bkey:\s*\S+/);
+    expect(payload.authorizationHeader).toMatch(/^Authorization: Bearer /);
+    expect(payload.authorizationHeaderMasked).toMatch(/^Authorization: Bearer ····/);
+    expect(payload.authorizationHeaderMasked).not.toBe(payload.authorizationHeader);
+
+    const creatorKey = payload.authorizationHeader.replace(/^Authorization: Bearer /, '');
+    expect(payload.kickoffPrompt).not.toContain(creatorKey);
+    for (const snippet of Object.values(payload.installSnippets)) {
+      expect(snippet).toContain(payload.authorizationHeaderMasked.replace(/^Authorization: /, ''));
+      expect(snippet).not.toContain(creatorKey);
+    }
+
+    const claims = verifyCreatorAgentKey(creatorKey, secret);
+    expect(claims).toMatchObject({ creatorUid: 'g:creator', keyGeneration: 3 });
+    expect(payload.expiresAt).toBe(claims.exp);
+    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS * 24 * 60 * 60);
+    expect(payload.keyGeneration).toBe(3);
+    expect(payload.fingerprint).toBe(creatorKey.slice(-5));
+    expect(() => assertCreatorAgentKeyActive(claims, { keyGeneration: 3 }, now)).not.toThrow();
+  });
+
+  it('mints a keyed per-game kickoff via mintGameKeyKickoff', () => {
+    const now = Date.parse('2026-07-31T12:00:00Z');
+    const payload = mintGameKeyKickoff({
+      slug: 'nebula',
+      ownerUid: 'g:creator',
+      keyGeneration: 2,
+      title: 'Nebula',
+      submissionTokenSecret: secret,
+      appBaseUrl: APP_BASE,
+      now,
+    });
     const keyMatch = payload.kickoffPrompt.match(/key: (\S+)/);
     expect(keyMatch).toBeTruthy();
     const gameKey = keyMatch![1]!;
     const claims = verifyGameAgentKey(gameKey, secret);
-    expect(claims).toMatchObject({ slug: 'nebula', creatorUid: 'g:creator', keyGeneration: 3 });
+    expect(claims).toMatchObject({ slug: 'nebula', creatorUid: 'g:creator', keyGeneration: 2 });
     expect(payload.expiresAt).toBe(claims.exp);
-    expect(payload.expiresAt).toBe(Math.floor(now / 1000) + DEFAULT_GAME_AGENT_KEY_TTL_DAYS * 24 * 60 * 60);
-    expect(payload.keyGeneration).toBe(3);
-    expect(() => assertGameAgentKeyActive(claims, { keyGeneration: 3 }, now)).not.toThrow();
+    expect(payload.keyGeneration).toBe(2);
+    expect(payload.kickoffPrompt).not.toMatch(/\bslug:/);
   });
 });
 
-describe('GET /api/submissions/:id/connect (BY-03)', () => {
+describe('GET /api/submissions/:id/connect (BY-03 / BY-27b)', () => {
   let app: FastifyInstance | null = null;
 
   afterEach(async () => {
@@ -159,7 +230,7 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     app = null;
   });
 
-  it('returns snippets, kickoff, and expiresAt for the owner of an active self round', async () => {
+  it('returns snippets, keyless kickoff, and creator-key fields for the owner of an active self round', async () => {
     const created = await createApp({ now: () => Date.parse('2026-07-31T12:00:00Z') });
     app = created.app;
     const { store } = created;
@@ -187,29 +258,85 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
       kickoffPrompt: string;
       expiresAt: number;
       keyGeneration: number;
+      authorizationHeader: string;
+      authorizationHeaderMasked: string;
+      fingerprint: string;
+      mcpUrl: string;
+      slug: string;
     };
 
     expect(Object.keys(body.installSnippets).sort()).toEqual(['claudeCode', 'cli', 'codex', 'cursor', 'kimi'].sort());
     const mcpUrl = `${APP_BASE}${MCP_ENDPOINT_PATH}`;
+    expect(body.mcpUrl).toBe(mcpUrl);
+    expect(record.slug).toBeTruthy();
+    expect(body.slug).toBe(record.slug);
+
+    const creatorKey = body.authorizationHeader.replace(/^Authorization: Bearer /, '');
+    expect(body.authorizationHeaderMasked).toBe(`Authorization: Bearer ····${body.fingerprint}`);
+    expect(body.authorizationHeaderMasked).not.toContain(creatorKey);
+
     for (const snippet of Object.values(body.installSnippets)) {
       expect(snippet).toContain(mcpUrl);
-      expect(snippet).not.toMatch(/key:|Bearer |\btoken\b/i);
+      expect(snippet).toMatch(/Authorization|Bearer/i);
+      expect(snippet).toContain(body.fingerprint);
+      expect(snippet).not.toContain(creatorKey);
+      expect(snippet).not.toMatch(/\bkey:\s*\S+/);
     }
 
     expect(body.kickoffPrompt).toContain('Build "Connect Game" for gamedev.pl.');
-    expect(body.kickoffPrompt).toMatch(/Start with the gamedevpl tool, key: \S+/);
+    expect(body.kickoffPrompt).toContain(`slug: ${record.slug}`);
+    expect(body.kickoffPrompt).not.toMatch(/\bkey:\s*\S+/);
+    expect(body.kickoffPrompt).not.toContain(creatorKey);
     expect(body.kickoffPrompt).not.toMatch(/\btoken\b/i);
 
-    expect(record.slug).toBeTruthy();
-    const gameKey = body.kickoffPrompt.match(/key: (\S+)/)![1]!;
-    const claims = verifyGameAgentKey(gameKey, secret);
-    expect(claims.slug).toBe(record.slug);
+    const claims = verifyCreatorAgentKey(creatorKey, secret);
     expect(claims.creatorUid).toBe(record.ownerUid);
-    const keyRecord = await store.getGameAgentKey(record.slug!);
+    const keyRecord = await store.getCreatorAgentKey(record.ownerUid);
     expect(keyRecord).toBeTruthy();
     expect(body.keyGeneration).toBe(keyRecord!.keyGeneration);
     expect(body.expiresAt).toBe(claims.exp);
-    expect(() => assertGameAgentKeyActive(claims, keyRecord!, Date.parse('2026-07-31T12:00:00Z'))).not.toThrow();
+    expect(() => assertCreatorAgentKeyActive(claims, keyRecord!, Date.parse('2026-07-31T12:00:00Z'))).not.toThrow();
+
+    // Creator key from connect can bind start via Bearer + slug.
+    const init = await app.inject({
+      method: 'POST',
+      url: '/api/mcp',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      },
+    });
+    const sessionId = init.headers['mcp-session-id'] as string;
+    const start = await app.inject({
+      method: 'POST',
+      url: '/api/mcp',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${creatorKey}`,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'start', arguments: { slug: record.slug } },
+      },
+    });
+    const startBody = start.json() as {
+      result?: { isError?: boolean; structuredContent?: { sessionKey?: string }; content?: Array<{ text: string }> };
+    };
+    expect(startBody.result?.isError).toBeFalsy();
+    const startStructured =
+      startBody.result?.structuredContent ??
+      (startBody.result?.content?.[0]?.text ? JSON.parse(startBody.result.content[0].text) : undefined);
+    expect((startStructured as { sessionKey?: string })?.sessionKey).toBeTruthy();
   });
 
   it('rejects a stranger with 403', async () => {
@@ -397,12 +524,16 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     expect(response.statusCode).toBe(200);
     const after = await store.getSubmission(66);
     expect(after?.slug).toBeTruthy();
-    const gameKey = (response.json().kickoffPrompt as string).match(/key: (\S+)/)![1]!;
-    const claims = verifyGameAgentKey(gameKey, secret);
-    expect(claims).toMatchObject({ slug: after!.slug, creatorUid: 'g:creator', keyGeneration: 1 });
+    const body = response.json() as { kickoffPrompt: string; slug: string; authorizationHeader: string };
+    expect(body.slug).toBe(after!.slug);
+    expect(body.kickoffPrompt).toContain(`slug: ${after!.slug}`);
+    expect(body.kickoffPrompt).not.toMatch(/\bkey:\s*\S+/);
+    const creatorKey = body.authorizationHeader.replace(/^Authorization: Bearer /, '');
+    const claims = verifyCreatorAgentKey(creatorKey, secret);
+    expect(claims).toMatchObject({ creatorUid: 'g:creator', keyGeneration: 1 });
   });
 
-  it('binds the minted key to the game keyGeneration, not the round generation', async () => {
+  it('agent-key binds the minted key to the game keyGeneration, not the round generation', async () => {
     const created = await createApp();
     app = created.app;
     const { store } = created;
@@ -425,7 +556,7 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     const id = mintToken(77, secret);
     const response = await app.inject({
       method: 'GET',
-      url: `/api/submissions/${id}/connect`,
+      url: `/api/submissions/${id}/agent-key`,
       headers: authHeaders(),
     });
     expect(response.statusCode).toBe(200);
@@ -464,6 +595,8 @@ describe('GET /api/submissions/:id/connect (BY-03)', () => {
     expect(prompt).toContain('also apply:');
     expect(prompt).toContain('- add a pause button');
     expect(prompt).not.toContain('make the ship faster');
+    expect(prompt).toMatch(/slug: \S+/);
+    expect(prompt).not.toMatch(/\bkey:\s*\S+/);
   });
 });
 
@@ -545,12 +678,13 @@ describe('game agent key API (BY-23)', () => {
     const { store } = created;
     const { id, record } = await submitSelfRound(store);
 
-    const connect = await app.inject({
+    const agentKey = await app.inject({
       method: 'GET',
-      url: `/api/submissions/${id}/connect`,
+      url: `/api/submissions/${id}/agent-key`,
       headers: authHeaders(),
     });
-    const oldKey = extractGameKey(connect.json().kickoffPrompt as string);
+    expect(agentKey.statusCode).toBe(200);
+    const oldKey = extractGameKey(agentKey.json().kickoffPrompt as string);
 
     const rotated = await app.inject({
       method: 'POST',
@@ -605,7 +739,7 @@ describe('game agent key API (BY-23)', () => {
 
     await app.inject({
       method: 'GET',
-      url: `/api/submissions/${id}/connect`,
+      url: `/api/submissions/${id}/agent-key`,
       headers: authHeaders(),
     });
     const beforeClose = await store.getGameAgentKey(record.slug!);

--- a/apps/api/src/self-build-connect.ts
+++ b/apps/api/src/self-build-connect.ts
@@ -1,14 +1,20 @@
 /**
- * Connect payload for a self-build round (BY-03 / BY-23).
+ * Connect payload for a self-build round (BY-03 / BY-27b).
  *
- * The Studio asks once for everything a creator needs to paste into their own coding
- * agent: per-client MCP install snippets (endpoint URL only — never a credential) and a
- * kickoff prompt that carries this game's durable opener key. Snippet templates live here
- * so docs and UI render from one source of truth. Regenerating the prompt remints a key
- * with a fresh signed `exp` at the same keyGeneration — it does NOT rotate. Pending
- * creator inbox lines ride along under "also apply:".
+ * The Studio asks once for everything a creator needs: a config block (MCP URL +
+ * Authorization header for the creator-wide key) and a keyless kickoff prompt that
+ * carries only the game slug. The secret never appears at full length in rendered
+ * markup — callers get a masked header for display and the real value for Copy.
+ *
+ * Pending creator inbox lines ride along under "also apply:".
  */
 
+import {
+  creatorAgentKeyFingerprint,
+  maskCreatorAgentKeyHeader,
+  mintCreatorAgentKey,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
 import { mintGameAgentKey, verifyGameAgentKey } from './agent-game-key.js';
 
 /** Path of the remote MCP endpoint (served by BY-05). Install snippets point here. */
@@ -24,32 +30,54 @@ export interface InstallSnippets {
 
 export interface ConnectPayload {
   installSnippets: InstallSnippets;
+  /** Keyless kickoff — slug only, never a key. */
   kickoffPrompt: string;
+  /** Absolute MCP endpoint URL. */
+  mcpUrl: string;
+  /** Full Authorization header line — for Copy only; never render. */
+  authorizationHeader: string;
+  /** Masked Authorization header for display. */
+  authorizationHeaderMasked: string;
+  /** Last five characters of the creator key — tell keys apart without leaking. */
+  fingerprint: string;
   /**
-   * Unix seconds. Identical to the minted key's signed `exp` claim — not a separate
-   * display clock the UI could drift from.
+   * Unix seconds. Identical to the minted creator key's signed `exp` claim — not a
+   * separate display clock the UI could drift from.
    */
   expiresAt: number;
-  /** Current keyGeneration — display/rotate UI; not a secret. */
+  /** Current creator keyGeneration — display/rotate UI; not a secret. */
   keyGeneration: number;
-  /** True when this kickoff is the same durable key the creator already pasted (BY-20 handoff). */
-  sameKeyAsBefore?: boolean;
+  /** Game slug embedded in the keyless prompt. */
+  slug: string;
 }
 
 export interface BuildInstallSnippetsInput {
   /** Absolute origin, e.g. `https://www.gamedev.pl`. */
   appBaseUrl: string;
+  /**
+   * Authorization header value to embed (already `Bearer …` or masked).
+   * Snippets for display should pass the masked form; Copy reconstructs with the real one.
+   */
+  authorizationBearer: string;
 }
 
 export interface BuildKickoffPromptInput {
   title: string;
-  /** Durable per-game opener key (embedded only in the kickoff, never in install). */
-  gameKey: string;
+  /**
+   * Keyed mode (legacy / per-game): durable opener embedded as `key: …`.
+   * Must not be set together with `slug` — never emit a key and a slug in one prompt.
+   */
+  gameKey?: string;
+  /**
+   * Keyless mode (BY-27b): game slug only. Requires the creator key to live in MCP
+   * client config, not in the prompt.
+   */
+  slug?: string;
   /** Undelivered creator inbox lines, oldest first. */
   pendingMessages?: readonly { text: string }[];
   /**
-   * When true, append a line that nothing new needs pasting unless the creator rotated
-   * (post-publish improve handoff — BY-20 + BY-23).
+   * When true (keyed mode only), append a line that nothing new needs pasting unless
+   * the creator rotated (post-publish improve handoff — BY-20 + BY-23).
    */
   sameKeyReminder?: boolean;
 }
@@ -62,8 +90,19 @@ export interface MintConnectPayloadInput {
   submissionTokenSecret: string;
   appBaseUrl: string;
   pendingMessages?: readonly { text: string }[];
-  sameKeyReminder?: boolean;
   /** Epoch ms; defaults to `Date.now()`. */
+  now?: number;
+}
+
+export interface MintGameKeyKickoffInput {
+  slug: string;
+  ownerUid: string;
+  keyGeneration: number;
+  title: string;
+  submissionTokenSecret: string;
+  appBaseUrl: string;
+  pendingMessages?: readonly { text: string }[];
+  sameKeyReminder?: boolean;
   now?: number;
 }
 
@@ -73,19 +112,30 @@ export function mcpEndpointUrl(appBaseUrl: string): string {
 }
 
 /**
- * Per-client install snippets. Every snippet configures the MCP endpoint URL and
- * nothing else — the game key rides the kickoff prompt, not the install.
+ * Per-client install snippets. Each configures the MCP endpoint URL and an
+ * Authorization Bearer header. Pass a masked bearer for display snippets.
  */
 export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallSnippets {
   const url = mcpEndpointUrl(input.appBaseUrl);
+  const bearer = input.authorizationBearer.trim();
+  const authHeaderLine = bearer.toLowerCase().startsWith('authorization:')
+    ? bearer
+    : `Authorization: ${bearer.startsWith('Bearer ') ? bearer : `Bearer ${bearer}`}`;
+  const bearerValue = authHeaderLine.replace(/^Authorization:\s*/i, '').trim();
+
   return {
-    claudeCode: `claude mcp add --transport http gamedevpl ${url}`,
-    codex: [`[mcp_servers.gamedevpl]`, `url = "${url}"`].join('\n'),
+    claudeCode: `claude mcp add --transport http gamedevpl ${url} --header "${authHeaderLine}"`,
+    codex: [`[mcp_servers.gamedevpl]`, `url = "${url}"`, `http_headers = { Authorization = "${bearerValue}" }`].join(
+      '\n',
+    ),
     cursor: JSON.stringify(
       {
         mcpServers: {
           gamedevpl: {
             url,
+            headers: {
+              Authorization: bearerValue,
+            },
           },
         },
       },
@@ -93,29 +143,43 @@ export function buildInstallSnippets(input: BuildInstallSnippetsInput): InstallS
       2,
     ),
     // Kimi Code has no first-class remote-HTTP add yet; mcp-remote is the documented
-    // stdio bridge (third-party — we publish no package). Same URL, still no key.
-    kimi: `npx -y mcp-remote ${url}`,
+    // stdio bridge (third-party — we publish no package). Header via env is client-specific.
+    kimi: `npx -y mcp-remote ${url}\n# set header: ${authHeaderLine}`,
     // Floor for agents that talk HTTP without an MCP client.
-    cli: `curl -sS -X POST ${url}`,
+    cli: `curl -sS -X POST ${url} -H "${authHeaderLine}"`,
   };
 }
 
 /**
- * Paste-ready kickoff: build instruction + gamedevpl tool key line + one line pointing at
- * the session loop (start returns the workflow; gate green ends the round — the game key
- * stays valid for the next round unless rotated), and any queued creator feedback as a
- * short "also apply:" list so a regenerate never drops them.
+ * Paste-ready kickoff. Exactly one of `gameKey` or `slug` must be set — never both
+ * (a key and a slug must not appear in the same prompt).
+ *
+ * Keyless (slug): Build "…" / Start with the gamedevpl tool, slug: … / start returns…
+ * Keyed (legacy): Build "…" / Start with the gamedevpl tool, key: … / …
  *
  * User-facing copy says "key", never "token".
  */
 export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
   const title = input.title.trim() || 'your game';
-  const lines = [
-    `Build "${title}" for gamedev.pl.`,
-    `Start with the gamedevpl tool, key: ${input.gameKey}`,
-    'start returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
-  ];
-  if (input.sameKeyReminder) {
+  const hasKey = Boolean(input.gameKey?.trim());
+  const hasSlug = Boolean(input.slug?.trim());
+  if (hasKey === hasSlug) {
+    throw new Error('buildKickoffPrompt requires exactly one of gameKey or slug');
+  }
+
+  const lines = hasSlug
+    ? [
+        `Build "${title}" for gamedev.pl.`,
+        `Start with the gamedevpl tool, slug: ${input.slug!.trim()}`,
+        'start returns your workflow; after gate green the round is done.',
+      ]
+    : [
+        `Build "${title}" for gamedev.pl.`,
+        `Start with the gamedevpl tool, key: ${input.gameKey!.trim()}`,
+        'start returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
+      ];
+
+  if (!hasSlug && input.sameKeyReminder) {
     lines.push('Same key as before — nothing new to copy unless the creator rotated it.');
   }
   const pending = (input.pendingMessages ?? []).map((message) => message.text.trim()).filter((text) => text.length > 0);
@@ -131,10 +195,16 @@ export function buildKickoffPrompt(input: BuildKickoffPromptInput): string {
 }
 
 /**
- * Mint a durable per-game opener and assemble the connect payload. `expiresAt` is taken
- * from the key's verified `exp` claim so the UI's "expires" line cannot disagree with auth.
+ * Legacy keyed kickoff for the per-game `/agent-key` routes (BY-23). Not used by the
+ * connect card after BY-27b — that path is keyless via {@link mintConnectPayload}.
  */
-export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPayload {
+export function mintGameKeyKickoff(input: MintGameKeyKickoffInput): {
+  kickoffPrompt: string;
+  expiresAt: number;
+  keyGeneration: number;
+  installSnippets: InstallSnippets;
+  sameKeyAsBefore?: boolean;
+} {
   const gameKey = mintGameAgentKey(input.submissionTokenSecret, {
     slug: input.slug,
     creatorUid: input.ownerUid,
@@ -143,7 +213,14 @@ export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPaylo
   });
   const claims = verifyGameAgentKey(gameKey, input.submissionTokenSecret);
   return {
-    installSnippets: buildInstallSnippets({ appBaseUrl: input.appBaseUrl }),
+    // URL-only snippets for the legacy panel — the per-game key still rides the kickoff.
+    installSnippets: {
+      claudeCode: `claude mcp add --transport http gamedevpl ${mcpEndpointUrl(input.appBaseUrl)}`,
+      codex: [`[mcp_servers.gamedevpl]`, `url = "${mcpEndpointUrl(input.appBaseUrl)}"`].join('\n'),
+      cursor: JSON.stringify({ mcpServers: { gamedevpl: { url: mcpEndpointUrl(input.appBaseUrl) } } }, null, 2),
+      kimi: `npx -y mcp-remote ${mcpEndpointUrl(input.appBaseUrl)}`,
+      cli: `curl -sS -X POST ${mcpEndpointUrl(input.appBaseUrl)}`,
+    },
     kickoffPrompt: buildKickoffPrompt({
       title: input.title,
       gameKey,
@@ -153,5 +230,43 @@ export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPaylo
     expiresAt: claims.exp,
     keyGeneration: claims.keyGeneration,
     sameKeyAsBefore: input.sameKeyReminder,
+  };
+}
+
+/**
+ * Mint a creator-wide opener and assemble the keyless connect payload.
+ * `expiresAt` is taken from the key's verified `exp` claim so the UI's "expires"
+ * line cannot disagree with auth. Install snippets embed the **masked** header;
+ * the real `authorizationHeader` is for Copy only.
+ */
+export function mintConnectPayload(input: MintConnectPayloadInput): ConnectPayload {
+  const creatorKey = mintCreatorAgentKey(input.submissionTokenSecret, {
+    creatorUid: input.ownerUid,
+    keyGeneration: input.keyGeneration,
+    now: input.now,
+  });
+  const claims = verifyCreatorAgentKey(creatorKey, input.submissionTokenSecret);
+  const authorizationHeader = `Authorization: Bearer ${creatorKey}`;
+  const authorizationHeaderMasked = maskCreatorAgentKeyHeader(creatorKey);
+  const fingerprint = creatorAgentKeyFingerprint(creatorKey);
+  const mcpUrl = mcpEndpointUrl(input.appBaseUrl);
+
+  return {
+    installSnippets: buildInstallSnippets({
+      appBaseUrl: input.appBaseUrl,
+      authorizationBearer: authorizationHeaderMasked,
+    }),
+    kickoffPrompt: buildKickoffPrompt({
+      title: input.title,
+      slug: input.slug,
+      pendingMessages: input.pendingMessages,
+    }),
+    mcpUrl,
+    authorizationHeader,
+    authorizationHeaderMasked,
+    fingerprint,
+    expiresAt: claims.exp,
+    keyGeneration: claims.keyGeneration,
+    slug: input.slug,
   };
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1119,7 +1119,8 @@ export interface AccessTokenRecord {
  *
  * The HMAC opener itself is never stored — only the generation that revokes it.
  * Round close does not bump `keyGeneration`; only an explicit creator rotate does.
- * `allowAgentOpenRounds` was the BY-24 opt-in; BY-27b ignores it (no migration).
+ * `allowAgentOpenRounds` was the BY-24 opt-in. Retained on the record type for existing
+ * Firestore documents only — BY-27b dropped the writer and all readers (no migration).
  */
 export interface GameAgentKeyRecord {
   slug: string;
@@ -1128,8 +1129,7 @@ export interface GameAgentKeyRecord {
   createdAt: string;
   updatedAt: string;
   /**
-   * Legacy BY-24 opt-in. Ignored by `open_round` after BY-27b — existing documents may
-   * still carry the field; readers must not require it.
+   * Legacy BY-24 opt-in. Retained for existing records; nothing reads or writes it after BY-27b.
    */
   allowAgentOpenRounds?: boolean;
   /** BY-24: admission lock while `open_round` is creating a job — cleared in finally. */
@@ -1766,13 +1766,6 @@ export interface Store {
    * or null when missing / not owned by `ownerUid`.
    */
   rotateGameAgentKey(slug: string, ownerUid: string, at: string): Promise<GameAgentKeyRecord | null>;
-  /** BY-24: set whether the creator's agent may open improvement rounds. */
-  setGameAgentOpenRounds(
-    slug: string,
-    ownerUid: string,
-    allow: boolean,
-    at: string,
-  ): Promise<GameAgentKeyRecord | null>;
   /**
    * BY-24: admit at most one in-flight `open_round` per slug. Returns false when another
    * caller already holds the lock.
@@ -3142,7 +3135,6 @@ export class InMemoryStore implements Store {
       keyGeneration: 1,
       createdAt: at,
       updatedAt: at,
-      allowAgentOpenRounds: false,
     };
     this.gameAgentKeys.set(slug, created);
     return { ...created };
@@ -3156,22 +3148,6 @@ export class InMemoryStore implements Store {
       keyGeneration: existing.keyGeneration + 1,
       updatedAt: at,
     };
-    this.gameAgentKeys.set(slug, next);
-    return { ...next };
-  }
-
-  async setGameAgentOpenRounds(
-    slug: string,
-    ownerUid: string,
-    allow: boolean,
-    at: string,
-  ): Promise<GameAgentKeyRecord | null> {
-    const ensured = await this.ensureGameAgentKey(slug, ownerUid, at);
-    if (!ensured) return null;
-    // Re-read after ensure: a concurrent rotate may have bumped keyGeneration.
-    const current = this.gameAgentKeys.get(slug);
-    if (!current || current.ownerUid !== ownerUid) return null;
-    const next: GameAgentKeyRecord = { ...current, allowAgentOpenRounds: allow, updatedAt: at };
     this.gameAgentKeys.set(slug, next);
     return { ...next };
   }
@@ -5159,7 +5135,6 @@ export class FirestoreStore implements Store {
         keyGeneration: 1,
         createdAt: at,
         updatedAt: at,
-        allowAgentOpenRounds: false,
       };
       tx.create(docRef, created);
       return created;
@@ -5176,39 +5151,6 @@ export class FirestoreStore implements Store {
       const next: GameAgentKeyRecord = {
         ...existing,
         keyGeneration: existing.keyGeneration + 1,
-        updatedAt: at,
-      };
-      tx.set(docRef, next);
-      return next;
-    });
-  }
-
-  async setGameAgentOpenRounds(
-    slug: string,
-    ownerUid: string,
-    allow: boolean,
-    at: string,
-  ): Promise<GameAgentKeyRecord | null> {
-    const docRef = this.db.collection('gameAgentKeys').doc(slug);
-    return this.db.runTransaction(async (tx) => {
-      const snap = await tx.get(docRef);
-      if (!snap.exists) {
-        const created: GameAgentKeyRecord = {
-          slug,
-          ownerUid,
-          keyGeneration: 1,
-          createdAt: at,
-          updatedAt: at,
-          allowAgentOpenRounds: allow,
-        };
-        tx.create(docRef, created);
-        return created;
-      }
-      const existing = snap.data() as GameAgentKeyRecord;
-      if (existing.ownerUid !== ownerUid) return null;
-      const next: GameAgentKeyRecord = {
-        ...existing,
-        allowAgentOpenRounds: allow,
         updatedAt: at,
       };
       tx.set(docRef, next);

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -48,7 +48,7 @@ import {
   type JobTransition,
 } from './job-state.js';
 import { createSelfBuildBackend } from './self-build-backend.js';
-import { mintConnectPayload } from './self-build-connect.js';
+import { mintConnectPayload, mintGameKeyKickoff } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
@@ -2117,9 +2117,10 @@ export async function registerSubmissionRoutes(
    * Everything a creator needs to connect their own coding agent to a self-build round.
    *
    * Creator-session auth, owner only. Valid only while the active round's builder is
-   * `self`. Install snippets configure the MCP URL alone; the durable per-game opener
-   * rides the kickoff prompt. Regenerating remints a key with a new signed `exp` at the
-   * same keyGeneration — it does NOT rotate. Pending, undelivered creator inbox lines
+   * `self`. Install snippets configure the MCP URL plus a masked Authorization header
+   * for the creator-wide key (BY-27b); the kickoff prompt is keyless (slug only).
+   * Regenerating remints a creator key with a new signed `exp` at the same
+   * keyGeneration — it does NOT rotate. Pending, undelivered creator inbox lines
    * are embedded under "also apply:" so a re-copy never drops queued feedback.
    * See self-build-connect.ts for the templates.
    */
@@ -2189,15 +2190,11 @@ export async function registerSubmissionRoutes(
       }
 
       const at = new Date(now()).toISOString();
-      const keyRecord = await store.ensureGameAgentKey(slug, fresh.ownerUid, at);
-      if (!keyRecord) {
-        return reply.status(403).send({ error: 'only the creator can connect a build' });
-      }
+      // BY-27b: connect hands out the creator-wide key (config header) + a keyless
+      // slug prompt. Per-game keys remain mintable via /agent-key for legacy setups.
+      const keyRecord = await store.ensureCreatorAgentKey(fresh.ownerUid, at);
 
       const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
-      // Improve handoff (BY-20): a new job for the same slug shows the same durable key —
-      // remind the creator there is nothing new to copy unless they rotated.
-      const sameKeyReminder = (fresh.roundGeneration ?? 1) > 1 || Boolean(fresh.publishedAt);
       const payload = mintConnectPayload({
         slug,
         ownerUid: fresh.ownerUid,
@@ -2206,10 +2203,9 @@ export async function registerSubmissionRoutes(
         submissionTokenSecret,
         appBaseUrl: notifyAppBaseUrl,
         pendingMessages,
-        sameKeyReminder,
         now: now(),
       });
-      // Kickoff embeds a capability — never let intermediaries cache it.
+      // Payload carries a capability for Copy — never let intermediaries cache it.
       return reply.header('Cache-Control', 'no-store').send(payload);
     },
   );
@@ -2256,7 +2252,7 @@ export async function registerSubmissionRoutes(
         return reply.status(403).send({ error: 'only the creator can manage this game key' });
       }
 
-      const payload = mintConnectPayload({
+      const payload = mintGameKeyKickoff({
         slug,
         ownerUid: record.ownerUid,
         keyGeneration: keyRecord.keyGeneration,
@@ -2270,7 +2266,6 @@ export async function registerSubmissionRoutes(
         slug,
         keyGeneration: keyRecord.keyGeneration,
         expiresAt: payload.expiresAt,
-        allowAgentOpenRounds: keyRecord.allowAgentOpenRounds === true,
         kickoffPrompt: payload.kickoffPrompt,
         installSnippets: payload.installSnippets,
       });
@@ -2317,7 +2312,7 @@ export async function registerSubmissionRoutes(
         return reply.status(403).send({ error: 'only the creator can rotate this game key' });
       }
 
-      const payload = mintConnectPayload({
+      const payload = mintGameKeyKickoff({
         slug,
         ownerUid: record.ownerUid,
         keyGeneration: rotated.keyGeneration,
@@ -2331,56 +2326,9 @@ export async function registerSubmissionRoutes(
         slug,
         keyGeneration: rotated.keyGeneration,
         expiresAt: payload.expiresAt,
-        allowAgentOpenRounds: rotated.allowAgentOpenRounds === true,
         kickoffPrompt: payload.kickoffPrompt,
         installSnippets: payload.installSnippets,
         rotated: true,
-      });
-    },
-  );
-
-  app.post(
-    '/api/submissions/:id/agent-key/open-rounds',
-    { config: { rateLimit: { max: 30, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!submissionTokenSecret || !store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-      if (!checkUserAccess(request, reply)) return;
-
-      const parsedBody = z.object({ allow: z.boolean() }).safeParse(request.body ?? {});
-      if (!parsedBody.success) {
-        return reply.status(400).send({ error: 'allow must be true or false' });
-      }
-
-      const id = z.string().parse((request.params as { id?: string }).id);
-      let issueNumber: number;
-      try {
-        issueNumber = verifyToken(id, submissionTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid submission token' });
-        }
-        throw error;
-      }
-
-      const record = await store.getSubmission(issueNumber);
-      if (!record || record.ownerUid !== request.user!.uid) {
-        return reply.status(403).send({ error: 'only the creator can manage this game key' });
-      }
-      if (!record.slug) {
-        return reply.status(409).send({ error: 'game_key_unavailable', reason: 'missing_slug' });
-      }
-
-      const at = new Date(now()).toISOString();
-      const updated = await store.setGameAgentOpenRounds(record.slug, record.ownerUid, parsedBody.data.allow, at);
-      if (!updated) {
-        return reply.status(403).send({ error: 'only the creator can manage this game key' });
-      }
-
-      return reply.send({
-        slug: record.slug,
-        allowAgentOpenRounds: updated.allowAgentOpenRounds === true,
       });
     },
   );

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -390,6 +390,8 @@ export interface SubmissionRoutesHandle {
     builder?: BuilderKind;
     /** Who opened this improvement — drives the queued transition and status.openedBy. */
     openedBy?: 'creator' | 'agent';
+    /** When set, the new job is owned by this uid (slug-transfer safe). */
+    ownerUid?: string;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
 }
 
@@ -1019,6 +1021,11 @@ export async function registerSubmissionRoutes(
     builder?: BuilderKind;
     /** Who opened this improvement — drives the queued transition and status.openedBy. */
     openedBy?: 'creator' | 'agent';
+    /**
+     * Owner of the new job. Defaults to the published source's ownerUid. Pass the
+     * authorized creator after a slug transfer so quota and Studio stay aligned.
+     */
+    ownerUid?: string;
   }): Promise<{ route: 'job'; jobId: number } | null> {
     if (!store) return null;
     const source = await store.getSubmission(input.issueNumber);
@@ -1031,7 +1038,7 @@ export async function registerSubmissionRoutes(
     const builder = input.builder ?? builderOf(source);
 
     const jobId = await store.allocateJobId();
-    await store.createSubmission(jobId, source.ownerUid, source.title);
+    await store.createSubmission(jobId, input.ownerUid ?? source.ownerUid, source.title);
     await store.setSubmissionLocale(jobId, input.locale);
     // Set before dispatch: the slug is what makes this an improvement rather than a new
     // game, and a job that dispatched without one has already told the agent the wrong

--- a/apps/web/src/CreatorStudioView.handoff.test.tsx
+++ b/apps/web/src/CreatorStudioView.handoff.test.tsx
@@ -101,7 +101,14 @@ describe('CreatorStudioView publish→improve handoff', () => {
           kimi: 'npx mcp-remote https://example.test/api/mcp',
           cli: 'curl https://example.test/api/mcp',
         },
-        kickoffPrompt: 'Build "TV Tycoon" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+        kickoffPrompt:
+          'Build "TV Tycoon" for gamedev.pl.\nStart with the gamedevpl tool, slug: tv-tycoon.\nstart returns your workflow; after gate green the round is done.',
+        mcpUrl: 'https://example.test/api/mcp',
+        authorizationHeader: 'Authorization: Bearer test-key-not-for-display',
+        authorizationHeaderMasked: 'Authorization: Bearer ····play',
+        fingerprint: 'play',
+        keyGeneration: 1,
+        slug: 'tv-tycoon',
         expiresAt: Math.floor(Date.now() / 1000) + 3600,
       }),
     }));

--- a/apps/web/src/StudioAgentKeyPanel.test.tsx
+++ b/apps/web/src/StudioAgentKeyPanel.test.tsx
@@ -5,14 +5,6 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
-import { recordStudioStep } from './visitTelemetry.js';
-
-vi.mock('./visitTelemetry', async () => {
-  const actual = await vi.importActual<typeof import('./visitTelemetry')>('./visitTelemetry');
-  return { ...actual, recordStudioStep: vi.fn() };
-});
-
-const mockedRecordStudioStep = vi.mocked(recordStudioStep);
 
 async function flush() {
   await Promise.resolve();
@@ -22,7 +14,6 @@ async function flush() {
 const agentKeyPayload = {
   slug: 'sky-dodge',
   keyGeneration: 1,
-  allowAgentOpenRounds: false,
   expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
   kickoffPrompt:
     'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def\nstart returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
@@ -37,7 +28,6 @@ const agentKeyPayload = {
 
 describe('StudioAgentKeyPanel', () => {
   beforeEach(() => {
-    mockedRecordStudioStep.mockClear();
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo) => {
@@ -51,12 +41,6 @@ describe('StudioAgentKeyPanel', () => {
               kickoffPrompt: agentKeyPayload.kickoffPrompt.replace('abc.def', 'rotated.key'),
               rotated: true,
             }),
-          };
-        }
-        if (url.includes('/agent-key/open-rounds')) {
-          return {
-            ok: true,
-            json: async () => ({ allowAgentOpenRounds: true }),
           };
         }
         return {
@@ -77,7 +61,7 @@ describe('StudioAgentKeyPanel', () => {
     vi.restoreAllMocks();
   });
 
-  it('shows kickoff after rotate and emits connect_copied only on copy', async () => {
+  it('loads expiry and offers rotate without an open-rounds toggle', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -93,35 +77,12 @@ describe('StudioAgentKeyPanel', () => {
       await flush();
     });
 
-    expect(container.textContent).not.toContain('rotated.key');
+    expect(container.textContent).toMatch(/Per-game key/i);
+    expect(container.textContent).toMatch(/legacy/i);
+    expect(container.querySelector('[role="switch"]')).toBeNull();
+    expect(container.textContent).not.toMatch(/Let my agent start new rounds/i);
+    expect(container.textContent).toContain('Rotate key');
 
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.studio-connect-skip')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flush();
-    });
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.studio-connect-skip.is-danger')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flush();
-      await flush();
-    });
-
-    expect(container.textContent).toContain('rotated.key');
-    expect(mockedRecordStudioStep).not.toHaveBeenCalledWith('connect_copied', expect.anything(), expect.anything());
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.status-share-copy')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flush();
-    });
-    expect(mockedRecordStudioStep).toHaveBeenCalledWith('connect_copied', 'self', 'kickoff');
-
-    await act(async () => {
-      root.unmount();
-    });
+    await act(async () => root.unmount());
   });
 });

--- a/apps/web/src/StudioAgentKeyPanel.tsx
+++ b/apps/web/src/StudioAgentKeyPanel.tsx
@@ -1,28 +1,24 @@
 import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getAgentKey, rotateAgentKey, setAgentOpenRounds } from './connectApi.js';
+import { getAgentKey, rotateAgentKey } from './connectApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 type StudioAgentKeyPanelProps = {
   token: string;
-  /** Compact mode hides rotate and extra copy — for the connect card. */
-  compact?: boolean;
 };
 
 /**
- * Durable per-game key controls (BY-23 / BY-24): opt-in for agent-opened rounds and
- * rotate. Never uses the word "token" in UI copy.
+ * Legacy per-game key controls (BY-23). Rotate only — the BY-24 open-rounds opt-in
+ * was withdrawn in BY-27b. Prefer the creator-wide key + keyless connect card.
  */
-export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPanelProps) {
+export function StudioAgentKeyPanel({ token }: StudioAgentKeyPanelProps) {
   const { t, i18n } = useTranslation();
   const baseId = useId();
-  const [allowAgentOpenRounds, setAllowAgentOpenRounds] = useState(false);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [kickoffPrompt, setKickoffPrompt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [toggleBusy, setToggleBusy] = useState(false);
   const [rotateArmed, setRotateArmed] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
@@ -35,7 +31,6 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
     getAgentKey(token)
       .then((payload) => {
         if (!cancelled) {
-          setAllowAgentOpenRounds(payload.allowAgentOpenRounds);
           setExpiresAt(payload.expiresAt);
           setLoading(false);
         }
@@ -58,22 +53,6 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
         )
       : '';
 
-  const handleToggle = async () => {
-    const next = !allowAgentOpenRounds;
-    setToggleBusy(true);
-    setError(null);
-    setAllowAgentOpenRounds(next);
-    try {
-      const result = await setAgentOpenRounds(token, next);
-      setAllowAgentOpenRounds(result.allowAgentOpenRounds);
-    } catch {
-      setAllowAgentOpenRounds(!next);
-      setError(t('agentKey.toggleError'));
-    } finally {
-      setToggleBusy(false);
-    }
-  };
-
   const copyKickoff = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -91,7 +70,6 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
     try {
       const next = await rotateAgentKey(token);
       setExpiresAt(next.expiresAt);
-      setAllowAgentOpenRounds(next.allowAgentOpenRounds);
       setKickoffPrompt(next.kickoffPrompt);
       setRotateArmed(false);
     } catch {
@@ -103,89 +81,63 @@ export function StudioAgentKeyPanel({ token, compact = false }: StudioAgentKeyPa
 
   return (
     <section className="studio-agent-key" aria-labelledby={`${baseId}-title`}>
-      {!compact ? (
-        <h3 id={`${baseId}-title`} className="studio-agent-key-title">
-          {t('agentKey.title')}
-        </h3>
-      ) : null}
+      <h3 id={`${baseId}-title`} className="studio-agent-key-title">
+        {t('agentKey.title')}
+      </h3>
 
       {loading ? <p className="studio-connect-state">{t('agentKey.loading')}</p> : null}
       {error ? <p className="error">{error}</p> : null}
 
       {!loading ? (
         <>
-          <div className="studio-share-head">
-            <h4 className="studio-share-title">{t('agentKey.openRounds.title')}</h4>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={allowAgentOpenRounds}
-              className={`studio-share-toggle${allowAgentOpenRounds ? ' is-on' : ''}`}
-              onClick={() => void handleToggle()}
-              disabled={toggleBusy}
-            >
-              <span className="studio-share-toggle-track" aria-hidden="true" />
-              {allowAgentOpenRounds ? t('agentKey.openRounds.on') : t('agentKey.openRounds.off')}
-            </button>
-          </div>
-          <p className="studio-share-hint">{t('agentKey.openRounds.hint')}</p>
-
-          {!compact ? (
-            <>
-              {expiresLabel ? (
-                <p className="studio-connect-expiry">{t('agentKey.expiry', { when: expiresLabel })}</p>
-              ) : null}
-              {kickoffPrompt ? (
-                <div className="studio-connect-step">
-                  <p className="studio-connect-same">{t('agentKey.rotatedKickoff')}</p>
-                  <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
-                    {kickoffPrompt}
-                  </pre>
-                  <div className="studio-connect-actions">
-                    <button type="button" className="status-share-copy" onClick={() => void copyKickoff(kickoffPrompt)}>
-                      <PixelIcon name={copiedKickoff ? 'check' : 'sparkle'} size={12} />{' '}
-                      {copiedKickoff ? t('connect.copied') : t('connect.copyKickoff')}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-              <div className="studio-connect-actions">
-                {!rotateArmed ? (
-                  <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
-                    {t('connect.rotate.start')}
-                  </button>
-                ) : (
-                  <span className="studio-connect-rotate-confirm">
-                    <span>{t('connect.rotate.confirm')}</span>
-                    <button
-                      type="button"
-                      className="studio-connect-skip is-danger"
-                      disabled={rotating}
-                      onClick={() => void handleRotate()}
-                    >
-                      {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
-                    </button>
-                    <button
-                      type="button"
-                      className="studio-connect-skip"
-                      disabled={rotating}
-                      onClick={() => setRotateArmed(false)}
-                    >
-                      {t('connect.rotate.no')}
-                    </button>
-                  </span>
-                )}
-              </div>
-              {rotateError ? <p className="error">{rotateError}</p> : null}
-            </>
+          <p className="studio-share-hint">{t('agentKey.legacyHint')}</p>
+          {expiresLabel ? (
+            <p className="studio-connect-expiry">{t('agentKey.expiry', { when: expiresLabel })}</p>
           ) : null}
+          {kickoffPrompt ? (
+            <div className="studio-connect-step">
+              <p className="studio-connect-same">{t('agentKey.rotatedKickoff')}</p>
+              <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
+                {kickoffPrompt}
+              </pre>
+              <div className="studio-connect-actions">
+                <button type="button" className="status-share-copy" onClick={() => void copyKickoff(kickoffPrompt)}>
+                  <PixelIcon name={copiedKickoff ? 'check' : 'sparkle'} size={12} />{' '}
+                  {copiedKickoff ? t('connect.copied') : t('connect.copyKickoff')}
+                </button>
+              </div>
+            </div>
+          ) : null}
+          <div className="studio-connect-actions">
+            {!rotateArmed ? (
+              <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                {t('connect.rotate.start')}
+              </button>
+            ) : (
+              <span className="studio-connect-rotate-confirm">
+                <span>{t('connect.rotate.confirm')}</span>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={rotating}
+                  onClick={() => void handleRotate()}
+                >
+                  {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={rotating}
+                  onClick={() => setRotateArmed(false)}
+                >
+                  {t('connect.rotate.no')}
+                </button>
+              </span>
+            )}
+          </div>
+          {rotateError ? <p className="error">{rotateError}</p> : null}
         </>
       ) : null}
     </section>
   );
-}
-
-/** Agent-open-rounds toggle only — shared by the connect card. */
-export function AgentOpenRoundsToggle({ token }: { token: string }) {
-  return <StudioAgentKeyPanel token={token} compact />;
 }

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -150,6 +150,54 @@ describe('StudioConnectCard', () => {
     await act(async () => root.unmount());
   });
 
+  it('Copy config replaces Bearer-only masks in Codex and Cursor snippets', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    const clientTabs = container.querySelector('[aria-label="Agent client"]');
+    expect(clientTabs).toBeTruthy();
+
+    for (const clientLabel of ['Codex', 'Cursor']) {
+      const tab = [...(clientTabs?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [])].find((btn) =>
+        btn.textContent?.includes(clientLabel),
+      );
+      expect(tab).toBeTruthy();
+      await act(async () => {
+        tab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flush();
+      });
+
+      vi.mocked(navigator.clipboard.writeText).mockClear();
+      // First share-copy in the config step (label toggles to "Copied" after click).
+      const copyConfig = container.querySelector<HTMLButtonElement>('.studio-connect-step .status-share-copy');
+      expect(copyConfig).toBeTruthy();
+      await act(async () => {
+        copyConfig?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flush();
+      });
+
+      const written = String(vi.mocked(navigator.clipboard.writeText).mock.calls.at(-1)?.[0] ?? '');
+      expect(written).toContain(FULL_KEY);
+      expect(written).toContain(`Bearer ${FULL_KEY}`);
+      expect(written).not.toContain('····9a10e');
+      expect(container.innerHTML).not.toContain(FULL_KEY);
+    }
+
+    await act(async () => root.unmount());
+  });
+
   it('remembers auth mode choice between Paste header and Sign in', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -12,33 +12,56 @@ async function flush() {
   await Promise.resolve();
 }
 
+const FULL_KEY = 'YzEu' + 'b'.repeat(120);
+const MASKED = 'Authorization: Bearer ····9a10e';
+
 const payload = {
   installSnippets: {
-    claudeCode: 'claude mcp add --transport http gamedevpl https://www.gamedev.pl/api/mcp',
-    codex: '[mcp_servers.gamedevpl]\nurl = "https://www.gamedev.pl/api/mcp"',
-    cursor: '{\n  "mcpServers": {\n    "gamedevpl": {\n      "url": "https://www.gamedev.pl/api/mcp"\n    }\n  }\n}',
-    kimi: 'npx -y mcp-remote https://www.gamedev.pl/api/mcp',
-    cli: 'curl -sS -X POST https://www.gamedev.pl/api/mcp',
+    claudeCode: `claude mcp add --transport http gamedevpl https://www.gamedev.pl/api/mcp --header "${MASKED}"`,
+    codex: `[mcp_servers.gamedevpl]\nurl = "https://www.gamedev.pl/api/mcp"\nhttp_headers = { Authorization = "Bearer ····9a10e" }`,
+    cursor: JSON.stringify(
+      {
+        mcpServers: {
+          gamedevpl: {
+            url: 'https://www.gamedev.pl/api/mcp',
+            headers: { Authorization: 'Bearer ····9a10e' },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    kimi: `npx -y mcp-remote https://www.gamedev.pl/api/mcp\n# set header: ${MASKED}`,
+    cli: `curl -sS -X POST https://www.gamedev.pl/api/mcp -H "${MASKED}"`,
   },
   kickoffPrompt:
-    'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, key: abc.def\nstart returns your workflow; after gate green the round is done — keep this key for the next round on this game unless the creator rotates it.',
+    'Build "Sky Dodge" for gamedev.pl.\nStart with the gamedevpl tool, slug: sky-dodge.\nstart returns your workflow; after gate green the round is done.',
+  mcpUrl: 'https://www.gamedev.pl/api/mcp',
+  authorizationHeader: `Authorization: Bearer ${FULL_KEY}`,
+  authorizationHeaderMasked: MASKED,
+  fingerprint: '9a10e',
   expiresAt: Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60,
   keyGeneration: 1,
+  slug: 'sky-dodge',
 };
 
 describe('StudioConnectCard', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo) => {
         const url = String(input);
-        if (url.includes('/agent-key/rotate')) {
+        if (url.includes('/creator-agent-key/rotate')) {
           return {
             ok: true,
             json: async () => ({
-              ...payload,
+              key: FULL_KEY + 'x',
               keyGeneration: 2,
-              kickoffPrompt: payload.kickoffPrompt.replace('abc.def', 'rotated.key'),
+              expiresAt: payload.expiresAt,
+              fingerprint: 'rotated',
+              authorizationHeader: `Authorization: Bearer ${FULL_KEY}x`,
+              authorizationHeaderMasked: 'Authorization: Bearer ····tated',
               rotated: true,
             }),
           };
@@ -61,7 +84,7 @@ describe('StudioConnectCard', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders install tabs, kickoff, expiry, and waiting state', async () => {
+  it('renders masked config + keyless kickoff and never puts the full key in markup', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -82,46 +105,24 @@ describe('StudioConnectCard', () => {
       expect.objectContaining({ credentials: 'include' }),
     );
     expect(container.querySelector('.studio-connect-title')?.textContent).toContain('Connect your coding agent');
-    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(5);
     expect(container.textContent).toContain('Add gamedev.pl to your agent');
     expect(container.textContent).toContain('Tell your agent what to build');
-    expect(container.textContent).toContain(payload.kickoffPrompt.split('\n')[0]);
-    expect(container.textContent).toMatch(/works for this game/i);
-    expect(container.textContent).toMatch(/stays too unless you rotate/i);
+    expect(container.textContent).toContain('slug: sky-dodge');
+    expect(container.textContent).not.toContain('key:');
+    expect(container.innerHTML).toContain(MASKED);
+    expect(container.innerHTML).not.toContain(FULL_KEY);
+    expect(container.querySelector('[data-testid="connect-config-snippet"]')?.textContent).not.toContain(FULL_KEY);
+    expect(container.querySelector('[data-testid="connect-kickoff"]')?.textContent).toContain('slug: sky-dodge');
+    expect(container.textContent).toMatch(/Ends in 9a10e/);
     expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
     expect(container.querySelector('.studio-connect-waiting')).not.toBeNull();
-    expect(container.textContent).toContain('Rotate key');
-
-    const cursorTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
-      tab.textContent?.includes('Cursor'),
-    );
-    await act(async () => {
-      cursorTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flush();
-    });
-    expect(container.querySelector('.studio-connect-snippet')?.textContent).toContain('mcpServers');
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.studio-connect-skip')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flush();
-    });
-    expect(container.textContent).toContain('Skipped');
 
     await act(async () => root.unmount());
   });
 
-  it('shows sameKeyAsBefore reminder when the payload says so', async () => {
+  it('Copy config puts the real Authorization header on the clipboard', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({ ...payload, sameKeyAsBefore: true }),
-      })),
-    );
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -135,11 +136,50 @@ describe('StudioConnectCard', () => {
       await flush();
     });
 
-    expect(container.textContent).toMatch(/Same key as before/i);
+    const copyConfig = [...container.querySelectorAll<HTMLButtonElement>('.status-share-copy')].find((btn) =>
+      btn.textContent?.includes('Copy config'),
+    );
+    await act(async () => {
+      copyConfig?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining(FULL_KEY));
+    expect(container.innerHTML).not.toContain(FULL_KEY);
+
     await act(async () => root.unmount());
   });
 
-  it('rotate flow confirms then refreshes the kickoff', async () => {
+  it('remembers auth mode choice between Paste header and Sign in', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    const oauthTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
+      tab.textContent?.includes('Sign in'),
+    );
+    await act(async () => {
+      oauthTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(localStorage.getItem('gamedev_connect_auth_mode')).toBe('oauth');
+    expect(container.textContent).toMatch(/Sign in from your agent/i);
+
+    await act(async () => root.unmount());
+  });
+
+  it('rotate uses the creator-key rotate endpoint', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -176,10 +216,9 @@ describe('StudioConnectCard', () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/submissions/status-tok/agent-key/rotate'),
+      expect.stringContaining('/api/me/creator-agent-key/rotate'),
       expect.objectContaining({ method: 'POST', credentials: 'include' }),
     );
-    expect(container.textContent).toContain('rotated.key');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -117,8 +117,15 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     const header = authHeaderRef.current;
     if (!payload || !header) return;
     // Rebuild the active client's snippet with the real Authorization value.
+    // Claude/Kimi/CLI embed the full "Authorization: Bearer …" line; Codex/Cursor
+    // embed only "Bearer …" — replace both forms so Copy never leaves the mask.
     const masked = payload.authorizationHeaderMasked;
-    const realSnippet = payload.installSnippets[client].split(masked).join(header);
+    const maskedBearer = masked.replace(/^Authorization:\s*/i, '').trim();
+    const realBearer = header.replace(/^Authorization:\s*/i, '').trim();
+    let realSnippet = payload.installSnippets[client].split(masked).join(header);
+    if (maskedBearer && maskedBearer !== masked) {
+      realSnippet = realSnippet.split(maskedBearer).join(realBearer);
+    }
     await copyText(realSnippet, 'config');
   };
 

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -1,14 +1,13 @@
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 import {
   CONNECT_CLIENTS,
   getConnectPayload,
-  rotateAgentKey,
+  rotateCreatorAgentKey,
   type ConnectClient,
   type ConnectPayload,
 } from './connectApi.js';
-import { AgentOpenRoundsToggle } from './StudioAgentKeyPanel.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
@@ -18,6 +17,27 @@ const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
   kimi: 'connect.clients.kimi',
   cli: 'connect.clients.cli',
 };
+
+const AUTH_MODE_STORAGE_KEY = 'gamedev_connect_auth_mode';
+
+type ConnectAuthMode = 'key' | 'oauth';
+
+function loadAuthMode(): ConnectAuthMode {
+  try {
+    const raw = localStorage.getItem(AUTH_MODE_STORAGE_KEY);
+    return raw === 'oauth' ? 'oauth' : 'key';
+  } catch {
+    return 'key';
+  }
+}
+
+function saveAuthMode(mode: ConnectAuthMode): void {
+  try {
+    localStorage.setItem(AUTH_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Convenience only.
+  }
+}
 
 type StudioConnectCardProps = {
   token: string;
@@ -30,21 +50,22 @@ type StudioConnectCardProps = {
 };
 
 /**
- * Connect card for a self-build round waiting on the creator's own coding agent.
+ * Connect card for a self-build round waiting on the creator's own coding agent (BY-27b).
  *
- * Step 1: add gamedev.pl to the agent (install snippets, skip if already done).
- * Step 2: paste the kickoff prompt (durable game key embedded). Live waiting flips away on
- * the first agent signal — the parent hides this when `stall` leaves `no_agent_yet`.
+ * Step 1: paste MCP config (URL + Authorization header) — or choose OAuth sign-in.
+ * Step 2: paste the keyless kickoff prompt (slug only; never a secret).
+ * The full Authorization value is held in memory for Copy and never rendered.
  */
 export function StudioConnectCard({ token, agentConnected = false }: StudioConnectCardProps) {
   const { t, i18n } = useTranslation();
   const baseId = useId();
+  const authHeaderRef = useRef<string | null>(null);
   const [payload, setPayload] = useState<ConnectPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [client, setClient] = useState<ConnectClient>('claudeCode');
-  const [step1Skipped, setStep1Skipped] = useState(false);
-  const [copied, setCopied] = useState<'install' | 'kickoff' | null>(null);
+  const [authMode, setAuthMode] = useState<ConnectAuthMode>(() => loadAuthMode());
+  const [copied, setCopied] = useState<'config' | 'kickoff' | null>(null);
   const [rotateArmed, setRotateArmed] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
@@ -56,6 +77,7 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     getConnectPayload(token)
       .then((next) => {
         if (!cancelled) {
+          authHeaderRef.current = next.authorizationHeader;
           setPayload(next);
           setLoading(false);
         }
@@ -75,7 +97,12 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     return null;
   }
 
-  const copy = async (text: string, which: 'install' | 'kickoff') => {
+  const chooseAuthMode = (mode: ConnectAuthMode) => {
+    setAuthMode(mode);
+    saveAuthMode(mode);
+  };
+
+  const copyText = async (text: string, which: 'config' | 'kickoff') => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(which);
@@ -83,14 +110,25 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     } catch {
       // Snippet stays on screen to select by hand.
     }
-    recordStudioStep('connect_copied', 'self', which);
+    recordStudioStep('connect_copied', 'self', which === 'config' ? 'install' : 'kickoff');
+  };
+
+  const copyConfig = async () => {
+    const header = authHeaderRef.current;
+    if (!payload || !header) return;
+    // Rebuild the active client's snippet with the real Authorization value.
+    const masked = payload.authorizationHeaderMasked;
+    const realSnippet = payload.installSnippets[client].split(masked).join(header);
+    await copyText(realSnippet, 'config');
   };
 
   const handleRotate = async () => {
     setRotating(true);
     setRotateError(null);
     try {
-      const next = await rotateAgentKey(token);
+      await rotateCreatorAgentKey();
+      const next = await getConnectPayload(token);
+      authHeaderRef.current = next.authorizationHeader;
       setPayload(next);
       setRotateArmed(false);
     } catch {
@@ -120,50 +158,117 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
 
       {payload && !loading ? (
         <>
-          <div className="studio-connect-step">
-            <div className="studio-connect-step-head">
-              <span className="studio-connect-step-num" aria-hidden="true">
-                1
-              </span>
-              <h4 className="studio-connect-step-title">{t('connect.step1.title')}</h4>
-            </div>
-            {step1Skipped ? (
-              <p className="studio-connect-skipped">{t('connect.step1.skipped')}</p>
-            ) : (
-              <>
-                <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.step1.clients')}>
-                  {CONNECT_CLIENTS.map((id) => (
-                    <button
-                      key={id}
-                      type="button"
-                      role="tab"
-                      aria-selected={client === id}
-                      className={`studio-connect-tab${client === id ? ' is-active' : ''}`}
-                      onClick={() => setClient(id)}
-                    >
-                      {t(CLIENT_LABEL_KEY[id])}
-                    </button>
-                  ))}
-                </div>
-                <pre className="studio-connect-snippet" tabIndex={0}>
-                  {installSnippet}
-                </pre>
-                <div className="studio-connect-actions">
-                  <button
-                    type="button"
-                    className="status-share-copy"
-                    onClick={() => void copy(installSnippet, 'install')}
-                  >
-                    <PixelIcon name={copied === 'install' ? 'check' : 'sparkle'} size={12} />{' '}
-                    {copied === 'install' ? t('connect.copied') : t('connect.copyInstall')}
-                  </button>
-                  <button type="button" className="studio-connect-skip" onClick={() => setStep1Skipped(true)}>
-                    {t('connect.step1.skip')}
-                  </button>
-                </div>
-              </>
-            )}
+          <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.authMode.label')}>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={authMode === 'key'}
+              className={`studio-connect-tab${authMode === 'key' ? ' is-active' : ''}`}
+              onClick={() => chooseAuthMode('key')}
+            >
+              {t('connect.authMode.key')}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={authMode === 'oauth'}
+              className={`studio-connect-tab${authMode === 'oauth' ? ' is-active' : ''}`}
+              onClick={() => chooseAuthMode('oauth')}
+            >
+              {t('connect.authMode.oauth')}
+            </button>
           </div>
+
+          {authMode === 'key' ? (
+            <div className="studio-connect-step">
+              <div className="studio-connect-step-head">
+                <span className="studio-connect-step-num" aria-hidden="true">
+                  1
+                </span>
+                <h4 className="studio-connect-step-title">{t('connect.step1.title')}</h4>
+              </div>
+              <p className="studio-connect-same">{t('connect.step1.configHint')}</p>
+              <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.step1.clients')}>
+                {CONNECT_CLIENTS.map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    role="tab"
+                    aria-selected={client === id}
+                    className={`studio-connect-tab${client === id ? ' is-active' : ''}`}
+                    onClick={() => setClient(id)}
+                  >
+                    {t(CLIENT_LABEL_KEY[id])}
+                  </button>
+                ))}
+              </div>
+              <pre className="studio-connect-snippet" tabIndex={0} data-testid="connect-config-snippet">
+                {installSnippet}
+              </pre>
+              <p className="studio-connect-expiry" data-testid="connect-key-meta">
+                {t('connect.step1.meta', {
+                  fingerprint: payload.fingerprint,
+                  when: expiresLabel,
+                  generation: payload.keyGeneration,
+                })}
+              </p>
+              <div className="studio-connect-actions">
+                <button type="button" className="status-share-copy" onClick={() => void copyConfig()}>
+                  <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
+                  {copied === 'config' ? t('connect.copied') : t('connect.copyConfig')}
+                </button>
+                {!rotateArmed ? (
+                  <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                    {t('connect.rotate.start')}
+                  </button>
+                ) : (
+                  <span className="studio-connect-rotate-confirm">
+                    <span>{t('connect.rotate.confirm')}</span>
+                    <button
+                      type="button"
+                      className="studio-connect-skip is-danger"
+                      disabled={rotating}
+                      onClick={() => void handleRotate()}
+                    >
+                      {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
+                    </button>
+                    <button
+                      type="button"
+                      className="studio-connect-skip"
+                      disabled={rotating}
+                      onClick={() => setRotateArmed(false)}
+                    >
+                      {t('connect.rotate.no')}
+                    </button>
+                  </span>
+                )}
+              </div>
+              {rotateError ? <p className="error">{rotateError}</p> : null}
+            </div>
+          ) : (
+            <div className="studio-connect-step">
+              <div className="studio-connect-step-head">
+                <span className="studio-connect-step-num" aria-hidden="true">
+                  1
+                </span>
+                <h4 className="studio-connect-step-title">{t('connect.oauth.title')}</h4>
+              </div>
+              <p className="studio-connect-same">{t('connect.oauth.hint')}</p>
+              <pre className="studio-connect-snippet" tabIndex={0}>
+                {payload.mcpUrl}
+              </pre>
+              <div className="studio-connect-actions">
+                <button
+                  type="button"
+                  className="status-share-copy"
+                  onClick={() => void copyText(payload.mcpUrl, 'config')}
+                >
+                  <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
+                  {copied === 'config' ? t('connect.copied') : t('connect.copyUrl')}
+                </button>
+              </div>
+            </div>
+          )}
 
           <div className="studio-connect-step">
             <div className="studio-connect-step-head">
@@ -173,50 +278,19 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
               <h4 className="studio-connect-step-title">{t('connect.step2.title')}</h4>
             </div>
             <p className="studio-connect-same">{t('connect.step2.sameConnection')}</p>
-            {payload.sameKeyAsBefore ? (
-              <p className="studio-connect-same-key">{t('connect.step2.sameKeyAsBefore')}</p>
-            ) : null}
-            <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0}>
+            <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0} data-testid="connect-kickoff">
               {payload.kickoffPrompt}
             </pre>
             <div className="studio-connect-actions">
               <button
                 type="button"
                 className="status-share-copy"
-                onClick={() => void copy(payload.kickoffPrompt, 'kickoff')}
+                onClick={() => void copyText(payload.kickoffPrompt, 'kickoff')}
               >
                 <PixelIcon name={copied === 'kickoff' ? 'check' : 'sparkle'} size={12} />{' '}
                 {copied === 'kickoff' ? t('connect.copied') : t('connect.copyKickoff')}
               </button>
-              {!rotateArmed ? (
-                <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
-                  {t('connect.rotate.start')}
-                </button>
-              ) : (
-                <span className="studio-connect-rotate-confirm">
-                  <span>{t('connect.rotate.confirm')}</span>
-                  <button
-                    type="button"
-                    className="studio-connect-skip is-danger"
-                    disabled={rotating}
-                    onClick={() => void handleRotate()}
-                  >
-                    {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
-                  </button>
-                  <button
-                    type="button"
-                    className="studio-connect-skip"
-                    disabled={rotating}
-                    onClick={() => setRotateArmed(false)}
-                  >
-                    {t('connect.rotate.no')}
-                  </button>
-                </span>
-              )}
             </div>
-            {rotateError ? <p className="error">{rotateError}</p> : null}
-            <p className="studio-connect-expiry">{t('connect.step2.expiry', { when: expiresLabel })}</p>
-            <AgentOpenRoundsToggle token={token} />
           </div>
 
           <p className="studio-connect-waiting" aria-live="polite">

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -583,7 +583,13 @@ describe('SubmissionStatusView', () => {
           kimi: 'npx mcp-remote https://example.test/api/mcp',
           cli: 'curl https://example.test/api/mcp',
         },
-        kickoffPrompt: 'Build "Await Game" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+        kickoffPrompt: 'Build "Await Game" for gamedev.pl.\nStart with the gamedevpl tool, slug: await-game',
+        mcpUrl: 'https://example.test/api/mcp',
+        authorizationHeader: 'Authorization: Bearer test-key-not-for-display',
+        authorizationHeaderMasked: 'Authorization: Bearer ····play',
+        fingerprint: 'play',
+        keyGeneration: 1,
+        slug: 'await-game',
         expiresAt: Math.floor(Date.now() / 1000) + 3600,
       }),
     }));
@@ -647,7 +653,13 @@ describe('SubmissionStatusView', () => {
           kimi: 'npx mcp-remote https://example.test/api/mcp',
           cli: 'curl https://example.test/api/mcp',
         },
-        kickoffPrompt: 'Build "Quiet Game" for gamedev.pl.\nStart with the gamedevpl tool, key: quiet.key',
+        kickoffPrompt: 'Build "Quiet Game" for gamedev.pl.\nStart with the gamedevpl tool, slug: quiet-game',
+        mcpUrl: 'https://example.test/api/mcp',
+        authorizationHeader: 'Authorization: Bearer test-key-not-for-display',
+        authorizationHeaderMasked: 'Authorization: Bearer ····play',
+        fingerprint: 'play',
+        keyGeneration: 1,
+        slug: 'quiet-game',
         expiresAt: Math.floor(Date.now() / 1000) + 3600,
       }),
     }));
@@ -1849,7 +1861,14 @@ describe('SubmissionStatusView stop & retry', () => {
       kimi: 'npx mcp-remote https://example.test/api/mcp',
       cli: 'curl https://example.test/api/mcp',
     },
-    kickoffPrompt: 'Build "Handoff Game" for gamedev.pl.\nStart with the gamedevpl tool, key: round.key',
+    kickoffPrompt:
+      'Build "Handoff Game" for gamedev.pl.\nStart with the gamedevpl tool, slug: handoff-game.\nstart returns your workflow; after gate green the round is done.',
+    mcpUrl: 'https://example.test/api/mcp',
+    authorizationHeader: 'Authorization: Bearer test-key-not-for-display',
+    authorizationHeaderMasked: 'Authorization: Bearer ····play',
+    fingerprint: 'play',
+    keyGeneration: 1,
+    slug: 'handoff-game',
   };
 
   it('standalone: a published improve navigates the browser to the new job’s thread', async () => {

--- a/apps/web/src/connectApi.ts
+++ b/apps/web/src/connectApi.ts
@@ -1,8 +1,9 @@
 /**
- * Client for GET /api/submissions/:id/connect and durable game key management (BY-03 / BY-23).
+ * Client for GET /api/submissions/:id/connect and creator/game key management
+ * (BY-03 / BY-23 / BY-27a / BY-27b).
  *
- * Returns everything the Studio connect card needs: per-client install snippets
- * (MCP URL only) and the kickoff prompt that carries this game's durable key.
+ * Connect returns a config block (MCP URL + Authorization header) and a keyless
+ * kickoff prompt (slug only). The full Authorization value is for Copy only.
  */
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
@@ -13,20 +14,27 @@ export type ConnectClient = (typeof CONNECT_CLIENTS)[number];
 export type InstallSnippets = Record<ConnectClient, string>;
 
 export type ConnectPayload = {
+  /** Display snippets — Authorization header is masked. */
   installSnippets: InstallSnippets;
+  /** Keyless kickoff — slug only, never a key. */
   kickoffPrompt: string;
-  /** Unix seconds — identical to the game key's signed exp. */
+  mcpUrl: string;
+  /** Full Authorization header — hold in memory for Copy; never render. */
+  authorizationHeader: string;
+  authorizationHeaderMasked: string;
+  fingerprint: string;
+  /** Unix seconds — identical to the creator key's signed exp. */
   expiresAt: number;
-  /** Current keyGeneration — display/rotate UI; not a secret. */
-  keyGeneration?: number;
-  /** True when this kickoff is the same durable key the creator already pasted. */
-  sameKeyAsBefore?: boolean;
+  keyGeneration: number;
+  slug: string;
 };
 
-export type AgentKeyPayload = ConnectPayload & {
+export type AgentKeyPayload = {
   slug: string;
   keyGeneration: number;
-  allowAgentOpenRounds: boolean;
+  expiresAt: number;
+  kickoffPrompt: string;
+  installSnippets: InstallSnippets;
   rotated?: boolean;
 };
 
@@ -72,7 +80,7 @@ export async function getConnectPayload(token: string): Promise<ConnectPayload> 
   return body;
 }
 
-/** Remint the durable game key at the current generation (fresh exp, no rotate). */
+/** Remint the durable per-game key at the current generation (fresh exp, no rotate). */
 export async function getAgentKey(token: string): Promise<AgentKeyPayload> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key`, {
     credentials: 'include',
@@ -85,7 +93,7 @@ export async function getAgentKey(token: string): Promise<AgentKeyPayload> {
   return (await response.json()) as AgentKeyPayload;
 }
 
-/** Bump keyGeneration and return a fresh kickoff — agents holding the old key are cut off. */
+/** Bump per-game keyGeneration and return a fresh keyed kickoff. */
 export async function rotateAgentKey(token: string): Promise<AgentKeyPayload> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key/rotate`, {
     method: 'POST',
@@ -97,22 +105,6 @@ export async function rotateAgentKey(token: string): Promise<AgentKeyPayload> {
   }
 
   return (await response.json()) as AgentKeyPayload;
-}
-
-/** Opt in or out of agent-opened improvement rounds for this game (BY-24). */
-export async function setAgentOpenRounds(token: string, allow: boolean): Promise<{ allowAgentOpenRounds: boolean }> {
-  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/agent-key/open-rounds`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ allow }),
-  });
-
-  if (!response.ok) {
-    await throwResponseError(response);
-  }
-
-  return (await response.json()) as { allowAgentOpenRounds: boolean };
 }
 
 export type OAuthGrantSummary = {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -863,24 +863,37 @@
   },
   "connect": {
     "title": "Connect your coding agent",
-    "lead": "This round waits for your agent. Add gamedev.pl once, then paste the build prompt.",
+    "lead": "This round waits for your agent. Paste the MCP config once, then the build prompt.",
     "loading": "Preparing your connect steps…",
     "loadError": "We couldn't load the connect steps right now. Refresh in a moment.",
     "copied": "Copied",
+    "copyConfig": "Copy config",
+    "copyUrl": "Copy URL",
     "copyInstall": "Copy",
     "copyKickoff": "Copy prompt",
     "waiting": "Waiting for your agent to check in…",
+    "authMode": {
+      "label": "How to connect",
+      "key": "Paste header",
+      "oauth": "Sign in"
+    },
     "step1": {
       "title": "Add gamedev.pl to your agent",
       "clients": "Agent client",
+      "configHint": "Paste this into your agent's MCP server settings. The Authorization line is masked here — Copy puts the real header on your clipboard.",
+      "meta": "Ends in {{fingerprint}} · generation {{generation}} · expires {{when}}",
       "skip": "Already added it for another game? Skip this",
       "skipped": "Skipped — using the install you already have."
     },
     "step2": {
       "title": "Tell your agent what to build",
-      "sameConnection": "Your gamedev.pl connection stays the same — this game's key in the prompt below stays too unless you rotate it. No need to change your agent's config between rounds.",
+      "sameConnection": "Your gamedev.pl connection stays in your agent config — this prompt carries only the game slug, never a secret.",
       "sameKeyAsBefore": "Same key as before — nothing new to copy unless you rotated it.",
       "expiry": "This key works for this game and expires {{when}}."
+    },
+    "oauth": {
+      "title": "Sign in from your agent",
+      "hint": "Add this MCP URL in your agent, then sign in when it asks. Pass the game slug from the prompt below when you start."
     },
     "clients": {
       "claudeCode": "Claude Code",
@@ -899,18 +912,12 @@
     }
   },
   "agentKey": {
-    "title": "Agent connection",
+    "title": "Per-game key (legacy)",
     "loading": "Loading agent settings…",
     "loadError": "We couldn't load agent settings right now.",
-    "toggleError": "We couldn't update that setting. Try again in a moment.",
+    "legacyHint": "Prefer the coding-agent key above — paste it once in your agent's MCP config. This per-game key is for older setups only.",
     "expiry": "This game's key expires {{when}}.",
-    "rotatedKickoff": "Your key was rotated — copy this fresh kickoff for your agent:",
-    "openRounds": {
-      "title": "Let my agent start new rounds",
-      "on": "On",
-      "off": "Off",
-      "hint": "When on, your coding agent can open post-publish improvement rounds with this game's key. Uses the same daily improvement limit as starting a round here."
-    }
+    "rotatedKickoff": "Your key was rotated — copy this fresh kickoff for your agent:"
   },
   "oauthClients": {
     "title": "Connected coding agents",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -867,24 +867,37 @@
   },
   "connect": {
     "title": "Podłącz swojego agenta",
-    "lead": "Ta runda czeka na Twojego agenta. Dodaj gamedev.pl raz, potem wklej prompt budowy.",
+    "lead": "Ta runda czeka na Twojego agenta. Wklej raz konfigurację MCP, potem prompt budowy.",
     "loading": "Przygotowujemy kroki połączenia…",
     "loadError": "Nie udało się wczytać kroków połączenia. Odśwież za chwilę.",
     "copied": "Skopiowano",
+    "copyConfig": "Kopiuj konfigurację",
+    "copyUrl": "Kopiuj URL",
     "copyInstall": "Kopiuj",
     "copyKickoff": "Kopiuj prompt",
     "waiting": "Czekamy, aż Twój agent się odezwie…",
+    "authMode": {
+      "label": "Jak się połączyć",
+      "key": "Wklej nagłówek",
+      "oauth": "Zaloguj się"
+    },
     "step1": {
       "title": "Dodaj gamedev.pl do swojego agenta",
       "clients": "Klient agenta",
+      "configHint": "Wklej to w ustawieniach serwera MCP swojego agenta. Linia Authorization jest tu zamaskowana — Kopiuj wstawia prawdziwy nagłówek do schowka.",
+      "meta": "Końcówka {{fingerprint}} · generacja {{generation}} · wygasa {{when}}",
       "skip": "Już dodałeś to przy innej grze? Pomiń",
       "skipped": "Pominięte — używasz wcześniejszej instalacji."
     },
     "step2": {
       "title": "Powiedz agentowi, co zbudować",
-      "sameConnection": "Połączenie z gamedev.pl pozostaje bez zmian — klucz tej gry w prompcie poniżej też zostaje, dopóki go nie obrócisz. Nie musisz zmieniać konfiguracji agenta między rundami.",
+      "sameConnection": "Połączenie z gamedev.pl zostaje w konfiguracji agenta — ten prompt niesie tylko slug gry, nigdy sekretu.",
       "sameKeyAsBefore": "Ten sam klucz co wcześniej — nic nowego do skopiowania, chyba że go obróciłeś.",
       "expiry": "Ten klucz działa dla tej gry i wygasa {{when}}."
+    },
+    "oauth": {
+      "title": "Zaloguj się z poziomu agenta",
+      "hint": "Dodaj ten URL MCP w agencie, a potem zaloguj się, gdy zapyta. Przy starcie podaj slug gry z promptu poniżej."
     },
     "clients": {
       "claudeCode": "Claude Code",
@@ -903,18 +916,12 @@
     }
   },
   "agentKey": {
-    "title": "Połączenie z agentem",
+    "title": "Klucz per-gra (legacy)",
     "loading": "Wczytywanie ustawień agenta…",
     "loadError": "Nie udało się wczytać ustawień agenta.",
-    "toggleError": "Nie udało się zapisać tego ustawienia. Spróbuj za chwilę.",
+    "legacyHint": "Preferuj klucz agenta kodującego powyżej — wklej go raz w konfiguracji MCP. Ten klucz per-gra jest tylko dla starszych ustawień.",
     "expiry": "Klucz tej gry wygasa {{when}}.",
-    "rotatedKickoff": "Klucz został obrócony — skopiuj ten nowy kickoff dla agenta:",
-    "openRounds": {
-      "title": "Niech mój agent otwiera nowe rundy",
-      "on": "Wł.",
-      "off": "Wył.",
-      "hint": "Gdy włączone, Twój agent może otwierać rundy ulepszeń po publikacji tym kluczem gry. Zużywa ten sam dzienny limit ulepszeń co start rundy w Studio."
-    }
+    "rotatedKickoff": "Klucz został obrócony — skopiuj ten nowy kickoff dla agenta:"
   },
   "oauthClients": {
     "title": "Podłączone agenty kodujące",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Depends on BY-27a (#470 / `byoca/creator-agent-key`).

The connect card stops handing out secrets in the prompt, and agent-opened rounds stop being opt-in.

### Part 1 — keyless kickoff
- `buildKickoffPrompt` keyless mode emits the game **slug** and no key material
- Connect card is (a) MCP config block — URL + `Authorization: Bearer …` — and (b) the keyless prompt
- **The secret is never rendered at full length.** Config shows `Authorization: Bearer ····9a10e` with Copy that puts the real header on the clipboard; fingerprint + expiry identify the key
- OAuth sign-in stays as the alternative; choice remembered per creator (`localStorage`)
- `buildKickoffPrompt` **throws** if given both `gameKey` and `slug` (runtime invariant)
- Connect-card tests assert against `container.innerHTML` so the key cannot leak through markup

### Part 2 — drop the open-rounds opt-in
- `open_round` no longer checks `allowAgentOpenRounds`; Studio toggle and `AGENT_OPEN_ROUNDS_DISABLED_REASON` removed
- `setGameAgentOpenRounds` writer removed; optional field retained on the record type for existing Firestore docs only
- Guards that stay (and are tested): daily improvement quota, one-round-at-a-time admission lock (`finally`), sanitize + moderate relayed feedback, creator notification / `openedBy: 'agent'` marking, telemetry builder dimension
- `open_round` also accepts creator-key Bearer + slug

### Review follow-ups
- Rebased onto #470 tip (`SLUG_NOT_ON_ACCOUNT_REASON` + creator-key review fixes)
- Restored `resolveCreatorAgentKeyForOpenRound` with the same unowned/missing-slug reason as `start`
- **Copy config** replaces both full `Authorization: Bearer ····` and Bearer-only masks (Codex/Cursor)
- **`ensureGameAgentKey` null** refuses instead of touching another account’s admission lock
- **Slug transfer:** `startImprovementRound` takes `ownerUid` so agent-opened rounds land on the authorized creator

### Threat model (required wording)

Dropping the opt-in alongside BY-27a's creator-wide key is **two widenings landing together** — a leaked key now reaches every game the creator owns **and** can open rounds on them, spending their daily quota. Not unchanged. Compensating controls: opener-only writes, quota, admission lock, moderation, gate, D7, TTL, revoke, agent-opened visibility + notification. Config is not a vault (BY-12 plaintext under `$HOME`). Ops T4 updated in a paired ops PR.

### Out of scope
Quota size, removing per-game/round key shapes, OAuth server changes, listings.

### Test plan
- [x] Keyless prompt contains slug and no key material
- [x] Config block rendered markup does not contain the full key
- [x] Copy config works for Claude **and** Codex/Cursor (Bearer-only)
- [x] `open_round` succeeds with no flag set; quota / idempotency / moderation stay
- [x] Unowned/missing slug → `SLUG_NOT_ON_ACCOUNT_REASON` on start and open_round
- [x] ensureGameAgentKey owner mismatch refuses; transferred slug keeps new owner
- [x] Full green gate on tip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4e5063-12f7-4e30-824d-d451ac26e577?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4e5063-12f7-4e30-824d-d451ac26e577&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

