### PR TITLE
Remix: a change that breaks the game must be visible, and reversible

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "contract:games-repo": "tsx scripts/check-games-repo-contract.ts",
     "snapshot:publish": "tsx scripts/publish-snapshot.ts",
     "gate:run": "tsx scripts/run-gate.ts",
+    "remix:probe": "tsx scripts/remix-lane-probe.ts",
     "beta:approve": "tsx scripts/beta-approve.ts",
     "beta:invite": "tsx scripts/beta-invite.ts",
     "token:mint": "tsx scripts/access-token.ts mint",

--- a/apps/api/scripts/remix-lane-probe.ts
+++ b/apps/api/scripts/remix-lane-probe.ts
@@ -1,0 +1,126 @@
+/**
+ * Run the remix code lane on your machine, and show its work.
+ *
+ * The lane is three moving parts — a symbol map, two model calls, and a
+ * server-side rebuild — and until now the only way to watch them was to remix a
+ * real game in production and read the wreckage afterwards. Every one of them
+ * runs locally against a games checkout, so this makes an edit reproducible,
+ * free to repeat, and inspectable at each step.
+ *
+ * It is deliberately the *real* lane: the real symbol map, the real Vertex
+ * calls, the real esbuild rebuild through the real assembler. A harness that
+ * stubs the interesting part would only prove the harness works.
+ *
+ *   npm run remix:probe -w @gamedevpl/api -- garden-gather "zamiast gwiazdek kolorowe kulki"
+ *   npm run remix:probe -w @gamedevpl/api -- garden-gather "make it faster" --html /tmp/out.html
+ *
+ * Needs application-default credentials for the model calls:
+ *   gcloud auth application-default login
+ *
+ * Reads games from ../../www.gamedev.pl-games by default; override with
+ * GAMES_DIR. No network to GitHub, no Firestore, no spend ledger — this is a
+ * bench, not a route.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { assembleGameHtml } from '../src/assemble.js';
+import { VertexCodeLane } from '../src/code-lane.js';
+import { createLocalGamesClient } from '../src/local-games-repo.js';
+import { buildSymbolMap, renderSymbolMap, sliceRegion } from '../src/symbol-map.js';
+
+const [slug, utterance, ...rest] = process.argv.slice(2);
+if (!slug || !utterance) {
+  console.error('usage: remix:probe <slug> "<what to change>" [--html <path>] [--map]');
+  process.exit(1);
+}
+const htmlOut = rest.includes('--html') ? rest[rest.indexOf('--html') + 1] : null;
+const showMap = rest.includes('--map');
+
+const rootDir = process.env.GAMES_DIR ?? new URL('../../../../www.gamedev.pl-games', import.meta.url).pathname;
+const client = createLocalGamesClient({ rootDir });
+
+const rule = (title: string) => console.log(`\n${'─'.repeat(72)}\n${title}\n${'─'.repeat(72)}`);
+
+const sources = await client.getGameSourceMap('main', slug);
+if (!sources) {
+  console.error(`no sources for "${slug}" under ${rootDir} — is the slug right?`);
+  process.exit(1);
+}
+
+rule(`SOURCES · ${slug}`);
+for (const [path, text] of Object.entries(sources)) {
+  console.log(`  ${path.padEnd(34)} ${String(text.split('\n').length).padStart(4)} lines`);
+}
+
+const regions = buildSymbolMap(sources);
+rule(`SYMBOL MAP · ${regions.length} regions — this, and only this, is what call 1 sees`);
+console.log(showMap ? renderSymbolMap(regions) : `  (pass --map to print it)`);
+
+/** The same check the route runs: does the whole document assemble. */
+let builds = 0;
+const build = async (overrides: Record<string, string>) => {
+  builds += 1;
+  const label = Object.keys(overrides).join(', ');
+  try {
+    const assembled = await client.getGameSources('main', slug, overrides);
+    if (!assembled) return { ok: false as const, errors: ['the game could not be assembled'] };
+    assembleGameHtml(
+      { title: slug, description: '', html: assembled.indexHtml, js: assembled.gameJs, css: assembled.styleCss },
+      { restrictNetwork: true },
+    );
+    console.log(`  build #${builds} (${label}): ok`);
+    return { ok: true as const };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`  build #${builds} (${label}): FAILED — ${message.split('\n')[0]}`);
+    return { ok: false as const, errors: [message] };
+  }
+};
+
+rule(`RUN · "${utterance}"`);
+const startedAt = Date.now();
+const outcome = await new VertexCodeLane().run({ slug, sources, utterance }, build);
+const elapsed = Date.now() - startedAt;
+
+rule('OUTCOME');
+console.log(`  ${outcome.ok ? 'ok' : `refused/failed — ${outcome.reason}`}`);
+console.log(`  ${elapsed}ms · ${builds} build(s) · tokens in ${outcome.tokens.input} out ${outcome.tokens.output}`);
+if ('detail' in outcome && outcome.detail) console.log(`  detail: ${outcome.detail}`);
+if (outcome.summary) console.log(`  summary: ${outcome.summary.en}`);
+
+if (!outcome.ok) process.exit(0);
+
+console.log(`  region: ${outcome.region.file} → ${outcome.region.name}  (rounds: ${outcome.rounds})`);
+
+const region = buildSymbolMap(sources).find(
+  (candidate) => candidate.file === outcome.region.file && candidate.name === outcome.region.name,
+);
+if (region) {
+  const before = sliceRegion(sources[region.file], region);
+  const after = sliceRegion(outcome.overrides[region.file], {
+    ...region,
+    // The replacement rarely has the same line count, so re-map the region onto
+    // the new file before slicing it, or the "after" is a window on the wrong lines.
+    ...(buildSymbolMap(outcome.overrides).find((r) => r.file === region.file && r.name === region.name) ?? region),
+  });
+  rule('BEFORE — what call 2 was given');
+  console.log(before);
+  rule('AFTER — what it wrote back');
+  console.log(after);
+}
+
+if (htmlOut) {
+  const assembled = await client.getGameSources('main', slug, outcome.overrides);
+  if (assembled) {
+    writeFileSync(
+      htmlOut,
+      assembleGameHtml(
+        { title: slug, description: '', html: assembled.indexHtml, js: assembled.gameJs, css: assembled.styleCss },
+        { restrictNetwork: true },
+      ),
+    );
+    rule('PLAYABLE');
+    console.log(`  ${htmlOut} — open it in a browser to see whether it actually runs.`);
+    console.log('  Assembling is not running: this is the step the lane cannot check for you.');
+  }
+}

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -96,6 +96,12 @@ export type CodeLaneOutcome =
       detail?: string;
       summary?: { en: string; pl: string };
       tokens: { input: number; output: number };
+      /**
+       * Present only under `REMIX_DEBUG` — and on failures above all. A flag
+       * that traced only the runs that worked would be silent on exactly the
+       * ones it exists to explain.
+       */
+      trace?: CodeLaneTrace;
     };
 
 /** Compiles a candidate. Injected so the lane is testable without esbuild or GitHub. */
@@ -162,7 +168,13 @@ export class VertexCodeLane {
       rounds: [],
     };
     if (regions.length === 0) {
-      return { ok: false, reason: 'no_region', detail: 'this game has no editable source regions', tokens };
+      return {
+        ok: false,
+        reason: 'no_region',
+        detail: 'this game has no editable source regions',
+        tokens,
+        ...(debug ? { trace } : {}),
+      };
     }
 
     let picked: z.infer<typeof PickSchema>;
@@ -172,7 +184,7 @@ export class VertexCodeLane {
         .signal(AbortSignal.timeout(this.options.pickTimeoutMs ?? DEFAULT_PICK_TIMEOUT_MS))
         .json((value) => PickSchema.parse(value));
     } catch (error) {
-      return { ok: false, reason: 'error', detail: String(error), tokens };
+      return { ok: false, reason: 'error', detail: String(error), tokens, ...(debug ? { trace } : {}) };
     }
 
     if (picked.decision === 'reject') {
@@ -181,6 +193,7 @@ export class VertexCodeLane {
         reason: 'refused',
         ...(bilingual(picked.summary) ? { summary: bilingual(picked.summary)! } : {}),
         tokens,
+        ...(debug ? { trace } : {}),
       };
     }
     const region = picked.file && picked.name ? findRegion(regions, picked.file, picked.name) : null;
@@ -194,7 +207,7 @@ export class VertexCodeLane {
       // A named region that does not exist is a hallucination, and there is
       // nothing to edit. Reported as "needs a bigger change" rather than as an
       // error, because from the player's side that is what it means.
-      return { ok: false, reason: 'no_region', tokens };
+      return { ok: false, reason: 'no_region', tokens, ...(debug ? { trace } : {}) };
     }
 
     const original = request.sources[region.file];
@@ -211,7 +224,14 @@ export class VertexCodeLane {
           .signal(AbortSignal.timeout(this.options.editTimeoutMs ?? DEFAULT_EDIT_TIMEOUT_MS))
           .json((value) => EditSchema.parse(value));
       } catch (error) {
-        return { ok: false, reason: 'error', detail: String(error), ...(summary ? { summary } : {}), tokens };
+        return {
+          ok: false,
+          reason: 'error',
+          detail: String(error),
+          ...(summary ? { summary } : {}),
+          tokens,
+          ...(debug ? { trace } : {}),
+        };
       }
       summary = bilingual(edit.summary) ?? summary;
 
@@ -247,6 +267,7 @@ export class VertexCodeLane {
       reason: 'did_not_compile',
       detail: errors.join('; ').slice(0, 400),
       ...(summary ? { summary } : {}),
+      ...(debug ? { trace } : {}),
       tokens,
     };
   }

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -39,6 +39,36 @@ export const DEFAULT_EDIT_TIMEOUT_MS = 20000;
 /** Rounds of "here is the compiler error, try again" before giving up. */
 export const MAX_REPAIR_ROUNDS = 2;
 
+/**
+ * Temporary: trace every step of a lane run into the response and the log.
+ *
+ * The lane is three moving parts and, until this existed, the only way to see
+ * any of them was to remix a real game and read the wreckage. Off by default,
+ * flipped by `REMIX_DEBUG` on a deploy, and meant to be deleted once the lane's
+ * hit rate is understood — `npm run remix:probe -w @gamedevpl/api` is the
+ * durable way to watch a run, since it costs no player a session.
+ *
+ * It carries the game's own source, which the player already has (the built
+ * document contains it) — but it also carries the utterance, so it must not
+ * outlive the question it was added to answer.
+ */
+export function codeLaneDebugEnabled(): boolean {
+  return process.env.REMIX_DEBUG === 'true';
+}
+
+/** Bounded so a trace cannot cost more than the answer it explains. */
+const TRACE_LIMIT = 4000;
+const clip = (text: string): string => (text.length > TRACE_LIMIT ? `${text.slice(0, TRACE_LIMIT)}…` : text);
+
+export interface CodeLaneTrace {
+  regionCount: number;
+  /** What call 1 chose, and whether that name existed. */
+  picked: { file?: string; name?: string; decision: string; found: boolean };
+  /** What call 2 was shown, and what it wrote back, per round. */
+  rounds: Array<{ round: number; replacement: string; buildErrors: string[] }>;
+  slice?: string;
+}
+
 export interface CodeLaneRequest {
   slug: string;
   /** Game-relative sources of the version being remixed. */
@@ -56,6 +86,8 @@ export type CodeLaneOutcome =
       summary?: { en: string; pl: string };
       rounds: number;
       tokens: { input: number; output: number };
+      /** Present only under `REMIX_DEBUG`. */
+      trace?: CodeLaneTrace;
     }
   | {
       ok: false;
@@ -122,7 +154,13 @@ export class VertexCodeLane {
    */
   async run(request: CodeLaneRequest, build: CodeLaneBuilder): Promise<CodeLaneOutcome> {
     const tokens = { input: 0, output: 0 };
+    const debug = codeLaneDebugEnabled();
     const regions = buildSymbolMap(request.sources);
+    const trace: CodeLaneTrace = {
+      regionCount: regions.length,
+      picked: { decision: 'none', found: false },
+      rounds: [],
+    };
     if (regions.length === 0) {
       return { ok: false, reason: 'no_region', detail: 'this game has no editable source regions', tokens };
     }
@@ -146,6 +184,12 @@ export class VertexCodeLane {
       };
     }
     const region = picked.file && picked.name ? findRegion(regions, picked.file, picked.name) : null;
+    trace.picked = {
+      ...(picked.file ? { file: picked.file } : {}),
+      ...(picked.name ? { name: picked.name } : {}),
+      decision: picked.decision,
+      found: region !== null,
+    };
     if (!region) {
       // A named region that does not exist is a hallucination, and there is
       // nothing to edit. Reported as "needs a bigger change" rather than as an
@@ -155,6 +199,7 @@ export class VertexCodeLane {
 
     const original = request.sources[region.file];
     const slice = sliceRegion(original, region);
+    if (debug) trace.slice = clip(slice);
     let errors: string[] = [];
     let summary = bilingual(picked.summary);
 
@@ -170,9 +215,11 @@ export class VertexCodeLane {
       }
       summary = bilingual(edit.summary) ?? summary;
 
+      if (debug) trace.rounds.push({ round, replacement: clip(edit.replacement), buildErrors: [] });
       const spliced = spliceRegion(original, region, edit.replacement);
       if (!spliced.ok) {
         errors = [spliced.error];
+        if (debug) trace.rounds.at(-1)!.buildErrors = errors;
         continue;
       }
       const overrides = { [region.file]: spliced.source };
@@ -185,12 +232,14 @@ export class VertexCodeLane {
           ...(summary ? { summary } : {}),
           rounds: round,
           tokens,
+          ...(debug ? { trace } : {}),
         };
       }
       // Only the errors go back — never the file again. The model still has the
       // region from its own last turn, and re-sending the source is what makes a
       // repair round cost as much as the first one.
       errors = built.errors.slice(0, 6);
+      if (debug) trace.rounds.at(-1)!.buildErrors = errors;
     }
 
     return {

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -391,6 +391,41 @@ describe('remix routes', () => {
     expect(again.json().reason).toBe('nothing_to_undo');
   });
 
+  it('carries the lane trace into the answer only under the debug flag', async () => {
+    // Temporary and deliberately loud: it carries the utterance, so it must be a
+    // deploy-time decision rather than something a request can ask for.
+    const codeLane = {
+      run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {
+        const good = { 'game/runtime.ts': 'export function startGame() {\n  return 0.08;\n}\n' };
+        await build(good);
+        return {
+          ok: true,
+          overrides: good,
+          region: { file: 'game/runtime.ts', name: 'startGame' },
+          rounds: 0,
+          tokens: { input: 1, output: 1 },
+          trace: { regionCount: 3, picked: { decision: 'edit', found: true }, rounds: [] },
+        };
+      },
+    };
+    const built = await buildTestApp({ codeLane });
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+    const url = `/api/remixes/${remixId}/code`;
+    const payload = { utterance: 'make it twice as fast' };
+
+    const quiet = await app.inject({ method: 'POST', url, headers: alice, payload });
+    expect(quiet.json().debug).toBeUndefined();
+
+    process.env.REMIX_DEBUG = 'true';
+    try {
+      const loud = await app.inject({ method: 'POST', url, headers: alice, payload });
+      expect(loud.json().debug).toMatchObject({ regionCount: 3, picked: { found: true } });
+    } finally {
+      delete process.env.REMIX_DEBUG;
+    }
+  });
+
   it('reports a failed code edit without swapping anything', async () => {
     const codeLane = {
       run: async () => ({ ok: false, reason: 'did_not_compile', tokens: { input: 1, output: 1 } }),

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -344,6 +344,53 @@ describe('remix routes', () => {
     await first;
   });
 
+  it('puts the game back when an edit that compiled turns out to be broken', async () => {
+    // The lane verifies that a rebuild assembles, not that it plays: a model can
+    // rewrite a render function into valid TypeScript that draws nothing. One
+    // step back is the only safety net there is, and it has to move the session
+    // too — undoing the document alone would leave the next edit building on the
+    // broken source.
+    const codeLane = {
+      run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {
+        const broken = { 'game/runtime.ts': 'export function startGame() {\n  return 0.99;\n}\n' };
+        await build(broken);
+        return {
+          ok: true,
+          overrides: broken,
+          region: { file: 'game/runtime.ts', name: 'startGame' },
+          rounds: 0,
+          tokens: { input: 1, output: 1 },
+        };
+      },
+    };
+    const built = await buildTestApp({ codeLane });
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+
+    const edit = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/code`,
+      headers: alice,
+      payload: { utterance: 'draw carrots' },
+    });
+    expect(edit.json().html).toContain('return 0.99;');
+
+    const undone = await app.inject({ method: 'POST', url: `/api/remixes/${remixId}/undo`, headers: alice });
+    expect(undone.statusCode).toBe(200);
+    // The published game, not the edit.
+    expect(undone.json().html).toContain('return 0.16;');
+    expect(undone.json().undoable).toBe(false);
+
+    // And the session went back with it: the next rebuild starts from the game,
+    // not from the change the player just rejected.
+    expect(built.seen.at(-1)?.['game/runtime.ts']).not.toContain('return 0.99;');
+
+    // Nothing left to undo.
+    const again = await app.inject({ method: 'POST', url: `/api/remixes/${remixId}/undo`, headers: alice });
+    expect(again.statusCode).toBe(409);
+    expect(again.json().reason).toBe('nothing_to_undo');
+  });
+
   it('reports a failed code edit without swapping anything', async () => {
     const codeLane = {
       run: async () => ({ ok: false, reason: 'did_not_compile', tokens: { input: 1, output: 1 } }),

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -79,6 +79,17 @@ interface RemixSession {
   /** Accumulated edits, newest wins. Applied over `sources` on every rebuild. */
   overrides: Record<string, string>;
   /**
+   * What `overrides` looked like before each code edit, newest last.
+   *
+   * A rebuild that compiles is not a rebuild that plays: the lane's only
+   * verification is that the document assembles, and a model can rewrite a
+   * render function into valid TypeScript that draws nothing. That happened on
+   * the first real remix, and the player had no way back — which turns a toy for
+   * exploring a game into one that can wreck it. One step back per edit, bounded
+   * by the same ceiling as the edits themselves.
+   */
+  history: Array<Record<string, string>>;
+  /**
    * Whether the game's authoritative copy is the store's. It decides where a
    * rebuild's base comes from: a store game's files replace the ref's entirely,
    * a repo game keeps the ref as its base and carries only the edit.
@@ -291,6 +302,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       fromStore: loaded.fromStore,
       sourcesLoaded: loaded.fromStore,
       overrides: {},
+      history: [],
       definition: editorJson ? parseEditorDefinition(editorJson).definition : null,
       title: claims.slug,
       codeEdits: 0,
@@ -394,6 +406,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         fromStore: loaded.fromStore,
         sourcesLoaded: loaded.fromStore,
         overrides: {},
+        history: [],
         definition,
         title: params.data.slug,
         codeEdits: 0,
@@ -628,6 +641,8 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           return reply.status(499).send({ ok: false, reason: 'abandoned' });
         }
 
+        session.history.push(session.overrides);
+        if (session.history.length > MAX_CODE_EDITS) session.history.shift();
         session.overrides = { ...session.overrides, ...outcome.overrides };
         session.codeEdits += 1;
         session.expiresAt = now() + REMIX_TTL_MS;
@@ -636,12 +651,56 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         return reply.send({
           ok: true,
           html,
+          undoable: true,
           region: outcome.region,
           ...(outcome.summary ? { summary: outcome.summary } : {}),
         });
       } finally {
         session.codeInFlight = false;
       }
+    },
+  );
+
+  /**
+   * One step back.
+   *
+   * The code lane verifies that a rebuild *assembles*, which is not the same as
+   * verifying that it still plays — a model can turn a render function into
+   * valid TypeScript that draws an empty board, and the first real remix did
+   * exactly that. Without this the player is left holding a broken game and a
+   * composer, which is a worse place than they started.
+   *
+   * Server-side rather than a client-side swap, because the session is what the
+   * *next* edit builds on: restoring the document in the browser while leaving
+   * the broken source in the session would quietly compound the damage. The
+   * spend is not refunded — the work happened — but `codeEdits` is given back,
+   * since a step undone should not also cost a step forward.
+   */
+  app.post(
+    '/api/remixes/:id/undo',
+    { config: { rateLimit: { max: 20, timeWindow: 60_000 } } },
+    async (request, reply) => {
+      if (!requireUser(request, reply)) return;
+      const session = await getSession(request);
+      if (!session) return reply.status(404).send({ error: 'this remix has expired — start a new one' });
+      const previous = session.history.pop();
+      if (previous === undefined) {
+        return reply.status(409).send({ error: 'there is nothing to undo', reason: 'nothing_to_undo' });
+      }
+      const restored = session.overrides;
+      session.overrides = previous;
+      session.codeEdits = Math.max(0, session.codeEdits - 1);
+      const html = await rebuild(session);
+      if (!html) {
+        // Put it back rather than leaving the session in a state the player
+        // cannot see: a failed undo must not silently become a third version.
+        session.overrides = restored;
+        session.history.push(previous);
+        session.codeEdits += 1;
+        return reply.status(503).send({ error: 'could not go back just now', reason: 'rebuild_failed' });
+      }
+      session.expiresAt = now() + REMIX_TTL_MS;
+      return reply.send({ ok: true, html, undoable: session.history.length > 0 });
     },
   );
 

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { PARAMS_KEY, parseEditorDefinition, type EditorDefinition } from './editor-contract.js';
 import { EDITOR_FILE } from './editor-contract.js';
 import { applyAssistPatches, assistEnabled, MAX_UTTERANCE_LENGTH, type EditorAssistant } from './editor-assist.js';
-import { codeLaneEnabled, type VertexCodeLane } from './code-lane.js';
+import { codeLaneDebugEnabled, codeLaneEnabled, type VertexCodeLane } from './code-lane.js';
 import { buildSuggestions } from './remix-suggestions.js';
 import type { GamesStore } from './games-store.js';
 import type { Store } from './store.js';
@@ -648,11 +648,21 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         session.expiresAt = now() + REMIX_TTL_MS;
         const html = await rebuild(session);
         if (!html) return reply.status(500).send({ ok: false, reason: 'error' });
+        if (codeLaneDebugEnabled()) {
+          // Temporary, flag-gated: the whole run, in the log and in the answer.
+          // The response is the useful half — it is where a failure is already
+          // being read from. Delete both with the flag.
+          request.log.info(
+            { slug: session.slug, utterance: body.data.utterance, region: outcome.region, trace: outcome.trace },
+            'remix code lane trace',
+          );
+        }
         return reply.send({
           ok: true,
           html,
           undoable: true,
           region: outcome.region,
+          ...(codeLaneDebugEnabled() && outcome.trace ? { debug: outcome.trace } : {}),
           ...(outcome.summary ? { summary: outcome.summary } : {}),
         });
       } finally {

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -618,10 +618,26 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           },
         );
 
+        if (codeLaneDebugEnabled()) {
+          // Before the success branch, deliberately: a trace that only ever
+          // described the runs that worked would be silent on the ones the flag
+          // exists to explain.
+          request.log.info(
+            {
+              slug: session.slug,
+              utterance: body.data.utterance,
+              ok: outcome.ok,
+              ...(outcome.ok ? { region: outcome.region } : { reason: outcome.reason, detail: outcome.detail }),
+              trace: outcome.trace,
+            },
+            'remix code lane trace',
+          );
+        }
         if (!outcome.ok) {
           return reply.send({
             ok: false,
             reason: outcome.reason,
+            ...(codeLaneDebugEnabled() && outcome.trace ? { debug: outcome.trace } : {}),
             ...(outcome.summary ? { summary: outcome.summary } : {}),
           });
         }
@@ -648,15 +664,6 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         session.expiresAt = now() + REMIX_TTL_MS;
         const html = await rebuild(session);
         if (!html) return reply.status(500).send({ ok: false, reason: 'error' });
-        if (codeLaneDebugEnabled()) {
-          // Temporary, flag-gated: the whole run, in the log and in the answer.
-          // The response is the useful half — it is where a failure is already
-          // being read from. Delete both with the flag.
-          request.log.info(
-            { slug: session.slug, utterance: body.data.utterance, region: outcome.region, trace: outcome.trace },
-            'remix code lane trace',
-          );
-        }
         return reply.send({
           ok: true,
           html,
@@ -700,10 +707,16 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       const restored = session.overrides;
       session.overrides = previous;
       session.codeEdits = Math.max(0, session.codeEdits - 1);
-      const html = await rebuild(session);
+      // Put it back rather than leaving the session in a state the player cannot
+      // see: a failed undo must not silently become a third version, and an
+      // assembler that *throws* fails exactly as much as one that returns null.
+      let html: string | null = null;
+      try {
+        html = await rebuild(session);
+      } catch (error) {
+        request.log.error({ err: error, slug: session.slug }, 'remix undo could not rebuild');
+      }
       if (!html) {
-        // Put it back rather than leaving the session in a state the player
-        // cannot see: a failed undo must not silently become a third version.
         session.overrides = restored;
         session.history.push(previous);
         session.codeEdits += 1;

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -204,6 +204,13 @@ export const REMIX_STEPS = [
   'painted',
   'asked',
   'applied',
+  // `applied` is recorded when the rebuild arrives, which is before the game has
+  // run a frame. A build that then throws was counted as a success, and one the
+  // player took back was counted twice over — so the rung that measures whether
+  // the safety flow works had no numbers at all. These two are read against
+  // `applied`, not against each other: not every broken edit is undone.
+  'broken',
+  'undone',
   'handoff',
   'refused',
   'shared',

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -104,6 +104,8 @@ const RemixStepSchema = z.enum([
   'painted',
   'asked',
   'applied',
+  'broken',
+  'undone',
   'handoff',
   'refused',
   'shared',

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -7,6 +7,7 @@ import { useGameTelemetry } from './gamePlayer.js';
 import { rememberRecentPlay } from './recentPlays.js';
 import { recordGamePlayed } from './recommendationsApi.js';
 import { RemixPanel } from './RemixPanel.js';
+import type { RemixSession } from './remixApi.js';
 import { readSharedParams } from './remixApi.js';
 
 type PublishedGameFrameProps = {
@@ -62,6 +63,17 @@ export function PublishedGameFrame({
    * the remix returns the player to the published game rather than to a reload.
    */
   const [remixHtml, setRemixHtml] = useState<string | null>(null);
+  /**
+   * The remix session, held above the panel so closing the sheet does not end it.
+   *
+   * The panel unmounts on Close while the remixed document keeps running, so a
+   * session owned by the panel meant the most natural sequence there is — change
+   * something, close the sheet to play it, find it broken, reopen — came back to
+   * a fresh session with no history and no way back. The session outlives the
+   * sheet because the *change* does.
+   */
+  const [remixSession, setRemixSession] = useState<RemixSession | null>(null);
+  const [remixUndoable, setRemixUndoable] = useState(false);
   const [remixOpen, setRemixOpen] = useState(false);
   /**
    * Remix is an invitation, revealed in the gaps rather than at second zero:
@@ -164,6 +176,10 @@ export function PublishedGameFrame({
           frameRef={activeFrameRef}
           initialParams={sharedParams}
           onSwapDocument={setRemixHtml}
+          session={remixSession}
+          onSession={setRemixSession}
+          undoable={remixUndoable}
+          onUndoable={setRemixUndoable}
           onClose={() => setRemixOpen(false)}
           painterRequest={painterNonce}
           onCapabilities={onRemixCapabilities}

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -523,6 +523,40 @@ describe('RemixPanel', () => {
     expect(container.querySelector('.remix-btn.is-primary')?.textContent).toBe('Undo');
   });
 
+  it('keeps the way back when the sheet is reopened over a running change', async () => {
+    // Close the sheet, play-test the change, find it broken, reopen — the most
+    // natural sequence there is, and the one a session owned by this panel could
+    // not survive: the change keeps running while the history that undoes it
+    // was thrown away with the unmount.
+    const session = {
+      remixId: 'r1',
+      params: null,
+      values: null,
+      canAssist: false,
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <RemixPanel
+          slug="dog-dash"
+          frameRef={frameRef as never}
+          onSwapDocument={(html) => swapped.push(html)}
+          onClose={() => {}}
+          session={session as never}
+          undoable
+        />,
+      );
+    });
+
+    // No second session was minted for the reopening...
+    expect(remixApi.startRemix).not.toHaveBeenCalled();
+    // ...and the way back is offered before anything else is asked for.
+    expect(container.querySelector('.remix-btn')?.textContent).toBe('Undo');
+  });
+
   async function send(text: string) {
     const input = container.querySelector('.remix-ask textarea') as HTMLTextAreaElement;
     await act(async () => {

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createRef } from 'react';
+import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
@@ -24,6 +24,7 @@ const remixApi = vi.hoisted(() => ({
   remixAssist: vi.fn(),
   remixCode: vi.fn(),
   remixShare: vi.fn(),
+  remixUndo: vi.fn(),
   coerceSharedParams: (_specs: unknown, values: unknown) => values,
 }));
 vi.mock('./remixApi', () => remixApi);
@@ -37,12 +38,14 @@ import { RemixPanel } from './RemixPanel.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;
+let swapped: string[] = [];
 
 beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   await i18n.changeLanguage('en');
   container = document.createElement('div');
   document.body.appendChild(container);
+  swapped = [];
 });
 
 afterEach(() => {
@@ -54,14 +57,18 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/** Stands in for the game frame, so a message can claim to come from it. */
+const frameWindow = { postMessage: () => {} } as unknown as Window;
+const frameRef = { current: { contentWindow: frameWindow } } as unknown as React.RefObject<HTMLIFrameElement>;
+
 async function draw() {
   root = createRoot(container);
   await act(async () => {
     root!.render(
       <RemixPanel
         slug="dog-dash"
-        frameRef={createRef<HTMLIFrameElement>() as never}
-        onSwapDocument={() => {}}
+        frameRef={frameRef as never}
+        onSwapDocument={(html) => swapped.push(html)}
         onClose={() => {}}
       />,
     );
@@ -431,6 +438,89 @@ describe('RemixPanel', () => {
     await draw();
 
     expect(container.querySelector('.remix-try')?.textContent).toBe('turn off rain');
+  });
+
+  it('does not offer a link that would carry nothing', async () => {
+    // A code change moves no declared value, so the link is an empty diff — a
+    // link to the game the player started with. Offering it makes the loudest
+    // button on the panel the least true thing on it.
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: { dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'dog size' } } },
+      values: { dogScale: 1 },
+      canAssist: true,
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist.mockResolvedValue({ lane: 'code' });
+    remixApi.remixCode.mockResolvedValue({
+      ok: true,
+      html: '<html></html>',
+      region: { file: 'game/render.ts', name: 'paintWorld' },
+      summary: { en: 'Replaced stars with drawn carrots.' },
+    });
+    await draw();
+    await send('replace the stars with carrots');
+
+    // The change landed and says so...
+    expect(container.querySelector('.remix-result')?.textContent).toContain('carrots');
+    // ...and there is nothing to share, so nothing is offered.
+    expect(container.querySelector('.remix-btn.is-primary')).toBeNull();
+
+    // But there is always a way back. A rebuild that compiles is not a rebuild
+    // that plays, and the lane cannot tell the difference — so the player must
+    // never be left holding a broken game and a composer.
+    const undo = container.querySelector('.remix-btn.is-quiet') as HTMLButtonElement;
+    expect(undo?.textContent).toBe('Undo');
+
+    remixApi.remixUndo.mockResolvedValue({ ok: true, html: '<html>original</html>', undoable: false });
+    await act(async () => {
+      undo.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(remixApi.remixUndo).toHaveBeenCalledWith('r1');
+    expect(swapped.at(-1)).toBe('<html>original</html>');
+  });
+
+  it('says so when the new build throws, and makes going back the loud option', async () => {
+    // The lane checked that it assembles. It did — and then `createRound` threw
+    // on `undefined.map` in the player's face, under a cheerful tick.
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: null,
+      values: null,
+      canAssist: false,
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixCode.mockResolvedValue({
+      ok: true,
+      html: '<html>broken</html>',
+      region: { file: 'game/render.ts', name: 'paintWorld' },
+      summary: { en: 'Added a pulsing animation.' },
+    });
+    await draw();
+    await send('make the seeds pulse');
+    expect(container.querySelector('.remix-result')?.textContent).toContain('pulsing');
+
+    // The frame reports its uncaught error over the same channel play telemetry
+    // uses; the panel is listening rather than leaving the player to notice.
+    await act(async () => {
+      const event = new MessageEvent('message', {
+        data: { source: 'gdpl-player', type: 'error', message: 'boom' },
+      });
+      // jsdom will not take a plain object as `source`/`origin` through the
+      // constructor, and the panel checks both — an opaque-origin frame is the
+      // only thing it listens to.
+      Object.defineProperty(event, 'source', { value: frameWindow });
+      Object.defineProperty(event, 'origin', { value: 'null' });
+      window.dispatchEvent(event);
+    });
+
+    expect(container.querySelector('.remix-result.is-broken')).not.toBeNull();
+    expect(container.querySelector('.remix-result')?.textContent).toContain('stopped the game working');
+    expect(container.querySelector('.remix-btn.is-primary')?.textContent).toBe('Undo');
   });
 
   async function send(text: string) {

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -176,6 +176,18 @@ export function RemixPanel(props: {
   /** Shared values from a `?remix=` link, already parsed. */
   initialParams?: Record<string, EditorParamValue> | null;
   /**
+   * The session, owned by the parent so it outlives this sheet.
+   *
+   * Closing the panel does not end a remix — the changed document keeps running
+   * — so minting a session per mount stranded the player: reopen after a
+   * play-test and the history that held their way back was gone.
+   */
+  session?: RemixSession | null;
+  onSession?: (session: RemixSession) => void;
+  /** Whether the server still has a step to give back. */
+  undoable?: boolean;
+  onUndoable?: (undoable: boolean) => void;
+  /**
    * The More-menu door to the painter: bumped by the theater when "Level
    * editor" is chosen. A nonce rather than a boolean so choosing it again
    * reopens a painter the player closed.
@@ -186,7 +198,16 @@ export function RemixPanel(props: {
 }) {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
-  const [session, setSession] = useState<RemixSession | null>(null);
+  const [ownSession, setOwnSession] = useState<RemixSession | null>(props.session ?? null);
+  const session = props.session ?? ownSession;
+  const setSession = useCallback(
+    (next: RemixSession) => {
+      setOwnSession(next);
+      props.onSession?.(next);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the callback prop is stable in practice
+    [],
+  );
   const [authOpen, setAuthOpen] = useState(false);
   /** Sliders and share stay tucked away unless explicitly asked for. */
   const expert = useMemo(() => new URLSearchParams(window.location.search).has('remixExpert'), []);
@@ -307,6 +328,9 @@ export function RemixPanel(props: {
     // No session without a session: the API 401s signed out, and the composer
     // needs nothing from the server until send — so a visitor can type first.
     if (!uid) return;
+    // Already have one from a previous opening of this sheet — reusing it is the
+    // whole point: its history is the player's way back.
+    if (props.session) return;
     let cancelled = false;
     startRemix(props.slug)
       .then((started) => {
@@ -338,7 +362,7 @@ export function RemixPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [props.slug, props.initialParams, pushToGame, uid, onCapabilities]);
+  }, [props.slug, props.initialParams, props.session, setSession, pushToGame, uid, onCapabilities]);
 
   /** Open the painter, remembering which door was first — telemetry keeps that one. */
   const openPainter = useCallback((door: RemixPaintedVia) => {
@@ -377,6 +401,15 @@ export function RemixPanel(props: {
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, MAX_INPUT_HEIGHT)}px`;
   }, [utterance, changed]);
+
+  // Reopened over a change that is still running: the way back is the first
+  // thing this sheet owes the player, before they ask for anything else.
+  useEffect(() => {
+    if (props.undoable && !changed) {
+      setChanged({ text: t('remix.changeStanding'), canShare: false, undoCode: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on arrival
+  }, [props.undoable]);
 
   // A panel that opened onto nothing. Recorded against the same `opened`
   // denominator so the share of visits that met a game with no way in is a
@@ -538,6 +571,7 @@ export function RemixPanel(props: {
           // cannot tell the difference. One tap back is the safety net.
           undoCode: result.undoable !== false,
         });
+        props.onUndoable?.(result.undoable !== false);
         setUndo(null);
         // The swap replaces the whole document, so the new build boots fresh and
         // the values the player has set are re-sent once it says hello.
@@ -602,7 +636,11 @@ export function RemixPanel(props: {
       const result = await remixUndo(active.remixId);
       props.onSwapDocument(result.html);
       window.setTimeout(() => pushToGame(valuesRef.current), 400);
-      setChanged(null);
+      recordRemixStep('undone');
+      props.onUndoable?.(result.undoable);
+      // More history behind it: the button stays, because the server can still
+      // give another step back and the player has no other way to ask for it.
+      setChanged(result.undoable ? { text: t('remix.changeStanding'), canShare: false, undoCode: true } : null);
       setNote({ kind: 'ok', text: t('remix.undone') });
     } catch {
       props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'resume' }, '*');
@@ -622,6 +660,10 @@ export function RemixPanel(props: {
       const data = event.data as { source?: string; type?: string } | null;
       if (data?.source !== 'gdpl-player' || data.type !== 'error') return;
       stop();
+      // `applied` was recorded when the rebuild arrived, a moment before the
+      // game ran a frame. Without this the funnel counts a broken build as a
+      // success and can never say whether the safety flow is working.
+      recordRemixStep('broken');
       setChanged((current) => (current ? { ...current, broke: true, canShare: false } : current));
     }
     function stop() {

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -9,13 +9,14 @@ import {
   remixAssist,
   remixCode,
   remixShare,
+  remixUndo,
   startRemix,
   type RemixApiError,
   type RemixSession,
   type RemixSuggestion,
 } from './remixApi.js';
 import { RemixPainter } from './RemixPainter.js';
-import type { EditorContentDoc, EditorLabel, EditorParamValue } from './studioApi.js';
+import type { EditorContentDoc, EditorLabel, EditorParamSpec, EditorParamValue } from './studioApi.js';
 import type { RemixPaintedVia } from './visitTelemetry.js';
 
 /**
@@ -119,6 +120,24 @@ function takePending(slug: string): string | null {
   }
 }
 
+/**
+ * Would a link carry anything?
+ *
+ * Only declared values travel — generated code never does, which is the whole
+ * point of the gate — and the link is a *diff*: a value sitting at its default
+ * says nothing a plain link to the game does not already say. So a change that
+ * lived entirely in code leaves nothing to share, and offering Share anyway
+ * hands the player a link to the game they started with. The loudest button on
+ * the panel must not be the one that produces the least true thing on it.
+ */
+function hasShareableValues(
+  specs: Record<string, EditorParamSpec> | null | undefined,
+  values: Record<string, EditorParamValue>,
+): boolean {
+  if (!specs) return false;
+  return Object.entries(specs).some(([key, spec]) => key in values && values[key] !== spec.default);
+}
+
 type Lane = 'idle' | 'asking' | 'building';
 
 /** After this long the shimmer needs words, or it reads as broken. */
@@ -134,6 +153,17 @@ const CODE_TIMEOUT_MS = 45_000;
 const MAX_UTTERANCE = 240;
 /** Three lines, then it scrolls. Past that a request is a paragraph, not a request. */
 const MAX_INPUT_HEIGHT = 84;
+/**
+ * How long to listen for the swapped document throwing.
+ *
+ * The code lane verifies that a rebuild *assembles*, which is not the same as
+ * verifying that it runs: the first real remix produced valid TypeScript whose
+ * `createRound` threw on `undefined.map`, and the player was left with a broken
+ * game, a cheerful tick and no way back. The frame already reports its uncaught
+ * errors to the host — the same channel play telemetry uses — so the panel can
+ * hear that rather than making the player be the detector.
+ */
+const SWAP_WATCH_MS = 6_000;
 
 type Note = { kind: 'ok' | 'info' | 'error'; text: string } | null;
 
@@ -170,7 +200,12 @@ export function RemixPanel(props: {
   const [undo, setUndo] = useState<Record<string, EditorParamValue> | null>(null);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   /** The last change that landed, and whether there is anything to share of it. */
-  const [changed, setChanged] = useState<{ text: string; canShare: boolean } | null>(null);
+  const [changed, setChanged] = useState<{
+    text: string;
+    canShare: boolean;
+    undoCode?: boolean;
+    broke?: boolean;
+  } | null>(null);
   /** The player's own words, echoed back while the rebuild runs. */
   const [asked, setAsked] = useState('');
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -434,7 +469,10 @@ export function RemixPanel(props: {
           // Share is offered whenever there is anything shareable — a link
           // carries declared values, so a game with no declaration has nothing
           // to put in one, and offering it there would be a broken promise.
-          setChanged({ text: label(result.summary) || t('remix.applied'), canShare: Boolean(active.params) });
+          setChanged({
+            text: label(result.summary) || t('remix.applied'),
+            canShare: hasShareableValues(active.params, next),
+          });
           return;
         }
         if (result.lane === 'reject') {
@@ -493,12 +531,18 @@ export function RemixPanel(props: {
         // copy says exactly that rather than implying the whole remix went.
         setChanged({
           text: `${label(result.summary) || t('remix.rebuilt')} ${t('remix.restarted')}`,
-          canShare: Boolean(active.params),
+          // A code change on its own carries nothing: the link is a diff of
+          // declared values, and this one moved none of them.
+          canShare: hasShareableValues(active.params, valuesRef.current),
+          // A rebuild that compiles is not a rebuild that plays, and the lane
+          // cannot tell the difference. One tap back is the safety net.
+          undoCode: result.undoable !== false,
         });
         setUndo(null);
         // The swap replaces the whole document, so the new build boots fresh and
         // the values the player has set are re-sent once it says hello.
         props.onSwapDocument(result.html);
+        watchSwappedDocument();
         window.setTimeout(() => pushToGame(valuesRef.current), 400);
       } else {
         recordRemixStep(result.reason === 'refused' ? 'refused' : 'handoff');
@@ -507,7 +551,14 @@ export function RemixPanel(props: {
           kind: result.reason === 'refused' ? 'error' : 'info',
           text:
             label(result.summary) ||
-            (result.reason === 'did_not_compile' ? t('remix.couldNotBuild') : t('remix.tooBig')),
+            // Each reason gets its own words. A refusal was reading as "too big",
+            // which tells the player to try something smaller for a request that
+            // size had nothing to do with.
+            (result.reason === 'refused'
+              ? t('remix.refused')
+              : result.reason === 'did_not_compile'
+                ? t('remix.couldNotBuild')
+                : t('remix.tooBig')),
         });
       }
     } catch (error) {
@@ -533,6 +584,52 @@ export function RemixPanel(props: {
       setSlow(false);
       setLane('idle');
     }
+  }
+
+  /**
+   * Put the game back the way it was before the last rebuild.
+   *
+   * The server owns this because the session is the base the next edit builds
+   * on; undoing only the document in the browser would leave the broken source
+   * in place and compound it on the following change.
+   */
+  async function undoCode() {
+    const active = session;
+    if (!active || lane !== 'idle') return;
+    setLane('building');
+    props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'pause' }, '*');
+    try {
+      const result = await remixUndo(active.remixId);
+      props.onSwapDocument(result.html);
+      window.setTimeout(() => pushToGame(valuesRef.current), 400);
+      setChanged(null);
+      setNote({ kind: 'ok', text: t('remix.undone') });
+    } catch {
+      props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'resume' }, '*');
+      setNote({ kind: 'error', text: t('remix.undoFailed') });
+    } finally {
+      setLane('idle');
+    }
+  }
+
+  /** Listen for the new build throwing, for a few seconds after the swap. */
+  function watchSwappedDocument() {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== 'null') return;
+      // Read the frame's window at delivery time: the swap replaced the document,
+      // so the window captured before it is not the one now reporting.
+      if (event.source !== props.frameRef.current?.contentWindow) return;
+      const data = event.data as { source?: string; type?: string } | null;
+      if (data?.source !== 'gdpl-player' || data.type !== 'error') return;
+      stop();
+      setChanged((current) => (current ? { ...current, broke: true, canShare: false } : current));
+    }
+    function stop() {
+      window.removeEventListener('message', onMessage);
+      window.clearTimeout(timer);
+    }
+    const timer = window.setTimeout(stop, SWAP_WATCH_MS);
+    window.addEventListener('message', onMessage);
   }
 
   function undoLast() {
@@ -692,21 +789,28 @@ export function RemixPanel(props: {
          * one that turns a remix into a habit.
          */
         <>
-          <p className="remix-result" role="status">
+          <p className={`remix-result${changed.broke ? ' is-broken' : ''}`} role="status">
             <span className="remix-tick" aria-hidden="true">
-              ✓
+              {changed.broke ? '!' : '✓'}
             </span>
-            <span>{changed.text}</span>
+            <span>{changed.broke ? t('remix.brokeIt') : changed.text}</span>
           </p>
-          {changed.canShare || undo ? (
+          {changed.canShare || undo || changed.undoCode ? (
             <div className="remix-actions-row">
               {changed.canShare ? (
                 <button type="button" className="remix-btn is-primary" onClick={() => void share()}>
                   {t('remix.share')}
                 </button>
               ) : null}
-              {undo ? (
-                <button type="button" className="remix-btn is-quiet" onClick={undoLast}>
+              {undo || changed.undoCode ? (
+                <button
+                  type="button"
+                  // A broken game makes going back the only thing worth doing,
+                  // so it stops being the quiet option.
+                  className={`remix-btn ${changed.broke ? 'is-primary' : 'is-quiet'}`}
+                  disabled={lane !== 'idle'}
+                  onClick={() => (changed.undoCode ? void undoCode() : undoLast())}
+                >
                   {t('remix.undo')}
                 </button>
               ) : null}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1058,6 +1058,7 @@
     "sharedWithoutContent": "Link copied — it carries your settings; painted maps stay in this remix.",
     "undone": "Put back the way it was.",
     "undoFailed": "Couldn't go back just now.",
-    "brokeIt": "That change stopped the game working. Put it back?"
+    "brokeIt": "That change stopped the game working. Put it back?",
+    "changeStanding": "Your change is running."
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1055,6 +1055,9 @@
     "editorTitle": "Level editor",
     "editorHide": "Hide",
     "editorButton": "Level editor",
-    "sharedWithoutContent": "Link copied — it carries your settings; painted maps stay in this remix."
+    "sharedWithoutContent": "Link copied — it carries your settings; painted maps stay in this remix.",
+    "undone": "Put back the way it was.",
+    "undoFailed": "Couldn't go back just now.",
+    "brokeIt": "That change stopped the game working. Put it back?"
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1062,6 +1062,7 @@
     "sharedWithoutContent": "Skopiowano link — zawiera Twoje ustawienia; namalowane mapy zostają w tym remiksie.",
     "undone": "Przywrócono poprzednią wersję.",
     "undoFailed": "Nie udało się cofnąć.",
-    "brokeIt": "Ta zmiana zepsuła grę. Cofnąć?"
+    "brokeIt": "Ta zmiana zepsuła grę. Cofnąć?",
+    "changeStanding": "Twoja zmiana działa."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1059,6 +1059,9 @@
     "editorTitle": "Edytor poziomów",
     "editorHide": "Ukryj",
     "editorButton": "Edytor poziomów",
-    "sharedWithoutContent": "Skopiowano link — zawiera Twoje ustawienia; namalowane mapy zostają w tym remiksie."
+    "sharedWithoutContent": "Skopiowano link — zawiera Twoje ustawienia; namalowane mapy zostają w tym remiksie.",
+    "undone": "Przywrócono poprzednią wersję.",
+    "undoFailed": "Nie udało się cofnąć.",
+    "brokeIt": "Ta zmiana zepsuła grę. Cofnąć?"
   }
 }

--- a/apps/web/src/remixApi.ts
+++ b/apps/web/src/remixApi.ts
@@ -47,7 +47,7 @@ export type RemixAssistResponse = {
 };
 
 export type RemixCodeResponse =
-  | { ok: true; html: string; region: { file: string; name: string }; summary?: EditorLabel }
+  | { ok: true; html: string; undoable?: boolean; region: { file: string; name: string }; summary?: EditorLabel }
   | { ok: false; reason: 'no_region' | 'refused' | 'did_not_compile' | 'error'; summary?: EditorLabel };
 
 export type RemixShare = {
@@ -89,6 +89,17 @@ export function remixAssist(
 
 export function remixCode(remixId: string, utterance: string, signal?: AbortSignal): Promise<RemixCodeResponse> {
   return post<RemixCodeResponse>(`/api/remixes/${encodeURIComponent(remixId)}/code`, { utterance }, signal);
+}
+
+/**
+ * One step back, server-side.
+ *
+ * Not a client-side swap: the session is what the *next* edit builds on, so
+ * restoring the document in the browser while leaving the broken source on the
+ * server would quietly compound the damage.
+ */
+export function remixUndo(remixId: string): Promise<{ ok: true; html: string; undoable: boolean }> {
+  return post<{ ok: true; html: string; undoable: boolean }>(`/api/remixes/${encodeURIComponent(remixId)}/undo`);
 }
 
 export function remixShare(remixId: string, params: Record<string, EditorParamValue>): Promise<RemixShare> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11089,3 +11089,9 @@ body.player-open {
   flex-direction: column;
   gap: 2px;
 }
+
+/* A build that compiled and then threw. The tick would be a lie. */
+.remix-result.is-broken .remix-tick {
+  background: rgba(242, 162, 162, 0.16);
+  color: #f2a2a2;
+}

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -188,6 +188,8 @@ export type RemixStep =
   | 'painted' // changed declared content in the remix painter — `tuned`'s sibling
   | 'asked'
   | 'applied'
+  | 'broken' // the swapped build threw — counted as applied a moment earlier
+  | 'undone' // and taken back, which is the safety flow working
   | 'handoff'
   | 'refused'
   | 'shared'


### PR DESCRIPTION
From the first real hand test of the code lane. Two edits on Garden Gather compiled, were reported as successes with a tick, and broke the game:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at createRound (about:srcdoc:3789:32)
    at Object.init  (about:srcdoc:3889:75)
    at restart      (about:srcdoc:1468:27)
```

The lane's only verification is that the rebuilt document **assembles**. Compiling is not running, and nothing here knew the difference — so the player got a cheerful summary, a broken game, and no way back.

## The frame already tells us

An uncaught error inside the game is reported to the host over the same channel play telemetry uses. The panel now listens for a few seconds after a swap. An error turns the tick red, replaces the summary with *"That change stopped the game working. Put it back?"*, withdraws Share, and promotes Undo from the quiet option to the loud one.

This is a detector, not a verifier: it catches a build that throws, not one that merely draws the wrong thing. That gap is real and named below.

## And there is now a way back

`POST /api/remixes/:id/undo` pops one step of accumulated overrides and rebuilds.

Server-side deliberately — the session is what the **next** edit builds on, so restoring the document in the browser while leaving the broken source on the server would compound the damage on the following change. The spend is not refunded (the work happened) but the edit count is, since a step undone should not also cost a step forward. A failed undo restores the session rather than leaving a third state nobody asked for.

## Two smaller things the same session surfaced

- **Share offered a link that carried nothing.** A link is a diff of declared values; a code-only change moves none of them, so tapping Share copied a link to the game the player started with — `code: "e30"`, which decodes to `{}`. It is offered only when something would actually travel.
- **A refusal read as "too big".** `reason: 'refused'` fell through to the size copy, telling a player to try something smaller for a request whose size was never the problem. Each reason has its own words now.

## What this does not fix

The lane can still produce a change that runs and is simply wrong — the board drawn empty, an object drawn off-screen. Detecting *that* needs the rebuilt document actually played, which is what the deploy's browser gate does and what no per-edit path can afford yet. Until then, reversibility is the safety net rather than verification, which is the honest trade for an ephemeral toy.

## Verification

- `npm run lint`, `npm run type-check` clean; API 1988, web 938 tests pass
- New: server undo restores both the document and the session, and 409s with `nothing_to_undo` when there is nothing left; the panel reacts to a frame error by offering the way back; an empty link is never offered (verified to fail on the previous behaviour)
- Rebased onto #485 — the painter's imports, strings and styles merged rather than replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_