### PR TITLE
byoca: an OAuth agent could join a round but never open one

### DIFF
--- a/apps/api/src/agent-creator-key-resolve.ts
+++ b/apps/api/src/agent-creator-key-resolve.ts
@@ -128,7 +128,34 @@ export async function resolveCreatorAgentKeyForOpenRound(
   const verified = await verifyDurableCreatorAgentKey(store, key, secret, nowMs);
   if (!verified.ok) return verified;
 
-  if (!(await creatorOwnsSlug(store, slug, verified.claims.creatorUid))) {
+  const owned = await resolveOwnedSlugForOpenRound(store, slug, verified.claims.creatorUid);
+  if (!owned.ok) return owned;
+  return {
+    ok: true,
+    claims: verified.claims,
+    publishedRecord: owned.publishedRecord,
+    activeRound: owned.activeRound,
+    slug: owned.slug,
+  };
+}
+
+/**
+ * Everything `open_round` needs once the caller's identity is known, whatever proved it.
+ *
+ * Split out of the creator-key resolver so the OAuth path can reach it. Both credentials
+ * answer the same question — *which creator is this* — and from there the slug ownership,
+ * publish state and active-round lookups are identical. Duplicating them is how the two
+ * paths drift into refusing different things for the same situation.
+ */
+export async function resolveOwnedSlugForOpenRound(
+  store: Store,
+  slug: string,
+  creatorUid: string,
+): Promise<
+  | { ok: true; publishedRecord: SubmissionRecord; activeRound: SubmissionRecord | null; slug: string }
+  | { ok: false; reason: string }
+> {
+  if (!(await creatorOwnsSlug(store, slug, creatorUid))) {
     return { ok: false, reason: SLUG_NOT_ON_ACCOUNT_REASON };
   }
 
@@ -137,6 +164,6 @@ export async function resolveCreatorAgentKeyForOpenRound(
     return { ok: false, reason: GAME_NOT_PUBLISHED_REASON };
   }
 
-  const activeRound = await findActiveRoundForSlug(store, slug, verified.claims.creatorUid);
-  return { ok: true, claims: verified.claims, publishedRecord, activeRound, slug };
+  const activeRound = await findActiveRoundForSlug(store, slug, creatorUid);
+  return { ok: true, publishedRecord, activeRound, slug };
 }

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -101,6 +101,82 @@ async function callStart(app: FastifyInstance, args: Record<string, unknown>, he
   return { structured, isError: Boolean(body.result?.isError), sessionId };
 }
 
+const PUBLISHED_ISSUE = 90;
+
+async function callOpenRound(
+  app: FastifyInstance,
+  args: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const res = await mcpCall(app, 'tools/call', { name: 'open_round', arguments: args }, headers);
+  expect(res.statusCode).toBe(200);
+  const body = res.json() as {
+    result?: { content?: Array<{ text: string }>; structuredContent?: unknown; isError?: boolean };
+  };
+  const structured =
+    body.result?.structuredContent ??
+    (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
+  return { structured, isError: Boolean(body.result?.isError) };
+}
+
+async function seedPublishedGame(store: InMemoryStore) {
+  await store.createSubmission(PUBLISHED_ISSUE, OWNER, 'Jagged Alliance');
+  await store.setSubmissionSlug(PUBLISHED_ISSUE, SLUG);
+  await store.setRoundBuilder(PUBLISHED_ISSUE, 'self');
+  await store.setSubmissionPublishedAt(PUBLISHED_ISSUE, '2026-07-01T00:00:00.000Z');
+  await store.recordJobTransition(PUBLISHED_ISSUE, {
+    to: 'published',
+    at: '2026-07-01T00:00:00.000Z',
+    by: 'operator',
+    reason: 'published',
+  });
+}
+
+/** Full CIMD-free OAuth flow: register, approve, exchange — returns an access token. */
+async function oauthAccessToken(app: FastifyInstance): Promise<string> {
+  const register = await app.inject({
+    method: 'POST',
+    url: '/oauth/register',
+    headers: { 'content-type': 'application/json' },
+    payload: {
+      redirect_uris: ['http://127.0.0.1/callback'],
+      client_name: 'Loop Agent',
+      token_endpoint_auth_method: 'none',
+    },
+  });
+  const clientId = register.json().client_id as string;
+  const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const approve = await app.inject({
+    method: 'POST',
+    url: '/oauth/authorize',
+    headers: { cookie: authHeaders().cookie, 'content-type': 'application/x-www-form-urlencoded' },
+    payload: new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: 'http://127.0.0.1/callback',
+      scope: 'mcp',
+      state: 'xyz',
+      code_challenge: pkceChallengeS256(verifier),
+      code_challenge_method: 'S256',
+      action: 'approve',
+    }).toString(),
+  });
+  const code = new URL(approve.headers.location as string).searchParams.get('code');
+  const tokenRes = await app.inject({
+    method: 'POST',
+    url: '/oauth/token',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    payload: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: code!,
+      redirect_uri: 'http://127.0.0.1/callback',
+      client_id: clientId,
+      code_verifier: verifier,
+    }).toString(),
+  });
+  return tokenRes.json().access_token as string;
+}
+
 describe('creator agent key routes + MCP start (BY-27a)', () => {
   let app: FastifyInstance | null = null;
 
@@ -631,5 +707,48 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
     // And it is stable again from here, rather than drifting on every visit.
     const again = await app.inject({ method: 'GET', url: '/api/me/creator-agent-key', headers: authHeaders() });
     expect((again.json() as { key: string }).key).toBe(body.key);
+  });
+
+  // CP-2 addendum: `start` accepted OAuth but `open_round` did not, so an OAuth-connected
+  // agent could join a round and never open the next one. After a round closed it went
+  // idle waiting for a human — the opposite of the promise that only a slug is needed.
+  it('opens an improvement round over OAuth, the same as a creator key does', async () => {
+    const store = new InMemoryStore();
+    await seedPublishedGame(store);
+    app = await createApp(store);
+
+    const accessToken = await oauthAccessToken(app);
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: SLUG, feedback: 'Tighten the jump arc.' },
+      { authorization: `Bearer ${accessToken}` },
+    );
+
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ slug: SLUG, alreadyOpen: false });
+    const jobId = (structured as { jobId: number }).jobId;
+    const job = await store.getSubmission(jobId);
+    expect(job?.ownerUid).toBe(OWNER);
+    // The change request still lands as the round brief on this path (#486).
+    expect(job?.spec).toBe('Tighten the jump arc.');
+  });
+
+  it('refuses an unowned slug over OAuth with the same reason the creator key gives', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(77, OTHER, 'Not Yours');
+    await store.setSubmissionSlug(77, 'not-yours');
+    await store.setSubmissionPublishedAt(77, '2026-07-01T00:00:00.000Z');
+    app = await createApp(store);
+
+    const accessToken = await oauthAccessToken(app);
+    const { structured, isError } = await callOpenRound(
+      app,
+      { slug: 'not-yours', feedback: 'Change something.' },
+      { authorization: `Bearer ${accessToken}` },
+    );
+
+    expect(isError).toBe(true);
+    // Names the slug, never the credential — a mistype must not push a destructive rotate.
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
   });
 });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
-import { resolveCreatorAgentKeyForOpenRound, resolveCreatorAgentKeyForStart } from './agent-creator-key-resolve.js';
+import {
+  resolveCreatorAgentKeyForOpenRound,
+  resolveCreatorAgentKeyForStart,
+  resolveOwnedSlugForOpenRound,
+} from './agent-creator-key-resolve.js';
 import {
   looksLikeGameAgentKey,
   GAME_KEY_GOES_IN_KEY_ARG_REASON,
@@ -739,7 +743,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     open_round: {
       description:
         'Open a new post-publish improvement round on a published game. ' +
-        'Accepts a durable per-game key, or Authorization: Bearer <creator key> + slug. ' +
+        'Accepts a durable per-game key, or Authorization: Bearer (creator key or OAuth access) + slug. ' +
         'Spends the same daily improvement quota as Studio. ' +
         'Returns jobId only — call start() next for a sessionKey. Idempotent while a round is already open.',
       inputSchema: {
@@ -747,11 +751,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: {
           key: {
             type: 'string',
-            description: 'Durable per-game key. Optional when using Authorization Bearer with a creator key + slug.',
+            description:
+              'Durable per-game key. Optional when using Authorization Bearer (creator key or OAuth) + slug.',
           },
           slug: {
             type: 'string',
-            description: 'Game slug. Required with a creator-key Bearer; ignored with a per-game key.',
+            description: 'Game slug. Required with a creator-key or OAuth Bearer; ignored with a per-game key.',
           },
           feedback: {
             type: 'string',
@@ -807,6 +812,29 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             publishedRecord: creatorResolved.publishedRecord,
             activeRound: creatorResolved.activeRound,
           };
+        } else if (!key && bearer && looksLikeAsAccessToken(bearer)) {
+          // OAuth could join a round but never open one, so an OAuth-connected agent went
+          // idle the moment a round closed and waited for a human to start the next. That
+          // is the whole promise inverted: after one-time configuration, only a slug is
+          // supposed to be needed. `start` already accepted OAuth here; `open_round` was
+          // simply never taught the same identity.
+          const asAccess = await verifyAsAccessToken(store, bearer, now());
+          if (!asAccess) {
+            return toolErr('invalid OAuth access — sign in again from your coding agent');
+          }
+          if (!slugArg) {
+            return toolErr('slug is required when using OAuth — pass the game slug to improve');
+          }
+          const oauthResolved = await resolveOwnedSlugForOpenRound(store, slugArg, asAccess.ownerUid);
+          if (!oauthResolved.ok) {
+            return toolErr(oauthResolved.reason);
+          }
+          resolved = {
+            creatorUid: asAccess.ownerUid,
+            slug: oauthResolved.slug,
+            publishedRecord: oauthResolved.publishedRecord,
+            activeRound: oauthResolved.activeRound,
+          };
         } else if (key && looksLikeGameAgentKey(key)) {
           const gameResolved = await resolveGameAgentKeyForOpenRound(store, key, agentTokenSecret, now());
           if (!gameResolved.ok) {
@@ -822,10 +850,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
         } else if (key) {
           return toolErr(
-            'open_round requires a durable per-game key or Authorization Bearer with a creator key + slug',
+            'open_round requires a durable per-game key, or Authorization Bearer (creator key or OAuth) + slug',
           );
         } else {
-          return toolErr('pass a durable per-game key, or Authorization Bearer with a creator key + slug');
+          return toolErr('pass a durable per-game key, or Authorization Bearer (creator key or OAuth) + slug');
         }
 
         const at = new Date(now()).toISOString();


### PR DESCRIPTION
From CP-2's PASS B re-run, which got OAuth working end to end for the first time and then found where the path stops.

## The gap

`start` accepts an OAuth Bearer + slug. `open_round` never learned the same identity — it has branches for a creator key and a per-game key, and an OAuth token falls through to the final `else`:

```json
{"error":"pass a durable per-game key, or Authorization Bearer with a creator key + slug"}
```

An agent holding a valid OAuth token *is* presenting an `Authorization: Bearer`, so the refusal reads as though its credential were malformed rather than out of scope.

The effect is the promise inverted. A creator who connects by signing in gets one round; when it closes, the agent goes idle until a human opens the next one in Studio. *"After one-time configuration, only a slug goes in the prompt"* held only while somebody else kept opening rounds.

## The fix

`open_round` accepts OAuth alongside the two key shapes.

The identity-agnostic half of the creator-key resolver — slug ownership, publish state, active round — is extracted as `resolveOwnedSlugForOpenRound` and shared. Both credentials answer the same question, *which creator is this*, and duplicating the lookups downstream is how two paths drift into refusing different things for the same situation. The refusals and both tool descriptions now name OAuth as accepted.

## Verification

The parity test asserts the unowned-slug refusal is byte-identical to the creator-key one — slug-centred, never blaming the credential — so a mistype cannot push someone toward a destructive rotate on either path.

Both tests fail against the unfixed source:

```
× opens an improvement round over OAuth, the same as a creator key does
  → expected true to be false
× refuses an unowned slug over OAuth with the same reason the creator key gives
  → expected 'pass a durable per-game key, or Autho…' to be 'no game with that slug on your accoun…'
```

Full gate green: `type-check`, `lint`, api 2007, web 949, world 19, rules 23.

## Not in this PR

The addendum's other finding — the consent screen never names the client, and the connected-agents list labels every entry `localhost` from the redirect host rather than the client's own name — is a UI change with a mock already drawn, and it belongs with the consent-CSRF hardening rather than here.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_