### PR TITLE
fix(web): claim handle in a modal at publish need

### DIFF
--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -34,7 +34,8 @@ const REFUSAL_COPY: Record<PublishRefusal, string> = {
   gate_red: 'the gate failed this version — read its report before publishing',
   not_gated: 'the gate has not run against this version yet',
   nothing_delivered: 'this build has never delivered a version',
-  profile_required: 'the creator has not claimed a public profile — ask them to claim a handle in Studio',
+  profile_required:
+    'the creator has not claimed a public profile — ask them to open Studio and use Claim handle to publish',
   store_unavailable: 'the games store is not configured on this deployment',
   unknown: 'refused, and the reason was not one this console knows',
 };

--- a/apps/web/src/ClaimHandleModal.tsx
+++ b/apps/web/src/ClaimHandleModal.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useId, type FormEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { useStudioCreatorProfile } from './studioCreatorProfile.js';
+import { PixelIcon } from './PixelIcon.js';
+import { creatorPath } from './router.js';
+
+/**
+ * Claim a public handle at the publish moment — not as Studio page chrome.
+ * Must render under StudioCreatorProfileProvider.
+ */
+export function ClaimHandleModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const { t } = useTranslation();
+  const formId = useId();
+  const { me, status, handleInput, availability, message, setHandleInput, onClaim, refusalCopy, clearMessage } =
+    useStudioCreatorProfile();
+
+  useEffect(() => {
+    if (isOpen && me?.publishReady) onClose();
+  }, [isOpen, me?.publishReady, onClose]);
+
+  if (!isOpen) return null;
+
+  const previewHandle = (handleInput.trim() || 'you').toLowerCase();
+  const previewPath = creatorPath(previewHandle);
+
+  const handleSubmit = async (event: FormEvent) => {
+    await onClaim(event);
+  };
+
+  const handleClose = () => {
+    clearMessage();
+    onClose();
+  };
+
+  return createPortal(
+    <div className="modal-backdrop" onClick={handleClose} role="presentation">
+      <div
+        className="claim-handle-modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${formId}-heading`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button type="button" className="modal-close-btn" onClick={handleClose} aria-label={t('studioPanel.close')}>
+          &times;
+        </button>
+
+        <header className="claim-handle-modal-head">
+          <h2 id={`${formId}-heading`}>
+            <PixelIcon name="sparkle" size={16} /> {t('creatorProfile.publishGateTitle')}
+          </h2>
+          <p>{t('creatorProfile.publishNudge')}</p>
+          <p className="claim-handle-modal-aside">{t('creatorProfile.editorNeeded')}</p>
+        </header>
+
+        {status === 'loading' ? <p className="creator-profile-editor-quiet">{t('creatorProfile.loading')}</p> : null}
+        {status === 'error' ? (
+          <p className="creator-profile-editor-quiet studio-error">{t('creatorProfile.error')}</p>
+        ) : null}
+
+        {status === 'ready' || status === 'saving' ? (
+          <div className="claim-handle-modal-body">
+            <form className="creator-profile-form" onSubmit={(event) => void handleSubmit(event)}>
+              <label className="creator-profile-field">
+                <span>{t('creatorProfile.handleLabel')}</span>
+                <div className="creator-profile-handle-row">
+                  <span className="creator-profile-at" aria-hidden>
+                    @
+                  </span>
+                  <input
+                    className="creator-profile-input"
+                    value={handleInput}
+                    onChange={(event) => setHandleInput(event.target.value.toLowerCase())}
+                    autoComplete="username"
+                    spellCheck={false}
+                    maxLength={24}
+                    pattern="[a-z][a-z0-9_]{2,23}"
+                    required
+                    autoFocus
+                  />
+                </div>
+                <span className="creator-profile-hint">{t('creatorProfile.handleHint')}</span>
+                {availability && !availability.available ? (
+                  <span className="creator-profile-avail is-taken">{refusalCopy(availability.reason ?? 'taken')}</span>
+                ) : null}
+                {availability?.available ? (
+                  <span className="creator-profile-avail is-free">{t('creatorProfile.available')}</span>
+                ) : null}
+              </label>
+              <div className="creator-profile-form-actions">
+                <button type="submit" className="primary-btn" disabled={status === 'saving'}>
+                  {t('creatorProfile.claimHandle')}
+                </button>
+              </div>
+            </form>
+
+            <aside className="creator-profile-preview" aria-label={t('creatorProfile.previewAria')}>
+              <p className="creator-profile-preview-kicker">{t('creatorProfile.previewKicker')}</p>
+              <div className="creator-profile-preview-card">
+                <span className="creator-profile-preview-letter" aria-hidden>
+                  {previewHandle.charAt(0).toUpperCase() || '?'}
+                </span>
+                <div className="creator-profile-preview-meta">
+                  <p className="creator-profile-preview-name">{previewHandle}</p>
+                  <p className="creator-profile-preview-handle">@{previewHandle}</p>
+                  <p className="creator-profile-preview-path">{previewPath}</p>
+                </div>
+              </div>
+            </aside>
+
+            {message ? (
+              <p className="creator-profile-message" role="status">
+                {message}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/ClaimHandleModal.tsx
+++ b/apps/web/src/ClaimHandleModal.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useId, type FormEvent } from 'react';
+import { useEffect, useId, useRef, type FormEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useStudioCreatorProfile } from './studioCreatorProfile.js';
 import { PixelIcon } from './PixelIcon.js';
 import { creatorPath } from './router.js';
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Claim a public handle at the publish moment — not as Studio page chrome.
@@ -12,16 +15,67 @@ import { creatorPath } from './router.js';
 export function ClaimHandleModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   const { t } = useTranslation();
   const formId = useId();
-  const { me, status, handleInput, availability, message, setHandleInput, onClaim, refusalCopy, clearMessage } =
-    useStudioCreatorProfile();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const {
+    me,
+    status,
+    handleInput,
+    nameInput,
+    availability,
+    message,
+    setHandleInput,
+    onClaim,
+    refusalCopy,
+    clearMessage,
+  } = useStudioCreatorProfile();
 
   useEffect(() => {
     if (isOpen && me?.publishReady) onClose();
   }, [isOpen, me?.publishReady, onClose]);
 
+  // Escape, focus trap, and restore focus to whatever opened the dialog (the claim CTA).
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        clearMessage();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = cardRef.current;
+      if (!root) return;
+      // Do not use offsetParent — it is null for descendants of position:fixed backdrops.
+      const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (el) => !el.hasAttribute('disabled') && el.getClientRects().length > 0,
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey) {
+        if (document.activeElement === first || !root.contains(document.activeElement)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last || !root.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [isOpen, onClose, clearMessage]);
+
   if (!isOpen) return null;
 
   const previewHandle = (handleInput.trim() || 'you').toLowerCase();
+  const previewName = (nameInput.trim() || previewHandle).trim();
+  const previewLetter = previewName.charAt(0).toUpperCase() || '?';
   const previewPath = creatorPath(previewHandle);
 
   const handleSubmit = async (event: FormEvent) => {
@@ -33,14 +87,21 @@ export function ClaimHandleModal({ isOpen, onClose }: { isOpen: boolean; onClose
     onClose();
   };
 
+  const stopCardKey = (event: ReactKeyboardEvent) => {
+    // Backdrop click closes; keep key events on the card from bubbling oddly.
+    event.stopPropagation();
+  };
+
   return createPortal(
-    <div className="modal-backdrop" onClick={handleClose} role="presentation">
+    <div className="modal-backdrop claim-handle-modal-backdrop" onClick={handleClose} role="presentation">
       <div
+        ref={cardRef}
         className="claim-handle-modal-card"
         role="dialog"
         aria-modal="true"
         aria-labelledby={`${formId}-heading`}
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={stopCardKey}
       >
         <button type="button" className="modal-close-btn" onClick={handleClose} aria-label={t('studioPanel.close')}>
           &times;
@@ -99,10 +160,10 @@ export function ClaimHandleModal({ isOpen, onClose }: { isOpen: boolean; onClose
               <p className="creator-profile-preview-kicker">{t('creatorProfile.previewKicker')}</p>
               <div className="creator-profile-preview-card">
                 <span className="creator-profile-preview-letter" aria-hidden>
-                  {previewHandle.charAt(0).toUpperCase() || '?'}
+                  {previewLetter}
                 </span>
                 <div className="creator-profile-preview-meta">
-                  <p className="creator-profile-preview-name">{previewHandle}</p>
+                  <p className="creator-profile-preview-name">{previewName}</p>
                   <p className="creator-profile-preview-handle">@{previewHandle}</p>
                   <p className="creator-profile-preview-path">{previewPath}</p>
                 </div>

--- a/apps/web/src/CreatorProfileEditor.test.tsx
+++ b/apps/web/src/CreatorProfileEditor.test.tsx
@@ -157,6 +157,41 @@ describe('ClaimHandleModal', () => {
     expect(dialog?.querySelector('button.primary-btn')?.textContent).toContain('Claim handle');
   });
 
+  it('closes on Escape', async () => {
+    profileApi.fetchMyProfile.mockResolvedValue({
+      profile: null,
+      publishReady: false,
+      picture: null,
+    });
+    let open = true;
+    root = createRoot(container);
+    const render = () => {
+      root!.render(
+        <StudioCreatorProfileProvider>
+          <ClaimHandleModal
+            isOpen={open}
+            onClose={() => {
+              open = false;
+            }}
+          />
+        </StudioCreatorProfileProvider>,
+      );
+    };
+    await act(async () => {
+      render();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.body.querySelector('.claim-handle-modal-card')).not.toBeNull();
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      render();
+      await Promise.resolve();
+    });
+    expect(open).toBe(false);
+  });
+
   it('reveals the chrome chip after a successful claim without remounting', async () => {
     profileApi.fetchMyProfile.mockResolvedValue({
       profile: null,

--- a/apps/web/src/CreatorProfileEditor.test.tsx
+++ b/apps/web/src/CreatorProfileEditor.test.tsx
@@ -19,11 +19,9 @@ vi.mock('./AuthContext.js', () => ({
   useAuth: () => ({ refreshUser: vi.fn(), user: { uid: 'g:test' } }),
 }));
 
-import {
-  CreatorProfileEditor,
-  StudioCreatorProfileProvider,
-  type CreatorProfileSurface,
-} from './CreatorProfileEditor.js';
+import { ClaimHandleModal } from './ClaimHandleModal.js';
+import { CreatorProfileEditor } from './CreatorProfileEditor.js';
+import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 
 let container: HTMLDivElement;
 let root: Root | null = null;
@@ -45,14 +43,15 @@ afterEach(() => {
   });
   root = null;
   container.remove();
+  document.body.querySelectorAll('.claim-handle-modal-card, .modal-backdrop').forEach((node) => node.remove());
 });
 
-async function draw(surface: CreatorProfileSurface): Promise<void> {
+async function drawChrome(): Promise<void> {
   root = createRoot(container);
   await act(async () => {
     root!.render(
       <StudioCreatorProfileProvider>
-        <CreatorProfileEditor surface={surface} />
+        <CreatorProfileEditor />
       </StudioCreatorProfileProvider>,
     );
   });
@@ -61,13 +60,13 @@ async function draw(surface: CreatorProfileSurface): Promise<void> {
   });
 }
 
-async function drawBoth(): Promise<void> {
+async function drawChromeAndModal(open = true): Promise<void> {
   root = createRoot(container);
   await act(async () => {
     root!.render(
       <StudioCreatorProfileProvider>
-        <CreatorProfileEditor surface="chrome" />
-        <CreatorProfileEditor surface="publish-gate" />
+        <CreatorProfileEditor />
+        <ClaimHandleModal isOpen={open} onClose={() => undefined} />
       </StudioCreatorProfileProvider>,
     );
   });
@@ -84,47 +83,9 @@ describe('CreatorProfileEditor', () => {
       picture: null,
     });
 
-    await draw('chrome');
+    await drawChrome();
 
     expect(container.textContent?.trim() ?? '').toBe('');
-    expect(container.querySelector('.creator-profile-editor')).toBeNull();
-  });
-
-  it('shows the claim form on the publish gate when a handle is missing', async () => {
-    profileApi.fetchMyProfile.mockResolvedValue({
-      profile: null,
-      publishReady: false,
-      picture: null,
-    });
-
-    await draw('publish-gate');
-
-    expect(container.textContent).toContain('Claim a handle to publish');
-    expect(container.textContent).toContain('claim a handle so it can go live');
-    expect(container.querySelector('.creator-profile-editor.is-publish-gate')).toBeTruthy();
-    expect(container.querySelector('.creator-profile-preview')).toBeTruthy();
-    expect(container.querySelector('button.primary-btn')?.textContent).toContain('Claim handle');
-    expect(container.querySelectorAll('button.primary-btn')).toHaveLength(1);
-  });
-
-  it('hides the publish gate once a profile is publish-ready', async () => {
-    profileApi.fetchMyProfile.mockResolvedValue({
-      profile: {
-        handle: 'ada',
-        profileName: 'Ada',
-        bio: '',
-        avatarUrl: null,
-        profileCreatedAt: '2026-08-01T00:00:00.000Z',
-      },
-      publishReady: true,
-      handle: 'ada',
-      profileName: 'Ada',
-      avatarMode: 'letter',
-      picture: null,
-    });
-
-    await draw('publish-gate');
-
     expect(container.querySelector('.creator-profile-editor')).toBeNull();
   });
 
@@ -144,7 +105,7 @@ describe('CreatorProfileEditor', () => {
       picture: null,
     });
 
-    await draw('chrome');
+    await drawChrome();
 
     expect(container.querySelector('.creator-profile-editor.is-collapsed')).toBeTruthy();
     expect(container.textContent).toContain('@ada');
@@ -168,7 +129,7 @@ describe('CreatorProfileEditor', () => {
       picture: null,
     });
 
-    await draw('chrome');
+    await drawChrome();
     const chip = container.querySelector('.creator-profile-chip') as HTMLButtonElement;
     await act(async () => {
       chip.click();
@@ -178,8 +139,25 @@ describe('CreatorProfileEditor', () => {
     expect(container.querySelector('button.primary-btn')?.textContent).toContain('Save profile');
     expect(container.querySelector('details.creator-profile-rename')).toBeTruthy();
   });
+});
 
-  it('shows the chrome chip after a claim on the publish gate without remounting', async () => {
+describe('ClaimHandleModal', () => {
+  it('shows the claim form in a modal when open and a handle is missing', async () => {
+    profileApi.fetchMyProfile.mockResolvedValue({
+      profile: null,
+      publishReady: false,
+      picture: null,
+    });
+
+    await drawChromeAndModal(true);
+
+    const dialog = document.body.querySelector('.claim-handle-modal-card');
+    expect(dialog?.textContent).toContain('Claim a handle to publish');
+    expect(dialog?.textContent).toContain('Pick a unique handle');
+    expect(dialog?.querySelector('button.primary-btn')?.textContent).toContain('Claim handle');
+  });
+
+  it('reveals the chrome chip after a successful claim without remounting', async () => {
     profileApi.fetchMyProfile.mockResolvedValue({
       profile: null,
       publishReady: false,
@@ -200,27 +178,32 @@ describe('CreatorProfileEditor', () => {
       picture: null,
     });
 
-    await drawBoth();
-    expect(container.querySelector('.creator-profile-editor.is-publish-gate')).toBeTruthy();
-    expect(container.querySelector('.creator-profile-editor.is-chrome')).toBeNull();
-
-    const input = container.querySelector('.creator-profile-input') as HTMLInputElement;
+    root = createRoot(container);
     await act(async () => {
-      // Simulate feeds the synthetic event into React's onChange; set the DOM value too
-      // so a stale read of input.value cannot win.
+      root!.render(
+        <StudioCreatorProfileProvider>
+          <CreatorProfileEditor />
+          <ClaimHandleModal isOpen onClose={() => undefined} />
+        </StudioCreatorProfileProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.creator-profile-editor.is-chrome')).toBeNull();
+    const input = document.body.querySelector('.claim-handle-modal-card .creator-profile-input') as HTMLInputElement;
+    await act(async () => {
       input.value = 'ada';
       Simulate.change(input);
     });
-
     await act(async () => {
-      Simulate.submit(container.querySelector('form.creator-profile-form') as HTMLFormElement);
+      Simulate.submit(document.body.querySelector('.claim-handle-modal-card form') as HTMLFormElement);
       await Promise.resolve();
     });
 
     expect(profileApi.claimHandle).toHaveBeenCalledWith('ada');
-    expect(container.querySelector('.creator-profile-editor.is-publish-gate')).toBeNull();
     expect(container.querySelector('.creator-profile-editor.is-chrome')).toBeTruthy();
     expect(container.textContent).toContain('@ada');
-    expect(container.textContent).toContain('Edit profile');
   });
 });

--- a/apps/web/src/CreatorProfileEditor.tsx
+++ b/apps/web/src/CreatorProfileEditor.tsx
@@ -1,193 +1,13 @@
-import { createContext, useContext, useEffect, useId, useState, type FormEvent, type ReactNode } from 'react';
+import { useId, useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from './AuthContext.js';
-import {
-  checkHandleAvailability,
-  claimHandle,
-  fetchMyProfile,
-  updateMyProfile,
-  type AvatarMode,
-  type HandleClaimError,
-  type MeProfile,
-} from './creatorProfileApi.js';
-import { PixelIcon } from './PixelIcon.js';
+import { useStudioCreatorProfile, type StudioCreatorProfile } from './studioCreatorProfile.js';
+import type { AvatarMode, HandleClaimError, MeProfile } from './creatorProfileApi.js';
 import { creatorPath } from './router.js';
 
-/**
- * Studio profile UI — never a permanent claim panel above the shelf.
- *
- * - `chrome`: quiet `@handle · Edit` chip once a profile exists; otherwise nothing.
- * - `publish-gate`: claim form on a game that is waiting to go live without a handle.
- *
- * Both surfaces must share one profile store: claiming on the gate has to reveal the
- * chrome chip without a remount/reload.
- */
-export type CreatorProfileSurface = 'chrome' | 'publish-gate';
+type ProfileStatus = StudioCreatorProfile['status'];
 
-type ProfileStatus = 'loading' | 'ready' | 'saving' | 'error';
-
-type StudioCreatorProfile = {
-  me: MeProfile | null;
-  status: ProfileStatus;
-  handleInput: string;
-  nameInput: string;
-  bioInput: string;
-  avatarMode: AvatarMode;
-  availability: { available: boolean; reason?: HandleClaimError } | null;
-  message: string | null;
-  setHandleInput: (value: string) => void;
-  setNameInput: (value: string) => void;
-  setBioInput: (value: string) => void;
-  setAvatarMode: (value: AvatarMode) => void;
-  onClaim: (event: FormEvent) => Promise<void>;
-  onSaveDetails: (event: FormEvent) => Promise<void>;
-  refusalCopy: (code: HandleClaimError) => string;
-  /** Cleared after chrome collapses following a successful claim/save. */
-  clearMessage: () => void;
-};
-
-const StudioCreatorProfileContext = createContext<StudioCreatorProfile | null>(null);
-
-export function StudioCreatorProfileProvider({ children }: { children: ReactNode }) {
-  const { t } = useTranslation();
-  const { refreshUser } = useAuth();
-  const [me, setMe] = useState<MeProfile | null>(null);
-  const [handleInput, setHandleInput] = useState('');
-  const [nameInput, setNameInput] = useState('');
-  const [bioInput, setBioInput] = useState('');
-  const [avatarMode, setAvatarMode] = useState<AvatarMode>('letter');
-  const [availability, setAvailability] = useState<{ available: boolean; reason?: HandleClaimError } | null>(null);
-  const [status, setStatus] = useState<ProfileStatus>('loading');
-  const [message, setMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    void fetchMyProfile()
-      .then((profile) => {
-        if (cancelled) return;
-        setMe(profile);
-        setHandleInput(profile.handle ?? '');
-        setNameInput(profile.profileName ?? profile.handle ?? '');
-        setBioInput(profile.bio ?? '');
-        setAvatarMode(profile.avatarMode ?? 'letter');
-        setStatus('ready');
-      })
-      .catch(() => {
-        if (!cancelled) setStatus('error');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!handleInput.trim() || (me?.handle && handleInput.trim().toLowerCase() === me.handle)) {
-      setAvailability(null);
-      return;
-    }
-    const handle = handleInput.trim().toLowerCase();
-    const timer = window.setTimeout(() => {
-      void checkHandleAvailability(handle)
-        .then((result) => setAvailability({ available: result.available, reason: result.reason }))
-        .catch(() => setAvailability(null));
-    }, 300);
-    return () => window.clearTimeout(timer);
-  }, [handleInput, me?.handle]);
-
-  const refusalCopy = (code: HandleClaimError): string => {
-    switch (code) {
-      case 'invalid':
-        return t('creatorProfile.errors.invalid');
-      case 'reserved':
-        return t('creatorProfile.errors.reserved');
-      case 'taken':
-        return t('creatorProfile.errors.taken');
-      case 'cooldown':
-        return t('creatorProfile.errors.cooldown');
-      case 'unchanged':
-        return t('creatorProfile.errors.unchanged');
-      default:
-        return t('creatorProfile.errors.unknown');
-    }
-  };
-
-  const applyProfile = (next: MeProfile) => {
-    setMe(next);
-    setHandleInput(next.handle ?? '');
-    setNameInput(next.profileName ?? next.handle ?? '');
-    setBioInput(next.bio ?? '');
-    setAvatarMode(next.avatarMode ?? 'letter');
-  };
-
-  const onClaim = async (event: FormEvent) => {
-    event.preventDefault();
-    setStatus('saving');
-    setMessage(null);
-    try {
-      const next = await claimHandle(handleInput.trim());
-      applyProfile(next);
-      setMessage(t('creatorProfile.claimed'));
-      setStatus('ready');
-      await refreshUser();
-    } catch (err) {
-      const code = ((err as { code?: HandleClaimError }).code ?? 'unknown') as HandleClaimError;
-      setMessage(refusalCopy(code));
-      setStatus('ready');
-    }
-  };
-
-  const onSaveDetails = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!me?.handle) return;
-    setStatus('saving');
-    setMessage(null);
-    try {
-      const next = await updateMyProfile({
-        profileName: nameInput.trim(),
-        bio: bioInput,
-        avatarMode,
-      });
-      applyProfile(next);
-      setMessage(t('creatorProfile.saved'));
-      setStatus('ready');
-      await refreshUser();
-    } catch {
-      setMessage(t('creatorProfile.errors.unknown'));
-      setStatus('ready');
-    }
-  };
-
-  const value: StudioCreatorProfile = {
-    me,
-    status,
-    handleInput,
-    nameInput,
-    bioInput,
-    avatarMode,
-    availability,
-    message,
-    setHandleInput,
-    setNameInput,
-    setBioInput,
-    setAvatarMode,
-    onClaim,
-    onSaveDetails,
-    refusalCopy,
-    clearMessage: () => setMessage(null),
-  };
-
-  return <StudioCreatorProfileContext.Provider value={value}>{children}</StudioCreatorProfileContext.Provider>;
-}
-
-function useStudioCreatorProfile(): StudioCreatorProfile {
-  const ctx = useContext(StudioCreatorProfileContext);
-  if (!ctx) {
-    throw new Error('CreatorProfileEditor requires StudioCreatorProfileProvider');
-  }
-  return ctx;
-}
-
-export function CreatorProfileEditor({ surface }: { surface: CreatorProfileSurface }) {
+/** Quiet Studio chrome: `@handle · Edit` once publish-ready; otherwise nothing. */
+export function CreatorProfileEditor() {
   const { t } = useTranslation();
   const formId = useId();
   const {
@@ -208,175 +28,69 @@ export function CreatorProfileEditor({ surface }: { surface: CreatorProfileSurfa
     refusalCopy,
     clearMessage,
   } = useStudioCreatorProfile();
-  /** Chrome only: stay collapsed until the creator asks to edit. */
   const [chromeExpanded, setChromeExpanded] = useState(false);
 
-  // Chrome stays silent until there is a handle to edit. Publish-gate stays silent once
-  // the gate is clear (or while we do not yet know). Errors only matter on the gate.
-  if (status === 'loading') {
-    if (surface === 'chrome') return null;
-    return (
-      <div className="creator-profile-editor is-loading is-publish-gate" aria-busy="true">
-        <p className="creator-profile-editor-quiet">{t('creatorProfile.loading')}</p>
-      </div>
-    );
-  }
-  if (status === 'error') {
-    if (surface === 'chrome') return null;
-    return (
-      <div className="creator-profile-editor is-error is-publish-gate">
-        <p className="creator-profile-editor-quiet studio-error">{t('creatorProfile.error')}</p>
-      </div>
-    );
-  }
+  if (status === 'loading' || status === 'error') return null;
 
   const publishReady = Boolean(me?.publishReady);
+  if (!publishReady || !me?.handle) return null;
 
-  if (surface === 'chrome') {
-    if (!publishReady || !me?.handle) return null;
-
-    if (!chromeExpanded) {
-      return (
-        <section className="creator-profile-editor is-collapsed is-chrome" aria-label={t('creatorProfile.editorTitle')}>
-          <div className="creator-profile-chip-row">
-            <button
-              type="button"
-              className="creator-profile-chip"
-              onClick={() => setChromeExpanded(true)}
-              aria-expanded={false}
-            >
-              <span className="creator-profile-chip-letter" aria-hidden>
-                {(me.profileName || me.handle).charAt(0).toUpperCase()}
-              </span>
-              <span className="creator-profile-chip-label">
-                @{me.handle}
-                <span className="creator-profile-chip-sep">·</span>
-                {t('creatorProfile.editProfile')}
-              </span>
-            </button>
-            <a className="creator-profile-chip-link" href={creatorPath(me.handle)}>
-              {t('creatorProfile.viewPublic')}
-            </a>
-          </div>
-        </section>
-      );
-    }
-
+  if (!chromeExpanded) {
     return (
-      <ProfileEditPanel
-        formId={formId}
-        me={me}
-        handleInput={handleInput}
-        nameInput={nameInput}
-        bioInput={bioInput}
-        avatarMode={avatarMode}
-        availability={availability}
-        status={status}
-        message={message}
-        surfaceClass="is-chrome"
-        title={t('creatorProfile.editorTitle')}
-        copy={t('creatorProfile.editorReady')}
-        onDone={() => {
-          setChromeExpanded(false);
-          clearMessage();
-        }}
-        onHandleChange={setHandleInput}
-        onNameChange={setNameInput}
-        onBioChange={setBioInput}
-        onAvatarModeChange={setAvatarMode}
-        onSaveDetails={async (event) => {
-          await onSaveDetails(event);
-          setChromeExpanded(false);
-        }}
-        onClaim={onClaim}
-        refusalCopy={refusalCopy}
-      />
+      <section className="creator-profile-editor is-collapsed is-chrome" aria-label={t('creatorProfile.editorTitle')}>
+        <div className="creator-profile-chip-row">
+          <button
+            type="button"
+            className="creator-profile-chip"
+            onClick={() => setChromeExpanded(true)}
+            aria-expanded={false}
+          >
+            <span className="creator-profile-chip-letter" aria-hidden>
+              {(me.profileName || me.handle).charAt(0).toUpperCase()}
+            </span>
+            <span className="creator-profile-chip-label">
+              @{me.handle}
+              <span className="creator-profile-chip-sep">·</span>
+              {t('creatorProfile.editProfile')}
+            </span>
+          </button>
+          <a className="creator-profile-chip-link" href={creatorPath(me.handle)}>
+            {t('creatorProfile.viewPublic')}
+          </a>
+        </div>
+      </section>
     );
   }
 
-  // publish-gate
-  if (publishReady) return null;
-
-  const previewHandle = (handleInput.trim() || 'you').toLowerCase();
-  const previewName = (nameInput.trim() || previewHandle).trim();
-  const previewLetter = previewName.charAt(0).toUpperCase() || '?';
-  const previewPath = creatorPath(previewHandle);
-
   return (
-    <section
-      className="creator-profile-editor is-expanded needs-handle is-publish-gate"
-      aria-labelledby={`${formId}-heading`}
-    >
-      <header className="creator-profile-editor-head">
-        <div className="creator-profile-editor-head-row">
-          <h2 id={`${formId}-heading`} className="creator-profile-editor-title">
-            {t('creatorProfile.publishGateTitle')}
-          </h2>
-        </div>
-        <p className="creator-profile-nudge" role="status">
-          <PixelIcon name="sparkle" size={12} /> {t('creatorProfile.publishNudge')}
-        </p>
-        <p className="creator-profile-editor-copy">{t('creatorProfile.editorNeeded')}</p>
-      </header>
-
-      <div className="creator-profile-editor-body">
-        <div className="creator-profile-editor-forms">
-          <form className="creator-profile-form" onSubmit={(event) => void onClaim(event)}>
-            <label className="creator-profile-field">
-              <span>{t('creatorProfile.handleLabel')}</span>
-              <div className="creator-profile-handle-row">
-                <span className="creator-profile-at" aria-hidden>
-                  @
-                </span>
-                <input
-                  className="creator-profile-input"
-                  value={handleInput}
-                  onChange={(event) => setHandleInput(event.target.value.toLowerCase())}
-                  autoComplete="username"
-                  spellCheck={false}
-                  maxLength={24}
-                  pattern="[a-z][a-z0-9_]{2,23}"
-                  required
-                  autoFocus
-                />
-              </div>
-              <span className="creator-profile-hint">{t('creatorProfile.handleHint')}</span>
-              {availability && !availability.available ? (
-                <span className="creator-profile-avail is-taken">{refusalCopy(availability.reason ?? 'taken')}</span>
-              ) : null}
-              {availability?.available ? (
-                <span className="creator-profile-avail is-free">{t('creatorProfile.available')}</span>
-              ) : null}
-            </label>
-            <div className="creator-profile-form-actions">
-              <button type="submit" className="primary-btn" disabled={status === 'saving'}>
-                {t('creatorProfile.claimHandle')}
-              </button>
-            </div>
-          </form>
-
-          {message ? (
-            <p className="creator-profile-message" role="status">
-              {message}
-            </p>
-          ) : null}
-        </div>
-
-        <aside className="creator-profile-preview" aria-label={t('creatorProfile.previewAria')}>
-          <p className="creator-profile-preview-kicker">{t('creatorProfile.previewKicker')}</p>
-          <div className="creator-profile-preview-card">
-            <span className="creator-profile-preview-letter" aria-hidden>
-              {previewLetter}
-            </span>
-            <div className="creator-profile-preview-meta">
-              <p className="creator-profile-preview-name">{previewName}</p>
-              <p className="creator-profile-preview-handle">@{previewHandle}</p>
-              <p className="creator-profile-preview-path">{previewPath}</p>
-            </div>
-          </div>
-        </aside>
-      </div>
-    </section>
+    <ProfileEditPanel
+      formId={formId}
+      me={me}
+      handleInput={handleInput}
+      nameInput={nameInput}
+      bioInput={bioInput}
+      avatarMode={avatarMode}
+      availability={availability}
+      status={status}
+      message={message}
+      surfaceClass="is-chrome"
+      title={t('creatorProfile.editorTitle')}
+      copy={t('creatorProfile.editorReady')}
+      onDone={() => {
+        setChromeExpanded(false);
+        clearMessage();
+      }}
+      onHandleChange={setHandleInput}
+      onNameChange={setNameInput}
+      onBioChange={setBioInput}
+      onAvatarModeChange={setAvatarMode}
+      onSaveDetails={async (event) => {
+        await onSaveDetails(event);
+        setChromeExpanded(false);
+      }}
+      onClaim={onClaim}
+      refusalCopy={refusalCopy}
+    />
   );
 }
 

--- a/apps/web/src/CreatorStudioView.claimGate.test.tsx
+++ b/apps/web/src/CreatorStudioView.claimGate.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreatorStudioView } from './CreatorStudioView.js';
+import i18n from './i18n/index.js';
+import type { StudioGame, StudioGamesResponse } from './studioApi.js';
+
+const fetchStudioGames = vi.fn();
+const fetchStudioHealth = vi.fn();
+const fetchStudioScorecards = vi.fn();
+const fetchStudioSuggestions = vi.fn();
+let authUser: { uid: string; name: string; handle?: string } | null = null;
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: authUser, logout: vi.fn(), refreshUser: vi.fn() }),
+}));
+
+vi.mock('./studioApi', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi.js')>('./studioApi.js');
+  return {
+    ...actual,
+    fetchStudioGames: (...args: unknown[]) => fetchStudioGames(...args),
+    fetchStudioHealth: (...args: unknown[]) => fetchStudioHealth(...args),
+    fetchStudioScorecards: (...args: unknown[]) => fetchStudioScorecards(...args),
+    fetchStudioSuggestions: (...args: unknown[]) => fetchStudioSuggestions(...args),
+    submitImprovement: vi.fn(),
+  };
+});
+
+vi.mock('./submissionApi', async () => {
+  const actual = await vi.importActual<typeof import('./submissionApi.js')>('./submissionApi.js');
+  return {
+    ...actual,
+    getSubmissionStatus: vi.fn(async () => ({ status: 'in_review', phase: 'ready_for_review', builder: 'self' })),
+    getSubmissionPreview: vi.fn(async () => {
+      throw Object.assign(new Error('no preview'), { status: 409 });
+    }),
+    getChannelPlayable: vi.fn(async () => {
+      throw Object.assign(new Error('no channel'), { status: 409 });
+    }),
+    abandonSubmission: vi.fn(),
+  };
+});
+
+vi.mock('./creatorProfileApi.js', () => ({
+  fetchMyProfile: vi.fn(async () => ({ profile: null, publishReady: false, picture: null })),
+  claimHandle: vi.fn(),
+  updateMyProfile: vi.fn(),
+  checkHandleAvailability: vi.fn(async () => ({ available: true })),
+}));
+
+function studioShelf(games: StudioGame[]): StudioGamesResponse {
+  return { games, truncated: false, totalGames: games.length };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('CreatorStudioView claim-handle gate', () => {
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:creator', name: 'Creator' };
+    fetchStudioGames.mockReset();
+    fetchStudioHealth.mockReset().mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset().mockResolvedValue([]);
+    fetchStudioSuggestions.mockReset().mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.querySelectorAll('.claim-handle-modal-card, .modal-backdrop').forEach((node) => node.remove());
+    window.history.pushState(null, '', '/');
+    vi.clearAllMocks();
+  });
+
+  async function renderInReview(handle?: string) {
+    if (handle) authUser = { uid: 'g:creator', name: 'Creator', handle };
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'tok-review',
+          title: 'Neon Drift',
+          createdAt: '2026-08-01T00:00:00.000Z',
+          lastKnownStatus: 'in_review',
+          slug: 'neon-drift',
+        },
+      ]),
+    );
+    window.history.replaceState(null, '', '/studio/neon-drift');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(CreatorStudioView, {
+          selectedGame: 'neon-drift',
+          onNavigate: vi.fn(),
+          onPlay: vi.fn(),
+        }),
+      );
+    });
+    await act(async () => {
+      await fetchStudioGames.mock.results[0]?.value;
+      await flush();
+      await flush();
+    });
+    return { container, root };
+  }
+
+  it('shows Claim handle to publish when an in_review game has no handle', async () => {
+    const { container, root } = await renderInReview();
+    const cta = container.querySelector('.studio-head-action--claim') as HTMLButtonElement | null;
+    expect(cta).not.toBeNull();
+    expect(cta?.textContent).toContain('Claim a handle to publish');
+    await act(async () => root.unmount());
+  });
+
+  it('hides the claim CTA once the creator already has a handle', async () => {
+    const { container, root } = await renderInReview('ada');
+    expect(container.querySelector('.studio-head-action--claim')).toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it('opens the claim modal from the CTA', async () => {
+    const { container, root } = await renderInReview();
+    const cta = container.querySelector('.studio-head-action--claim') as HTMLButtonElement;
+    await act(async () => {
+      cta.click();
+      await flush();
+    });
+    expect(document.body.querySelector('.claim-handle-modal-card')).not.toBeNull();
+    expect(document.body.querySelector('.claim-handle-modal-card')?.textContent).toContain('Claim a handle to publish');
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -2,7 +2,9 @@ import { useEffect, useId, useMemo, useRef, useState, type RefObject } from 'rea
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
-import { CreatorProfileEditor, StudioCreatorProfileProvider } from './CreatorProfileEditor.js';
+import { ClaimHandleModal } from './ClaimHandleModal.js';
+import { CreatorProfileEditor } from './CreatorProfileEditor.js';
+import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 import type { GameHealth } from './healthApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
@@ -166,6 +168,8 @@ export function CreatorStudioView({
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
   const [authOpen, setAuthOpen] = useState(false);
+  /** Claim-handle modal — only opened when the creator asks to clear the publish gate. */
+  const [claimOpen, setClaimOpen] = useState(false);
   const [games, setGames] = useState<StudioGame[]>([]);
   const [healthRows, setHealthRows] = useState<GameHealth[]>([]);
   const [scorecards, setScorecards] = useState<StudioScorecard[]>([]);
@@ -532,10 +536,9 @@ export function CreatorStudioView({
           </button>
         </header>
 
-        {/* Quiet @handle chip only — claim lives on the game waiting to publish.
-          Both surfaces share StudioCreatorProfileProvider so a claim on the gate
-          reveals this chip without a reload. */}
-        {!loading ? <CreatorProfileEditor surface="chrome" /> : null}
+        {/* Quiet @handle chip once claimed. Claiming is a modal at publish need. */}
+        {!loading ? <CreatorProfileEditor /> : null}
+        <ClaimHandleModal isOpen={claimOpen} onClose={() => setClaimOpen(false)} />
 
         {loading ? (
           <>
@@ -682,6 +685,18 @@ export function CreatorStudioView({
                       {/* Labels are wrapped rather than left as bare text so a phone can
                         hide the word and keep the icon — and hide it the way that leaves
                         the button still named for a screen reader, not display: none. */}
+                      {!user.handle &&
+                      (activeGame.lastKnownStatus === 'in_review' || activeGame.lastKnownStatus === 'publishing') ? (
+                        <button
+                          type="button"
+                          className="studio-head-action studio-head-action--claim"
+                          onClick={() => setClaimOpen(true)}
+                          aria-label={t('creatorProfile.publishGateTitle')}
+                        >
+                          <PixelIcon name="sparkle" size={12} />{' '}
+                          <span className="studio-head-action-label">{t('creatorProfile.publishGateTitle')}</span>
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         className={`studio-head-action is-primary${tab === 'playtest' ? ' is-active' : ''}`}
@@ -703,12 +718,6 @@ export function CreatorStudioView({
                     </div>
                   </div>
                 </div>
-
-                {/* Profile is required only to publish — show the claim form on this game
-                  when it is waiting on review / publishing, not as Studio page chrome. */}
-                {user && (activeGame.lastKnownStatus === 'in_review' || activeGame.lastKnownStatus === 'publishing') ? (
-                  <CreatorProfileEditor surface="publish-gate" />
-                ) : null}
 
                 {/* The thread stays put. Details opens beside it on a wide screen and over
                   it on a narrow one; only playtest, which needs the whole viewport to be

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -685,7 +685,7 @@ export function CreatorStudioView({
                       {/* Labels are wrapped rather than left as bare text so a phone can
                         hide the word and keep the icon — and hide it the way that leaves
                         the button still named for a screen reader, not display: none. */}
-                      {!user.handle &&
+                      {!user?.handle &&
                       (activeGame.lastKnownStatus === 'in_review' || activeGame.lastKnownStatus === 'publishing') ? (
                         <button
                           type="button"

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -227,3 +227,106 @@ describe('NavHeader operator link', () => {
     await act(async () => root.unmount());
   });
 });
+
+describe('NavHeader profile link', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('links the signed-in name to /creators/:handle when a handle is claimed', async () => {
+    await i18n.changeLanguage('en');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(
+          JSON.stringify({
+            user: {
+              uid: 'g:ada',
+              tier: 'standard',
+              name: 'Ada Lovelace',
+              handle: 'ada',
+              profileName: 'Ada',
+            },
+          }),
+        );
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const profile = container.querySelector<HTMLAnchorElement>('a.user-name--profile');
+    expect(profile).not.toBeNull();
+    expect(profile?.getAttribute('href')).toBe('/creators/ada');
+    expect(profile?.textContent).toBe('Ada');
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not link the account name when no handle is claimed', async () => {
+    await i18n.changeLanguage('en');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:ada', tier: 'standard', name: 'Ada Lovelace' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('a.user-name--profile')).toBeNull();
+    expect(container.querySelector('.user-name')?.textContent).toBe('Ada Lovelace');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -7,6 +7,7 @@ import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
 import { fetchAdminSummary } from './adminApi.js';
+import { creatorPath } from './router.js';
 import { usePageScrolling } from './usePageScrolling.js';
 import githubIcon from './assets/github-mark-white.svg';
 
@@ -130,7 +131,13 @@ export function NavHeader({
                 <PixelIcon name="user" size={16} />
               </span>
             )}
-            <span className="user-name">{user.name || user.email || 'User'}</span>
+            {user.handle ? (
+              <a className="user-name user-name--profile" href={creatorPath(user.handle)}>
+                {user.profileName || `@${user.handle}`}
+              </a>
+            ) : (
+              <span className="user-name">{user.name || user.email || 'User'}</span>
+            )}
             <NotificationBell />
             <button className="logout-btn" onClick={logout} title={t('header.signOut')}>
               {t('header.signOut')}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -853,7 +853,7 @@
     "publishGateTitle": "Claim a handle to publish",
     "editorNeeded": "Building and playtesting do not need a handle — publishing does.",
     "editorReady": "This is how players see you on catalog cards and the player.",
-    "publishNudge": "This game is waiting on review — claim a handle so it can go live.",
+    "publishNudge": "This game is ready to go live. Pick a unique handle for your public page.",
     "editProfile": "Edit profile",
     "done": "Done",
     "previewAria": "Public profile preview",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -857,7 +857,7 @@
     "publishGateTitle": "Zajmij handle, żeby opublikować",
     "editorNeeded": "Do budowania i testów handle nie jest potrzebny — do publikacji tak.",
     "editorReady": "Tak widzą Cię gracze na kartach katalogu i w playerze.",
-    "publishNudge": "Ta gra czeka na recenzję — zajmij handle, żeby mogła trafić na stronę.",
+    "publishNudge": "Ta gra jest gotowa do publikacji. Wybierz unikalny handle na swoją publiczną stronę.",
     "editProfile": "Edytuj profil",
     "done": "Gotowe",
     "previewAria": "Podgląd publicznego profilu",

--- a/apps/web/src/studioCreatorProfile.tsx
+++ b/apps/web/src/studioCreatorProfile.tsx
@@ -76,12 +76,22 @@ export function StudioCreatorProfileProvider({ children }: { children: ReactNode
       return;
     }
     const handle = handleInput.trim().toLowerCase();
+    let cancelled = false;
     const timer = window.setTimeout(() => {
       void checkHandleAvailability(handle)
-        .then((result) => setAvailability({ available: result.available, reason: result.reason }))
-        .catch(() => setAvailability(null));
+        .then((result) => {
+          // Ignore stale responses from a previous keystroke after the user typed again.
+          if (cancelled) return;
+          setAvailability({ available: result.available, reason: result.reason });
+        })
+        .catch(() => {
+          if (!cancelled) setAvailability(null);
+        });
     }, 300);
-    return () => window.clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, [handleInput, me?.handle]);
 
   const refusalCopy = (code: HandleClaimError): string => {

--- a/apps/web/src/studioCreatorProfile.tsx
+++ b/apps/web/src/studioCreatorProfile.tsx
@@ -1,0 +1,179 @@
+import { createContext, useContext, useEffect, useState, type FormEvent, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from './AuthContext.js';
+import {
+  checkHandleAvailability,
+  claimHandle,
+  fetchMyProfile,
+  updateMyProfile,
+  type AvatarMode,
+  type HandleClaimError,
+  type MeProfile,
+} from './creatorProfileApi.js';
+
+type ProfileStatus = 'loading' | 'ready' | 'saving' | 'error';
+
+export type StudioCreatorProfile = {
+  me: MeProfile | null;
+  status: ProfileStatus;
+  handleInput: string;
+  nameInput: string;
+  bioInput: string;
+  avatarMode: AvatarMode;
+  availability: { available: boolean; reason?: HandleClaimError } | null;
+  message: string | null;
+  setHandleInput: (value: string) => void;
+  setNameInput: (value: string) => void;
+  setBioInput: (value: string) => void;
+  setAvatarMode: (value: AvatarMode) => void;
+  onClaim: (event: FormEvent) => Promise<void>;
+  onSaveDetails: (event: FormEvent) => Promise<void>;
+  refusalCopy: (code: HandleClaimError) => string;
+  clearMessage: () => void;
+};
+
+const StudioCreatorProfileContext = createContext<StudioCreatorProfile | null>(null);
+
+/**
+ * Shared Studio profile store — chrome chip and claim modal both read/write here so a
+ * claim reveals `@handle` without remounting.
+ */
+export function StudioCreatorProfileProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation();
+  const { refreshUser } = useAuth();
+  const [me, setMe] = useState<MeProfile | null>(null);
+  const [handleInput, setHandleInput] = useState('');
+  const [nameInput, setNameInput] = useState('');
+  const [bioInput, setBioInput] = useState('');
+  const [avatarMode, setAvatarMode] = useState<AvatarMode>('letter');
+  const [availability, setAvailability] = useState<{ available: boolean; reason?: HandleClaimError } | null>(null);
+  const [status, setStatus] = useState<ProfileStatus>('loading');
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchMyProfile()
+      .then((profile) => {
+        if (cancelled) return;
+        setMe(profile);
+        setHandleInput(profile.handle ?? '');
+        setNameInput(profile.profileName ?? profile.handle ?? '');
+        setBioInput(profile.bio ?? '');
+        setAvatarMode(profile.avatarMode ?? 'letter');
+        setStatus('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!handleInput.trim() || (me?.handle && handleInput.trim().toLowerCase() === me.handle)) {
+      setAvailability(null);
+      return;
+    }
+    const handle = handleInput.trim().toLowerCase();
+    const timer = window.setTimeout(() => {
+      void checkHandleAvailability(handle)
+        .then((result) => setAvailability({ available: result.available, reason: result.reason }))
+        .catch(() => setAvailability(null));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [handleInput, me?.handle]);
+
+  const refusalCopy = (code: HandleClaimError): string => {
+    switch (code) {
+      case 'invalid':
+        return t('creatorProfile.errors.invalid');
+      case 'reserved':
+        return t('creatorProfile.errors.reserved');
+      case 'taken':
+        return t('creatorProfile.errors.taken');
+      case 'cooldown':
+        return t('creatorProfile.errors.cooldown');
+      case 'unchanged':
+        return t('creatorProfile.errors.unchanged');
+      default:
+        return t('creatorProfile.errors.unknown');
+    }
+  };
+
+  const applyProfile = (next: MeProfile) => {
+    setMe(next);
+    setHandleInput(next.handle ?? '');
+    setNameInput(next.profileName ?? next.handle ?? '');
+    setBioInput(next.bio ?? '');
+    setAvatarMode(next.avatarMode ?? 'letter');
+  };
+
+  const onClaim = async (event: FormEvent) => {
+    event.preventDefault();
+    setStatus('saving');
+    setMessage(null);
+    try {
+      const next = await claimHandle(handleInput.trim());
+      applyProfile(next);
+      setMessage(t('creatorProfile.claimed'));
+      setStatus('ready');
+      await refreshUser();
+    } catch (err) {
+      const code = ((err as { code?: HandleClaimError }).code ?? 'unknown') as HandleClaimError;
+      setMessage(refusalCopy(code));
+      setStatus('ready');
+    }
+  };
+
+  const onSaveDetails = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!me?.handle) return;
+    setStatus('saving');
+    setMessage(null);
+    try {
+      const next = await updateMyProfile({
+        profileName: nameInput.trim(),
+        bio: bioInput,
+        avatarMode,
+      });
+      applyProfile(next);
+      setMessage(t('creatorProfile.saved'));
+      setStatus('ready');
+      await refreshUser();
+    } catch {
+      setMessage(t('creatorProfile.errors.unknown'));
+      setStatus('ready');
+    }
+  };
+
+  const value: StudioCreatorProfile = {
+    me,
+    status,
+    handleInput,
+    nameInput,
+    bioInput,
+    avatarMode,
+    availability,
+    message,
+    setHandleInput,
+    setNameInput,
+    setBioInput,
+    setAvatarMode,
+    onClaim,
+    onSaveDetails,
+    refusalCopy,
+    clearMessage: () => setMessage(null),
+  };
+
+  return <StudioCreatorProfileContext.Provider value={value}>{children}</StudioCreatorProfileContext.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useStudioCreatorProfile(): StudioCreatorProfile {
+  const ctx = useContext(StudioCreatorProfileContext);
+  if (!ctx) {
+    throw new Error('useStudioCreatorProfile requires StudioCreatorProfileProvider');
+  }
+  return ctx;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10922,6 +10922,14 @@ a.user-name--profile:focus-visible {
   opacity: 0.7;
 }
 
+/* Phone + on-screen keyboard: the visual viewport shrinks; keep the claim action reachable. */
+.claim-handle-modal-backdrop {
+  align-items: safe center;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 1rem 0;
+}
+
 .claim-handle-modal-card {
   background: var(--panel);
   border: 1px solid var(--panel-border);
@@ -10929,9 +10937,13 @@ a.user-name--profile:focus-visible {
   padding: 1.5rem 1.35rem 1.35rem;
   max-width: 520px;
   width: min(92vw, 520px);
+  max-height: min(92dvh, 92vh);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   position: relative;
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
   text-align: left;
+  margin: auto;
 }
 
 .claim-handle-modal-head h2 {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3554,6 +3554,18 @@ body.player-open {
   color: var(--text);
 }
 
+a.user-name--profile {
+  text-decoration: none;
+  color: var(--text);
+}
+
+a.user-name--profile:hover,
+a.user-name--profile:focus-visible {
+  color: var(--turquoise, #3dd6c6);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .logout-btn {
   background: none;
   border: none;
@@ -4538,6 +4550,11 @@ body.player-open {
   border-color: var(--turquoise);
   color: #08241d;
   font-weight: 700;
+}
+
+.studio-head-action--claim {
+  border-color: rgba(0, 228, 172, 0.45);
+  color: #c8f5da;
 }
 
 .studio-head-action.is-primary:hover {
@@ -10903,6 +10920,55 @@ body.player-open {
   margin: 0;
   font-size: 0.85rem;
   opacity: 0.7;
+}
+
+.claim-handle-modal-card {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 1.5rem 1.35rem 1.35rem;
+  max-width: 520px;
+  width: min(92vw, 520px);
+  position: relative;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  text-align: left;
+}
+
+.claim-handle-modal-head h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.claim-handle-modal-head p {
+  margin: 0 0 0.35rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.claim-handle-modal-aside {
+  font-size: 0.85rem !important;
+  opacity: 0.85;
+}
+
+.claim-handle-modal-body {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (min-width: 640px) {
+  .claim-handle-modal-body {
+    grid-template-columns: 1fr minmax(10rem, 11.5rem);
+    align-items: start;
+  }
+
+  .claim-handle-modal-body .creator-profile-message {
+    grid-column: 1 / -1;
+  }
 }
 
 .creator-profile-chip-row {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to creator profiles UX.

## Change
- **No inline claim panel** on the game thread
- Games waiting at `in_review` without a handle show a compact **Claim handle to publish** control → opens a **modal** (handle + claim + public-page preview)
- **Header**: once a handle exists, the signed-in name links to `/creators/:handle` (shows profileName / `@handle`, not as a byline before claim)
- Still **no forced slug at signup**; still **`/creators/:handle`** (not root `/$handle`)

## Review follow-ups (Codex + Copilot)
- Claim modal: Escape to close, Tab focus trap, restore focus to opener
- Short viewport / OSK: backdrop scrolls; card `max-height` + overflow
- Handle availability: ignore stale responses after further typing
- Preview uses profile name (`nameInput`), not the handle twice
- Regression tests for claim CTA show/hide/open (`CreatorStudioView.claimGate.test.tsx`)

## Screenshots

Compact CTA on a game waiting to publish (no inline panel):

[Claim handle to publish CTA on Neon Drift](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-claim-cta.png)

Modal at the publish moment:

[Claim handle modal](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-claim-modal.png)

Header name links to public profile after claim:

[Header profile link](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fheader-profile-link.png)

Ops plan: https://github.com/gamedevpl/www.gamedev.pl-ops/pull/54

## Verification
- Unit tests: chrome chip, claim modal (incl. Escape), claim CTA gate, sync after claim, header profile link / no-link
- lint + web type-check green

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

