### PR TITLE
Remix: thread the code-lane trace so it can be turned on, and off again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,8 +193,14 @@ jobs:
           # to answer one question: how often does the lane actually land, and
           # why does it miss? It is not a permanent setting. It carries the
           # player's own utterance, so leaving it on past that question turns a
-          # window into a habit — clear `vars.REMIX_DEBUG` to close it, and no
-          # deploy is needed to do so.
+          # window into a habit.
+          #
+          # This variable only *opens* the window, and opening it should be slow
+          # and deliberate: the value is read here, at deploy time, so clearing
+          # it leaves the running revision exactly as it was until the next
+          # release. To *close* the window, set `remixTracePaused` on the
+          # creation-limits document — same place as the spend breaker, in
+          # effect within its TTL, no deploy involved.
           #
           # Threaded rather than hand-set for the same reason as everything here:
           # --set-env-vars replaces the whole map, so a value typed onto the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,24 @@ jobs:
             ENV_VARS="${ENV_VARS}|CODE_LANE=${CODE_LANE_VAL}"
           fi
 
+          # The remix code-lane trace: every step of a run, in the log and in the
+          # response — which region call 1 picked, what call 2 was shown, what it
+          # wrote back, and every build error. On by owner decision (2026-08-03)
+          # to answer one question: how often does the lane actually land, and
+          # why does it miss? It is not a permanent setting. It carries the
+          # player's own utterance, so leaving it on past that question turns a
+          # window into a habit — clear `vars.REMIX_DEBUG` to close it, and no
+          # deploy is needed to do so.
+          #
+          # Threaded rather than hand-set for the same reason as everything here:
+          # --set-env-vars replaces the whole map, so a value typed onto the
+          # service would vanish on the next deploy and the trace would go quiet
+          # with nothing to explain it.
+          REMIX_DEBUG_VAL="${{ vars.REMIX_DEBUG }}"
+          if [ -n "$REMIX_DEBUG_VAL" ]; then
+            ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG_VAL}"
+          fi
+
           # Threaded through the same way as ZONE_HOST_URL, and for the same reason:
           # --set-env-vars replaces the whole map, so a value set by hand on the service
           # would be wiped by the next deploy — here that would silently pull room

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -43,10 +43,16 @@ export const MAX_REPAIR_ROUNDS = 2;
  * Temporary: trace every step of a lane run into the response and the log.
  *
  * The lane is three moving parts and, until this existed, the only way to see
- * any of them was to remix a real game and read the wreckage. Off by default,
- * flipped by `REMIX_DEBUG` on a deploy, and meant to be deleted once the lane's
- * hit rate is understood — `npm run remix:probe -w @gamedevpl/api` is the
- * durable way to watch a run, since it costs no player a session.
+ * any of them was to remix a real game and read the wreckage.
+ *
+ * On by owner decision (2026-08-03), while one question is open: how often does
+ * the lane land, and why does it miss? The switch is `vars.REMIX_DEBUG`, threaded
+ * through the deploy — so closing it again is a settings change and not a
+ * release. It is meant to close with the question, because it carries the
+ * player's own utterance and a window left open long enough becomes a habit.
+ *
+ * The durable way to watch a run is `npm run remix:probe -w @gamedevpl/api`,
+ * which costs no player a session and needs no flag at all.
  *
  * It carries the game's own source, which the player already has (the built
  * document contains it) — but it also carries the utterance, so it must not

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -46,10 +46,14 @@ export const MAX_REPAIR_ROUNDS = 2;
  * any of them was to remix a real game and read the wreckage.
  *
  * On by owner decision (2026-08-03), while one question is open: how often does
- * the lane land, and why does it miss? The switch is `vars.REMIX_DEBUG`, threaded
- * through the deploy — so closing it again is a settings change and not a
- * release. It is meant to close with the question, because it carries the
- * player's own utterance and a window left open long enough becomes a habit.
+ * the lane land, and why does it miss?
+ *
+ * Opening it is `vars.REMIX_DEBUG`, threaded through both deploy paths — slow
+ * and deliberate, which is right for a window onto players' own words. Closing
+ * it is *not* that switch: clearing a repository variable changes nothing on a
+ * revision already running, and the wait for the next deploy would be spent
+ * logging. `remixTracePaused` on the creation-limits document stops emission
+ * within the breaker's TTL, from the same place an operator already looks.
  *
  * The durable way to watch a run is `npm run remix:probe -w @gamedevpl/api`,
  * which costs no player a session and needs no flag at all.

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -212,6 +212,17 @@ export function createCreationGate(options: CreationGateOptions): CreationGate {
 export interface EditingGate {
   /** Decides and spends one of the day's editing-model slots, or refuses. */
   checkAndSpend(uid: string, dateStr: string): Promise<CreationGateOutcome>;
+  /**
+   * Whether the operator has closed the code-lane trace window.
+   *
+   * The trace is turned *on* by a deploy-threaded env flag — deliberate and
+   * slow, which is right for opening it. Turning it off must not need a
+   * release: clearing the repository variable changes nothing on a revision
+   * already running, and the interval between "I turned it off" and "it is off"
+   * is spent writing players' words to the log. So off lives here, in the same
+   * document the breaker uses, and takes effect within its TTL.
+   */
+  isTracePaused(): Promise<boolean>;
 }
 
 /**
@@ -234,6 +245,7 @@ export function createEditingGate(options: CreationGateOptions): EditingGate {
     globalDailySubmissionCap: null,
     editingPaused: false,
     globalDailyEditCap: null,
+    remixTracePaused: false,
   };
   let cache: { value: CreationLimits; expiresAt: number } | null = null;
 
@@ -254,6 +266,10 @@ export function createEditingGate(options: CreationGateOptions): EditingGate {
   }
 
   return {
+    async isTracePaused() {
+      return (await limits()).remixTracePaused === true;
+    },
+
     async checkAndSpend(uid, dateStr) {
       if (bypassesBreaker(uid)) return { allowed: true };
 

--- a/apps/api/src/remix-debug-flag.test.ts
+++ b/apps/api/src/remix-debug-flag.test.ts
@@ -5,25 +5,31 @@ import { describe, expect, it } from 'vitest';
  * `REMIX_DEBUG` puts the player's own words in the response and the log.
  *
  * It is on by owner decision while one question is open — how often does the
- * code lane land, and why does it miss — and it is meant to close again after.
- * What this pins is not whether it is on, which is the owner's call, but that
- * the switch stays where a decision can be seen and reversed: threaded from a
- * repository variable through the deploy, never a literal in the workflow and
- * never typed onto the Cloud Run service, where `--set-env-vars` would wipe it
- * on the next deploy and the trace would go quiet with nothing to explain it.
+ * code lane land, and why does it miss. What these pin is not whether it is on,
+ * which is the owner's call, but that the two directions work the way the
+ * comments claim, because the first version of this claimed something false:
+ * that clearing the repository variable closed the window. It does not. A
+ * revision already running keeps the value it was deployed with.
+ *
+ * So opening is deploy-threaded — through *both* supported paths, or a deploy
+ * from the script would silently drop what the workflow set — and closing lives
+ * at runtime on the breaker document, where it takes effect within the TTL.
  */
 
 const workflow = readFileSync(new URL('../../../.github/workflows/deploy.yml', import.meta.url), 'utf8');
+const script = readFileSync(new URL('../../../infra/deploy-api.sh', import.meta.url), 'utf8');
 
 describe('the remix debug flag', () => {
-  it('is threaded from a repository variable, so turning it off needs no deploy', () => {
+  it('is threaded by both deploy paths, so neither drops what the other set', () => {
     expect(workflow).toContain('REMIX_DEBUG_VAL="${{ vars.REMIX_DEBUG }}"');
     expect(workflow).toContain('ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG_VAL}"');
+    expect(script).toContain('ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG}"');
   });
 
-  it('is never pinned on in the workflow itself', () => {
+  it('is never pinned on in either path', () => {
     // A literal would survive every attempt to turn it off from the settings
     // page, which is the only place anyone will think to look.
     expect(workflow).not.toMatch(/REMIX_DEBUG=(true|"true")/);
+    expect(script).not.toMatch(/REMIX_DEBUG=(true|"true")/);
   });
 });

--- a/apps/api/src/remix-debug-flag.test.ts
+++ b/apps/api/src/remix-debug-flag.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * `REMIX_DEBUG` puts the player's own words in the response and the log.
+ *
+ * It is on by owner decision while one question is open — how often does the
+ * code lane land, and why does it miss — and it is meant to close again after.
+ * What this pins is not whether it is on, which is the owner's call, but that
+ * the switch stays where a decision can be seen and reversed: threaded from a
+ * repository variable through the deploy, never a literal in the workflow and
+ * never typed onto the Cloud Run service, where `--set-env-vars` would wipe it
+ * on the next deploy and the trace would go quiet with nothing to explain it.
+ */
+
+const workflow = readFileSync(new URL('../../../.github/workflows/deploy.yml', import.meta.url), 'utf8');
+
+describe('the remix debug flag', () => {
+  it('is threaded from a repository variable, so turning it off needs no deploy', () => {
+    expect(workflow).toContain('REMIX_DEBUG_VAL="${{ vars.REMIX_DEBUG }}"');
+    expect(workflow).toContain('ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG_VAL}"');
+  });
+
+  it('is never pinned on in the workflow itself', () => {
+    // A literal would survive every attempt to turn it off from the settings
+    // page, which is the only place anyone will think to look.
+    expect(workflow).not.toMatch(/REMIX_DEBUG=(true|"true")/);
+  });
+});

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -426,6 +426,67 @@ describe('remix routes', () => {
     }
   });
 
+  it('stops emitting the trace when the operator closes the window, without a deploy', async () => {
+    // Clearing the repository variable changes nothing on a revision already
+    // running, and the wait for the next deploy would be spent logging players'
+    // own words. So closing it is a runtime read, not a release.
+    const store = new InMemoryStore();
+    await store.setPublication({
+      slug: 'dog-dash',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: new Date(0).toISOString(),
+    });
+    const instance = Fastify({ routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH } });
+    instance.decorateRequest('user', null);
+    instance.addHook('onRequest', async (request) => {
+      const uid = request.headers['x-test-uid'];
+      (request as { user?: unknown }).user = typeof uid === 'string' ? { uid, tier: 'standard' } : null;
+    });
+    let tracePaused = false;
+    await registerRemixRoutes(instance, {
+      store,
+      gamesStore: stubGamesStore(),
+      githubClient: stubGitHubClient([]),
+      publishedRef: 'main',
+      editingGate: {
+        checkAndSpend: async () => ({ allowed: true }),
+        isTracePaused: async () => tracePaused,
+      },
+      codeLane: {
+        run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {
+          const good = { 'game/runtime.ts': 'export function startGame() {\n  return 0.08;\n}\n' };
+          await build(good);
+          return {
+            ok: true,
+            overrides: good,
+            region: { file: 'game/runtime.ts', name: 'startGame' },
+            rounds: 0,
+            tokens: { input: 1, output: 1 },
+            trace: { regionCount: 3, picked: { decision: 'edit', found: true }, rounds: [] },
+          };
+        },
+      } as never,
+    });
+    await instance.ready();
+    app = instance;
+
+    const { remixId } = (
+      await instance.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })
+    ).json();
+    const url = `/api/remixes/${remixId}/code`;
+    const payload = { utterance: 'make it twice as fast' };
+
+    process.env.REMIX_DEBUG = 'true';
+    try {
+      expect((await instance.inject({ method: 'POST', url, headers: alice, payload })).json().debug).toBeTruthy();
+      tracePaused = true;
+      expect((await instance.inject({ method: 'POST', url, headers: alice, payload })).json().debug).toBeUndefined();
+    } finally {
+      delete process.env.REMIX_DEBUG;
+    }
+  });
+
   it('reports a failed code edit without swapping anything', async () => {
     const codeLane = {
       run: async () => ({ ok: false, reason: 'did_not_compile', tokens: { input: 1, output: 1 } }),

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -618,7 +618,13 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           },
         );
 
-        if (codeLaneDebugEnabled()) {
+        // The flag opens the window; the breaker document closes it. Asymmetric
+        // on purpose: opening it is a deploy, because it should be deliberate,
+        // and closing it must not wait for one, because until it closes the log
+        // is filling with players' own words. Emission is what this gates — the
+        // lane may still assemble a trace, but nothing leaves the process.
+        const tracing = codeLaneDebugEnabled() && !(await options.editingGate?.isTracePaused());
+        if (tracing) {
           // Before the success branch, deliberately: a trace that only ever
           // described the runs that worked would be silent on the ones the flag
           // exists to explain.
@@ -637,7 +643,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           return reply.send({
             ok: false,
             reason: outcome.reason,
-            ...(codeLaneDebugEnabled() && outcome.trace ? { debug: outcome.trace } : {}),
+            ...(tracing && outcome.trace ? { debug: outcome.trace } : {}),
             ...(outcome.summary ? { summary: outcome.summary } : {}),
           });
         }
@@ -669,7 +675,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           html,
           undoable: true,
           region: outcome.region,
-          ...(codeLaneDebugEnabled() && outcome.trace ? { debug: outcome.trace } : {}),
+          ...(tracing && outcome.trace ? { debug: outcome.trace } : {}),
           ...(outcome.summary ? { summary: outcome.summary } : {}),
         });
       } finally {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -510,6 +510,16 @@ export interface CreationLimits {
   /** Refuse the real-time editing lanes (assist + code) outright. Play is untouched. */
   editingPaused: boolean;
   /**
+   * Stop emitting the remix code-lane trace, without waiting for a deploy.
+   *
+   * The trace is switched *on* by a deploy-threaded env flag, which is right for
+   * something deliberate — but it carries the player's own utterance, so "off"
+   * cannot wait for the next release. Clearing the variable does nothing to a
+   * running revision; this does, within the breaker's TTL, from the same
+   * document an operator already opens during an incident.
+   */
+  remixTracePaused?: boolean;
+  /**
    * Ceiling on paid editing model calls per UTC day, everyone together — the
    * "worst day costs a known number" breaker the remix lanes require before any
    * flag goes on. Same null semantics as the submission cap.
@@ -2819,6 +2829,7 @@ export class InMemoryStore implements Store {
           ? patch.globalDailySubmissionCap
           : (this.creationLimits?.globalDailySubmissionCap ?? null),
       editingPaused: patch.editingPaused ?? this.creationLimits?.editingPaused ?? false,
+      remixTracePaused: patch.remixTracePaused ?? this.creationLimits?.remixTracePaused ?? false,
       globalDailyEditCap:
         patch.globalDailyEditCap !== undefined
           ? patch.globalDailyEditCap
@@ -4633,6 +4644,7 @@ export class FirestoreStore implements Store {
       globalDailySubmissionCap:
         typeof data?.globalDailySubmissionCap === 'number' ? data.globalDailySubmissionCap : null,
       editingPaused: data?.editingPaused === true,
+      remixTracePaused: data?.remixTracePaused === true,
       globalDailyEditCap: typeof data?.globalDailyEditCap === 'number' ? data.globalDailyEditCap : null,
       ...(data?.updatedAt ? { updatedAt: data.updatedAt } : {}),
       ...(data?.updatedBy ? { updatedBy: data.updatedBy } : {}),

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -205,6 +205,18 @@ if [ -n "${GAMES_STORE_BUCKET:-}" ]; then
   # would pile up stored and unverified with nothing in the logs saying why.
   ENV_VARS="${ENV_VARS}|GATE_BUILD_PROJECT=${PROJECT_ID}"
 fi
+# The remix code-lane trace. Threaded here as well as in the Actions workflow,
+# because --set-env-vars replaces the whole map: a deploy from this script would
+# otherwise drop a flag the workflow had set, and the trace would stop with
+# nothing to say why. Both supported paths carry it or neither should.
+#
+# Note this only opens the window. Closing it does not wait for either path —
+# `remixTracePaused` on the creation-limits document stops emission within the
+# breaker's TTL, because the interval between deciding to stop and stopping is
+# spent writing players' own words to the log.
+if [ -n "${REMIX_DEBUG:-}" ]; then
+  ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG}"
+fi
 if [ -n "${CANONICAL_HOST:-}" ]; then
   ENV_VARS="${ENV_VARS}|CANONICAL_HOST=${CANONICAL_HOST}"
 fi


### PR DESCRIPTION
`REMIX_DEBUG` shipped with a reader and no switch — nothing in any deploy path set it, so it could be neither enabled nor disabled without editing this repository. On by owner decision while one question is open: **how often does the code lane land, and why does it miss?**

## Opening and closing are not the same act

The first version of this pull request said clearing `vars.REMIX_DEBUG` closed the window. It does not, and review caught it. The workflow reads that variable **at deploy time**; a revision already running keeps the value it was deployed with. The interval between an operator deciding to stop and it actually stopping would have been spent writing players' own words to the log — while the settings page said otherwise.

So the two directions now have two switches, deliberately asymmetric:

| | mechanism | takes effect |
|---|---|---|
| **Open** | `vars.REMIX_DEBUG`, threaded through both deploy paths | next deploy — slow on purpose |
| **Close** | `remixTracePaused` on the creation-limits document | within the spend breaker's TTL |

Closing gates **emission**: the lane may still assemble a trace, but nothing leaves the process — no log line, no `debug` field on the response. It lives on the same document as the spend breaker because that is the document an operator already has open when something is going wrong.

Opening stays deploy-threaded for the reason the comments around `EDITOR_ASSIST` and `CODE_LANE` already give: `--set-env-vars` replaces the whole map, so a value typed onto the Cloud Run service vanishes on the next deploy and the trace goes quiet with nothing to explain it. Both deploy paths carry it — the workflow *and* `infra/deploy-api.sh` — or a manual deploy would silently drop what the other had set.

## ⚠️ One manual step, which I cannot do

Set the repository variable, or this ships as a no-op:

**Settings → Secrets and variables → Actions → Variables → New variable**
`REMIX_DEBUG` = `true`

Then redeploy (any merge to master will do). To close the window later, set `remixTracePaused: true` on the creation-limits document — no deploy, no release, effective within the TTL. Deleting the repository variable is the follow-up that makes it permanent, not the thing that stops it.

## What it exposes when on

Every code-lane run, in the log line and in the `/code` response as `debug`:

- how many regions the symbol map had, and which one call 1 picked (and whether that name existed)
- the slice call 2 was shown
- what it wrote back, per repair round, with the build errors from each
- on failures too — that was fixed in #487 after review, since the failures are the runs worth reading

Each field is clipped to 4KB so a trace cannot cost more than the answer it explains.

## The tests

`remix-debug-flag.test.ts` pins the switch's *shape*, not its state — whether the flag is on is the owner's call, but the switch must stay somewhere a decision can be seen and reversed: threaded from a repository variable in both paths, never a literal, never hand-set on the service. A route test flips `isTracePaused` between two otherwise identical requests and asserts the second carries no `debug`.

Ops doc §D.14 records the same asymmetry, including that the earlier entry claimed the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_