### PR TITLE
Remix content painter: the declared editor attaches to Remix

### DIFF
--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -20,6 +20,29 @@ const EDITOR_JSON = JSON.stringify({
     dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'Dog size', pl: 'Pies' } },
     tagline: { type: 'text', max: 40, default: 'go!', label: { en: 'Tagline', pl: 'Hasło' } },
   },
+  // A collection too, so the start response's `content` half — what the remix
+  // painter renders — is exercised against a full declaration, not a
+  // tunables-only one.
+  content: {
+    maps: {
+      widget: 'collection',
+      label: { en: 'Maps', pl: 'Mapy' },
+      itemLabel: { en: 'Map', pl: 'Mapa' },
+      min: 1,
+      max: 3,
+      item: {
+        widget: 'tilemap',
+        grid: { minCols: 3, maxCols: 8, minRows: 3, maxRows: 8 },
+        tiles: [
+          { key: 'path', char: '.', label: { en: 'Path', pl: 'Ścieżka' } },
+          { key: 'wall', char: '#', label: { en: 'Wall', pl: 'Mur' } },
+        ],
+        properties: {},
+        constraints: [],
+      },
+      defaults: [{ properties: {}, rows: ['...', '.#.', '...'] }],
+    },
+  },
 });
 
 const SOURCES: Record<string, string> = {
@@ -172,6 +195,11 @@ describe('remix routes', () => {
     expect(body.remixId).toBeTruthy();
     expect(body.params.dogScale.max).toBe(3);
     expect(body.values).toEqual({ dogScale: 1, tagline: 'go!' });
+    // The painter's half of the declaration rides along, defaults included —
+    // painted content then never comes back to the server, so this response is
+    // the painter's entire diet.
+    expect(body.content.maps.item.tiles.map((tile: { key: string }) => tile.key)).toEqual(['path', 'wall']);
+    expect(body.content.maps.defaults).toEqual([{ properties: {}, rows: ['...', '.#.', '...'] }]);
   });
 
   it('404s an unknown game and an expired remix id', async () => {
@@ -444,6 +472,9 @@ describe('remix across the two catalog eras', () => {
     const body = response.json();
     // The declaration came from a file read, not from an assembly.
     expect(body.params.dogScale.max).toBe(3);
+    // The painter's half too: the content lane is the one editing lane that
+    // works catalog-wide, precisely because it needs only this file.
+    expect(body.content.maps.defaults.length).toBe(1);
     expect(body.canAssist).toBe(true);
     // ...and the deep lane is offered too: a repo game's sources are reachable
     // through the bundler's walk. Whether this particular game assembles is

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -142,6 +142,12 @@ function ownerTag(uid: string): string {
   return createHash('sha256').update(uid).digest('base64url').slice(0, 12);
 }
 
+/** The declaration's collections at their defaults — the base every params-only document sits on. */
+function defaultCollections(definition: EditorDefinition | null): Record<string, unknown> {
+  if (!definition) return {};
+  return Object.fromEntries(Object.entries(definition.content).map(([key, spec]) => [key, spec.defaults]));
+}
+
 /**
  * `1.<owner>.<expiry>.<nonce>.<slug>` — every part URL-safe, none containing a
  * dot, so it travels as a path segment without escaping. Deliberately not
@@ -408,6 +414,12 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         values: definition?.params
           ? Object.fromEntries(Object.entries(definition.params).map(([key, spec]) => [key, spec.default]))
           : null,
+        // The collections half of the declaration, defaults included — what the
+        // painter renders. Already validated (it parsed), already public (it
+        // ships inside the game's own bundle), and edits to it never come back
+        // to this server: painted content lives in the player's session and
+        // reaches the game over the bridge, exactly like params.
+        content: definition && Object.keys(definition.content).length > 0 ? definition.content : null,
         canAssist,
         canCode,
         // What is worth saying here, derived from what this game can do.
@@ -446,7 +458,11 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
 
       if (!(await spendEditSlot(request, reply))) return;
 
-      const content = { [PARAMS_KEY]: body.data.params ?? {} };
+      // Seeded with the declaration's own default collections, not params
+      // alone: `applyAssistPatches` validates the whole document, and a game
+      // that declares maps would otherwise fail that validation on every
+      // request — dropping perfectly good tuning patches into the code lane.
+      const content = { ...defaultCollections(session.definition), [PARAMS_KEY]: body.data.params ?? {} };
       try {
         const result = await options.assistant.assist({
           definition: session.definition,
@@ -651,10 +667,15 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         }
       }
       // Validated against the declaration, so a hand-edited link cannot smuggle a
-      // value the game never allowed.
+      // value the game never allowed. Seeded with the default collections for
+      // the same reason as the assist route: the validator judges the whole
+      // document, and a link would otherwise share nothing on a game with maps.
       const { patches } = applyAssistPatches(
         session.definition!,
-        { [PARAMS_KEY]: Object.fromEntries(Object.entries(specs).map(([key, spec]) => [key, spec.default])) },
+        {
+          ...defaultCollections(session.definition),
+          [PARAMS_KEY]: Object.fromEntries(Object.entries(specs).map(([key, spec]) => [key, spec.default])),
+        },
         Object.entries(values).map(([key, value]) => ({ key, value })),
       );
       const shared = Object.fromEntries(patches.map((patch) => [patch.key, patch.value]));

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -643,7 +643,7 @@ export interface VisitEvent {
   route?: string;
   /**
    * `create_step` / `waitlist_step` / `studio_step` / `editor_step` /
-   * `assist_step`: which funnel step or outcome this visit reached.
+   * `assist_step` / `remix_step`: which funnel step or outcome this visit reached.
    */
   step?: string;
   /**
@@ -659,7 +659,9 @@ export interface VisitEvent {
   detail?: string;
   /**
    * `how_to_play_opened`: which chrome surface opened the card (`bar` | `more`).
-   * Absent on events recorded before the field existed; never a game identity.
+   * `remix_step` with `step: 'painted'`: which door led to the painter
+   * (`redirect` | `menu`). Absent on events recorded before the field existed;
+   * never a game identity.
    */
   via?: string;
   /**

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -209,6 +209,52 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.waitlist[0]).toEqual({ step: 'cta_clicked', visits: 1 });
   });
 
+  it('counts painting visits and splits them by the door that led to the brush', () => {
+    const remix = (visitId: string, step: string, via?: string): VisitEvent =>
+      ({
+        visitId,
+        type: 'remix_step',
+        at: '2026-07-26T10:00:00.000Z',
+        msSinceStart: 0,
+        step,
+        ...(via ? { via } : {}),
+      }) as VisitEvent;
+
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      remix('a', 'opened'),
+      remix('a', 'painted', 'redirect'),
+      started('b'),
+      remix('b', 'opened'),
+      remix('b', 'painted', 'menu'),
+      started('c'),
+      remix('c', 'opened'),
+      // A client from before the dimension existed: painted, door unknown.
+      remix('c', 'painted'),
+      started('d'),
+      remix('d', 'opened'),
+      remix('d', 'tuned'),
+    ]);
+
+    expect(funnel.remixing.find((row) => row.step === 'painted')?.visits).toBe(3);
+    expect(funnel.remixing.find((row) => row.step === 'tuned')?.visits).toBe(1);
+    expect(funnel.remixPaintedVia).toEqual([
+      { via: 'redirect', visits: 1 },
+      { via: 'menu', visits: 1 },
+      { via: 'panel', visits: 0 },
+      { via: 'unknown', visits: 1 },
+    ]);
+  });
+
+  it('emits zeroed door rows while nobody has painted, so the split cannot read as missing', () => {
+    const funnel = summarizeVisitFunnel([started('a')]);
+    expect(funnel.remixPaintedVia).toEqual([
+      { via: 'redirect', visits: 0 },
+      { via: 'menu', visits: 0 },
+      { via: 'panel', visits: 0 },
+    ]);
+  });
+
   it('survives a window with no events at all', () => {
     const funnel = summarizeVisitFunnel([]);
     expect(funnel).toMatchObject({ visits: 0, bounces: 0, plays: 0, medianPlaysPerPlayingVisit: 0 });

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -86,6 +86,16 @@ export interface VisitFunnel {
   /** The remix loop, against `opened`. See REMIX_STEPS for what the order means. */
   remixing: Array<{ step: RemixStep; visits: number }>;
   /**
+   * Which door brought painting visits to the brush: the router proposing the
+   * painter after a content-shaped request (`redirect`), the theater's More
+   * menu (`menu`), or the panel opening it as the game's only lane (`panel` —
+   * every collections game while the model flags are off). All doors always
+   * present, zeroes included, `unknown` only when a client outlived the deploy
+   * that added the dimension. The doors are the hypothesis of
+   * remix-content-editing-plan §3.1; this is what settles it.
+   */
+  remixPaintedVia: Array<{ via: 'redirect' | 'menu' | 'panel' | 'unknown'; visits: number }>;
+  /**
    * How to play card usage — the numbers that decide whether a richer per-game format
    * is worth building (github.com/gamedevpl/www.gamedev.pl/issues/395).
    *
@@ -187,6 +197,11 @@ export const REMIX_STEPS = [
   'wall_shown',
   'signed_in',
   'tuned',
+  // `tuned`'s sibling for declared content: this visit changed a map in the
+  // remix painter. Beside it rather than below it — a visit may paint without
+  // ever touching a slider, and both answer the same "did they touch anything"
+  // question the surface's bet rests on.
+  'painted',
   'asked',
   'applied',
   'handoff',
@@ -205,6 +220,8 @@ interface VisitRollup {
   waitlistSteps: Set<string>;
   /** Editor steps this visit reached. Separate again, for the same reason. */
   editorSteps: Set<string>;
+  /** The door on this visit's `painted`, first one wins (the client dedupes). */
+  paintedVia?: string;
   assistSteps: Set<string>;
   remixSteps: Set<string>;
   entry?: string;
@@ -273,6 +290,9 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       if (event.step) rollup.assistSteps.add(event.step);
     } else if (event.type === 'remix_step') {
       if (event.step) rollup.remixSteps.add(event.step);
+      if (event.step === 'painted' && rollup.paintedVia === undefined) {
+        rollup.paintedVia = event.via ?? 'unknown';
+      }
     } else if (event.type === 'play_started') {
       rollup.plays += 1;
       // Earliest wins: a flush can deliver events out of order, and "time to first
@@ -439,6 +459,17 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       step,
       visits: rollups.filter((rollup) => rollup.remixSteps.has(step)).length,
     })),
+    remixPaintedVia: (() => {
+      const doors = ['redirect', 'menu', 'panel'] as const;
+      const painting = rollups.filter((rollup) => rollup.remixSteps.has('painted'));
+      const rows: Array<{ via: 'redirect' | 'menu' | 'panel' | 'unknown'; visits: number }> = doors.map((via) => ({
+        via,
+        visits: painting.filter((rollup) => rollup.paintedVia === via).length,
+      }));
+      const unknown = painting.filter((rollup) => !doors.includes(rollup.paintedVia as (typeof doors)[number])).length;
+      if (unknown > 0) rows.push({ via: 'unknown', visits: unknown });
+      return rows;
+    })(),
     howToPlay: {
       opens: howToOpens,
       visits: openedHowTo.length,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -101,6 +101,7 @@ const RemixStepSchema = z.enum([
   'wall_shown',
   'signed_in',
   'tuned',
+  'painted',
   'asked',
   'applied',
   'handoff',
@@ -108,6 +109,8 @@ const RemixStepSchema = z.enum([
   'shared',
   'keep_clicked',
 ]);
+/** Which door led to the painter — recorded on `painted`, closed like every grouping key. */
+const RemixViaSchema = z.enum(['redirect', 'menu', 'panel']);
 /**
  * Which chrome surface opened How to play. Optional so a tab still running the previous
  * client can record the open without `via` — the aggregate treats missing as unknown
@@ -167,7 +170,7 @@ const EventSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('editor_step'), step: EditorStepSchema, ...offsetField }),
   z.object({ type: z.literal('assist_step'), step: AssistStepSchema, ...offsetField }),
-  z.object({ type: z.literal('remix_step'), step: RemixStepSchema, ...offsetField }),
+  z.object({ type: z.literal('remix_step'), step: RemixStepSchema, via: RemixViaSchema.optional(), ...offsetField }),
 ]);
 
 const RequestSchema = z.object({
@@ -279,7 +282,12 @@ export async function registerVisitTelemetryRoutes(
         case 'assist_step':
           return { ...base, type: event.type, step: event.step };
         case 'remix_step':
-          return { ...base, type: event.type, step: event.step };
+          return {
+            ...base,
+            type: event.type,
+            step: event.step,
+            ...(event.via === undefined ? {} : { via: event.via }),
+          };
         case 'how_to_play_opened':
           return {
             ...base,

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
+import { blankItem, itemProblems, setCell } from './editorContentTools.js';
 import { recordAssistStep, recordEditorStep } from './visitTelemetry.js';
 import {
   deleteEditorDraft,
@@ -8,7 +9,6 @@ import {
   publishEditorContent,
   putEditorDraft,
   requestEditorAssist,
-  type EditorCollectionSpec,
   type EditorContentDoc,
   type EditorItemContent,
   type EditorLabel,
@@ -63,122 +63,6 @@ function useLabel(): (label: EditorLabel) => string {
 }
 
 /**
- * Four-way flood fill, mirroring the contract's `reachable` rule.
- *
- * A live check that cannot see a rule the server enforces is worse than none:
- * without this the panel reported "all checks pass" for a map whose goal was
- * walled off, and the creator only found out when the save was refused.
- */
-function unreachableCount(
-  spec: EditorCollectionSpec['item'],
-  item: EditorItemContent,
-  rule: { from: string; blockedBy: string[]; require: string[] },
-): number {
-  const rows = item.rows;
-  const height = rows.length;
-  const width = height > 0 ? rows[0].length : 0;
-  const charToKey = new Map(spec.tiles.map((tile) => [tile.char, tile.key]));
-  const keyAt = (row: number, col: number) => charToKey.get(rows[row][col]);
-  const blocked = new Set(rule.blockedBy);
-  const required = new Set(rule.require);
-
-  const seen = new Set<number>();
-  const queue: Array<[number, number]> = [];
-  for (let row = 0; row < height; row += 1) {
-    for (let col = 0; col < width; col += 1) {
-      if (keyAt(row, col) !== rule.from) continue;
-      seen.add(row * width + col);
-      queue.push([row, col]);
-    }
-  }
-  if (queue.length === 0) return 0;
-  while (queue.length > 0) {
-    const [row, col] = queue.shift() as [number, number];
-    for (const [dr, dc] of [
-      [1, 0],
-      [-1, 0],
-      [0, 1],
-      [0, -1],
-    ] as const) {
-      const nextRow = row + dr;
-      const nextCol = col + dc;
-      if (nextRow < 0 || nextCol < 0 || nextRow >= height || nextCol >= width) continue;
-      if (rows[nextRow].length !== width) continue;
-      const key = keyAt(nextRow, nextCol);
-      if (key === undefined || blocked.has(key)) continue;
-      const index = nextRow * width + nextCol;
-      if (seen.has(index)) continue;
-      seen.add(index);
-      queue.push([nextRow, nextCol]);
-    }
-  }
-  let missed = 0;
-  for (let row = 0; row < height; row += 1) {
-    for (let col = 0; col < width; col += 1) {
-      const key = keyAt(row, col);
-      if (key !== undefined && required.has(key) && !seen.has(row * width + col)) missed += 1;
-    }
-  }
-  return missed;
-}
-
-/** Client-side mirror of the constraint arithmetic — hints only; the server re-checks. */
-function itemProblems(
-  spec: EditorCollectionSpec['item'],
-  item: EditorItemContent,
-  name: (label: EditorLabel) => string,
-) {
-  const counts = new Map<string, number>(spec.tiles.map((tile) => [tile.key, 0]));
-  const charToKey = new Map(spec.tiles.map((tile) => [tile.char, tile.key]));
-  for (const row of item.rows) {
-    for (const char of row) {
-      const key = charToKey.get(char);
-      if (key) counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-  }
-  const tileName = (key: string) => {
-    const tile = spec.tiles.find((entry) => entry.key === key);
-    return tile ? name(tile.label) : key;
-  };
-  const problems: string[] = [];
-  for (const rule of spec.constraints) {
-    if ('reachable' in rule) {
-      const missed = unreachableCount(spec, item, rule.reachable);
-      if (missed > 0) {
-        problems.push(
-          `${missed} × ${tileName(rule.reachable.require[0] ?? '')} walled off from ${tileName(rule.reachable.from)}`,
-        );
-      }
-      continue;
-    }
-    if ('equalCounts' in rule) {
-      const [a, b] = rule.equalCounts;
-      if (counts.get(a) !== counts.get(b)) {
-        problems.push(`${tileName(a)} ${counts.get(a) ?? 0} ≠ ${tileName(b)} ${counts.get(b) ?? 0}`);
-      }
-      continue;
-    }
-    const count = counts.get(rule.tile) ?? 0;
-    if (rule.exactly !== undefined && count !== rule.exactly) {
-      problems.push(`${tileName(rule.tile)}: ${count} / ${rule.exactly}`);
-    }
-    if (rule.min !== undefined && count < rule.min) {
-      problems.push(`${tileName(rule.tile)}: ${count} < ${rule.min}`);
-    }
-    if (rule.max !== undefined && count > rule.max) {
-      problems.push(`${tileName(rule.tile)}: ${count} > ${rule.max}`);
-    }
-  }
-  return problems;
-}
-
-function setCell(item: EditorItemContent, row: number, col: number, char: string): EditorItemContent {
-  const rows = item.rows.slice();
-  rows[row] = rows[row].slice(0, col) + char + rows[row].slice(col + 1);
-  return { ...item, rows };
-}
-
-/**
  * A saved draft with the game's current defaults underneath. The point is
  * params added *after* the draft was saved: the server refuses a document
  * missing a declared param, so a pre-params draft must not resurface without
@@ -199,20 +83,6 @@ function mergeDraft(loaded: GameEditorState): EditorContentDoc {
 /** A collection's items out of the mixed content document (params ride beside them). */
 function itemsOf(doc: EditorContentDoc, key: string): EditorItemContent[] {
   return (doc[key] ?? []) as EditorItemContent[];
-}
-
-function blankItem(spec: EditorCollectionSpec['item']): EditorItemContent {
-  // A fresh item starts as the smallest legal grid, all first-tile — the
-  // creator paints from there; constraints show what is still missing.
-  const fill = spec.tiles[0]?.char ?? '.';
-  const properties: Record<string, unknown> = {};
-  for (const [name, propertySpec] of Object.entries(spec.properties)) {
-    if (propertySpec.type === 'text') properties[name] = '';
-    else if (propertySpec.type === 'int' || propertySpec.type === 'number') properties[name] = propertySpec.min;
-    else if (propertySpec.type === 'enum') properties[name] = propertySpec.values[0];
-    else properties[name] = false;
-  }
-  return { properties, rows: Array.from({ length: spec.grid.minRows }, () => fill.repeat(spec.grid.minCols)) };
 }
 
 export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => void; onBack: () => void }) {

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -144,6 +144,18 @@ export function GameTheater({
   const moreRef = useRef<HTMLDivElement | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
   const [howToOpen, setHowToOpen] = useState(false);
+  /**
+   * The always-available doors to Remix and its painter (ops repo,
+   * remix-content-editing-plan §3.1): nonces the menu bumps, threaded down to
+   * the frame. They complement the pause-moment invitation, which is untouched.
+   * The painter entry appears only once the panel has reported this game
+   * declares paintable content — a door that opens onto nothing is the
+   * `no_lane` lesson, and this menu does not repeat it.
+   */
+  const [remixOpenNonce, setRemixOpenNonce] = useState(0);
+  const [painterNonce, setPainterNonce] = useState(0);
+  const [remixHasPainter, setRemixHasPainter] = useState(false);
+  const onRemixCapabilities = useCallback((caps: { painter: boolean }) => setRemixHasPainter(caps.painter), []);
   // Per theater mount, not per visit: opening once in game A and once in game B is not
   // a "card did not answer" signal. The theater remounts when the slug changes (`key`),
   // so this resets with each published play without needing a game identity on the wire.
@@ -620,6 +632,36 @@ export function GameTheater({
                   {micControl('theater-menu-item mic-menu')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
+                  {'slug' in source ? (
+                    <>
+                      <button
+                        type="button"
+                        className="theater-menu-item"
+                        role="menuitem"
+                        onClick={() => {
+                          setMoreOpen(false);
+                          setRemixOpenNonce((nonce) => nonce + 1);
+                        }}
+                      >
+                        <PixelIcon name="wrench" size={13} />
+                        <span className="btn-label">{t('remix.button')}</span>
+                      </button>
+                      {remixHasPainter ? (
+                        <button
+                          type="button"
+                          className="theater-menu-item"
+                          role="menuitem"
+                          onClick={() => {
+                            setMoreOpen(false);
+                            setPainterNonce((nonce) => nonce + 1);
+                          }}
+                        >
+                          <PixelIcon name="pencil" size={13} />
+                          <span className="btn-label">{t('remix.editorButton')}</span>
+                        </button>
+                      ) : null}
+                    </>
+                  ) : null}
                   {reportSlug && (
                     <>
                       <div className="theater-menu-divider theater-mobile-chrome" role="separator" />
@@ -650,7 +692,17 @@ export function GameTheater({
           <BackdropVideo stream={sensing.backdrop.stream} facing={sensing.backdrop.facing} />
         ) : null}
         {'slug' in source ? (
-          <PublishedGameFrame key={source.slug} slug={source.slug} title={title} frameRef={frameRef} embed remixable />
+          <PublishedGameFrame
+            key={source.slug}
+            slug={source.slug}
+            title={title}
+            frameRef={frameRef}
+            embed
+            remixable
+            remixOpenNonce={remixOpenNonce}
+            painterNonce={painterNonce}
+            onRemixCapabilities={onRemixCapabilities}
+          />
         ) : (
           <GameFrame title={title} html={source.html} frameRef={frameRef} embed />
         )}

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -21,6 +21,16 @@ type PublishedGameFrameProps = {
    * frame is not the player's alone to bend.
    */
   remixable?: boolean;
+  /**
+   * The theater's More-menu doors, as nonces so a re-chosen entry re-opens what
+   * the player closed. `remixOpenNonce` opens the remix sheet; `painterNonce`
+   * opens it with the level painter showing. The pause-moment invitation below
+   * is untouched by either — these add doors, they do not move the invitation.
+   */
+  remixOpenNonce?: number;
+  painterNonce?: number;
+  /** Reports whether this game's remix has a painter, for the menu to show its entry. */
+  onRemixCapabilities?: (caps: { painter: boolean }) => void;
 };
 
 /**
@@ -28,7 +38,17 @@ type PublishedGameFrameProps = {
  * sandboxed GameFrame. Published games are served through the app (not public
  * GitHub Pages), so this works even when the games repo is private.
  */
-export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixable }: PublishedGameFrameProps) {
+export function PublishedGameFrame({
+  slug,
+  title,
+  frameRef,
+  embed,
+  slots,
+  remixable,
+  remixOpenNonce,
+  painterNonce,
+  onRemixCapabilities,
+}: PublishedGameFrameProps) {
   const { t } = useTranslation();
   const [html, setHtml] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
@@ -91,6 +111,12 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
     };
   }, [slug, title, loadAttempt]);
 
+  // Either menu door opens the sheet; the painter door additionally tells the
+  // panel to show the brush (it carries the nonce through as `painterRequest`).
+  useEffect(() => {
+    if ((remixOpenNonce ?? 0) > 0 || (painterNonce ?? 0) > 0) setRemixOpen(true);
+  }, [remixOpenNonce, painterNonce]);
+
   useEffect(() => {
     if (!remixable || slots !== undefined || remixRevealed) return;
     const frame = activeFrameRef.current;
@@ -139,6 +165,8 @@ export function PublishedGameFrame({ slug, title, frameRef, embed, slots, remixa
           initialParams={sharedParams}
           onSwapDocument={setRemixHtml}
           onClose={() => setRemixOpen(false)}
+          painterRequest={painterNonce}
+          onCapabilities={onRemixCapabilities}
         />
       ) : remixRevealed ? (
         <button type="button" className="remix-open is-revealed" onClick={() => setRemixOpen(true)}>

--- a/apps/web/src/RemixPainter.tsx
+++ b/apps/web/src/RemixPainter.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { blankItem, itemProblems, setCell } from './editorContentTools.js';
+import type { EditorCollectionSpec, EditorContentDoc, EditorItemContent, EditorLabel } from './studioApi.js';
+
+/**
+ * The declared content painter, in the remix sheet.
+ *
+ * The Studio's EditorPanel renders the same vocabulary for creators; this is
+ * the player-shaped cut of it — one column, thumb-sized cells, no drafts and
+ * no publish, because a remix's paintings live in the session and reach the
+ * game over the bridge exactly like a slider move. The constraint mirror is
+ * shared (`editorContentTools`), so a remixer who walls off a seed is told so
+ * live — their content never reaches the server, which makes the live check
+ * the *only* check they will ever see.
+ */
+
+export function RemixPainter(props: {
+  content: Record<string, EditorCollectionSpec>;
+  doc: EditorContentDoc;
+  onChange: (next: EditorContentDoc) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const name = (label: EditorLabel) => (i18n.language?.startsWith('pl') ? label.pl : label.en);
+
+  // One collection is the vocabulary's reality today; the first is the surface.
+  const collectionKey = Object.keys(props.content)[0] ?? null;
+  const spec = collectionKey ? props.content[collectionKey] : null;
+  const items = collectionKey
+    ? (((props.doc[collectionKey] as EditorItemContent[] | undefined) ?? []) as EditorItemContent[])
+    : [];
+  const [itemIndex, setItemIndex] = useState(0);
+  const [tileKey, setTileKey] = useState<string | null>(spec?.item.tiles[0]?.key ?? null);
+  const item = items[Math.min(itemIndex, Math.max(0, items.length - 1))] ?? null;
+  const activeIndex = Math.min(itemIndex, Math.max(0, items.length - 1));
+
+  if (!spec || !collectionKey) return null;
+
+  function updateItems(list: EditorItemContent[]) {
+    props.onChange({ ...props.doc, [collectionKey as string]: list });
+  }
+
+  function updateItem(next: EditorItemContent) {
+    const list = items.slice();
+    list[activeIndex] = next;
+    updateItems(list);
+  }
+
+  const problems = item ? itemProblems(spec.item, item, name) : [];
+  const width = item ? (item.rows[0]?.length ?? 0) : 0;
+
+  return (
+    <div className="remix-painter">
+      <div className="remix-painter-items" role="tablist" aria-label={name(spec.label)}>
+        {items.map((entry, index) => (
+          <button
+            key={index}
+            type="button"
+            role="tab"
+            aria-selected={index === activeIndex}
+            className={`remix-painter-item${index === activeIndex ? ' is-active' : ''}`}
+            onClick={() => setItemIndex(index)}
+          >
+            {typeof entry.properties.name === 'string' && entry.properties.name
+              ? entry.properties.name
+              : `${name(spec.itemLabel)} ${index + 1}`}
+          </button>
+        ))}
+        {items.length < spec.max ? (
+          <button
+            type="button"
+            className="remix-painter-item is-add"
+            aria-label={t('studioPanel.editor.addItem', { name: name(spec.itemLabel) })}
+            onClick={() => {
+              updateItems([...items, blankItem(spec.item)]);
+              setItemIndex(items.length);
+            }}
+          >
+            ＋
+          </button>
+        ) : null}
+        {items.length > spec.min ? (
+          <button
+            type="button"
+            className="remix-painter-item is-remove"
+            aria-label={t('studioPanel.editor.removeItem')}
+            onClick={() => {
+              updateItems(items.filter((_, index) => index !== activeIndex));
+              setItemIndex((current) => Math.max(0, Math.min(current, items.length - 2)));
+            }}
+          >
+            −
+          </button>
+        ) : null}
+      </div>
+
+      {item ? (
+        <>
+          <div
+            className="editor-board"
+            role="grid"
+            aria-label={name(spec.itemLabel)}
+            style={{ gridTemplateColumns: `repeat(${width}, var(--editor-cell))` }}
+          >
+            {item.rows.map((rowChars, row) =>
+              Array.from(rowChars).map((char, col) => {
+                const tile = spec.item.tiles.find((entry) => entry.char === char);
+                return (
+                  <button
+                    key={`${row}-${col}`}
+                    type="button"
+                    role="gridcell"
+                    className={`editor-cell${tile?.color ? '' : ` tile-${tile?.key ?? 'unknown'}`}`}
+                    {...(tile?.color ? { style: { background: tile.color } } : {})}
+                    aria-label={`${row + 1},${col + 1}: ${tile ? name(tile.label) : char}`}
+                    onClick={() => {
+                      const selected = spec.item.tiles.find((entry) => entry.key === tileKey);
+                      if (selected) updateItem(setCell(item, row, col, selected.char));
+                    }}
+                  />
+                );
+              }),
+            )}
+          </div>
+          <div className="editor-palette" role="radiogroup" aria-label={t('studioPanel.editor.tiles')}>
+            {spec.item.tiles.map((tile) => (
+              <button
+                key={tile.key}
+                type="button"
+                role="radio"
+                aria-checked={tileKey === tile.key}
+                className={`editor-tile${tileKey === tile.key ? ' is-selected' : ''}`}
+                onClick={() => setTileKey(tile.key)}
+              >
+                <span
+                  className={`editor-tile-swatch${tile.color ? '' : ` tile-${tile.key}`}`}
+                  {...(tile.color ? { style: { background: tile.color } } : {})}
+                  aria-hidden="true"
+                />
+                {name(tile.label)}
+              </button>
+            ))}
+          </div>
+          {/*
+           * Verdicts, not vetoes: nothing here blocks anything (there is no save
+           * to refuse), but a map that breaks its own game's rules should say so
+           * before the player wonders why their level cannot be won.
+           */}
+          {problems.length > 0 ? (
+            <div className="remix-painter-checks" role="status">
+              {problems.slice(0, 3).map((problem) => (
+                <p key={problem} className="editor-check is-bad">
+                  ✕ {problem}
+                </p>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -199,6 +199,155 @@ describe('RemixPanel', () => {
     expect(container.querySelector('.remix-btn.is-quiet')?.textContent).toBe('Undo');
   });
 
+  it('proposes the painter for a content-shaped request instead of falling through to code', async () => {
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: { dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'dog size' } } },
+      values: { dogScale: 1 },
+      content: {
+        maps: {
+          widget: 'collection',
+          label: { en: 'Maps', pl: 'Mapy' },
+          itemLabel: { en: 'Map', pl: 'Mapa' },
+          min: 1,
+          max: 3,
+          item: {
+            widget: 'tilemap',
+            grid: { minCols: 3, maxCols: 8, minRows: 3, maxRows: 8 },
+            tiles: [
+              { key: 'path', char: '.', label: { en: 'Path', pl: 'Ścieżka' } },
+              { key: 'wall', char: '#', label: { en: 'Wall', pl: 'Mur' } },
+            ],
+            properties: {},
+            constraints: [],
+          },
+          defaults: [{ properties: {}, rows: ['...', '.#.', '...'] }],
+        },
+      },
+      canAssist: true,
+      // The code lane is live — and must still not be where a map change lands.
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist.mockResolvedValue({ lane: 'content' });
+    await draw();
+    await send('move the walls around');
+
+    // No rebuild was requested; the proposal is the whole answer.
+    expect(remixApi.remixCode).not.toHaveBeenCalled();
+    const offer = container.querySelector('.remix-actions-row .remix-btn.is-primary');
+    expect(offer?.textContent).toBe('Open the level editor');
+
+    // Taking the offer opens the painter, rendered from the declaration.
+    await act(async () => {
+      offer!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.remix-painter .editor-board')).not.toBeNull();
+    expect(container.querySelectorAll('.remix-painter .editor-tile').length).toBe(2);
+
+    // Painting a cell records the rung with the door that led here — and the
+    // dedupe means the funnel keeps this first door.
+    const cell = container.querySelector('.remix-painter .editor-cell') as HTMLButtonElement;
+    await act(async () => {
+      cell.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('painted', { via: 'redirect' });
+  });
+
+  it('opens straight onto the painter when it is the only lane — the flags-off state', async () => {
+    // Both model flags off, no params — but the game declares maps. The free
+    // lane needs no model, so the panel must not say "can't be remixed yet",
+    // and the visit must not count as `no_lane`: a painter is a way in.
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: null,
+      values: null,
+      content: {
+        maps: {
+          widget: 'collection',
+          label: { en: 'Maps', pl: 'Mapy' },
+          itemLabel: { en: 'Map', pl: 'Mapa' },
+          min: 1,
+          max: 3,
+          item: {
+            widget: 'tilemap',
+            grid: { minCols: 3, maxCols: 8, minRows: 3, maxRows: 8 },
+            tiles: [{ key: 'path', char: '.', label: { en: 'Path', pl: 'Ścieżka' } }],
+            properties: {},
+            constraints: [],
+          },
+          defaults: [{ properties: {}, rows: ['...', '...', '...'] }],
+        },
+      },
+      canAssist: false,
+      canCode: false,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    await draw();
+
+    expect(container.querySelector('.remix-painter .editor-board')).not.toBeNull();
+    expect(container.textContent).not.toContain("This game can't be remixed yet");
+    expect(telemetry.recordRemixStep).not.toHaveBeenCalledWith('no_lane');
+
+    const cell = container.querySelector('.remix-painter .editor-cell') as HTMLButtonElement;
+    await act(async () => {
+      cell.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('painted', { via: 'panel' });
+  });
+
+  it('pushes the whole content document over the bridge, never params alone', async () => {
+    // The game-side module replaces its content with what arrives. A params-only
+    // push to a game that also declares collections hands it a document with no
+    // maps — and its next restart reads maps that are no longer there.
+    const postMessage = vi.fn();
+    const frameRef = {
+      current: { contentWindow: { postMessage } },
+    } as unknown as React.MutableRefObject<HTMLIFrameElement | null>;
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: { dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'dog size' } } },
+      values: { dogScale: 1 },
+      content: {
+        maps: {
+          widget: 'collection',
+          label: { en: 'Maps', pl: 'Mapy' },
+          itemLabel: { en: 'Map', pl: 'Mapa' },
+          min: 1,
+          max: 3,
+          item: {
+            widget: 'tilemap',
+            grid: { minCols: 3, maxCols: 8, minRows: 3, maxRows: 8 },
+            tiles: [{ key: 'path', char: '.', label: { en: 'Path', pl: 'Ścieżka' } }],
+            properties: {},
+            constraints: [],
+          },
+          defaults: [{ properties: {}, rows: ['...', '...', '...'] }],
+        },
+      },
+      canAssist: true,
+      canCode: false,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist.mockResolvedValue({ lane: 'params', values: { dogScale: 2 } });
+
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<RemixPanel slug="dog-dash" frameRef={frameRef} onSwapDocument={() => {}} onClose={() => {}} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await send('bigger dog');
+
+    const pushed = postMessage.mock.calls.at(-1)?.[0] as { content: Record<string, unknown> };
+    expect(pushed.content.params).toEqual({ dogScale: 2 });
+    expect(pushed.content.maps).toEqual([{ properties: {}, rows: ['...', '...', '...'] }]);
+  });
+
   it('offers a toggle the way the running game is not currently set', async () => {
     // Arrived on a shared link that flipped a default-off toggle on. The server
     // derived "turn on" from the declaration; offering that here would be a

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -348,6 +348,72 @@ describe('RemixPanel', () => {
     expect(pushed.content.maps).toEqual([{ properties: {}, rows: ['...', '...', '...'] }]);
   });
 
+  it('flushes a stroke still on the debounce when the sheet closes', async () => {
+    // Paint, then close the sheet inside the 500 ms window. The frame outlives
+    // the panel, so cancelling the only scheduled push would silently lose the
+    // last stroke with the state that held it — the flush is the promise.
+    const postMessage = vi.fn();
+    const frameRef = {
+      current: { contentWindow: { postMessage } },
+    } as unknown as React.MutableRefObject<HTMLIFrameElement | null>;
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: null,
+      values: null,
+      content: {
+        maps: {
+          widget: 'collection',
+          label: { en: 'Maps', pl: 'Mapy' },
+          itemLabel: { en: 'Map', pl: 'Mapa' },
+          min: 1,
+          max: 3,
+          item: {
+            widget: 'tilemap',
+            grid: { minCols: 3, maxCols: 8, minRows: 3, maxRows: 8 },
+            tiles: [
+              { key: 'path', char: '.', label: { en: 'Path', pl: 'Ścieżka' } },
+              { key: 'wall', char: '#', label: { en: 'Wall', pl: 'Mur' } },
+            ],
+            properties: {},
+            constraints: [],
+          },
+          defaults: [{ properties: {}, rows: ['...', '...', '...'] }],
+        },
+      },
+      canAssist: false,
+      canCode: false,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<RemixPanel slug="dog-dash" frameRef={frameRef} onSwapDocument={() => {}} onClose={() => {}} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Select the wall tile and paint one cell — the push is now debounced.
+    const wall = container.querySelectorAll('.remix-painter .editor-tile')[1] as HTMLButtonElement;
+    await act(async () => {
+      wall.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const cell = container.querySelector('.remix-painter .editor-cell') as HTMLButtonElement;
+    await act(async () => {
+      cell.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(postMessage).not.toHaveBeenCalled();
+
+    // Close before the debounce fires.
+    await act(async () => {
+      root!.unmount();
+    });
+    root = null;
+    const pushed = postMessage.mock.calls.at(-1)?.[0] as { content: { maps: Array<{ rows: string[] }> } };
+    expect(pushed.content.maps[0].rows[0]).toBe('#..');
+  });
+
   it('offers a toggle the way the running game is not currently set', async () => {
     // Arrived on a shared link that flipped a default-off toggle on. The server
     // derived "turn on" from the declaration; offering that here would be a

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -236,11 +236,19 @@ export function RemixPanel(props: {
     [pushToGame],
   );
 
+  // Flush, not just cancel: the frame outlives the sheet, and a player who
+  // paints and immediately closes the panel is exactly the player who wants to
+  // go play what they painted — cancelling the only scheduled push would lose
+  // their last stroke with the panel state that held it.
   useEffect(
     () => () => {
-      if (contentPushTimer.current !== null) window.clearTimeout(contentPushTimer.current);
+      if (contentPushTimer.current !== null) {
+        window.clearTimeout(contentPushTimer.current);
+        contentPushTimer.current = null;
+        pushToGame(valuesRef.current);
+      }
     },
-    [],
+    [pushToGame],
   );
 
   // The panel is open the moment it renders, signed in or not. Recorded here

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -14,7 +14,9 @@ import {
   type RemixSession,
   type RemixSuggestion,
 } from './remixApi.js';
-import type { EditorLabel, EditorParamValue } from './studioApi.js';
+import { RemixPainter } from './RemixPainter.js';
+import type { EditorContentDoc, EditorLabel, EditorParamValue } from './studioApi.js';
+import type { RemixPaintedVia } from './visitTelemetry.js';
 
 /**
  * Remix: a player bends a published game while playing it.
@@ -143,6 +145,14 @@ export function RemixPanel(props: {
   onClose: () => void;
   /** Shared values from a `?remix=` link, already parsed. */
   initialParams?: Record<string, EditorParamValue> | null;
+  /**
+   * The More-menu door to the painter: bumped by the theater when "Level
+   * editor" is chosen. A nonce rather than a boolean so choosing it again
+   * reopens a painter the player closed.
+   */
+  painterRequest?: number;
+  /** Tells the theater whether this game has a painter to put in its menu. */
+  onCapabilities?: (caps: { painter: boolean }) => void;
 }) {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
@@ -167,21 +177,70 @@ export function RemixPanel(props: {
   const [failed, setFailed] = useState<'unsupported' | 'error' | null>(null);
   const valuesRef = useRef(values);
   valuesRef.current = values;
+  /**
+   * The painter's document — the game's declared collections, seeded from the
+   * declaration's defaults. Client-only: painted content reaches the game over
+   * the bridge and never travels to the server (decision 3.2 in the ops plan —
+   * remixes stay ephemeral; the session is the only home this has).
+   */
+  const [contentDoc, setContentDoc] = useState<EditorContentDoc>({});
+  const contentDocRef = useRef(contentDoc);
+  contentDocRef.current = contentDoc;
+  const [painterOpen, setPainterOpen] = useState(false);
+  /** Whether the router proposed the painter and the offer is still on screen. */
+  const [painterOffer, setPainterOffer] = useState(false);
+  /** First door wins — matches the telemetry dedupe, which keeps the first via. */
+  const painterDoorRef = useRef<RemixPaintedVia | null>(null);
+  const contentEditedRef = useRef(false);
+  const contentPushTimer = useRef<number | null>(null);
 
   const label = useCallback(
     (both: EditorLabel | undefined) => (both ? (i18n.language?.startsWith('pl') ? both.pl : both.en) : ''),
     [i18n.language],
   );
 
-  /** Push the whole params document into the running game. */
+  /**
+   * Push the whole content document into the running game.
+   *
+   * Whole, not partial, because the game-side module *replaces* its content
+   * with what arrives — it never merges with the build-inlined defaults. A
+   * params-only push to a game that also declares collections used to hand it
+   * a document with no maps, and the game's next restart read them off a
+   * content object that no longer had any.
+   */
   const pushToGame = useCallback(
-    (next: Record<string, EditorParamValue>) => {
+    (next: Record<string, EditorParamValue>, contentOverride?: EditorContentDoc) => {
+      const collections = contentOverride ?? contentDocRef.current;
       props.frameRef.current?.contentWindow?.postMessage(
-        { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content: { params: next } },
+        { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content: { ...collections, params: next } },
         '*',
       );
     },
     [props.frameRef],
+  );
+
+  /**
+   * A painting burst is many cell taps in a second, and the pilot game restarts
+   * its round on every content change it sees — so painted content lands on a
+   * short debounce while a slider stays instant. Half a second is long enough
+   * to absorb a stroke and short enough that "paint, look up, play" never waits.
+   */
+  const pushContentSoon = useCallback(
+    (next: EditorContentDoc) => {
+      if (contentPushTimer.current !== null) window.clearTimeout(contentPushTimer.current);
+      contentPushTimer.current = window.setTimeout(() => {
+        contentPushTimer.current = null;
+        pushToGame(valuesRef.current, next);
+      }, 500);
+    },
+    [pushToGame],
+  );
+
+  useEffect(
+    () => () => {
+      if (contentPushTimer.current !== null) window.clearTimeout(contentPushTimer.current);
+    },
+    [],
   );
 
   // The panel is open the moment it renders, signed in or not. Recorded here
@@ -197,7 +256,10 @@ export function RemixPanel(props: {
   // about the viewer it depends on is which account they are. Keying on the
   // object would re-run — and re-mint — on any render that hands back a fresh
   // one, and a game that declares no values makes that loop self-sustaining.
+  // `onCapabilities` sits in the deps for lint's sake, so the parent MUST hand
+  // down a stable callback — an inline arrow here re-mints the session per render.
   const uid = user?.uid ?? null;
+  const onCapabilities = props.onCapabilities;
   useEffect(() => {
     // No session without a session: the API 401s signed out, and the composer
     // needs nothing from the server until send — so a visitor can type first.
@@ -213,6 +275,15 @@ export function RemixPanel(props: {
             ? coerceSharedParams(started.params, { ...base, ...props.initialParams })
             : base;
         setValues(merged);
+        // The painter's starting point is the declaration's own defaults. Set on
+        // the ref synchronously as well, so a push scheduled in this same tick
+        // (the shared-link one below) already carries the maps.
+        const contentDefaults: EditorContentDoc = started.content
+          ? Object.fromEntries(Object.entries(started.content).map(([key, spec]) => [key, spec.defaults]))
+          : {};
+        contentDocRef.current = contentDefaults;
+        setContentDoc(contentDefaults);
+        onCapabilities?.({ painter: Boolean(started.content) });
         // A shared link's values are live the moment the game is listening.
         if (props.initialParams) window.setTimeout(() => pushToGame(merged), 300);
       })
@@ -224,7 +295,21 @@ export function RemixPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [props.slug, props.initialParams, pushToGame, uid]);
+  }, [props.slug, props.initialParams, pushToGame, uid, onCapabilities]);
+
+  /** Open the painter, remembering which door was first — telemetry keeps that one. */
+  const openPainter = useCallback((door: RemixPaintedVia) => {
+    if (painterDoorRef.current === null) painterDoorRef.current = door;
+    setPainterOffer(false);
+    setPainterOpen(true);
+  }, []);
+
+  // The More-menu door. A nonce: the same entry chosen again reopens a painter
+  // the player closed, which a boolean prop cannot express.
+  const painterRequest = props.painterRequest ?? 0;
+  useEffect(() => {
+    if (painterRequest > 0) openPainter('menu');
+  }, [painterRequest, openPainter]);
 
   // The reward lands the second they're through the wall: once the session
   // exists and a stashed request is waiting, run it with no further taps.
@@ -253,10 +338,18 @@ export function RemixPanel(props: {
   // A panel that opened onto nothing. Recorded against the same `opened`
   // denominator so the share of visits that met a game with no way in is a
   // number rather than an anecdote — it is the difference between "people are
-  // not interested" and "we showed them a door that does not open".
+  // not interested" and "we showed them a door that does not open". A painter
+  // is a way in, so a collections game never counts here — and while the model
+  // flags are off it is the *only* lane, so the panel opens straight onto it
+  // rather than onto a composer that cannot answer.
   useEffect(() => {
-    if (session && !session.canAssist && !session.canCode) recordRemixStep('no_lane');
-  }, [session]);
+    if (!session || session.canAssist || session.canCode) return;
+    if (session.content) {
+      openPainter('panel');
+      return;
+    }
+    recordRemixStep('no_lane');
+  }, [session, openPainter]);
 
   /**
    * A suggestion, written out in the player's language.
@@ -342,7 +435,18 @@ export function RemixPanel(props: {
           setNote({ kind: 'error', text: label(result.summary) || t('remix.refused') });
           return;
         }
-        // `code` or `content`: falls through to the code lane below.
+        // A content-shaped request, and this game has a painter: the honest
+        // answer is the brush, not a rebuild. The refusal this lane used to be
+        // becomes a proposal (ops plan, decision 3.1) — the prompt stays the
+        // one door, and the painter is where this conversation lands. No model
+        // ever emits map cells; the router only classified.
+        if (result.lane === 'content' && active.content) {
+          setLane('idle');
+          setPainterOffer(true);
+          setNote({ kind: 'info', text: label(result.summary) || t('remix.editorOffer') });
+          return;
+        }
+        // `code` (or `content` with nothing to paint): falls through to the code lane below.
         if (!active.canCode) {
           setLane('idle');
           recordRemixStep('handoff');
@@ -432,6 +536,15 @@ export function RemixPanel(props: {
     setChanged(null);
   }
 
+  /** The player painted — update the doc, tell the funnel, and land it after the stroke. */
+  function paintContent(next: EditorContentDoc) {
+    setContentDoc(next);
+    contentDocRef.current = next;
+    contentEditedRef.current = true;
+    recordRemixStep('painted', { via: painterDoorRef.current ?? 'menu' });
+    pushContentSoon(next);
+  }
+
   async function share() {
     if (!session) return;
     try {
@@ -440,9 +553,17 @@ export function RemixPanel(props: {
       setShareUrl(url);
       recordRemixStep('shared');
       await navigator.clipboard?.writeText(url).catch(() => {});
+      // A link carries declared values only. Painted maps stay behind for the
+      // same reason code edits do — the share payload is schema-bounded params
+      // until the age-rating question is answered (ops plan §4) — and leaving
+      // that unsaid would promise a level the link does not deliver.
       setNote({
         kind: 'ok',
-        text: result.codeEditsExcluded ? t('remix.sharedWithoutCode') : t('remix.shared'),
+        text: result.codeEditsExcluded
+          ? t('remix.sharedWithoutCode')
+          : contentEditedRef.current
+            ? t('remix.sharedWithoutContent')
+            : t('remix.shared'),
       });
     } catch {
       setNote({ kind: 'error', text: t('remix.shareFailed') });
@@ -521,6 +642,18 @@ export function RemixPanel(props: {
           ×
         </button>
       </div>
+
+      {painterOpen && session?.content && lane !== 'building' ? (
+        <div className="remix-painter-host">
+          <div className="remix-painter-head">
+            <span className="remix-painter-title">{t('remix.editorTitle')}</span>
+            <button type="button" className="remix-btn is-quiet" onClick={() => setPainterOpen(false)}>
+              {t('remix.editorHide')}
+            </button>
+          </div>
+          <RemixPainter content={session.content} doc={contentDoc} onChange={paintContent} />
+        </div>
+      ) : null}
 
       {lane === 'building' ? (
         /*
@@ -604,12 +737,14 @@ export function RemixPanel(props: {
             </div>
           ) : null}
         </>
-      ) : (
+      ) : session?.content ? null : (
         /*
-         * No lane answers here — the game declares no parameters and its code
-         * cannot be assembled. The panel has to say so: a surface whose whole
-         * promise is "say what you want" cannot open with no place to say it and
-         * no explanation, which reads as broken rather than as not-yet.
+         * No lane answers here — the game declares no parameters, its code
+         * cannot be assembled, and there is nothing to paint. The panel has to
+         * say so: a surface whose whole promise is "say what you want" cannot
+         * open with no place to say it and no explanation, which reads as
+         * broken rather than as not-yet. (A game with declared content skips
+         * this branch — its painter opened above, and it is a full answer.)
          */
         <p className="remix-note is-info" role="status">
           {t('remix.notHere')}
@@ -620,6 +755,13 @@ export function RemixPanel(props: {
         <p className={`remix-note is-${note.kind}`} role="status">
           {note.text}
         </p>
+      ) : null}
+      {painterOffer && !painterOpen && session?.content ? (
+        <div className="remix-actions-row">
+          <button type="button" className="remix-btn is-primary" onClick={() => openPainter('redirect')}>
+            {t('remix.openEditor')}
+          </button>
+        </div>
       ) : null}
 
       {expert && specs ? (

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -43,12 +43,20 @@ const REMIX_LABELS: Record<string, string> = {
   wall_shown: 'hit the sign-in wall',
   signed_in: 'came through the wall',
   tuned: 'moved a slider',
+  painted: 'painted a map',
   asked: 'typed a request',
   applied: 'got a change applied',
   handoff: 'told it needs more',
   refused: 'was refused',
   shared: 'shared their version',
   keep_clicked: 'clicked "make it mine"',
+};
+
+const REMIX_VIA_LABELS: Record<string, string> = {
+  redirect: 'prompt hand-off',
+  menu: 'More menu',
+  panel: 'only lane (flags off)',
+  unknown: 'unknown (pre-via clients)',
 };
 
 const ASSIST_LABELS: Record<string, string> = {
@@ -292,6 +300,19 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
               </tbody>
             </table>
           )}
+          {(funnel.remixPaintedVia ?? []).some((row) => row.visits > 0) ? (
+            /*
+             * One line, not a table: the door split exists to settle a single
+             * hypothesis (does the prompt's redirect or the menu bring people
+             * to the brush), and it only means anything while `painted` > 0.
+             */
+            <p className="health-note">
+              Painter door:{' '}
+              {(funnel.remixPaintedVia ?? [])
+                .map((row) => `${REMIX_VIA_LABELS[row.via] ?? row.via} ${row.visits}`)
+                .join(' · ')}
+            </p>
+          ) : null}
         </div>
 
         <div className="funnel-block">

--- a/apps/web/src/editorContentTools.ts
+++ b/apps/web/src/editorContentTools.ts
@@ -1,0 +1,140 @@
+import type { EditorCollectionSpec, EditorItemContent, EditorLabel } from './studioApi.js';
+
+/**
+ * The pure half of the content painter, shared by its two surfaces: the
+ * Studio's EditorPanel (creator drafts) and the RemixPanel's painter (player
+ * sessions). Promoted here on the repo's two-consumer rule — above all so the
+ * `reachable` mirror stays one flood fill: a live check that drifts from the
+ * rule the server enforces is worse than none, and two copies is how it
+ * drifts.
+ */
+
+/**
+ * Four-way flood fill, mirroring the contract's `reachable` rule.
+ *
+ * Without this the panel reported "all checks pass" for a map whose goal was
+ * walled off, and the creator only found out when the save was refused — and a
+ * remixer, whose paintings never reach the server, would never find out at all.
+ */
+export function unreachableCount(
+  spec: EditorCollectionSpec['item'],
+  item: EditorItemContent,
+  rule: { from: string; blockedBy: string[]; require: string[] },
+): number {
+  const rows = item.rows;
+  const height = rows.length;
+  const width = height > 0 ? rows[0].length : 0;
+  const charToKey = new Map(spec.tiles.map((tile) => [tile.char, tile.key]));
+  const keyAt = (row: number, col: number) => charToKey.get(rows[row][col]);
+  const blocked = new Set(rule.blockedBy);
+  const required = new Set(rule.require);
+
+  const seen = new Set<number>();
+  const queue: Array<[number, number]> = [];
+  for (let row = 0; row < height; row += 1) {
+    for (let col = 0; col < width; col += 1) {
+      if (keyAt(row, col) !== rule.from) continue;
+      seen.add(row * width + col);
+      queue.push([row, col]);
+    }
+  }
+  if (queue.length === 0) return 0;
+  while (queue.length > 0) {
+    const [row, col] = queue.shift() as [number, number];
+    for (const [dr, dc] of [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ] as const) {
+      const nextRow = row + dr;
+      const nextCol = col + dc;
+      if (nextRow < 0 || nextCol < 0 || nextRow >= height || nextCol >= width) continue;
+      if (rows[nextRow].length !== width) continue;
+      const key = keyAt(nextRow, nextCol);
+      if (key === undefined || blocked.has(key)) continue;
+      const index = nextRow * width + nextCol;
+      if (seen.has(index)) continue;
+      seen.add(index);
+      queue.push([nextRow, nextCol]);
+    }
+  }
+  let missed = 0;
+  for (let row = 0; row < height; row += 1) {
+    for (let col = 0; col < width; col += 1) {
+      const key = keyAt(row, col);
+      if (key !== undefined && required.has(key) && !seen.has(row * width + col)) missed += 1;
+    }
+  }
+  return missed;
+}
+
+/** Client-side mirror of the constraint arithmetic — hints only; the server re-checks. */
+export function itemProblems(
+  spec: EditorCollectionSpec['item'],
+  item: EditorItemContent,
+  name: (label: EditorLabel) => string,
+) {
+  const counts = new Map<string, number>(spec.tiles.map((tile) => [tile.key, 0]));
+  const charToKey = new Map(spec.tiles.map((tile) => [tile.char, tile.key]));
+  for (const row of item.rows) {
+    for (const char of row) {
+      const key = charToKey.get(char);
+      if (key) counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  const tileName = (key: string) => {
+    const tile = spec.tiles.find((entry) => entry.key === key);
+    return tile ? name(tile.label) : key;
+  };
+  const problems: string[] = [];
+  for (const rule of spec.constraints) {
+    if ('reachable' in rule) {
+      const missed = unreachableCount(spec, item, rule.reachable);
+      if (missed > 0) {
+        problems.push(
+          `${missed} × ${tileName(rule.reachable.require[0] ?? '')} walled off from ${tileName(rule.reachable.from)}`,
+        );
+      }
+      continue;
+    }
+    if ('equalCounts' in rule) {
+      const [a, b] = rule.equalCounts;
+      if (counts.get(a) !== counts.get(b)) {
+        problems.push(`${tileName(a)} ${counts.get(a) ?? 0} ≠ ${tileName(b)} ${counts.get(b) ?? 0}`);
+      }
+      continue;
+    }
+    const count = counts.get(rule.tile) ?? 0;
+    if (rule.exactly !== undefined && count !== rule.exactly) {
+      problems.push(`${tileName(rule.tile)}: ${count} / ${rule.exactly}`);
+    }
+    if (rule.min !== undefined && count < rule.min) {
+      problems.push(`${tileName(rule.tile)}: ${count} < ${rule.min}`);
+    }
+    if (rule.max !== undefined && count > rule.max) {
+      problems.push(`${tileName(rule.tile)}: ${count} > ${rule.max}`);
+    }
+  }
+  return problems;
+}
+
+export function setCell(item: EditorItemContent, row: number, col: number, char: string): EditorItemContent {
+  const rows = item.rows.slice();
+  rows[row] = rows[row].slice(0, col) + char + rows[row].slice(col + 1);
+  return { ...item, rows };
+}
+
+export function blankItem(spec: EditorCollectionSpec['item']): EditorItemContent {
+  // A fresh item starts as the smallest legal grid, all first-tile — the
+  // creator paints from there; constraints show what is still missing.
+  const fill = spec.tiles[0]?.char ?? '.';
+  const properties: Record<string, unknown> = {};
+  for (const [name, propertySpec] of Object.entries(spec.properties)) {
+    if (propertySpec.type === 'text') properties[name] = '';
+    else if (propertySpec.type === 'int' || propertySpec.type === 'number') properties[name] = propertySpec.min;
+    else if (propertySpec.type === 'enum') properties[name] = propertySpec.values[0];
+    else properties[name] = false;
+  }
+  return { properties, rows: Array.from({ length: spec.grid.minRows }, () => fill.repeat(spec.grid.minCols)) };
+}

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -91,6 +91,8 @@ export interface VisitFunnel {
   assisting?: Array<{ step: string; visits: number }>;
   /** The player-side remix loop. Optional for the same client-outlives-deploy reason. */
   remixing?: Array<{ step: string; visits: number }>;
+  /** Which door brought painting visits to the brush. Optional, same reason. */
+  remixPaintedVia?: Array<{ via: string; visits: number }>;
   /** How to play card usage — open rate, repeats, and where it was opened. */
   howToPlay: HowToPlayFunnel;
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1049,6 +1049,12 @@
       "faster": "make it faster",
       "look": "change the colours",
       "harder": "make it harder"
-    }
+    },
+    "editorOffer": "That's a map change — the level editor can do it.",
+    "openEditor": "Open the level editor",
+    "editorTitle": "Level editor",
+    "editorHide": "Hide",
+    "editorButton": "Level editor",
+    "sharedWithoutContent": "Link copied — it carries your settings; painted maps stay in this remix."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1053,6 +1053,12 @@
       "faster": "niech będzie szybciej",
       "look": "zmień kolory",
       "harder": "niech będzie trudniej"
-    }
+    },
+    "editorOffer": "To zmiana mapy — edytor poziomów to potrafi.",
+    "openEditor": "Otwórz edytor poziomów",
+    "editorTitle": "Edytor poziomów",
+    "editorHide": "Ukryj",
+    "editorButton": "Edytor poziomów",
+    "sharedWithoutContent": "Skopiowano link — zawiera Twoje ustawienia; namalowane mapy zostają w tym remiksie."
   }
 }

--- a/apps/web/src/remixApi.ts
+++ b/apps/web/src/remixApi.ts
@@ -1,4 +1,4 @@
-import type { EditorLabel, EditorParamSpec, EditorParamValue } from './studioApi.js';
+import type { EditorCollectionSpec, EditorLabel, EditorParamSpec, EditorParamValue } from './studioApi.js';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -25,6 +25,13 @@ export type RemixSession = {
   remixId: string;
   params: Record<string, EditorParamSpec> | null;
   values: Record<string, EditorParamValue> | null;
+  /**
+   * The collections half of the game's declaration, defaults included — what
+   * the painter renders. Absent from an older server; null when the game
+   * declares only tunables. Painted content never travels back to the server:
+   * it lives in this session and reaches the game over the bridge like params.
+   */
+  content?: Record<string, EditorCollectionSpec> | null;
   canAssist: boolean;
   canCode: boolean;
   /** Absent from an older server; an empty list is the same as none. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11015,3 +11015,77 @@ body.player-open {
     aspect-ratio: 16 / 9;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Remix painter — the declared content editor inside the remix sheet.
+ * Reuses the Studio's board/palette/check classes (one grammar, two surfaces);
+ * this block only sets the sheet-sized frame around them: smaller thumb cells,
+ * a horizontal scroll for maps wider than a phone, and the chip row that
+ * stands in for the Studio's item list.
+ * ------------------------------------------------------------------------- */
+
+.remix-painter-host {
+  --editor-cell: clamp(18px, 5.6vw, 30px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0 8px;
+  border-bottom: 1px solid var(--panel-border, rgba(255, 255, 255, 0.12));
+}
+
+.remix-painter-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.remix-painter-title {
+  font-weight: 700;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.remix-painter {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.remix-painter .editor-board {
+  align-self: flex-start;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.remix-painter-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.remix-painter-item {
+  border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.18));
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.remix-painter-item.is-active {
+  background: var(--accent, #65f59a);
+  color: #10131c;
+  border-color: transparent;
+}
+
+.remix-painter-item.is-add,
+.remix-painter-item.is-remove {
+  min-width: 30px;
+}
+
+.remix-painter-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -68,7 +68,7 @@ export type VisitEvent =
   | { type: 'studio_step'; step: StudioStep; builder: BuilderDimension; detail?: StudioStepDetail }
   | { type: 'editor_step'; step: EditorStep }
   | { type: 'assist_step'; step: AssistStep }
-  | { type: 'remix_step'; step: RemixStep };
+  | { type: 'remix_step'; step: RemixStep; via?: RemixPaintedVia };
 
 /**
  * The creation funnel, in the order a creator meets it.
@@ -185,12 +185,24 @@ export type RemixStep =
   | 'wall_shown' // the sign-in wall dropped between typing and spending
   | 'signed_in' // came through the wall; the stashed request runs next
   | 'tuned'
+  | 'painted' // changed declared content in the remix painter — `tuned`'s sibling
   | 'asked'
   | 'applied'
   | 'handoff'
   | 'refused'
   | 'shared'
   | 'keep_clicked';
+
+/**
+ * Which door led to the painter: the router proposing it after a content-shaped
+ * request (`redirect`), the theater's More menu (`menu`), or the panel opening
+ * it itself because it was the only lane this game had (`panel` — the state of
+ * every collections game while the model flags are off). Recorded on `painted`
+ * only — the decision that shaped the doors (ops repo,
+ * remix-content-editing-plan §3.1) is a hypothesis about which one converts,
+ * and this dimension is what settles it.
+ */
+export type RemixPaintedVia = 'redirect' | 'menu' | 'panel';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;
@@ -514,11 +526,13 @@ export function recordAssistStep(step: AssistStep): void {
 
 let recordedRemixSteps = new Set<string>();
 
-export function recordRemixStep(step: RemixStep): void {
+export function recordRemixStep(step: RemixStep, options?: { via?: RemixPaintedVia }): void {
   if (!currentSession) return;
   if (recordedRemixSteps.has(step)) return;
   recordedRemixSteps.add(step);
-  currentSession.record({ type: 'remix_step', step });
+  // Dedupe means the via is the *first* door of the visit — which is the right
+  // reading: the question is which door brought someone to the brush at all.
+  currentSession.record({ type: 'remix_step', step, ...(options?.via ? { via: options.via } : {}) });
 }
 
 /** Test seam: installs a session without touching the DOM. */


### PR DESCRIPTION
Implements the ops repo's `remix-content-editing-plan.md` (§6 steps 1–4) under its two taken decisions: the prompt stays the main gate and *proposes* the painter as an outcome, with quiet always-available doors in the theater's More menu — for the painter and for Remix itself. The pause-moment invitation is untouched.

## What's new

- **The remix start response carries the collections half of the declaration**, defaults included. The server already parsed the full `EDITOR.json` for both catalog eras and only ever sent the params half — so the painter inherits the one editing lane that works catalog-wide for the cost of one response field. Painted content never travels back: it lives in the session and reaches the game over the existing `editor:content` bridge, exactly like params.
- **`RemixPainter`** — a sheet-sized cut of the Studio's painter: item chips, board, palette, live constraint verdicts. The `reachable` flood fill and constraint arithmetic moved to a shared `editorContentTools` module (two consumers now — the repo's own promotion rule), so one mirror serves both surfaces. For a remixer the live check is the *only* check they will ever see.
- **The doors (decision 3.1):** the router's content-lane refusal becomes a propose-editor redirect — no model ever emits map cells; the classification just lands on the brush instead of a dead end. The More menu gains **Remix** and, once the session reports paintable content, **Level editor**.
- **Flags-off reality:** with `EDITOR_ASSIST` and `CODE_LANE` both off — the current production state — a collections game has no composer lane. The panel now opens straight onto the painter instead of recording `no_lane` over a game with a fully working free lane.
- **Telemetry** (three-place contract): `remix_step` gains a `painted` rung beside `tuned`, carrying the door that led to the brush (`redirect` | `menu` | `panel`), rolled up as `remixPaintedVia` and rendered as one line on the operator funnel panel. Which door converts is the plan's stated hypothesis; this measures it.

## Two latent production bugs on collections games, found and fixed

Both from the remix wave having been exercised only against params-only shapes:

1. **The bridge push replaced a game's maps with nothing.** The panel pushed `{ params }` alone, but the game-side module replaces its content wholesale by design. On `garden-gather`, one slider move handed the game a document with no `gardens` — its next restart would have thrown. The panel now always pushes the whole document.
2. **The assist and share routes validated params-only documents against the full definition.** On a collections game the validator correctly failed the missing collection — so every valid tuning patch was silently dropped to the code lane, and a share link carried nothing. Both routes now seed the declaration's default collections under the params.

Neither was findable from the params-only fixtures; both fell out of pointing the existing tests at a collections declaration.

## Instrumentation note (per the skill's definition of done)

This touches question 2's sibling ("does a player who can bend a game touch anything"): `painted` extends the existing `remixing` funnel, deduped per visit, no slug — the visit stream stays unjoinable to the game stream. Share stays declared-parameter-values-only (the plan's age-rating deferral); the panel says painted maps stay behind rather than implying they travel.

## Checks

- Full suite (`npm test`, all workspaces + rules) — green
- `npm run type-check` / `npm run lint` — clean
- New tests: painter proposal + door telemetry + flags-off auto-open + whole-document push (RemixPanel), content in the start response for both eras (remix routes), `painted`/via rollup with zeroed door rows (visit funnel)

Not in this PR, per the plan: the share payload extension (behind the age-rating check) and the owner phone hand-test, which is the exit criterion for the whole lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_017kX5dgxdkYGLc8ZGAAvQMw)_