### PR TITLE
Bake catalog screenshots at display size

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,12 +40,14 @@
     "genaicode": "^2.1.0",
     "google-auth-library": "^10.9.0",
     "jose": "^6.2.4",
+    "pngjs": "^7.0.0",
     "typescript": "^5.5.4",
     "web-push": "^3.6.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.15",
+    "@types/pngjs": "^6.0.5",
     "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1",
     "tsx": "^4.16.5",

--- a/apps/api/src/game-snapshot-publish.test.ts
+++ b/apps/api/src/game-snapshot-publish.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PNG } from 'pngjs';
+import { VARIANT_WIDTHS } from './image-variants.js';
 import { publishSnapshot } from './game-snapshot-publish.js';
 import type { GameSnapshotWriter, SnapshotGame, SnapshotMedia, SnapshotPointer } from './game-snapshot.js';
 import type { CatalogGameEntry, GameSources, GitHubClient } from './github-client.js';
@@ -64,9 +66,10 @@ function createWriterSpy() {
       order.push(`game:${game.slug}`);
       games.set(game.slug, game);
     },
-    async putMedia(_id, slug, filename, value) {
-      order.push(`media:${slug}/${filename}`);
-      media.set(`${slug}/${filename}`, value);
+    async putMedia(_id, slug, filename, value, width) {
+      const key = width === undefined ? `${slug}/${filename}` : `${slug}/w${width}/${filename}`;
+      order.push(`media:${key}`);
+      media.set(key, value);
     },
     async putPointer(value) {
       order.push('pointer');
@@ -268,5 +271,79 @@ describe('publishSnapshot failure handling', () => {
     expect(result.published).toBe(0);
     expect(spy.catalog).toEqual([]);
     expect(spy.pointer?.gameCount).toBe(0);
+  });
+});
+
+/**
+ * Size variants, baked once at publish rather than resized per request. The arcade
+ * shows the same screenshot at ~48 CSS px in the moment strip and a few hundred as a
+ * card poster; serving the original for both means every near-fold poster (and each
+ * moment thumb after engage) pays for a full-size decode.
+ */
+describe('publishSnapshot media variants', () => {
+  function pngOfWidth(width: number, height: number): Uint8Array {
+    const png = new PNG({ width, height });
+    for (let i = 0; i < png.data.length; i += 4) {
+      png.data[i] = i % 255;
+      png.data[i + 1] = 40;
+      png.data[i + 2] = 90;
+      png.data[i + 3] = 255;
+    }
+    return new Uint8Array(PNG.sync.write(png));
+  }
+
+  const withMedia = catalogEntry('bubble-pop', {
+    media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+  });
+
+  it('writes a downscaled copy of each screenshot alongside the original', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': pngOfWidth(1280, 720) },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(spy.media.has('bubble-pop/opening.png')).toBe(true);
+    for (const width of VARIANT_WIDTHS) {
+      const variant = spy.media.get(`bubble-pop/w${width}/opening.png`);
+      expect(variant, `w${width}`).toBeDefined();
+      expect(PNG.sync.read(variant!.body).width).toBe(width);
+      // The whole point: materially fewer bytes than the original.
+      expect(variant!.body.byteLength).toBeLessThan(spy.media.get('bubble-pop/opening.png')!.body.byteLength);
+    }
+  });
+
+  it('leaves video alone — variants are a screenshot idea', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': pngOfWidth(1280, 720) },
+    });
+    const spy = createWriterSpy();
+
+    await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(spy.media.has('bubble-pop/gameplay.mp4')).toBe(true);
+    for (const width of VARIANT_WIDTHS) {
+      expect(spy.media.has(`bubble-pop/w${width}/gameplay.mp4`)).toBe(false);
+    }
+  });
+
+  // A screenshot smaller than the target, or bytes that are not a readable PNG, must
+  // not fail the bake: the media route falls back to the original, which is what every
+  // snapshot baked before variants existed contains.
+  it('publishes the game even when no variant can be produced', async () => {
+    const { client } = createClientStub({
+      catalog: [withMedia],
+      mediaBySlug: { 'bubble-pop': new Uint8Array([1, 2, 3]) },
+    });
+    const spy = createWriterSpy();
+
+    const result = await publishSnapshot({ client, writer: spy.writer, ref, now: fixedNow });
+
+    expect(result.published).toBe(1);
+    expect(spy.media.has('bubble-pop/opening.png')).toBe(true);
+    expect(spy.media.has('bubble-pop/w96/opening.png')).toBe(false);
   });
 });

--- a/apps/api/src/game-snapshot-publish.ts
+++ b/apps/api/src/game-snapshot-publish.ts
@@ -7,6 +7,7 @@ import {
   type SnapshotPointer,
 } from './game-snapshot.js';
 import type { CatalogGameEntry, GitHubClient } from './github-client.js';
+import { downscalePng, VARIANT_WIDTHS } from './image-variants.js';
 
 /**
  * Bakes every published game into the snapshot bucket.
@@ -159,11 +160,33 @@ async function bakeGame(args: {
       // filename until a later bake catches up.
       continue;
     }
+    const body = Buffer.from(bytes);
     await writer.putMedia(snapshotId, entry.slug, filename, {
-      body: Buffer.from(bytes),
+      body,
       contentType: mediaContentType(filename),
     });
     mediaFiles += 1;
+
+    // Size variants for screenshots. The arcade shows the same file at ~48 CSS px in
+    // the moment strip and a few hundred as a card poster; serving the original for
+    // both means decoding a full screenshot for every near-fold poster (and again for
+    // each moment thumb after engage), and a PNG cannot be decoded partially. A
+    // variant that cannot be produced is simply not written — the media route falls
+    // back to the original, which is what every snapshot baked before this contains.
+    if (filename.endsWith('.png')) {
+      for (const width of VARIANT_WIDTHS) {
+        const scaled = downscalePng(body, width);
+        if (!scaled) continue;
+        await writer.putMedia(
+          snapshotId,
+          entry.slug,
+          filename,
+          { body: scaled, contentType: mediaContentType(filename) },
+          width,
+        );
+        mediaFiles += 1;
+      }
+    }
   }
 
   return { mediaFiles };

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -346,6 +346,31 @@ describe('gallery media', () => {
     await app.close();
   });
 
+  // Variants are screenshots only. An MP4 with `?w=` must not attempt a variant read
+  // or land in a separate cache key — that would multiply video entries for free.
+  it('ignores ?w= on video and serves the original once', async () => {
+    const withVideo = catalogEntry('bubble-pop', {
+      media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: 'gameplay.mp4' },
+    });
+    const { githubClient } = createGithubStub([withVideo]);
+    const snapshot = createSnapshotStub({
+      catalog: [withVideo],
+      media: { 'bubble-pop/gameplay.mp4': Buffer.from('video-bytes') },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const withWidth = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/gameplay.mp4?w=96' });
+    const plain = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/gameplay.mp4' });
+
+    expect(withWidth.statusCode).toBe(200);
+    expect(withWidth.rawPayload.toString()).toBe('video-bytes');
+    expect(plain.rawPayload.toString()).toBe('video-bytes');
+    // One read for the first request; the second hits the same `full` cache entry.
+    expect(snapshot.getMedia).toHaveBeenCalledTimes(1);
+    expect(snapshot.getMedia).toHaveBeenCalledWith('bubble-pop', 'gameplay.mp4');
+    await app.close();
+  });
+
   it('returns 404 when the file is allowlisted but missing from the snapshot', async () => {
     const { githubClient, getGameMedia } = createGithubStub([withMedia]);
     const snapshot = createSnapshotStub({ catalog: [withMedia], media: {} });

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -70,9 +70,10 @@ function createSnapshotStub(params: {
   const getGame = vi.fn(async (slug: string) =>
     params.failWith ? fail<SnapshotGame | null>() : (params.games?.[slug] ?? null),
   );
-  const getMedia = vi.fn(async (slug: string, filename: string) => {
+  const getMedia = vi.fn(async (slug: string, filename: string, width?: number) => {
     if (params.failWith) return fail<{ body: Buffer; contentType: string } | null>();
-    const body = params.media?.[`${slug}/${filename}`];
+    const key = width === undefined ? `${slug}/${filename}` : `${slug}/w${width}/${filename}`;
+    const body = params.media?.[key];
     return body ? { body, contentType: 'image/png' } : null;
   });
   const reader: GameSnapshotReader = {
@@ -255,6 +256,93 @@ describe('gallery media', () => {
     expect(response.statusCode).toBe(200);
     expect(response.rawPayload.toString()).toBe('baked-bytes');
     expect(getGameMedia).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  /**
+   * Size variants. The arcade shows the same screenshot at ~48 CSS px in the moment
+   * strip and a few hundred as a card poster; serving the original for both means
+   * every near-fold poster (and each moment thumb after engage) pays for a full-size
+   * decode.
+   */
+  it('serves the baked size variant when one is asked for', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w96/opening.png': Buffer.from('thumb'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawPayload.toString()).toBe('thumb');
+    await app.close();
+  });
+
+  // Snapshots baked before variants existed have none, and a bake skips a variant it
+  // could not produce. Either way the original is the right answer — a 404 here would
+  // blank the strip on every game published before this shipped.
+  it('falls back to the original when the variant was never baked', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: { 'bubble-pop/opening.png': Buffer.from('full-size') },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawPayload.toString()).toBe('full-size');
+    await app.close();
+  });
+
+  // An allowlist, not a number: an arbitrary `?w=` would be an invitation to fill the
+  // media cache with one entry per width anybody felt like naming.
+  it('ignores a width it does not bake and serves the original', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w97/opening.png': Buffer.from('never-asked-for'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    for (const query of ['?w=97', '?w=abc', '?w=-96', '?w=']) {
+      const response = await app.inject({ method: 'GET', url: `/api/games/bubble-pop/media/opening.png${query}` });
+      expect(response.statusCode, query).toBe(200);
+      expect(response.rawPayload.toString(), query).toBe('full-size');
+    }
+    await app.close();
+  });
+
+  // The cache is keyed per variant, or the first width asked for would be handed to
+  // every other one until the entry expired.
+  it('does not serve one width from another width’s cache entry', async () => {
+    const { githubClient } = createGithubStub([withMedia]);
+    const snapshot = createSnapshotStub({
+      catalog: [withMedia],
+      media: {
+        'bubble-pop/opening.png': Buffer.from('full-size'),
+        'bubble-pop/w96/opening.png': Buffer.from('thumb'),
+        'bubble-pop/w640/opening.png': Buffer.from('poster'),
+      },
+    });
+    const app = await createApp({ githubClient, snapshotReader: snapshot.reader });
+
+    const thumb = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=96' });
+    const poster = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png?w=640' });
+    const full = await app.inject({ method: 'GET', url: '/api/games/bubble-pop/media/opening.png' });
+
+    expect(thumb.rawPayload.toString()).toBe('thumb');
+    expect(poster.rawPayload.toString()).toBe('poster');
+    expect(full.rawPayload.toString()).toBe('full-size');
     await app.close();
   });
 

--- a/apps/api/src/game-snapshot.ts
+++ b/apps/api/src/game-snapshot.ts
@@ -22,6 +22,7 @@ import type { CatalogGameEntry } from './github-client.js';
  *   snapshots/<id>/catalog.json               → CatalogGameEntry[]
  *   snapshots/<id>/games/<slug>.json          → { slug, title, html }
  *   snapshots/<id>/media/<slug>/<filename>    → screenshot / video bytes
+ *   snapshots/<id>/media/<slug>/w<width>/<f>  → downscaled screenshot (see image-variants)
  *
  * Snapshot prefixes are immutable and content-addressed by publish; only
  * `current.json` is ever overwritten. Three things fall out of that:
@@ -87,14 +88,19 @@ export interface GameSnapshotReader {
   getPointer(): Promise<SnapshotPointer | null>;
   getCatalog(): Promise<CatalogGameEntry[] | null>;
   getGame(slug: string): Promise<SnapshotGame | null>;
-  getMedia(slug: string, filename: string): Promise<SnapshotMedia | null>;
+  /**
+   * `width` asks for a baked size variant. Callers must treat a null as "serve the
+   * original": snapshots baked before variants existed have none, and a bake that
+   * could not read one PNG skips only that variant.
+   */
+  getMedia(slug: string, filename: string, width?: number): Promise<SnapshotMedia | null>;
 }
 
 /** The write side, used by the publish job. */
 export interface GameSnapshotWriter {
   putCatalog(snapshotId: string, entries: CatalogGameEntry[]): Promise<void>;
   putGame(snapshotId: string, game: SnapshotGame): Promise<void>;
-  putMedia(snapshotId: string, slug: string, filename: string, media: SnapshotMedia): Promise<void>;
+  putMedia(snapshotId: string, slug: string, filename: string, media: SnapshotMedia, width?: number): Promise<void>;
   putPointer(pointer: SnapshotPointer): Promise<void>;
 }
 
@@ -110,8 +116,12 @@ export function gameObject(snapshotId: string, slug: string): string {
   return `snapshots/${snapshotId}/games/${slug}.json`;
 }
 
-export function mediaObject(snapshotId: string, slug: string, filename: string): string {
-  return `snapshots/${snapshotId}/media/${slug}/${filename}`;
+export function mediaObject(snapshotId: string, slug: string, filename: string, width?: number): string {
+  // Variants live in their own directory rather than behind a filename suffix: the
+  // filename is validated against the game's own catalog entry, and inventing
+  // `opening-96.png` would put a synthetic name into a space real screenshots occupy.
+  const prefix = `snapshots/${snapshotId}/media/${slug}`;
+  return width === undefined ? `${prefix}/${filename}` : `${prefix}/w${width}/${filename}`;
 }
 
 export function mediaContentType(filename: string): string {
@@ -338,12 +348,12 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
       return readJson<SnapshotGame>(gameObject(pointer.snapshotId, slug));
     },
 
-    async getMedia(slug, filename) {
+    async getMedia(slug, filename, width) {
       assertSafeSlug(slug);
       assertSafeMediaFilename(filename);
       const pointer = await this.getPointer();
       if (!pointer) return null;
-      const body = await readObject(mediaObject(pointer.snapshotId, slug, filename));
+      const body = await readObject(mediaObject(pointer.snapshotId, slug, filename, width));
       if (!body) return null;
       return { body, contentType: mediaContentType(filename) };
     },
@@ -369,11 +379,11 @@ export function createGcsSnapshotStore(options: GcsSnapshotStoreOptions): GameSn
       );
     },
 
-    async putMedia(snapshotId, slug, filename, media) {
+    async putMedia(snapshotId, slug, filename, media, width) {
       assertSafeSnapshotId(snapshotId);
       assertSafeSlug(slug);
       assertSafeMediaFilename(filename);
-      await writeObject(mediaObject(snapshotId, slug, filename), media.body, media.contentType, IMMUTABLE_CACHE);
+      await writeObject(mediaObject(snapshotId, slug, filename, width), media.body, media.contentType, IMMUTABLE_CACHE);
     },
 
     async putPointer(pointer) {

--- a/apps/api/src/image-variants.test.ts
+++ b/apps/api/src/image-variants.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { PNG } from 'pngjs';
+import { downscalePng, isVariantWidth, VARIANT_WIDTHS } from './image-variants.js';
+
+/** A PNG with a hard vertical split, so averaging is visible in the result. */
+function halfAndHalf(width: number, height: number): Buffer {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) << 2;
+      const left = x < width / 2;
+      png.data[i] = left ? 255 : 0;
+      png.data[i + 1] = left ? 0 : 0;
+      png.data[i + 2] = left ? 0 : 255;
+      png.data[i + 3] = 255;
+    }
+  }
+  return PNG.sync.write(png);
+}
+
+function pixel(buffer: Buffer, x: number, y: number) {
+  const png = PNG.sync.read(buffer);
+  const i = (y * png.width + x) << 2;
+  return { r: png.data[i], g: png.data[i + 1], b: png.data[i + 2], a: png.data[i + 3] };
+}
+
+describe('downscalePng', () => {
+  it('scales to the requested width and keeps the aspect ratio', () => {
+    const out = downscalePng(halfAndHalf(1280, 720), 96)!;
+    const png = PNG.sync.read(out);
+    expect(png.width).toBe(96);
+    expect(png.height).toBe(54);
+  });
+
+  it('produces a far smaller file, which is the entire point', () => {
+    const source = halfAndHalf(1280, 720);
+    const out = downscalePng(source, 96)!;
+    expect(out.byteLength).toBeLessThan(source.byteLength / 4);
+  });
+
+  it('keeps the colours where they were', () => {
+    const out = downscalePng(halfAndHalf(1280, 720), 96)!;
+    expect(pixel(out, 5, 20)).toMatchObject({ r: 255, g: 0, b: 0 });
+    expect(pixel(out, 90, 20)).toMatchObject({ r: 0, g: 0, b: 255 });
+  });
+
+  /**
+   * Averaging rather than picking one source pixel. A screenshot of a pixel-art game
+   * downscaled by nearest neighbour turns into aliased noise, which would trade a
+   * performance problem for a visible one.
+   */
+  it('averages across the box rather than sampling a single pixel', () => {
+    const source = new PNG({ width: 4, height: 1 });
+    for (let x = 0; x < 4; x++) {
+      const i = x << 2;
+      source.data[i] = x < 2 ? 0 : 200;
+      source.data[i + 1] = x < 2 ? 0 : 200;
+      source.data[i + 2] = x < 2 ? 0 : 200;
+      source.data[i + 3] = 255;
+    }
+    const out = downscalePng(PNG.sync.write(source), 2)!;
+    const png = PNG.sync.read(out);
+    expect(png.width).toBe(2);
+    // Each destination pixel covers two identical source pixels, so the halves survive
+    // intact — proof the box is being walked rather than one corner being read.
+    expect(png.data[0]).toBe(0);
+    expect(png.data[4]).toBe(200);
+  });
+
+  it('declines when the source is already at or below the target', () => {
+    expect(downscalePng(halfAndHalf(96, 54), 96)).toBeNull();
+    expect(downscalePng(halfAndHalf(64, 36), 96)).toBeNull();
+  });
+
+  // A bake must not die on one odd file: the media route falls back to the original,
+  // which is exactly what every game got before variants existed.
+  it('declines on bytes it cannot read rather than throwing', () => {
+    expect(downscalePng(Buffer.from('not a png at all'), 96)).toBeNull();
+  });
+
+  it('never rounds a very wide, very short image away to nothing', () => {
+    const out = downscalePng(halfAndHalf(4000, 3), 96)!;
+    expect(PNG.sync.read(out).height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('guards the width allowlist the route validates against', () => {
+    expect(VARIANT_WIDTHS).toEqual([96, 640]);
+    expect(isVariantWidth(96)).toBe(true);
+    expect(isVariantWidth(97)).toBe(false);
+  });
+});

--- a/apps/api/src/image-variants.ts
+++ b/apps/api/src/image-variants.ts
@@ -1,0 +1,91 @@
+import { PNG } from 'pngjs';
+
+/**
+ * Size-appropriate copies of catalog screenshots, baked once at publish time.
+ *
+ * The arcade shows the same PNG at two very different sizes: a moment thumbnail
+ * about 48 CSS pixels wide, and a card poster a few hundred. Serving the original
+ * for both means the browser decodes a full screenshot for every near-fold poster
+ * (and again for each moment thumb after engage) — and a PNG cannot be decoded
+ * partially, so there is no client-side trick that avoids it.
+ *
+ * Baking rather than resizing per request: a published game's media changes only when
+ * somebody merges, so this is a constant being recomputed, and the play path is the
+ * one that must never be slow.
+ *
+ * Pure JS on purpose. A native encoder would be faster, but this runs once per bake in
+ * CI rather than per request, and a native dependency is a build and deploy liability
+ * out of all proportion to that.
+ */
+
+/** Widths the catalog asks for: thumbnail strip, then card poster at 2× its CSS box. */
+export const VARIANT_WIDTHS = [96, 640] as const;
+
+export type VariantWidth = (typeof VARIANT_WIDTHS)[number];
+
+export function isVariantWidth(value: number): value is VariantWidth {
+  return (VARIANT_WIDTHS as readonly number[]).includes(value);
+}
+
+/**
+ * Downscale a PNG to `targetWidth`, preserving aspect ratio.
+ *
+ * Returns null when there is nothing to gain — a source already at or below the target
+ * would only be re-encoded, and an unreadable one is not worth failing a bake over
+ * (the route falls back to the original, which is exactly today's behaviour).
+ */
+export function downscalePng(source: Buffer, targetWidth: number): Buffer | null {
+  let image: PNG;
+  try {
+    image = PNG.sync.read(source);
+  } catch {
+    return null;
+  }
+
+  if (image.width <= targetWidth) return null;
+
+  const width = targetWidth;
+  const height = Math.max(1, Math.round((image.height * targetWidth) / image.width));
+  const out = new PNG({ width, height });
+
+  // Box filter: average every source pixel that lands in the destination pixel. Nearest
+  // neighbour is cheaper and looks it — a downscaled screenshot of a pixel-art game
+  // turns into aliased noise, which is worse than the cost this exists to remove.
+  const xRatio = image.width / width;
+  const yRatio = image.height / height;
+
+  for (let y = 0; y < height; y++) {
+    const srcYStart = Math.floor(y * yRatio);
+    const srcYEnd = Math.max(srcYStart + 1, Math.floor((y + 1) * yRatio));
+
+    for (let x = 0; x < width; x++) {
+      const srcXStart = Math.floor(x * xRatio);
+      const srcXEnd = Math.max(srcXStart + 1, Math.floor((x + 1) * xRatio));
+
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      let samples = 0;
+
+      for (let sy = srcYStart; sy < srcYEnd && sy < image.height; sy++) {
+        for (let sx = srcXStart; sx < srcXEnd && sx < image.width; sx++) {
+          const i = (sy * image.width + sx) << 2;
+          r += image.data[i];
+          g += image.data[i + 1];
+          b += image.data[i + 2];
+          a += image.data[i + 3];
+          samples += 1;
+        }
+      }
+
+      const o = (y * width + x) << 2;
+      out.data[o] = Math.round(r / samples);
+      out.data[o + 1] = Math.round(g / samples);
+      out.data[o + 2] = Math.round(b / samples);
+      out.data[o + 3] = Math.round(a / samples);
+    }
+  }
+
+  return PNG.sync.write(out);
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -4087,10 +4087,12 @@ export async function registerSubmissionRoutes(
     }
 
     // An allowlist, not a number: `?w=` naming an arbitrary size would be an invitation
-    // to fill the cache with one entry per width somebody felt like asking for. Anything
-    // else is ignored and the original is served, so a stale client cannot break.
+    // to fill the cache with one entry per width somebody felt like asking for. Variants
+    // are a PNG-only idea — an MP4 with `?w=` would only add a useless extra read and a
+    // duplicate cache entry. Anything else is ignored and the original is served.
     const requestedWidth = Number((request.query as { w?: string } | undefined)?.w);
-    const variantWidth = isVariantWidth(requestedWidth) ? requestedWidth : undefined;
+    const variantWidth =
+      parsedParams.data.filename.endsWith('.png') && isVariantWidth(requestedWidth) ? requestedWidth : undefined;
 
     const currentTime = now();
     if (isRateLimited(mediaByIp, request.ip, currentTime, maxMediaPerWindow, gamesRateLimitWindowMs)) {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -75,6 +75,7 @@ import {
 } from './submission-status.js';
 import { InvalidTokenError, mintToken, verifyToken } from './submission-token.js';
 import { createTranslatorFromEnv, normalizeLocale, type Translator } from './translate.js';
+import { isVariantWidth } from './image-variants.js';
 import { logModerationRejection } from './moderation-metrics.js';
 
 const CreateSubmissionRequestSchema = z.object({
@@ -1494,9 +1495,17 @@ export async function registerSubmissionRoutes(
   async function readSnapshotMedia(
     slug: string,
     filename: string,
+    width?: number,
   ): Promise<{ body: Buffer; contentType: string } | null> {
     if (!snapshotReader) return null;
     try {
+      if (width !== undefined) {
+        // Fall back rather than 404: snapshots baked before variants existed have
+        // none, and a bake skips a variant it could not produce. Either way the
+        // original is the right answer, and it is what was served before this.
+        const variant = await snapshotReader.getMedia(slug, filename, width);
+        if (variant) return variant;
+      }
       return await snapshotReader.getMedia(slug, filename);
     } catch (error) {
       if (error instanceof SnapshotUnavailableError) throw error;
@@ -4077,6 +4086,12 @@ export async function registerSubmissionRoutes(
       return reply.status(404).send({ error: 'media not found' });
     }
 
+    // An allowlist, not a number: `?w=` naming an arbitrary size would be an invitation
+    // to fill the cache with one entry per width somebody felt like asking for. Anything
+    // else is ignored and the original is served, so a stale client cannot break.
+    const requestedWidth = Number((request.query as { w?: string } | undefined)?.w);
+    const variantWidth = isVariantWidth(requestedWidth) ? requestedWidth : undefined;
+
     const currentTime = now();
     if (isRateLimited(mediaByIp, request.ip, currentTime, maxMediaPerWindow, gamesRateLimitWindowMs)) {
       return reply.status(429).send({ error: 'too many game requests, please try again later' });
@@ -4084,7 +4099,7 @@ export async function registerSubmissionRoutes(
 
     // Serving from cache still respects the allowlist below on the first fetch;
     // a cached entry can only exist for a filename that already passed it.
-    const cacheKey = `${parsedParams.data.slug}/${parsedParams.data.filename}`;
+    const cacheKey = `${parsedParams.data.slug}/${variantWidth ?? 'full'}/${parsedParams.data.filename}`;
     const cachedMedia = mediaCache.get(cacheKey);
     if (cachedMedia && cachedMedia.expiresAt > currentTime) {
       return sendMedia(request, reply, cachedMedia);
@@ -4102,7 +4117,11 @@ export async function registerSubmissionRoutes(
       let body: Buffer | null = null;
       if (entry && allowedFiles.has(parsedParams.data.filename)) {
         if (snapshotReader) {
-          const snapshotMedia = await readSnapshotMedia(parsedParams.data.slug, parsedParams.data.filename);
+          const snapshotMedia = await readSnapshotMedia(
+            parsedParams.data.slug,
+            parsedParams.data.filename,
+            variantWidth,
+          );
           body = snapshotMedia?.body ?? null;
         } else {
           const media = await githubClient.getGameMedia(

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -90,7 +90,7 @@ describe('catalog playback', () => {
     // Poster-first: cards near the fold show a still until preview is armed.
     // Default still prefers a mid-capture over `opening`.
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png');
+    expect(poster?.getAttribute('src')).toBe('/api/games/sky-dodge/media/close-call.png?w=640');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     const previewButton = container.querySelector<HTMLButtonElement>('.preview-toggle');
@@ -101,7 +101,7 @@ describe('catalog playback', () => {
     });
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/sky-dodge/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/sky-dodge/media/close-call.png?w=640');
     expect(previewButton?.textContent).toContain('Pause preview');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -165,7 +165,7 @@ describe('ArcadeCatalog lazy media', () => {
     // Near-fold: poster only — no moment thumbs and no MP4 until engage.
     expect(container.querySelectorAll('video')).toHaveLength(0);
     const poster = container.querySelector<HTMLImageElement>('img.catalog-preview');
-    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png');
+    expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png?w=640');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
     await act(async () => {
@@ -175,14 +175,15 @@ describe('ArcadeCatalog lazy media', () => {
 
     const preview = container.querySelector<HTMLVideoElement>('video.catalog-preview');
     expect(preview?.getAttribute('src')).toBe('/api/games/above-fold/media/gameplay.mp4');
-    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png');
+    expect(preview?.getAttribute('poster')).toBe('/api/games/above-fold/media/mid.png?w=640');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
     // The second card still has no media srcs — it never intersected.
     expect(container.querySelectorAll('video')).toHaveLength(1);
-    expect(container.querySelectorAll('.catalog-moment img')).toHaveLength(2);
-    const momentSrcs = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')].map((img) => img.src);
-    expect(momentSrcs.every((src) => src.includes('/api/games/above-fold/'))).toBe(true);
+    const moments = [...container.querySelectorAll<HTMLImageElement>('.catalog-moment img')];
+    expect(moments).toHaveLength(2);
+    expect(moments.every((img) => img.src.includes('/api/games/above-fold/'))).toBe(true);
+    expect(moments.every((img) => img.getAttribute('src')?.endsWith('?w=96'))).toBe(true);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -96,7 +96,9 @@ function CatalogCard({
   const [videoArmed, setVideoArmed] = useState(false);
   const [extrasOpen, setExtrasOpen] = useState(false);
   const selected = screenshots[selectedScreenshot] ?? screenshots[0];
-  const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file) : undefined;
+  // 640 rather than the original: the card box is a few hundred CSS pixels, so this is
+  // roughly 2x what is drawn and a fraction of a full screenshot to decode.
+  const posterUrl = selected && inView ? catalogMediaUrl(entry.slug, selected.file, 640) : undefined;
   const hasVideo = Boolean(entry.media?.video);
   const hasMoments = screenshots.length > 1;
   const videoUrl =
@@ -388,7 +390,7 @@ function CatalogCard({
                 aria-pressed={index === selectedScreenshot}
                 onClick={() => selectScreenshot(index)}
               >
-                <img src={catalogMediaUrl(entry.slug, screenshot.file)} alt="" loading="lazy" decoding="async" />
+                <img src={catalogMediaUrl(entry.slug, screenshot.file, 96)} alt="" loading="lazy" decoding="async" />
               </button>
             ))}
           </div>

--- a/apps/web/src/catalog.test.ts
+++ b/apps/web/src/catalog.test.ts
@@ -177,6 +177,11 @@ describe('catalog helpers', () => {
     );
   });
 
+  it('asks for a baked width with ?w= when one is given', () => {
+    expect(catalogMediaUrl('sky-dodge', 'mid.png', 640)).toBe('/api/games/sky-dodge/media/mid.png?w=640');
+    expect(catalogMediaUrl('sky-dodge', 'mid.png', 96)).toBe('/api/games/sky-dodge/media/mid.png?w=96');
+  });
+
   it('surfaces the API error body when the catalog request fails', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ error: 'failed to load catalog' }), { status: 502, statusText: '' }),

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -93,8 +93,18 @@ export interface PublishedGame {
 // only access boundary is the app's own gate. Same origin in production.
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export function catalogMediaUrl(slug: string, filename: string): string {
-  return `${API_BASE}/api/games/${encodeURIComponent(slug)}/media/${encodeURIComponent(filename)}`;
+/**
+ * `width` asks the API for a baked size variant instead of the original screenshot.
+ *
+ * Worth asking for: the arcade shows the same PNG at ~48 CSS px in the moment strip
+ * and a few hundred as a card poster, and a PNG cannot be decoded partially — so
+ * without this the browser decodes a full screenshot for every near-fold poster
+ * (and again for each moment thumb after engage). An API that has no variant serves
+ * the original, so this is safe to ask for against any deploy.
+ */
+export function catalogMediaUrl(slug: string, filename: string, width?: number): string {
+  const base = `${API_BASE}/api/games/${encodeURIComponent(slug)}/media/${encodeURIComponent(filename)}`;
+  return width === undefined ? base : `${base}?w=${width}`;
 }
 
 function parseCatalogMedia(value: unknown): CatalogMedia | null {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,15 +47,17 @@
         "genaicode": "^2.1.0",
         "google-auth-library": "^10.9.0",
         "jose": "^6.2.4",
+        "pngjs": "^7.0.0",
+        "typescript": "^5.5.4",
         "web-push": "^3.6.7",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^20.14.15",
+        "@types/pngjs": "^6.0.5",
         "@types/web-push": "^3.6.4",
         "@types/ws": "^8.18.1",
         "tsx": "^4.16.5",
-        "typescript": "^5.5.4",
         "vitest": "^3.2.7",
         "ws": "^8.18.0"
       }
@@ -2372,6 +2374,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5278,6 +5290,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.22",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
@@ -6221,7 +6242,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up after closing #493 / #498. Those PRs mixed two ideas; #497 already shipped the important one (defer the moment strip). This keeps only the leftover: serve catalog screenshots at the size they are drawn.

- Bake `w96` / `w640` PNG variants at snapshot publish (`pngjs`, pure JS)
- Media route accepts allowlisted `?w=` on PNGs only (ignores width on video) and falls back to the original for older snapshots
- Catalog asks for `640` on posters and `96` on moment thumbs

Credits the media-variants half of #434 (authored by @jactan77).

## Copilot feedback

- Gated `?w=` to `.png` so MP4 requests don’t fan out cache keys / extra reads.

## Test plan

- [x] `npm run type-check && npm run lint`
- [x] Focused: image-variants / snapshot publish+serve / ArcadeCatalog / App.catalog / catalog
- [x] Full `npm test && npm run build`
- [x] Serve suite after Copilot fix (includes MP4 `?w=` ignore)
- [ ] After merge: next snapshot publish writes variants; cards request `?w=` and still render on pre-variant snapshots
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8627211-3e74-43be-bd36-f0598c8e9536?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8627211-3e74-43be-bd36-f0598c8e9536&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

