### PR TITLE
byoca: an improvement round must tell the agent what game it is improving

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -140,6 +140,36 @@ Two concrete instances of that (observed 2026-07-23):
   class of bug fails closed (it rejects access), so it is a contract/UX defect rather
   than a security hole — say so explicitly when reporting, so severity is not
   overstated.
+- **A fix that narrows a predicate can reintroduce the same defect through a smaller
+  door — and its regression test will not notice.** Observed (BY-25, 2026-08-02): a
+  correct fix replaced "does the creator have ANY non-abandoned job with this slug"
+  (a scan) with "is the NEWEST job for this slug owned by them and non-abandoned" (a
+  point read). Both agree in the seeded regression scenario, so a 250-job probe
+  encoded straight from the bug report passed. They disagree when a *newer* job on the
+  same slug is abandoned — a canceled improvement round, or the `no_connect` sweep
+  auto-abandoning one — at which point ownership of a live published game reads false
+  and the durable key is refused with the same misleading "rotated" message the fix
+  existed to remove. Lesson: when a fix swaps a **scan** for a **point read**, ask
+  what the scan used to tolerate. Enumerate the states the discarded records could be
+  in (abandoned, canceled, superseded, owned-by-someone-else) and test the newest
+  record in each, not just the one from the bug report.
+- **Run your probe against the PRE-fix branch too.** A probe that only fails on the
+  candidate proves a defect exists; running the identical probe on the base proves
+  whether the PR *introduced* it or merely failed to fix it. Those are different
+  verdicts with different remedies, and the A/B costs one command — check out the base
+  in a second worktree and run the same file. Pair it with a control case that must
+  pass on both, so a green-everywhere result reads as a broken probe rather than a
+  clean bill of health.
+- **A PR that changes an error's SHAPE has changed agent behaviour even when no test
+  turns red.** Observed (BY-18a, 2026-08-02): a tools/call missing its credential used
+  to return a JSON-RPC tool error carrying recovery instructions ("pass sessionKey from
+  start(), or configure Authorization: Bearer"); the OAuth work replaced it with a bare
+  HTTP 401. The suite stayed green because the assertion was rewritten in the same
+  commit. Diff test files for assertions that were *edited* rather than *added* — an
+  edited expectation is a behaviour change the author decided was acceptable, and it
+  deserves the same scrutiny as the source change. For agent-facing surfaces
+  specifically, check that any replacement error still tells the agent what to do next;
+  a status code is not an instruction.
 
 ## Read the diff against the spec
 

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -41,6 +41,15 @@ export const PLATFORM_ROUND_REASON =
 export const SLUG_NOT_ON_ACCOUNT_REASON =
   'no game with that slug on your account — check the slug in your Studio thread';
 
+/**
+ * A sessionKey offered where an opener belongs — the mirror of the opener-in-sessionKey
+ * refusals. Says which credential arrived, because the generic "key is required" claims
+ * nothing was sent and sends an agent looking for a key it already has.
+ */
+export const SESSION_KEY_IS_NOT_AN_OPENER_REASON =
+  'that is a sessionKey from an earlier start() — start needs an opener: a game key, or ' +
+  'Authorization Bearer (creator key or OAuth) with the game slug';
+
 /** Rotated or generation-mismatched durable key. */
 export const ROTATED_GAME_KEY_REASON =
   'this game key was rotated — get a fresh prompt from the Studio thread for this game';

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -46,6 +46,16 @@ export const SLUG_NOT_ON_ACCOUNT_REASON =
  * refusals. Says which credential arrived, because the generic "key is required" claims
  * nothing was sent and sends an agent looking for a key it already has.
  */
+/**
+ * A durable game key arrives in `Authorization: Bearer` — which every other tool
+ * recognises and answers with "only opens a session via start()". `start` itself takes
+ * game keys from the `key` argument alone, so without this the agent is sent to start
+ * and told "key is required", and the two refusals loop.
+ */
+export const GAME_KEY_GOES_IN_KEY_ARG_REASON =
+  'a game key opens a session through the key argument, not Authorization: Bearer — call start with ' +
+  'key: <game key>, or use a creator key or OAuth access with the game slug';
+
 export const SESSION_KEY_IS_NOT_AN_OPENER_REASON =
   'that is a sessionKey from an earlier start() — start needs an opener: a game key, or ' +
   'Authorization Bearer (creator key or OAuth) with the game slug';

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -107,8 +107,8 @@ export function shouldIssueMcpOAuthChallenge(request: FastifyRequest, message: J
  * drift into saying different things.
  */
 export const MCP_MISSING_CREDENTIAL_HINT =
-  'missing credential: pass sessionKey from start(), or configure Authorization: Bearer with a creator key, ' +
-  'a game key, or OAuth access and call start() first';
+  'missing credential: pass sessionKey from start(), or call start() first — a game key goes in its key ' +
+  'argument; a creator key or OAuth access goes in Authorization: Bearer with your game slug';
 
 export function sendMcpOAuthChallenge(reply: FastifyReply): FastifyReply {
   return reply

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -107,7 +107,8 @@ export function shouldIssueMcpOAuthChallenge(request: FastifyRequest, message: J
  * drift into saying different things.
  */
 export const MCP_MISSING_CREDENTIAL_HINT =
-  'missing credential: pass sessionKey from start(), or configure Authorization: Bearer <round key>';
+  'missing credential: pass sessionKey from start(), or configure Authorization: Bearer with a creator key, ' +
+  'a game key, or OAuth access and call start() first';
 
 export function sendMcpOAuthChallenge(reply: FastifyReply): FastifyReply {
   return reply

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -307,6 +307,36 @@ describe('MCP open_round (BY-24 / BY-27b)', () => {
     expect(job?.ownerUid).not.toBe('g:previous');
   });
 
+  // CP-2: the feedback reached dispatchBuild but was never persisted as the round's
+  // brief, so a self round — which has no backend to read the dispatch prompt — served
+  // get_brief with spec:"" and the agent never learned what the creator asked for.
+  it('persists the change request as the new round brief so get_brief can serve it', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    const at = new Date().toISOString();
+    await store.ensureCreatorAgentKey(OWNER, at);
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: SLUG, feedback: 'Make the title screen background a solid coloured rectangle.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(false);
+    const jobId = (structured as { jobId: number }).jobId;
+
+    const job = await store.getSubmission(jobId);
+    expect(job?.spec).toBe('Make the title screen background a solid coloured rectangle.');
+    expect(job?.spec).not.toBe('');
+    // The change request is free text, not a clarifications block.
+    expect(job?.qa).toEqual([]);
+  });
+
   it('admits only one concurrent open_round per slug', async () => {
     const store = new InMemoryStore();
     await seedPublishedGame(store);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -326,6 +326,12 @@ describe('POST /api/mcp (BY-05)', () => {
     const joined = workflow.join('\n');
     expect(joined).toMatch(/get_brief/);
     expect(joined).toMatch(/get_seed/);
+    // CP-2: an improvement round has no seed and a brief that is only the change
+    // request, so without this step the loop reads as "scaffold from the kit" and an
+    // agent following it overwrites the published game it was asked to improve.
+    expect(joined).toMatch(/get_sources/);
+    expect(joined).toMatch(/available:true/);
+    expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/submit_sources/);
@@ -427,6 +433,39 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const bad = await callTool(app, 'get_brief', { sessionKey: forgedKey }, { 'mcp-session-id': sessionId });
     expect(bad.isError).toBe(true);
+  });
+
+  // CP-2 N4: the opener-in-sessionKey-slot refusals name the credential ("this creator
+  // key only opens a session via start()"), but the mirror case fell through to
+  // "key is required" — which tells an agent nothing was sent when something was.
+  it('names the sessionKey when one is offered where start wants an opener', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId,
+      jobId: ISSUE,
+      roundGeneration: 1,
+      now: Date.now(),
+      ttlHours: 1,
+    });
+
+    for (const attempt of [
+      { args: { key: sessionKey }, headers: {} as Record<string, string> },
+      { args: {}, headers: { authorization: `Bearer ${sessionKey}` } },
+    ]) {
+      const res = await callTool(app, 'start', attempt.args, {
+        'mcp-session-id': sessionId,
+        ...attempt.headers,
+      });
+      expect(res.isError).toBe(true);
+      const text = JSON.stringify(res);
+      expect(text).toMatch(/that is a sessionKey from an earlier start\(\)/i);
+      // It must not claim nothing arrived, and must not blame the creator's key.
+      expect(text).not.toMatch(/key is required/i);
+      expect(text).not.toMatch(/rotated/i);
+    }
   });
 
   it('rejects an expired sessionKey', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -455,17 +455,44 @@ describe('POST /api/mcp (BY-05)', () => {
       { args: { key: sessionKey }, headers: {} as Record<string, string> },
       { args: {}, headers: { authorization: `Bearer ${sessionKey}` } },
     ]) {
-      const res = await callTool(app, 'start', attempt.args, {
+      const { structured, isError } = await callTool(app, 'start', attempt.args, {
         'mcp-session-id': sessionId,
         ...attempt.headers,
       });
-      expect(res.isError).toBe(true);
-      const text = JSON.stringify(res);
-      expect(text).toMatch(/that is a sessionKey from an earlier start\(\)/i);
+      expect(isError).toBe(true);
+      const { error } = structured as { error: string };
+      expect(error).toMatch(/that is a sessionKey from an earlier start\(\)/i);
       // It must not claim nothing arrived, and must not blame the creator's key.
-      expect(text).not.toMatch(/key is required/i);
-      expect(text).not.toMatch(/rotated/i);
+      expect(error).not.toMatch(/key is required/i);
+      expect(error).not.toMatch(/rotated/i);
     }
+  });
+
+  // A Bearer game key is recognised everywhere else ("only opens a session via
+  // start()"), so start must not answer it with "key is required" — that pair of
+  // refusals sends the agent back and forth with no way out.
+  it('routes a Bearer game key to the key argument instead of claiming none was sent', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const gameKey = mintGameAgentKey(secret, {
+      slug: 'comet-courier',
+      creatorUid: 'g:owner',
+      keyGeneration: 1,
+      now: Date.now(),
+    });
+
+    const { structured, isError } = await callTool(
+      app,
+      'start',
+      {},
+      { 'mcp-session-id': sessionId, authorization: `Bearer ${gameKey}` },
+    );
+    expect(isError).toBe(true);
+    const { error } = structured as { error: string };
+    expect(error).toMatch(/key argument/i);
+    expect(error).not.toMatch(/key is required/i);
   });
 
   it('rejects an expired sessionKey', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -4,6 +4,7 @@ import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
 import { resolveCreatorAgentKeyForOpenRound, resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
 import {
   looksLikeGameAgentKey,
+  GAME_KEY_GOES_IN_KEY_ARG_REASON,
   IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
   NO_OPEN_ROUND_REASON,
   OPEN_ROUND_IN_PROGRESS_REASON,
@@ -628,6 +629,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (looksLikeMcpSessionKey(key || bearer || '')) {
           noteInvalidStart(ctx.request);
           return toolErr(SESSION_KEY_IS_NOT_AN_OPENER_REASON);
+        }
+
+        // Every other tool answers a Bearer game key with "only opens a session via
+        // start()". Falling through to "key is required" here made those two refusals
+        // a loop with no exit.
+        if (!key && bearer && looksLikeGameAgentKey(bearer)) {
+          noteInvalidStart(ctx.request);
+          return toolErr(GAME_KEY_GOES_IN_KEY_ARG_REASON);
         }
 
         if (!key) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -8,6 +8,7 @@ import {
   NO_OPEN_ROUND_REASON,
   OPEN_ROUND_IN_PROGRESS_REASON,
   PLATFORM_ROUND_REASON,
+  SESSION_KEY_IS_NOT_AN_OPENER_REASON,
   SLUG_NOT_ON_ACCOUNT_REASON,
 } from './agent-game-key.js';
 import {
@@ -32,6 +33,7 @@ import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import {
   assertMcpSessionKeyUnexpired,
+  looksLikeMcpSessionKey,
   mintMcpSessionKey,
   newMcpSessionId,
   verifyMcpSessionKey,
@@ -223,8 +225,14 @@ const BEHAVIOURAL_CONTRACT = [
  */
 const SESSION_WORKFLOW: readonly string[] = [
   'get_brief — read the brief; if seedAvailable, get_seed and continue that draft rather than scaffolding from scratch.',
+  // An improvement round has no seed (seeds are a new-game facility) and its brief is
+  // the change request alone, so nothing above this told the agent a game already
+  // existed. Following the loop literally, it scaffolded a fresh game over a published
+  // one. get_sources is cheap and answers available:false on a new game, so it is
+  // unconditional rather than gated on a round type the agent cannot see.
+  'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them.',
   'get_kit — unpack the tarball, open entry (gamedevpl-creator-kit/SKILL.md), and follow it. Keep the engineRef it returns for submit_sources.',
-  'Build the game from the kit; report_progress before and after long steps.',
+  'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
   'Run the kit checks green (at least check:static) before delivering.',
   'submit_sources with the kitEngineRef get_kit returned.',
@@ -611,6 +619,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (key && looksLikeCreatorAgentKey(key)) {
           noteInvalidStart(ctx.request);
           return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
+        }
+
+        // A sessionKey in either opener slot is a specific mistake with a specific fix,
+        // and the generic refusals below both misdescribe it: "key is required" reads as
+        // "you sent nothing" when something was sent, and the legacy path would call it
+        // an invalid build key. Name what was supplied instead.
+        if (looksLikeMcpSessionKey(key || bearer || '')) {
+          noteInvalidStart(ctx.request);
+          return toolErr(SESSION_KEY_IS_NOT_AN_OPENER_REASON);
         }
 
         if (!key) {

--- a/apps/api/src/mcp-session-key.ts
+++ b/apps/api/src/mcp-session-key.ts
@@ -88,6 +88,29 @@ export function mintMcpSessionKey(secret: string, options: MintMcpSessionKeyOpti
 }
 
 /**
+ * Shape-only classifier: does this string carry a sessionKey's wire format?
+ *
+ * Never a stand-in for {@link verifyMcpSessionKey} — no signature is checked, so this
+ * decides only *which credential the caller supplied*, never whether it is valid. It
+ * exists so `start` can tell an agent that presented a sessionKey that it presented
+ * the wrong kind of key, rather than the generic "key is required", which reads as
+ * "you sent nothing" when in fact something was sent.
+ */
+export function looksLikeMcpSessionKey(candidate: string): boolean {
+  const parts = Buffer.from(candidate, 'base64url').toString('utf8').split('.');
+  if (parts.length !== 5) return false;
+  const [sessionId, jobIdRaw, generationRaw, expRaw, signature] = parts;
+  return (
+    Boolean(sessionId) &&
+    SESSION_ID_RE.test(sessionId) &&
+    /^\d+$/.test(jobIdRaw ?? '') &&
+    /^\d+$/.test(generationRaw ?? '') &&
+    /^\d+$/.test(expRaw ?? '') &&
+    /^[a-f0-9]{64}$/i.test(signature ?? '')
+  );
+}
+
+/**
  * Verifies the HMAC and returns claims. Does **not** check generation against the
  * job document — {@link classifyAgentTokenAccess} (via the MCP auth path) does that.
  */

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1070,6 +1070,12 @@ export async function registerSubmissionRoutes(
     // game, and a job that dispatched without one has already told the agent the wrong
     // thing.
     await store.setSubmissionSlug(jobId, source.slug);
+    // The change request is this round's brief, so persist it. `dispatchBuild` below
+    // carries the same text into a platform backend's prompt, but a self round has no
+    // backend to read it: the creator's own agent calls get_brief, which serves the
+    // stored brief and nothing else. Without this an agent-opened improvement round
+    // starts with an empty spec and no idea what the creator asked for.
+    await store.setSubmissionBrief(jobId, { spec: input.text, qa: [] });
     await store.recordJobTransition(jobId, {
       to: 'queued',
       at: new Date(now()).toISOString(),


### PR DESCRIPTION
Four fixes from CP-2, the live-client checkpoint. Two are severe and compound; two are wording.

## An improvement round arrived empty, and the loop said "scaffold"

**The change request was never persisted.** `startImprovementRound` passed the creator's feedback to `dispatchBuild` and stopped. The only non-test caller of `setSubmissionBrief` was the new-submission path. For a platform build that is invisible — the backend reads the dispatch prompt. For a self build it is total: there is no backend, the creator's own agent calls `get_brief`, and `get_brief` serves the stored brief. It got `spec: ""`.

**Nothing routed the agent to `get_sources`.** Step one of `SESSION_WORKFLOW` offered `get_seed`, which is a new-game facility and absent on an improvement round; step three said to build from the kit. `get_sources` appeared exactly once in `mcp-server.ts` — its own tool definition. The tool described itself correctly and no ordered instruction ever mentioned it.

Together an improvement round read, end to end, as *scaffold a new game*. An agent following the numbered loop it was handed would replace the published game it was asked to improve — and the gate would pass the replacement, because it is a valid game. It just isn't the creator's.

`get_sources` is now step two, unconditional. It answers `available:false` on a new game, and the round type it would otherwise be gated on is not something the agent can see.

## Two refusals misdescribed what arrived

- `MCP_MISSING_CREDENTIAL_HINT` still said `<round key>` — written before creator keys and OAuth existed.
- A sessionKey offered where an opener belongs fell through to `key is required`, which tells an agent nothing was sent when something was. The mirror case already names the credential (*"this creator key only opens a session via start()"*); this direction now does too, via a shape-only `looksLikeMcpSessionKey` that checks format and never signature.

## Verification

Each new test was run against the unfixed source first and fails there — brief `expected undefined`, workflow `expected … to match /get_sources/`, sessionKey naming — with the surrounding tests passing on both sides as a control.

Full gate green: `type-check`, `lint`, api 1983 passed (129 files), web 932 passed (106 files).

## Note

Neither severe defect was reachable by a unit test, because both live in what the platform *tells* an agent rather than in what it computes. They surfaced only by driving a real MCP client through a live round.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_