### PR TITLE
Speed up catalog load and scroll (poster-first videos)

### DIFF
--- a/apps/api/src/recommendations.test.ts
+++ b/apps/api/src/recommendations.test.ts
@@ -226,4 +226,132 @@ describe('recommendation routes', () => {
     expect(body.items.some((item) => item.slug === 'puzzle-two' && item.reason === 'for_you')).toBe(true);
     await server.close();
   });
+
+  it('caches shared community signals and still personalises per request', async () => {
+    let scorecardReads = 0;
+    let recentPublishedReads = 0;
+    let clock = 1_000_000;
+
+    const countingStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (prop === 'listScorecards') {
+          return async (...args: Parameters<InMemoryStore['listScorecards']>) => {
+            scorecardReads += 1;
+            return target.listScorecards(...args);
+          };
+        }
+        if (prop === 'listRecentlyPublished') {
+          return async (...args: Parameters<InMemoryStore['listRecentlyPublished']>) => {
+            recentPublishedReads += 1;
+            return target.listRecentlyPublished(...args);
+          };
+        }
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    await store.putScorecard(
+      'arcade-hit',
+      scorecard({
+        slug: 'arcade-hit',
+        sessions: { count: 40, bounces: 0, closes: 0, medianPlaySeconds: 30, totalPlaySeconds: 1200 },
+        votes: { up: 5, down: 0 },
+      }),
+    );
+    await store.recordPlayAffinity('g:alice', 'puzzle-one', new Date().toISOString());
+
+    const server = await buildApp({
+      store: countingStore as InMemoryStore,
+      sessionSecret,
+      recommendationRoutes: {
+        publishedSlugs: slugGate(games.map((g) => g.slug)),
+        catalog: catalogOf(games),
+        now: () => clock,
+        sharedSignalsTtlMs: 60_000,
+      },
+    });
+
+    const first = await server.inject({ method: 'GET', url: '/api/recommendations' });
+    expect(first.statusCode).toBe(200);
+    expect(scorecardReads).toBe(1);
+    expect(recentPublishedReads).toBe(1);
+
+    const second = await server.inject({ method: 'GET', url: '/api/recommendations' });
+    expect(second.statusCode).toBe(200);
+    expect(scorecardReads).toBe(1);
+    expect(recentPublishedReads).toBe(1);
+    expect(second.json()).toEqual(first.json());
+
+    const personal = await server.inject({
+      method: 'GET',
+      url: '/api/recommendations',
+      headers: authHeaders('g:alice'),
+    });
+    expect(personal.statusCode).toBe(200);
+    // Affinity is per-request; community Firestore reads stay cached.
+    expect(scorecardReads).toBe(1);
+    expect(recentPublishedReads).toBe(1);
+    const personalBody = personal.json() as { items: Array<{ slug: string; reason: string }> };
+    expect(personalBody.items[0]).toEqual({ slug: 'puzzle-one', reason: 'continue' });
+
+    clock += 60_000 + 1;
+    const afterTtl = await server.inject({ method: 'GET', url: '/api/recommendations' });
+    expect(afterTtl.statusCode).toBe(200);
+    expect(scorecardReads).toBe(2);
+    expect(recentPublishedReads).toBe(2);
+
+    await server.close();
+  });
+
+  it('coalesces concurrent cold shared-signal refreshes into one store read', async () => {
+    let scorecardReads = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const countingStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (prop === 'listScorecards') {
+          return async (...args: Parameters<InMemoryStore['listScorecards']>) => {
+            scorecardReads += 1;
+            await gate;
+            return target.listScorecards(...args);
+          };
+        }
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    await store.putScorecard(
+      'arcade-hit',
+      scorecard({
+        slug: 'arcade-hit',
+        sessions: { count: 10, bounces: 0, closes: 0, medianPlaySeconds: 10, totalPlaySeconds: 100 },
+      }),
+    );
+
+    const server = await buildApp({
+      store: countingStore as InMemoryStore,
+      sessionSecret,
+      recommendationRoutes: {
+        publishedSlugs: slugGate(games.map((g) => g.slug)),
+        catalog: catalogOf(games),
+      },
+    });
+
+    const pending = Promise.all([
+      server.inject({ method: 'GET', url: '/api/recommendations' }),
+      server.inject({ method: 'GET', url: '/api/recommendations' }),
+      server.inject({ method: 'GET', url: '/api/recommendations' }),
+    ]);
+    release();
+    const responses = await pending;
+    expect(responses.every((res) => res.statusCode === 200)).toBe(true);
+    expect(scorecardReads).toBe(1);
+
+    await server.close();
+  });
 });

--- a/apps/api/src/recommendations.ts
+++ b/apps/api/src/recommendations.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import type { PublishedSlugGate } from './published-slugs.js';
-import { rankRecommendations, type RecommendGame } from './recommend.js';
+import { rankRecommendations, type RecommendGame, type RecommendScorecardSignals } from './recommend.js';
 import type { Scorecard, Store } from './store.js';
 
 /**
@@ -12,6 +12,10 @@ import type { Scorecard, Store } from './store.js';
  * Affinity recording (`POST /api/games/:slug/played`) is identity-attached account
  * data, erased with the account. It never writes to the anonymous play/visit
  * telemetry streams and must not grow a join key between them.
+ *
+ * Community half (scorecards + newest) is process-local cached: those reads hit
+ * Firestore on every home load otherwise, and scorecards only move on the nightly
+ * sweep. Personal affinity stays per-request.
  */
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
@@ -27,6 +31,8 @@ const RecentQuerySchema = z.object({
 });
 
 const MAX_RECENT_HINTS = 8;
+/** Shared community signals: scorecards are nightly; a few minutes of staleness is fine. */
+export const RECOMMENDATION_SHARED_TTL_MS = 5 * 60_000;
 
 export interface CatalogGenreSource {
   listPublished(): Promise<RecommendGame[]>;
@@ -38,7 +44,19 @@ export interface RecommendationRoutesOptions {
   publishedSlugs?: PublishedSlugGate | null;
   /** Published catalog with genres; tests inject a fixed list. */
   catalog?: CatalogGenreSource | null;
+  /** Injectable clock for cache expiry tests. */
+  now?: () => number;
+  /** Override shared-signals TTL (defaults to {@link RECOMMENDATION_SHARED_TTL_MS}). */
+  sharedSignalsTtlMs?: number;
 }
+
+type SharedCommunitySignals = {
+  expiresAt: number;
+  games: RecommendGame[];
+  scorecards: Map<string, RecommendScorecardSignals>;
+  popularity: Array<{ slug: string; sessions: number }>;
+  newest: string[];
+};
 
 function parseRecentHints(raw: string | undefined): string[] {
   if (!raw) return [];
@@ -54,7 +72,7 @@ function parseRecentHints(raw: string | undefined): string[] {
   return out;
 }
 
-function scorecardSignals(card: Scorecard) {
+function scorecardSignals(card: Scorecard): RecommendScorecardSignals {
   return {
     sessions: card.sessions.count,
     votesUp: card.votes.up,
@@ -69,14 +87,105 @@ function isBotUid(uid: string): boolean {
   return uid.startsWith('bot:');
 }
 
+function buildNewestOrder(games: RecommendGame[], publishedAtBySlug: Map<string, string>): string[] {
+  const dated = games
+    .filter((game) => publishedAtBySlug.has(game.slug))
+    .sort(
+      (a, b) =>
+        (publishedAtBySlug.get(b.slug) ?? '').localeCompare(publishedAtBySlug.get(a.slug) ?? '') ||
+        a.slug.localeCompare(b.slug),
+    )
+    .map((game) => game.slug);
+  const datedSet = new Set(dated);
+  const undatedNewestFirst = [...games]
+    .reverse()
+    .filter((game) => !datedSet.has(game.slug))
+    .map((game) => game.slug);
+  return [...dated, ...undatedNewestFirst];
+}
+
 export async function registerRecommendationRoutes(
   app: FastifyInstance,
   options: RecommendationRoutesOptions,
 ): Promise<void> {
   const { store, publishedSlugs, catalog } = options;
+  const now = options.now ?? Date.now;
+  const sharedTtlMs = options.sharedSignalsTtlMs ?? RECOMMENDATION_SHARED_TTL_MS;
+
+  let sharedCache: SharedCommunitySignals | null = null;
+  let sharedRefresh: Promise<SharedCommunitySignals> | null = null;
 
   async function isPublished(slug: string): Promise<boolean> {
     return (await publishedSlugs?.isPublished(slug)) ?? false;
+  }
+
+  async function refreshSharedSignals(): Promise<SharedCommunitySignals> {
+    const games = (await catalog?.listPublished()) ?? [];
+    if (games.length === 0) {
+      return {
+        expiresAt: now() + sharedTtlMs,
+        games: [],
+        scorecards: new Map(),
+        popularity: [],
+        newest: [],
+      };
+    }
+
+    const published = new Set(games.map((game) => game.slug));
+    const [scorecards, recentPublished] = await Promise.all([
+      store.listScorecards({ limit: 500 }),
+      store.listRecentlyPublished(500),
+    ]);
+
+    const scorecardMap = new Map(
+      scorecards.filter((card) => published.has(card.slug)).map((card) => [card.slug, scorecardSignals(card)]),
+    );
+    const popularity = [...scorecardMap.entries()]
+      .map(([slug, signals]) => ({ slug, sessions: signals.sessions }))
+      .sort((a, b) => b.sessions - a.sessions || a.slug.localeCompare(b.slug));
+
+    const publishedAtBySlug = new Map<string, string>();
+    for (const submission of recentPublished) {
+      if (!submission.slug || !submission.publishedAt || !published.has(submission.slug)) continue;
+      const existing = publishedAtBySlug.get(submission.slug);
+      if (!existing || submission.publishedAt > existing) {
+        publishedAtBySlug.set(submission.slug, submission.publishedAt);
+      }
+    }
+
+    const entry: SharedCommunitySignals = {
+      expiresAt: now() + sharedTtlMs,
+      games,
+      scorecards: scorecardMap,
+      popularity,
+      newest: buildNewestOrder(games, publishedAtBySlug),
+    };
+    sharedCache = entry;
+    return entry;
+  }
+
+  async function getSharedSignals(): Promise<SharedCommunitySignals> {
+    if (sharedCache && sharedCache.expiresAt > now()) {
+      return sharedCache;
+    }
+    if (sharedRefresh) {
+      return sharedRefresh;
+    }
+
+    sharedRefresh = refreshSharedSignals()
+      .catch((error: unknown) => {
+        // Stale community signals beat a visitor-facing failure: scorecards move nightly.
+        if (sharedCache) {
+          app.log.warn({ err: error }, 'recommendation shared signals refresh failed; serving stale');
+          return sharedCache;
+        }
+        throw error;
+      })
+      .finally(() => {
+        sharedRefresh = null;
+      });
+
+    return sharedRefresh;
   }
 
   /**
@@ -105,12 +214,12 @@ export async function registerRecommendationRoutes(
       return reply.status(400).send({ error: query.error.issues[0]?.message ?? 'invalid query' });
     }
 
-    const games = (await catalog?.listPublished()) ?? [];
-    if (games.length === 0) {
-      return reply.send({ items: [] });
+    const shared = await getSharedSignals();
+    if (shared.games.length === 0) {
+      return reply.send({ items: [], popularity: [], lastPlayed: [], newest: [] });
     }
 
-    const published = new Set(games.map((game) => game.slug));
+    const published = new Set(shared.games.map((game) => game.slug));
     const recentHints = parseRecentHints(query.data.recent).filter((slug) => published.has(slug));
 
     let affinity: Awaited<ReturnType<Store['listPlayAffinity']>> = [];
@@ -118,58 +227,24 @@ export async function registerRecommendationRoutes(
       affinity = await store.listPlayAffinity(request.user.uid);
     }
 
-    const scorecards = await store.listScorecards({ limit: 500 });
-    const scorecardMap = new Map(
-      scorecards.filter((card) => published.has(card.slug)).map((card) => [card.slug, scorecardSignals(card)]),
-    );
-
     const ranked = rankRecommendations({
-      games,
-      scorecards: scorecardMap,
+      games: shared.games,
+      scorecards: shared.scorecards,
       affinity,
       recentHints,
-      limit: query.data.limit ?? games.length,
+      limit: query.data.limit ?? shared.games.length,
     });
-
-    const popularity = [...scorecardMap.entries()]
-      .map(([slug, signals]) => ({ slug, sessions: signals.sessions }))
-      .sort((a, b) => b.sessions - a.sessions || a.slug.localeCompare(b.slug));
 
     const lastPlayed = affinity
       .filter((entry) => published.has(entry.slug))
       .map((entry) => ({ slug: entry.slug, lastPlayedAt: entry.lastPlayedAt }))
       .sort((a, b) => b.lastPlayedAt.localeCompare(a.lastPlayedAt) || a.slug.localeCompare(b.slug));
 
-    // Newest: submission publish time when we have it; undated games follow in reverse
-    // catalog order (committed catalogs tend to grow oldest→newest).
-    const recentPublished = await store.listRecentlyPublished(500);
-    const publishedAtBySlug = new Map<string, string>();
-    for (const submission of recentPublished) {
-      if (!submission.slug || !submission.publishedAt || !published.has(submission.slug)) continue;
-      const existing = publishedAtBySlug.get(submission.slug);
-      if (!existing || submission.publishedAt > existing) {
-        publishedAtBySlug.set(submission.slug, submission.publishedAt);
-      }
-    }
-    const dated = games
-      .filter((game) => publishedAtBySlug.has(game.slug))
-      .sort(
-        (a, b) =>
-          (publishedAtBySlug.get(b.slug) ?? '').localeCompare(publishedAtBySlug.get(a.slug) ?? '') ||
-          a.slug.localeCompare(b.slug),
-      )
-      .map((game) => game.slug);
-    const datedSet = new Set(dated);
-    const undatedNewestFirst = [...games]
-      .reverse()
-      .filter((game) => !datedSet.has(game.slug))
-      .map((game) => game.slug);
-
     return reply.send({
       items: ranked.map((item) => ({ slug: item.slug, reason: item.reason })),
-      popularity,
+      popularity: shared.popularity,
       lastPlayed,
-      newest: [...dated, ...undatedNewestFirst],
+      newest: shared.newest,
     });
   });
 }

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2296,6 +2296,22 @@ describe('published game media route', () => {
     expect(unsatisfiable.statusCode).toBe(416);
     expect(unsatisfiable.headers['content-range']).toBe('bytes */10');
 
+    const staleIfRange = await app.inject({
+      method: 'GET',
+      url: '/api/games/foo/media/gameplay.mp4',
+      headers: { range: 'bytes=2-5', 'if-range': '"not-this-etag"' },
+    });
+    expect(staleIfRange.statusCode).toBe(200);
+    expect(Buffer.from(staleIfRange.rawPayload)).toEqual(Buffer.from(body));
+
+    const matchingIfRange = await app.inject({
+      method: 'GET',
+      url: '/api/games/foo/media/gameplay.mp4',
+      headers: { range: 'bytes=2-5', 'if-range': full.headers['etag'] as string },
+    });
+    expect(matchingIfRange.statusCode).toBe(206);
+    expect(Buffer.from(matchingIfRange.rawPayload)).toEqual(Buffer.from([2, 3, 4, 5]));
+
     await app.close();
   });
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2265,6 +2265,40 @@ describe('published game media route', () => {
     await app.close();
   });
 
+  it('honours byte Range requests so video clients need not pull the whole file', async () => {
+    const body = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const { githubClient } = createGithubClientStub({
+      catalog: [catalogEntry('foo', { media })],
+      gameMedia: body,
+    });
+    const { app } = await createApp({ githubClient, submissionTokenSecret: secret });
+
+    const full = await app.inject({ method: 'GET', url: '/api/games/foo/media/gameplay.mp4' });
+    expect(full.statusCode).toBe(200);
+    expect(full.headers['accept-ranges']).toBe('bytes');
+    expect(full.headers['content-length']).toBe(String(body.length));
+
+    const ranged = await app.inject({
+      method: 'GET',
+      url: '/api/games/foo/media/gameplay.mp4',
+      headers: { range: 'bytes=2-5' },
+    });
+    expect(ranged.statusCode).toBe(206);
+    expect(ranged.headers['content-range']).toBe('bytes 2-5/10');
+    expect(ranged.headers['content-length']).toBe('4');
+    expect(Buffer.from(ranged.rawPayload)).toEqual(Buffer.from([2, 3, 4, 5]));
+
+    const unsatisfiable = await app.inject({
+      method: 'GET',
+      url: '/api/games/foo/media/gameplay.mp4',
+      headers: { range: 'bytes=99-100' },
+    });
+    expect(unsatisfiable.statusCode).toBe(416);
+    expect(unsatisfiable.headers['content-range']).toBe('bytes */10');
+
+    await app.close();
+  });
+
   it('does not expose unlisted media or media from unpublished games', async () => {
     const { githubClient, getGameMedia } = createGithubClientStub({
       catalog: [catalogEntry('foo', { media }), catalogEntry('draft', { status: 'draft', media })],

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -405,7 +405,13 @@ function sendMedia(
   if (range === 'invalid') {
     return reply.status(416).header('Content-Range', `bytes */${size}`).send();
   }
-  if (range) {
+  // If-Range: only honour Range when the validator still matches this representation.
+  // A mismatched ETag means the client may stitch bytes from two video versions.
+  const ifRangeRaw = request.headers['if-range'];
+  const ifRange = typeof ifRangeRaw === 'string' ? ifRangeRaw.trim() : undefined;
+  const rangeAllowed =
+    !ifRange || ifRange === entry.etag || ifRange.replace(/^W\//, '') === entry.etag.replace(/^W\//, '');
+  if (range && rangeAllowed) {
     const chunk = entry.body.subarray(range.start, range.end + 1);
     return reply
       .status(206)

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -349,13 +349,47 @@ function isRateLimited(
  * worth a long browser TTL. The ETag is what keeps that honest: once the TTL
  * lapses the browser revalidates and we answer 304 with no body (and, because
  * the entry is already cached server-side, no GitHub call either).
+ *
+ * Accept-Ranges matters for MP4 previews: without it the browser cannot seek /
+ * fetch only the moov atom and ends up pulling (or aborting) the whole file
+ * through Cloud Run on every card that armed a `<video>`.
  */
+function parseBytesRange(header: string | undefined, size: number): { start: number; end: number } | 'invalid' | null {
+  if (!header) return null;
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(header.trim());
+  if (!match) return 'invalid';
+  const startRaw = match[1] ?? '';
+  const endRaw = match[2] ?? '';
+  if (startRaw === '' && endRaw === '') return 'invalid';
+
+  let start: number;
+  let end: number;
+  if (startRaw === '') {
+    const suffix = Number(endRaw);
+    if (!Number.isInteger(suffix) || suffix <= 0) return 'invalid';
+    start = Math.max(0, size - suffix);
+    end = size - 1;
+  } else {
+    start = Number(startRaw);
+    end = endRaw === '' ? size - 1 : Number(endRaw);
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start) {
+      return 'invalid';
+    }
+    if (start >= size) return 'invalid';
+    end = Math.min(end, size - 1);
+  }
+  return { start, end };
+}
+
 function sendMedia(
   request: FastifyRequest,
   reply: FastifyReply,
   entry: { etag: string; contentType: string; body: Buffer },
 ): FastifyReply {
-  reply.header('ETag', entry.etag).header('Cache-Control', 'public, max-age=86400, stale-while-revalidate=604800');
+  reply
+    .header('ETag', entry.etag)
+    .header('Cache-Control', 'public, max-age=86400, stale-while-revalidate=604800')
+    .header('Accept-Ranges', 'bytes');
 
   // A conditional request may carry a list, and "*" matches anything we hold.
   const ifNoneMatch = request.headers['if-none-match'];
@@ -366,7 +400,22 @@ function sendMedia(
     }
   }
 
-  return reply.type(entry.contentType).send(entry.body);
+  const size = entry.body.length;
+  const range = parseBytesRange(typeof request.headers.range === 'string' ? request.headers.range : undefined, size);
+  if (range === 'invalid') {
+    return reply.status(416).header('Content-Range', `bytes */${size}`).send();
+  }
+  if (range) {
+    const chunk = entry.body.subarray(range.start, range.end + 1);
+    return reply
+      .status(206)
+      .header('Content-Range', `bytes ${range.start}-${range.end}/${size}`)
+      .header('Content-Length', String(chunk.length))
+      .type(entry.contentType)
+      .send(chunk);
+  }
+
+  return reply.type(entry.contentType).header('Content-Length', String(size)).send(entry.body);
 }
 
 /** What `registerSubmissionRoutes` hands back for other route modules to build on. */

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -87,9 +87,9 @@ describe('catalog playback', () => {
 
     const playButton = container.querySelector('.catalog-card .card-actions .primary-btn');
     expect(playButton?.textContent).toContain('Play');
-    const preview = container.querySelector<HTMLVideoElement>('.catalog-preview');
-    expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/opening.png');
+    // Poster-first: cards near the fold show a still until preview is armed.
+    const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
+    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/opening.png');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     const previewButton = container.querySelector<HTMLButtonElement>('.preview-toggle');
@@ -98,6 +98,9 @@ describe('catalog playback', () => {
       previewButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
+    const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
+    expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/opening.png');
     expect(previewButton?.textContent).toContain('Pause preview');
 
     // history.pushState fires nothing, so in-app navigation is announced explicitly

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -88,8 +88,9 @@ describe('catalog playback', () => {
     const playButton = container.querySelector('.catalog-card .card-actions .primary-btn');
     expect(playButton?.textContent).toContain('Play');
     // Poster-first: cards near the fold show a still until preview is armed.
+    // Default still prefers a mid-capture over `opening`.
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/opening.png');
+    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     const previewButton = container.querySelector<HTMLButtonElement>('.preview-toggle');
@@ -100,7 +101,7 @@ describe('catalog playback', () => {
     });
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/opening.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png');
     expect(previewButton?.textContent).toContain('Pause preview');
 
     // history.pushState fires nothing, so in-app navigation is announced explicitly

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -129,7 +129,7 @@ describe('ArcadeCatalog lazy media', () => {
     vi.restoreAllMocks();
   });
 
-  it('does not attach image or video sources until a card enters the viewport', async () => {
+  it('loads posters near the fold but arms video only on preview intent', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
     const container = document.createElement('div');
@@ -162,16 +162,118 @@ describe('ArcadeCatalog lazy media', () => {
       await flushEffects();
     });
 
+    // Near-fold: poster image only — no MP4 fetch until hover / play.
+    expect(container.querySelectorAll('video')).toHaveLength(0);
+    const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
+    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/opening.png');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.preview-toggle')?.click();
+      await flushEffects();
+    });
+
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
     expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/opening.png');
-    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     // The second card still has no media srcs — it never intersected.
     expect(container.querySelectorAll('video')).toHaveLength(1);
     expect(container.querySelectorAll('.catalog-moment img')).toHaveLength(2);
     const momentSrcs = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')].map((img) => img.src);
     expect(momentSrcs.every((src) => src.includes('/api/games/above-fold/'))).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('unloads poster and video when a card leaves the viewport', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const firstMedia = container.querySelectorAll('.catalog-media')[0]!;
+    await act(async () => {
+      intersect(observers[0]!, firstMedia, true);
+      await flushEffects();
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.preview-toggle')?.click();
+      await flushEffects();
+    });
+    expect(container.querySelector('video.catalog-preview')).not.toBeNull();
+
+    await act(async () => {
+      intersect(observers[0]!, firstMedia, false);
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('video')).toHaveLength(0);
+    expect(container.querySelectorAll('img.catalog-preview')).toHaveLength(0);
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('renders the grid immediately without waiting for sort signals', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    sessionStorage.clear();
+    let resolveSignals: ((value: Response) => void) | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveSignals = resolve;
+        }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelector('.catalog-state')).toBeNull();
+
+    await act(async () => {
+      resolveSignals?.(
+        new Response(JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      await flushEffects();
+    });
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -116,7 +116,7 @@ describe('ArcadeCatalog lazy media', () => {
     installIntersectionObserverMock();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
-      JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }),
+      JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
     );
     await i18n.changeLanguage('en');
   });
@@ -315,6 +315,36 @@ describe('ArcadeCatalog lazy media', () => {
       root.unmount();
     });
   });
+
+  it('paints the grid with catalog order when the signals fetch rejects', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    sessionStorage.clear();
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network down'));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelector('.catalog-state')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });
 
 describe('ArcadeCatalog shared-world badge', () => {
@@ -322,7 +352,7 @@ describe('ArcadeCatalog shared-world badge', () => {
     installIntersectionObserverMock();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
-      JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }),
+      JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
     );
     await i18n.changeLanguage('en');
   });
@@ -381,7 +411,7 @@ describe('ArcadeCatalog soft-refresh failure', () => {
     installIntersectionObserverMock();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
-      JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }),
+      JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
     );
     await i18n.changeLanguage('en');
   });
@@ -437,7 +467,7 @@ describe('ArcadeCatalog in-progress builds', () => {
     installIntersectionObserverMock();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
-      JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }),
+      JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
     );
     await i18n.changeLanguage('en');
   });

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -163,9 +163,10 @@ describe('ArcadeCatalog lazy media', () => {
     });
 
     // Near-fold: poster image only — no MP4 fetch until hover / play.
+    // Default still prefers a mid-capture over `opening` (often an empty ready frame).
     expect(container.querySelectorAll('video')).toHaveLength(0);
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/opening.png');
+    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     await act(async () => {
@@ -175,7 +176,7 @@ describe('ArcadeCatalog lazy media', () => {
 
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/opening.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png');
 
     // The second card still has no media srcs — it never intersected.
     expect(container.querySelectorAll('video')).toHaveLength(1);
@@ -234,7 +235,7 @@ describe('ArcadeCatalog lazy media', () => {
     });
   });
 
-  it('renders the grid immediately without waiting for sort signals', async () => {
+  it('waits for sort signals before painting the grid (no provisional re-sort)', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     sessionStorage.clear();
     let resolveSignals: ((value: Response) => void) | undefined;
@@ -262,8 +263,8 @@ describe('ArcadeCatalog lazy media', () => {
       await flushEffects();
     });
 
-    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
-    expect(container.querySelector('.catalog-state')).toBeNull();
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
+    expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
 
     await act(async () => {
       resolveSignals?.(
@@ -274,6 +275,41 @@ describe('ArcadeCatalog lazy media', () => {
       );
       await flushEffects();
     });
+
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('paints immediately when sort signals are already cached', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>(() => {
+          /* leave hanging — cache must be enough for first paint */
+        }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -381,11 +381,29 @@ function payloadToSignals(payload: CatalogSortPayload): CatalogSortSignals {
   };
 }
 
-function initialSignals(): { signals: CatalogSortSignals; ready: boolean } {
+function sameCatalogSortSignals(a: CatalogSortSignals, b: CatalogSortSignals): boolean {
+  if (a.recommended.length !== b.recommended.length || a.newest.length !== b.newest.length) return false;
+  if (a.sessions.size !== b.sessions.size || a.affinityLastPlayed.size !== b.affinityLastPlayed.size) return false;
+  for (let i = 0; i < a.recommended.length; i++) {
+    if (a.recommended[i] !== b.recommended[i]) return false;
+  }
+  for (let i = 0; i < a.newest.length; i++) {
+    if (a.newest[i] !== b.newest[i]) return false;
+  }
+  for (const [slug, sessions] of a.sessions) {
+    if (b.sessions.get(slug) !== sessions) return false;
+  }
+  for (const [slug, at] of a.affinityLastPlayed) {
+    if (b.affinityLastPlayed.get(slug) !== at) return false;
+  }
+  return true;
+}
+
+function initialSignals(viewerUid: string | null): { signals: CatalogSortSignals; ready: boolean } {
   if (typeof sessionStorage === 'undefined') {
     return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
   }
-  const cached = readCachedCatalogSortPayload();
+  const cached = readCachedCatalogSortPayload(viewerUid);
   if (!cached) return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
   return { signals: payloadToSignals(cached), ready: true };
 }
@@ -432,6 +450,7 @@ export function ArcadeCatalog({
 }: ArcadeCatalogProps) {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
+  const viewerUid = user?.uid ?? null;
   const locale = i18n.language;
   const [sortMode, setSortMode] = useState<CatalogSortMode>(() =>
     typeof localStorage === 'undefined' ? DEFAULT_CATALOG_SORT : readCatalogSortMode(),
@@ -441,27 +460,45 @@ export function ArcadeCatalog({
   );
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const sortMenuRef = useRef<HTMLDivElement | null>(null);
-  const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals().signals);
-  const [signalsReady, setSignalsReady] = useState(() => initialSignals().ready);
-  // If sessionStorage already gave us an order, a background refresh must not reshuffle
-  // the painted grid. Explicit bumps (after play) still re-rank.
-  const hadCachedSignalsRef = useRef(signalsReady);
+  const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
+  const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
 
   // Fetch sort signals as soon as the arcade mounts — in parallel with App's
   // catalog fetch — so cold load waits for max(catalog, signals), not their sum.
+  // Cache is viewer-scoped; a matching cache paints immediately, then the network
+  // response replaces it only when the payload actually differs (account switch,
+  // affinity drift) or an explicit post-play refresh asked for a re-rank.
   useEffect(() => {
     let cancelled = false;
-    const replaceOrder = !hadCachedSignalsRef.current || recommendationsRefreshKey > 0;
-    void fetchCatalogSortSignals(getRecentPlays()).then((payload) => {
-      if (cancelled) return;
-      if (replaceOrder) setSignals(payloadToSignals(payload));
+    const cached = readCachedCatalogSortPayload(viewerUid);
+    if (cached) {
+      setSignals(payloadToSignals(cached));
       setSignalsReady(true);
-    });
+    } else {
+      setSignalsReady(false);
+    }
+    const forceReplace = recommendationsRefreshKey > 0;
+    void fetchCatalogSortSignals(getRecentPlays(), viewerUid)
+      .then((payload) => {
+        if (cancelled) return;
+        const next = payloadToSignals(payload);
+        if (forceReplace) {
+          setSignals(next);
+        } else {
+          setSignals((prev) => (sameCatalogSortSignals(prev, next) ? prev : next));
+        }
+        setSignalsReady(true);
+      })
+      .catch(() => {
+        // Transport failure must not leave the arcade stuck on the loading mascot.
+        if (cancelled) return;
+        setSignalsReady(true);
+      });
     return () => {
       cancelled = true;
     };
-  }, [recommendationsRefreshKey]);
+  }, [recommendationsRefreshKey, viewerUid]);
 
   // Creator games (published + in progress) — only while the gallery is visible.
   useEffect(() => {

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -5,7 +5,6 @@ import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.
 import {
   applyCatalogFilters,
   CATALOG_SORT_MODES,
-  catalogSortNeedsSignals,
   DEFAULT_CATALOG_SORT,
   EMPTY_CATALOG_SORT_SIGNALS,
   orderCatalogEntries,
@@ -73,34 +72,61 @@ function CatalogCard({
 }) {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
-  // Defer preview media until the card is near the viewport — below-fold cards
-  // must not fetch posters/videos on initial home load.
-  const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '200px 0px', once: true });
+  // Poster when near the fold; video `src` only on hover/play. Leave-view unloads
+  // so scrolled-away cards do not keep decoders and MP4 buffers alive.
+  const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '200px 0px', once: false });
   const [selectedScreenshot, setSelectedScreenshot] = useState(0);
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const [isPreviewPinned, setIsPreviewPinned] = useState(false);
+  const [videoArmed, setVideoArmed] = useState(false);
   const screenshots = entry.media?.screenshots ?? [];
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
   const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
-  const videoUrl = entry.media?.video && inView ? catalogMediaUrl(entry.slug, entry.media.video) : null;
   const hasVideo = Boolean(entry.media?.video);
+  const videoUrl =
+    hasVideo && inView && videoArmed && entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
 
-  function playPreview() {
+  useEffect(() => {
+    if (inView) return;
+    setVideoArmed(false);
+    setIsPreviewPlaying(false);
+    setIsPreviewPinned(false);
+  }, [inView]);
+
+  useEffect(() => {
+    if (!videoUrl) return;
     const video = videoRef.current;
     if (!video) return;
     void video.play().then(
       () => setIsPreviewPlaying(true),
       () => setIsPreviewPlaying(false),
     );
+  }, [videoUrl]);
+
+  function armPreview() {
+    setVideoArmed(true);
+    const video = videoRef.current;
+    if (!video?.src) return;
+    void video.play().then(
+      () => setIsPreviewPlaying(true),
+      () => setIsPreviewPlaying(false),
+    );
   }
 
-  function pausePreview(reset = false) {
+  function stopPreview() {
     const video = videoRef.current;
-    if (!video) return;
-    video.pause();
-    if (reset) {
-      video.currentTime = 0;
+    if (video) {
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
     }
+    setVideoArmed(false);
+    setIsPreviewPlaying(false);
+  }
+
+  function pausePreview() {
+    const video = videoRef.current;
+    if (video) video.pause();
     setIsPreviewPlaying(false);
   }
 
@@ -110,14 +136,14 @@ function CatalogCard({
       pausePreview();
     } else {
       setIsPreviewPinned(true);
-      playPreview();
+      armPreview();
     }
   }
 
   function selectScreenshot(index: number) {
     setSelectedScreenshot(index);
     setIsPreviewPinned(false);
-    pausePreview(true);
+    stopPreview();
   }
 
   return (
@@ -129,21 +155,21 @@ function CatalogCard({
         onPointerEnter={
           hasVideo
             ? (event) => {
-                if (event.pointerType === 'mouse') playPreview();
+                if (event.pointerType === 'mouse') armPreview();
               }
             : undefined
         }
         onPointerLeave={
           hasVideo
             ? (event) => {
-                if (event.pointerType === 'mouse' && !isPreviewPinned) pausePreview(true);
+                if (event.pointerType === 'mouse' && !isPreviewPinned) stopPreview();
               }
             : undefined
         }
         onFocus={
           hasVideo
             ? (event) => {
-                if (event.target === event.currentTarget) playPreview();
+                if (event.target === event.currentTarget) armPreview();
               }
             : undefined
         }
@@ -152,7 +178,7 @@ function CatalogCard({
             ? (event) => {
                 if (!event.currentTarget.contains(event.relatedTarget)) {
                   setIsPreviewPinned(false);
-                  pausePreview(true);
+                  stopPreview();
                 }
               }
             : undefined
@@ -160,7 +186,6 @@ function CatalogCard({
       >
         {videoUrl ? (
           <video
-            key={posterUrl}
             ref={videoRef}
             className="catalog-preview"
             src={videoUrl}
@@ -168,7 +193,7 @@ function CatalogCard({
             muted
             loop
             playsInline
-            preload="metadata"
+            preload="auto"
             aria-label={t('catalog.previewVideo', { title: entry.title })}
             onPlay={() => setIsPreviewPlaying(true)}
             onPause={() => setIsPreviewPlaying(false)}
@@ -341,13 +366,10 @@ function payloadToSignals(payload: CatalogSortPayload): CatalogSortSignals {
   };
 }
 
-function initialSignals(): { signals: CatalogSortSignals; ready: boolean } {
-  if (typeof sessionStorage === 'undefined') {
-    return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
-  }
+function initialSignals(): CatalogSortSignals {
+  if (typeof sessionStorage === 'undefined') return EMPTY_CATALOG_SORT_SIGNALS;
   const cached = readCachedCatalogSortPayload();
-  if (!cached) return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
-  return { signals: payloadToSignals(cached), ready: true };
+  return cached ? payloadToSignals(cached) : EMPTY_CATALOG_SORT_SIGNALS;
 }
 
 function InProgressCard({ item, onOpen }: { item: CreatorGameItem; onOpen: (address: string) => void }) {
@@ -401,9 +423,7 @@ export function ArcadeCatalog({
   );
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const sortMenuRef = useRef<HTMLDivElement | null>(null);
-  const initial = initialSignals();
-  const [signals, setSignals] = useState<CatalogSortSignals>(initial.signals);
-  const [signalsReady, setSignalsReady] = useState(initial.ready);
+  const [signals, setSignals] = useState<CatalogSortSignals>(initialSignals);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
 
   useEffect(() => {
@@ -414,7 +434,6 @@ export function ArcadeCatalog({
     void fetchCatalogSortSignals(getRecentPlays()).then((payload) => {
       if (cancelled) return;
       setSignals(payloadToSignals(payload));
-      setSignalsReady(true);
     });
     return () => {
       cancelled = true;
@@ -512,9 +531,6 @@ export function ArcadeCatalog({
       return next;
     });
   }
-  const awaitingSignals =
-    catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
-
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
       ? t('catalog.emptyYourGamesNotPlayed')
@@ -524,11 +540,7 @@ export function ArcadeCatalog({
           ? t('catalog.emptyNotPlayed')
           : t('catalog.empty');
   const showEmpty =
-    !awaitingSignals &&
-    catalogStatus !== 'loading' &&
-    catalogStatus !== 'error' &&
-    orderedEntries.length === 0 &&
-    inProgress.length === 0;
+    catalogStatus !== 'loading' && catalogStatus !== 'error' && orderedEntries.length === 0 && inProgress.length === 0;
 
   return (
     <section id="arcade" className="arcade-section">
@@ -621,7 +633,7 @@ export function ArcadeCatalog({
         </div>
       ) : null}
 
-      {catalogStatus === 'loading' || awaitingSignals ? (
+      {catalogStatus === 'loading' ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
           <p>{t('catalog.loading')}</p>
         </MascotMoment>

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -5,6 +5,7 @@ import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.
 import {
   applyCatalogFilters,
   CATALOG_SORT_MODES,
+  catalogSortNeedsSignals,
   DEFAULT_CATALOG_SORT,
   EMPTY_CATALOG_SORT_SIGNALS,
   orderCatalogEntries,
@@ -59,6 +60,12 @@ function humanizeMoment(name: string): string {
     .join(' ');
 }
 
+/** Prefer a mid-capture still — `opening` is often an empty ready/title frame. */
+function defaultScreenshotIndex(screenshots: Array<{ name: string }>): number {
+  const idx = screenshots.findIndex((shot) => shot.name !== 'opening');
+  return idx >= 0 ? idx : 0;
+}
+
 function CatalogCard({
   entry,
   isYours = false,
@@ -75,11 +82,11 @@ function CatalogCard({
   // Poster when near the fold; video `src` only on hover/play. Leave-view unloads
   // so scrolled-away cards do not keep decoders and MP4 buffers alive.
   const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '200px 0px', once: false });
-  const [selectedScreenshot, setSelectedScreenshot] = useState(0);
+  const screenshots = entry.media?.screenshots ?? [];
+  const [selectedScreenshot, setSelectedScreenshot] = useState(() => defaultScreenshotIndex(screenshots));
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const [isPreviewPinned, setIsPreviewPinned] = useState(false);
   const [videoArmed, setVideoArmed] = useState(false);
-  const screenshots = entry.media?.screenshots ?? [];
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
   const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
   const hasVideo = Boolean(entry.media?.video);
@@ -374,10 +381,13 @@ function payloadToSignals(payload: CatalogSortPayload): CatalogSortSignals {
   };
 }
 
-function initialSignals(): CatalogSortSignals {
-  if (typeof sessionStorage === 'undefined') return EMPTY_CATALOG_SORT_SIGNALS;
+function initialSignals(): { signals: CatalogSortSignals; ready: boolean } {
+  if (typeof sessionStorage === 'undefined') {
+    return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
+  }
   const cached = readCachedCatalogSortPayload();
-  return cached ? payloadToSignals(cached) : EMPTY_CATALOG_SORT_SIGNALS;
+  if (!cached) return { signals: EMPTY_CATALOG_SORT_SIGNALS, ready: false };
+  return { signals: payloadToSignals(cached), ready: true };
 }
 
 function InProgressCard({ item, onOpen }: { item: CreatorGameItem; onOpen: (address: string) => void }) {
@@ -431,22 +441,27 @@ export function ArcadeCatalog({
   );
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const sortMenuRef = useRef<HTMLDivElement | null>(null);
-  const [signals, setSignals] = useState<CatalogSortSignals>(initialSignals);
+  const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals().signals);
+  const [signalsReady, setSignalsReady] = useState(() => initialSignals().ready);
+  // If sessionStorage already gave us an order, a background refresh must not reshuffle
+  // the painted grid. Explicit bumps (after play) still re-rank.
+  const hadCachedSignalsRef = useRef(signalsReady);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
 
+  // Fetch sort signals as soon as the arcade mounts — in parallel with App's
+  // catalog fetch — so cold load waits for max(catalog, signals), not their sum.
   useEffect(() => {
-    if (catalogStatus !== 'ready' || catalogEntries.length === 0) {
-      return;
-    }
     let cancelled = false;
+    const replaceOrder = !hadCachedSignalsRef.current || recommendationsRefreshKey > 0;
     void fetchCatalogSortSignals(getRecentPlays()).then((payload) => {
       if (cancelled) return;
-      setSignals(payloadToSignals(payload));
+      if (replaceOrder) setSignals(payloadToSignals(payload));
+      setSignalsReady(true);
     });
     return () => {
       cancelled = true;
     };
-  }, [catalogStatus, catalogEntries, recommendationsRefreshKey]);
+  }, [recommendationsRefreshKey]);
 
   // Creator games (published + in progress) — only while the gallery is visible.
   useEffect(() => {
@@ -539,6 +554,9 @@ export function ArcadeCatalog({
       return next;
     });
   }
+  const awaitingSignals =
+    catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
+
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
       ? t('catalog.emptyYourGamesNotPlayed')
@@ -548,7 +566,11 @@ export function ArcadeCatalog({
           ? t('catalog.emptyNotPlayed')
           : t('catalog.empty');
   const showEmpty =
-    catalogStatus !== 'loading' && catalogStatus !== 'error' && orderedEntries.length === 0 && inProgress.length === 0;
+    !awaitingSignals &&
+    catalogStatus !== 'loading' &&
+    catalogStatus !== 'error' &&
+    orderedEntries.length === 0 &&
+    inProgress.length === 0;
 
   return (
     <section id="arcade" className="arcade-section">
@@ -641,7 +663,7 @@ export function ArcadeCatalog({
         </div>
       ) : null}
 
-      {catalogStatus === 'loading' ? (
+      {catalogStatus === 'loading' || awaitingSignals ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
           <p>{t('catalog.loading')}</p>
         </MascotMoment>

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -97,20 +97,28 @@ function CatalogCard({
     if (!videoUrl) return;
     const video = videoRef.current;
     if (!video) return;
-    void video.play().then(
-      () => setIsPreviewPlaying(true),
-      () => setIsPreviewPlaying(false),
-    );
+    try {
+      void Promise.resolve(video.play()).then(
+        () => setIsPreviewPlaying(true),
+        () => setIsPreviewPlaying(false),
+      );
+    } catch {
+      setIsPreviewPlaying(false);
+    }
   }, [videoUrl]);
 
   function armPreview() {
     setVideoArmed(true);
     const video = videoRef.current;
     if (!video?.src) return;
-    void video.play().then(
-      () => setIsPreviewPlaying(true),
-      () => setIsPreviewPlaying(false),
-    );
+    try {
+      void Promise.resolve(video.play()).then(
+        () => setIsPreviewPlaying(true),
+        () => setIsPreviewPlaying(false),
+      );
+    } catch {
+      setIsPreviewPlaying(false);
+    }
   }
 
   function stopPreview() {

--- a/apps/web/src/AuthContext.tsx
+++ b/apps/web/src/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { clearCachedCatalogSortPayload } from './recommendationsApi.js';
 
 export interface User {
   uid: string;
@@ -167,6 +168,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = async () => {
     await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    clearCachedCatalogSortPayload();
     setUser(null);
   };
 

--- a/apps/web/src/catalogSort.ts
+++ b/apps/web/src/catalogSort.ts
@@ -3,13 +3,7 @@ import { getRecentPlays } from './recentPlays.js';
 
 export type CatalogSortMode = 'recommended' | 'newest' | 'most_played' | 'last_played' | 'alpha';
 
-export const CATALOG_SORT_MODES: CatalogSortMode[] = [
-  'recommended',
-  'newest',
-  'most_played',
-  'last_played',
-  'alpha',
-];
+export const CATALOG_SORT_MODES: CatalogSortMode[] = ['recommended', 'newest', 'most_played', 'last_played', 'alpha'];
 
 export const DEFAULT_CATALOG_SORT: CatalogSortMode = 'recommended';
 
@@ -242,9 +236,4 @@ export function orderCatalogEntries(
   const others = entries.filter((entry) => !mySlugs.has(entry.slug));
   if (mine.length === 0) return sortCatalogEntries(others, mode, signals);
   return [...sortCatalogEntries(mine, mode, signals), ...sortCatalogEntries(others, mode, signals)];
-}
-
-/** Sort modes that need the recommendations payload to avoid a wrong first paint. */
-export function catalogSortNeedsSignals(mode: CatalogSortMode): boolean {
-  return mode !== 'alpha';
 }

--- a/apps/web/src/catalogSort.ts
+++ b/apps/web/src/catalogSort.ts
@@ -237,3 +237,8 @@ export function orderCatalogEntries(
   if (mine.length === 0) return sortCatalogEntries(others, mode, signals);
   return [...sortCatalogEntries(mine, mode, signals), ...sortCatalogEntries(others, mode, signals)];
 }
+
+/** Sort modes that need the recommendations payload to avoid painting the wrong order. */
+export function catalogSortNeedsSignals(mode: CatalogSortMode): boolean {
+  return mode !== 'alpha';
+}

--- a/apps/web/src/recommendationsApi.test.ts
+++ b/apps/web/src/recommendationsApi.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  clearCachedCatalogSortPayload,
   orderCatalogByRecommendations,
   readCachedCatalogSortPayload,
   writeCachedCatalogSortPayload,
@@ -34,18 +35,37 @@ describe('catalog sort signals cache', () => {
     sessionStorage.clear();
   });
 
-  it('round-trips a payload through sessionStorage', () => {
-    writeCachedCatalogSortPayload({
+  it('round-trips a payload through sessionStorage for a viewer', () => {
+    writeCachedCatalogSortPayload(
+      {
+        items: [{ slug: 'neon-drift', reason: 'popular' }],
+        popularity: [{ slug: 'neon-drift', sessions: 3 }],
+        lastPlayed: [{ slug: 'mid-game', lastPlayedAt: '2026-07-29T12:00:00.000Z' }],
+        newest: ['pixel-pong', 'neon-drift'],
+      },
+      'g:alice',
+    );
+    expect(readCachedCatalogSortPayload('g:alice')).toEqual({
       items: [{ slug: 'neon-drift', reason: 'popular' }],
       popularity: [{ slug: 'neon-drift', sessions: 3 }],
       lastPlayed: [{ slug: 'mid-game', lastPlayedAt: '2026-07-29T12:00:00.000Z' }],
       newest: ['pixel-pong', 'neon-drift'],
     });
-    expect(readCachedCatalogSortPayload()).toEqual({
-      items: [{ slug: 'neon-drift', reason: 'popular' }],
-      popularity: [{ slug: 'neon-drift', sessions: 3 }],
-      lastPlayed: [{ slug: 'mid-game', lastPlayedAt: '2026-07-29T12:00:00.000Z' }],
-      newest: ['pixel-pong', 'neon-drift'],
-    });
+    expect(readCachedCatalogSortPayload('g:bob')).toBeNull();
+    expect(readCachedCatalogSortPayload(null)).toBeNull();
+  });
+
+  it('ignores legacy unscoped cache entries', () => {
+    sessionStorage.setItem(
+      'gdpl.catalogSortSignals',
+      JSON.stringify({ items: [{ slug: 'old', reason: 'popular' }], popularity: [], lastPlayed: [], newest: [] }),
+    );
+    expect(readCachedCatalogSortPayload(null)).toBeNull();
+  });
+
+  it('clearCachedCatalogSortPayload drops the entry', () => {
+    writeCachedCatalogSortPayload({ items: [], popularity: [], lastPlayed: [], newest: [] }, 'g:alice');
+    clearCachedCatalogSortPayload();
+    expect(readCachedCatalogSortPayload('g:alice')).toBeNull();
   });
 });

--- a/apps/web/src/recommendationsApi.ts
+++ b/apps/web/src/recommendationsApi.ts
@@ -67,11 +67,15 @@ function parseNewest(body: unknown): string[] {
   );
 }
 
-function parseCachedPayload(raw: string): CatalogSortPayload | null {
+function parseCachedPayload(raw: string): (CatalogSortPayload & { viewer: string }) | null {
   try {
     const body: unknown = JSON.parse(raw);
     if (typeof body !== 'object' || body === null) return null;
+    const viewer = (body as { viewer?: unknown }).viewer;
+    // Unscoped legacy entries are unusable — affinity is account-specific.
+    if (typeof viewer !== 'string') return null;
     return {
+      viewer,
       items: parseItems(body),
       popularity: parsePopularity(body),
       lastPlayed: parseLastPlayed(body),
@@ -82,25 +86,51 @@ function parseCachedPayload(raw: string): CatalogSortPayload | null {
   }
 }
 
-/** Last recommendations payload — used so reload does not flash catalog-default order. */
-export function readCachedCatalogSortPayload(): CatalogSortPayload | null {
+function viewerKey(viewerUid: string | null | undefined): string {
+  return viewerUid ?? '';
+}
+
+/**
+ * Last recommendations payload for this viewer — used so reload does not flash
+ * catalog-default order. Returns null when missing or cached for another account.
+ */
+export function readCachedCatalogSortPayload(viewerUid: string | null = null): CatalogSortPayload | null {
   try {
     const raw = sessionStorage.getItem(SIGNALS_CACHE_KEY);
-    return raw ? parseCachedPayload(raw) : null;
+    const parsed = raw ? parseCachedPayload(raw) : null;
+    if (!parsed || parsed.viewer !== viewerKey(viewerUid)) return null;
+    return {
+      items: parsed.items,
+      popularity: parsed.popularity,
+      lastPlayed: parsed.lastPlayed,
+      newest: parsed.newest,
+    };
   } catch {
     return null;
   }
 }
 
-export function writeCachedCatalogSortPayload(payload: CatalogSortPayload): void {
+export function writeCachedCatalogSortPayload(payload: CatalogSortPayload, viewerUid: string | null = null): void {
   try {
-    sessionStorage.setItem(SIGNALS_CACHE_KEY, JSON.stringify(payload));
+    sessionStorage.setItem(SIGNALS_CACHE_KEY, JSON.stringify({ viewer: viewerKey(viewerUid), ...payload }));
   } catch {
-    // Private mode / quota — next reload may flash once.
+    // Private mode / quota — next reload may wait on the network once.
   }
 }
 
-export async function fetchCatalogSortSignals(recent: string[] = []): Promise<CatalogSortPayload> {
+/** Drop the sort-signals cache (logout / account switch). */
+export function clearCachedCatalogSortPayload(): void {
+  try {
+    sessionStorage.removeItem(SIGNALS_CACHE_KEY);
+  } catch {
+    // Private mode — ignore.
+  }
+}
+
+export async function fetchCatalogSortSignals(
+  recent: string[] = [],
+  viewerUid: string | null = null,
+): Promise<CatalogSortPayload> {
   const params = new URLSearchParams();
   if (recent.length > 0) params.set('recent', recent.slice(0, 8).join(','));
   const query = params.toString();
@@ -117,7 +147,7 @@ export async function fetchCatalogSortSignals(recent: string[] = []): Promise<Ca
       lastPlayed: parseLastPlayed(body),
       newest: parseNewest(body),
     };
-    writeCachedCatalogSortPayload(payload);
+    writeCachedCatalogSortPayload(payload, viewerUid);
     return payload;
   } catch {
     return empty;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1190,6 +1190,9 @@ button:disabled {
   border: 1px solid var(--panel-border);
   border-radius: 14px;
   background: var(--panel-card);
+  /* Skip layout/paint for off-screen cards while scrolling a ~100-game grid. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 160px;
   transition:
     transform 0.2s,
     border-color 0.2s,

--- a/apps/web/src/useInView.ts
+++ b/apps/web/src/useInView.ts
@@ -3,7 +3,10 @@ import { useEffect, useRef, useState, type RefObject } from 'react';
 export type UseInViewOptions = {
   /** Expand the root intersection box so media can prefetch before it enters view. */
   rootMargin?: string;
-  /** Once true, stay true — catalog media should not unload after scrolling away. */
+  /**
+   * When true (default), stay true after the first intersection.
+   * Catalog cards pass false so off-screen preview media can unload.
+   */
   once?: boolean;
 };
 

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -81,6 +81,10 @@ recent publishes) is cached in-process for ~5 minutes and coalesced while refres
 those Firestore reads otherwise run on every home-page load. Personal affinity and
 `?recent=` hints are applied per request on top of that shared snapshot.
 
+The browser also caches the last payload in `sessionStorage`, keyed to the signed-in
+viewer (cleared on logout), so a reload can paint immediately without flashing the
+wrong account's affinity.
+
 ## UI
 
 [`ArcadeCatalog`](../apps/web/src/ArcadeCatalog.tsx) shows the My games / Not played

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -8,13 +8,13 @@
 
 ## Sort modes
 
-| Mode | Signal |
-| ---- | ------ |
+| Mode        | Signal                                                                                                         |
+| ----------- | -------------------------------------------------------------------------------------------------------------- |
 | Recommended | Scorecards + signed-in play affinity / anonymous recent hints ([`recommend.ts`](../apps/api/src/recommend.ts)) |
-| Newest | Submission `publishedAt` when known; otherwise reverse catalog order |
-| Most played | Scorecard session counts |
-| Last played | Signed-in play affinity timestamps, else device-local recent plays |
-| A–Z | Title, case-insensitive |
+| Newest      | Submission `publishedAt` when known; otherwise reverse catalog order                                           |
+| Most played | Scorecard session counts                                                                                       |
+| Last played | Signed-in play affinity timestamps, else device-local recent plays                                             |
+| A–Z         | Title, case-insensitive                                                                                        |
 
 ## Your games (merged into Games)
 
@@ -30,10 +30,10 @@ heading when you have builds or published games. Published slugs come from
 
 ## Filters
 
-| Filter | Effect |
-| ------ | ------ |
-| My games | Show only the signed-in creator’s published games (plus in-progress builds). Hidden when signed out or when you have no builds/published games. |
-| Not played | Show only games with no play affinity and no device-local recent open |
+| Filter     | Effect                                                                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| My games   | Show only the signed-in creator’s published games (plus in-progress builds). Hidden when signed out or when you have no builds/published games. |
+| Not played | Show only games with no play affinity and no device-local recent open                                                                           |
 
 Filters combine with AND. Sort preference is remembered in `localStorage`
 (`gdpl.catalogSort`); filters in `gdpl.catalogFilters`. The last recommendations
@@ -45,12 +45,12 @@ games) + Not played + Sort ▾ (menu closes on outside tap / Escape).
 
 ## Signals & privacy
 
-| Source | What | Identity |
-| ------ | ---- | -------- |
-| Scorecards | Sessions, vote net, finish rate, median play time (28-day roll) | None — aggregates about games |
-| Play affinity | `users/{uid}/playAffinity/{slug}` — open count + last opened | Signed-in humans only |
-| Recent plays (browser) | `localStorage` list, forwarded as `?recent=` hints | Device-local |
-| My submissions | Published slugs pinned first in the gallery | Signed-in creator |
+| Source                 | What                                                            | Identity                      |
+| ---------------------- | --------------------------------------------------------------- | ----------------------------- |
+| Scorecards             | Sessions, vote net, finish rate, median play time (28-day roll) | None — aggregates about games |
+| Play affinity          | `users/{uid}/playAffinity/{slug}` — open count + last opened    | Signed-in humans only         |
+| Recent plays (browser) | `localStorage` list, forwarded as `?recent=` hints              | Device-local                  |
+| My submissions         | Published slugs pinned first in the gallery                     | Signed-in creator             |
 
 Anonymous play telemetry (`playEvents`) and visit telemetry stay **unjoinable** and
 **unattributed**. Affinity is an account feature like votes and saves, disclosed in the
@@ -75,6 +75,11 @@ games-repo order rather than inventing a shuffle.
   "newest": ["slug-a", "slug-b"]
 }
 ```
+
+Community half (`scorecards` → popularity / recommended base, plus newest from
+recent publishes) is cached in-process for ~5 minutes and coalesced while refreshing —
+those Firestore reads otherwise run on every home-page load. Personal affinity and
+`?recent=` hints are applied per request on top of that shared snapshot.
 
 ## UI
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The home arcade felt slow in two ways:
1. **Catalog paint blocked on sort signals** — and painting unsorted then reshuffling was worse.
2. **Sluggish scrolling** — every near-viewport card attached a `<video src>` and never unloaded it.
3. **`/api/recommendations` itself was slow** — every home load hit Firestore for scorecards + recent publishes with no server cache.

## Changes
- **No provisional re-sort:** wait for sort signals (or viewer-scoped session cache) before first paint; apply network payload only when it differs (or after play refresh).
- **Signals fetch resilience:** transport failure marks signals ready so the grid never sticks on loading.
- **Viewer-scoped cache:** sessionStorage keyed to uid, cleared on logout.
- **Parallel client fetch** of recommendations alongside catalog.
- **Server cache** for shared community signals (~5 min, coalesce, stale-on-failure).
- **Poster-first video** with unload off-screen; prefer non-`opening` still.
- Gallery media: `Accept-Ranges` / `206`, and **If-Range** mismatch → full `200`.

## Test plan
- [x] Unit: recommendations shared cache + coalesce
- [x] Unit: signals reject fallback / viewer-scoped cache / If-Range
- [x] Unit: poster-first + unload
- [x] Green gate
- [ ] Manual: cold load, account switch, hover preview, scroll
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

