### PR TITLE
Remix: the abandon check called every real request abandoned

### DIFF
--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -679,7 +679,15 @@ describe('remix code lane over a real connection', () => {
         run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {
           const good = { 'game/runtime.ts': 'export function startGame() {\n  return 0.08;\n}\n' };
           await build(good);
-          return { ok: true, overrides: good, region: { file: 'game/runtime.ts', name: 'startGame' } };
+          // Full outcome shape, as the lane really returns: a stub that omits
+          // fields the route does not read yet ages into a false green.
+          return {
+            ok: true,
+            overrides: good,
+            region: { file: 'game/runtime.ts', name: 'startGame' },
+            rounds: 0,
+            tokens: { input: 1, output: 1 },
+          };
         },
       },
     });

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -647,3 +647,58 @@ describe('remix survives an instance change', () => {
     expect(response.statusCode).toBe(404);
   });
 });
+
+/*
+ * Over a real socket, because `inject()` is what hid the defect this pins.
+ *
+ * A mock request is never a stream that ends, so `request.raw.destroyed` stayed
+ * false in every test while being true for every real request with a body — Node
+ * destroys the request stream once its payload has been consumed. The route read
+ * that as "the player walked away", discarded the finished rebuild and returned
+ * without replying, so production answered 200 with an empty body for every code
+ * edit. Twenty passing route tests could not see it.
+ */
+describe('remix code lane over a real connection', () => {
+  let app: FastifyInstance | null = null;
+
+  beforeEach(() => {
+    process.env.EDITOR_ASSIST = 'true';
+    process.env.CODE_LANE = 'true';
+  });
+
+  afterEach(async () => {
+    delete process.env.EDITOR_ASSIST;
+    delete process.env.CODE_LANE;
+    if (app) await app.close();
+    app = null;
+  });
+
+  it('lands an edit for a caller who is still there', async () => {
+    const built = await buildTestApp({
+      codeLane: {
+        run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {
+          const good = { 'game/runtime.ts': 'export function startGame() {\n  return 0.08;\n}\n' };
+          await build(good);
+          return { ok: true, overrides: good, region: { file: 'game/runtime.ts', name: 'startGame' } };
+        },
+      },
+    });
+    app = built.app;
+    const address = await app.listen({ port: 0, host: '127.0.0.1' });
+
+    const started = await fetch(`${address}/api/games/dog-dash/remix`, { method: 'POST', headers: alice });
+    const { remixId } = (await started.json()) as { remixId: string };
+
+    const response = await fetch(`${address}/api/remixes/${remixId}/code`, {
+      method: 'POST',
+      headers: { ...alice, 'content-type': 'application/json' },
+      body: JSON.stringify({ utterance: 'make it twice as fast' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; html?: string };
+    // The body is the whole point: an empty 200 is what this defect produced.
+    expect(body.ok).toBe(true);
+    expect(body.html).toContain('return 0.08;');
+  });
+});

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -555,8 +555,19 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
        * closing is the only signal we get, and it is enough: an abandoned run
        * is discarded here, which makes the client's promise true.
        */
-      const abandoned = () =>
-        options.isAbandoned ? options.isAbandoned(request) : request.raw.destroyed || request.socket.destroyed;
+      let clientGone = false;
+      // On the *response*, not the request. `request.raw.destroyed` reads as
+      // "the client hung up" and is not: Node destroys the request stream once
+      // its body has been consumed, which for any request with a JSON payload is
+      // always — so in production this fired on every single edit, the finished
+      // rebuild was discarded, and the route answered 200 with an empty body.
+      // `inject()` never reproduced it, because a mock request is never a stream
+      // that ends. The response socket closing before the reply is written is
+      // the one event that actually means nobody is listening.
+      reply.raw.on('close', () => {
+        if (!reply.raw.writableFinished) clientGone = true;
+      });
+      const abandoned = () => (options.isAbandoned ? options.isAbandoned(request) : clientGone);
 
       session.codeInFlight = true;
       try {
@@ -592,7 +603,11 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
             { slug: session.slug, region: outcome.region },
             'remix code edit abandoned before it landed',
           );
-          return;
+          // Answered rather than dropped. Nobody is listening by definition, but
+          // a handler that returns without replying leaves Fastify holding an
+          // open request — which is what an abandoned edit looked like from the
+          // outside: a 200 with nothing in it.
+          return reply.status(499).send({ ok: false, reason: 'abandoned' });
         }
 
         session.overrides = { ...session.overrides, ...outcome.overrides };

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -480,6 +480,33 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     '/api/remixes/:id/code',
     { config: { rateLimit: { max: 6, timeWindow: 60_000 } } },
     async (request, reply) => {
+      /**
+       * Did the player walk away while we worked?
+       *
+       * Watched from the first line of the handler, before anything is awaited:
+       * a disconnect during moderation or the spend gate would otherwise fire
+       * its event before there was a listener, and the run would land anyway.
+       *
+       * On the *response*, not the request. `request.raw.destroyed` reads as
+       * "the client hung up" and is not — Node destroys the request stream once
+       * its body has been consumed, which for any request with a JSON payload is
+       * always. That check was true on arrival for every real edit, so every
+       * finished rebuild was discarded and the route answered 200 with an empty
+       * body. `inject()` never reproduced it, because a mock request is never a
+       * stream that ends.
+       */
+      let clientGone = false;
+      reply.raw.on('close', () => {
+        if (!reply.raw.writableFinished) clientGone = true;
+      });
+      // Belt as well as braces: a connection that was already gone before this
+      // handler ran has no event left to emit, so the state is read directly too.
+      const abandoned = () =>
+        options.isAbandoned
+          ? options.isAbandoned(request)
+          : clientGone ||
+            ((reply.raw.destroyed || reply.raw.socket?.destroyed === true) && !reply.raw.writableFinished);
+
       if (!requireUser(request, reply)) return;
       const session = await getSession(request);
       if (!session) return reply.status(404).send({ error: 'this remix has expired — start a new one' });
@@ -543,31 +570,6 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         return reply.status(409).send({ error: 'still working on your last change' });
       }
       if (!(await spendEditSlot(request, reply))) return;
-
-      /**
-       * Did the player walk away while we worked?
-       *
-       * The client aborts its fetch at its own timeout and tells the player
-       * their game came back untouched. Nothing about that reaches this
-       * handler, so without this check the rebuild would finish anyway and
-       * write itself into the session — and the *next* edit would silently
-       * build on a change the player was told had been discarded. The socket
-       * closing is the only signal we get, and it is enough: an abandoned run
-       * is discarded here, which makes the client's promise true.
-       */
-      let clientGone = false;
-      // On the *response*, not the request. `request.raw.destroyed` reads as
-      // "the client hung up" and is not: Node destroys the request stream once
-      // its body has been consumed, which for any request with a JSON payload is
-      // always — so in production this fired on every single edit, the finished
-      // rebuild was discarded, and the route answered 200 with an empty body.
-      // `inject()` never reproduced it, because a mock request is never a stream
-      // that ends. The response socket closing before the reply is written is
-      // the one event that actually means nobody is listening.
-      reply.raw.on('close', () => {
-        if (!reply.raw.writableFinished) clientGone = true;
-      });
-      const abandoned = () => (options.isAbandoned ? options.isAbandoned(request) : clientGone);
 
       session.codeInFlight = true;
       try {


### PR DESCRIPTION
`/code` answers **200 with an empty body** for every code edit in production. Measured directly against the live API:

```
start: 200 724ms
canAssist: true canCode: true
code:  200 8379ms
body length: 0
```

## Good news first

The lane works. esbuild runs in the container now, the two model calls and the rebuild complete, and the whole round trip is **8.4 seconds** — well inside the client's 45s ceiling. The previous fix did what it claimed.

## Then the guard threw the result away

`request.raw.destroyed` reads as "the client hung up" and is not. Node destroys the request stream once its body has been consumed — which, for any request with a JSON payload, is always. So the abandon check was true on arrival, every finished rebuild was discarded, and the handler returned without replying, leaving Fastify to close the request with a 200 and nothing in it.

The signal that actually means nobody is listening is on the **response**: its socket closing before the reply has been written.

```js
reply.raw.on('close', () => {
  if (!reply.raw.writableFinished) clientGone = true;
});
```

An abandoned run now also answers (499) instead of returning silently. Nobody is there to read it by definition, but a handler that never replies leaves an open request behind — which is exactly what this looked like from outside.

## Why the tests didn't catch it

`inject()` is what hid it. A mock request is never a stream that ends, so `request.raw.destroyed` stayed false in all twenty route tests while being true for every real request. The guard's own test passed by injecting the seam, which proved the branch worked and never that the default was right.

So this one is pinned **over a real socket** — `app.listen({ port: 0 })` and a real `fetch`. Reverted against the old check, the new test fails with the production symptom:

```
× lands an edit for a caller who is still there
  → expected 499 to be 200
```

## Verification

- `npm run lint`, `npm run type-check` clean; API 1964 tests pass
- New test verified to fail on the previous code and pass on this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_