### PR TITLE
Deploy gate: a game that waits at the start line is not a broken game

### DIFF
--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -96,21 +96,37 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
         .then(() => true)
         .catch(() => false);
       if (booted) {
+        // A canvas that exists is not yet a canvas that is running. These games
+        // draw everything — HUD included — into it, so the frame's innerText
+        // never moves and pixels are the only readable output; a canvas still
+        // producing new frames is a game that booted and kept going, which is
+        // the failure this catches: a black or frozen theater.
+        //
+        // Inside the candidate loop, deliberately. It used to sit after it, and
+        // that is how a working game blocked a deploy: apex-sprint became a
+        // racer that idles at the start line until the player moves, sorted
+        // first in the catalog, and every deploy failed on a game that was fine.
+        // A still opening beat is a legitimate design, so it costs this game its
+        // turn as the sample rather than costing the site its release. If none
+        // of the three ever move, that is a real finding and still fails.
+        const canvas = found.locator('canvas').first();
+        const render = async () => (await canvas.screenshot()).toString('base64');
+        const before = await render();
+        const moving = await expect
+          .poll(render, { timeout: 10_000 })
+          .not.toBe(before)
+          .then(() => true)
+          .catch(() => false);
+        if (!moving) {
+          watcher.drain();
+          continue;
+        }
         frame = found;
         break;
       }
       watcher.drain(); // a candidate that never booted leaves noise that is not this test's finding
     }
-    expect(frame, 'no sampled single-player game booted a canvas').toBeTruthy();
-
-    // These games draw everything — HUD included — into the canvas, so the frame's
-    // innerText never moves and pixels are the only readable output. A canvas that
-    // keeps producing new frames is a game that booted and is still running, which
-    // is the failure this catches: a black or frozen theater.
-    const canvas = frame!.locator('canvas').first();
-    const render = async () => (await canvas.screenshot()).toString('base64');
-    const first = await render();
-    await expect.poll(render, { timeout: 20_000 }).not.toBe(first);
+    expect(frame, 'no sampled single-player game booted a canvas that kept drawing').toBeTruthy();
 
     // Deliberately *not* asserting that the picture changes in response to a
     // keystroke: most of these games animate on their own, so a pixel diff after


### PR DESCRIPTION
**Master cannot deploy right now.** This unblocks it. The last two attempts on `f722acb` both failed the browser gate, so production is still serving the revision before #476.

## What failed

`boots a generated game into a live canvas` screenshots the game's canvas twice and requires the picture to change within twenty seconds. It did not — twice, on the same commit, so not flake.

## Why, and why it is not the merged change

Driven against **production** — which is still on the older revision, so this is provable independently of anything in #476:

```
first 3 single-player: apex-sprint, beat-teacher, biplane-skirmish
apex-sprint → canvas 180176b | changed@1.5s=false | changed@5.5s=false
apex-sprint → changed after input=true
frame text: "Go! The clock is running."
```

Apex Sprint became a 3D racer (games repo #403) that idles at the start line until the player moves, and it sorts first in the catalog. Its canvas is byte-identical over five seconds and changes the instant a key is pressed. **The game is fine.** The gate was asserting that the catalog's first game animates unattended, which is not a property any game promises.

The timing fits: the two games-snapshot bakes at 22:41 and 22:53 — the first ones using #474's new catalog derivation — landed between the last green gate (22:34) and the first red one (23:08).

## The fix

The candidate loop above the assertion exists for exactly this. Its own comment says letting one game fail this test would hold the website hostage to another repo's content — but it only ever covered whether a canvas *appeared*. The animation check sat after the loop, outside that protection.

It moves inside. A game that opens on a still beat costs itself its turn as the sample rather than costing the site its release, and if none of the three sampled games ever move, that is a real finding and still fails.

## Verification

Ran the full walkthrough suite against production with the fix — 6/6 pass, and the game it samples is now the next one in the catalog rather than the racer:

```
✓ src/walkthrough.test.ts (6 tests) 55964ms
  ✓ boots a generated game into a live canvas that can receive input  26353ms
```

`npm run lint`, `npm run type-check` clean.

## Worth a separate look

Nothing here is wrong, but two things are worth knowing: the catalog's first game now shows a still frame until the player acts, which is also the first impression for anyone landing on it; and `games-playable.test.ts` passed throughout, so it does not catch a frozen theater the way this test is meant to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_