### PR TITLE
byoca: make the consent screen a consent screen

### DIFF
--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -13,6 +13,7 @@ import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { buildApp } from './app.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import { mintMcpSessionKey } from './mcp-session-key.js';
+import { consentToken } from './oauth-as.js';
 import { pkceChallengeS256 } from './oauth-pkce.js';
 import { InMemoryStore } from './store.js';
 import type { CreatorAgentKeyRecord } from './store.js';
@@ -164,6 +165,7 @@ async function oauthAccessToken(app: FastifyInstance): Promise<string> {
   });
   const clientId = register.json().client_id as string;
   const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const challenge = pkceChallengeS256(verifier);
   const approve = await app.inject({
     method: 'POST',
     url: '/oauth/authorize',
@@ -174,9 +176,10 @@ async function oauthAccessToken(app: FastifyInstance): Promise<string> {
       redirect_uri: 'http://127.0.0.1/callback',
       scope: 'mcp',
       state: 'xyz',
-      code_challenge: pkceChallengeS256(verifier),
+      code_challenge: challenge,
       code_challenge_method: 'S256',
       action: 'approve',
+      consent_token: consentToken({ uid: OWNER, clientId, codeChallenge: challenge, secret: sessionSecret }),
     }).toString(),
   });
   const code = new URL(approve.headers.location as string).searchParams.get('code');
@@ -374,6 +377,7 @@ describe('creator agent key routes + MCP start (BY-27a)', () => {
         code_challenge: challenge,
         code_challenge_method: 'S256',
         action: 'approve',
+        consent_token: consentToken({ uid: OWNER, clientId, codeChallenge: challenge, secret: sessionSecret }),
       }).toString(),
     });
     expect(approve.statusCode).toBe(302);

--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -6,6 +6,7 @@ import { mintGameAgentKey } from './agent-game-key.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { OAUTH_AS_METADATA_PATH } from './oauth-as.js';
 import { pkceChallengeS256 } from './oauth-pkce.js';
+import { consentToken } from './oauth-as.js';
 import { AS_ACCESS_TOKEN_TTL_MS, generateAsAccessToken, generateAsRefreshToken } from './oauth-tokens.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { InMemoryStore } from './store.js';
@@ -98,6 +99,7 @@ async function authorizeAndExchange(
       code_challenge: challenge,
       code_challenge_method: 'S256',
       action: 'approve',
+      consent_token: consentToken({ uid, clientId, codeChallenge: challenge, secret: SESSION_SECRET }),
     }).toString(),
   });
   expect(approve.statusCode).toBe(302);
@@ -202,6 +204,7 @@ describe('OAuth authorization server (BY-18b)', () => {
         code_challenge: challenge,
         code_challenge_method: 'S256',
         action: 'approve',
+        consent_token: consentToken({ uid: 'g:creator', clientId, codeChallenge: challenge, secret: SESSION_SECRET }),
       }).toString(),
     });
     const code = new URL(approve.headers.location as string).searchParams.get('code');
@@ -238,6 +241,7 @@ describe('OAuth authorization server (BY-18b)', () => {
         code_challenge: challenge,
         code_challenge_method: 'S256',
         action: 'approve',
+        consent_token: consentToken({ uid: 'g:creator', clientId, codeChallenge: challenge, secret: SESSION_SECRET }),
       }).toString(),
     });
     const code = new URL(approve.headers.location as string).searchParams.get('code')!;
@@ -592,5 +596,86 @@ describe('oauth token helpers', () => {
     });
     const { verifyAsAccessToken } = await import('./oauth-tokens.js');
     expect(await verifyAsAccessToken(store, generated.token, Date.now())).toBeNull();
+  });
+
+  // The screen mints durable write access to someone's games, and `sameSite: 'lax'` does
+  // not stop a top-level cross-site form POST — so before this, the consent screen could
+  // be skipped entirely by a page the creator never saw.
+  it('names who is asking, and only accepts a submit that came from its own screen', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator', email: 'creator@example.com' });
+    const app = await buildOAuthApp(store);
+    const clientId = await registerClient(app);
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = pkceChallengeS256(verifier);
+
+    const query = {
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: 'http://127.0.0.1/callback',
+      scope: 'mcp',
+      state: 'xyz',
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    };
+
+    const page = await app.inject({
+      method: 'GET',
+      url: `/oauth/authorize?${new URLSearchParams(query).toString()}`,
+      headers: { cookie: sessionCookie('g:creator') },
+    });
+    expect(page.statusCode).toBe(200);
+
+    // Two different clients must not produce an identical screen — that is what makes
+    // consent informed rather than a formality.
+    expect(page.body).toContain('Test Agent');
+    expect(page.body).not.toContain('A coding agent is asking');
+    expect(page.body).toContain('creator@example.com');
+    // It says what the grant permits, and for how long.
+    expect(page.body).toMatch(/build rounds on games you own/i);
+    expect(page.body).toMatch(/until you revoke it/i);
+    // The site is dark; a consent page that looks foreign is one nobody can vet.
+    expect(page.body).toContain('#0f1418');
+
+    const issued = /name="consent_token" value="([^"]+)"/.exec(page.body);
+    expect(issued, 'the screen must issue a token').toBeTruthy();
+
+    const fields = { ...query, action: 'approve' };
+
+    // A submit that never saw the screen is refused.
+    const forged = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { cookie: sessionCookie('g:creator'), 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams(fields).toString(),
+    });
+    expect(forged.statusCode).toBe(403);
+    expect(forged.json()).toMatchObject({ error: 'invalid_consent' });
+
+    // So is another creator's token — it is bound to the uid, not just to the request.
+    const lifted = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { cookie: sessionCookie('g:creator'), 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        ...fields,
+        consent_token: consentToken({
+          uid: 'g:someone-else',
+          clientId,
+          codeChallenge: challenge,
+          secret: SESSION_SECRET,
+        }),
+      }).toString(),
+    });
+    expect(lifted.statusCode).toBe(403);
+
+    // And the real one is accepted, so this is a gate rather than a wall.
+    const accepted = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { cookie: sessionCookie('g:creator'), 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ ...fields, consent_token: issued![1]! }).toString(),
+    });
+    expect(accepted.statusCode).toBe(302);
   });
 });

--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -59,10 +59,22 @@ async function seedSelfRound(store: InMemoryStore, issue = 42, owner = 'g:creato
   });
 }
 
+/**
+ * Registers a client from its own source IP.
+ *
+ * `/oauth/register` is rate limited per IP and the whole suite shares 127.0.0.1, so
+ * whether a given test got a 201 or a 429 depended on how many registrations ran before
+ * it — which is file order, which differs between a local run and CI. That is how a
+ * green local suite went red on the runner. Each caller now gets its own bucket.
+ */
+let registrarIp = 0;
+
 async function registerClient(app: FastifyInstance, redirectUri = 'http://127.0.0.1/callback') {
+  registrarIp += 1;
   const res = await app.inject({
     method: 'POST',
     url: '/oauth/register',
+    remoteAddress: `10.9.${Math.floor(registrarIp / 250)}.${(registrarIp % 250) + 1}`,
     headers: { 'content-type': 'application/json' },
     payload: {
       redirect_uris: [redirectUri],
@@ -633,6 +645,10 @@ describe('oauth token helpers', () => {
     // It says what the grant permits, and for how long.
     expect(page.body).toMatch(/build rounds on games you own/i);
     expect(page.body).toMatch(/until you revoke it/i);
+    // The grant also dies on its own after 90 days of inactivity — refresh rotation only
+    // resets that clock. Saying "until you revoke it" alone would be a promise the
+    // refresh TTL breaks, which is the same defect as #488's "rotating stops every agent".
+    expect(page.body).toMatch(/90 days without connecting/i);
     // The site is dark; a consent page that looks foreign is one nobody can vet.
     expect(page.body).toContain('#0f1418');
 
@@ -712,20 +728,7 @@ describe('oauth token helpers', () => {
       },
     });
 
-    // Distinct source IP: /oauth/register is rate limited per IP and the suite shares one.
-    const reg = await app.inject({
-      method: 'POST',
-      url: '/oauth/register',
-      remoteAddress: '10.1.2.3',
-      headers: { 'content-type': 'application/json' },
-      payload: {
-        redirect_uris: ['http://127.0.0.1/rotate'],
-        client_name: 'Rotation Agent',
-        token_endpoint_auth_method: 'none',
-      },
-    });
-    expect(reg.statusCode).toBe(201);
-    const clientId = reg.json().client_id as string;
+    const clientId = await registerClient(app, 'http://127.0.0.1/rotate');
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
     const challenge = pkceChallengeS256(verifier);
     const fields = {

--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -4,9 +4,8 @@ import { buildApp } from './app.js';
 import { mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
 import { mintGameAgentKey } from './agent-game-key.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
-import { OAUTH_AS_METADATA_PATH } from './oauth-as.js';
+import { consentToken, OAUTH_AS_METADATA_PATH } from './oauth-as.js';
 import { pkceChallengeS256 } from './oauth-pkce.js';
-import { consentToken } from './oauth-as.js';
 import { AS_ACCESS_TOKEN_TTL_MS, generateAsAccessToken, generateAsRefreshToken } from './oauth-tokens.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { InMemoryStore } from './store.js';
@@ -677,5 +676,87 @@ describe('oauth token helpers', () => {
       payload: new URLSearchParams({ ...fields, consent_token: issued![1]! }).toString(),
     });
     expect(accepted.statusCode).toBe(302);
+  });
+
+  // Sessions verify against the previous secret during a rotation, so a consent token
+  // that did not would 403 a creator who did nothing wrong — on the one screen where a
+  // refusal reads like an attack rather than a config change.
+  it('still accepts a consent token issued under the previous session secret', async () => {
+    const PREV = 'previous-session-secret-value';
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator', email: 'creator@example.com' });
+    const app = await buildApp({
+      store,
+      sessionSecret: SESSION_SECRET,
+      sessionSecretPrev: PREV,
+      submissionRoutes: {
+        githubClient: {
+          createIssue: async () => ({ number: 42 }),
+          getIssueState: async () => ({ state: 'open' as const }),
+          findLinkedPR: async () => null,
+          createIssueComment: async () => ({ id: 1 }),
+          updateIssueBody: async () => {},
+          closeIssue: async () => {},
+          closePullRequest: async () => {},
+          ensureOpenPullRequest: async () => ({ number: 1 }),
+          deleteBranch: async () => {},
+          getGameSources: async () => null,
+          getGameMedia: async () => null,
+          getCatalog: async () => [],
+          getProgressNotes: async () => null,
+        } as never,
+        githubToken: 'gh-token',
+        submissionTokenSecret: MCP_SECRET,
+        translator: new NoopTranslator(),
+        agentChannel: {},
+      },
+    });
+
+    // Distinct source IP: /oauth/register is rate limited per IP and the suite shares one.
+    const reg = await app.inject({
+      method: 'POST',
+      url: '/oauth/register',
+      remoteAddress: '10.1.2.3',
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        redirect_uris: ['http://127.0.0.1/rotate'],
+        client_name: 'Rotation Agent',
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(reg.statusCode).toBe(201);
+    const clientId = reg.json().client_id as string;
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = pkceChallengeS256(verifier);
+    const fields = {
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: 'http://127.0.0.1/rotate',
+      scope: 'mcp',
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      action: 'approve',
+    };
+
+    // The token the screen handed out before the rotation.
+    const beforeRotation = consentToken({ uid: 'g:creator', clientId, codeChallenge: challenge, secret: PREV });
+    const accepted = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { cookie: sessionCookie('g:creator'), 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ ...fields, consent_token: beforeRotation }).toString(),
+    });
+    expect(accepted.statusCode).toBe(302);
+
+    // A secret that was never ours is still refused — this widens the window, not the gate.
+    const foreign = consentToken({ uid: 'g:creator', clientId, codeChallenge: challenge, secret: 'not-our-secret' });
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { cookie: sessionCookie('g:creator'), 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ ...fields, consent_token: foreign }).toString(),
+    });
+    expect(refused.statusCode).toBe(403);
+    await app.close();
   });
 });

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -275,7 +275,7 @@ function consentHtml(input: {
 </head>
 <body>
   <main>
-    <p class="brand">gamedev.pl</p>
+    <p class="brand">${MASCOT_SVG}<span>gamedev.pl</span></p>
     <h1>${escapeHtml(copy.title)}</h1>
     <p class="lead">${escapeHtml(copy.lead)}</p>
     ${input.account ? `<p class="who">${escapeHtml(copy.as)} <strong>${escapeHtml(input.account)}</strong></p>` : ''}
@@ -311,6 +311,19 @@ function consentHtml(input: {
 }
 
 /**
+ * The gamedev.pl mascot, idle pose, as one static path.
+ *
+ * Traced spans from apps/web/src/mascotSpans.ts, flattened at authoring time because
+ * this page is server-rendered plain HTML with no bundler and no React — and because a
+ * consent screen must not depend on a network fetch that can fail or leak a referrer.
+ *
+ * It is here for recognition, which is the only anti-phishing cue a creator actually
+ * has: a page that looks like gamedev.pl is one they can judge. Small and beside the
+ * wordmark rather than a hero, so the permissions stay above the fold on a phone.
+ */
+const MASCOT_SVG = `<svg class="mascot" viewBox="0 0 70 60" width="34" height="29" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M21 1h28v1h-28zM19 2h32v1h-32zM18 3h14v1h-14zM33 3h4v1h-4zM39 3h14v1h-14zM17 4h13v1h-13zM34 4h3v1h-3zM40 4h14v1h-14zM16 5h13v1h-13zM33 5h5v1h-5zM41 5h14v1h-14zM15 6h13v1h-13zM32 6h6v1h-6zM41 6h14v1h-14zM14 7h14v1h-14zM31 7h8v1h-8zM41 7h15v1h-15zM14 8h42v1h-42zM14 9h43v1h-43zM14 10h43v1h-43zM13 11h20v1h-20zM38 11h19v1h-19zM13 12h19v1h-19zM39 12h18v1h-18zM13 13h18v1h-18zM39 13h18v1h-18zM13 14h18v1h-18zM40 14h17v1h-17zM13 15h17v1h-17zM40 15h10v1h-10zM51 15h7v1h-7zM13 16h6v1h-6zM21 16h9v1h-9zM41 16h8v1h-8zM51 16h7v1h-7zM5 17h6v1h-6zM13 17h6v1h-6zM22 17h7v1h-7zM41 17h8v1h-8zM52 17h6v1h-6zM59 17h6v1h-6zM3 18h15v1h-15zM23 18h6v1h-6zM42 18h6v1h-6zM52 18h14v1h-14zM2 19h16v1h-16zM23 19h5v1h-5zM43 19h4v1h-4zM53 19h15v1h-15zM1 20h16v1h-16zM24 20h3v1h-3zM43 20h3v1h-3zM53 20h15v1h-15zM1 21h4v1h-4zM11 21h6v1h-6zM25 21h2v1h-2zM44 21h2v1h-2zM53 21h6v1h-6zM64 21h5v1h-5zM0 22h4v1h-4zM12 22h5v1h-5zM44 22h1v1h-1zM53 22h5v1h-5zM66 22h3v1h-3zM0 23h3v1h-3zM6 23h4v1h-4zM12 23h5v1h-5zM53 23h4v1h-4zM60 23h4v1h-4zM66 23h4v1h-4zM0 24h3v1h-3zM5 24h6v1h-6zM13 24h4v1h-4zM53 24h4v1h-4zM59 24h5v1h-5zM67 24h3v1h-3zM0 25h3v1h-3zM5 25h6v1h-6zM13 25h4v1h-4zM53 25h4v1h-4zM59 25h6v1h-6zM67 25h3v1h-3zM0 26h3v1h-3zM5 26h6v1h-6zM13 26h4v1h-4zM53 26h4v1h-4zM59 26h6v1h-6zM67 26h3v1h-3zM0 27h3v1h-3zM5 27h6v1h-6zM13 27h4v1h-4zM53 27h4v1h-4zM59 27h6v1h-6zM67 27h3v1h-3zM0 28h3v1h-3zM6 28h4v1h-4zM13 28h4v1h-4zM53 28h4v1h-4zM60 28h4v1h-4zM66 28h4v1h-4zM0 29h4v1h-4zM12 29h5v1h-5zM53 29h5v1h-5zM66 29h3v1h-3zM1 30h4v1h-4zM11 30h6v1h-6zM53 30h6v1h-6zM64 30h5v1h-5zM1 31h16v1h-16zM53 31h15v1h-15zM2 32h15v1h-15zM53 32h15v1h-15zM3 33h14v1h-14zM53 33h14v1h-14zM5 34h12v1h-12zM26 34h1v1h-1zM44 34h1v1h-1zM53 34h12v1h-12zM10 35h8v1h-8zM26 35h2v1h-2zM43 35h2v1h-2zM53 35h7v1h-7zM10 36h8v1h-8zM25 36h4v1h-4zM42 36h4v1h-4zM53 36h7v1h-7zM9 37h9v1h-9zM25 37h5v1h-5zM41 37h5v1h-5zM52 37h10v1h-10zM7 38h12v1h-12zM25 38h6v1h-6zM40 38h7v1h-7zM52 38h11v1h-11zM6 39h13v1h-13zM24 39h8v1h-8zM39 39h8v1h-8zM51 39h13v1h-13zM5 40h15v1h-15zM24 40h9v1h-9zM38 40h9v1h-9zM50 40h15v1h-15zM4 41h5v1h-5zM10 41h11v1h-11zM23 41h11v1h-11zM37 41h11v1h-11zM49 41h11v1h-11zM61 41h4v1h-4zM4 42h4v1h-4zM11 42h11v1h-11zM23 42h12v1h-12zM36 42h24v1h-24zM62 42h4v1h-4zM3 43h4v1h-4zM11 43h48v1h-48zM63 43h3v1h-3zM3 44h4v1h-4zM12 44h47v1h-47zM63 44h3v1h-3zM3 45h3v1h-3zM12 45h46v1h-46zM63 45h4v1h-4zM3 46h3v1h-3zM13 46h44v1h-44zM63 46h4v1h-4zM3 47h3v1h-3zM14 47h42v1h-42zM63 47h4v1h-4zM3 48h3v1h-3zM16 48h38v1h-38zM63 48h4v1h-4zM3 49h3v1h-3zM18 49h34v1h-34zM63 49h4v1h-4zM3 50h3v1h-3zM21 50h8v1h-8zM40 50h8v1h-8zM63 50h4v1h-4zM3 51h3v1h-3zM21 51h8v1h-8zM40 51h8v1h-8zM64 51h3v1h-3zM4 52h1v1h-1zM21 52h8v1h-8zM40 52h8v1h-8zM21 53h8v1h-8zM40 53h8v1h-8zM21 54h8v1h-8zM40 54h8v1h-8zM21 55h8v1h-8zM40 55h8v1h-8zM21 56h7v1h-7zM40 56h8v1h-8zM22 57h6v1h-6zM41 57h6v1h-6zM23 58h4v1h-4zM42 58h4v1h-4z"/></svg>`;
+
+/**
  * The site's own tokens, copied from apps/web/src/styles.css.
  *
  * This page is server-rendered and never met the design system, so it shipped on the
@@ -332,7 +345,9 @@ const CONSENT_STYLES = `<style>
     }
     main { max-width: 34rem; margin: 0 auto; background: var(--panel);
       border: 1px solid var(--panel-border); border-radius: 14px; padding: 2rem; }
-    .brand { margin: 0 0 1.25rem; font-size: 0.8rem; font-weight: 700; color: var(--turquoise); }
+    .brand { margin: 0 0 1.25rem; font-size: 0.8rem; font-weight: 700; color: var(--turquoise);
+      display: flex; align-items: center; gap: 0.5rem; }
+    .mascot { display: block; flex: none; }
     h1 { font-size: 1.5rem; line-height: 1.2; margin: 0 0 0.75rem; }
     h2 { font-size: 0.9rem; margin: 1.5rem 0 0.5rem; }
     .lead { margin: 0 0 1rem; }

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID } from 'node:crypto';
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
@@ -170,29 +170,86 @@ function clientLabel(client: OAuthClientRecord, redirectUri?: string): string {
   return client.clientId;
 }
 
+/**
+ * Binds the consent form to the session that was shown it.
+ *
+ * `POST /oauth/authorize` mints a real, durable grant, and its only protection was the
+ * session cookie's `sameSite: 'lax'` — which does not cover a top-level form POST from
+ * another origin. That is the one request on this server where a cross-site submit is
+ * worth mounting: it hands a coding agent standing write access to someone's games
+ * without the consent screen ever rendering.
+ *
+ * Stateless on purpose: the HMAC covers the uid together with the exact request being
+ * consented to, so a token cannot be lifted from one creator's form onto another's, nor
+ * replayed against a different client or PKCE challenge.
+ */
+export function consentToken(input: { uid: string; clientId: string; codeChallenge: string; secret: string }): string {
+  return createHmac('sha256', input.secret)
+    .update(`oauth-consent-v1:${input.uid}:${input.clientId}:${input.codeChallenge}`)
+    .digest('hex');
+}
+
+function consentTokenValid(candidate: string, expected: string): boolean {
+  const a = Buffer.from(candidate, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
 function consentHtml(input: {
   lang: 'en' | 'pl';
   redirectUri: string;
   clientId: string;
+  clientName?: string;
+  account?: string;
   state?: string;
   codeChallenge: string;
   scope: string;
+  consentToken: string;
 }): string {
+  // Falls back to the client_id when a client registered without a name. Better a URL
+  // the creator can read than "a coding agent", which every client would say.
+  const client = input.clientName?.trim() || input.clientId;
   const copy =
     input.lang === 'pl'
       ? {
-          title: 'Połącz agenta kodującego',
-          lead: 'Agent kodujący prosi o dostęp do Twojego konta gamedev.pl.',
-          redirect: 'Po zatwierdzeniu zostaniesz przekierowany na:',
+          title: `Połącz ${client}`,
+          lead: `${client} prosi o budowanie gier na Twoim koncie.`,
+          as: 'Zatwierdzasz jako',
+          canTitle: 'Będzie mógł',
+          can: [
+            'Rozpoczynać i kontynuować rundy budowania Twoich gier',
+            'Zużywać Twój dzienny limit poprawek',
+            'Czytać i zastępować źródła Twoich gier',
+            'Publikować nowe wersje w arcade',
+          ],
+          cannotTitle: 'Nie będzie mógł',
+          cannot: ['Dotykać gier, których nie jesteś właścicielem', 'Zmieniać Twojego konta ani logowania'],
+          redirect: 'Wrócisz na',
+          redirectHint: 'To powinien być agent, którego przed chwilą użyłeś. Jeśli go nie rozpoznajesz — odmów.',
+          duration: 'Dostęp trwa, dopóki go nie cofniesz w Studio.',
           approve: 'Zatwierdź',
           deny: 'Odmów',
+          bail: 'Nie łączyłeś przed chwilą agenta? Naciśnij Odmów — nic nie zostanie udostępnione.',
         }
       : {
-          title: 'Connect your coding agent',
-          lead: 'A coding agent is asking to access your gamedev.pl account.',
-          redirect: 'After you approve, you will be sent back to:',
+          title: `Connect ${client}`,
+          lead: `${client} is asking to build games on your account.`,
+          as: 'Granting as',
+          canTitle: 'It will be able to',
+          can: [
+            'Start and continue build rounds on games you own',
+            'Use your daily improvement rounds',
+            'Read and replace the sources of your games',
+            'Publish new versions to the arcade',
+          ],
+          cannotTitle: 'It will not be able to',
+          cannot: ['Touch games you do not own', 'Change your account or how you sign in'],
+          redirect: "You'll be sent back to",
+          redirectHint: 'This should be the agent you just used. If you do not recognise it, deny.',
+          duration: 'Access lasts until you revoke it in Studio.',
           approve: 'Approve',
           deny: 'Deny',
+          bail: 'Did not just connect an agent? Press Deny — nothing is shared unless you approve.',
         };
 
   const hidden = [
@@ -203,37 +260,102 @@ function consentHtml(input: {
     `<input type="hidden" name="code_challenge_method" value="S256" />`,
     `<input type="hidden" name="scope" value="${escapeHtml(input.scope)}" />`,
     `<input type="hidden" name="response_type" value="code" />`,
+    `<input type="hidden" name="consent_token" value="${escapeHtml(input.consentToken)}" />`,
   ].join('\n');
+
+  const list = (items: string[]) => items.map((item) => `<li>${escapeHtml(item)}</li>`).join('\n      ');
 
   return `<!doctype html>
 <html lang="${input.lang}">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${copy.title}</title>
-  <style>
-    body { font-family: system-ui, sans-serif; max-width: 36rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
-    .redirect { font-family: ui-monospace, monospace; word-break: break-all; background: #f4f4f5; padding: 0.75rem; border-radius: 0.5rem; }
-    .actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
-    button { font: inherit; padding: 0.5rem 1rem; border-radius: 0.5rem; border: 1px solid #ccc; cursor: pointer; }
-    .approve { background: #111; color: #fff; border-color: #111; }
-  </style>
+  <title>${escapeHtml(copy.title)}</title>
+  ${CONSENT_STYLES}
 </head>
 <body>
-  <h1>${copy.title}</h1>
-  <p>${copy.lead}</p>
-  <p><strong>${copy.redirect}</strong></p>
-  <p class="redirect">${escapeHtml(input.redirectUri)}</p>
-  <form method="post" action="/oauth/authorize">
-    ${hidden}
-    <div class="actions">
-      <button type="submit" name="action" value="approve" class="approve">${copy.approve}</button>
-      <button type="submit" name="action" value="deny">${copy.deny}</button>
-    </div>
-  </form>
+  <main>
+    <p class="brand">gamedev.pl</p>
+    <h1>${escapeHtml(copy.title)}</h1>
+    <p class="lead">${escapeHtml(copy.lead)}</p>
+    ${input.account ? `<p class="who">${escapeHtml(copy.as)} <strong>${escapeHtml(input.account)}</strong></p>` : ''}
+
+    <h2>${escapeHtml(copy.canTitle)}</h2>
+    <ul class="can">
+      ${list(copy.can)}
+    </ul>
+
+    <h2>${escapeHtml(copy.cannotTitle)}</h2>
+    <ul class="cannot">
+      ${list(copy.cannot)}
+    </ul>
+
+    <h2>${escapeHtml(copy.redirect)}</h2>
+    <p class="redirect">${escapeHtml(input.redirectUri)}</p>
+    <p class="hint">${escapeHtml(copy.redirectHint)}</p>
+
+    <p class="duration">${escapeHtml(copy.duration)}</p>
+
+    <form method="post" action="/oauth/authorize">
+      ${hidden}
+      <div class="actions">
+        <button type="submit" name="action" value="approve" class="approve">${escapeHtml(copy.approve)}</button>
+        <button type="submit" name="action" value="deny">${escapeHtml(copy.deny)}</button>
+      </div>
+    </form>
+
+    <p class="bail">${escapeHtml(copy.bail)}</p>
+  </main>
 </body>
 </html>`;
 }
+
+/**
+ * The site's own tokens, copied from apps/web/src/styles.css.
+ *
+ * This page is server-rendered and never met the design system, so it shipped on the
+ * browser default white while gamedev.pl is dark. That is not only ugly: a consent
+ * screen is where someone decides whether a page is really the site it claims to be,
+ * and one that looks nothing like the site removes the only cue they have.
+ */
+const CONSENT_STYLES = `<style>
+    :root {
+      --bg: #0f1418; --panel: #161c22; --panel-border: #232c35; --panel-card: #1c242c;
+      --text: #f0f4f8; --muted: #94a3b8; --turquoise: #00e4ac; --warn: #e5b76a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; padding: 2rem 1rem 4rem; background: var(--bg);
+      background-image: radial-gradient(circle at 50% 0%, #1a232b 0%, #0f1418 70%);
+      background-attachment: fixed; color: var(--text);
+      font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.55;
+    }
+    main { max-width: 34rem; margin: 0 auto; background: var(--panel);
+      border: 1px solid var(--panel-border); border-radius: 14px; padding: 2rem; }
+    .brand { margin: 0 0 1.25rem; font-size: 0.8rem; font-weight: 700; color: var(--turquoise); }
+    h1 { font-size: 1.5rem; line-height: 1.2; margin: 0 0 0.75rem; }
+    h2 { font-size: 0.9rem; margin: 1.5rem 0 0.5rem; }
+    .lead { margin: 0 0 1rem; }
+    .who { margin: 0 0 1rem; padding: 0.75rem 0; color: var(--muted); font-size: 0.9rem;
+      border-top: 1px solid var(--panel-border); border-bottom: 1px solid var(--panel-border); }
+    .who strong { color: var(--text); }
+    ul { margin: 0; padding-left: 1.1rem; }
+    ul.can li { margin: 0.25rem 0; }
+    ul.cannot li { margin: 0.25rem 0; color: var(--muted); font-size: 0.92rem; }
+    .redirect { font-family: ui-monospace, monospace; word-break: break-all;
+      background: var(--panel-card); border: 1px solid var(--panel-border);
+      padding: 0.75rem; border-radius: 0.5rem; margin: 0; }
+    .hint, .duration { color: var(--muted); font-size: 0.85rem; }
+    .duration { background: var(--panel-card); padding: 0.7rem 0.8rem; border-radius: 0.5rem; margin: 1.25rem 0 0; }
+    .waiting { display: inline-block; margin: 0 0 0.75rem; padding: 0.25rem 0.75rem; border-radius: 999px;
+      background: rgba(229,183,106,0.14); color: var(--warn); font-size: 0.8rem; font-weight: 700; }
+    .actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap; }
+    button { font: inherit; font-weight: 700; padding: 0.6rem 1.25rem; border-radius: 0.55rem;
+      border: 1px solid var(--panel-border); background: transparent; color: var(--text); cursor: pointer; }
+    .approve { background: var(--turquoise); color: #0b1017; border-color: var(--turquoise); }
+    .bail { margin: 1.25rem 0 0; padding-top: 1rem; border-top: 1px solid var(--panel-border);
+      color: var(--muted); font-size: 0.85rem; }
+  </style>`;
 
 function escapeHtml(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -384,15 +506,34 @@ export function registerOAuthAuthorizationServerRoutes(
       return reply.status(validated.status).send({ error: validated.error });
     }
 
-    const { params } = validated;
+    const { params, client } = validated;
+    const lang = pickLang(request);
+    const user = await store.getUser(uid);
+
+    // NOT gated on beta access here, deliberately. A waitlisted creator can still approve
+    // and then meet the wall at their agent's first call, which is a bad late failure —
+    // but the access rule in auth.ts is three-way (betaAllowedUids, betaAllowedEmails,
+    // then the waitlist), and checking only the waitlist would refuse every creator
+    // allowlisted by environment, which is most of the ones using this. Fixing the late
+    // failure means extracting that predicate so both places share it, not copying a
+    // third of it here.
+
     return reply.type('text/html').send(
       consentHtml({
-        lang: pickLang(request),
+        lang,
         redirectUri: params.redirect_uri,
         clientId: params.client_id,
+        clientName: client?.clientName,
+        account: user?.email,
         state: params.state,
         codeChallenge: params.code_challenge,
         scope: params.scope ?? MCP_SCOPE,
+        consentToken: consentToken({
+          uid,
+          clientId: params.client_id,
+          codeChallenge: params.code_challenge,
+          secret: sessionSecret,
+        }),
       }),
     );
   });
@@ -409,6 +550,24 @@ export function registerOAuthAuthorizationServerRoutes(
     }
 
     const { params } = validated;
+
+    // A grant is durable write access to someone's games, and `sameSite: 'lax'` does not
+    // stop a top-level cross-site form POST — so without this the screen above could be
+    // skipped entirely. Checked before the action is even read.
+    const submittedToken =
+      typeof (request.body as { consent_token?: string }).consent_token === 'string'
+        ? (request.body as { consent_token: string }).consent_token
+        : '';
+    const expectedToken = consentToken({
+      uid,
+      clientId: params.client_id,
+      codeChallenge: params.code_challenge,
+      secret: sessionSecret,
+    });
+    if (!consentTokenValid(submittedToken, expectedToken)) {
+      return reply.status(403).send({ error: 'invalid_consent' });
+    }
+
     const action =
       typeof (request.body as { action?: string }).action === 'string'
         ? (request.body as { action: string }).action

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -171,6 +171,15 @@ function clientLabel(client: OAuthClientRecord, redirectUri?: string): string {
 }
 
 /**
+ * Days of inactivity after which a grant dies on its own.
+ *
+ * Derived, not typed as a number: the consent screen states this as a promise, and a
+ * promise that drifts from the constant enforcing it is the defect this whole screen
+ * exists to stop making.
+ */
+const INACTIVITY_DAYS = Math.round(AS_REFRESH_TOKEN_TTL_MS / (24 * 60 * 60 * 1000));
+
+/**
  * Binds the consent form to the session that was shown it.
  *
  * `POST /oauth/authorize` mints a real, durable grant, and its only protection was the
@@ -226,7 +235,7 @@ function consentHtml(input: {
           cannot: ['Dotykać gier, których nie jesteś właścicielem', 'Zmieniać Twojego konta ani logowania'],
           redirect: 'Wrócisz na',
           redirectHint: 'To powinien być agent, którego przed chwilą użyłeś. Jeśli go nie rozpoznajesz — odmów.',
-          duration: 'Dostęp trwa, dopóki go nie cofniesz w Studio.',
+          duration: `Dostęp trwa, dopóki go nie cofniesz w Studio — albo dopóki agent nie połączy się przez ${INACTIVITY_DAYS} dni.`,
           approve: 'Zatwierdź',
           deny: 'Odmów',
           bail: 'Nie łączyłeś przed chwilą agenta? Naciśnij Odmów — nic nie zostanie udostępnione.',
@@ -246,7 +255,7 @@ function consentHtml(input: {
           cannot: ['Touch games you do not own', 'Change your account or how you sign in'],
           redirect: "You'll be sent back to",
           redirectHint: 'This should be the agent you just used. If you do not recognise it, deny.',
-          duration: 'Access lasts until you revoke it in Studio.',
+          duration: `Access lasts until you revoke it in Studio, or until the agent goes ${INACTIVITY_DAYS} days without connecting.`,
           approve: 'Approve',
           deny: 'Deny',
           bail: 'Did not just connect an agent? Press Deny — nothing is shared unless you approve.',

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -573,13 +573,18 @@ export function registerOAuthAuthorizationServerRoutes(
       typeof (request.body as { consent_token?: string }).consent_token === 'string'
         ? (request.body as { consent_token: string }).consent_token
         : '';
-    const expectedToken = consentToken({
-      uid,
-      clientId: params.client_id,
-      codeChallenge: params.code_challenge,
-      secret: sessionSecret,
-    });
-    if (!consentTokenValid(submittedToken, expectedToken)) {
+    // Both secrets, exactly as the session cookie is read. A rotation between the GET
+    // that issued the token and the POST that spends it leaves the session valid — it
+    // verifies against `sessionSecretPrev` — so rejecting the token would 403 a creator
+    // who did nothing wrong, on the one screen where a refusal looks like a break-in.
+    const acceptedSecrets = sessionSecretPrev ? [sessionSecret, sessionSecretPrev] : [sessionSecret];
+    const tokenAccepted = acceptedSecrets.some((secret) =>
+      consentTokenValid(
+        submittedToken,
+        consentToken({ uid, clientId: params.client_id, codeChallenge: params.code_challenge, secret }),
+      ),
+    );
+    if (!tokenAccepted) {
       return reply.status(403).send({ error: 'invalid_consent' });
     }
 


### PR DESCRIPTION
It rendered, and that was all it did.

> "A coding agent is asking to access your gamedev.pl account."

A sentence every client produces identically, about an account it never named, granting something it never described, on a page that looked nothing like gamedev.pl.

## It could be reached without being seen

`POST /oauth/authorize` mints a durable grant, and its only protection was the session cookie's `sameSite: 'lax'` — which does not cover a top-level cross-site form POST. A page the creator never visited could hand a coding agent standing write access to their games with the consent screen never rendering.

**Every existing test in the suite submitted exactly that shape and passed**, which is the clearest evidence the hole was real — they all had to be changed to go through the form.

Consent is now bound to the screen that issued it by an HMAC over `(uid, client_id, code_challenge)`. Stateless, and covering the uid means a token cannot be lifted from one creator's form onto another's, nor replayed against a different client or PKCE challenge.

## It says who, what, and as whom

- **Who** — from the `clientName` already on the record and previously discarded, falling back to `client_id` so a nameless client shows a URL rather than a generic phrase.
- **As whom** — the account being granted from, which matters most for anyone signed into more than one Google account.
- **What** — rounds, daily quota, sources, publishing. Not "access".
- **How long, and where to undo it.**

The redirect URI is still shown, but reframed from *"you will be sent back to"* into the thing to check.

## It looks like the site

The page set no background at all, so it shipped on the browser default white while gamedev.pl is dark (`--bg: #0f1418`). That is not decoration: a consent screen is exactly where someone decides whether a page really belongs to the site it claims to, and one that looks foreign removes the only cue they have — while training people that unfamiliar-looking gamedev.pl pages are normal.

## Deliberately not included: the waitlisted state

Catching beta access at consent rather than at the agent's first call is right, and I built it. Then a test failed and showed the gate was wrong: `auth.ts` allows on `betaAllowedUids` **OR** `betaAllowedEmails` **OR** `isWaitlistApproved`, and I had checked only the third. It would have refused every creator allowlisted by environment — most of the people using this, very likely including the owner.

Shipping a wrong gate on a consent screen is worse than shipping it later. Doing it properly means extracting that predicate so both call sites share it rather than copying a third of it, and that is its own change.

## Verification

Full gate by exit code: `type-check`, `lint`, `test`, `build` all 0.

A/B against the unfixed source shows the six pre-existing OAuth tests failing on the CSRF check — the bypass they were unknowingly exercising.

---
_Generated by [Claude Code](https://claude.ai/code/session_013awM1ccVuMcobGWsHMJSE8)_