### PR TITLE
fix: annotate create_game, which merged in after the rule that requires it

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1202,7 +1202,7 @@ describe('POST /api/mcp (BY-05)', () => {
 
     // Only these: the rest return the channel's body verbatim, and declaring a shape
     // this file does not construct would be asserting a contract it cannot keep.
-    for (const name of ['start', 'open_round', 'get_sources', 'list_examples', 'report_progress']) {
+    for (const name of ['start', 'create_game', 'open_round', 'get_sources', 'list_examples', 'report_progress']) {
       expect(tools.find((tool) => tool.name === name)?.outputSchema?.type, name).toBe('object');
     }
     const startSchema = tools.find((tool) => tool.name === 'start')?.outputSchema as {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -843,6 +843,22 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     create_game: {
+      annotations: {
+        title: 'Create a game',
+        // Additive: it makes a game that did not exist and removes nothing. The daily
+        // creation allowance it spends is the whole blast radius.
+        ...WRITES,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'number' },
+          slug: { type: 'string', description: 'Pass this to start().' },
+          studioUrl: { type: 'string' },
+          next: { type: 'string' },
+        },
+        required: ['jobId', 'slug'],
+      },
       description:
         "Create a new game on the creator's account and open its first build round. " +
         'Accepts Authorization: Bearer (creator key or OAuth access) — a per-game key cannot create ' +


### PR DESCRIPTION
**Master is red.** Merge this first.

```
× annotates every tool, so a reader is not advertised as destructive
  → create_game has no annotations: expected undefined to be truthy
```

#496 asserts every tool carries annotations. #495 added `create_game` without them. Merging in that order put a tool on master the rule cannot accept.

The test did exactly what it was written to do — *a tool added later must not inherit the destructive default silently* — and it caught the case one merge after being written.

## The annotation

`create_game` is **additive**: it makes a game that did not exist and removes nothing. The daily creation allowance it spends is the whole blast radius, so `WRITES` rather than `CONSUMES` — the distinction #496 introduced for `submit_sources` and `ack_inbox`, which consume a capped delivery and make messages stop appearing.

`outputSchema` is declared for the same reason as its siblings: this file constructs that payload, so the shape is one it can keep.

## Verification

Reproduced red on `origin/master` before fixing, green after. Gate by exit code: `type-check`, `lint`, `test`, `build` all 0.

## On the ordering

I flagged this sequencing while both PRs were open and did not make it impossible — a warning in a message is not a mechanism. The mechanism now exists: annotating a tool is covered by a test, so the next tool added without one fails CI rather than shipping a wrong badge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_