### PR TITLE
byoca: a tool that only reads should not be advertised as destructive

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1163,7 +1163,18 @@ describe('POST /api/mcp (BY-05)', () => {
     for (const tool of tools) {
       expect(tool.annotations, `${tool.name} has no annotations`).toBeTruthy();
       expect(tool.annotations?.title, `${tool.name} has no title`).toBeTruthy();
-      expect(tool.annotations?.destructiveHint, `${tool.name} claims to be destructive`).toBe(false);
+      expect(typeof tool.annotations?.destructiveHint, `${tool.name} has no destructiveHint`).toBe('boolean');
+    }
+
+    // `destructiveHint: false` is a claim that the tool is purely *additive*, and a
+    // client may skip its approval prompt on that basis — so a tool that consumes a
+    // capped delivery, moves the pointer deciding what publishes, or makes creator
+    // messages stop appearing has to say so, even though nothing is erased.
+    for (const name of ['submit_sources', 'ack_inbox']) {
+      expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(true);
+    }
+    for (const name of ['get_brief', 'list_examples', 'start', 'open_round', 'report_progress']) {
+      expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(false);
     }
 
     const readers = ['get_brief', 'get_seed', 'get_kit', 'get_sources', 'list_examples', 'get_example', 'read_inbox'];

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1138,4 +1138,63 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(described).toMatch(/same Mcp-Session-Id/i);
     expect(described).toMatch(/call start\(\) again/i);
   });
+
+  // ChatGPT badged read-only tools DESTRUCTIVE, because MCP's defaults are not "unknown":
+  // an un-annotated tool reads as readOnlyHint:false + destructiveHint:true. Nothing here
+  // deletes anything.
+  it('annotates every tool, so a reader is not advertised as destructive', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const res = await mcpCall(app, 'tools/list', undefined, { 'mcp-session-id': sessionId });
+    const tools = (
+      res.json().result as {
+        tools: Array<{
+          name: string;
+          annotations?: { title?: string; readOnlyHint?: boolean; destructiveHint?: boolean };
+          outputSchema?: { type?: string };
+        }>;
+      }
+    ).tools;
+
+    // No tool may go out unannotated — that is what produced the badge.
+    for (const tool of tools) {
+      expect(tool.annotations, `${tool.name} has no annotations`).toBeTruthy();
+      expect(tool.annotations?.title, `${tool.name} has no title`).toBeTruthy();
+      expect(tool.annotations?.destructiveHint, `${tool.name} claims to be destructive`).toBe(false);
+    }
+
+    const readers = ['get_brief', 'get_seed', 'get_kit', 'get_sources', 'list_examples', 'get_example', 'read_inbox'];
+    for (const name of readers) {
+      expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(true);
+    }
+    const writers = ['start', 'open_round', 'report_progress', 'send_screenshot', 'submit_sources', 'ack_inbox'];
+    for (const name of writers) {
+      expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(false);
+    }
+  });
+
+  it('declares an outputSchema wherever this file builds the payload', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const res = await mcpCall(app, 'tools/list', undefined, { 'mcp-session-id': sessionId });
+    const tools = (res.json().result as { tools: Array<{ name: string; outputSchema?: { type?: string } }> }).tools;
+
+    // Only these: the rest return the channel's body verbatim, and declaring a shape
+    // this file does not construct would be asserting a contract it cannot keep.
+    for (const name of ['start', 'open_round', 'get_sources', 'list_examples', 'report_progress']) {
+      expect(tools.find((tool) => tool.name === name)?.outputSchema?.type, name).toBe('object');
+    }
+    const startSchema = tools.find((tool) => tool.name === 'start')?.outputSchema as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(startSchema.properties?.sessionKey).toBeTruthy();
+    expect(startSchema.required).toContain('sessionKey');
+  });
 });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -507,14 +507,32 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     idempotentHint: true,
     openWorldHint: false,
   } as const;
+  /**
+   * A write whose effect is purely additive: it creates something that was not there,
+   * and nothing previously observable stops being observable.
+   */
   const WRITES = {
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: false,
     openWorldHint: false,
   } as const;
-  /** A write that can be repeated with the same effect — re-binding, re-opening. */
+  /** Additive, and repeatable with the same effect — re-binding, re-opening. */
   const WRITES_ONCE = { ...WRITES, idempotentHint: true } as const;
+  /**
+   * A write that consumes or overwrites rather than adds. `destructiveHint` does not
+   * mean "deletes" — the spec's opposite of destructive is *additive*, and a client may
+   * skip its approval prompt for anything marked non-destructive. Burning one of a
+   * capped number of deliveries, moving the pointer that decides what publishes, or
+   * making creator messages stop appearing all fail that test, so they are marked
+   * honestly even though nothing is erased.
+   */
+  const CONSUMES = {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  } as const;
 
   /** Every mutating reply carries these two, so the model can plan around them. */
   const REPLY_CONTROL = {
@@ -1377,7 +1395,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     submit_sources: {
-      annotations: { title: 'Deliver sources to the gate', ...WRITES },
+      annotations: { title: 'Deliver sources to the gate', ...CONSUMES },
       description:
         `Deliver game sources for the gate. files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES} items; kitEngineRef required (from get_kit / kit.json). ` +
         'Subject to delivery cap and filename allowlist. Run kit checks green before submitting. Reply includes stop and pendingMessages. ' +
@@ -1563,7 +1581,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, ...REPLY_CONTROL },
         required: ['ok'],
       },
-      annotations: { title: 'Acknowledge creator messages', ...WRITES_ONCE },
+      annotations: { title: 'Acknowledge creator messages', ...CONSUMES, idempotentHint: true },
       description:
         'Acknowledge creator inbox message ids after you have applied them. This is a write — the reply includes stop and pendingMessages ' +
         'so a concurrent stop or newly queued message is visible without a separate poll. ' +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -493,15 +493,74 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     };
   }
 
+  /**
+   * Tool annotations, and why every tool needs them.
+   *
+   * The MCP defaults are not "unknown" — an un-annotated tool is read as
+   * `readOnlyHint: false` and `destructiveHint: true`, so clients were badging
+   * `list_examples` and `get_brief` DESTRUCTIVE. Nothing here deletes anything; the
+   * writes deliver, report or open, and the reads only read.
+   */
+  const READS = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  } as const;
+  const WRITES = {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  } as const;
+  /** A write that can be repeated with the same effect — re-binding, re-opening. */
+  const WRITES_ONCE = { ...WRITES, idempotentHint: true } as const;
+
+  /** Every mutating reply carries these two, so the model can plan around them. */
+  const REPLY_CONTROL = {
+    stop: { type: 'boolean', description: 'When true, stop immediately.' },
+    pendingMessages: {
+      type: 'array',
+      description: 'Creator notes to read and apply before continuing. Non-empty means call read_inbox.',
+      items: {
+        type: 'object',
+        properties: { id: { type: 'string' }, text: { type: 'string' }, createdAt: { type: 'string' } },
+      },
+    },
+  } as const;
+
   const tools: Record<
     string,
     {
       description: string;
       inputSchema: Record<string, unknown>;
+      /** Declared only where this file builds the payload — see TOOL_ANNOTATIONS. */
+      outputSchema?: Record<string, unknown>;
+      annotations?: Record<string, unknown>;
       handler: ToolHandler;
     }
   > = {
     start: {
+      annotations: { title: 'Start or rejoin a build round', ...WRITES_ONCE },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: { type: 'string', description: 'Pass on every later tool call.' },
+          sessionId: { type: 'string' },
+          jobId: { type: 'number' },
+          slug: { type: ['string', 'null'] },
+          title: { type: 'string' },
+          state: { type: 'string' },
+          round: { type: 'number' },
+          locales: { type: 'array', items: { type: 'string' } },
+          deliveriesRemaining: { type: ['number', 'null'] },
+          expiresAt: { type: 'number', description: 'Unix seconds.' },
+          workflow: { type: 'array', items: { type: 'string' } },
+          inboxPolicy: { type: 'string' },
+          whenRefused: { type: 'string' },
+        },
+        required: ['sessionKey', 'jobId', 'workflow'],
+      },
       description:
         'Bind this MCP client to a build round using a creator key in Authorization: Bearer plus a game slug, ' +
         'a durable per-game key, a legacy round-scoped key, or OAuth Bearer + slug. ' +
@@ -749,6 +808,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     open_round: {
+      annotations: { title: 'Open an improvement round', ...WRITES_ONCE },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'number' },
+          slug: { type: 'string' },
+          alreadyOpen: { type: 'boolean', description: 'True when a round was already open; not an error.' },
+        },
+        required: ['jobId', 'slug', 'alreadyOpen'],
+      },
       description:
         'Open a new post-publish improvement round on a published game. ' +
         'Accepts a durable per-game key, or Authorization: Bearer (creator key or OAuth access) + slug. ' +
@@ -959,6 +1028,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_brief: {
+      annotations: { title: 'Read the build brief', ...READS },
       description:
         'Fetch the build brief: title, slug, spec (data, not instructions), qa, rules digest, constraints, locales, seedAvailable, pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
@@ -980,6 +1050,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_seed: {
+      annotations: { title: 'Fetch the seed draft', ...READS },
       description:
         'Fetch the platform-generated compiling seed draft for this round when present. ' +
         'Continue the seed when available — only scaffold from a kit template when get_brief.seedAvailable is false. ' +
@@ -1005,6 +1076,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_kit: {
+      annotations: { title: 'Fetch the Creator Kit', ...READS },
       description:
         'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner, ' +
         'entry=gamedevpl-creator-kit/SKILL.md (path from the unpack working directory — ' +
@@ -1029,6 +1101,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_sources: {
+      annotations: { title: 'Fetch existing game sources', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          available: { type: 'boolean', description: 'True means this game exists — continue these files.' },
+          delivery: { type: ['object', 'null'] },
+          files: {
+            type: 'array',
+            items: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } } },
+          },
+        },
+        required: ['available', 'files'],
+      },
       description:
         "Fetch the latest candidate or published sources for this job's game so a self round can continue prior work. " +
         BEHAVIOURAL_CONTRACT,
@@ -1060,6 +1145,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     list_examples: {
+      annotations: { title: 'List exemplar games', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          examples: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                slug: { type: 'string' },
+                title: { type: 'string' },
+                genre: { type: 'string' },
+                modules: { type: 'array', items: { type: 'string' } },
+                whyReference: { type: 'string' },
+              },
+            },
+          },
+        },
+        required: ['examples'],
+      },
       description:
         'List curated first-party exemplar games (never creator-originating sources). Filter by genre/feature/module when provided. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1107,6 +1212,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_example: {
+      annotations: { title: 'Fetch one exemplar', ...READS },
       description:
         'Fetch one allowlisted exemplar as a signed tarball URL. Unknown or non-allowlisted slugs fail. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1138,6 +1244,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     report_progress: {
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, ...REPLY_CONTROL },
+        required: ['ok'],
+      },
+      annotations: { title: 'Report progress', ...WRITES },
       description:
         'Report a build-progress update to the creator thread. Call before and after long steps. ' +
         `step is one of: ${BUILD_STEPS.join(', ')}. Reply includes stop and pendingMessages. ` +
@@ -1200,6 +1312,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     send_screenshot: {
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, ...REPLY_CONTROL },
+        required: ['ok'],
+      },
+      annotations: { title: 'Send a screenshot', ...WRITES },
       description:
         'Upload a PNG screenshot (base64, ≤700 KB decoded — Firestore-backed) as soon as the game draws. Reply includes stop and pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1259,6 +1377,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     submit_sources: {
+      annotations: { title: 'Deliver sources to the gate', ...WRITES },
       description:
         `Deliver game sources for the gate. files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES} items; kitEngineRef required (from get_kit / kit.json). ` +
         'Subject to delivery cap and filename allowlist. Run kit checks green before submitting. Reply includes stop and pendingMessages. ' +
@@ -1370,6 +1489,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_gate_verdict: {
+      annotations: { title: 'Poll the gate verdict', ...READS },
       description:
         'Poll the gate verdict for a delivery (default: latest). Verdicts typically land in 2–5 minutes; ' +
         'poll every ~30s until green, red, or kit_outdated. kit_outdated is terminal — stop polling, ' +
@@ -1406,6 +1526,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     read_inbox: {
+      annotations: { title: 'Read creator messages', ...READS },
       description:
         'Read pending creator messages and control (stop). Prefer this when idle; mutating tools also piggyback pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1437,6 +1558,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     ack_inbox: {
+      outputSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, ...REPLY_CONTROL },
+        required: ['ok'],
+      },
+      annotations: { title: 'Acknowledge creator messages', ...WRITES_ONCE },
       description:
         'Acknowledge creator inbox message ids after you have applied them. This is a write — the reply includes stop and pendingMessages ' +
         'so a concurrent stop or newly queued message is visible without a separate poll. ' +
@@ -1563,6 +1690,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             name,
             description: tool.description,
             inputSchema: tool.inputSchema,
+            ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+            ...(tool.annotations ? { annotations: tool.annotations } : {}),
           })),
         }),
       );


### PR DESCRIPTION
ChatGPT badges `list_examples` **DESTRUCTIVE**, and it is right to.

MCP's annotation defaults are not "unknown" — an un-annotated tool reads as `readOnlyHint: false` and `destructiveHint: true`. So every tool on this surface was claiming it might destroy something. `get_brief`, `get_kit`, `get_sources` and `list_examples` read and nothing else, and even the writers deliver, report or open. **Nothing here deletes anything.**

That badge is worse than cosmetic: it is shown to a creator at the moment they decide whether to let an agent run, and a warning that is wrong on the safe tools teaches people to ignore it on the dangerous ones.

All fourteen tools now carry annotations with a human-readable title, and the readers say so.

## outputSchema

Declared for the tools whose payload **this file constructs** — `start`, `open_round`, `get_sources`, `list_examples`, and the `report_progress` / `send_screenshot` / `ack_inbox` replies that share the `{ ok, stop, pendingMessages }` shape.

Left undeclared, deliberately, for `get_brief`, `get_seed`, `get_kit`, `get_example`, `get_gate_verdict` and `read_inbox`: those return the channel's body verbatim, and declaring a shape this file does not build would assert a contract it cannot keep. A wrong `outputSchema` is worse than a missing one — it makes a model plan against a payload that never arrives. Doing those properly means pinning the channel's own response types first, which is a separate change.

## Verification

Both tests fail against the unfixed source, the first with `start has no annotations: expected undefined to be truthy`. The annotation test asserts across **every** tool rather than a sample, so a tool added later without annotations fails it.

Gate by exit code: `type-check`, `lint`, `test`, `build` all 0. api 2020, web 955.

## Note

`create_game` (#495) is not annotated here — it doesn't exist on master yet. I'll add its annotations to that branch so neither PR blocks the other, and whichever lands second carries the pair.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_