### PR TITLE
byoca: three promises the system did not keep

### DIFF
--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import { assertCreatorAgentKeyActive, looksLikeCreatorAgentKey, verifyCreatorAgentKey } from './agent-creator-key.js';
+import {
+  assertCreatorAgentKeyActive,
+  DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS,
+  looksLikeCreatorAgentKey,
+  verifyCreatorAgentKey,
+} from './agent-creator-key.js';
 import { NO_OPEN_ROUND_REASON, PLATFORM_ROUND_REASON, SLUG_NOT_ON_ACCOUNT_REASON } from './agent-game-key.js';
 import { mintGameAgentKey } from './agent-game-key.js';
 import { mintAgentToken } from './agent-token.js';
@@ -10,6 +15,7 @@ import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } f
 import { mintMcpSessionKey } from './mcp-session-key.js';
 import { pkceChallengeS256 } from './oauth-pkce.js';
 import { InMemoryStore } from './store.js';
+import type { CreatorAgentKeyRecord } from './store.js';
 import { NoopTranslator } from './translate.js';
 
 const secret = 'creator-agent-routes-secret';
@@ -443,5 +449,100 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
       roundGeneration: 1,
     });
     expect(sessionKey).toBeTruthy();
+  });
+
+  // CP-2, against production: the Studio panel promises "rotating stops every agent still
+  // using the old key". It did not. A sessionKey minted before the rotation authenticates
+  // on the round's generation and never consults the creator key, so report_progress kept
+  // succeeding afterwards and the write landed in the creator's thread.
+  it('rotating the creator key ends sessions already holding a sessionKey', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Rotate Kills', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+    await store.ensureRoundGeneration(record.issueNumber);
+
+    const minted = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const creatorKey = minted.json().key as string;
+    const started = await callStart(app, { slug: SLUG }, { authorization: `Bearer ${creatorKey}` });
+    expect(started.isError).toBe(false);
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const writeProgress = async () => {
+      const res = await mcpCall(
+        app,
+        'tools/call',
+        { name: 'report_progress', arguments: { sessionKey, step: 'planning', text: 'still here' } },
+        { 'mcp-session-id': started.sessionId },
+      );
+      return (res.json() as { result?: { isError?: boolean } }).result?.isError === true;
+    };
+
+    // The session is live before the rotation — otherwise this test proves nothing.
+    expect(await writeProgress()).toBe(false);
+
+    const rotated = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key/rotate',
+      headers: authHeaders(),
+    });
+    expect(rotated.statusCode).toBe(200);
+    expect((rotated.json() as { sessionsEnded: number }).sessionsEnded).toBe(1);
+
+    // The write capability is gone, which is what the panel told the creator would happen.
+    expect(await writeProgress()).toBe(true);
+  });
+
+  // The panel showed a different "Ends in ..." tail on every visit, because GET re-minted
+  // at the wall clock. A creator comparing it against their agent's header always saw a
+  // mismatch, and the remedy the panel offers for a mismatch is Rotate — destructive.
+  it('mints one stable key per generation, so the displayed tail matches the pasted header', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    // Backdate the generation, the way it is for any creator who minted last week.
+    // Two back-to-back reads are identical even without the fix — `exp` has second
+    // granularity — so a same-second probe could never have produced the failure.
+    await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const MINTED_AT = '2026-07-01T00:00:00.000Z';
+    const records = (store as unknown as { creatorAgentKeys: Map<string, CreatorAgentKeyRecord> }).creatorAgentKeys;
+    records.set(OWNER, { ...records.get(OWNER)!, updatedAt: MINTED_AT });
+
+    const first = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const second = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+
+    const a = first.json() as { key: string; fingerprint: string; expiresAt: number; keyGeneration: number };
+    const b = second.json() as { key: string; fingerprint: string; expiresAt: number; keyGeneration: number };
+
+    // The key belongs to the generation, not to the moment the panel was opened: its
+    // expiry is measured from when the generation was minted.
+    expect(b.expiresAt).toBe(
+      Math.floor(Date.parse(MINTED_AT) / 1000) + DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS * 24 * 60 * 60,
+    );
+    expect(verifyCreatorAgentKey(b.key, secret).exp).toBe(b.expiresAt);
+
+    expect(b.keyGeneration).toBe(a.keyGeneration);
+    expect(b.key).toBe(a.key);
+    expect(b.fingerprint).toBe(a.fingerprint);
+    // The stated expiry is a real deadline, not one that slid forward on every page load.
+    expect(b.expiresAt).toBe(a.expiresAt);
+
+    // Rotation still produces a genuinely different key.
+    const rotated = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key/rotate',
+      headers: authHeaders(),
+    });
+    const c = rotated.json() as { key: string; keyGeneration: number };
+    expect(c.keyGeneration).toBe(a.keyGeneration + 1);
+    expect(c.key).not.toBe(a.key);
   });
 });

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -545,4 +545,91 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     expect(c.keyGeneration).toBe(a.keyGeneration + 1);
     expect(c.key).not.toBe(a.key);
   });
+
+  // Review (#488): the creator key cannot even open a platform round, so bumping a
+  // platform build's generation revokes nothing the key could reach — it just stalls
+  // a build the creator did not ask to stop.
+  it('leaves a platform-built round alone when the creator key is rotated', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Platform Build', concept: CONCEPT, builder: 'platform' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+    await store.setRoundBuilder(record.issueNumber, 'platform');
+    await store.ensureRoundGeneration(record.issueNumber);
+    const before = (await store.getSubmission(record.issueNumber))?.roundGeneration;
+
+    const rotated = await app.inject({
+      method: 'POST',
+      url: '/api/me/creator-agent-key/rotate',
+      headers: authHeaders(),
+    });
+    expect(rotated.statusCode).toBe(200);
+    expect((rotated.json() as { sessionsEnded: number }).sessionsEnded).toBe(0);
+    expect((await store.getSubmission(record.issueNumber))?.roundGeneration).toBe(before);
+  });
+
+  // Review (#488): if the revocation persisted but ending sessions then failed, a 404
+  // on retry would strand those sessions writable forever — no retry could reach the
+  // cleanup again.
+  it('finishes the session cleanup when revoke is retried on an already-revoked key', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Retry Revoke', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const record = (await store.listSubmissionsByOwner(OWNER))[0]!;
+    await store.setSubmissionSlug(record.issueNumber, SLUG);
+    await store.ensureRoundGeneration(record.issueNumber);
+
+    // Stand in for the interrupted attempt: revocation persisted, cleanup never ran.
+    await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    await store.revokeCreatorAgentKey(OWNER, new Date().toISOString());
+    const stranded = (await store.getSubmission(record.issueNumber))?.roundGeneration;
+
+    const retry = await app.inject({
+      method: 'DELETE',
+      url: '/api/me/creator-agent-key',
+      headers: authHeaders(),
+    });
+    expect(retry.statusCode).toBe(204);
+    expect((await store.getSubmission(record.issueNumber))?.roundGeneration).toBe((stranded ?? 1) + 1);
+  });
+
+  // Review (#488): anchoring every mint to updatedAt means a generation older than the
+  // TTL would mint an already-expired key forever, while the panel still offered it for
+  // copying and the only remedy on screen is the destructive Rotate.
+  it('re-dates a generation whose key has expired instead of serving a dead one', async () => {
+    const store = new InMemoryStore();
+    app = await createApp(store);
+
+    await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const records = (store as unknown as { creatorAgentKeys: Map<string, CreatorAgentKeyRecord> }).creatorAgentKeys;
+    const aged = new Date(Date.now() - (DEFAULT_CREATOR_AGENT_KEY_TTL_DAYS + 30) * 24 * 60 * 60 * 1000);
+    records.set(OWNER, { ...records.get(OWNER)!, updatedAt: aged.toISOString() });
+
+    const res = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    const body = res.json() as { key: string; keyGeneration: number; expiresAt: number };
+
+    // Same generation — nothing that was dead comes back, every key of it had expired.
+    expect(body.keyGeneration).toBe(1);
+    expect(body.expiresAt * 1000).toBeGreaterThan(Date.now());
+    expect(verifyCreatorAgentKey(body.key, secret).exp).toBe(body.expiresAt);
+
+    // And it is stable again from here, rather than drifting on every visit.
+    const again = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
+    expect((again.json() as { key: string }).key).toBe(body.key);
+  });
 });

--- a/apps/api/src/creator-agent-key-routes.ts
+++ b/apps/api/src/creator-agent-key-routes.ts
@@ -66,6 +66,32 @@ function generationAnchor(record: CreatorAgentKeyRecord, fallbackMs: number): nu
 }
 
 /**
+ * Mints this generation's key, re-dating the generation first if its anchor has aged
+ * past the key TTL.
+ *
+ * Anchoring alone would hand back an already-expired key forever once a generation is
+ * older than 90 days: the panel would still present it as active and offer it for
+ * copying, every `start` would reject it, and the only remedy the panel offers is the
+ * destructive Rotate. Re-dating keeps the generation — every key of it had already
+ * expired, so nothing dead is resurrected — and the creator's pasted header keeps
+ * working after one visit rather than needing a rotation they did not need.
+ */
+async function mintCurrentKey(
+  store: Store,
+  secret: string,
+  ownerUid: string,
+  record: CreatorAgentKeyRecord,
+  nowMs: number,
+): Promise<ReturnType<typeof mintPayload>> {
+  const payload = mintPayload(secret, ownerUid, record.keyGeneration, generationAnchor(record, nowMs));
+  if (payload.expiresAt * 1000 > nowMs) return payload;
+
+  const refreshed = await store.touchCreatorAgentKey(ownerUid, new Date(nowMs).toISOString());
+  if (!refreshed) return payload;
+  return mintPayload(secret, ownerUid, refreshed.keyGeneration, generationAnchor(refreshed, nowMs));
+}
+
+/**
  * Ends every agent session opened against this creator's still-open rounds.
  *
  * Bumping `keyGeneration` alone does not do what the Studio panel promises — "rotating
@@ -79,13 +105,21 @@ function generationAnchor(record: CreatorAgentKeyRecord, fallbackMs: number): nu
  * revocation the round-close path already performs, and `classifyAgentTokenAccess` already
  * rejects a stale generation on every tool call, so nothing new has to be trusted.
  *
- * Deliberately broader than the sentence promises: this also ends sessions opened with a
- * per-game key on those rounds. Rotation is a security action and should fail safe, and
- * the cost is recoverable — the agent calls `start` again for a fresh session.
+ * Deliberately broader than the sentence promises for *self* rounds: this also ends
+ * sessions opened with a per-game key on them. Rotation is a security action and should
+ * fail safe, and the cost is recoverable — the agent calls `start` again.
+ *
+ * Platform rounds are excluded, and that is not the same trade-off. A platform build's
+ * credential is not derived from the creator key — the creator key cannot even open a
+ * platform round (see PLATFORM_ROUND_REASON) — so bumping its generation would stall a
+ * build for no security gain at all. Failing safe means revoking what the key could
+ * reach, not everything the creator owns.
  */
 async function endOpenAgentSessions(store: Store, ownerUid: string): Promise<number> {
   const owned = await store.listSubmissionsByOwner(ownerUid);
-  const open = owned.filter((job) => !job.abandonedAt && isActiveBuildRound(job));
+  const open = owned.filter(
+    (job) => !job.abandonedAt && isActiveBuildRound(job) && (job.builder ?? 'platform') === 'self',
+  );
   let ended = 0;
   for (const job of open) {
     if ((await store.bumpRoundGeneration(job.issueNumber)) !== null) ended += 1;
@@ -116,7 +150,7 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
     }
 
     const record = existing ?? (await store.ensureCreatorAgentKey(uid, at));
-    const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, generationAnchor(record, now()));
+    const payload = await mintCurrentKey(store, submissionTokenSecret, uid, record, now());
     return reply.header('Cache-Control', 'no-store').send(payload);
   });
 
@@ -133,7 +167,7 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
 
       const at = new Date(now()).toISOString();
       const record = await store.reactivateCreatorAgentKey(uid, at);
-      const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, generationAnchor(record, now()));
+      const payload = await mintCurrentKey(store, submissionTokenSecret, uid, record, now());
       return reply.header('Cache-Control', 'no-store').send(payload);
     },
   );
@@ -170,13 +204,18 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
       if (!uid) return reply.status(401).send({ error: 'unauthorized' });
 
       const existing = await store.getCreatorAgentKey(uid);
-      if (!existing || existing.revokedAt) {
-        return reply.status(404).send({ error: 'not_found' });
-      }
+      if (!existing) return reply.status(404).send({ error: 'not_found' });
 
       const at = new Date(now()).toISOString();
-      const revoked = await store.revokeCreatorAgentKey(uid, at);
-      if (!revoked) return reply.status(404).send({ error: 'not_found' });
+      // Already revoked is not "nothing to do": if a previous attempt persisted the
+      // revocation and then failed to end the sessions, returning 404 here would leave
+      // those sessions writable forever, because no retry could ever reach the cleanup.
+      // Ending sessions is idempotent — a generation bump on an already-dead round costs
+      // nothing — so the retry finishes the job the first attempt started.
+      if (!existing.revokedAt) {
+        const revoked = await store.revokeCreatorAgentKey(uid, at);
+        if (!revoked) return reply.status(404).send({ error: 'not_found' });
+      }
       // Revoke is the stronger of the two controls, so it must at least do what rotate
       // does — a revoked key that leaves live sessions writing is not a revocation.
       await endOpenAgentSessions(store, uid);

--- a/apps/api/src/creator-agent-key-routes.ts
+++ b/apps/api/src/creator-agent-key-routes.ts
@@ -12,7 +12,8 @@ import {
   mintCreatorAgentKey,
   verifyCreatorAgentKey,
 } from './agent-creator-key.js';
-import type { Store } from './store.js';
+import { isActiveBuildRound } from './builder.js';
+import type { CreatorAgentKeyRecord, Store } from './store.js';
 
 export interface CreatorAgentKeyRoutesOptions {
   store: Store;
@@ -47,6 +48,51 @@ function mintPayload(
   };
 }
 
+/**
+ * The instant a generation was minted — the anchor every mint of that generation uses.
+ *
+ * GET re-mints so the panel can offer "Copy header" without a second round trip, and
+ * minting at `now()` made every visit produce a *different* key. The displayed "Ends in …"
+ * tail therefore never matched the header the agent was actually holding, so a creator
+ * checking whether their agent was current always saw a mismatch — and the remedy the
+ * panel offers is Rotate, which is destructive. Anchoring to the generation's own
+ * timestamp makes a generation mint to exactly one key: the tail is stable, it is the
+ * tail of the key they pasted, and the stated expiry is the real one rather than a
+ * deadline that slid forward on every page load.
+ */
+function generationAnchor(record: CreatorAgentKeyRecord, fallbackMs: number): number {
+  const minted = Date.parse(record.updatedAt);
+  return Number.isFinite(minted) ? minted : fallbackMs;
+}
+
+/**
+ * Ends every agent session opened against this creator's still-open rounds.
+ *
+ * Bumping `keyGeneration` alone does not do what the Studio panel promises — "rotating
+ * stops every agent still using the old key". A `sessionKey` minted before the rotation
+ * authenticates on the *round's* generation and never consults the creator key at all, so
+ * it kept full write access for the rest of its 24-hour life. CP-2 confirmed it against
+ * production: `report_progress` succeeded after a rotation and the write landed in the
+ * creator's thread.
+ *
+ * Advancing `roundGeneration` is what actually cuts those sessions off. It is the same
+ * revocation the round-close path already performs, and `classifyAgentTokenAccess` already
+ * rejects a stale generation on every tool call, so nothing new has to be trusted.
+ *
+ * Deliberately broader than the sentence promises: this also ends sessions opened with a
+ * per-game key on those rounds. Rotation is a security action and should fail safe, and
+ * the cost is recoverable — the agent calls `start` again for a fresh session.
+ */
+async function endOpenAgentSessions(store: Store, ownerUid: string): Promise<number> {
+  const owned = await store.listSubmissionsByOwner(ownerUid);
+  const open = owned.filter((job) => !job.abandonedAt && isActiveBuildRound(job));
+  let ended = 0;
+  for (const job of open) {
+    if ((await store.bumpRoundGeneration(job.issueNumber)) !== null) ended += 1;
+  }
+  return ended;
+}
+
 export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: CreatorAgentKeyRoutesOptions): void {
   const { store, submissionTokenSecret } = options;
   const now = options.now ?? Date.now;
@@ -70,7 +116,7 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
     }
 
     const record = existing ?? (await store.ensureCreatorAgentKey(uid, at));
-    const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, now());
+    const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, generationAnchor(record, now()));
     return reply.header('Cache-Control', 'no-store').send(payload);
   });
 
@@ -87,7 +133,7 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
 
       const at = new Date(now()).toISOString();
       const record = await store.reactivateCreatorAgentKey(uid, at);
-      const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, now());
+      const payload = mintPayload(submissionTokenSecret, uid, record.keyGeneration, generationAnchor(record, now()));
       return reply.header('Cache-Control', 'no-store').send(payload);
     },
   );
@@ -106,8 +152,9 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
       if (!rotated) {
         return reply.status(500).send({ error: 'could not rotate creator key' });
       }
-      const payload = mintPayload(submissionTokenSecret, uid, rotated.keyGeneration, now());
-      return reply.header('Cache-Control', 'no-store').send({ ...payload, rotated: true });
+      const sessionsEnded = await endOpenAgentSessions(store, uid);
+      const payload = mintPayload(submissionTokenSecret, uid, rotated.keyGeneration, generationAnchor(rotated, now()));
+      return reply.header('Cache-Control', 'no-store').send({ ...payload, rotated: true, sessionsEnded });
     },
   );
 
@@ -130,6 +177,9 @@ export function registerCreatorAgentKeyRoutes(app: FastifyInstance, options: Cre
       const at = new Date(now()).toISOString();
       const revoked = await store.revokeCreatorAgentKey(uid, at);
       if (!revoked) return reply.status(404).send({ error: 'not_found' });
+      // Revoke is the stronger of the two controls, so it must at least do what rotate
+      // does — a revoked key that leaves live sessions writing is not a revocation.
+      await endOpenAgentSessions(store, uid);
       return reply.status(204).send();
     },
   );

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1048,4 +1048,30 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(progress.isError).toBe(false);
   });
+
+  // Every client reads this before it sees a tool. It described the pre-BYOCA model —
+  // "using the key from the creator's Studio kickoff prompt" — which is exactly what a
+  // creator key removes, so the first thing a keyless client was told was to go find a
+  // key that no longer exists in the prompt.
+  it('initialize tells a creator-key client to pass only a slug', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const res = await mcpCall(app, 'initialize', {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' },
+    });
+    const instructions = (res.json().result as { instructions: string }).instructions;
+
+    expect(instructions).toMatch(/creator key/i);
+    expect(instructions).toMatch(/only the game slug/i);
+    // The kickoff-prompt key is still real, but it is the alternative, not the default.
+    expect(instructions).not.toMatch(/Start with the gamedevpl start tool using the key/i);
+    // The rest of the loop must survive the rewrite.
+    expect(instructions).toMatch(/sessionKey/);
+    expect(instructions).toMatch(/get_gate_verdict/);
+    expect(instructions).toMatch(/honour stop/i);
+  });
 });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1478,10 +1478,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             version: '1.0.0',
           },
           instructions:
-            "Install is URL-only. Start with the gamedevpl start tool using the key from the creator's Studio kickoff prompt; " +
-            'pass the returned sessionKey on every later tool call. start returns your workflow (the ordered start→done ' +
-            'loop) — follow it: honour stop; screenshot early; kit-check before submit; poll get_gate_verdict until green, ' +
-            'then finish. Do not poll the inbox on a schedule; a green verdict ends the round and the key retires.',
+            'Call the gamedevpl start tool first. With a creator key configured in Authorization: Bearer, pass only ' +
+            "the game slug — nothing else is needed. A per-game or legacy key from the creator's Studio kickoff " +
+            'prompt goes in the key argument instead. start returns a sessionKey — pass it on every later tool call — ' +
+            'and your workflow (the ordered start→done loop): follow it; honour stop; screenshot early; kit-check ' +
+            'before submit; poll get_gate_verdict until green, then finish. Do not poll the inbox on a schedule; ' +
+            'a green verdict ends the round and the key retires.',
         }),
       );
     }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1903,6 +1903,16 @@ export interface Store {
    * record, or null when missing. Keeps the doc so generation never resets to 1.
    */
   revokeCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
+  /**
+   * Re-dates a generation without bumping it, so it mints a valid key again.
+   *
+   * Mints are anchored to `updatedAt` (one generation, one key), which means a
+   * generation older than the key TTL would otherwise mint an expired key forever —
+   * and the only escape the panel offers is the destructive Rotate. Re-dating keeps
+   * the generation, so nothing that was already dead comes back: every key of this
+   * generation had expired before this could run.
+   */
+  touchCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null>;
   /** Persist a dynamically registered or CIMD-cached OAuth client. */
   createOAuthClient(record: OAuthClientRecord): Promise<void>;
   getOAuthClient(clientId: string): Promise<OAuthClientRecord | null>;
@@ -3449,6 +3459,14 @@ export class InMemoryStore implements Store {
       createdAt: existing.createdAt,
       updatedAt: at,
     };
+    this.creatorAgentKeys.set(ownerUid, next);
+    return { ...next };
+  }
+
+  async touchCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const existing = this.creatorAgentKeys.get(ownerUid);
+    if (!existing || existing.revokedAt) return null;
+    const next: CreatorAgentKeyRecord = { ...existing, updatedAt: at };
     this.creatorAgentKeys.set(ownerUid, next);
     return { ...next };
   }
@@ -5648,6 +5666,19 @@ export class FirestoreStore implements Store {
         createdAt: existing.createdAt,
         updatedAt: at,
       };
+      tx.set(docRef, next);
+      return next;
+    });
+  }
+
+  async touchCreatorAgentKey(ownerUid: string, at: string): Promise<CreatorAgentKeyRecord | null> {
+    const docRef = this.db.collection('creatorAgentKeys').doc(ownerUid);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (!snap.exists) return null;
+      const existing = snap.data() as CreatorAgentKeyRecord;
+      if (existing.revokedAt) return null;
+      const next: CreatorAgentKeyRecord = { ...existing, updatedAt: at };
       tx.set(docRef, next);
       return next;
     });

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -125,6 +125,20 @@ function isApiRequest(url) {
   return url.pathname === '/api' || url.pathname.startsWith('/api/');
 }
 
+/**
+ * Server-rendered routes that are NOT part of the SPA. These must reach the origin even
+ * as navigations, because the router has no route for them: answering from the shell
+ * renders the NotFound page behind an HTTP 200 and the server never sees the request.
+ *
+ * `/oauth/authorize` is the case that proved this matters — the MCP consent screen is
+ * server-rendered, so every creator who had ever loaded the site (which is all of them;
+ * minting a key requires Studio) got a 404 page instead of a consent prompt. It looked
+ * healthy to curl and in a fresh incognito window, because neither runs this worker.
+ */
+function isServerRenderedRoute(url) {
+  return url.pathname === '/oauth' || url.pathname.startsWith('/oauth/') || url.pathname.startsWith('/.well-known/');
+}
+
 self.addEventListener('fetch', (event) => {
   const request = event.request;
 
@@ -136,6 +150,7 @@ self.addEventListener('fetch', (event) => {
   const url = new URL(request.url);
   if (url.origin !== self.location.origin) return;
   if (isApiRequest(url)) return;
+  if (isServerRenderedRoute(url)) return;
 
   if (request.mode === 'navigate') {
     event.respondWith(navigationResponse(request));

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -628,7 +628,7 @@
       "task_failed": "The build agent stopped unexpectedly before finishing. Your game and everything built so far are safe — send feedback below to start another round.",
       "task_timed_out": "The build ran out of time before finishing. Your progress is safe — send feedback below to start another round.",
       "task_completed_without_delivery": "The agent finished without delivering the game. Send feedback below to start another round.",
-      "gate_red": "This build didn't pass our automatic checks, so it can't go live yet. Send feedback below to start another round — the agent will see what failed and fix it.",
+      "gate_red": "This build didn't pass our automatic checks, so it can't go live yet. Tell the agent what to change below — it will see what failed and fix it.",
       "self_build_delivery_cap": "This round hit its delivery limit, so your agent can't submit another build until you start a new round. Send a short note below to continue — your progress so far is safe.",
       "generic": "This build round ended with an error. Your progress is safe — send feedback below to start another round."
     },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -632,7 +632,7 @@
       "task_failed": "Agent budujący niespodziewanie przerwał pracę. Twoja gra i dotychczasowe postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "task_timed_out": "Budowanie nie zdążyło się skończyć w wyznaczonym czasie. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
       "task_completed_without_delivery": "Agent zakończył pracę, ale nie dostarczył gry. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę.",
-      "gate_red": "Ta wersja nie przeszła naszych automatycznych testów, więc jeszcze nie może trafić do arcade. Wyślij poniżej uwagi, aby rozpocząć kolejną rundę — agent zobaczy, co nie przeszło, i to poprawi.",
+      "gate_red": "Ta wersja nie przeszła naszych automatycznych testów, więc jeszcze nie może trafić do arcade. Napisz poniżej, co zmienić — agent zobaczy, co nie przeszło, i to poprawi.",
       "self_build_delivery_cap": "Ta runda wyczerpała limit dostarczeń, więc Twój agent nie może wysłać kolejnej wersji, dopóki nie zaczniesz nowej rundy. Wyślij poniżej krótką uwagę, aby kontynuować — dotychczasowe postępy są bezpieczne.",
       "generic": "Ta runda budowania zakończyła się błędem. Postępy są bezpieczne — wyślij poniżej uwagi, aby rozpocząć kolejną rundę."
     },

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import enLocale from './i18n/locales/en.json';
+import plLocale from './i18n/locales/pl.json';
 import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 
 describe('selfStatusCopy', () => {
@@ -76,5 +78,37 @@ describe('selfComposerRoute', () => {
         failureReason: 'self_build_delivery_cap',
       }),
     ).toBe('waiting');
+  });
+});
+
+// CP-2 confirmed this pair on a live failed round: the banner told the creator that
+// sending feedback starts another round, while the helper directly beneath it said
+// their agent would pick the note up on its next check-in. A creator could not tell
+// whether they were starting something or feeding something already running.
+//
+// The helper is the accurate one — a gate_red self round stays open, and the agent
+// resubmits on the same key — so the banner must not claim a new round begins.
+describe('the failed-round card reads as one story', () => {
+  const en = enLocale.statusView as {
+    failure: Record<string, string>;
+    feedback: Record<string, string>;
+  };
+  const pl = plLocale.statusView as {
+    failure: Record<string, string>;
+    feedback: Record<string, string>;
+  };
+
+  it('routes a failed self round to the composer that says the agent picks it up', () => {
+    // Establishes that these two strings really do render together.
+    expect(selfComposerRoute({ builder: 'self', failureReason: 'gate_red' })).toBe('active');
+    expect(selfStatusCopy({ builder: 'self', stall: null })).toBeNull();
+  });
+
+  it('does not tell the creator they start a round the agent is already in', () => {
+    expect(en.failure.gate_red).not.toMatch(/start another round/i);
+    expect(pl.failure.gate_red).not.toMatch(/rozpocząć kolejną rundę/i);
+    // Still has to say what to do, or removing the claim would just leave a dead end.
+    expect(en.failure.gate_red).toMatch(/below/i);
+    expect(en.feedback.routeSelfActive).toMatch(/picks this up/i);
   });
 });

--- a/apps/web/src/shellPrecache.test.ts
+++ b/apps/web/src/shellPrecache.test.ts
@@ -133,6 +133,39 @@ describe('the worker source this module rewrites', () => {
     expect(SW_SOURCE).toContain("url.pathname.startsWith('/api/')");
   });
 
+  // Executes the shipped predicate rather than matching its source text: this rule is
+  // the difference between a consent screen and a 404, and a substring assertion would
+  // pass on a version that never reaches the fetch handler.
+  it('lets server-rendered routes reach the origin, so OAuth consent is not a 404', () => {
+    const source = SW_SOURCE.match(/function isServerRenderedRoute[\s\S]*?\n}/)?.[0];
+    expect(source, 'isServerRenderedRoute must exist in the shipped worker').toBeTruthy();
+    const isServerRenderedRoute = new Function('url', `${source}\nreturn isServerRenderedRoute(url);`) as (
+      url: URL,
+    ) => boolean;
+
+    // CP-2 found every returning creator got the SPA NotFound page here, because the
+    // shell answered the navigation and the server never saw it.
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/oauth/authorize?client_id=x'))).toBe(true);
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/.well-known/oauth-authorization-server'))).toBe(true);
+
+    // Real SPA routes must keep being served from the shell — that is the whole point
+    // of the worker, and exempting them would give up offline deep links.
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/studio'))).toBe(false);
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/play/tv-tycoon'))).toBe(false);
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/'))).toBe(false);
+    // Not a prefix match on the bare word: /oauthorize is an SPA path, not our route.
+    expect(isServerRenderedRoute(new URL('https://www.gamedev.pl/oauthorize'))).toBe(false);
+  });
+
+  it('applies the server-route exemption before the navigation branch', () => {
+    const handler = SW_SOURCE.slice(SW_SOURCE.indexOf("self.addEventListener('fetch'"));
+    const exemption = handler.indexOf('isServerRenderedRoute(url)');
+    const navigation = handler.indexOf("request.mode === 'navigate'");
+    expect(exemption).toBeGreaterThan(-1);
+    // Order is the bug: the navigation branch answers everything it reaches.
+    expect(exemption).toBeLessThan(navigation);
+  });
+
   it('stores its navigable documents rebuilt, never straight from cache.add', () => {
     // Found in a browser, not in review: `npx serve` 301s /index.html to /index, so
     // `cache.add` stored a redirected response — and answering a navigation with one


### PR DESCRIPTION
From CP-2 run against production by a real MCP client. None of the three was reachable from a unit test written against the code as it stood.

## OAuth was dead for every returning creator

The service worker answers every same-origin GET navigation with the precached shell, exempting only `/api/`. `/oauth/authorize` is server-rendered, so the SPA router — which has no route for it — rendered its NotFound page behind an HTTP 200 and the request never reached the server.

It looked healthy to `curl` and in a fresh incognito window, because neither runs a service worker. It failed for everyone else — and since minting a key requires visiting Studio, everyone else is everyone. The worker's own comment anticipated losing the 200-vs-404 distinction for *typo'd* URLs; it did not anticipate a real server route living outside `/api/`.

Server-rendered routes (`/oauth/*`, `/.well-known/*`) now bypass the worker.

## Rotation was not a kill switch

Studio promises, verbatim: *"rotating stops every agent still using the old key."* It did not. A `sessionKey` authenticates on the **round's** generation and never consults the creator key, so a session opened before a rotation kept full write access for the rest of its 24-hour life. Confirmed against production: `report_progress` succeeded after a rotation and the write landed in the creator's thread.

Rotate and revoke now advance `roundGeneration` on the creator's open rounds — the same revocation the round-close path already performs, and one `classifyAgentTokenAccess` already checks on every tool call, so nothing new has to be trusted.

Deliberately broader than the sentence promises: it also ends per-game-key sessions on those rounds. Rotation is a security action and should fail safe, and the cost is recoverable — the agent calls `start` again.

## The key panel invited the destructive button

`GET` re-minted at the wall clock, so the displayed `Ends in …` tail changed on every visit and never matched the header the agent was holding. A creator checking whether their agent was current always saw a mismatch — and the remedy the panel offers for a mismatch is **Rotate**.

A generation now mints to exactly one key, and the stated expiry is a real deadline rather than one that slid forward on every page load.

## Verification

Each new test was run against the unfixed source first.

The stable-key test **passed there on its first draft** — two mints in the same second are byte-identical whatever the code does, so the probe could never have produced the failure it was meant to catch. Rewritten to backdate the generation, which is the case that actually discriminates; it now fails pre-fix with `expected 1793521998 to be 1790640000`.

The service-worker test executes the shipped predicate via `new Function` rather than matching source text, so it cannot pass on a version that never reaches the fetch handler, and asserts the exemption precedes the navigation branch — the ordering *is* the bug.

Full gate green: `type-check`, `lint`, api 1987, web 934, world 19, rules 23.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_