### PR TITLE
Remix code lane: ship esbuild with its engine, and stop laundering the failure

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -54,11 +54,21 @@ COPY packages/game-generator/package.json packages/game-generator/
 COPY packages/zone-core/package.json packages/zone-core/
 COPY apps/api/package.json apps/api/
 COPY apps/web/package.json apps/web/
-# --omit=optional keeps `isolated-vm` out of THIS image. It is zone-core's only external
-# dependency and it is optional precisely so that consumers who never open a cage skip a
-# native build. The API only mints tickets and parses schemas; the cage runs in the
-# separate world service, which has its own Dockerfile and installs it there.
-RUN npm ci --omit=dev --omit=optional --ignore-scripts
+# NOT --omit=optional, and the reason is worth the paragraph. It used to be here to keep
+# `isolated-vm` (zone-core's optional dependency, needed only by the world service) out of
+# this image — but esbuild ships its native engine the same way, as optional per-platform
+# packages (`@esbuild/linux-x64`), with its postinstall as the only fallback. Combined with
+# --ignore-scripts, that flag installed esbuild's JavaScript wrapper and none of its engine,
+# so every `build()` and `transform()` in this container threw at runtime.
+#
+# Nothing noticed for months: published games are served from the pre-baked snapshot, so the
+# server never assembled one. The remix code lane is the first feature that needs to, and it
+# answered "this game cannot be remixed that deeply yet" for every game on the site.
+#
+# --ignore-scripts still does the job the flag was reached for: isolated-vm arrives as source
+# and is never compiled, which costs disk and nothing else, while esbuild's engine is a
+# prebuilt binary that needs no script to work. Keep both flags off this line together.
+RUN npm ci --omit=dev --ignore-scripts
 
 # Built output: API dist, game-generator dist + runtime templates, and the static web bundle.
 COPY --from=builder /app/packages/game-generator/dist packages/game-generator/dist

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1149,20 +1149,20 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     async getGameSourceMap(ref, slug) {
       if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) return null;
       const entry = await readRawFile(`games/${slug}/game.ts`, ref);
+      // No entry point is the only absence this reports. Everything else — a read
+      // that fails, a bundle that will not build — *throws*, because the first
+      // version of this swallowed both into the same null and the caller turned
+      // that null into "this game cannot be remixed that deeply yet". A game with
+      // an entry point and a broken pipeline then looked exactly like a game we
+      // had chosen not to support, which is the same laundering that made every
+      // remix answer "game not found" (see the note on `getGameFile`).
       if (entry === null) return null;
       const collected = new Map<string, string>([['game.ts', entry]]);
-      try {
-        // The bundle output is discarded — this runs the walk for its trail. Doing
-        // it any other way (a directory listing, a hand-rolled import parser)
-        // would be a second, quietly different answer to "what is this game made
-        // of", and the two would drift the first time an import convention moved.
-        await bundleGameTypeScript(entry, ref, slug, undefined, collected);
-      } catch {
-        // A game that cannot be bundled cannot be edited either — the lane needs
-        // a baseline that builds, and saying so here keeps the caller's answer
-        // "not this game" rather than a failure halfway through an edit.
-        return null;
-      }
+      // The bundle output is discarded — this runs the walk for its trail. Doing
+      // it any other way (a directory listing, a hand-rolled import parser)
+      // would be a second, quietly different answer to "what is this game made
+      // of", and the two would drift the first time an import convention moved.
+      await bundleGameTypeScript(entry, ref, slug, undefined, collected);
       return Object.fromEntries(collected);
     },
 

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -486,6 +486,49 @@ describe('remix across the two catalog eras', () => {
     expect(mapCalls).toEqual(['dog-dash']);
   });
 
+  it('separates a broken pipeline from a game it cannot edit', async () => {
+    // The two used to arrive as the same sentence, and that is how a working
+    // feature reads as a missing one: a game with an entry point and a failing
+    // bundle looked exactly like a game we had chosen not to support.
+    const store = new InMemoryStore();
+    const instance = Fastify({ routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH } });
+    instance.decorateRequest('user', null);
+    instance.addHook('onRequest', async (request) => {
+      const uid = request.headers['x-test-uid'];
+      (request as { user?: unknown }).user = typeof uid === 'string' ? { uid, tier: 'standard' } : null;
+    });
+    const client = stubGitHubClient([]) as GitHubClient & {
+      getGameSourceMap: (ref: string, slug: string) => Promise<Record<string, string> | null>;
+    };
+    client.getGameSourceMap = async () => {
+      throw new Error('github said no');
+    };
+    await registerRemixRoutes(instance, {
+      store,
+      gamesStore: stubGamesStore(),
+      githubClient: client,
+      publishedRef: 'main',
+      assistant: { assist: async () => ({ lane: 'params' }) } as EditorAssistant,
+      codeLane: { run: async () => ({ ok: true }) } as never,
+    });
+    await instance.ready();
+    app = instance;
+
+    const { remixId } = (
+      await instance.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })
+    ).json();
+    const response = await instance.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'add a double jump' },
+    });
+
+    // Ours, not the game's: a fault the player can retry, not a limit they cannot.
+    expect(response.statusCode).toBe(503);
+    expect(response.json().reason).toBe('sources_unavailable');
+  });
+
   it('declines the deep lane for a game whose sources will not assemble', async () => {
     app = await repoEraApp({ codeLane: { run: async () => ({ ok: true }) } });
     // `no-sources` has a manifest and a declaration but no assemblable code.

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -492,13 +492,29 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       // overwhelming majority of remixes never ask for a rebuild — the cost lands
       // on the request that needs it, once per session.
       if (!session.fromStore && !session.sourcesLoaded) {
-        const sources = options.githubClient
-          ? await options.githubClient.getGameSourceMap(session.ref, session.slug)
-          : null;
+        let sources: Record<string, string> | null;
+        try {
+          sources = options.githubClient
+            ? await options.githubClient.getGameSourceMap(session.ref, session.slug)
+            : null;
+        } catch (error) {
+          // A pipeline that broke is not a game we decided not to support, and
+          // the two must not arrive as the same sentence. This one is ours: it
+          // is logged with the cause, and answered as a fault the player can
+          // retry rather than as a limit they cannot.
+          request.log.error(
+            { err: error, slug: session.slug, ref: session.ref },
+            'remix code lane could not read a game source map',
+          );
+          return reply.status(503).send({
+            error: 'editing is resting right now — the game still plays',
+            reason: 'sources_unavailable',
+          });
+        }
         if (!sources) {
-          // A game whose sources cannot be assembled cannot be edited; that is a
-          // fact about this game, not a failure of the request.
-          return reply.status(409).send({ error: 'this game cannot be remixed that deeply yet' });
+          // No entry point. A fact about this game, and the only absence this
+          // route reports as one.
+          return reply.status(409).send({ error: 'this game cannot be remixed that deeply yet', reason: 'no_sources' });
         }
         // The declaration already in hand stays: it is not part of the import
         // graph, and the params lane is still reading it.

--- a/apps/api/src/runtime-image.test.ts
+++ b/apps/api/src/runtime-image.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * The runtime image has to be able to bundle a game.
+ *
+ * This is a source guard rather than a unit test because the failure it catches
+ * cannot be reproduced anywhere a test runs: every machine that runs this suite
+ * has a full node_modules, so esbuild works here and only here. In the container
+ * it did not, for months, and nothing noticed — published games are served from
+ * the pre-baked snapshot, so the server never assembled one until the remix code
+ * lane asked it to, and then every game on the site answered "this game cannot be
+ * remixed that deeply yet".
+ */
+
+const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
+const runtimeInstall = dockerfile
+  .split('\n')
+  .filter((line) => line.startsWith('RUN npm ci'))
+  .at(-1)!;
+
+describe('the API runtime image', () => {
+  it('does not strip optional dependencies, which is where esbuild keeps its engine', () => {
+    // esbuild ships per-platform binaries as optionalDependencies (@esbuild/linux-x64)
+    // and its postinstall is the only fallback — so --omit=optional together with
+    // --ignore-scripts leaves the JavaScript wrapper with nothing to execute.
+    expect(runtimeInstall).not.toContain('--omit=optional');
+  });
+
+  it('keeps esbuild a real dependency of the API, not a build-time one', () => {
+    // --omit=dev is correct and stays; that makes this the load-bearing half.
+    const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(manifest.dependencies?.esbuild).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Garden Gather answered `409 this game cannot be remixed that deeply yet` for a request the code lane should take. Root cause found, in the Dockerfile.

## 1. The runtime image ships esbuild without its engine

```
RUN npm ci --omit=dev --omit=optional --ignore-scripts
```

`esbuild@0.25.12` ships its native engine as **optional per-platform packages** (`@esbuild/linux-x64`), with its `postinstall` as the only fallback. `--omit=optional` strips the engine; `--ignore-scripts` disables the fallback. The container has esbuild's JavaScript wrapper and nothing to execute, so every `build()` and `transform()` throws.

Nothing noticed for months, because **nothing in production bundles**: published games are served from the pre-baked snapshot (`submissions.ts` returns `readSnapshotGame` when a `snapshotReader` is present), and the server assembles a game only on the draft path. The remix code lane is the first shipped feature that needs it — for the source map, and again in `rebuild()` — so it failed on every game on the site, in a sentence about the game for a fact about the image.

`--omit=optional` was reached for to keep `isolated-vm` (zone-core's optional dependency, used only by the world service) out of this image, and it took esbuild with it. `--ignore-scripts` already does that job alone: isolated-vm arrives as source and is never compiled, costing disk and nothing else, while esbuild's engine is a prebuilt binary needing no script to run.

Guarded by a source test, because this cannot be reproduced where tests run — every machine running the suite has a full `node_modules`, so esbuild works there and only there.

## 2. The failure said the wrong thing, and left no way to tell

`getGameSourceMap` returned `null` for every failure — missing entry point, failed read, bundle that would not build — and the route turned every `null` into the one sentence meaning "we chose not to support this game". Same defect this file was burned by yesterday, one function over: the start route once used `getGameSources` as an existence probe inside a `catch`, and every remix answered "game not found".

Now only a missing entry point is an absence:

- **No `game.ts`** → `409`, `reason: 'no_sources'`. A fact about the game.
- **A failed read or bundle** → throws, logged with its cause, `503` `reason: 'sources_unavailable'`. Ours, and retryable.

Worth keeping even though the first commit fixes the immediate cause: it is what turns the next occurrence into an answer instead of an investigation.

## Verification

- `npm run lint`, `npm run type-check` clean; API 1963 tests pass
- New: a source-map walk that throws produces `503 sources_unavailable`, not `409`
- New: source guard asserting the runtime install line never strips optional dependencies

## Still unproven after this

That the code lane works end to end in production. The image fix is reasoned from the package layout, not observed — I cannot build the container here. The first real remix on a merged build is the test, and if it still fails, the 503 will now carry the reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG