### PR TITLE
Add GET /api/agent/build/media endpoint for gate-produced media (BY-28)

### DIFF
--- a/apps/api/src/agent-build-media.test.ts
+++ b/apps/api/src/agent-build-media.test.ts
@@ -1,0 +1,333 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import { buildApp } from './app.js';
+import type { GamesStore } from './games-store.js';
+import type { GcsObjectStore } from './gcs-sign.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+/**
+ * BY-28 — the gate's own media, read back over the channel.
+ *
+ * The posture under test is the agent that cannot run the game: it delivers, the gate
+ * runs, and everything it knows about the result is prose. These cases pin the two
+ * properties that make the read safe to expose — filenames come only from the
+ * validated metadata allowlist, and URLs are signed under this job's own slug+version.
+ */
+
+const secret = 'test-secret';
+const ISSUE = 91;
+const SLUG = 'comet-courier';
+const VERSION = 'v20260803T101500000-abc123';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02]);
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: ISSUE }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+function agentHeaders(issueNumber = ISSUE, roundGeneration = 1) {
+  return { authorization: `Bearer ${mintAgentToken(issueNumber, secret, { roundGeneration })}` };
+}
+
+const METADATA = JSON.stringify({
+  captures: {
+    opening: { file: 'opening.png' },
+    engagement: { file: 'engagement.png' },
+  },
+  video: { file: 'gameplay.mp4' },
+});
+
+/** Derived artifacts as the gate would have left them for one delivered version. */
+function stubGamesStore(
+  overrides: {
+    artifacts?: Map<string, Buffer>;
+    manifest?: unknown;
+  } = {},
+) {
+  const artifacts =
+    overrides.artifacts ??
+    new Map<string, Buffer>([
+      ['media/metadata.json', Buffer.from(METADATA)],
+      ['media/opening.png', PNG],
+      ['media/engagement.png', PNG],
+      ['media/gameplay.mp4', Buffer.from('mp4-bytes')],
+    ]);
+  const manifest =
+    overrides.manifest === undefined
+      ? { slug: SLUG, version: VERSION, gate: { green: true, ranAt: '2026-08-03T10:20:00.000Z' } }
+      : overrides.manifest;
+  return {
+    getManifest: async (slug: string, version: string) => (slug === SLUG && version === VERSION ? manifest : null),
+    getDerivedArtifact: async (slug: string, version: string, name: string) =>
+      slug === SLUG && version === VERSION ? (artifacts.get(name) ?? null) : null,
+    getSourceFile: async () => null,
+    putCandidateSources: async () => ({ version: VERSION, manifest: {} as never }),
+    putGateResult: async () => {},
+    putDerivedArtifact: async () => {},
+    getKitRegistry: async () => null,
+  } as unknown as GamesStore;
+}
+
+function stubObjectStore(signReadUrl = vi.fn(async (name: string) => `https://signed.example/${name}?sig=1`)) {
+  return {
+    objectStore: {
+      readObject: async () => null,
+      objectExists: async () => true,
+      signReadUrl,
+    } as GcsObjectStore,
+    signReadUrl,
+  };
+}
+
+async function createApp(store: InMemoryStore, gamesStore?: GamesStore, objectStore?: GcsObjectStore) {
+  return await buildApp({
+    store,
+    sessionSecret: 'dev-session-secret-change-me',
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh-token',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      agentChannel: { ...(gamesStore ? { gamesStore } : {}), ...(objectStore ? { objectStore } : {}) },
+    },
+  });
+}
+
+async function seedDeliveredJob(store: InMemoryStore) {
+  await store.createSubmission(ISSUE, 'g:owner', 'Comet Courier');
+  await store.setSubmissionSlug(ISSUE, SLUG);
+  await store.setSubmissionDeliveredVersion(ISSUE, VERSION);
+}
+
+describe('GET /api/agent/build/media (BY-28)', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('requires a build token, like every other channel read', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    app = await createApp(store, stubGamesStore(), stubObjectStore().objectStore);
+
+    const none = await app.inject({ method: 'GET', url: '/api/agent/build/media' });
+    expect(none.statusCode).toBe(401);
+    expect(none.json().error).toMatch(/missing build token/i);
+
+    const bad = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media',
+      headers: { authorization: 'Bearer not-a-token' },
+    });
+    expect(bad.statusCode).toBe(401);
+  });
+
+  it('signs every allowlisted capture and the video under the slug+version this job owns', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const { objectStore, signReadUrl } = stubObjectStore();
+    app = await createApp(store, stubGamesStore(), objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({
+      available: true,
+      deliveryId: VERSION,
+      gate: { green: true, ranAt: '2026-08-03T10:20:00.000Z' },
+      video: {
+        file: 'gameplay.mp4',
+        url: `https://signed.example/games/${SLUG}/versions/${VERSION}/media/gameplay.mp4?sig=1`,
+      },
+    });
+    expect(body.screenshots).toEqual([
+      {
+        name: 'opening',
+        file: 'opening.png',
+        url: `https://signed.example/games/${SLUG}/versions/${VERSION}/media/opening.png?sig=1`,
+      },
+      {
+        name: 'engagement',
+        file: 'engagement.png',
+        url: `https://signed.example/games/${SLUG}/versions/${VERSION}/media/engagement.png?sig=1`,
+      },
+    ]);
+    expect(body.expiresInSeconds).toBeGreaterThan(0);
+    // Every signed object sits under this job's own game and delivery — nothing else
+    // is reachable no matter what the round asks for.
+    for (const [name] of signReadUrl.mock.calls) {
+      expect(name).toMatch(new RegExp(`^games/${SLUG}/versions/${VERSION}/media/`));
+    }
+    // The inline frame is the opening shot, so a client that cannot fetch a URL still
+    // sees the game.
+    expect(body.openingShot).toEqual({ file: 'opening.png', png: PNG.toString('base64') });
+  });
+
+  it('serves only filenames the validated metadata declares', async () => {
+    // A capture directory can hold more than the metadata vouches for; the allowlist
+    // is the metadata, exactly as on the published-media route.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const artifacts = new Map<string, Buffer>([
+      ['media/metadata.json', Buffer.from(JSON.stringify({ captures: { opening: { file: 'opening.png' } } }))],
+      ['media/opening.png', PNG],
+      ['media/leftover-debug.png', PNG],
+    ]);
+    const { objectStore, signReadUrl } = stubObjectStore();
+    app = await createApp(store, stubGamesStore({ artifacts }), objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().screenshots).toEqual([expect.objectContaining({ file: 'opening.png' })]);
+    expect(res.json().video).toBeNull();
+    expect(signReadUrl.mock.calls.map(([name]) => name)).not.toContain(
+      `games/${SLUG}/versions/${VERSION}/media/leftover-debug.png`,
+    );
+  });
+
+  it('falls back to the manifest screenshot when a red run stored frames but no metadata', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const artifacts = new Map<string, Buffer>([['media/opening.png', PNG]]);
+    const manifest = {
+      slug: SLUG,
+      version: VERSION,
+      gate: { green: false, ranAt: '2026-08-03T10:20:00.000Z', screenshot: 'media/opening.png' },
+    };
+    app = await createApp(store, stubGamesStore({ artifacts, manifest }), stubObjectStore().objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: true, gate: { green: false } });
+    expect(res.json().screenshots).toEqual([expect.objectContaining({ name: 'opening', file: 'opening.png' })]);
+  });
+
+  it('says nothing is available before a delivery, rather than erroring', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(ISSUE, 'g:owner', 'Comet Courier');
+    await store.setSubmissionSlug(ISSUE, SLUG);
+    app = await createApp(store, stubGamesStore(), stubObjectStore().objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: false, deliveryId: null });
+    expect(res.json().reason).toMatch(/nothing has been delivered/i);
+  });
+
+  it('says nothing is available when the gate stored no media', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    app = await createApp(store, stubGamesStore({ artifacts: new Map() }), stubObjectStore().objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: false, deliveryId: VERSION });
+  });
+
+  it('refuses a version that does not resolve under the slug this job owns', async () => {
+    // The manifest read is the ownership proof: a version id borrowed from another
+    // game simply does not exist here, so nothing is signed for it.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const { objectStore, signReadUrl } = stubObjectStore();
+    app = await createApp(store, stubGamesStore(), objectStore);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?version=v20260101T000000000-ffffff',
+      headers: agentHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: false, reason: 'no such delivery' });
+    expect(signReadUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a version argument that is not shaped like a version id', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const { objectStore, signReadUrl } = stubObjectStore();
+    app = await createApp(store, stubGamesStore(), objectStore);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/agent/build/media?version=${encodeURIComponent('../../other-game/versions/v1')}`,
+      headers: agentHeaders(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(signReadUrl).not.toHaveBeenCalled();
+  });
+
+  it('answers a retired key for the delivery its round owns, and refuses any other', async () => {
+    // Terminal receipt, same rule as the verdict read: green closes the round, and
+    // post-green is exactly when the agent wants the frames to show the creator.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    await store.bumpRoundGeneration(ISSUE);
+    app = await createApp(store, stubGamesStore(), stubObjectStore().objectStore);
+
+    const receipt = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media',
+      headers: agentHeaders(ISSUE, 1),
+    });
+    expect(receipt.statusCode).toBe(200);
+    expect(receipt.json()).toMatchObject({ available: true, access: 'terminal_receipt' });
+
+    const otherDelivery = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?version=v20260101T000000000-ffffff',
+      headers: agentHeaders(ISSUE, 1),
+    });
+    expect(otherDelivery.statusCode).toBe(401);
+    expect(otherDelivery.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('rejects a key more than one generation behind', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    await store.bumpRoundGeneration(ISSUE);
+    await store.bumpRoundGeneration(ISSUE);
+    app = await createApp(store, stubGamesStore(), stubObjectStore().objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders(ISSUE, 1) });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('answers 503 rather than half a result when the media store is unconfigured', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    app = await createApp(store);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/apps/api/src/agent-build-media.test.ts
+++ b/apps/api/src/agent-build-media.test.ts
@@ -71,7 +71,14 @@ function stubGamesStore(
     ]);
   const manifest =
     overrides.manifest === undefined
-      ? { slug: SLUG, version: VERSION, gate: { green: true, ranAt: '2026-08-03T10:20:00.000Z' } }
+      ? {
+          slug: SLUG,
+          version: VERSION,
+          // The job that produced this delivery — the ownership check, since a slug
+          // is shared by every improvement round on the same game.
+          issueNumber: ISSUE,
+          gate: { green: true, ranAt: '2026-08-03T10:20:00.000Z' },
+        }
       : overrides.manifest;
   return {
     getManifest: async (slug: string, version: string) => (slug === SLUG && version === VERSION ? manifest : null),
@@ -85,11 +92,15 @@ function stubGamesStore(
   } as unknown as GamesStore;
 }
 
-function stubObjectStore(signReadUrl = vi.fn(async (name: string) => `https://signed.example/${name}?sig=1`)) {
+function stubObjectStore(
+  signReadUrl = vi.fn(async (name: string) => `https://signed.example/${name}?sig=1`),
+  /** Which objects actually landed; the gate tolerates a per-file upload failure. */
+  objectExists: (name: string) => Promise<boolean> = async () => true,
+) {
   return {
     objectStore: {
       readObject: async () => null,
-      objectExists: async () => true,
+      objectExists,
       signReadUrl,
     } as GcsObjectStore,
     signReadUrl,
@@ -213,6 +224,7 @@ describe('GET /api/agent/build/media (BY-28)', () => {
     const manifest = {
       slug: SLUG,
       version: VERSION,
+      issueNumber: ISSUE,
       gate: { green: false, ranAt: '2026-08-03T10:20:00.000Z', screenshot: 'media/opening.png' },
     };
     app = await createApp(store, stubGamesStore({ artifacts, manifest }), stubObjectStore().objectStore);
@@ -263,7 +275,7 @@ describe('GET /api/agent/build/media (BY-28)', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ available: false, reason: 'no such delivery' });
+    expect(res.json()).toMatchObject({ available: false, reason: 'no such delivery for this build' });
     expect(signReadUrl).not.toHaveBeenCalled();
   });
 
@@ -319,6 +331,89 @@ describe('GET /api/agent/build/media (BY-28)', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+  });
+
+  it('refuses a version delivered by a different job on the same slug', async () => {
+    // Every improvement round is a new job that inherits the published slug, so an
+    // earlier round's version resolves fine under this one's slug — and after a slug
+    // transfer that earlier job can belong to a different creator. The manifest's own
+    // issueNumber is the ownership check; the slug never was one. Codex #506 P2.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const EARLIER_JOB_VERSION = 'v20260101T090000000-aaaaaa';
+    const gamesStore = {
+      getManifest: async (slug: string, version: string) =>
+        slug === SLUG && version === EARLIER_JOB_VERSION
+          ? // Same slug, different job — a predecessor round's delivery.
+            { slug: SLUG, version: EARLIER_JOB_VERSION, issueNumber: ISSUE - 7, gate: { green: true, ranAt: 'x' } }
+          : null,
+      getDerivedArtifact: async () => Buffer.from(METADATA),
+      getSourceFile: async () => null,
+      putCandidateSources: async () => ({ version: VERSION, manifest: {} as never }),
+      putGateResult: async () => {},
+      putDerivedArtifact: async () => {},
+      getKitRegistry: async () => null,
+    } as unknown as GamesStore;
+    const { objectStore, signReadUrl } = stubObjectStore();
+    app = await createApp(store, gamesStore, objectStore);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/agent/build/media?version=${EARLIER_JOB_VERSION}`,
+      headers: agentHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: false, reason: 'no such delivery for this build' });
+    // Nothing was signed — the refusal happens before any URL exists.
+    expect(signReadUrl).not.toHaveBeenCalled();
+    // Absent and not-yours read identically, so a round cannot enumerate what its
+    // predecessors delivered.
+    const absent = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?version=v20260101T000000000-ffffff',
+      headers: agentHeaders(),
+    });
+    expect(absent.json().reason).toBe(res.json().reason);
+  });
+
+  it('does not advertise media whose upload never landed', async () => {
+    // The gate writes each media file independently and swallows a per-file failure to
+    // protect the verdict, so metadata.json can name an mp4 that is not in the bucket.
+    // Signing it would hand the agent a dead URL to show the creator. Codex #506 P2.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const { objectStore, signReadUrl } = stubObjectStore(
+      vi.fn(async (name: string) => `https://signed.example/${name}?sig=1`),
+      async (name: string) => !name.endsWith('gameplay.mp4') && !name.endsWith('engagement.png'),
+    );
+    app = await createApp(store, stubGamesStore(), objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().video).toBeNull();
+    expect(res.json().screenshots).toEqual([
+      { name: 'opening', file: 'opening.png', url: expect.stringContaining('opening.png') },
+    ]);
+    expect(signReadUrl).not.toHaveBeenCalledWith(expect.stringContaining('gameplay.mp4'), expect.anything());
+    expect(signReadUrl).not.toHaveBeenCalledWith(expect.stringContaining('engagement.png'), expect.anything());
+  });
+
+  it('reports unavailable when metadata names files but none of them landed', async () => {
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const { objectStore, signReadUrl } = stubObjectStore(
+      vi.fn(async (name: string) => `https://signed.example/${name}?sig=1`),
+      async () => false,
+    );
+    app = await createApp(store, stubGamesStore(), objectStore);
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ available: false, reason: 'the gate stored no media for this delivery' });
+    expect(signReadUrl).not.toHaveBeenCalled();
   });
 
   it('answers 503 rather than half a result when the media store is unconfigured', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1508,11 +1508,23 @@ export async function registerAgentChannelRoutes(
       }
 
       const slug = record.slug;
-      // The manifest is the proof this version exists under this job's slug; a version
-      // id from anywhere else simply does not resolve here, so nothing gets signed.
+      // The manifest proves this version exists — but a slug is not a job. Every
+      // improvement round is a *new* job that inherits the published slug, so a
+      // version delivered by an earlier round resolves perfectly well under this
+      // one's slug, and after a slug transfer that earlier job can belong to a
+      // different creator entirely. The manifest records the job that produced it;
+      // that is the ownership check, and the slug never was one.
+      //
+      // Absent and not-yours answer identically on purpose: distinguishing them
+      // would let a round enumerate which versions its predecessors delivered.
       const manifest = await options.gamesStore.getManifest(slug, version);
-      if (!manifest) {
-        return reply.send({ available: false, deliveryId: version, reason: 'no such delivery', access });
+      if (!manifest || manifest.issueNumber !== record.issueNumber) {
+        return reply.send({
+          available: false,
+          deliveryId: version,
+          reason: 'no such delivery for this build',
+          access,
+        });
       }
 
       const metadataBody = await options.gamesStore.getDerivedArtifact(slug, version, 'media/metadata.json');
@@ -1542,22 +1554,47 @@ export async function registerAgentChannelRoutes(
       }
 
       const mediaObject = (file: string) => `games/${slug}/versions/${version}/media/${file}`;
+
+      // Metadata names what capture *intended* to store, which is not the same as what
+      // landed: the gate writes each media file independently and swallows a per-file
+      // failure to protect the verdict (gate-runner `storeCaptureMedia`), so a run can
+      // store metadata.json and lose the mp4. Signing a name we never confirmed hands
+      // the agent a URL that 404s — and the agent then tells the creator their video is
+      // ready. Probe before advertising; a signed URL is a promise about bytes.
+      const probed = await Promise.all(
+        screenshotFiles.map(async (shot) =>
+          (await options.objectStore!.objectExists(mediaObject(shot.file))) ? shot : null,
+        ),
+      );
+      const storedShots = probed.filter((shot): shot is { name: string; file: string } => shot !== null);
+      const storedVideo =
+        videoFile && (await options.objectStore.objectExists(mediaObject(videoFile))) ? videoFile : null;
+
+      if (storedShots.length === 0 && !storedVideo) {
+        return reply.send({
+          available: false,
+          deliveryId: version,
+          reason: 'the gate stored no media for this delivery',
+          access,
+        });
+      }
+
       const screenshots = await Promise.all(
-        screenshotFiles.map(async (shot) => ({
+        storedShots.map(async (shot) => ({
           ...shot,
           url: await options.objectStore!.signReadUrl(mediaObject(shot.file), DEFAULT_SIGNED_URL_TTL_SECONDS),
         })),
       );
-      const video = videoFile
+      const video = storedVideo
         ? {
-            file: videoFile,
-            url: await options.objectStore.signReadUrl(mediaObject(videoFile), DEFAULT_SIGNED_URL_TTL_SECONDS),
+            file: storedVideo,
+            url: await options.objectStore.signReadUrl(mediaObject(storedVideo), DEFAULT_SIGNED_URL_TTL_SECONDS),
           }
         : null;
 
       // One frame inline, for clients that can render an image but not fetch a URL.
       // Best effort and bounded: an absent or oversized frame degrades to URLs-only.
-      const openingFile = (screenshotFiles.find((shot) => shot.name === 'opening') ?? screenshotFiles[0])?.file;
+      const openingFile = (storedShots.find((shot) => shot.name === 'opening') ?? storedShots[0])?.file;
       let openingShot: { file: string; png: string } | null = null;
       if (openingFile) {
         const body = await options.gamesStore

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -19,7 +19,7 @@ import {
 import { selfBuildDeliveryCap } from './builder.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import { InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
-import { parseSpecTitle } from './github-client.js';
+import { parseGameMedia, parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import {
   KitFilesError,
@@ -1447,6 +1447,143 @@ export async function registerAgentChannelRoutes(
           : (gate.report?.split('\n').at(-1) ?? 'gate refused this delivery'),
         ...(gate.report ? { report: gate.report } : {}),
         ...(gate.status ? { gateStatus: gate.status } : {}),
+        access,
+      });
+    },
+  );
+
+  /**
+   * Gate-produced media for a delivery (BY-28).
+   *
+   * Exists for the agent that cannot run the game — a connector-surface client
+   * (ChatGPT, claude.ai) with no shell and no browser builds and submits fine, but
+   * iterates blind on verdict text and finishes with nothing to show the creator.
+   * The gate already produced the missing evidence on every run: capture PNGs and a
+   * gameplay MP4, stored as derived artifacts on the version. This is the read back.
+   *
+   * Read-only over runs that already happened — deliberately *not* an on-demand
+   * capture: rendering agent code is gate compute, and it stays behind the delivery
+   * cap. Filenames come exclusively from the validated `media/metadata.json` (the
+   * same allowlist rule as the published-media route), with the manifest's own
+   * `gate.screenshot` as the fallback for runs capture abandoned partway. Terminal
+   * receipt is accepted exactly as on the verdict read, and for the same reason:
+   * green closes the round, and post-green is when there is something worth showing.
+   */
+  app.get(
+    '/api/agent/build/media',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply, { allowTerminalReceipt: true });
+      if (!resolved) return reply;
+      const { record, access } = resolved;
+
+      if (!options.gamesStore || !options.objectStore) {
+        return reply.status(503).send({ error: 'the media store is not configured' });
+      }
+
+      const query = request.query as { version?: string };
+      const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
+      const version = requestedVersion ?? record.deliveredVersion ?? null;
+
+      if (!version || !record.slug) {
+        return reply.send({
+          available: false,
+          deliveryId: null,
+          reason: 'nothing has been delivered yet — media is produced by the gate, after submit',
+          access,
+        });
+      }
+
+      // Same receipt rule as the verdict read: a closed round may only look at the
+      // delivery it owns.
+      if (access === 'terminal_receipt' && version !== record.deliveredVersion) {
+        return reply.status(401).send({ error: STALE_AGENT_TOKEN_REASON });
+      }
+
+      // Version ids are ours (timestamp + suffix), but this one arrived in a query
+      // string and is about to be interpolated into a signed object path — shape-check
+      // it rather than trusting the round to have asked nicely.
+      if (!/^[A-Za-z0-9-]+$/.test(version)) {
+        return reply.status(400).send({ error: 'invalid version' });
+      }
+
+      const slug = record.slug;
+      // The manifest is the proof this version exists under this job's slug; a version
+      // id from anywhere else simply does not resolve here, so nothing gets signed.
+      const manifest = await options.gamesStore.getManifest(slug, version);
+      if (!manifest) {
+        return reply.send({ available: false, deliveryId: version, reason: 'no such delivery', access });
+      }
+
+      const metadataBody = await options.gamesStore.getDerivedArtifact(slug, version, 'media/metadata.json');
+      const media = parseGameMedia(metadataBody?.toString('utf8') ?? null);
+
+      // Runs that failed mid-capture store frames without metadata; the manifest's
+      // gate verdict names the first stored frame (`media/opening.png` shape).
+      const fallbackShot =
+        !media && manifest.gate?.screenshot && /^media\/[a-z0-9][a-z0-9_.-]*\.png$/i.test(manifest.gate.screenshot)
+          ? manifest.gate.screenshot.slice('media/'.length)
+          : null;
+
+      const screenshotFiles = media
+        ? media.screenshots.map((shot) => ({ name: shot.name, file: shot.file }))
+        : fallbackShot
+          ? [{ name: 'opening', file: fallbackShot }]
+          : [];
+      const videoFile = media?.video ?? null;
+
+      if (screenshotFiles.length === 0 && !videoFile) {
+        return reply.send({
+          available: false,
+          deliveryId: version,
+          reason: 'the gate stored no media for this delivery',
+          access,
+        });
+      }
+
+      const mediaObject = (file: string) => `games/${slug}/versions/${version}/media/${file}`;
+      const screenshots = await Promise.all(
+        screenshotFiles.map(async (shot) => ({
+          ...shot,
+          url: await options.objectStore!.signReadUrl(mediaObject(shot.file), DEFAULT_SIGNED_URL_TTL_SECONDS),
+        })),
+      );
+      const video = videoFile
+        ? {
+            file: videoFile,
+            url: await options.objectStore.signReadUrl(mediaObject(videoFile), DEFAULT_SIGNED_URL_TTL_SECONDS),
+          }
+        : null;
+
+      // One frame inline, for clients that can render an image but not fetch a URL.
+      // Best effort and bounded: an absent or oversized frame degrades to URLs-only.
+      const openingFile = (screenshotFiles.find((shot) => shot.name === 'opening') ?? screenshotFiles[0])?.file;
+      let openingShot: { file: string; png: string } | null = null;
+      if (openingFile) {
+        const body = await options.gamesStore
+          .getDerivedArtifact(slug, version, `media/${openingFile}`)
+          .catch(() => null);
+        if (body && body.length > 0 && body.length <= maxShotBytes) {
+          openingShot = { file: openingFile, png: body.toString('base64') };
+        }
+      }
+
+      return reply.send({
+        available: true,
+        deliveryId: version,
+        ...(manifest.gate
+          ? {
+              gate: {
+                green: manifest.gate.green,
+                ranAt: manifest.gate.ranAt,
+                ...(manifest.gate.status ? { status: manifest.gate.status } : {}),
+              },
+            }
+          : {}),
+        screenshots,
+        video,
+        ...(openingShot ? { openingShot } : {}),
+        expiresInSeconds: DEFAULT_SIGNED_URL_TTL_SECONDS,
         access,
       });
     },

--- a/apps/api/src/agent-token.ts
+++ b/apps/api/src/agent-token.ts
@@ -209,10 +209,13 @@ export function assertAgentTokenActive(
  *
  * - `active` — generation matches; full channel access.
  * - `terminal_receipt` — generation is exactly one behind current and unexpired.
- *   Only {@link get_gate_verdict} (and its plain-HTTP twin) may use this: gate-green
- *   closes the round, so the agent's next verdict poll would otherwise be rejected
- *   a moment before it can observe the green it was told to wait for. Every write
- *   and every other read still rejects. Expiry still applies.
+ *   Only the gate reads — the verdict and the gate media (`get_gate_verdict` /
+ *   `get_gate_media` and their plain-HTTP twins) — may use this: gate-green closes
+ *   the round, so the agent's next verdict poll would otherwise be rejected a moment
+ *   before it can observe the green it was told to wait for, and the frames it wants
+ *   to show the creator exist only once that same run finished. Both are limited to
+ *   the delivery the closed round owns. Every write and every other read still
+ *   rejects. Expiry still applies.
  */
 export type AgentTokenAccess = 'active' | 'terminal_receipt';
 

--- a/apps/api/src/mcp-debug-log.ts
+++ b/apps/api/src/mcp-debug-log.ts
@@ -100,7 +100,13 @@ export function mcpSessionStartedFields(input: {
 export function toolErrorReason(result: {
   isError?: boolean;
   structuredContent?: unknown;
-  content?: Array<{ type: string; text: string }>;
+  /**
+   * `text` is optional because a tool result may carry non-text blocks —
+   * `get_gate_media` attaches the gate's opening frame as an MCP image. The read
+   * below is already guarded, and a refusal is always text (see `toolErr`), so this
+   * widening costs nothing and keeps this module independent of the tool union.
+   */
+  content?: Array<{ type: string; text?: string }>;
 }): string | null {
   if (!result.isError) return null;
   const structured = result.structuredContent;

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -4,6 +4,7 @@ import { classifyAgentTokenAccess, mintAgentToken, STALE_AGENT_TOKEN_REASON } fr
 import { mintGameAgentKey } from './agent-game-key.js';
 import { buildApp } from './app.js';
 import type { GamesStore } from './games-store.js';
+import type { GcsObjectStore } from './gcs-sign.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import { mintMcpSessionKey, verifyMcpSessionKey } from './mcp-session-key.js';
 import { InMemoryStore } from './store.js';
@@ -80,7 +81,7 @@ function stubGamesStore(gate?: { green: boolean; ranAt?: string; report?: string
   return { gamesStore, stored };
 }
 
-async function createApp(store: InMemoryStore, gamesStore?: GamesStore) {
+async function createApp(store: InMemoryStore, gamesStore?: GamesStore, objectStore?: GcsObjectStore) {
   return await buildApp({
     store,
     sessionSecret: 'dev-session-secret-change-me',
@@ -89,7 +90,7 @@ async function createApp(store: InMemoryStore, gamesStore?: GamesStore) {
       githubToken: 'gh-token',
       submissionTokenSecret: secret,
       translator: new NoopTranslator(),
-      agentChannel: gamesStore ? { gamesStore } : {},
+      agentChannel: { ...(gamesStore ? { gamesStore } : {}), ...(objectStore ? { objectStore } : {}) },
     },
   });
 }
@@ -1259,5 +1260,173 @@ describe('POST /api/mcp (BY-05)', () => {
     };
     expect(startSchema.properties?.sessionKey).toBeTruthy();
     expect(startSchema.required).toContain('sessionKey');
+  });
+  describe('get_gate_media (BY-28)', () => {
+    const MEDIA_METADATA = JSON.stringify({
+      captures: { opening: { file: 'opening.png' } },
+      video: { file: 'gameplay.mp4' },
+    });
+
+    /** A gate run that stored one frame and a video for delivery v1. */
+    function mediaGamesStore(green = true) {
+      const artifacts = new Map<string, Buffer>([
+        ['media/metadata.json', Buffer.from(MEDIA_METADATA)],
+        ['media/opening.png', Buffer.from(TINY_PNG, 'base64')],
+        ['media/gameplay.mp4', Buffer.from('mp4-bytes')],
+      ]);
+      return {
+        getManifest: async (slug: string, version: string) =>
+          slug === 'comet-courier' && version === 'v1'
+            ? { slug, version, gate: { green, ranAt: '2026-08-01T12:00:00.000Z' } }
+            : null,
+        getDerivedArtifact: async (slug: string, version: string, name: string) =>
+          slug === 'comet-courier' && version === 'v1' ? (artifacts.get(name) ?? null) : null,
+        getSourceFile: async () => null,
+        putCandidateSources: async () => ({ version: 'v1', manifest: {} as never }),
+        putGateResult: async () => {},
+        putDerivedArtifact: async () => {},
+        getKitRegistry: async () => null,
+      } as unknown as GamesStore;
+    }
+
+    function mediaObjectStore(): GcsObjectStore {
+      return {
+        readObject: async () => null,
+        objectExists: async () => true,
+        signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+      };
+    }
+
+    it('returns signed media and attaches the opening frame as an image block', async () => {
+      // The whole point of the tool: a client that cannot run the game gets something
+      // it can look at and something it can show the creator.
+      const store = new InMemoryStore();
+      await seedJob(store);
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+      app = await createApp(store, mediaGamesStore(), mediaObjectStore());
+      const sessionId = await initialize(app);
+      const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      const res = await mcpCall(
+        app,
+        'tools/call',
+        { name: 'get_gate_media', arguments: { sessionKey } },
+        { 'mcp-session-id': sessionId },
+      );
+      expect(res.statusCode).toBe(200);
+      const result = res.json().result as {
+        content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+        structuredContent: {
+          available: boolean;
+          deliveryId: string;
+          screenshots: Array<{ file: string; url: string }>;
+          video: { file: string; url: string };
+          openingShot?: { file: string; attached: boolean };
+        };
+        isError?: boolean;
+      };
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({
+        available: true,
+        deliveryId: 'v1',
+        screenshots: [
+          {
+            file: 'opening.png',
+            url: 'https://signed.example/games/comet-courier/versions/v1/media/opening.png?sig=1',
+          },
+        ],
+        video: {
+          file: 'gameplay.mp4',
+          url: 'https://signed.example/games/comet-courier/versions/v1/media/gameplay.mp4?sig=1',
+        },
+        openingShot: { file: 'opening.png', attached: true },
+      });
+
+      const image = result.content.find((part) => part.type === 'image');
+      expect(image).toMatchObject({ mimeType: 'image/png', data: TINY_PNG });
+      // The frame rides the image block only — duplicating it into the JSON body would
+      // put the same base64 into every client's context twice.
+      const text = result.content.find((part) => part.type === 'text')?.text ?? '';
+      expect(text).not.toContain(TINY_PNG);
+    });
+
+    it('reports available:false instead of erroring before anything is delivered', async () => {
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store, mediaGamesStore(), mediaObjectStore());
+      const sessionId = await initialize(app);
+      const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      const media = await callTool(app, 'get_gate_media', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(media.isError).toBe(false);
+      expect(media.structured).toMatchObject({ available: false, deliveryId: null });
+    });
+
+    it('stays readable on the terminal receipt after green closes the round', async () => {
+      // Post-green is exactly when the agent wants the frames — the round it just
+      // finished is the one that produced them.
+      const store = new InMemoryStore();
+      await seedJob(store);
+      const gamesStore = mediaGamesStore();
+      app = await createApp(store, gamesStore, mediaObjectStore());
+      const sessionId = await initialize(app);
+      const originalKey = roundKey(1);
+      const started = await callTool(app, 'start', { key: originalKey }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+      await store.recordJobTransition(ISSUE, {
+        to: 'submitted',
+        at: '2026-08-01T11:00:00.000Z',
+        by: 'agent',
+        reason: 'sources_delivered',
+      });
+      await store.recordJobTransition(ISSUE, {
+        to: 'ready_for_review',
+        at: '2026-08-01T12:00:00.000Z',
+        by: 'gate',
+        reason: 'gate_green',
+      });
+      expect((await store.getSubmission(ISSUE))?.roundGeneration).toBe(2);
+
+      const viaSession = await callTool(app, 'get_gate_media', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(viaSession.isError).toBe(false);
+      expect(viaSession.structured).toMatchObject({ available: true, access: 'terminal_receipt' });
+
+      const viaBearer = await callTool(
+        app,
+        'get_gate_media',
+        {},
+        { 'mcp-session-id': sessionId, authorization: `Bearer ${originalKey}` },
+      );
+      expect(viaBearer.isError).toBe(false);
+      expect(viaBearer.structured).toMatchObject({ available: true, access: 'terminal_receipt' });
+
+      // The receipt is not a general read grant: other reads still reject.
+      const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(brief.isError).toBe(true);
+    });
+
+    it('is advertised as a read, not a destructive tool', async () => {
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store);
+      const sessionId = await initialize(app);
+
+      const listed = await mcpCall(app, 'tools/list', {}, { 'mcp-session-id': sessionId });
+      const tools = listed.json().result.tools as Array<{
+        name: string;
+        description: string;
+        annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+      }>;
+      const media = tools.find((tool) => tool.name === 'get_gate_media');
+      expect(media?.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false });
+      // The description has to carry why an agent would call it — descriptions are the
+      // one prompt surface every client reads.
+      expect(media?.description).toMatch(/screenshot/i);
+      expect(media?.description).toMatch(/video|mp4/i);
+    });
   });
 });

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1277,7 +1277,9 @@ describe('POST /api/mcp (BY-05)', () => {
       return {
         getManifest: async (slug: string, version: string) =>
           slug === 'comet-courier' && version === 'v1'
-            ? { slug, version, gate: { green, ranAt: '2026-08-01T12:00:00.000Z' } }
+            ? // issueNumber is the ownership check the route makes — a slug is shared
+              // by every improvement round on the same game.
+              { slug, version, issueNumber: ISSUE, gate: { green, ranAt: '2026-08-01T12:00:00.000Z' } }
             : null,
         getDerivedArtifact: async (slug: string, version: string, name: string) =>
           slug === 'comet-courier' && version === 'v1' ? (artifacts.get(name) ?? null) : null,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -140,8 +140,14 @@ interface JsonRpcRequest {
   params?: unknown;
 }
 
+type ToolContent =
+  /** The JSON body every tool answers with. */
+  | { type: 'text'; text: string }
+  /** A rendered frame (get_gate_media) — clients show these inline in chat. */
+  | { type: 'image'; data: string; mimeType: string };
+
 interface ToolResult {
-  content: Array<{ type: 'text'; text: string }>;
+  content: ToolContent[];
   structuredContent?: unknown;
   isError?: boolean;
 }
@@ -259,12 +265,13 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Run the kit checks green (at least check:static) before delivering when you have a local kit checkout; otherwise deliver and let the gate run checks.',
   'submit_sources with the kitEngineRef get_kit returned.',
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated.',
+  'Once a verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red: read the report, fix, and resubmit on the SAME key.',
   'kit_outdated: re-run get_kit, rebuild against the new kit, and resubmit.',
   // Green closes the round before the next tool call; writes and non-receipt reads then
   // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
   // happen on earlier write replies — do not instruct post-green tools (Codex P1).
-  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict may still answer via terminal receipt).',
+  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict and get_gate_media may still answer via terminal receipt).',
 ];
 
 /**
@@ -1864,6 +1871,58 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr(body.error ?? `gate verdict failed (${res.statusCode})`);
         }
         return toolOk(body);
+      },
+    },
+
+    get_gate_media: {
+      annotations: { title: "Fetch the gate's screenshots and video", ...READS },
+      description:
+        'Fetch the media the gate itself produced for a delivery (default: latest): capture screenshots and a ' +
+        'gameplay MP4 as short-lived signed URLs, plus the opening frame attached inline as an image. ' +
+        'Use it when you cannot run the game yourself — check the frames for visual defects (blank canvas, ' +
+        'missing sprites) before resubmitting, and share the screenshots/video with the creator. ' +
+        'Read-only over the gate run that already happened; it never triggers a build, and media exists only ' +
+        'after a delivery has been gated. Terminal receipt: like get_gate_verdict, the latest delivery stays ' +
+        'readable after green closes the round. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          deliveryId: { type: 'string', description: "Delivery version id; default is the job's latest." },
+        },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args, { allowTerminalReceipt: true });
+        if (!('channelToken' in auth)) return auth;
+
+        const deliveryId =
+          typeof args.deliveryId === 'string' && args.deliveryId.trim() ? args.deliveryId.trim() : null;
+        const path = deliveryId
+          ? `/api/agent/build/media?version=${encodeURIComponent(deliveryId)}`
+          : '/api/agent/build/media';
+        const res = await injectChannel(ctx.request, 'GET', path, auth.channelToken);
+        const body = res.json() as Record<string, unknown> & {
+          error?: string;
+          openingShot?: { file?: string; png?: string };
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `gate media failed (${res.statusCode})`);
+        }
+        // The inline frame travels as an MCP image block, not inside the JSON body —
+        // duplicating ~700 KB of base64 into the text content would bloat every client's
+        // context for no benefit, and image blocks are the shape chat surfaces render.
+        const { openingShot, ...rest } = body;
+        const structured = {
+          ...rest,
+          ...(openingShot?.file ? { openingShot: { file: openingShot.file, attached: Boolean(openingShot.png) } } : {}),
+        };
+        const result = toolOk(structured);
+        if (openingShot?.png) {
+          result.content.push({ type: 'image', data: openingShot.png, mimeType: 'image/png' });
+        }
+        return result;
       },
     },
 


### PR DESCRIPTION
## Summary
Implements a new endpoint for agents to retrieve gate-produced media (screenshots and gameplay video) from completed deliveries. This addresses the use case where agents cannot run games themselves and need visual evidence to iterate on submissions and show creators.

## Key Changes

- **New HTTP endpoint** `GET /api/agent/build/media`: Returns signed URLs for gate-produced capture PNGs and gameplay MP4, plus the opening frame embedded as base64 PNG data
  - Requires valid agent build token (same auth as other channel reads)
  - Supports optional `version` query parameter to fetch specific delivery versions
  - Returns `available: false` gracefully before any delivery or when gate stored no media
  - Enforces filename allowlist from validated `media/metadata.json` (same rule as published-media route)
  - Falls back to manifest's `gate.screenshot` for runs that failed mid-capture
  - Implements terminal receipt access: readable after green closes the round, but only for the delivery the token owns

- **New MCP tool** `get_gate_media`: Wraps the HTTP endpoint for Claude/ChatGPT clients
  - Returns structured content with signed URLs and inline opening frame as image block
  - Marked as read-only (non-destructive)
  - Documented in session workflow to guide agents on when/how to use it

- **Security & validation**:
  - Version IDs shape-checked to prevent path traversal
  - Manifest lookup proves ownership (version must exist under the job's slug)
  - Signed URLs scoped to `games/{slug}/versions/{version}/media/` paths
  - Terminal receipt enforces single-delivery access (retired keys cannot read other versions)
  - Returns 503 if media store (GamesStore/GcsObjectStore) is unconfigured

- **Test coverage**: Comprehensive test suite covering auth, allowlisting, fallbacks, terminal receipt, version validation, and store configuration scenarios

## Implementation Details

- Reuses `parseGameMedia()` from github-client to parse metadata structure
- Inline frame limited to reasonable size (maxShotBytes) to avoid bloating responses
- Opening shot selection: prefers 'opening' name, falls back to first screenshot
- Respects existing `DEFAULT_SIGNED_URL_TTL_SECONDS` for URL expiry
- Integrates with existing `resolveBuild()` auth flow with `allowTerminalReceipt: true` flag

https://claude.ai/code/session_01PrXBSADXMndFNkj9FfEkMn