### PR TITLE
Serve catalog media at the size it is drawn (rebase of #434)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,11 +40,13 @@
     "genaicode": "^2.1.0",
     "google-auth-library": "^10.9.0",
     "jose": "^6.2.4",
+    "pngjs": "^7.0.0",
     "web-push": "^3.6.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.15",
+    "@types/pngjs": "^6.0.5",
     "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1",
     "tsx": "^4.16.5",

--- a/apps/api/src/game-snapshot-publish.test.ts
+++ b/apps/api/src/game-snapshot-publish.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PNG } from 'pngjs';
+import { VARIANT_WIDTHS } from './image-variants.js';
 import { publishSnapshot } from './game-snapshot-publish.js';
 import type { GameSnapshotWriter, SnapshotGame, SnapshotMedia, SnapshotPointer } from './game-snapshot.js';
 import type { CatalogGameEntry, GameSources, GitHubClient } from './github-client.js';
@@ -64,9 +66,10 @@ function createWriterSpy() {
       order.push(`game:${game.slug}`);
       games.set(game.slug, game);
     },
-    async putMedia(_id, slug, filename, value) {
-      order.push(`media:${slug}/${filename}`);
-      media.set(`${slug}/${filename}`, value);
+    async putMedia(_id, slug, filename, value, width) {
+      const key = width === undefined ? `${slug}/${filename}` : `${slug}/w${width}/${filename}`;
+      order.push(`media:${key}`);
+      media.set(key, value);
     },
     async putPointer(value) {
       order.push('pointer');
@@ -268,5 +271,79 @@ describe('publishSnapshot failure handling', () => {
     expect(result.published).toBe(0);
     expect(spy.catalog).toEqual([]);
     expect(spy.pointer?.gameCount).toBe(0);
+  });
+});
+
+/**
+ * Size variants, baked once at publish rather than resized per request. The arcade
+ * shows the same screenshot at ~48 CSS px in the moment strip and a few hundred as a
+ * card poster; serving the original for both is why scrolling a sixty-game arcade was
+ * paying for 240 full-size decodes and requests.
+ */
+describe('publishSnapshot media variants', () => {
+  function pngOfWidth(width: number, height: number): Uint8Array {
+    const png = new PNG({ width, height });
+    for (let i = 0; i < png.data.length; i += 4) {
+      png.data[i] = i % 255;
+      png.data[i + 1] = 40;
+      png.data[i + 2] = 90;
+      png.data[i + 3] = 255;
+    }
+    return new Uint8Array(PNG.sync.write(png));
+  }
+
+  const withMedia = catalogEntry('bubble-pop', {
+    media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+  });
+
+  it('writes a downscaled copy of each screenshot alongside the original', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': pngOfWidth(1280, 720) },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(spy.media.has('bubble-pop/opening.png')).toBe(true);
+    for (const width of VARIANT_WIDTHS) {
+      const variant = spy.media.get(`bubble-pop/w${width}/opening.png`);
+      expect(variant, `w${width}`).toBeDefined();
+      expect(PNG.sync.read(variant!.body).width).toBe(width);
+      // The whole point: materially fewer bytes than the original.
+      expect(variant!.body.byteLength).toBeLessThan(spy.media.get('bubble-pop/opening.png')!.body.byteLength);
+    }
+  });
+
+  it('leaves video alone — variants are a screenshot idea', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': pngOfWidth(1280, 720) },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(spy.media.has('bubble-pop/gameplay.mp4')).toBe(true);
+    for (const width of VARIANT_WIDTHS) {
+      expect(spy.media.has(`bubble-pop/w${width}/gameplay.mp4`)).toBe(false);
+    }
+  });
+
+  // A screenshot smaller than the target, or bytes that are not a readable PNG, must
+  // not fail the bake: the media route falls back to the original, which is what every
+  // snapshot baked before variants existed contains.
+  it('publishes the game even when no variant can be produced', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': new Uint8Array([1, 2, 3]) },
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    expect(spy.media.has('bubble-pop/opening.png')).toBe(true);
+    expect(spy.media.has('bubble-pop/w96/opening.png')).toBe(false);
   });
 });

--- a/apps/api/src/game-snapshot-publish.ts
+++ b/apps/api/src/game-snapshot-publish.ts
@@ -7,6 +7,7 @@ import {
   type SnapshotPointer,
 } from './game-snapshot.js';
 import type { CatalogGameEntry, GitHubClient } from './github-client.js';
+import { downscalePng, VARIANT_WIDTHS } from './image-variants.js';
 
 /**
  * Bakes every published game into the snapshot bucket.
@@ -159,11 +160,33 @@ async function bakeGame(args: {
       // filename until a later bake catches up.
       continue;
     }
+    const body = Buffer.from(bytes);
     await writer.putMedia(snapshotId, entry.slug, filename, {
-      body: Buffer.from(bytes),
+      body,
       contentType: mediaContentType(filename),
     });
     mediaFiles += 1;
+
+    // Size variants for screenshots. The arcade shows the same file at ~48 CSS px in
+    // the moment strip and a few hundred as a card poster; serving the original for
+    // both is four full-screenshot decodes per card on the scroll path, and a PNG
+    // cannot be decoded partially. A variant that cannot be produced is simply not
+    // written — the media route falls back to the original, which is what every
+    // snapshot baked before this contains.
+    if (filename.endsWith('.png')) {
+      for (const width of VARIANT_WIDTHS) {
+        const scaled = downscalePng(body, width);
+        if (!scaled) continue;
+        await writer.putMedia(
+          snapshotId,
+          entry.slug,
+          filename,
+          { body: scaled, contentType: mediaContentType(filename) },
+          width,
+        );
+        mediaFiles += 1;
+      }
+    }
   }
 
   return { mediaFiles };

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -70,9 +70,10 @@ function createSnapshotStub(params: {
   const getGame = vi.fn(async (slug: string) =>
     params.failWith ? fail<SnapshotGame | null>() : (params.games?.[slug] ?? null),
   );
-  const getMedia = vi.fn(async (slug: string, filename: string) => {
+  const getMedia = vi.fn(async (slug: string, filename: string, width?: number) => {
     if (params.failWith) return fail<{ body: Buffer; contentType: string } | null>();
-    const body = params.media?.[`${slug}/${filename}`];
+    const key = width === undefined ? `${slug}/${filename}` : `${slug}/w${width}/${filename}`;
+    const body = params.media?.[key];
     return body ? { body, contentType: 'image/png' } : null;
   });
   const reader: GameSnapshotReader = {
@@ -255,6 +256,92 @@ describe('gallery media', () => {
     expect(response.statusCode).toBe(200);
     expect(response.rawPayload.toString()).toBe('baked-bytes');
     expect(getGameMedia).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  /**
+   * Size variants. The arcade shows the same screenshot at ~48 CSS px in the moment
+   * strip and a few hundred as a card poster; serving the original for both put 240
+   * full-size decodes and requests on the scroll path of a sixty-game arcade.
+   */
+  it('serves the baked size variant when one is asked for', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w96/opening.png': Buffer.from('thumb'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawPayload.toString()).toBe('thumb');
+    await app.close();
+  });
+
+  // Snapshots baked before variants existed have none, and a bake skips a variant it
+  // could not produce. Either way the original is the right answer — a 404 here would
+  // blank the strip on every game published before this shipped.
+  it('falls back to the original when the variant was never baked', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: { 'bubble-pop/opening.png': Buffer.from('full-size') },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawPayload.toString()).toBe('full-size');
+    await app.close();
+  });
+
+  // An allowlist, not a number: an arbitrary `?w=` would be an invitation to fill the
+  // media cache with one entry per width anybody felt like naming.
+  it('ignores a width it does not bake and serves the original', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w97/opening.png': Buffer.from('never-asked-for'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    for (const query of ['?w=97', '?w=abc', '?w=-96', '?w=']) {
+      const response = await app.inject({ method: 'GET', url: `/api/games/bubble-pop/media/opening.png${query}` });
+      expect(response.statusCode, query).toBe(200);
+      expect(response.rawPayload.toString(), query).toBe('full-size');
+    }
+    await app.close();
+  });
+
+  // The cache is keyed per variant, or the first width asked for would be handed to
+  // every other one until the entry expired.
+  it('does not serve one width from another width’s cache entry', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w96/opening.png': Buffer.from('thumb'),
+        'bubble-pop/w640/opening.png': Buffer.from('poster'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const thumb = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+    const poster = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=640' });
+    const full = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
+
+    expect(thumb.rawPayload.toString()).toBe('thumb');
+    expect(poster.rawPayload.toString()).toBe('poster');
+    expect(full.rawPayload.toString()).toBe('full-size');
     await app.close();
   });
 

--- a/apps/api/src/game-snapshot.ts
+++ b/apps/api/src/game-snapshot.ts
@@ -22,6 +22,7 @@ import type { CatalogGameEntry } from './github-client.js';
  *   snapshots/<id>/catalog.json               → CatalogGameEntry[]
  *   snapshots/<id>/games/<slug>.json          → { slug, title, html }
  *   snapshots/<id>/media/<slug>/<filename>    → screenshot / video bytes
+ *   snapshots/<id>/media/<slug>/w<width>/<f>  → downscaled screenshot (see image-variants)
  *
  * Snapshot prefixes are immutable and content-addressed by publish; only
  * `current.json` is ever overwritten. Three things fall out of that:
@@ -87,14 +88,19 @@ export interface GameSnapshotReader {
   getPointer(): Promise<SnapshotPointer | null>;
   getCatalog(): Promise<CatalogGameEntry[] | null>;
   getGame(slug: string): Promise<SnapshotGame | null>;
-  getMedia(slug: string, filename: string): Promise<SnapshotMedia | null>;
+  /**
+   * `width` asks for a baked size variant. Callers must treat a null as "serve the
+   * original": snapshots baked before variants existed have none, and a bake that
+   * could not read one PNG skips only that variant.
+   */
+  getMedia(slug: string, filename: string, width?: number): Promise<SnapshotMedia | null>;
 }
 
 /** The write side, used by the publish job. */
 export interface GameSnapshotWriter {
   putCatalog(snapshotId: string, entries: CatalogGameEntry[]): Promise<void>;
   putGame(snapshotId: string, game: SnapshotGame): Promise<void>;
-  putMedia(snapshotId: string, slug: string, filename: string, media: SnapshotMedia): Promise<void>;
+  putMedia(snapshotId: string, slug: string, filename: string, media: SnapshotMedia, width?: number): Promise<void>;
   putPointer(pointer: SnapshotPointer): Promise<void>;
 }
 
@@ -110,8 +116,12 @@ export function gameObject(snapshotId: string, slug: string): string {
   return `snapshots/${snapshotId}/games/${slug}.json`;
 }
 
-export function mediaObject(snapshotId: string, slug: string, filename: string): string {
-  return `snapshots/${snapshotId}/media/${slug}/${filename}`;
+export function mediaObject(snapshotId: string, slug: string, filename: string, width?: number): string {
+  // Variants live in their own directory rather than behind a filename suffix: the
+  // filename is validated against the game's own catalog entry, and inventing
+  // `opening-96.png` would put a synthetic name into a space real screenshots occupy.
+  const prefix = `snapshots/${snapshotId}/media/${slug}`;
+  return width === undefined ? `${prefix}/${filename}` : `${prefix}/w${width}/${filename}`;
 }
 
 export function mediaContentType(filename: string): string {
@@ -338,12 +348,12 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
       return readJson<SnapshotGame>(gameObject(pointer.snapshotId, slug));
     },
 
-    async getMedia(slug, filename) {
+    async getMedia(slug, filename, width) {
       assertSafeSlug(slug);
       assertSafeMediaFilename(filename);
       const pointer = await this.getPointer();
       if (!pointer) return null;
-      const body = await readObject(mediaObject(pointer.snapshotId, slug, filename));
+      const body = await readObject(mediaObject(pointer.snapshotId, slug, filename, width));
       if (!body) return null;
       return { body, contentType: mediaContentType(filename) };
     },
@@ -369,11 +379,11 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
       );
     },
 
-    async putMedia(snapshotId, slug, filename, media) {
+    async putMedia(snapshotId, slug, filename, media, width) {
       assertSafeSnapshotId(snapshotId);
       assertSafeSlug(slug);
       assertSafeMediaFilename(filename);
-      await writeObject(mediaObject(snapshotId, slug, filename), media.body, media.contentType, IMMUTABLE_CACHE);
+      await writeObject(mediaObject(snapshotId, slug, filename, width), media.body, media.contentType, IMMUTABLE_CACHE);
     },
 
     async putPointer(pointer) {

--- a/apps/api/src/image-variants.test.ts
+++ b/apps/api/src/image-variants.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { PNG } from 'pngjs';
+import { downscalePng, isVariantWidth, VARIANT_WIDTHS } from './image-variants.js';
+
+/** A PNG with a hard vertical split, so averaging is visible in the result. */
+function halfAndHalf(width: number, height: number): Buffer {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) << 2;
+      const left = x < width / 2;
+      png.data[i] = left ? 255 : 0;
+      png.data[i + 1] = left ? 0 : 0;
+      png.data[i + 2] = left ? 0 : 255;
+      png.data[i + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}
+
+function pixel(buffer: Buffer, x: number, y: number) {
+  const png = PNG.sync.read(buffer);
+  const i = (y * png.width + x) << 2;
+  return { r: png.data[i], g: png.data[i + 1], b: png.data[i + 2], a: png.data[i + 3] };
+}
+
+describe('downscalePng', () => {
+  it('scales to the requested width and keeps the aspect ratio', () => {
+    const out = downscalePng(halfAndHalf(1280, 720), 96)!;
+    const png = PNG.sync.read(out);
+    expect(png.width).toBe(96);
+    expect(png.height).toBe(54);
+  });
+
+  it('produces a far smaller file, which is the entire point', () => {
+    const source = halfAndHalf(1280, 720);
+    const out = downscalePng(source, 96)!;
+    expect(out.byteLength).toBeLessThan(source.byteLength / 4);
+  });
+
+  it('keeps the colours where they were', () => {
+    const out = downscalePng(halfAndHalf(1280, 720), 96)!;
+    expect(pixel(out, 5, 20)).toMatchObject({ r: 255, g: 0, b: 0 });
+    expect(pixel(out, 90, 20)).toMatchObject({ r: 0, g: 0, b: 255 });
+  });
+
+  /**
+   * Averaging rather than picking one source pixel. A screenshot of a pixel-art game
+   * downscaled by nearest neighbour turns into aliased noise, which would trade a
+   * performance problem for a visible one.
+   */
+  it('averages across the box rather than sampling a single pixel', () => {
+    const source = new PNG({ width: 4, height: 1 });
+    for (let x = 0; x < 4; x++) {
+      const i = x << 2;
+      source.data[i] = x < 2 ? 0 : 200;
+      source.data[i + 1] = x < 2 ? 0 : 200;
+      source.data[i + 2] = x < 2 ? 0 : 200;
+      source.data[i + 3] = 255;
+    }
+    const out = downscalePng(PNG.sync.write(source), 2)!;
+    const png = PNG.sync.read(out);
+    expect(png.width).toBe(2);
+    // Each destination pixel covers two identical source pixels, so the halves survive
+    // intact — proof the box is being walked rather than one corner being read.
+    expect(png.data[0]).toBe(0);
+    expect(png.data[4]).toBe(200);
+  });
+
+  it('declines when the source is already at or below the target', () => {
+    expect(downscalePng(halfAndHalf(96, 54), 96)).toBeNull();
+    expect(downscalePng(halfAndHalf(64, 36), 96)).toBeNull();
+  });
+
+  // A bake must not die on one odd file: the media route falls back to the original,
+  // which is exactly what every game got before variants existed.
+  it('declines on bytes it cannot read rather than throwing', () => {
+    expect(downscalePng(Buffer.from('not a png at all'), 96)).toBeNull();
+  });
+
+  it('never rounds a very wide, very short image away to nothing', () => {
+    const out = downscalePng(halfAndHalf(4000, 3), 96)!;
+    expect(PNG.sync.read(out).height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('guards the width allowlist the route validates against', () => {
+    expect(VARIANT_WIDTHS).toEqual([96, 640]);
+    expect(isVariantWidth(96)).toBe(true);
+    expect(isVariantWidth(97)).toBe(false);
+  });
+});

--- a/apps/api/src/image-variants.ts
+++ b/apps/api/src/image-variants.ts
@@ -1,0 +1,93 @@
+import { PNG } from 'pngjs';
+
+/**
+ * Size-appropriate copies of catalog screenshots, baked once at publish time.
+ *
+ * The arcade displays the same PNG at two very different sizes: a moment thumbnail
+ * about 48 CSS pixels wide, and a card poster a few hundred. Serving the original for
+ * both means the browser decodes a full screenshot four times per card for thumbnails
+ * nobody has clicked — and **a PNG cannot be decoded partially**, so there is no
+ * client-side trick that avoids it. Measured over a full-page scroll of sixty cards,
+ * that decoding was the whole of the stutter left after the preview players were
+ * dealt with.
+ *
+ * Baking rather than resizing per request: a published game's media changes only when
+ * somebody merges, so this is a constant being recomputed, and the play path is the
+ * one that must never be slow.
+ *
+ * Pure JS on purpose. A native encoder would be faster, but this runs once per bake in
+ * CI rather than per request, and a native dependency is a build and deploy liability
+ * out of all proportion to that.
+ */
+
+/** Widths the catalog asks for: thumbnail strip, then card poster at 2× its CSS box. */
+export const VARIANT_WIDTHS = [96, 640] as const;
+
+export type VariantWidth = (typeof VARIANT_WIDTHS)[number];
+
+export function isVariantWidth(value: number): value is VariantWidth {
+  return (VARIANT_WIDTHS as readonly number[]).includes(value);
+}
+
+/**
+ * Downscale a PNG to `targetWidth`, preserving aspect ratio.
+ *
+ * Returns null when there is nothing to gain — a source already at or below the target
+ * would only be re-encoded, and an unreadable one is not worth failing a bake over
+ * (the route falls back to the original, which is exactly today's behaviour).
+ */
+export function downscalePng(source: Buffer, targetWidth: number): Buffer | null {
+  let image: PNG;
+  try {
+    image = PNG.sync.read(source);
+  } catch {
+    return null;
+  }
+
+  if (image.width <= targetWidth) return null;
+
+  const width = targetWidth;
+  const height = Math.max(1, Math.round((image.height * targetWidth) / image.width));
+  const out = new PNG({ width, height });
+
+  // Box filter: average every source pixel that lands in the destination pixel. Nearest
+  // neighbour is cheaper and looks it — a downscaled screenshot of a pixel-art game
+  // turns into aliased noise, which is worse than the cost this exists to remove.
+  const xRatio = image.width / width;
+  const yRatio = image.height / height;
+
+  for (let y = 0; y < height; y++) {
+    const srcYStart = Math.floor(y * yRatio);
+    const srcYEnd = Math.max(srcYStart + 1, Math.floor((y + 1) * yRatio));
+
+    for (let x = 0; x < width; x++) {
+      const srcXStart = Math.floor(x * xRatio);
+      const srcXEnd = Math.max(srcXStart + 1, Math.floor((x + 1) * xRatio));
+
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      let samples = 0;
+
+      for (let sy = srcYStart; sy < srcYEnd && sy < image.height; sy++) {
+        for (let sx = srcXStart; sx < srcXEnd && sx < image.width; sx++) {
+          const i = (sy * image.width + sx) << 2;
+          r += image.data[i];
+          g += image.data[i + 1];
+          b += image.data[i + 2];
+          a += image.data[i + 3];
+          samples += 1;
+        }
+      }
+
+      const o = (y * width + x) << 2;
+      out.data[o] = Math.round(r / samples);
+      out.data[o + 1] = Math.round(g / samples);
+      out.data[o + 2] = Math.round(b / samples);
+      out.data[o + 3] = Math.round(a / samples);
+    }
+  }
+
+  return PNG.sync.write(out);
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -75,6 +75,7 @@ import {
 } from './submission-status.js';
 import { InvalidTokenError, mintToken, verifyToken } from './submission-token.js';
 import { createTranslatorFromEnv, normalizeLocale, type Translator } from './translate.js';
+import { isVariantWidth } from './image-variants.js';
 import { logModerationRejection } from './moderation-metrics.js';
 
 const CreateSubmissionRequestSchema = z.object({
@@ -1494,9 +1495,17 @@ export async function registerSubmissionRoutes(
   async function readSnapshotMedia(
     slug: string,
     filename: string,
+    width?: number,
   ): Promise<{ body: Buffer; contentType: string } | null> {
     if (!snapshotReader) return null;
     try {
+      if (width !== undefined) {
+        // Fall back rather than 404: snapshots baked before variants existed have
+        // none, and a bake skips a variant it could not produce. Either way the
+        // original is the right answer, and it is what was served before this.
+        const variant = await snapshotReader.getMedia(slug, filename, width);
+        if (variant) return variant;
+      }
       return await snapshotReader.getMedia(slug, filename);
     } catch (error) {
       if (error instanceof SnapshotUnavailableError) throw error;
@@ -4075,6 +4084,12 @@ export async function registerSubmissionRoutes(
       return reply.status(404).send({ error: 'media not found' });
     }
 
+    // An allowlist, not a number: `?w=` naming an arbitrary size would be an invitation
+    // to fill the cache with one entry per width somebody felt like asking for. Anything
+    // else is ignored and the original is served, so a stale client cannot break.
+    const requestedWidth = Number((request.query as { w?: string } | undefined)?.w);
+    const variantWidth = isVariantWidth(requestedWidth) ? requestedWidth : undefined;
+
     const currentTime = now();
     if (isRateLimited(mediaByIp, request.ip, currentTime, maxMediaPerWindow, gamesRateLimitWindowMs)) {
       return reply.status(429).send({ error: 'too many game requests, please try again later' });
@@ -4082,7 +4097,7 @@ export async function registerSubmissionRoutes(
 
     // Serving from cache still respects the allowlist below on the first fetch;
     // a cached entry can only exist for a filename that already passed it.
-    const cacheKey = `${parsedParams.data.slug}/${parsedParams.data.filename}`;
+    const cacheKey = `${parsedParams.data.slug}/${variantWidth ?? 'full'}/${parsedParams.data.filename}`;
     const cachedMedia = mediaCache.get(cacheKey);
     if (cachedMedia && cachedMedia.expiresAt > currentTime) {
       return sendMedia(request, reply, cachedMedia);
@@ -4100,7 +4115,11 @@ export async function registerSubmissionRoutes(
       let body: Buffer | null = null;
       if (entry && allowedFiles.has(parsedParams.data.filename)) {
         if (snapshotReader) {
-          const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
+          const snapshotMedia = await readSnapshotMedia(
+            parsedParams.data.slug,
+            parsedParams.data.filename,
+            variantWidth,
+          );
           body = snapshotMedia?.body ?? null;
         } else {
           const media = await githubClient.getGameMedia(

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -90,8 +90,11 @@ describe('catalog playback', () => {
     // Poster-first: cards near the fold show a still until preview is armed.
     // Default still prefers a mid-capture over `opening`.
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png');
-    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png?w=640');
+    expect(container.querySelector('video')).toBeNull();
+    // The moment strip waits for engagement too — 240 extra elements across a sixty-game
+    // arcade is what the scroll was paying for.
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     const previewButton = container.querySelector<HTMLButtonElement>('.preview-toggle');
     await act(async () => {
@@ -101,7 +104,8 @@ describe('catalog playback', () => {
     });
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png?w=640');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
     expect(previewButton?.textContent).toContain('Pause preview');
 
     // history.pushState fires nothing, so in-app navigation is announced explicitly

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -162,12 +162,14 @@ describe('ArcadeCatalog lazy media', () => {
       await flushEffects();
     });
 
-    // Near-fold: poster image only — no MP4 fetch until hover / play.
-    // Default still prefers a mid-capture over `opening` (often an empty ready frame).
+    // Entering the viewport buys one poster (downscaled — the card box is a few
+    // hundred CSS pixels) and nothing else. Neither the media player nor the moment
+    // strip is on the scroll path any more — see the note on `engaged` in
+    // ArcadeCatalog.tsx. Default still prefers a mid-capture over `opening`.
     expect(container.querySelectorAll('video')).toHaveLength(0);
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png');
-    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png?w=640');
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     await act(async () => {
       container.querySelector<HTMLButtonElement>('.preview-toggle')?.click();
@@ -176,13 +178,15 @@ describe('ArcadeCatalog lazy media', () => {
 
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png?w=640');
 
+    // Engaging reveals the strip as well, at thumbnail size rather than full.
     // The second card still has no media srcs — it never intersected.
     expect(container.querySelectorAll('video')).toHaveLength(1);
-    expect(container.querySelectorAll('.catalog-moment img')).toHaveLength(2);
-    const momentSrcs = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')].map((img) => img.src);
-    expect(momentSrcs.every((src) => src.includes('/api/games/above-fold/'))).toBe(true);
+    const moments = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')];
+    expect(moments).toHaveLength(2);
+    expect(moments.every((img) => img.src.includes('/api/games/above-fold/'))).toBe(true);
+    expect(moments.every((img) => img.getAttribute('src')?.endsWith('?w=96'))).toBe(true);
 
     await act(async () => {
       root.unmount();
@@ -229,6 +233,58 @@ describe('ArcadeCatalog lazy media', () => {
     expect(container.querySelectorAll('video')).toHaveLength(0);
     expect(container.querySelectorAll('img.catalog-preview')).toHaveLength(0);
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  /**
+   * The engagement handlers used to be attached only when a card had a video. Gating
+   * the moment strip on them without fixing that would have left every screenshots-only
+   * game without a strip for good — a silent feature loss on exactly the cards where
+   * the strip is the only thing to look at.
+   */
+  it('reveals the strip on a card that has screenshots but no video', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] })));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const silent: CatalogEntry[] = [{ ...entries[0]!, media: { ...entries[0]!.media!, video: null } }];
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: silent,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const media = container.querySelectorAll<HTMLElement>('.catalog-media')[0]!;
+    await act(async () => {
+      intersect(observers[0]!, media, true);
+      await flushEffects();
+    });
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
+    // Reachable by keyboard even with no preview to play, because there is now
+    // something behind the focus.
+    expect(media.getAttribute('tabindex')).toBe('0');
+
+    await act(async () => {
+      media.focus();
+      await flushEffects();
+    });
+
+    expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
+    expect(container.querySelector('video')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -87,8 +87,27 @@ function CatalogCard({
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const [isPreviewPinned, setIsPreviewPinned] = useState(false);
   const [videoArmed, setVideoArmed] = useState(false);
+  /**
+   * Whether the viewer has engaged with this card at all — pointer over it, keyboard
+   * focus on it, or the preview toggle pressed.
+   *
+   * Gates the moment strip. Four thumbnails per card is 240 extra elements and 240
+   * extra requests across a sixty-game arcade, and measurement says that count — not
+   * the pixels — is what the scroll pays for: serving the thumbnails at 96px instead
+   * of full size (a 40x cut in bytes) moved the hitch count by nothing at all while
+   * the strip was still built for every card. Taking the strip off the scroll path
+   * takes a full-page scroll from a median of 11.5 hitches to 0.5, which is the floor
+   * an arcade with no media at all measures.
+   *
+   * Nobody can pick a moment on a card going past at speed, so nothing is lost while
+   * scrolling. The cost is on touch, where the strip now waits for a tap rather than
+   * being there on arrival.
+   */
+  const [engaged, setEngaged] = useState(false);
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
-  const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
+  // 640 rather than the original: the card box is a few hundred CSS pixels, so this is
+  // roughly 2x what is drawn and a fraction of a full screenshot to decode.
+  const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file, 640) : undefined;
   const hasVideo = Boolean(entry.media?.video);
   const videoUrl =
     hasVideo && inView && videoArmed && entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
@@ -98,6 +117,9 @@ function CatalogCard({
     setVideoArmed(false);
     setIsPreviewPlaying(false);
     setIsPreviewPinned(false);
+    // Engagement resets with the rest: a scrolled-away card gives its strip's
+    // elements back, and coming around again costs one hover to re-reveal.
+    setEngaged(false);
   }, [inView]);
 
   useEffect(() => {
@@ -115,6 +137,9 @@ function CatalogCard({
   }, [videoUrl]);
 
   function armPreview() {
+    // Arming is engagement by definition: it happens on hover, focus or the
+    // toggle press, and any of those should also reveal the moment strip.
+    setEngaged(true);
     setVideoArmed(true);
     const video = videoRef.current;
     if (!video?.src) return;
@@ -166,14 +191,15 @@ function CatalogCard({
       <div
         ref={mediaRef}
         className="catalog-media"
-        tabIndex={hasVideo ? 0 : undefined}
-        onPointerEnter={
-          hasVideo
-            ? (event) => {
-                if (event.pointerType === 'mouse') armPreview();
-              }
-            : undefined
-        }
+        tabIndex={hasVideo || screenshots.length > 1 ? 0 : undefined}
+        // Engagement is tracked whether or not there is a video: a game with
+        // screenshots and no clip still has a moment strip to reveal, and gating that
+        // on `hasVideo` would leave those cards without one for good.
+        onPointerEnter={(event) => {
+          if (event.pointerType !== 'mouse') return;
+          setEngaged(true);
+          if (hasVideo) armPreview();
+        }}
         onPointerLeave={
           hasVideo
             ? (event) => {
@@ -181,13 +207,11 @@ function CatalogCard({
               }
             : undefined
         }
-        onFocus={
-          hasVideo
-            ? (event) => {
-                if (event.target === event.currentTarget) armPreview();
-              }
-            : undefined
-        }
+        onFocus={(event) => {
+          if (event.target !== event.currentTarget) return;
+          setEngaged(true);
+          if (hasVideo) armPreview();
+        }}
         onBlur={
           hasVideo
             ? (event) => {
@@ -284,7 +308,7 @@ function CatalogCard({
 
         <span className="genre-pill">{entry.genre}</span>
 
-        {inView && screenshots.length > 1 && (
+        {engaged && screenshots.length > 1 && (
           <div className="catalog-moments" aria-label={t('catalog.gameMoments', { title: entry.title })}>
             {screenshots.slice(0, 4).map((screenshot, index) => (
               <button
@@ -295,7 +319,7 @@ function CatalogCard({
                 aria-pressed={index === selectedScreenshot}
                 onClick={() => selectScreenshot(index)}
               >
-                <img src={catalogMediaUrl(entry.slug, screenshot.file)} alt="" loading="lazy" decoding="async" />
+                <img src={catalogMediaUrl(entry.slug, screenshot.file, 96)} alt="" loading="lazy" decoding="async" />
               </button>
             ))}
           </div>

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -93,8 +93,18 @@ export interface PublishedGame {
 // only access boundary is the app's own gate. Same origin in production.
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export function catalogMediaUrl(slug: string, filename: string): string {
-  return `${API_BASE}/api/games/${encodeURIComponent(slug)}/media/${encodeURIComponent(filename)}`;
+/**
+ * `width` asks the API for a baked size variant instead of the original screenshot.
+ *
+ * Worth asking for: the arcade shows the same PNG at ~48 CSS px in the moment strip
+ * and a few hundred as a card poster, and a PNG cannot be decoded partially — so
+ * without this the browser decodes a full screenshot four times per card, on the
+ * scroll path, for thumbnails nobody has clicked. An API that has no variant serves
+ * the original, so this is safe to ask for against any deploy.
+ */
+export function catalogMediaUrl(slug: string, filename: string, width?: number): string {
+  const base = `${API_BASE}/api/games/${encodeURIComponent(slug)}/media/${encodeURIComponent(filename)}`;
+  return width === undefined ? base : `${base}?w=${width}`;
 }
 
 function parseCatalogMedia(value: unknown): CatalogMedia | null {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,13 @@
         "genaicode": "^2.1.0",
         "google-auth-library": "^10.9.0",
         "jose": "^6.2.4",
+        "pngjs": "^7.0.0",
         "web-push": "^3.6.7",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^20.14.15",
+        "@types/pngjs": "^6.0.5",
         "@types/web-push": "^3.6.4",
         "@types/ws": "^8.18.1",
         "tsx": "^4.16.5",
@@ -2372,6 +2374,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5276,6 +5288,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {


### PR DESCRIPTION
Rebase of #434 onto current master. The original branch could not be rebased in place, so this PR carries the surviving commit; authorship stays with @jactan77.

What happened to the two commits:

- **"Mount a catalog card's video only when somebody asks to watch it"** — superseded by #489, which shipped the same on-demand video mounting (`videoArmed`). Dropped.
- **"Take the moment strip and full-size decodes off the scroll path"** — still valuable and carried here: screenshots are baked at 96px/640px variants at snapshot publish (`pngjs`, `?w=` allowlist with original fallback for pre-variant snapshots), the poster asks for `?w=640`, moment thumbs for `?w=96`, and the moment strip mounts only after engagement (hover/focus/toggle), with the engagement handlers widened so screenshots-only cards keep their strip and become keyboard-reachable.

Conflict resolution mapped the change onto #489's mechanics: `engaged` state gates the strip and resets on leave-view alongside the rest of the unload path; `armPreview` marks engagement; master's mid-capture poster preference and store-published media fallback are kept.

Verified: type-check green across workspaces; ArcadeCatalog/App.catalog/snapshot-publish/snapshot-serve/image-variants suites (53 tests) and submissions suite (144 tests) all pass, including the new screenshots-only strip test.

Supersedes #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)