### PR TITLE
feat(snapshot): derive catalog from games archive at bake time

### DIFF
--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -5,8 +5,9 @@ name: Publish games snapshot
 # the request path (apps/api/src/game-snapshot.ts).
 #
 # Fires on a repository_dispatch from the games repo's validate workflow, right
-# after a merge to main regenerates catalog.json — see
-# gamedevpl/www.gamedev.pl-games/.github/workflows/validate.yml. The
+# after a merge to main passes the games-repo gate — see
+# gamedevpl/www.gamedev.pl-games/.github/workflows/validate.yml. The bake derives
+# the snapshot catalog from that SHA's archive (no committed catalog.json). The
 # workflow_dispatch entry point is the manual escape hatch: re-baking after an
 # assembler change here, or recovering from a failed publish.
 #

--- a/apps/api/scripts/publish-snapshot.ts
+++ b/apps/api/scripts/publish-snapshot.ts
@@ -55,13 +55,13 @@ const commitSha = readFlag('commit-sha')?.trim() || null;
 /**
  * What the bake actually reads.
  *
- * A branch name is a moving target. The games repo pushes its refreshed
- * `catalog.json` and dispatches this job seconds later, so resolving `main`
- * here can still land on the pre-push tree — and it did: a merge that added a
- * game published a snapshot of the previous 92 while recording the newer
+ * A branch name is a moving target. The games repo used to push a refreshed
+ * `catalog.json` and dispatch this job seconds later, so resolving `main`
+ * here could still land on the pre-push tree — and it did: a merge that added
+ * a game published a snapshot of the previous 92 while recording the newer
  * commit in the pointer. Green run, correct-looking metadata, missing game,
  * and nothing else retires that snapshot until the next merge or the nightly
- * re-bake.
+ * re-bake. The bake now derives the catalog from the pinned archive itself.
  *
  * The dispatch already tells us the exact commit, so bake that. `ref` stays
  * the fallback for callers that cannot name one (a manual bake, the nightly).

--- a/apps/api/src/catalog-touch.test.ts
+++ b/apps/api/src/catalog-touch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { classifyTouchSource } from './catalog-touch.js';
+
+describe('classifyTouchSource', () => {
+  it('detects GameKit createInput as gamekit', () => {
+    expect(classifyTouchSource('const input = GameKit.createInput(canvas);')).toBe('gamekit');
+  });
+
+  it('detects defineGame as gamekit', () => {
+    expect(classifyTouchSource('GameKit.defineGame().input({ steer: "origin" }).start();')).toBe('gamekit');
+  });
+
+  it('treats touch: false + pointer polls as native', () => {
+    expect(
+      classifyTouchSource(`
+        const input = GameKit.createInput(canvas, { touch: false });
+        input.consumeClick();
+      `),
+    ).toBe('native');
+  });
+
+  it('detects party games as controllers', () => {
+    expect(classifyTouchSource('const party = GameKit.createParty(canvas);')).toBe('controllers');
+  });
+
+  it('returns none for keyboard-only code', () => {
+    expect(classifyTouchSource('window.addEventListener("keydown", () => {});')).toBe('none');
+  });
+});

--- a/apps/api/src/catalog-touch.test.ts
+++ b/apps/api/src/catalog-touch.test.ts
@@ -23,6 +23,15 @@ describe('classifyTouchSource', () => {
     expect(classifyTouchSource('const party = GameKit.createParty(canvas);')).toBe('controllers');
   });
 
+  it('keeps party ahead of createInput when both appear', () => {
+    expect(
+      classifyTouchSource(`
+        const party = GameKit.createParty(canvas);
+        const input = GameKit.createInput(canvas);
+      `),
+    ).toBe('controllers');
+  });
+
   it('returns none for keyboard-only code', () => {
     expect(classifyTouchSource('window.addEventListener("keydown", () => {});')).toBe('none');
   });

--- a/apps/api/src/catalog-touch.ts
+++ b/apps/api/src/catalog-touch.ts
@@ -10,7 +10,7 @@
  * - `controllers` — party game; phones are the controllers
  * - `none` — keyboard-only
  */
-export type CatalogTouchSupport = 'gamekit' | 'native' | 'controllers' | 'none';
+export type CatalogGameTouch = 'gamekit' | 'native' | 'controllers' | 'none';
 
 const OPTS_OUT = /touch\s*:\s*false/;
 const USES_GAMEKIT_INPUT = /createInput\s*\(|\bdefineGame\b/;
@@ -19,7 +19,7 @@ const HANDLES_POINTERS =
   /consumeClick\s*\(|consumePress\s*\(|\.position\s*\(|\.held\s*\(|pointerdown|pointermove|pointerup|touchstart|\.pointer\s*\(/;
 
 /** Classifies a game's concatenated TypeScript. Pure so it is directly testable. */
-export function classifyTouchSource(code: string): CatalogTouchSupport {
+export function classifyTouchSource(code: string): CatalogGameTouch {
   if (USES_PARTY.test(code)) return 'controllers';
   if (USES_GAMEKIT_INPUT.test(code) && !OPTS_OUT.test(code)) return 'gamekit';
   if (HANDLES_POINTERS.test(code)) return 'native';

--- a/apps/api/src/catalog-touch.ts
+++ b/apps/api/src/catalog-touch.ts
@@ -1,0 +1,27 @@
+/**
+ * How a game can be played with a thumb (and with mouse / touchpad via the same path).
+ *
+ * Mirrors www.gamedev.pl-games `tools/lib/touch.ts` `classifyTouchSource` — kept here so
+ * the snapshot bake can derive a website-ready catalog from a games-repo archive without
+ * reading a committed `catalog.json` (or re-implementing a second, drifting classifier).
+ *
+ * - `gamekit` — reads input through `GameKit.createInput` / `defineGame`
+ * - `native` — opted out of the overlay and handles pointer polls itself
+ * - `controllers` — party game; phones are the controllers
+ * - `none` — keyboard-only
+ */
+export type CatalogTouchSupport = 'gamekit' | 'native' | 'controllers' | 'none';
+
+const OPTS_OUT = /touch\s*:\s*false/;
+const USES_GAMEKIT_INPUT = /createInput\s*\(|\bdefineGame\b/;
+const USES_PARTY = /\bcreateParty\s*\(/;
+const HANDLES_POINTERS =
+  /consumeClick\s*\(|consumePress\s*\(|\.position\s*\(|\.held\s*\(|pointerdown|pointermove|pointerup|touchstart|\.pointer\s*\(/;
+
+/** Classifies a game's concatenated TypeScript. Pure so it is directly testable. */
+export function classifyTouchSource(code: string): CatalogTouchSupport {
+  if (USES_PARTY.test(code)) return 'controllers';
+  if (USES_GAMEKIT_INPUT.test(code) && !OPTS_OUT.test(code)) return 'gamekit';
+  if (HANDLES_POINTERS.test(code)) return 'native';
+  return 'none';
+}

--- a/apps/api/src/games-repo-archive.ts
+++ b/apps/api/src/games-repo-archive.ts
@@ -49,8 +49,10 @@ export interface GamesRepoArchive extends RepoFileSource {
   listPaths(): string[];
 }
 
-/** Sources, media, and the committed catalog — everything the bake reads. */
+/** Sources and media — everything the bake needs to assemble games and derive the catalog. */
 function defaultInclude(path: string): boolean {
+  // Legacy committed catalog.json is still retained when present so older SHAs
+  // keep working; the bake prefers deriving from games/ via listPaths.
   return path === 'catalog.json' || path.startsWith('games/') || path.startsWith('shared/');
 }
 

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -524,6 +524,60 @@ describe('getCatalog', () => {
     expect(catalog[0].slug).toBe('bubble-pop');
     expect(catalog[0].touch).toBeUndefined();
   });
+
+  it('derives the catalog (including touch) from an archive file source without network', async () => {
+    const files = new Map<string, string>([
+      [
+        'games/bubble-pop/SPEC.md',
+        specMd({
+          title: 'Bubble Pop Rush',
+          status: 'published',
+          genre: 'arcade',
+          orientation: 'portrait',
+        }),
+      ],
+      [
+        'games/bubble-pop/media/metadata.json',
+        JSON.stringify({
+          captures: { opening: { file: 'opening.png' }, gone: { file: 'missing.png' } },
+          video: { file: 'gameplay.mp4' },
+        }),
+      ],
+      ['games/bubble-pop/media/opening.png', 'png'],
+      ['games/bubble-pop/media/gameplay.mp4', 'mp4'],
+      ['games/bubble-pop/game.ts', 'const input = GameKit.createInput(canvas);\n'],
+      ['games/arena-tag/SPEC.md', specMd({ title: 'Arena Tag', status: 'published', multiplayer: 'controllers' })],
+      ['games/arena-tag/game.ts', 'const party = GameKit.createParty(canvas);\n'],
+      // Stale committed catalog must not win over archive derivation.
+      ['catalog.json', JSON.stringify([{ slug: 'stale', title: 'Stale' }])],
+    ]);
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('archive-backed getCatalog must not hit the network');
+    }) as unknown as typeof fetch;
+
+    const client = createGitHubClient({
+      token: 'test-token',
+      repo,
+      fetchImpl,
+      files: {
+        async readText(path) {
+          return files.get(path) ?? null;
+        },
+        async readBytes() {
+          return null;
+        },
+        listPaths: () => [...files.keys()],
+      },
+    });
+
+    const catalog = await client.getCatalog('main');
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(catalog.map((entry) => [entry.slug, entry.touch, entry.media?.screenshots.map((s) => s.file)])).toEqual([
+      ['arena-tag', 'controllers', undefined],
+      ['bubble-pop', 'gamekit', ['opening.png']],
+    ]);
+    expect(catalog.find((entry) => entry.slug === 'bubble-pop')?.media?.video).toBe('gameplay.mp4');
+  });
 });
 
 describe('getGameMedia', () => {
@@ -1074,12 +1128,16 @@ describe('failed request reporting', () => {
   }
 
   it('reports the permission a refused write actually wanted', async () => {
-    const fetchImpl = respondWith(403, JSON.stringify({ message: 'Resource not accessible by personal access token' }), {
-      'x-accepted-github-permissions': 'contents=write',
-      // Present and non-zero: this is a permission problem, not a throttle, and the
-      // client must not retry it as one.
-      'x-ratelimit-remaining': '4998',
-    });
+    const fetchImpl = respondWith(
+      403,
+      JSON.stringify({ message: 'Resource not accessible by personal access token' }),
+      {
+        'x-accepted-github-permissions': 'contents=write',
+        // Present and non-zero: this is a permission problem, not a throttle, and the
+        // client must not retry it as one.
+        'x-ratelimit-remaining': '4998',
+      },
+    );
     const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
 
     const error = await client.deleteBranch('copilot/spent').catch((err: unknown) => err);

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
+import { classifyTouchSource } from './catalog-touch.js';
 import { GAME_KIT_MODULES } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
@@ -246,10 +247,10 @@ export interface CatalogGameEntry {
    */
   submittedBy: string | null;
   /**
-   * Touch playability class, derived from each game's *code* by the games repo's
-   * own build (it runs inferTouchSupport over the sources). Nothing readable from
-   * SPEC.md can reproduce it, so it is present only when the catalog came from the
-   * committed catalog.json artifact — the GraphQL fallback below leaves it absent.
+   * Touch playability class, derived from each game's *code* (createInput /
+   * defineGame / party / pointer polls). Present when the catalog was built from
+   * a games-repo archive (snapshot bake) or from a legacy committed catalog.json.
+   * The GraphQL SPEC-only fallback leaves it absent.
    */
   touch?: CatalogGameTouch;
 }
@@ -450,12 +451,13 @@ export interface GitHubClient {
    */
   getGameMediaManifest(ref: string, slug: string): Promise<CatalogGameMedia | null>;
   /**
-   * Builds the game catalog straight from the repo: lists `games/` directories
-   * on `ref`, then reads each game's SPEC.md (and media metadata) in a small
-   * number of GraphQL round-trips. Replaces both the old public Pages
-   * `catalog.json` and the previous per-file Contents-API fan-out, so the games
-   * repo can stay private without a rate-limit storm. Games with a missing or
-   * unparseable SPEC.md are skipped.
+   * Builds the game catalog for `ref`. Prefer, in order:
+   * 1. Derive from an archive file source (`listPaths`) — used by the snapshot
+   *    bake; includes code-derived `touch` and does not need a committed
+   *    `catalog.json` in the games repo.
+   * 2. A legacy committed `catalog.json` (older SHAs / non-archive callers).
+   * 3. GraphQL SPEC + media fan-out (no `touch`).
+   * Games with a missing or unparseable SPEC.md are skipped.
    */
   getCatalog(ref: string): Promise<CatalogGameEntry[]>;
   /**
@@ -490,10 +492,15 @@ export interface GitHubClient {
  * (`fetchGamesRepoArchive`) instead, which is the same files at 1/1000th the
  * request count. Reads that are not plain file reads — GraphQL, issues, PRs —
  * always go to the API.
+ *
+ * `listPaths` is present on archive sources and lets `getCatalog` derive the
+ * website catalog (including code-derived `touch`) without a committed
+ * `catalog.json` in the games repo.
  */
 export interface RepoFileSource {
   readText(path: string, ref: string): Promise<string | null>;
   readBytes(path: string, ref: string): Promise<Uint8Array | null>;
+  listPaths?(): string[];
 }
 
 export interface GitHubClientOptions {
@@ -1284,12 +1291,14 @@ ${gameJs}`;
         throw new Error(`invalid published ref "${ref}"`);
       }
 
-      // Fast path: the games repo commits a website-ready catalog.json at its root,
-      // held fresh by its own validate gate. One read answers the whole catalog, and
-      // it is the only source that can carry `touch` — a value derived from each
-      // game's code, which no amount of SPEC.md reading here can reproduce.
-      // The GraphQL fan-out below stays as the fallback for refs without the
-      // artifact (older commits, and PR branches during a build).
+      // Snapshot bake supplies an archive with listPaths — derive there so the
+      // games repo no longer has to commit catalog.json onto a protected main.
+      const listPaths = options.files?.listPaths;
+      if (typeof listPaths === 'function') {
+        return buildCatalogFromArchive(ref, readRawFile, listPaths());
+      }
+
+      // Legacy fast path: older SHAs still carry a committed catalog.json.
       const committed = await readRawFile('catalog.json', ref);
       if (committed !== null) {
         const entries = parseCommittedCatalog(committed);
@@ -1381,6 +1390,53 @@ const SAFE_MEDIA_NAME = /^[a-z0-9][a-z0-9-]*$/;
 const SAFE_MEDIA_PNG = /^[a-z0-9][a-z0-9-]*\.png$/;
 const SAFE_MEDIA_MP4 = /^[a-z0-9][a-z0-9-]*\.mp4$/;
 const CATALOG_TOUCH_VALUES = new Set<CatalogGameTouch>(['gamekit', 'native', 'controllers', 'none']);
+
+/**
+ * Builds the website catalog from a games-repo archive listing. Same fields as
+ * the old committed catalog.json (including code-derived `touch`), but computed
+ * at bake time from the tree being published — so a merge never has to push a
+ * regenerated aggregate onto protected `main` first.
+ */
+async function buildCatalogFromArchive(
+  ref: string,
+  readRawFile: (path: string, ref: string) => Promise<string | null>,
+  paths: readonly string[],
+): Promise<CatalogGameEntry[]> {
+  const pathSet = new Set(paths);
+  const slugs = [
+    ...new Set(
+      paths.flatMap((filePath) => {
+        const match = /^games\/([a-z0-9][a-z0-9-]*)\/SPEC\.md$/.exec(filePath);
+        return match?.[1] ? [match[1]] : [];
+      }),
+    ),
+  ].sort();
+
+  const entries: CatalogGameEntry[] = [];
+  for (const slug of slugs) {
+    const specMd = await readRawFile(`games/${slug}/SPEC.md`, ref);
+    if (specMd === null) continue;
+
+    const mediaPath = `games/${slug}/media/metadata.json`;
+    const mediaJson = pathSet.has(mediaPath) ? await readRawFile(mediaPath, ref) : null;
+    const entry = catalogEntryFromSpec(slug, specMd, (name) => (name === 'media/metadata.json' ? mediaJson : null));
+    if (!entry) continue;
+
+    if (entry.media) {
+      const screenshots = entry.media.screenshots.filter((shot) => pathSet.has(`games/${slug}/media/${shot.file}`));
+      const video =
+        entry.media.video && pathSet.has(`games/${slug}/media/${entry.media.video}`) ? entry.media.video : null;
+      entry.media = screenshots.length > 0 || video ? { screenshots, video } : null;
+    }
+
+    const tsPaths = paths.filter((filePath) => filePath.startsWith(`games/${slug}/`) && filePath.endsWith('.ts'));
+    const sources = await Promise.all(tsPaths.map((filePath) => readRawFile(filePath, ref)));
+    entry.touch = classifyTouchSource(sources.filter((text): text is string => text !== null).join('\n'));
+
+    entries.push(entry);
+  }
+  return entries;
+}
 
 /**
  * Parses the games repo's committed catalog.json into catalog entries. The file

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,8 +1,10 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
-import { classifyTouchSource } from './catalog-touch.js';
+import { classifyTouchSource, type CatalogGameTouch } from './catalog-touch.js';
 import { GAME_KIT_MODULES } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
+
+export type { CatalogGameTouch } from './catalog-touch.js';
 
 interface CreateIssueInput {
   title: string;
@@ -254,8 +256,6 @@ export interface CatalogGameEntry {
    */
   touch?: CatalogGameTouch;
 }
-
-export type CatalogGameTouch = 'gamekit' | 'native' | 'controllers' | 'none';
 
 export type CatalogGameOrientation = 'any' | 'portrait' | 'landscape';
 
@@ -1402,18 +1402,28 @@ async function buildCatalogFromArchive(
   readRawFile: (path: string, ref: string) => Promise<string | null>,
   paths: readonly string[],
 ): Promise<CatalogGameEntry[]> {
+  // One pass over the archive listing: slug set, per-slug .ts paths, path Set for
+  // media existence. Avoids O(paths × games) rescans inside the per-game loop.
   const pathSet = new Set(paths);
-  const slugs = [
-    ...new Set(
-      paths.flatMap((filePath) => {
-        const match = /^games\/([a-z0-9][a-z0-9-]*)\/SPEC\.md$/.exec(filePath);
-        return match?.[1] ? [match[1]] : [];
-      }),
-    ),
-  ].sort();
+  const slugs = new Set<string>();
+  const tsPathsBySlug = new Map<string, string[]>();
+  for (const filePath of paths) {
+    const match = /^games\/([a-z0-9][a-z0-9-]*)\/(.+)$/.exec(filePath);
+    if (!match) continue;
+    const slug = match[1];
+    const relative = match[2];
+    if (relative === 'SPEC.md') {
+      slugs.add(slug);
+    }
+    if (relative.endsWith('.ts')) {
+      const list = tsPathsBySlug.get(slug);
+      if (list) list.push(filePath);
+      else tsPathsBySlug.set(slug, [filePath]);
+    }
+  }
 
   const entries: CatalogGameEntry[] = [];
-  for (const slug of slugs) {
+  for (const slug of [...slugs].sort()) {
     const specMd = await readRawFile(`games/${slug}/SPEC.md`, ref);
     if (specMd === null) continue;
 
@@ -1429,7 +1439,7 @@ async function buildCatalogFromArchive(
       entry.media = screenshots.length > 0 || video ? { screenshots, video } : null;
     }
 
-    const tsPaths = paths.filter((filePath) => filePath.startsWith(`games/${slug}/`) && filePath.endsWith('.ts'));
+    const tsPaths = tsPathsBySlug.get(slug) ?? [];
     const sources = await Promise.all(tsPaths.map((filePath) => readRawFile(filePath, ref)));
     entry.touch = classifyTouchSource(sources.filter((text): text is string => text !== null).join('\n'));
 

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -108,9 +108,10 @@ still in flight.
 ```
 merge to games-repo main
   → validate.yml: npm run check
-  → validate.yml: regenerate + commit catalog.json
-  → validate.yml: repository_dispatch → this repo
+  → validate.yml: repository_dispatch → this repo (pinned SHA)
   → publish-games.yml: npm run snapshot:publish
+      (derives catalog.json from the games archive — including code-derived touch —
+       and writes it into the snapshot; the games repo does not commit catalog.json)
   → objects written, then current.json moves (only if every game baked cleanly)
   → running instances pick it up within the pointer TTL (~1 min)
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Live `GET /api/catalog` already reads `snapshots/<id>/catalog.json` from GCS. The games repo was still committing that aggregate to protected `main` just so the bake could copy it — and that push now fails with `GH006`.

## What

When the bake has a games-repo archive (`listPaths`), derive the catalog from `games/*/SPEC.md` + media + TypeScript (including code-derived `touch`) and write it into the snapshot. Legacy committed `catalog.json` remains a fallback for older SHAs / non-archive callers; GraphQL SPEC fan-out stays last.

Paired with gamedevpl/www.gamedev.pl-games#422 (stop committing `catalog.json`, dispatch bake after gate).

**Merge this before the games PR** so production bake can derive `touch` the moment games drops the committed file.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-315b23f1-d7e5-4768-8960-decf94c49bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-315b23f1-d7e5-4768-8960-decf94c49bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

