### PR TITLE
fix: honour sessionKey when OAuth Bearer is still on the request

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,7 +4,7 @@ import fastifyWebsocket from '@fastify/websocket';
 import type { GameGenerator } from '@gamedevpl/game-generator';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from 'fastify';
 import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { registerAccessTokenRoutes } from './access-token-routes.js';
@@ -74,7 +74,8 @@ const GenerateRequestSchema = z.object({
 
 export interface BuildAppOptions {
   generator?: GameGenerator;
-  logger?: boolean;
+  /** `false` in tests by default; pass a Pino destination to assert on log lines. */
+  logger?: FastifyServerOptions['logger'];
   store?: Store;
   sessionSecret?: string;
   sessionSecretPrev?: string;

--- a/apps/api/src/mcp-debug-log.test.ts
+++ b/apps/api/src/mcp-debug-log.test.ts
@@ -1,0 +1,230 @@
+import { Writable } from 'node:stream';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mintGameAgentKey } from './agent-game-key.js';
+import { mintAgentToken } from './agent-token.js';
+import { buildApp } from './app.js';
+import {
+  classifyMcpBearerKind,
+  classifyMcpSessionKeyShape,
+  mcpToolRefusalFields,
+  toolErrorReason,
+} from './mcp-debug-log.js';
+import { mintMcpSessionKey, newMcpSessionId } from './mcp-session-key.js';
+import { generateAsAccessToken } from './oauth-tokens.js';
+import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'mcp-debug-log-secret';
+
+describe('mcp-debug-log classifiers', () => {
+  it('classifies bearer and sessionKey shapes without needing the secret', () => {
+    const oat = generateAsAccessToken().token;
+    expect(classifyMcpBearerKind(null)).toBe('none');
+    expect(classifyMcpBearerKind(oat)).toBe('oauth');
+    expect(classifyMcpBearerKind(mintGameAgentKey(secret, { slug: 'pong', creatorUid: 'g:u', keyGeneration: 1 }))).toBe(
+      'game_key',
+    );
+    expect(classifyMcpBearerKind(mintAgentToken(1, secret, { roundGeneration: 1 }))).toBe('round_or_other');
+
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId: newMcpSessionId(),
+      jobId: 1000016,
+      roundGeneration: 1,
+    });
+    expect(classifyMcpSessionKeyShape(undefined)).toBe('absent');
+    expect(classifyMcpSessionKeyShape(sessionKey)).toBe('session');
+    expect(classifyMcpSessionKeyShape('not-a-key')).toBe('other');
+  });
+
+  it('builds refusal fields with jobId and session mismatch, never the raw key', () => {
+    const sessionId = newMcpSessionId();
+    const sessionKey = mintMcpSessionKey(secret, {
+      sessionId,
+      jobId: 1000016,
+      roundGeneration: 1,
+    });
+    const oat = generateAsAccessToken().token;
+    const fields = mcpToolRefusalFields({
+      tool: 'get_brief',
+      reason: 'sessionKey is bound to a different Mcp-Session-Id',
+      bearer: oat,
+      sessionKey,
+      transportSessionId: newMcpSessionId(),
+      agentTokenSecret: secret,
+      userAgent: 'openai-mcp/1.0.0',
+    });
+    expect(fields).toMatchObject({
+      event: 'mcp_tool_refused',
+      tool: 'get_brief',
+      bearerKind: 'oauth',
+      sessionKeyShape: 'session',
+      jobId: 1000016,
+      boundSessionId: sessionId,
+      sessionIdMismatch: true,
+      userAgent: 'openai-mcp/1.0.0',
+    });
+    expect(JSON.stringify(fields)).not.toContain(sessionKey);
+    expect(JSON.stringify(fields)).not.toContain(oat);
+  });
+
+  it('reads the refusal reason from structuredContent or content text', () => {
+    expect(
+      toolErrorReason({
+        isError: true,
+        structuredContent: { error: 'OAuth access proves your identity only' },
+      }),
+    ).toBe('OAuth access proves your identity only');
+    expect(
+      toolErrorReason({
+        isError: true,
+        content: [{ type: 'text', text: JSON.stringify({ error: 'unknown build' }) }],
+      }),
+    ).toBe('unknown build');
+    expect(toolErrorReason({ isError: false, structuredContent: { title: 'Pong' } })).toBeNull();
+  });
+});
+
+describe('mcp tool refusal logging', () => {
+  let app: FastifyInstance | undefined;
+  const lines: Array<Record<string, unknown>> = [];
+
+  afterEach(async () => {
+    if (app) await app.close();
+    app = undefined;
+    lines.length = 0;
+  });
+
+  async function createLoggedApp(store: InMemoryStore) {
+    const stream = new Writable({
+      write(chunk, _enc, cb) {
+        try {
+          lines.push(JSON.parse(String(chunk)) as Record<string, unknown>);
+        } catch {
+          // ignore non-JSON
+        }
+        cb();
+      },
+    });
+    return buildApp({
+      store,
+      logger: { level: 'info', stream },
+      sessionSecret: 'dev-session-secret-change-me',
+      submissionRoutes: {
+        githubClient: {
+          createIssue: async () => ({ number: 42 }),
+          getIssueState: async () => ({ state: 'open' as const }),
+          findLinkedPR: async () => null,
+          createIssueComment: async () => ({ id: 1 }),
+          updateIssueBody: async () => {},
+          closeIssue: async () => {},
+          closePullRequest: async () => {},
+          ensureOpenPullRequest: async () => ({ number: 1 }),
+          deleteBranch: async () => {},
+          getGameSources: async () => null,
+          getGameMedia: async () => null,
+          getCatalog: async () => [],
+          getProgressNotes: async () => null,
+        },
+        githubToken: 'gh-token',
+        submissionTokenSecret: secret,
+        translator: new NoopTranslator(),
+        agentChannel: {},
+      },
+    });
+  }
+
+  it('logs mcp_session_started and mcp_tool_refused when OAuth Bearer is present without sessionKey', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(1000016, 'g:owner', 'Pong');
+    await store.setSubmissionSlug(1000016, 'pong');
+    await store.setRoundBuilder(1000016, 'self');
+    await store.ensureRoundGeneration(1000016);
+    await store.setSubmissionBrief(1000016, { spec: 'pong', qa: [] });
+    await store.recordJobTransition(1000016, {
+      to: 'dispatched',
+      at: new Date().toISOString(),
+      by: 'system',
+    });
+
+    app = await createLoggedApp(store);
+    const roundKey = mintAgentToken(1000016, secret, { roundGeneration: 1 });
+    // Shape-only OAuth access (prefix match) — enough to pass the HTTP challenge and
+    // hit the tool-level "OAuth is identity only" refusal, which is what ChatGPT hides.
+    const oauthAccess = generateAsAccessToken().token;
+
+    const init = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json', 'user-agent': 'openai-mcp/1.0.0' },
+      payload: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        },
+      },
+    });
+    const sessionId = String(init.headers['mcp-session-id']);
+
+    await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        'user-agent': 'openai-mcp/1.0.0',
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'start', arguments: { key: roundKey } },
+      },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${oauthAccess}`,
+        'user-agent': 'openai-mcp/1.0.0',
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: {} },
+      },
+    });
+
+    const started = lines.find((line) => line.event === 'mcp_session_started');
+    expect(started).toMatchObject({
+      event: 'mcp_session_started',
+      jobId: 1000016,
+      slug: 'pong',
+      sessionId,
+      msg: 'mcp session started',
+    });
+
+    const refused = lines.find((line) => line.event === 'mcp_tool_refused');
+    expect(refused).toMatchObject({
+      event: 'mcp_tool_refused',
+      tool: 'get_brief',
+      bearerKind: 'oauth',
+      sessionKeyShape: 'absent',
+      transportSessionId: sessionId,
+      userAgent: 'openai-mcp/1.0.0',
+      msg: 'mcp tool refused',
+    });
+    expect(String(refused?.reason ?? '')).toMatch(/OAuth access proves your identity only/i);
+    expect(JSON.stringify(lines)).not.toContain(oauthAccess);
+    expect(JSON.stringify(lines)).not.toContain(roundKey);
+  });
+});

--- a/apps/api/src/mcp-debug-log.ts
+++ b/apps/api/src/mcp-debug-log.ts
@@ -1,0 +1,121 @@
+/**
+ * Structured MCP debug fields for Cloud Logging — never include credentials.
+ *
+ * ChatGPT / Claude connectors often drop `isError` tool payloads from the chat
+ * transcript, so the only durable signal for "why did get_brief fail after start"
+ * is what we write here. Grep: `jsonPayload.event="mcp_tool_refused"` or
+ * `jsonPayload.msg="mcp tool refused"`.
+ */
+
+import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
+import { looksLikeGameAgentKey } from './agent-game-key.js';
+import { looksLikeMcpSessionKey, verifyMcpSessionKey } from './mcp-session-key.js';
+import { looksLikeAsAccessToken } from './oauth-tokens.js';
+
+export type McpBearerKind = 'none' | 'oauth' | 'creator_key' | 'game_key' | 'round_or_other';
+export type McpSessionKeyShape = 'absent' | 'session' | 'game_key' | 'creator_key' | 'other';
+
+export function classifyMcpBearerKind(bearer: string | null | undefined): McpBearerKind {
+  if (!bearer) return 'none';
+  if (looksLikeAsAccessToken(bearer)) return 'oauth';
+  if (looksLikeCreatorAgentKey(bearer)) return 'creator_key';
+  if (looksLikeGameAgentKey(bearer)) return 'game_key';
+  return 'round_or_other';
+}
+
+export function classifyMcpSessionKeyShape(sessionKey: string | null | undefined): McpSessionKeyShape {
+  if (!sessionKey) return 'absent';
+  if (looksLikeMcpSessionKey(sessionKey)) return 'session';
+  if (looksLikeGameAgentKey(sessionKey)) return 'game_key';
+  if (looksLikeCreatorAgentKey(sessionKey)) return 'creator_key';
+  return 'other';
+}
+
+/** Claims peek for logging only — never log the raw sessionKey. */
+export function peekMcpSessionKeyForLog(
+  sessionKey: string | null | undefined,
+  secret: string | undefined,
+): { jobId: number; boundSessionId: string; roundGeneration: number } | null {
+  if (!sessionKey || !secret || !looksLikeMcpSessionKey(sessionKey)) return null;
+  try {
+    const claims = verifyMcpSessionKey(sessionKey, secret);
+    return {
+      jobId: claims.jobId,
+      boundSessionId: claims.sessionId,
+      roundGeneration: claims.roundGeneration,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function mcpToolRefusalFields(input: {
+  tool: string;
+  reason: string;
+  bearer: string | null | undefined;
+  sessionKey: string | null | undefined;
+  transportSessionId: string | null | undefined;
+  agentTokenSecret?: string;
+  userAgent?: string | null;
+}): Record<string, unknown> {
+  const peeked = peekMcpSessionKeyForLog(input.sessionKey, input.agentTokenSecret);
+  const transportSessionId = input.transportSessionId ?? null;
+  return {
+    event: 'mcp_tool_refused',
+    tool: input.tool,
+    reason: input.reason,
+    bearerKind: classifyMcpBearerKind(input.bearer),
+    sessionKeyShape: classifyMcpSessionKeyShape(input.sessionKey),
+    transportSessionId,
+    ...(peeked
+      ? {
+          jobId: peeked.jobId,
+          boundSessionId: peeked.boundSessionId,
+          roundGeneration: peeked.roundGeneration,
+          sessionIdMismatch: Boolean(transportSessionId && transportSessionId !== peeked.boundSessionId),
+        }
+      : {}),
+    ...(input.userAgent ? { userAgent: input.userAgent.slice(0, 120) } : {}),
+  };
+}
+
+export function mcpSessionStartedFields(input: {
+  jobId: number;
+  slug: string | null;
+  sessionId: string;
+  round: number;
+  userAgent?: string | null;
+}): Record<string, unknown> {
+  return {
+    event: 'mcp_session_started',
+    tool: 'start',
+    jobId: input.jobId,
+    slug: input.slug,
+    sessionId: input.sessionId,
+    round: input.round,
+    ...(input.userAgent ? { userAgent: input.userAgent.slice(0, 120) } : {}),
+  };
+}
+
+export function toolErrorReason(result: {
+  isError?: boolean;
+  structuredContent?: unknown;
+  content?: Array<{ type: string; text: string }>;
+}): string | null {
+  if (!result.isError) return null;
+  const structured = result.structuredContent;
+  if (structured && typeof structured === 'object' && 'error' in structured) {
+    const error = (structured as { error?: unknown }).error;
+    if (typeof error === 'string' && error.trim()) return error.trim();
+  }
+  const text = result.content?.[0]?.text;
+  if (typeof text === 'string' && text.trim()) {
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.trim()) return parsed.error.trim();
+    } catch {
+      return text.trim().slice(0, 300);
+    }
+  }
+  return 'unknown error';
+}

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -577,6 +577,30 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(brief.structured).toMatchObject({ title: 'Comet Courier' });
   });
 
+  // Codex P2 on #504: preferring sessionKey over a valid round Bearer broke reconnects
+  // that still had a stale sessionKey in tool args from an earlier transport session.
+  it('round Bearer still wins when a stale mismatched sessionKey is also present', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionA = await initialize(app);
+    const sessionB = await initialize(app);
+    const staleKey = mintMcpSessionKey(secret, {
+      sessionId: sessionA,
+      jobId: ISSUE,
+      roundGeneration: 1,
+    });
+
+    const brief = await callTool(
+      app,
+      'get_brief',
+      { sessionKey: staleKey },
+      { 'mcp-session-id': sessionB, authorization: `Bearer ${roundKey()}` },
+    );
+    expect(brief.isError).toBe(false);
+    expect(brief.structured).toMatchObject({ title: 'Comet Courier' });
+  });
+
   it('piggybacks stop and pendingMessages on every write including ack_inbox', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -433,6 +433,8 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const bad = await callTool(app, 'get_brief', { sessionKey: forgedKey }, { 'mcp-session-id': sessionId });
     expect(bad.isError).toBe(true);
+    expect(JSON.stringify(bad.structured)).toMatch(/invalid sessionKey/i);
+    expect(JSON.stringify(bad.structured)).not.toMatch(/finished/i);
   });
 
   // CP-2 N4: the opener-in-sessionKey-slot refusals name the credential ("this creator

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -389,35 +389,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     let claims: AgentTokenClaims;
     let channelToken: string;
 
-    // Paste-once MCP config leaves Authorization: Bearer <opener> on every request.
-    // When the tool also passes sessionKey, prefer that — openers never authorize writes.
+    // Paste-once MCP config leaves Authorization: Bearer <opener or OAuth access> on
+    // every request (ChatGPT Apps, Claude connectors, Studio "connect" snippets).
+    // When the tool also passes sessionKey, prefer that — openers and OAuth access
+    // never authorize writes by themselves.
     const bearerIsOpener = Boolean(bearer) && (looksLikeGameAgentKey(bearer!) || looksLikeCreatorAgentKey(bearer!));
+    const bearerIsOAuth = Boolean(bearer) && looksLikeAsAccessToken(bearer!);
 
-    if (bearer && looksLikeAsAccessToken(bearer)) {
-      return toolErr(
-        'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
-      );
-    }
-
-    if (bearerIsOpener && !sessionKeyArg) {
-      return toolErr(
-        looksLikeCreatorAgentKey(bearer!)
-          ? 'this creator key only opens a session via start() — pass the sessionKey start returned for later tools'
-          : 'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
-      );
-    }
-
-    if (bearer && !bearerIsOpener) {
-      try {
-        claims = verifyAgentToken(bearer, agentTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidAgentTokenError) {
-          return toolErr(error.message || 'invalid build key');
-        }
-        throw error;
-      }
-      channelToken = bearer;
-    } else if (sessionKeyArg) {
+    if (sessionKeyArg) {
       if (looksLikeGameAgentKey(sessionKeyArg)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
@@ -455,6 +434,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         now: now(),
         ttlDays: 1,
       });
+    } else if (bearerIsOAuth) {
+      return toolErr(
+        'OAuth access proves your identity only — call start() with your game slug (Authorization: Bearer <oauth access>) to get a session key',
+      );
+    } else if (bearerIsOpener) {
+      return toolErr(
+        looksLikeCreatorAgentKey(bearer!)
+          ? 'this creator key only opens a session via start() — pass the sessionKey start returned for later tools'
+          : 'this game key only opens a session via start() — pass the sessionKey start returned for later tools',
+      );
+    } else if (bearer) {
+      try {
+        claims = verifyAgentToken(bearer, agentTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidAgentTokenError) {
+          return toolErr(error.message || 'invalid build key');
+        }
+        throw error;
+      }
+      channelToken = bearer;
     } else {
       // Possession of Mcp-Session-Id alone authorizes nothing.
       return toolErr(MCP_MISSING_CREDENTIAL_HINT);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -417,7 +417,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         assertMcpSessionKeyUnexpired(sessionClaims, now());
       } catch (error) {
         if (error instanceof InvalidAgentTokenError) {
-          return toolErr(error.message || FINISHED_REASON);
+          // Expired keys carry STALE_AGENT_TOKEN_REASON (correct: round is done).
+          // Forge/malformed throws InvalidAgentTokenError with the generic default —
+          // do not rewrite that as "finished" or agents will chase the wrong fix.
+          return toolErr(
+            error.message === STALE_AGENT_TOKEN_REASON
+              ? STALE_AGENT_TOKEN_REASON
+              : 'invalid sessionKey — call start() again',
+          );
         }
         throw error;
       }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -44,6 +44,7 @@ import {
   newMcpSessionId,
   verifyMcpSessionKey,
 } from './mcp-session-key.js';
+import { mcpSessionStartedFields, mcpToolRefusalFields, toolErrorReason } from './mcp-debug-log.js';
 import {
   MCP_MISSING_CREDENTIAL_HINT,
   sendMcpOAuthChallenge,
@@ -1803,6 +1804,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     // Non-initialize requests: require session header when we issued one (transport only).
     if (sessionHeader && !transportSessions.has(sessionHeader)) {
+      // In-memory map miss (multi-instance, prune, or client inventing an id). ChatGPT
+      // often hides the 404 body — log so GCP can show the correlator that was refused.
+      request.log.warn(
+        {
+          event: 'mcp_unknown_session',
+          transportSessionId: sessionHeader,
+          userAgent: headerValue(request.headers['user-agent'])?.slice(0, 120) ?? undefined,
+        },
+        'mcp unknown session',
+      );
       return reply.status(404).send({ error: 'unknown MCP session' });
     }
 
@@ -1843,6 +1854,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return reply.send(jsonRpcError(message.id, -32601, `unknown tool: ${name}`));
       }
       const args = params.arguments && typeof params.arguments === 'object' ? params.arguments : {};
+      const sessionKeyArg = typeof args.sessionKey === 'string' ? args.sessionKey.trim() : '';
+      const userAgent = headerValue(request.headers['user-agent']);
       try {
         const result = await tool.handler(args, ctx);
         // Echo session id on tool responses when we have one (transport correlator).
@@ -1852,9 +1865,47 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           const sid = (result.structuredContent as { sessionId?: string }).sessionId;
           if (sid) reply.header('Mcp-Session-Id', sid);
         }
+
+        // Connectors often omit isError payloads from the chat transcript. These lines
+        // are the durable signal in Cloud Logging — never include sessionKey / bearer.
+        const reason = toolErrorReason(result);
+        if (reason) {
+          request.log.warn(
+            mcpToolRefusalFields({
+              tool: name,
+              reason,
+              bearer: bearerToken,
+              sessionKey: sessionKeyArg,
+              transportSessionId: sessionHeader,
+              agentTokenSecret,
+              userAgent,
+            }),
+            'mcp tool refused',
+          );
+        } else if (name === 'start' && result.structuredContent && typeof result.structuredContent === 'object') {
+          const started = result.structuredContent as {
+            jobId?: unknown;
+            slug?: unknown;
+            sessionId?: unknown;
+            round?: unknown;
+          };
+          if (typeof started.jobId === 'number' && typeof started.sessionId === 'string') {
+            request.log.info(
+              mcpSessionStartedFields({
+                jobId: started.jobId,
+                slug: typeof started.slug === 'string' ? started.slug : null,
+                sessionId: started.sessionId,
+                round: typeof started.round === 'number' ? started.round : 0,
+                userAgent,
+              }),
+              'mcp session started',
+            );
+          }
+        }
+
         return reply.send(jsonRpcResult(message.id, result));
       } catch (error) {
-        app.log.error({ err: error }, 'MCP tool handler failed');
+        app.log.error({ err: error, tool: name }, 'MCP tool handler failed');
         return reply.send(
           jsonRpcResult(message.id, toolErr(error instanceof Error ? error.message : 'internal error')),
         );
@@ -1888,6 +1939,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     const message = body as JsonRpcRequest;
     if (shouldIssueMcpOAuthChallenge(request, message)) {
+      const tool =
+        message.method === 'tools/call' && message.params && typeof message.params === 'object'
+          ? String((message.params as { name?: unknown }).name ?? '')
+          : '';
+      request.log.warn(
+        {
+          event: 'mcp_oauth_challenge',
+          tool: tool || undefined,
+          method: message.method,
+          userAgent: headerValue(request.headers['user-agent'])?.slice(0, 120) ?? undefined,
+        },
+        'mcp oauth challenge',
+      );
       return sendMcpOAuthChallenge(reply);
     }
 

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -392,12 +392,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     // Paste-once MCP config leaves Authorization: Bearer <opener or OAuth access> on
     // every request (ChatGPT Apps, Claude connectors, Studio "connect" snippets).
-    // When the tool also passes sessionKey, prefer that — openers and OAuth access
-    // never authorize writes by themselves.
+    // Those credentials never authorize writes — prefer sessionKey when present.
+    // A round-scoped Bearer is different: it is itself a write credential, and must
+    // keep working even if the client also echoes a stale sessionKey from an earlier
+    // transport session (reconnect with retained tool args).
     const bearerIsOpener = Boolean(bearer) && (looksLikeGameAgentKey(bearer!) || looksLikeCreatorAgentKey(bearer!));
     const bearerIsOAuth = Boolean(bearer) && looksLikeAsAccessToken(bearer!);
+    const preferSessionKey = Boolean(sessionKeyArg) && (!bearer || bearerIsOAuth || bearerIsOpener);
 
-    if (sessionKeyArg) {
+    if (preferSessionKey) {
       if (looksLikeGameAgentKey(sessionKeyArg)) {
         return toolErr(
           'this game key only opens a session via start() — pass the sessionKey start returned for later tools',

--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -473,6 +473,60 @@ describe('MCP OAuth integration (BY-18b)', () => {
     expect(startedBody.result?.structuredContent?.title).toBe('Comet Courier');
   });
 
+  // ChatGPT Apps (and other OAuth MCP clients) keep Authorization: Bearer <access>
+  // on every tools/call. That must not shadow the sessionKey start() just minted —
+  // otherwise the client can create a game, start a round, and then every write
+  // tool is refused immediately ("rejected the session key").
+  it('honours sessionKey for write tools even when Authorization still carries OAuth access', async () => {
+    const store = new InMemoryStore();
+    await seedSelfRound(store, 43, 'g:creator');
+    await store.upsertUser({ uid: 'g:creator' });
+    app = await buildOAuthApp(store);
+    const clientId = await registerClient(app);
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const tokens = await authorizeAndExchange(app, clientId, 'http://127.0.0.1/callback', verifier, 'g:creator');
+    const sessionId = await mcpInitialize();
+
+    const started = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${tokens.access_token}`,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'start', arguments: { slug: 'comet-courier' } },
+      },
+    });
+    const sessionKey = (started.json() as { result?: { structuredContent?: { sessionKey?: string } } }).result
+      ?.structuredContent?.sessionKey;
+    expect(typeof sessionKey).toBe('string');
+
+    const brief = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${tokens.access_token}`,
+      },
+      payload: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'get_brief', arguments: { sessionKey } },
+      },
+    });
+    expect(brief.statusCode).toBe(200);
+    const body = brief.json() as { result?: { isError?: boolean; structuredContent?: { error?: string } } };
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent?.error).toBeUndefined();
+  });
+
   it('static round key, durable game key, and sessionKey still work', async () => {
     const store = new InMemoryStore();
     await seedSelfRound(store, 77, 'g:owner');

--- a/docs/agent-gcp-access.md
+++ b/docs/agent-gcp-access.md
@@ -82,6 +82,30 @@ node infra/gcp-read.mjs describe gamedev-app            # full service config
 node infra/gcp-read.mjs raw GET <any GCP REST url>      # anything not wrapped above
 ```
 
+### MCP / self-build debugging
+
+ChatGPT Apps and some other MCP clients drop `isError` tool payloads from the chat
+transcript, so a failed `get_brief` after a successful `start` can look like “no
+response”. The API writes structured lines for that path (never the `sessionKey` or
+Bearer secret):
+
+```bash
+# Tool-level refusals: reason, tool, bearerKind, sessionKeyShape, jobId, sessionIdMismatch, ua
+node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_tool_refused" OR jsonPayload.msg="mcp tool refused"' --since 6h --limit 50
+
+# Successful start() binds (jobId, slug, transport sessionId)
+node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_session_started" OR jsonPayload.msg="mcp session started"' --since 6h --limit 50
+
+# HTTP 401 OAuth challenge (no sessionKey / Bearer on tools/call)
+node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_oauth_challenge" OR jsonPayload.msg="mcp oauth challenge"' --since 6h --limit 50
+
+# Client sent an Mcp-Session-Id this instance does not know (multi-instance / stale)
+node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_unknown_session" OR jsonPayload.msg="mcp unknown session"' --since 6h --limit 50
+
+# HTTP shape next to those lines (responseSize includes headers)
+node infra/gcp-read.mjs logs 'resource.type="cloud_run_revision" AND httpRequest.requestUrl=~"/api/mcp" AND httpRequest.userAgent=~"openai|claude"' --since 6h --limit 50
+```
+
 `raw` is the escape hatch: any runbook `gcloud` step has a REST equivalent, and the credential
 — not the wrapper — is what stops a mutation. Start with `whoami`; if a command 403s, that
 output tells you immediately whether it is a permission boundary or a real fault.

--- a/docs/agent-gcp-access.md
+++ b/docs/agent-gcp-access.md
@@ -90,7 +90,7 @@ response”. The API writes structured lines for that path (never the `sessionKe
 Bearer secret):
 
 ```bash
-# Tool-level refusals: reason, tool, bearerKind, sessionKeyShape, jobId, sessionIdMismatch, ua
+# Tool-level refusals: reason, tool, bearerKind, sessionKeyShape, jobId, sessionIdMismatch, userAgent
 node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_tool_refused" OR jsonPayload.msg="mcp tool refused"' --since 6h --limit 50
 
 # Successful start() binds (jobId, slug, transport sessionId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ChatGPT Apps keeps `Authorization: Bearer <OAuth access>` on every `tools/call`. `create_game` and `start` accept that; write tools used to short-circuit on the OAuth bearer **before** reading `sessionKey`, so the round could start and then the next tool came back as an `isError` result the ChatGPT transcript did not surface (“no response”).

**Fix:** prefer `sessionKey` when Authorization is OAuth/opener (paste-once) or absent. A valid **round-scoped Bearer still wins** over a stale/mismatched `sessionKey` (Codex P2) so legacy reconnects keep working. Forge/malformed sessionKeys refuse with `invalid sessionKey — call start() again`, not “finished” (Copilot).

### Observability

Structured Cloud Logging lines (never `sessionKey` / Bearer secrets):

| `event` | When |
|---|---|
| `mcp_session_started` | `start()` minted a session |
| `mcp_tool_refused` | tool returned `isError` — `reason`, `tool`, `bearerKind`, `sessionKeyShape`, `jobId`, `sessionIdMismatch`, `userAgent` |
| `mcp_oauth_challenge` | HTTP 401 challenge (no credential on `tools/call`) |
| `mcp_unknown_session` | `Mcp-Session-Id` unknown to this instance |

Filters in `docs/agent-gcp-access.md`.

### Review feedback

- **Codex P2:** round Bearer vs stale `sessionKey` precedence → addressed
- **Copilot:** docs field name `userAgent`; misleading finished reason on bad `sessionKey` → addressed

## Test plan

- [x] OAuth Bearer + `sessionKey` on `get_brief` succeeds
- [x] OAuth Bearer alone still refused
- [x] Round Bearer + stale mismatched `sessionKey` still succeeds
- [x] Forged `sessionKey` → `invalid sessionKey`, not finished
- [x] Creator-key paste-once + `sessionKey` still succeeds
- [x] Logging tests (no secrets in log lines)
- [ ] After deploy: reconnect ChatGPT to `/studio/pong`; on failure grep `mcp_tool_refused`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

