### PR TITLE
Move in-progress studio work to a header chip

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1050,7 +1050,6 @@ export function App() {
                 onRetryCatalog={handleRetryCatalog}
                 recommendationsRefreshKey={recommendationsRefreshKey}
                 creatorGamesRefreshKey={myGamesRefreshKey}
-                onOpenStatus={(address) => navigate(studioPath(address))}
                 onOpenStudio={() => navigate(studioPath())}
               />
             )}

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -521,7 +521,7 @@ describe('ArcadeCatalog soft-refresh failure', () => {
   });
 });
 
-describe('ArcadeCatalog in-progress builds', () => {
+describe('ArcadeCatalog Studio chip', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
     sessionStorage.setItem(
@@ -539,7 +539,7 @@ describe('ArcadeCatalog in-progress builds', () => {
     vi.restoreAllMocks();
   });
 
-  it('waits for the creator shelf before painting so in-progress cards do not shove the grid', async () => {
+  it('keeps in-progress builds out of the grid and surfaces them on the Studio chip', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
       user: { uid: 'test-user', tier: 'standard' },
@@ -561,6 +561,7 @@ describe('ArcadeCatalog in-progress builds', () => {
       });
     });
 
+    const onOpenStudio = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -574,16 +575,15 @@ describe('ArcadeCatalog in-progress builds', () => {
           onPlayGame: vi.fn(),
           onPlayTogether: vi.fn(),
           onRetryCatalog: vi.fn(),
-          onOpenStatus: vi.fn(),
+          onOpenStudio,
         }),
       );
       await flushEffects();
     });
 
-    // Catalog + signals are ready, but the shelf is still in flight — keep the
-    // loading state rather than painting a grid that will jump when builds arrive.
-    expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
-    expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
+    // Published grid paints without waiting on the shelf — no shove when builds arrive.
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelector('.catalog-studio-chip')).toBeNull();
 
     await act(async () => {
       resolveMine?.(
@@ -597,6 +597,13 @@ describe('ArcadeCatalog in-progress builds', () => {
                 lastKnownStatus: 'building',
                 slug: 'building-game',
               },
+              {
+                token: 'tok-queued',
+                title: 'Queued Game',
+                createdAt: new Date(Date.now() - 1000).toISOString(),
+                lastKnownStatus: 'queued',
+                slug: null,
+              },
             ],
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
@@ -605,86 +612,17 @@ describe('ArcadeCatalog in-progress builds', () => {
       await flushEffects();
     });
 
-    const cards = container.querySelectorAll('.catalog-card');
-    expect(cards.length).toBe(3);
-    expect(container.querySelectorAll('.catalog-build-card')).toHaveLength(1);
-    expect(cards[0]?.classList.contains('catalog-build-card')).toBe(true);
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelectorAll('.catalog-build-card')).toHaveLength(0);
+    const chip = container.querySelector<HTMLButtonElement>('.catalog-studio-chip');
+    expect(chip?.classList.contains('is-live')).toBe(true);
+    expect(chip?.textContent).toMatch(/2 in progress/i);
+    expect(chip?.textContent).toMatch(/Studio/i);
 
     await act(async () => {
-      root.unmount();
+      chip?.click();
     });
-  });
-
-  it('passes slug or token to onOpenStatus when opening an in-progress card', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
-      user: { uid: 'test-user', tier: 'standard' },
-      loading: false,
-      privateBeta: false,
-    } as ReturnType<typeof AuthContextModule.useAuth>);
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.includes('/api/submissions/mine')) {
-        return new Response(
-          JSON.stringify({
-            submissions: [
-              {
-                token: 'token-with-slug',
-                title: 'Building Game 1',
-                createdAt: new Date().toISOString(),
-                lastKnownStatus: 'building',
-                slug: 'my-cool-game',
-              },
-              {
-                token: 'token-without-slug',
-                title: 'Building Game 2',
-                createdAt: new Date(Date.now() - 1000).toISOString(),
-                lastKnownStatus: 'queued',
-                slug: null,
-              },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      return new Response(JSON.stringify({ items: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    });
-
-    const onOpenStatus = vi.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        createElement(ArcadeCatalog, {
-          catalogStatus: 'ready',
-          catalogError: null,
-          catalogEntries: entries,
-          onPlayGame: vi.fn(),
-          onPlayTogether: vi.fn(),
-          onRetryCatalog: vi.fn(),
-          onOpenStatus,
-        }),
-      );
-      await flushEffects();
-    });
-
-    const openButtons = container.querySelectorAll<HTMLButtonElement>('.catalog-build-card .primary-btn');
-    expect(openButtons).toHaveLength(2);
-
-    await act(async () => {
-      openButtons[0]?.click();
-    });
-    expect(onOpenStatus).toHaveBeenLastCalledWith('my-cool-game');
-
-    await act(async () => {
-      openButtons[1]?.click();
-    });
-    expect(onOpenStatus).toHaveBeenLastCalledWith('token-without-slug');
+    expect(onOpenStudio).toHaveBeenCalledOnce();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -539,6 +539,82 @@ describe('ArcadeCatalog in-progress builds', () => {
     vi.restoreAllMocks();
   });
 
+  it('waits for the creator shelf before painting so in-progress cards do not shove the grid', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+      user: { uid: 'test-user', tier: 'standard' },
+      loading: false,
+      privateBeta: false,
+    } as ReturnType<typeof AuthContextModule.useAuth>);
+
+    let resolveMine: ((value: Response) => void) | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/submissions/mine')) {
+        return new Promise<Response>((resolve) => {
+          resolveMine = resolve;
+        });
+      }
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+          onOpenStatus: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // Catalog + signals are ready, but the shelf is still in flight — keep the
+    // loading state rather than painting a grid that will jump when builds arrive.
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
+    expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
+
+    await act(async () => {
+      resolveMine?.(
+        new Response(
+          JSON.stringify({
+            submissions: [
+              {
+                token: 'tok-build',
+                title: 'Building Game',
+                createdAt: new Date().toISOString(),
+                lastKnownStatus: 'building',
+                slug: 'building-game',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+      await flushEffects();
+    });
+
+    const cards = container.querySelectorAll('.catalog-card');
+    expect(cards.length).toBe(3);
+    expect(container.querySelectorAll('.catalog-build-card')).toHaveLength(1);
+    expect(cards[0]?.classList.contains('catalog-build-card')).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('passes slug or token to onOpenStatus when opening an in-progress card', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -556,6 +556,11 @@ export function ArcadeCatalog({
   const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
   const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
+  // Signed-in creators get in-progress cards (and "Yours" pins) prepended to the
+  // grid. Waiting for that first shelf fetch avoids painting the published grid
+  // and then shoving it aside when the builds arrive — the jump people notice.
+  // Refresh ticks and post-submit bumps update in place without re-blocking.
+  const [creatorGamesReady, setCreatorGamesReady] = useState(() => !viewerUid);
 
   useEffect(() => watchCatalogScrollIdle(), []);
 
@@ -595,16 +600,26 @@ export function ArcadeCatalog({
     };
   }, [recommendationsRefreshKey, viewerUid]);
 
-  // Creator games (published + in progress) — only while the gallery is visible.
+  // Block grid paint again when the viewer (or locale) changes — a different
+  // shelf must not flash under the previous one's layout.
   useEffect(() => {
-    if (!user) {
+    if (!viewerUid) {
       setCreatorItems([]);
+      setCreatorGamesReady(true);
       return;
     }
-    if (catalogStatus === 'loading') return;
+    setCreatorGamesReady(false);
+  }, [viewerUid, locale]);
+
+  // Creator games (published + in progress). Starts with the arcade mount so cold
+  // load waits for max(catalog, signals, shelf), not catalog then shelf in series.
+  useEffect(() => {
+    if (!viewerUid) return;
     let cancelled = false;
     void loadCreatorGames(locale).then((items) => {
-      if (!cancelled) setCreatorItems(items);
+      if (cancelled) return;
+      setCreatorItems(items);
+      setCreatorGamesReady(true);
     });
     const timer = window.setInterval(() => {
       void loadCreatorGames(locale).then((items) => {
@@ -615,7 +630,7 @@ export function ArcadeCatalog({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [user, catalogStatus, creatorGamesRefreshKey, locale]);
+  }, [viewerUid, creatorGamesRefreshKey, locale]);
 
   // Close the sort menu on outside tap or Escape — phones have no hover to dismiss it.
   useEffect(() => {
@@ -688,6 +703,7 @@ export function ArcadeCatalog({
   }
   const awaitingSignals =
     catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
+  const awaitingCreatorShelf = Boolean(viewerUid) && !creatorGamesReady;
 
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
@@ -795,7 +811,7 @@ export function ArcadeCatalog({
         </div>
       ) : null}
 
-      {catalogStatus === 'loading' || awaitingSignals ? (
+      {catalogStatus === 'loading' || awaitingSignals || awaitingCreatorShelf ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
           <p>{t('catalog.loading')}</p>
         </MascotMoment>

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -19,8 +19,6 @@ import {
 } from './catalogSort.js';
 import {
   CREATOR_LIVE_STATUSES,
-  CREATOR_STATUS_ICONS,
-  inProgressCreatorGames,
   loadCreatorGames,
   publishedCreatorSlugs,
   type CreatorGameItem,
@@ -34,7 +32,6 @@ import {
   readCachedCatalogSortPayload,
   type CatalogSortPayload,
 } from './recommendationsApi.js';
-import { formatRelativeTime } from './relativeTime.js';
 import { useInView } from './useInView.js';
 import { isCatalogScrolling, watchCatalogScrollIdle, whenCatalogScrollIdle } from './catalogScrollIdle.js';
 
@@ -47,10 +44,8 @@ type ArcadeCatalogProps = {
   onRetryCatalog: () => void;
   /** Bump after a play so the grid can re-sort from fresh affinity. */
   recommendationsRefreshKey?: number;
-  /** Bump after a new submission so in-progress cards appear immediately. */
+  /** Bump after a new submission so the Studio chip refreshes. */
   creatorGamesRefreshKey?: number;
-  /** Open the studio view for an in-progress build or creator game by address (slug or token). */
-  onOpenStatus?: (address: string) => void;
   onOpenStudio?: () => void;
 };
 
@@ -501,34 +496,6 @@ function initialSignals(viewerUid: string | null): { signals: CatalogSortSignals
   return { signals: payloadToSignals(cached), ready: true };
 }
 
-function InProgressCard({ item, onOpen }: { item: CreatorGameItem; onOpen: (address: string) => void }) {
-  const { t, i18n } = useTranslation();
-  const status = item.status;
-  const isLive = status !== null && CREATOR_LIVE_STATUSES.has(status);
-  // Prefer the permanent address when we have one — the status token still works, but
-  // it is the capability grant the studio was redesigned to keep out of the URL bar.
-  const address = item.slug ?? item.token;
-
-  return (
-    <article className={`catalog-card catalog-build-card${isLive ? ' is-live' : ''}`}>
-      <div className="catalog-build-body">
-        <span className={`my-game-status my-game-status-${status ?? 'unknown'}`}>
-          <PixelIcon name={status ? CREATOR_STATUS_ICONS[status] : 'clock'} size={12} />{' '}
-          {status ? t(`statusView.states.${status}.label`) : t('myGames.checking')}
-        </span>
-        <span className="yours-pill catalog-build-yours">
-          <PixelIcon name="user" size={10} /> {t('catalog.yoursBadge')}
-        </span>
-        <h3 className="card-title">{item.title}</h3>
-        <p className="catalog-build-meta">{formatRelativeTime(item.createdAt, i18n.language)}</p>
-        <button type="button" className="primary-btn" onClick={() => onOpen(address)}>
-          <PixelIcon name="eye" size={13} /> {t('myGames.open')}
-        </button>
-      </div>
-    </article>
-  );
-}
-
 export function ArcadeCatalog({
   catalogStatus,
   catalogError,
@@ -538,7 +505,6 @@ export function ArcadeCatalog({
   onRetryCatalog,
   recommendationsRefreshKey = 0,
   creatorGamesRefreshKey = 0,
-  onOpenStatus,
   onOpenStudio,
 }: ArcadeCatalogProps) {
   const { t, i18n } = useTranslation();
@@ -556,11 +522,6 @@ export function ArcadeCatalog({
   const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
   const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
-  // Signed-in creators get in-progress cards (and "Yours" pins) prepended to the
-  // grid. Waiting for that first shelf fetch avoids painting the published grid
-  // and then shoving it aside when the builds arrive — the jump people notice.
-  // Refresh ticks and post-submit bumps update in place without re-blocking.
-  const [creatorGamesReady, setCreatorGamesReady] = useState(() => !viewerUid);
 
   useEffect(() => watchCatalogScrollIdle(), []);
 
@@ -600,26 +561,16 @@ export function ArcadeCatalog({
     };
   }, [recommendationsRefreshKey, viewerUid]);
 
-  // Block grid paint again when the viewer (or locale) changes — a different
-  // shelf must not flash under the previous one's layout.
+  // Creator shelf feeds the Studio chip and "Yours" pins — never the grid itself.
+  // Fetch in parallel; when it lands the chip appears without shoving published cards.
   useEffect(() => {
     if (!viewerUid) {
       setCreatorItems([]);
-      setCreatorGamesReady(true);
       return;
     }
-    setCreatorGamesReady(false);
-  }, [viewerUid, locale]);
-
-  // Creator games (published + in progress). Starts with the arcade mount so cold
-  // load waits for max(catalog, signals, shelf), not catalog then shelf in series.
-  useEffect(() => {
-    if (!viewerUid) return;
     let cancelled = false;
     void loadCreatorGames(locale).then((items) => {
-      if (cancelled) return;
-      setCreatorItems(items);
-      setCreatorGamesReady(true);
+      if (!cancelled) setCreatorItems(items);
     });
     const timer = window.setInterval(() => {
       void loadCreatorGames(locale).then((items) => {
@@ -655,17 +606,17 @@ export function ArcadeCatalog({
   }, [sortMenuOpen]);
 
   const mySlugs = useMemo(() => publishedCreatorSlugs(creatorItems), [creatorItems]);
-  const inProgress = useMemo(() => inProgressCreatorGames(creatorItems), [creatorItems]);
+  const hasInProgress = useMemo(() => creatorItems.some((item) => item.status !== 'published'), [creatorItems]);
   const liveCount = useMemo(
-    () => inProgress.filter((item) => item.status !== null && CREATOR_LIVE_STATUSES.has(item.status)).length,
-    [inProgress],
+    () => creatorItems.filter((item) => item.status !== null && CREATOR_LIVE_STATUSES.has(item.status)).length,
+    [creatorItems],
   );
+  const showStudioChip = Boolean(onOpenStudio) && (hasInProgress || mySlugs.size > 0);
 
   const hasCatalog = catalogStatus === 'ready' && catalogEntries.length > 0;
-  const hasBuilds = inProgress.length > 0;
-  // My games only makes sense when signed in and you actually have something yours.
-  const canFilterYourGames = Boolean(user) && (mySlugs.size > 0 || hasBuilds);
-  const showControls = hasCatalog || hasBuilds;
+  // My games only makes sense when signed in and you have a published game of yours.
+  const canFilterYourGames = Boolean(user) && mySlugs.size > 0;
+  const showControls = hasCatalog;
   const yourGamesOnly = canFilterYourGames && filters.has('your_games');
   const notPlayedOnly = filters.has('not_played');
   const filtersActive = yourGamesOnly || notPlayedOnly;
@@ -703,7 +654,6 @@ export function ArcadeCatalog({
   }
   const awaitingSignals =
     catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
-  const awaitingCreatorShelf = Boolean(viewerUid) && !creatorGamesReady;
 
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
@@ -714,32 +664,39 @@ export function ArcadeCatalog({
           ? t('catalog.emptyNotPlayed')
           : t('catalog.empty');
   const showEmpty =
-    !awaitingSignals &&
-    catalogStatus !== 'loading' &&
-    catalogStatus !== 'error' &&
-    orderedEntries.length === 0 &&
-    inProgress.length === 0;
+    !awaitingSignals && catalogStatus !== 'loading' && catalogStatus !== 'error' && orderedEntries.length === 0;
+
+  const studioChipLabel =
+    liveCount > 0
+      ? `${t('myGames.liveCount', { count: liveCount })} — ${t('myGames.openStudio')}`
+      : t('myGames.openStudio');
 
   return (
     <section id="arcade" className="arcade-section">
       <div className="arcade-header">
         <div className="arcade-title-row">
           <h2 className="arcade-title">{t('catalog.title')}</h2>
-          {liveCount > 0 ? (
-            <span className="status-live catalog-live-count">
-              <span className="live-dot" aria-hidden="true" />
-              {t('myGames.liveCount', { count: liveCount })}
-            </span>
-          ) : null}
-          {onOpenStudio && (hasBuilds || mySlugs.size > 0) ? (
-            <button type="button" className="secondary-btn catalog-studio-btn" onClick={onOpenStudio}>
-              <PixelIcon name="wrench" size={12} /> {t('myGames.openStudio')}
+          {showStudioChip ? (
+            <button
+              type="button"
+              className={`catalog-studio-chip${liveCount > 0 ? ' is-live' : ''}`}
+              onClick={onOpenStudio}
+              aria-label={studioChipLabel}
+            >
+              {liveCount > 0 ? (
+                <>
+                  <span className="live-dot" aria-hidden="true" />
+                  <span className="catalog-studio-chip-count">{t('myGames.liveCount', { count: liveCount })}</span>
+                </>
+              ) : null}
+              <PixelIcon name="wrench" size={12} />
+              <span className="catalog-studio-chip-label">{t('myGames.openStudio')}</span>
             </button>
           ) : null}
         </div>
         {showControls ? (
           <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>
-            {hasCatalog && canFilterYourGames ? (
+            {canFilterYourGames ? (
               <button
                 type="button"
                 className={`catalog-filter-trigger${yourGamesOnly ? ' is-active' : ''}`}
@@ -749,55 +706,51 @@ export function ArcadeCatalog({
                 {t('catalog.filter.your_games')}
               </button>
             ) : null}
-            {hasCatalog ? (
+            <button
+              type="button"
+              className={`catalog-filter-trigger${notPlayedOnly ? ' is-active' : ''}`}
+              aria-pressed={notPlayedOnly}
+              onClick={() => toggleFilter('not_played')}
+            >
+              {t('catalog.filter.not_played')}
+            </button>
+            <div className={`catalog-sort-menu${sortMenuOpen ? ' is-open' : ''}`} ref={sortMenuRef}>
               <button
                 type="button"
-                className={`catalog-filter-trigger${notPlayedOnly ? ' is-active' : ''}`}
-                aria-pressed={notPlayedOnly}
-                onClick={() => toggleFilter('not_played')}
+                className="catalog-sort-trigger"
+                aria-expanded={sortMenuOpen}
+                aria-haspopup="menu"
+                aria-label={t('catalog.sortLabel')}
+                onClick={() => setSortMenuOpen((open) => !open)}
               >
-                {t('catalog.filter.not_played')}
+                <span className="catalog-sort-trigger-label">{t(`catalog.sort.${sortMode}`)}</span>
+                <span className="catalog-sort-caret" aria-hidden="true">
+                  ▾
+                </span>
               </button>
-            ) : null}
-            {hasCatalog ? (
-              <div className={`catalog-sort-menu${sortMenuOpen ? ' is-open' : ''}`} ref={sortMenuRef}>
-                <button
-                  type="button"
-                  className="catalog-sort-trigger"
-                  aria-expanded={sortMenuOpen}
-                  aria-haspopup="menu"
-                  aria-label={t('catalog.sortLabel')}
-                  onClick={() => setSortMenuOpen((open) => !open)}
-                >
-                  <span className="catalog-sort-trigger-label">{t(`catalog.sort.${sortMode}`)}</span>
-                  <span className="catalog-sort-caret" aria-hidden="true">
-                    ▾
-                  </span>
-                </button>
-                {sortMenuOpen ? (
-                  <ul className="catalog-sort-panel" role="menu" aria-label={t('catalog.sortLabel')}>
-                    {CATALOG_SORT_MODES.map((mode) => (
-                      <li key={mode} role="none">
-                        <button
-                          type="button"
-                          role="menuitemradio"
-                          className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
-                          aria-checked={sortMode === mode}
-                          onClick={() => handleSortChange(mode)}
-                        >
-                          {sortMode === mode ? (
-                            <PixelIcon name="check" size={12} />
-                          ) : (
-                            <span className="catalog-sort-check-spacer" />
-                          )}
-                          <span className="catalog-sort-option-label">{t(`catalog.sort.${mode}`)}</span>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </div>
-            ) : null}
+              {sortMenuOpen ? (
+                <ul className="catalog-sort-panel" role="menu" aria-label={t('catalog.sortLabel')}>
+                  {CATALOG_SORT_MODES.map((mode) => (
+                    <li key={mode} role="none">
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        className={`catalog-sort-option${sortMode === mode ? ' is-active' : ''}`}
+                        aria-checked={sortMode === mode}
+                        onClick={() => handleSortChange(mode)}
+                      >
+                        {sortMode === mode ? (
+                          <PixelIcon name="check" size={12} />
+                        ) : (
+                          <span className="catalog-sort-check-spacer" />
+                        )}
+                        <span className="catalog-sort-option-label">{t(`catalog.sort.${mode}`)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </div>
@@ -811,11 +764,11 @@ export function ArcadeCatalog({
         </div>
       ) : null}
 
-      {catalogStatus === 'loading' || awaitingSignals || awaitingCreatorShelf ? (
+      {catalogStatus === 'loading' || awaitingSignals ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
           <p>{t('catalog.loading')}</p>
         </MascotMoment>
-      ) : catalogStatus === 'error' && inProgress.length === 0 ? (
+      ) : catalogStatus === 'error' ? (
         <MascotMoment className="load-error" emotion="sad" size={64} title={t('mascot.sadAlt')}>
           <p className="error" role="alert">
             {t('catalog.error', { message: catalogError ?? t('errors.generic') })}
@@ -827,7 +780,7 @@ export function ArcadeCatalog({
       ) : showEmpty ? (
         <MascotMoment className="catalog-state" emotion="curious" size={64} title={t('mascot.curiousAlt')}>
           <p>{emptyMessage}</p>
-          {filtersActive && (catalogEntries.length > 0 || mySlugs.size > 0 || hasBuilds) ? (
+          {filtersActive && (catalogEntries.length > 0 || mySlugs.size > 0) ? (
             <button type="button" className="secondary-btn" onClick={clearFilters}>
               {t('catalog.clearFilters')}
             </button>
@@ -835,9 +788,6 @@ export function ArcadeCatalog({
         </MascotMoment>
       ) : (
         <div className="catalog-grid">
-          {onOpenStatus
-            ? inProgress.map((item) => <InProgressCard key={item.token} item={item} onOpen={onOpenStatus} />)
-            : null}
           {orderedEntries.map((entry) => (
             <CatalogCard
               key={entry.slug}

--- a/apps/web/src/creatorGames.ts
+++ b/apps/web/src/creatorGames.ts
@@ -3,9 +3,9 @@ import { getSubmissionStatus, listMySubmissions, type SubmissionState } from './
 import type { PixelIconName } from './PixelIcon.js';
 
 /**
- * Creator-owned games for the home gallery. Published ones pin at the front of
- * the catalog; in-progress builds render as cards in the same grid so there is
- * no separate "Your games" section.
+ * Creator-owned games for the home arcade. Published ones pin at the front of
+ * the catalog and earn a "Yours" badge; in-progress builds feed the Studio chip
+ * beside the Games heading (not the grid — mixing them shoved published cards).
  *
  * Statuses come from the store (kept current by the notify sweep) — one list
  * request, no per-card GitHub reads. Locally saved specs fill gaps for
@@ -22,14 +22,9 @@ export const CREATOR_STATUS_ICONS: Record<SubmissionState, PixelIconName> = {
   abandoned: 'trash',
 };
 
-export const CREATOR_LIVE_STATUSES = new Set<SubmissionState>([
-  'queued',
-  'building',
-  'in_review',
-  'publishing',
-]);
+export const CREATOR_LIVE_STATUSES = new Set<SubmissionState>(['queued', 'building', 'in_review', 'publishing']);
 
-/** How many in-progress builds the home gallery shows. Full shelf is Studio. */
+/** Cap kept for callers that still want a short in-progress list. Full shelf is Studio. */
 export const MAX_IN_PROGRESS_IN_GALLERY = 4;
 
 export type CreatorGameItem = {
@@ -89,16 +84,12 @@ export async function loadCreatorGames(locale: string): Promise<CreatorGameItem[
   return visible.map((item) => byToken.get(item.token) ?? item).filter((item) => item.status !== 'abandoned');
 }
 
-/** Builds still in flight — shown as cards ahead of the published catalog. */
+/** Builds still in flight (capped). The arcade uses a count for the Studio chip. */
 export function inProgressCreatorGames(items: CreatorGameItem[]): CreatorGameItem[] {
-  return items
-    .filter((item) => item.status !== 'published')
-    .slice(0, MAX_IN_PROGRESS_IN_GALLERY);
+  return items.filter((item) => item.status !== 'published').slice(0, MAX_IN_PROGRESS_IN_GALLERY);
 }
 
 /** Published slugs owned by the creator — pin these first in the catalog grid. */
 export function publishedCreatorSlugs(items: CreatorGameItem[]): Set<string> {
-  return new Set(
-    items.flatMap((item) => (item.status === 'published' && item.slug ? [item.slug] : [])),
-  );
+  return new Set(items.flatMap((item) => (item.status === 'published' && item.slug ? [item.slug] : [])));
 }

--- a/apps/web/src/styles.catalogGrid.test.ts
+++ b/apps/web/src/styles.catalogGrid.test.ts
@@ -15,11 +15,10 @@ function ruleBody(selector: string): string {
   return match![1]!;
 }
 
-describe('catalog grid next to in-progress cards', () => {
+describe('catalog grid layout', () => {
   /**
-   * Regression: an in-progress "Yours" card in the first row stretched the published
-   * neighbours to its height. Those cards are only a 16:9 video, so the stretch showed
-   * up as empty padding under the preview.
+   * Cards in a row must not stretch to a taller neighbour — published cards are a
+   * single 16:9 media box, and any leftover empty padding under the preview looks broken.
    */
   it('does not stretch cards in a row to the tallest neighbour', () => {
     const rule = ruleBody('.catalog-grid');

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -981,49 +981,54 @@ button:disabled {
   min-width: 0;
 }
 
-.catalog-live-count {
+/* Compact Studio entry next to Games — live count + wrench in one control so
+   in-progress work never owns a catalog grid cell (or shoves published cards). */
+.catalog-studio-chip {
+  display: inline-flex;
   flex: none;
-  font-size: 0.8rem;
-}
-
-.catalog-studio-btn {
-  flex: none;
+  align-items: center;
+  gap: 7px;
   min-height: 36px;
   padding: 0.35rem 0.75rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: var(--panel-card);
+  color: var(--text);
   font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.catalog-build-card {
-  justify-content: center;
-  min-height: 180px;
+.catalog-studio-chip:hover,
+.catalog-studio-chip:focus-visible {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
 }
 
-.catalog-build-card.is-live {
-  border-color: rgba(45, 212, 191, 0.4);
-  box-shadow: 0 0 18px rgba(45, 212, 191, 0.08);
+.catalog-studio-chip.is-live {
+  border-color: rgba(56, 189, 248, 0.35);
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--accent-blue);
 }
 
-.catalog-build-body {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 18px;
+.catalog-studio-chip.is-live:hover,
+.catalog-studio-chip.is-live:focus-visible {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
 }
 
-.catalog-build-yours {
-  /* Static badge on build cards — not over media. */
-  position: static;
+.catalog-studio-chip-count {
+  font-weight: 700;
 }
 
-.catalog-build-meta {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.85rem;
+.catalog-studio-chip .live-dot {
+  background: var(--accent-blue);
 }
 
-.catalog-build-body .primary-btn {
-  margin-top: auto;
+@media (pointer: coarse), (max-width: 768px) {
+  .catalog-studio-chip {
+    min-height: 44px;
+  }
 }
 
 .arcade-subtitle {
@@ -1175,10 +1180,8 @@ button:disabled {
   display: grid;
   gap: 20px;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  /* Published cards are a single 16:9 media box. A build card in the same row is often
-     taller (status + title + Open), and the grid's default stretch would grow every
-     neighbour to match — leaving empty panel padding under their videos. Keep each
-     card at its own height. */
+  /* Published cards are a single 16:9 media box. Keep each card at its own height so
+     a taller neighbour cannot stretch the row and leave empty padding under previews. */
   align-items: start;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In-progress studio builds no longer occupy catalog grid cells. That was the layout jump: published games painted first, then build cards prepended and shoved everything.

**Now:** the arcade grid is published games only. Signed-in creators with in-progress (or published) work get a compact **Studio chip** beside the Games title — live count when builds are active, one tap into Studio. Works on phone and desktop without fighting bottom overlays.

Also drops the earlier “hold paint until shelf” approach from this branch; with builds out of the grid, the catalog can paint immediately and the chip appears when ready.

## Test plan

- [x] `npm run type-check && npm run lint`
- [x] `npm test --workspace apps/web -- --run src/ArcadeCatalog.test.tsx src/styles.catalogGrid.test.ts src/creatorGames.test.ts`
- [ ] Signed in with builds: catalog paints stable; chip shows “N in progress · Studio” and opens Studio
- [ ] Signed in, only published yours: chip shows Studio (no live count); My games filter still works
- [ ] Signed out: no chip; catalog unchanged
- [ ] Mobile: chip is a 44px tap target and wraps cleanly in the title row

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

