### PR TITLE
Support the GameKit racing vertical

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -11,6 +11,7 @@
     "actors",
     "gfx",
     "gfx3d",
+    "racing",
     "effects",
     "audio",
     "party",
@@ -28,10 +29,7 @@
   "maxProjectBytes": 486387,
   "audio": {
     "musicField": "string",
-    "musicCatalogRequiredKeys": [
-      "version",
-      "tracks"
-    ],
+    "musicCatalogRequiredKeys": ["version", "tracks"],
     "injectedGlobals": {
       "assets": "__GAME_AUDIO_ASSETS__",
       "defaultMusic": "__GAME_AUDIO_MUSIC__",

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -79,9 +79,10 @@ describe('runGamesRepoContractCheck', () => {
   });
 
   it('allows the website to list modules the games tip has not shipped yet', async () => {
-    // Website-first add: GAME_KIT_MODULES here already includes `voice`, but main's
-    // assemble.ts may still list the pre-voice order. That window must stay green.
-    const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => name !== 'voice');
+    // Website-first adds: GAME_KIT_MODULES here already includes these modules, but
+    // main's assemble.ts may still list the older order. That window must stay green.
+    const aheadModules = new Set(['voice', 'racing']);
+    const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => !aheadModules.has(name));
     const olderAssemble = `
       const GAME_KIT_MODULES = [${withoutAheadExtras.map((name) => `'${name}'`).join(', ')}];
       const catalog = readMusicCatalog();

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -243,7 +243,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   // before the games-repo tip merges them. If a local-only module is NOT in this
   // list, it means games-repo dropped or rolled it back — that is drift, not an
   // intentional lead. (Codex review — PR #379.)
-  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice', 'editor']);
+  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice', 'editor', 'racing']);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const undeclaredExtras = websiteExtras.filter((m) => !DECLARED_AHEAD_MODULES.has(m));
   if (undeclaredExtras.length > 0) {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -52,6 +52,7 @@ describe('games-repo-contract (website half)', () => {
       'actors',
       'gfx',
       'gfx3d',
+      'racing',
       'effects',
       'audio',
       'party',
@@ -78,7 +79,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'gfx3d', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
+        'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;
     `;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -31,6 +31,8 @@ export const GAME_KIT_MODULES = [
   'actors',
   'gfx',
   'gfx3d',
+  // Genre vertical: the GitHub client bundles its private shared/verticals/racing graph.
+  'racing',
   'effects',
   'audio',
   'party',

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -727,6 +727,37 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
+  it('bundles an opt-in GameKit vertical from its private TypeScript graph', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/racer/index.html', '<canvas id="game"></canvas>'],
+      ['games/racer/game.ts', 'GameKit.mount({ vertical: GameKit.circuitRacer });'],
+      ['games/racer/style.css', '.game {}'],
+      ['games/racer/SPEC.md', specMd({ title: 'Racer' })],
+      ['games/racer/GAME.json', JSON.stringify({ engine: { modules: ['racing'] } })],
+      ['shared/game-shell.css', '.shell {}'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      [
+        'shared/verticals/racing/index.ts',
+        "import { createRace } from './simulation.ts'; Object.assign(GameKit, { circuitRacer: { createRace } });",
+      ],
+      ['shared/verticals/racing/simulation.ts', "export function createRace(): string { return 'vertical-loaded'; }"],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const requestedPath = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(requestedPath);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'racer');
+
+    expect(sources?.gameJs).toContain('vertical-loaded');
+    expect(sources?.gameJs).not.toContain('import ');
+    expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
+  });
+
   it('rejects a GAME.json that still uses a pre-draw-surface module list as incomplete order', async () => {
     // modules that omit required ordering relative to the canonical list are fine
     // as a subset — but unknown names must throw (the live 502 root cause).

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
 import { classifyTouchSource, type CatalogGameTouch } from './catalog-touch.js';
-import { GAME_KIT_MODULES } from './games-repo-contract.js';
+import { GAME_KIT_MODULES, type GameKitModuleName } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
 export type { CatalogGameTouch } from './catalog-touch.js';
@@ -69,8 +69,11 @@ export interface GameSources {
 
 // GAME_KIT_MODULES lives in games-repo-contract.ts — CI re-checks the live
 // games repo copy when GAMES_REPO_TOKEN is set (issue #247).
-const MAX_GAME_MODULES = 64;
-const MAX_GAME_SOURCE_BYTES = 200 * 1024;
+const MAX_SOURCE_GRAPH_MODULES = 64;
+const MAX_SOURCE_GRAPH_BYTES = 200 * 1024;
+const GAME_KIT_MODULE_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
+  racing: 'shared/verticals/racing/index.ts',
+};
 
 /**
  * Maps a relative import specifier onto a `.ts` source path.
@@ -109,7 +112,7 @@ interface GameManifest {
 }
 
 interface ParsedGameManifest {
-  modules: string[];
+  modules: GameKitModuleName[];
   sounds: string[];
   /**
    * Selected BGM track id from GAME.json (`audio.music` string). Null when the
@@ -141,7 +144,7 @@ function parseGameManifest(source: string): ParsedGameManifest {
   }
 
   if (!modules.includes('audio')) {
-    return { modules, sounds: [], music: null };
+    return { modules: modules as GameKitModuleName[], sounds: [], music: null };
   }
 
   const sounds = manifest.audio?.sounds;
@@ -161,7 +164,7 @@ function parseGameManifest(source: string): ParsedGameManifest {
     throw new Error('game manifest contains invalid audio music');
   }
 
-  return { modules, sounds, music };
+  return { modules: modules as GameKitModuleName[], sounds, music };
 }
 
 /**
@@ -797,27 +800,28 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     return (await response.json()) as T;
   }
 
-  async function bundleGameTypeScript(
+  async function bundleTypeScriptGraph(
     entrySource: string,
     ref: string,
-    slug: string,
+    sourceRoot: string,
+    entryPath: string,
+    sourceKind: 'game' | 'GameKit module',
     overrides?: Record<string, string>,
-    /** When given, every module the walk loads is recorded here by game-relative path. */
+    /** When given, every module the walk loads is recorded here by root-relative path. */
     collect?: Map<string, string>,
   ): Promise<string> {
-    const gameRoot = `/games/${slug}`;
-    const loadedPaths = new Set([`${gameRoot}/game.ts`]);
+    const loadedPaths = new Set([entryPath]);
     let sourceBytes = Buffer.byteLength(entrySource, 'utf8');
-    if (sourceBytes > MAX_GAME_SOURCE_BYTES) {
-      throw new Error(`game TypeScript exceeds ${MAX_GAME_SOURCE_BYTES} bytes`);
+    if (sourceBytes > MAX_SOURCE_GRAPH_BYTES) {
+      throw new Error(`${sourceKind} TypeScript exceeds ${MAX_SOURCE_GRAPH_BYTES} bytes`);
     }
 
     const result = await build({
       stdin: {
         contents: entrySource,
         loader: 'ts',
-        resolveDir: gameRoot,
-        sourcefile: `${gameRoot}/game.ts`,
+        resolveDir: sourceRoot,
+        sourcefile: entryPath,
       },
       bundle: true,
       write: false,
@@ -827,43 +831,43 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       legalComments: 'inline',
       plugins: [
         {
-          name: 'github-game-modules',
+          name: 'github-typescript-modules',
           setup(builder) {
             builder.onResolve({ filter: /^\./ }, (args) => {
               // Games-repo TypeScript follows normal ESM habits: relative imports may
               // carry a `.ts` suffix, a `.js` suffix (TypeScript's Node ESM convention
               // — the source file is still `.ts`), or no suffix at all. Map all three
-              // onto a path under the game directory before the sandbox check; anything
-              // that escapes the game root is rejected.
+              // onto a path under the source root before the sandbox check; anything
+              // that escapes that root is rejected.
               const sourcePath = resolveGameTypeScriptPath(args.resolveDir, args.path);
-              if (!sourcePath || !sourcePath.startsWith(`${gameRoot}/`)) {
+              if (!sourcePath || !sourcePath.startsWith(`${sourceRoot}/`)) {
                 return {
-                  errors: [{ text: `game imports must be TypeScript files inside ${gameRoot}` }],
+                  errors: [{ text: `${sourceKind} imports must be TypeScript files inside ${sourceRoot}` }],
                 };
               }
-              return { path: sourcePath, namespace: 'github-game-source' };
+              return { path: sourcePath, namespace: 'github-typescript-source' };
             });
             builder.onResolve({ filter: /^[^.]/ }, (args) => ({
-              errors: [{ text: `game runtime dependency is forbidden: "${args.path}"` }],
+              errors: [{ text: `${sourceKind} runtime dependency is forbidden: "${args.path}"` }],
             }));
-            builder.onLoad({ filter: /.*/, namespace: 'github-game-source' }, async (args) => {
+            builder.onLoad({ filter: /.*/, namespace: 'github-typescript-source' }, async (args) => {
               // Prefer the resolved file; if an extensionless import pointed at a
               // directory, fall back to its index.ts (same rule TypeScript uses).
               // Count the *actual* source path once — not the synthetic `dir.ts`
               // plus `dir/index.ts` — so directory imports don't burn two slots
-              // toward MAX_GAME_MODULES.
+              // toward MAX_SOURCE_GRAPH_MODULES.
               let loadedPath = args.path;
               // An override shadows the ref's copy of the same file. Keyed by the
-              // game-relative path, which is what a source edit names.
+              // root-relative path, which is what a source edit names.
               const overrideOf = (absolutePath: string): string | null => {
-                if (!overrides || !absolutePath.startsWith(`${gameRoot}/`)) return null;
-                const relative = absolutePath.slice(gameRoot.length + 1);
+                if (!overrides || !absolutePath.startsWith(`${sourceRoot}/`)) return null;
+                const relative = absolutePath.slice(sourceRoot.length + 1);
                 return Object.hasOwn(overrides, relative) ? overrides[relative] : null;
               };
               let source = overrideOf(loadedPath) ?? (await readRawFile(loadedPath.slice(1), ref));
               if (source === null && loadedPath.endsWith('.ts')) {
                 const indexPath = `${loadedPath.slice(0, -'.ts'.length)}/index.ts`;
-                if (indexPath.startsWith(`${gameRoot}/`)) {
+                if (indexPath.startsWith(`${sourceRoot}/`)) {
                   const indexSource = overrideOf(indexPath) ?? (await readRawFile(indexPath.slice(1), ref));
                   if (indexSource !== null) {
                     loadedPath = indexPath;
@@ -872,17 +876,19 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
                 }
               }
               if (source === null) {
-                return { errors: [{ text: `game module not found: ${args.path}` }] };
+                return { errors: [{ text: `${sourceKind} module not found: ${args.path}` }] };
               }
-              collect?.set(loadedPath.slice(gameRoot.length + 1), source);
+              collect?.set(loadedPath.slice(sourceRoot.length + 1), source);
               if (!loadedPaths.has(loadedPath)) {
-                if (loadedPaths.size >= MAX_GAME_MODULES) {
-                  return { errors: [{ text: `game exceeds ${MAX_GAME_MODULES} TypeScript modules` }] };
+                if (loadedPaths.size >= MAX_SOURCE_GRAPH_MODULES) {
+                  return {
+                    errors: [{ text: `${sourceKind} exceeds ${MAX_SOURCE_GRAPH_MODULES} TypeScript modules` }],
+                  };
                 }
                 loadedPaths.add(loadedPath);
                 sourceBytes += Buffer.byteLength(source, 'utf8');
-                if (sourceBytes > MAX_GAME_SOURCE_BYTES) {
-                  return { errors: [{ text: `game TypeScript exceeds ${MAX_GAME_SOURCE_BYTES} bytes` }] };
+                if (sourceBytes > MAX_SOURCE_GRAPH_BYTES) {
+                  return { errors: [{ text: `${sourceKind} TypeScript exceeds ${MAX_SOURCE_GRAPH_BYTES} bytes` }] };
                 }
               }
               return {
@@ -897,9 +903,36 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     });
     const output = result.outputFiles?.[0];
     if (!output) {
-      throw new Error('game TypeScript bundler produced no output');
+      throw new Error(`${sourceKind} TypeScript bundler produced no output`);
     }
     return output.text;
+  }
+
+  function bundleGameTypeScript(
+    entrySource: string,
+    ref: string,
+    slug: string,
+    overrides?: Record<string, string>,
+    collect?: Map<string, string>,
+  ): Promise<string> {
+    const gameRoot = `/games/${slug}`;
+    return bundleTypeScriptGraph(entrySource, ref, gameRoot, `${gameRoot}/game.ts`, 'game', overrides, collect);
+  }
+
+  async function compileGameKitModule(moduleName: GameKitModuleName, ref: string): Promise<string | null> {
+    const entryPath = GAME_KIT_MODULE_ENTRIES[moduleName] ?? `shared/modules/${moduleName}.ts`;
+    const source = await readRawFile(entryPath, ref);
+    if (source === null) return null;
+    if (GAME_KIT_MODULE_ENTRIES[moduleName]) {
+      return bundleTypeScriptGraph(source, ref, `/${path.posix.dirname(entryPath)}`, `/${entryPath}`, 'GameKit module');
+    }
+    const result = await transform(source, {
+      loader: 'ts',
+      target: 'es2022',
+      format: 'iife',
+      legalComments: 'inline',
+    });
+    return result.code;
   }
 
   return {
@@ -1241,7 +1274,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
 
       const manifest = parseGameManifest(manifestSource);
       const moduleSources = await Promise.all(
-        manifest.modules.map((moduleName) => readRawFile(`shared/modules/${moduleName}.ts`, ref)),
+        manifest.modules.map((moduleName) => compileGameKitModule(moduleName, ref)),
       );
       if (moduleSources.some((source) => source === null)) {
         return null;
@@ -1285,17 +1318,13 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       }
 
       const assetsJs = assetChunks.length > 0 ? `${assetChunks.join('\n')}\n` : '';
-      const transpiledSources = await Promise.all(
-        [coreTs, ...availableModuleSources].map(async (source) => {
-          const result = await transform(source, {
-            loader: 'ts',
-            target: 'es2022',
-            format: 'iife',
-            legalComments: 'inline',
-          });
-          return result.code;
-        }),
-      );
+      const coreResult = await transform(coreTs, {
+        loader: 'ts',
+        target: 'es2022',
+        format: 'iife',
+        legalComments: 'inline',
+      });
+      const transpiledSources = [coreResult.code, ...availableModuleSources];
       const gameJs = await bundleGameTypeScript(gameTs, ref, slug, overrides);
       const bundledJs = `${assetsJs}${transpiledSources.join('\n')}
 Object.freeze(window.GameKit);


### PR DESCRIPTION
## Summary

- add `racing` to the website-side GameKit module contract
- bundle mapped GameKit vertical entrypoints together with their private TypeScript imports
- keep the single-file path unchanged for foundational GameKit modules
- update the contract fixture and add regression coverage for the racing source graph

## Why

This is paired with gamedevpl/www.gamedev.pl-games#435. The new opt-in racing module lives under `shared/verticals/racing/`; without graph bundling, PR previews and serve-time assembly would request a nonexistent `shared/modules/racing.ts` file.

## Rollout

Merge this website-side PR before gamedevpl/www.gamedev.pl-games#435, following the module-addition contract ordering.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` (API 2038, web 963, world 19, rules 23 passing; 3 expected isolated-vm skips)
- `npm run build`
