### PR TITLE
Kill catalog scroll jank (moments, hover, paint)

### DIFF
--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -91,7 +91,7 @@ describe('catalog playback', () => {
     // Default still prefers a mid-capture over `opening`.
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
     expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png');
-    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     const previewButton = container.querySelector<HTMLButtonElement>('.preview-toggle');
     await act(async () => {
@@ -103,6 +103,7 @@ describe('catalog playback', () => {
     expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
     expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png');
     expect(previewButton?.textContent).toContain('Pause preview');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     // history.pushState fires nothing, so in-app navigation is announced explicitly
     // for listeners outside App (analytics). Without it their only option is to

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -129,7 +129,7 @@ describe('ArcadeCatalog lazy media', () => {
     vi.restoreAllMocks();
   });
 
-  it('loads posters near the fold but arms video only on preview intent', async () => {
+  it('loads posters near the fold but arms video and moments only on preview intent', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
     const container = document.createElement('div');
@@ -162,12 +162,11 @@ describe('ArcadeCatalog lazy media', () => {
       await flushEffects();
     });
 
-    // Near-fold: poster image only — no MP4 fetch until hover / play.
-    // Default still prefers a mid-capture over `opening` (often an empty ready frame).
+    // Near-fold: poster only — no moment thumbs and no MP4 until engage.
     expect(container.querySelectorAll('video')).toHaveLength(0);
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
     expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png');
-    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     await act(async () => {
       container.querySelector<HTMLButtonElement>('.preview-toggle')?.click();
@@ -177,6 +176,7 @@ describe('ArcadeCatalog lazy media', () => {
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
     expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     // The second card still has no media srcs — it never intersected.
     expect(container.querySelectorAll('video')).toHaveLength(1);

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -189,6 +189,65 @@ describe('ArcadeCatalog lazy media', () => {
     });
   });
 
+  it('opens moments on video-less cards via the moments toggle', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
+    const stillsOnly: CatalogEntry[] = [
+      {
+        ...entries[0]!,
+        slug: 'stills-only',
+        title: 'Stills Only',
+        media: {
+          screenshots: [
+            { name: 'opening', file: 'opening.png' },
+            { name: 'mid', file: 'mid.png' },
+          ],
+          video: null,
+        },
+      },
+    ];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: stillsOnly,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const media = container.querySelector('.catalog-media')!;
+    expect(media.getAttribute('tabindex')).toBe('0');
+    await act(async () => {
+      intersect(observers[0]!, media, true);
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
+    const toggle = container.querySelector<HTMLButtonElement>('.preview-toggle');
+    expect(toggle?.getAttribute('aria-label')).toMatch(/Show moments/i);
+
+    await act(async () => {
+      toggle?.click();
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(container.querySelectorAll('video')).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('unloads poster and video when a card leaves the viewport', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -36,7 +36,7 @@ import {
 } from './recommendationsApi.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { useInView } from './useInView.js';
-import { isCatalogScrolling, watchCatalogScrollIdle } from './catalogScrollIdle.js';
+import { isCatalogScrolling, watchCatalogScrollIdle, whenCatalogScrollIdle } from './catalogScrollIdle.js';
 
 type ArcadeCatalogProps = {
   catalogStatus: 'loading' | 'ready' | 'error';
@@ -84,6 +84,8 @@ function CatalogCard({
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
   const hoverTimerRef = useRef<number | null>(null);
+  const hoveringRef = useRef(false);
+  const cancelIdleWaitRef = useRef<(() => void) | null>(null);
   // Poster when near the fold; video/moments only after deliberate engage (dwell hover,
   // keyboard focus, or play). Leave-view unloads so scrolled-away cards stay light.
   const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '80px 0px', once: false });
@@ -96,16 +98,20 @@ function CatalogCard({
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
   const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
   const hasVideo = Boolean(entry.media?.video);
+  const hasMoments = screenshots.length > 1;
   const videoUrl =
     hasVideo && inView && videoArmed && entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
-  const showMoments = extrasOpen && inView && screenshots.length > 1;
+  const showMoments = extrasOpen && inView && hasMoments;
 
   useEffect(() => {
     if (inView) return;
+    hoveringRef.current = false;
     if (hoverTimerRef.current != null) {
       window.clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;
     }
+    cancelIdleWaitRef.current?.();
+    cancelIdleWaitRef.current = null;
     setExtrasOpen(false);
     setVideoArmed(false);
     setIsPreviewPlaying(false);
@@ -128,7 +134,10 @@ function CatalogCard({
 
   useEffect(
     () => () => {
+      hoveringRef.current = false;
       if (hoverTimerRef.current != null) window.clearTimeout(hoverTimerRef.current);
+      cancelIdleWaitRef.current?.();
+      cancelIdleWaitRef.current = null;
     },
     [],
   );
@@ -169,19 +178,38 @@ function CatalogCard({
       window.clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;
     }
+    cancelIdleWaitRef.current?.();
+    cancelIdleWaitRef.current = null;
+  }
+
+  /** Open moments (and arm video when present) once the pointer is idle over the card. */
+  function armExtrasFromHover() {
+    if (!hoveringRef.current) return;
+    if (isCatalogScrolling()) {
+      // Inertial scroll can leave the cursor parked on the same card — wait for idle
+      // instead of discarding the intent until the user re-enters.
+      cancelIdleWaitRef.current?.();
+      cancelIdleWaitRef.current = whenCatalogScrollIdle(() => {
+        cancelIdleWaitRef.current = null;
+        armExtrasFromHover();
+      });
+      return;
+    }
+    setExtrasOpen(true);
+    if (hasVideo) armPreview();
   }
 
   function scheduleHoverIntent() {
     clearHoverIntent();
+    hoveringRef.current = true;
     hoverTimerRef.current = window.setTimeout(() => {
       hoverTimerRef.current = null;
-      if (isCatalogScrolling()) return;
-      setExtrasOpen(true);
-      if (hasVideo) armPreview();
+      armExtrasFromHover();
     }, HOVER_INTENT_MS);
   }
 
   function endHoverIntent() {
+    hoveringRef.current = false;
     clearHoverIntent();
     if (isPreviewPinned) return;
     setExtrasOpen(false);
@@ -189,6 +217,7 @@ function CatalogCard({
   }
 
   function togglePreview() {
+    hoveringRef.current = false;
     clearHoverIntent();
     if (isPreviewPlaying) {
       setIsPreviewPinned(false);
@@ -197,6 +226,19 @@ function CatalogCard({
       setExtrasOpen(true);
       setIsPreviewPinned(true);
       armPreview();
+    }
+  }
+
+  /** Video-less cards have no play toggle — pin/unpin the moment strip explicitly. */
+  function toggleMoments() {
+    hoveringRef.current = false;
+    clearHoverIntent();
+    if (extrasOpen) {
+      setIsPreviewPinned(false);
+      setExtrasOpen(false);
+    } else {
+      setExtrasOpen(true);
+      setIsPreviewPinned(true);
     }
   }
 
@@ -211,7 +253,7 @@ function CatalogCard({
       <div
         ref={mediaRef}
         className="catalog-media"
-        tabIndex={hasVideo ? 0 : undefined}
+        tabIndex={hasVideo || hasMoments ? 0 : undefined}
         onPointerEnter={(event) => {
           if (event.pointerType === 'mouse') scheduleHoverIntent();
         }}
@@ -225,6 +267,8 @@ function CatalogCard({
         }}
         onBlur={(event) => {
           if (event.currentTarget.contains(event.relatedTarget)) return;
+          hoveringRef.current = false;
+          clearHoverIntent();
           setIsPreviewPinned(false);
           setExtrasOpen(false);
           stopPreview();
@@ -284,6 +328,24 @@ function CatalogCard({
               <span className="btn-label">
                 {isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
               </span>
+            </button>
+          )}
+
+          {/* Cards without a trailer still need a deliberate, accessible way to open
+              the moment strip — hover dwell is mouse-only and media focus is easy to
+              miss on touch. Reuse the preview-toggle chrome so the badge column stays
+              one shape. */}
+          {!hasVideo && hasMoments && (
+            <button
+              type="button"
+              className="preview-toggle"
+              aria-pressed={extrasOpen}
+              aria-label={extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}
+              disabled={!inView}
+              onClick={toggleMoments}
+            >
+              <PixelIcon name="image" size={11} />
+              <span className="btn-label">{extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}</span>
             </button>
           )}
 

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -36,6 +36,7 @@ import {
 } from './recommendationsApi.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { useInView } from './useInView.js';
+import { isCatalogScrolling, watchCatalogScrollIdle } from './catalogScrollIdle.js';
 
 type ArcadeCatalogProps = {
   catalogStatus: 'loading' | 'ready' | 'error';
@@ -66,6 +67,9 @@ function defaultScreenshotIndex(screenshots: Array<{ name: string }>): number {
   return idx >= 0 ? idx : 0;
 }
 
+/** Hover must dwell this long before we fetch moments / arm video — scroll sweeps skip it. */
+const HOVER_INTENT_MS = 240;
+
 function CatalogCard({
   entry,
   isYours = false,
@@ -79,22 +83,30 @@ function CatalogCard({
 }) {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
-  // Poster when near the fold; video `src` only on hover/play. Leave-view unloads
-  // so scrolled-away cards do not keep decoders and MP4 buffers alive.
-  const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '200px 0px', once: false });
+  const hoverTimerRef = useRef<number | null>(null);
+  // Poster when near the fold; video/moments only after deliberate engage (dwell hover,
+  // keyboard focus, or play). Leave-view unloads so scrolled-away cards stay light.
+  const { ref: mediaRef, inView } = useInView<HTMLDivElement>({ rootMargin: '80px 0px', once: false });
   const screenshots = entry.media?.screenshots ?? [];
   const [selectedScreenshot, setSelectedScreenshot] = useState(() => defaultScreenshotIndex(screenshots));
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const [isPreviewPinned, setIsPreviewPinned] = useState(false);
   const [videoArmed, setVideoArmed] = useState(false);
+  const [extrasOpen, setExtrasOpen] = useState(false);
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
   const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
   const hasVideo = Boolean(entry.media?.video);
   const videoUrl =
     hasVideo && inView && videoArmed && entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
+  const showMoments = extrasOpen && inView && screenshots.length > 1;
 
   useEffect(() => {
     if (inView) return;
+    if (hoverTimerRef.current != null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    setExtrasOpen(false);
     setVideoArmed(false);
     setIsPreviewPlaying(false);
     setIsPreviewPinned(false);
@@ -113,6 +125,13 @@ function CatalogCard({
       setIsPreviewPlaying(false);
     }
   }, [videoUrl]);
+
+  useEffect(
+    () => () => {
+      if (hoverTimerRef.current != null) window.clearTimeout(hoverTimerRef.current);
+    },
+    [],
+  );
 
   function armPreview() {
     setVideoArmed(true);
@@ -145,11 +164,37 @@ function CatalogCard({
     setIsPreviewPlaying(false);
   }
 
+  function clearHoverIntent() {
+    if (hoverTimerRef.current != null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }
+
+  function scheduleHoverIntent() {
+    clearHoverIntent();
+    hoverTimerRef.current = window.setTimeout(() => {
+      hoverTimerRef.current = null;
+      if (isCatalogScrolling()) return;
+      setExtrasOpen(true);
+      if (hasVideo) armPreview();
+    }, HOVER_INTENT_MS);
+  }
+
+  function endHoverIntent() {
+    clearHoverIntent();
+    if (isPreviewPinned) return;
+    setExtrasOpen(false);
+    stopPreview();
+  }
+
   function togglePreview() {
+    clearHoverIntent();
     if (isPreviewPlaying) {
       setIsPreviewPinned(false);
       pausePreview();
     } else {
+      setExtrasOpen(true);
       setIsPreviewPinned(true);
       armPreview();
     }
@@ -167,37 +212,23 @@ function CatalogCard({
         ref={mediaRef}
         className="catalog-media"
         tabIndex={hasVideo ? 0 : undefined}
-        onPointerEnter={
-          hasVideo
-            ? (event) => {
-                if (event.pointerType === 'mouse') armPreview();
-              }
-            : undefined
-        }
-        onPointerLeave={
-          hasVideo
-            ? (event) => {
-                if (event.pointerType === 'mouse' && !isPreviewPinned) stopPreview();
-              }
-            : undefined
-        }
-        onFocus={
-          hasVideo
-            ? (event) => {
-                if (event.target === event.currentTarget) armPreview();
-              }
-            : undefined
-        }
-        onBlur={
-          hasVideo
-            ? (event) => {
-                if (!event.currentTarget.contains(event.relatedTarget)) {
-                  setIsPreviewPinned(false);
-                  stopPreview();
-                }
-              }
-            : undefined
-        }
+        onPointerEnter={(event) => {
+          if (event.pointerType === 'mouse') scheduleHoverIntent();
+        }}
+        onPointerLeave={(event) => {
+          if (event.pointerType === 'mouse') endHoverIntent();
+        }}
+        onFocus={(event) => {
+          if (event.target !== event.currentTarget) return;
+          setExtrasOpen(true);
+          if (hasVideo) armPreview();
+        }}
+        onBlur={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget)) return;
+          setIsPreviewPinned(false);
+          setExtrasOpen(false);
+          stopPreview();
+        }}
       >
         {videoUrl ? (
           <video
@@ -284,7 +315,7 @@ function CatalogCard({
 
         <span className="genre-pill">{entry.genre}</span>
 
-        {inView && screenshots.length > 1 && (
+        {showMoments && (
           <div className="catalog-moments" aria-label={t('catalog.gameMoments', { title: entry.title })}>
             {screenshots.slice(0, 4).map((screenshot, index) => (
               <button
@@ -463,6 +494,8 @@ export function ArcadeCatalog({
   const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
   const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
+
+  useEffect(() => watchCatalogScrollIdle(), []);
 
   // Fetch sort signals as soon as the arcade mounts — in parallel with App's
   // catalog fetch — so cold load waits for max(catalog, signals), not their sum.

--- a/apps/web/src/catalogScrollIdle.test.ts
+++ b/apps/web/src/catalogScrollIdle.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isCatalogScrolling,
+  resetCatalogScrollIdleForTests,
+  setCatalogScrollingForTests,
+  watchCatalogScrollIdle,
+} from './catalogScrollIdle.js';
+
+describe('catalogScrollIdle', () => {
+  afterEach(() => {
+    resetCatalogScrollIdleForTests();
+    vi.useRealTimers();
+  });
+
+  it('marks scrolling during scroll events and clears after idle', () => {
+    vi.useFakeTimers();
+    watchCatalogScrollIdle();
+    expect(isCatalogScrolling()).toBe(false);
+
+    window.dispatchEvent(new Event('scroll'));
+    expect(isCatalogScrolling()).toBe(true);
+
+    vi.advanceTimersByTime(139);
+    expect(isCatalogScrolling()).toBe(true);
+    vi.advanceTimersByTime(2);
+    expect(isCatalogScrolling()).toBe(false);
+  });
+
+  it('allows tests to force the flag', () => {
+    setCatalogScrollingForTests(true);
+    expect(isCatalogScrolling()).toBe(true);
+    setCatalogScrollingForTests(false);
+    expect(isCatalogScrolling()).toBe(false);
+  });
+});

--- a/apps/web/src/catalogScrollIdle.test.ts
+++ b/apps/web/src/catalogScrollIdle.test.ts
@@ -6,6 +6,7 @@ import {
   resetCatalogScrollIdleForTests,
   setCatalogScrollingForTests,
   watchCatalogScrollIdle,
+  whenCatalogScrollIdle,
 } from './catalogScrollIdle.js';
 
 describe('catalogScrollIdle', () => {
@@ -33,5 +34,36 @@ describe('catalogScrollIdle', () => {
     expect(isCatalogScrolling()).toBe(true);
     setCatalogScrollingForTests(false);
     expect(isCatalogScrolling()).toBe(false);
+  });
+
+  it('runs whenCatalogScrollIdle immediately when idle', () => {
+    const fn = vi.fn();
+    whenCatalogScrollIdle(fn);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('defers whenCatalogScrollIdle until scrolling settles', () => {
+    vi.useFakeTimers();
+    watchCatalogScrollIdle();
+    window.dispatchEvent(new Event('scroll'));
+
+    const fn = vi.fn();
+    whenCatalogScrollIdle(fn);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(140);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('lets callers cancel a pending idle waiter', () => {
+    vi.useFakeTimers();
+    watchCatalogScrollIdle();
+    window.dispatchEvent(new Event('scroll'));
+
+    const fn = vi.fn();
+    const cancel = whenCatalogScrollIdle(fn);
+    cancel();
+    vi.advanceTimersByTime(140);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/catalogScrollIdle.ts
+++ b/apps/web/src/catalogScrollIdle.ts
@@ -1,0 +1,54 @@
+/**
+ * True while the page (or any nested scroller) is mid-scroll.
+ * Catalog cards use this so hover-intent cannot arm videos / moment strips
+ * while the pointer is merely sweeping the grid during a scroll.
+ */
+
+let scrolling = false;
+let idleTimer: number | null = null;
+let listenersAttached = false;
+
+const IDLE_MS = 140;
+
+function onScroll() {
+  scrolling = true;
+  if (idleTimer != null) window.clearTimeout(idleTimer);
+  idleTimer = window.setTimeout(() => {
+    scrolling = false;
+    idleTimer = null;
+  }, IDLE_MS);
+}
+
+function ensureListeners() {
+  if (listenersAttached || typeof window === 'undefined') return;
+  listenersAttached = true;
+  window.addEventListener('scroll', onScroll, { passive: true, capture: true });
+}
+
+/** Call once from the arcade mount so scroll tracking is live before first hover. */
+export function watchCatalogScrollIdle(): () => void {
+  ensureListeners();
+  return () => {
+    // Keep the listener for the session — multiple ArcadeCatalog mounts would
+    // otherwise thrash add/remove. Tests call {@link resetCatalogScrollIdleForTests}.
+  };
+}
+
+export function isCatalogScrolling(): boolean {
+  ensureListeners();
+  return scrolling;
+}
+
+/** Test-only: clear scroll state between cases. */
+export function resetCatalogScrollIdleForTests(): void {
+  scrolling = false;
+  if (idleTimer != null) {
+    window.clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
+/** Test-only: force the scrolling flag. */
+export function setCatalogScrollingForTests(value: boolean): void {
+  scrolling = value;
+}

--- a/apps/web/src/catalogScrollIdle.ts
+++ b/apps/web/src/catalogScrollIdle.ts
@@ -1,25 +1,37 @@
 /**
- * True while the page (or any nested scroller) is mid-scroll.
- * Catalog cards use this so hover-intent cannot arm videos / moment strips
- * while the pointer is merely sweeping the grid during a scroll.
+ * Shared "is the catalog viewport scrolling?" signal so card hover handlers can
+ * ignore hover that only happens because cards slide under a stationary pointer.
+ *
+ * Also exposes `whenCatalogScrollIdle` so a hover that started during scroll can
+ * still arm once the viewport settles (without needing another mouseenter).
  */
 
 let scrolling = false;
 let idleTimer: number | null = null;
 let listenersAttached = false;
+/** Callbacks waiting for the next idle edge. */
+let idleWaiters: Array<() => void> = [];
 
 const IDLE_MS = 140;
 
-function onScroll() {
+function flushIdleWaiters(): void {
+  if (idleWaiters.length === 0) return;
+  const waiters = idleWaiters;
+  idleWaiters = [];
+  for (const fn of waiters) fn();
+}
+
+function onScroll(): void {
   scrolling = true;
   if (idleTimer != null) window.clearTimeout(idleTimer);
   idleTimer = window.setTimeout(() => {
     scrolling = false;
     idleTimer = null;
+    flushIdleWaiters();
   }, IDLE_MS);
 }
 
-function ensureListeners() {
+function ensureListeners(): void {
   if (listenersAttached || typeof window === 'undefined') return;
   listenersAttached = true;
   window.addEventListener('scroll', onScroll, { passive: true, capture: true });
@@ -34,21 +46,47 @@ export function watchCatalogScrollIdle(): () => void {
   };
 }
 
+/** True while a catalog scroll gesture is in flight (plus a short settle window). */
 export function isCatalogScrolling(): boolean {
   ensureListeners();
   return scrolling;
 }
 
+/**
+ * Run `fn` now if the catalog is idle, otherwise once scrolling settles.
+ * Returns a cancel function for the pending waiter (no-op if `fn` already ran).
+ */
+export function whenCatalogScrollIdle(fn: () => void): () => void {
+  ensureListeners();
+  if (!scrolling) {
+    fn();
+    return () => undefined;
+  }
+  idleWaiters.push(fn);
+  return () => {
+    const i = idleWaiters.indexOf(fn);
+    if (i >= 0) idleWaiters.splice(i, 1);
+  };
+}
+
 /** Test-only: clear scroll state between cases. */
 export function resetCatalogScrollIdleForTests(): void {
   scrolling = false;
+  idleWaiters = [];
   if (idleTimer != null) {
     window.clearTimeout(idleTimer);
     idleTimer = null;
   }
 }
 
-/** Test-only: force the scrolling flag. */
-export function setCatalogScrollingForTests(value: boolean): void {
-  scrolling = value;
+/** Test-only: force the scrolling flag (and flush waiters when clearing). */
+export function setCatalogScrollingForTests(next: boolean): void {
+  scrolling = next;
+  if (!next) {
+    if (idleTimer != null) {
+      window.clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+    flushIdleWaiters();
+  }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -185,6 +185,8 @@
     "watchPreview": "Watch preview",
     "pausePreview": "Pause preview",
     "gameMoments": "Gameplay moments from {{title}}",
+    "showMoments": "Show moments",
+    "hideMoments": "Hide moments",
     "viewMoment": "View {{moment}} from {{title}}",
     "keyboardOnly": "Keyboard only",
     "keyboardOnlyTooltip": "This game has no touch controls — it needs a keyboard.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -185,6 +185,8 @@
     "watchPreview": "Obejrzyj podgląd",
     "pausePreview": "Wstrzymaj podgląd",
     "gameMoments": "Moment rozgrywki z {{title}}",
+    "showMoments": "Pokaż momenty",
+    "hideMoments": "Ukryj momenty",
     "viewMoment": "Zobacz {{moment}} z {{title}}",
     "keyboardOnly": "Tylko klawiatura",
     "keyboardOnlyTooltip": "Ta gra nie ma sterowania dotykowego — wymaga klawiatury.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1193,16 +1193,11 @@ button:disabled {
   /* Skip layout/paint for off-screen cards while scrolling a ~100-game grid. */
   content-visibility: auto;
   contain-intrinsic-size: auto 160px;
-  transition:
-    transform 0.2s,
-    border-color 0.2s,
-    box-shadow 0.2s;
+  transition: border-color 0.15s;
 }
 
 .catalog-card:hover {
-  transform: translateY(-2px);
   border-color: var(--turquoise);
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.24);
 }
 
 .catalog-media {
@@ -1269,9 +1264,8 @@ button:disabled {
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 999px;
   color: #fff;
-  background: rgba(6, 10, 14, 0.84);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  /* Solid scrim — backdrop-filter on every visible card is scroll paint cost. */
+  background: rgba(6, 10, 14, 0.92);
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -1336,9 +1330,7 @@ button:disabled {
   align-items: center;
   gap: 4px;
   color: var(--error);
-  background: rgba(6, 10, 14, 0.86);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  background: rgba(6, 10, 14, 0.92);
   border: 1px solid rgba(255, 107, 107, 0.55);
   font-size: 10px;
   font-weight: 700;
@@ -1435,9 +1427,7 @@ button:disabled {
   white-space: nowrap;
   text-overflow: ellipsis;
   color: #fff;
-  background: rgba(6, 10, 14, 0.82);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  background: rgba(6, 10, 14, 0.92);
   border: 1px solid rgba(255, 255, 255, 0.22);
   font-size: 10px;
   font-weight: 700;
@@ -7066,9 +7056,7 @@ body.player-open {
   align-items: center;
   gap: 4px;
   color: rgba(255, 255, 255, 0.85);
-  background: rgba(6, 10, 14, 0.72);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  background: rgba(6, 10, 14, 0.92);
   border: 1px solid rgba(255, 255, 255, 0.18);
   font-size: 10px;
   font-weight: 600;
@@ -7084,9 +7072,7 @@ body.player-open {
   align-items: center;
   gap: 4px;
   color: var(--turquoise);
-  background: rgba(0, 228, 172, 0.14);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  background: rgba(0, 40, 32, 0.92);
   border: 1px solid rgba(0, 228, 172, 0.35);
   font-size: 10px;
   font-weight: 600;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cut catalog scroll jank after the poster-first media work in #489.

Warm recommendations are already fast; remaining jank came from mounting moment thumbnails (and sometimes video) on every near-fold card during scroll, plus expensive paint (`backdrop-filter`, hover lift/shadow).

### Changes

- **Defer moments** until deliberate engage (240ms hover dwell / focus / play toggle) — near-fold cards stay poster-only while scrolling.
- **Scroll-aware hover** via `catalogScrollIdle`: ignore pointerenter that only happens because cards slide under a stationary cursor; if dwell fires while still scrolling (inertial scroll), **re-arm on scroll idle** instead of discarding the intent.
- **Tighter `rootMargin`** (`80px`) so fewer cards arm posters ahead of the fold.
- **Cheaper paint**: drop catalog `backdrop-filter` and card hover translate/shadow.
- **Video-less multi-screenshot cards**: accessible Show/Hide moments control + tabbable media (Codex P2).

### Test plan

- [x] `npm run type-check && npm run lint`
- [x] `npm test --workspace apps/web -- --run src/catalogScrollIdle.test.ts src/ArcadeCatalog.test.tsx`
- [ ] Manual: scroll the live catalog — posters load near fold; moments/video only after hover dwell or play; video-less cards can open moments via the new control

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

