### PR TITLE
fix(oauth): path-suffixed PRM + resume authorize after login (Cursor compat)

### DIFF
--- a/apps/api/src/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/mcp-oauth-metadata.test.ts
@@ -9,6 +9,7 @@ import {
   MCP_MISSING_CREDENTIAL_HINT,
   OAUTH_PROTECTED_RESOURCE_PATH,
   oauthProtectedResourceMetadataUrl,
+  oauthProtectedResourcePathForMcp,
 } from './mcp-oauth-metadata.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { InMemoryStore } from './store.js';
@@ -126,6 +127,17 @@ describe('GET /.well-known/oauth-protected-resource (BY-18a)', () => {
     const res = await app.inject({ method: 'GET', url: OAUTH_PROTECTED_RESOURCE_PATH });
     expect(res.statusCode).toBe(200);
     expect(res.json().resource).toBe(`https://www.gamedev.pl${MCP_ENDPOINT_PATH}`);
+  });
+
+  it('serves the same document at the RFC 9728 path-suffixed URL clients probe first', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    process.env.MCP_AUTHORIZATION_SERVERS = 'https://www.gamedev.pl';
+    app = await buildApp({ store: new InMemoryStore(), sessionSecret: 'dev-session-secret-change-me' });
+    const path = oauthProtectedResourcePathForMcp();
+    expect(path).toBe('/.well-known/oauth-protected-resource/api/mcp');
+    const res = await app.inject({ method: 'GET', url: path });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(buildOAuthProtectedResourceDocument());
   });
 });
 

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { readBearerToken } from './bearer.js';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
-import { mcpEndpointUrl } from './self-build-connect.js';
+import { MCP_ENDPOINT_PATH, mcpEndpointUrl } from './self-build-connect.js';
 
 /** RFC 9728 protected-resource metadata document (BY-18a). */
 export const OAUTH_PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
@@ -116,11 +116,26 @@ export function sendMcpOAuthChallenge(reply: FastifyReply): FastifyReply {
     .send({ error: 'authentication required', hint: MCP_MISSING_CREDENTIAL_HINT });
 }
 
+/**
+ * RFC 9728 path insertion: for resource `https://host/api/mcp`, clients also probe
+ * `/.well-known/oauth-protected-resource/api/mcp`. Claude Code and Cursor hit the
+ * path-suffixed URL first; a 404 is recoverable (they fall back to the root document)
+ * but wastes a round trip and breaks callers that lose the WWW-Authenticate
+ * `resource_metadata` URL across the OAuth redirect (Cursor forum #151331).
+ */
+export function oauthProtectedResourcePathForMcp(): string {
+  const suffix = MCP_ENDPOINT_PATH.replace(/^\/+/, '');
+  return `${OAUTH_PROTECTED_RESOURCE_PATH}/${suffix}`;
+}
+
 export function registerOAuthProtectedResourceRoutes(app: FastifyInstance): void {
-  app.get(OAUTH_PROTECTED_RESOURCE_PATH, async (_request, reply) => {
+  const sendDocument = async (_request: FastifyRequest, reply: FastifyReply) => {
     return reply
       .header('Cache-Control', METADATA_CACHE_CONTROL)
       .type('application/json')
       .send(buildOAuthProtectedResourceDocument());
-  });
+  };
+
+  app.get(OAUTH_PROTECTED_RESOURCE_PATH, sendDocument);
+  app.get(oauthProtectedResourcePathForMcp(), sendDocument);
 }

--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -167,6 +167,23 @@ describe('OAuth authorization server (BY-18b)', () => {
     expect(tokens.scope).toBe('mcp');
   });
 
+  it('sends unauthenticated browsers to studio with oauth_return so login can resume authorize', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    const store = new InMemoryStore();
+    app = await buildOAuthApp(store);
+    const clientId = await registerClient(app);
+    const challenge = pkceChallengeS256('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+    const authorizePath =
+      `/oauth/authorize?response_type=code&client_id=${clientId}` +
+      `&redirect_uri=${encodeURIComponent('http://127.0.0.1/callback')}` +
+      `&code_challenge=${challenge}&code_challenge_method=S256`;
+    const res = await app.inject({ method: 'GET', url: authorizePath });
+    expect(res.statusCode).toBe(302);
+    const location = new URL(res.headers.location as string);
+    expect(location.origin + location.pathname).toBe('https://www.gamedev.pl/studio');
+    expect(location.searchParams.get('oauth_return')).toBe(authorizePath);
+  });
+
   it('rejects authorization_code without PKCE verifier', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:creator' });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -60,6 +60,7 @@ import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { ControllerView } from './mp/ControllerView.js';
 import { PartyStage } from './mp/PartyStage.js';
 import { createPartySession, type PartySession } from './mp/mpApi.js';
+import { parseOAuthReturnParam } from './oauthReturn.js';
 
 type StageContent =
   | { type: 'catalog'; game: CatalogEntry }
@@ -476,6 +477,19 @@ export function App() {
 
     return () => window.clearInterval(timer);
   }, [pendingScrollTarget, route.view]);
+
+  // MCP OAuth: `/oauth/authorize` redirects here when the browser has no session.
+  // After sign-in, resume the authorize URL so the agent gets its PKCE code.
+  useEffect(() => {
+    if (authLoading) return;
+    const oauthReturn = parseOAuthReturnParam(window.location.search);
+    if (!oauthReturn) return;
+    if (!user) {
+      setIsAuthModalOpen(true);
+      return;
+    }
+    window.location.replace(oauthReturn);
+  }, [authLoading, user]);
 
   async function handleGenerateMock(text: string) {
     if (!user) {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -937,7 +937,7 @@
     },
     "oauth": {
       "title": "Sign in from your agent",
-      "hint": "Or copy this MCP URL into any other agent, then sign in when it asks. Pass the game slug from the prompt below when you start."
+      "hint": "Or copy this MCP URL into any other agent, then sign in when it asks. Pass the game slug from the prompt below when you start. If Cursor shows Unauthorized without opening a browser, open the authorize URL from Output → MCP logs (known Cursor bug), or use Paste header."
     },
     "clients": {
       "claudeCode": "Claude Code",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -941,7 +941,7 @@
     },
     "oauth": {
       "title": "Zaloguj się z poziomu agenta",
-      "hint": "Albo skopiuj ten URL MCP do innego agenta, a potem zaloguj się, gdy zapyta. Przy starcie podaj slug gry z promptu poniżej."
+      "hint": "Albo skopiuj ten URL MCP do innego agenta, a potem zaloguj się, gdy zapyta. Przy starcie podaj slug gry z promptu poniżej. Jeśli Cursor pokazuje Unauthorized bez otwarcia przeglądarki, otwórz URL autoryzacji z Output → MCP (znany bug Cursora) albo użyj Wklej nagłówek."
     },
     "clients": {
       "claudeCode": "Claude Code",

--- a/apps/web/src/oauthReturn.test.ts
+++ b/apps/web/src/oauthReturn.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseOAuthReturnParam, sanitizeOAuthReturnPath } from './oauthReturn.js';
+
+describe('sanitizeOAuthReturnPath', () => {
+  it('accepts bare authorize and authorize with query', () => {
+    expect(sanitizeOAuthReturnPath('/oauth/authorize')).toBe('/oauth/authorize');
+    expect(
+      sanitizeOAuthReturnPath(
+        '/oauth/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback&code_challenge=x&code_challenge_method=S256',
+      ),
+    ).toMatch(/^\/oauth\/authorize\?/);
+  });
+
+  it('rejects open redirects and near-miss paths', () => {
+    expect(sanitizeOAuthReturnPath('https://evil.test/oauth/authorize')).toBeNull();
+    expect(sanitizeOAuthReturnPath('//evil.test/oauth/authorize')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/authorize/../admin')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/token')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/studio')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/authorize\n/evil')).toBeNull();
+  });
+});
+
+describe('parseOAuthReturnParam', () => {
+  it('reads oauth_return from the query string', () => {
+    const path =
+      '/oauth/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback&code_challenge=x&code_challenge_method=S256';
+    expect(parseOAuthReturnParam(`?oauth_return=${encodeURIComponent(path)}`)).toBe(path);
+    expect(parseOAuthReturnParam(`oauth_return=${encodeURIComponent(path)}`)).toBe(path);
+  });
+
+  it('returns null when absent or unsafe', () => {
+    expect(parseOAuthReturnParam('')).toBeNull();
+    expect(parseOAuthReturnParam('?oauth_return=%2Fadmin')).toBeNull();
+  });
+});

--- a/apps/web/src/oauthReturn.ts
+++ b/apps/web/src/oauthReturn.ts
@@ -1,0 +1,25 @@
+/**
+ * Resume path after Google/Apple sign-in when `/oauth/authorize` bounced an
+ * unauthenticated browser to `/studio?oauth_return=…`.
+ *
+ * Only same-origin relative `/oauth/authorize` paths are accepted — anything else
+ * would be an open redirect into a phishing page after login.
+ */
+
+export function parseOAuthReturnParam(search: string): string | null {
+  const raw = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get('oauth_return');
+  if (!raw) return null;
+  return sanitizeOAuthReturnPath(raw);
+}
+
+/** True when `path` is a relative authorize URL we may navigate to after login. */
+export function sanitizeOAuthReturnPath(path: string): string | null {
+  const trimmed = path.trim();
+  if (!trimmed.startsWith('/oauth/authorize')) return null;
+  // Reject scheme-relative (`//evil`), encoded tricks, and backslashes.
+  if (trimmed.startsWith('//') || trimmed.includes('\\') || /[\r\n]/.test(trimmed)) return null;
+  if (trimmed.includes('://')) return null;
+  // Allow bare authorize or authorize with a query string only.
+  if (trimmed !== '/oauth/authorize' && !trimmed.startsWith('/oauth/authorize?')) return null;
+  return trimmed;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Native Cursor MCP OAuth against `https://www.gamedev.pl/api/mcp` stalls at **Unauthorized** after discovery. Prod logs from the owner IP show the exact sequence:

1. `GET /.well-known/oauth-protected-resource/api/mcp` → was **404**
2. `GET /.well-known/oauth-protected-resource` → 200
3. `GET /.well-known/oauth-authorization-server` → 200
4. `POST /oauth/register` → 201
5. **No** `GET /oauth/authorize` and **no** `POST /oauth/token`

That matches a known Cursor IDE bug: after DCR the SDK builds the authorize URL and then never opens the browser ([forum #160328](https://forum.cursor.com/t/mcp-http-sse-oauth-sdk-silently-fails-to-open-browser-after-mcp-oauth-redirect-to-authorization-3-2-11-latest/160328) — Cursor staff: tracked, no fix shipped as of 2026-05-26). We cannot repair that step from the server.

## What this PR does fix (our side)

- Serve the same RFC 9728 PRM document at `/.well-known/oauth-protected-resource/api/mcp` (path insertion clients probe first; also needed when Cursor loses the `WWW-Authenticate` `resource_metadata` URL across callback — forum #151331).
- Resume `/oauth/authorize` after Studio sign-in when the AS bounced an unauthenticated browser to `/studio?oauth_return=…` (that query param was previously dead).
- Connect-card copy: if Cursor shows Unauthorized without a browser, open the authorize URL from Output → MCP logs (or use Paste header).

## What this does not fix

Cursor’s missing `redirectToAuthorization` / browser open. Until Cursor ships a fix, practical paths for Cursor desktop:

- Paste authorize URL from Output → MCP logs into a browser, or
- `mcp-remote` stdio proxy (opens the browser itself), or
- Paste header (creator key).

## Test plan

- [x] `mcp-oauth-metadata` + `oauth-as` + `oauthReturn` unit tests
- [x] Green gate (`type-check` / `lint` / `test` / `build`)
- [ ] After deploy: path-suffixed PRM returns 200 with same body as root
- [ ] Manual: open a crafted `/oauth/authorize?…` while logged out → Studio sign-in → consent HTML

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3049abc-5d14-4c55-89fd-c523260ff890?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3049abc-5d14-4c55-89fd-c523260ff890&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

