### PR TITLE
byoca: tell the agent which field, and that the session id matters

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1074,4 +1074,68 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(instructions).toMatch(/get_gate_verdict/);
     expect(instructions).toMatch(/honour stop/i);
   });
+
+  // CP-2: an agent that guessed `phase`/`message` got the channel's bare
+  // {"error":"Required"} — which names neither the missing field nor the real ones.
+  // The tool declared `text` required and then forwarded whatever arrived.
+  it('names the fields when report_progress is called with the wrong ones', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const wrong = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, phase: 'planning', message: 'thinking' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(wrong.isError).toBe(true);
+    const { error } = wrong.structured as { error: string };
+    expect(error).toMatch(/report_progress needs text/i);
+    expect(error).toMatch(/step \(one of/i);
+    expect(error).not.toBe('Required');
+
+    const badStep = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, step: 'vibing', text: 'ok' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(badStep.isError).toBe(true);
+    expect((badStep.structured as { error: string }).error).toMatch(/step must be one of/i);
+
+    // The declared shape still works.
+    const good = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, step: 'planning', text: 'ok' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(good.isError).toBe(false);
+  });
+
+  // The binding is real and was documented nowhere: start's own description says
+  // "Does not treat Mcp-Session-Id as authority", which reads as "the header does not
+  // matter" when in fact it is necessary, just not sufficient.
+  it('documents that a sessionKey is bound to the session that minted it', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const res = await mcpCall(app, 'tools/list', undefined, { 'mcp-session-id': sessionId });
+    const tools = (
+      res.json().result as {
+        tools: Array<{ name: string; inputSchema: { properties?: Record<string, { description?: string }> } }>;
+      }
+    ).tools;
+    const brief = tools.find((tool) => tool.name === 'get_brief');
+    const described = brief?.inputSchema.properties?.sessionKey?.description ?? '';
+
+    expect(described).toMatch(/same Mcp-Session-Id/i);
+    expect(described).toMatch(/call start\(\) again/i);
+  });
 });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -275,6 +275,14 @@ const SESSION_WORKFLOW_TEXT = [
   `If a call is refused: ${RETIRED_KEY_ETIQUETTE}`,
 ].join('\n');
 
+/**
+ * `BUILD_STEPS` widened to plain strings, for validating input that is `unknown`.
+ *
+ * `BUILD_STEPS.includes(x)` only accepts the `BuildStep` union, so checking a raw
+ * argument against it is a type error rather than a check.
+ */
+const BUILD_STEP_NAMES: ReadonlySet<string> = new Set<string>(BUILD_STEPS);
+
 const SESSION_KEY_PROP = {
   type: 'string' as const,
   description:
@@ -1131,7 +1139,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               `Optional: step (one of ${BUILD_STEPS.join(', ')}), textLocalized, locale, done, total.`,
           );
         }
-        if (args.step !== undefined && (typeof args.step !== 'string' || !BUILD_STEPS.includes(args.step))) {
+        if (args.step !== undefined && (typeof args.step !== 'string' || !BUILD_STEP_NAMES.has(args.step))) {
           return toolErr(`step must be one of: ${BUILD_STEPS.join(', ')}`);
         }
         const payload: Record<string, unknown> = {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -278,7 +278,7 @@ const SESSION_WORKFLOW_TEXT = [
 const SESSION_KEY_PROP = {
   type: 'string' as const,
   description:
-    'Short-lived session capability from start(). Present this argument OR configure Authorization: Bearer <round key> — not both required. Mcp-Session-Id alone is never authority.',
+    'Short-lived session capability from start(). Present this argument OR configure Authorization: Bearer <round key> — not both required. Send it with the same Mcp-Session-Id header start() used: that header alone is never authority, but a sessionKey is bound to the session that minted it, so a different one is refused. If the transport session is lost, call start() again — it re-binds and re-mints.',
 };
 
 export async function registerMcpServerRoutes(app: FastifyInstance, options: McpServerOptions = {}): Promise<void> {
@@ -1122,6 +1122,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
+        // The tool declares `text` required and then forwarded whatever arrived, so an
+        // agent guessing `phase`/`message` got the channel's bare `{"error":"Required"}`
+        // — which names neither the field that was missing nor the ones that exist.
+        if (typeof args.text !== 'string' || !args.text.trim()) {
+          return toolErr(
+            'report_progress needs text: a short English sentence about what you are doing. ' +
+              `Optional: step (one of ${BUILD_STEPS.join(', ')}), textLocalized, locale, done, total.`,
+          );
+        }
+        if (args.step !== undefined && (typeof args.step !== 'string' || !BUILD_STEPS.includes(args.step))) {
+          return toolErr(`step must be one of: ${BUILD_STEPS.join(', ')}`);
+        }
         const payload: Record<string, unknown> = {
           text: args.text,
           ...(typeof args.step === 'string' ? { step: args.step } : {}),


### PR DESCRIPTION
Two CP-2 leftovers, both cases of the platform answering an agent with less than it knows.

## `report_progress` rejected without naming anything

The tool declares `text` required and then forwarded whatever arrived. An agent that guessed `phase`/`message` — plausible names, and the ones CP-2 actually tried — got the channel's bare:

```json
{"error":"Required"}
```

That names neither the field that was missing nor the fields that exist. It now names both, and an out-of-enum `step` says which values are legal instead of failing the same anonymous way.

## The `sessionKey` ↔ `Mcp-Session-Id` binding was documented nowhere

A `sessionKey` is refused under a different transport session, which is correct. But `start` said only *"Does not treat Mcp-Session-Id as authority"* — true, and read as *"the header does not matter."* It is **necessary, just not sufficient**, and nothing said so.

The description now says to send the same one, and that a lost transport session is recovered by calling `start()` again. CP-2 discovered that by having it happen overnight and guessing correctly.

## Verification

Both tests fail against the unfixed source. The first fails with the literal string `Required`, which is the entire complaint:

```
× names the fields when report_progress is called with the wrong ones
  → expected 'Required' to match /report_progress needs text/i
× documents that a sessionKey is bound to the session that minted it
  → expected 'Short-lived session capability from s…' to match /same Mcp-Session-Id/i
```

Full gate green: `type-check`, `lint`, api 2007, web 949, world 19, rules 23.

## The third item is not a defect

CP-2 flagged that unauthenticated `initialize` returns 200, so `claude mcp list` reports **Connected** with no credential and never volunteers OAuth. Returning a 401 challenge there would be wrong: **game keys and legacy round keys arrive as the `key` tool argument, not as a header**, so those clients legitimately send no `Authorization` on `initialize`. Challenging it would break both paths to fix a cosmetic signal.

`shouldIssueMcpOAuthChallenge` already encodes this — it exempts the handshake and fires only on `tools/call`. The current behaviour is deliberate and correct; the false "Connected" is a client-side inference from a successful handshake, and there is no protocol-legal way to say "you will need auth later" while still supporting argument-carried credentials.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_