### PR TITLE
feat: browse Creator Kit files over MCP (no full-kit dump)

### DIFF
--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
 import { AGENT_BUILD_RULES_DIGEST } from './agent-build-brief.js';
@@ -7,6 +8,7 @@ import { buildApp } from './app.js';
 import { MAX_PROJECT_BYTES } from './games-repo-contract.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { KIT_ROOT_DIR } from './kit-registry.js';
 import { InMemoryStore } from './store.js';
 import { NoopTranslator } from './translate.js';
 
@@ -14,6 +16,25 @@ const secret = 'test-secret';
 const ISSUE = 77;
 const ENGINE = 'deadbeef0123456789abcdef0123456789abcdef';
 const SHA = 'a'.repeat(64);
+const TAR_BLOCK = 512;
+
+function kitEntryBlocks(name: string, body: string | Buffer): Buffer {
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+  const header = Buffer.alloc(TAR_BLOCK);
+  header.write(name, 0, 100, 'utf8');
+  header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+  header.write('0', 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  const padding = Buffer.alloc((TAR_BLOCK - (payload.length % TAR_BLOCK)) % TAR_BLOCK);
+  return Buffer.concat([header, payload, padding]);
+}
+
+function packedKitTarball(files: Record<string, string | Buffer>): Buffer {
+  const entries = Object.entries(files).map(([name, body]) =>
+    kitEntryBlocks(name.startsWith(`${KIT_ROOT_DIR}/`) ? name : `${KIT_ROOT_DIR}/${name}`, body),
+  );
+  return gzipSync(Buffer.concat([...entries, Buffer.alloc(TAR_BLOCK * 2)]));
+}
 
 function stubGitHub(): GitHubClient {
   return {
@@ -81,6 +102,10 @@ describe('agent build reads (BY-04)', () => {
     '/api/agent/build/brief',
     '/api/agent/build/seed',
     '/api/agent/build/kit',
+    '/api/agent/build/kit/files',
+    '/api/agent/build/kit/search?q=GameKit',
+    '/api/agent/build/kit/file?path=SKILL.md',
+    '/api/agent/build/kit/file/fragment?path=SKILL.md&limit=2',
     '/api/agent/build/examples',
     '/api/agent/build/examples/block-cascade',
   ];
@@ -209,7 +234,75 @@ describe('agent build reads (BY-04)', () => {
       entry: 'gamedevpl-creator-kit/SKILL.md',
     });
     expect(res.json().unpack).toBe(`curl -fsSL 'https://signed.example/kits/${ENGINE}.tgz?sig=1' | tar -xz`);
+    expect(res.json().browse).toEqual({
+      list: 'list_kit_files',
+      search: 'search_kit_files',
+      read: 'read_kit_file',
+      fragment: 'read_kit_file_fragment',
+    });
     expect(signReadUrl).toHaveBeenCalledWith(`kits/${ENGINE}.tgz`, expect.any(Number));
+  });
+
+  it('lists, searches, and reads kit files from the packed tarball over the channel', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const tgz = packedKitTarball({
+      'SKILL.md': '# Kit\n\nUse GameKit.createCanvasGame.\n',
+      'shared/modules/core.ts': 'export const core = 1; // GameKit\n',
+      'shared/audio/beep.wav': Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0]),
+    });
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(
+          JSON.stringify({
+            current: ENGINE,
+            previous: null,
+            updatedAt: '2026-07-31T00:00:00.000Z',
+          }),
+        ),
+      ],
+      ['kits/' + ENGINE + '.json', Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-07-31T00:00:00.000Z' }))],
+      ['kits/' + ENGINE + '.tgz', tgz],
+    ]);
+    app = await createApp(store, mockObjectStore(objects));
+
+    const listed = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/kit/files?prefix=shared',
+      headers: agentHeaders(),
+    });
+    expect(listed.statusCode).toBe(200);
+    expect(listed.json().engineRef).toBe(ENGINE);
+    expect(listed.json().files.every((f: { path: string }) => f.path.includes('/shared/'))).toBe(true);
+
+    const searched = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/kit/search?q=createCanvasGame',
+      headers: agentHeaders(),
+    });
+    expect(searched.statusCode).toBe(200);
+    expect(searched.json().matches[0]).toMatchObject({
+      path: `${KIT_ROOT_DIR}/SKILL.md`,
+      line: expect.any(Number),
+    });
+
+    const read = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/kit/file?path=SKILL.md',
+      headers: agentHeaders(),
+    });
+    expect(read.statusCode).toBe(200);
+    expect(read.json().content).toMatch(/Creator Kit|# Kit/);
+
+    const fragment = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/kit/file/fragment?path=SKILL.md&unit=lines&offset=0&limit=1',
+      headers: agentHeaders(),
+    });
+    expect(fragment.statusCode).toBe(200);
+    expect(fragment.json().content).toBe('# Kit');
+    expect(fragment.json().eof).toBe(false);
   });
 
   it('returns a machine-readable error when kits/current.json is missing', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -313,6 +313,12 @@ export async function registerAgentChannelRoutes(
   const submitsByBuild = new Map<number, number[]>();
   const kitFileStore = options.objectStore ? createKitFileStore(options.objectStore) : null;
 
+  function optionalFiniteQuery(raw: string | undefined): number | undefined {
+    if (raw === undefined) return undefined;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : undefined;
+  }
+
   function sendKitFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
     if (error instanceof KitFilesError) {
       const status =
@@ -1196,14 +1202,12 @@ export async function registerAgentChannelRoutes(
           offset?: string;
         };
         const tree = await kitFileStore.loadCurrentTree();
-        const limitNum = query.limit !== undefined ? Number(query.limit) : undefined;
-        const offsetNum = query.offset !== undefined ? Number(query.offset) : undefined;
         return reply.send(
           listKitFiles(tree, {
             prefix: query.prefix,
             glob: query.glob,
-            limit: limitNum !== undefined && Number.isFinite(limitNum) ? limitNum : undefined,
-            offset: offsetNum !== undefined && Number.isFinite(offsetNum) ? offsetNum : undefined,
+            limit: optionalFiniteQuery(query.limit),
+            offset: optionalFiniteQuery(query.offset),
           }),
         );
       } catch (error) {
@@ -1231,7 +1235,7 @@ export async function registerAgentChannelRoutes(
           searchKitFiles(tree, {
             query: query.q ?? query.query ?? '',
             prefix: query.prefix,
-            limit: query.limit !== undefined ? Number(query.limit) : undefined,
+            limit: optionalFiniteQuery(query.limit),
           }),
         );
       } catch (error) {
@@ -1294,8 +1298,8 @@ export async function registerAgentChannelRoutes(
         const tree = await kitFileStore.loadCurrentTree();
         return reply.send(
           readKitFileFragment(tree, query.path, {
-            offset: query.offset !== undefined ? Number(query.offset) : undefined,
-            limit: query.limit !== undefined ? Number(query.limit) : undefined,
+            offset: optionalFiniteQuery(query.offset),
+            limit: optionalFiniteQuery(query.limit),
             unit,
             encoding,
           }),

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -329,7 +329,9 @@ export async function registerAgentChannelRoutes(
               error.code === 'kit_artifact_missing' ||
               error.code === 'kit_file_missing'
             ? 404
-            : 400;
+            : error.code === 'kit_revision_unsupported'
+              ? 409
+              : 400;
       return reply.status(status).send({ error: error.code, message: error.message });
     }
     if (error instanceof KitRegistryError) {
@@ -1200,8 +1202,9 @@ export async function registerAgentChannelRoutes(
           glob?: string;
           limit?: string;
           offset?: string;
+          engineRef?: string;
         };
-        const tree = await kitFileStore.loadCurrentTree();
+        const tree = await kitFileStore.loadTree(query.engineRef);
         return reply.send(
           listKitFiles(tree, {
             prefix: query.prefix,
@@ -1229,8 +1232,14 @@ export async function registerAgentChannelRoutes(
         return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
       }
       try {
-        const query = request.query as { q?: string; query?: string; prefix?: string; limit?: string };
-        const tree = await kitFileStore.loadCurrentTree();
+        const query = request.query as {
+          q?: string;
+          query?: string;
+          prefix?: string;
+          limit?: string;
+          engineRef?: string;
+        };
+        const tree = await kitFileStore.loadTree(query.engineRef);
         return reply.send(
           searchKitFiles(tree, {
             query: query.q ?? query.query ?? '',
@@ -1257,12 +1266,12 @@ export async function registerAgentChannelRoutes(
         return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
       }
       try {
-        const query = request.query as { path?: string; encoding?: string };
+        const query = request.query as { path?: string; encoding?: string; engineRef?: string };
         if (!query.path?.trim()) {
           return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
         }
         const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
-        const tree = await kitFileStore.loadCurrentTree();
+        const tree = await kitFileStore.loadTree(query.engineRef);
         return reply.send(readKitFile(tree, query.path, { encoding }));
       } catch (error) {
         const sent = sendKitFilesError(reply, error);
@@ -1289,13 +1298,14 @@ export async function registerAgentChannelRoutes(
           limit?: string;
           unit?: string;
           encoding?: string;
+          engineRef?: string;
         };
         if (!query.path?.trim()) {
           return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
         }
         const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
         const unit = query.unit === 'bytes' || query.unit === 'lines' ? query.unit : undefined;
-        const tree = await kitFileStore.loadCurrentTree();
+        const tree = await kitFileStore.loadTree(query.engineRef);
         return reply.send(
           readKitFileFragment(tree, query.path, {
             offset: optionalFiniteQuery(query.offset),

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -22,6 +22,14 @@ import { InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-s
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import {
+  KitFilesError,
+  createKitFileStore,
+  listKitFiles,
+  readKitFile,
+  readKitFileFragment,
+  searchKitFiles,
+} from './kit-files.js';
+import {
   KIT_ENTRY,
   KitRegistryError,
   exampleUnpackCommand,
@@ -303,6 +311,26 @@ export async function registerAgentChannelRoutes(
   const shotsByBuild = new Map<number, number[]>();
   const previewsByBuild = new Map<number, number[]>();
   const submitsByBuild = new Map<number, number[]>();
+  const kitFileStore = options.objectStore ? createKitFileStore(options.objectStore) : null;
+
+  function sendKitFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
+    if (error instanceof KitFilesError) {
+      const status =
+        error.code === 'kit_store_unavailable'
+          ? 503
+          : error.code === 'kit_registry_missing' ||
+              error.code === 'kit_registry_invalid' ||
+              error.code === 'kit_artifact_missing' ||
+              error.code === 'kit_file_missing'
+            ? 404
+            : 400;
+      return reply.status(status).send({ error: error.code, message: error.message });
+    }
+    if (error instanceof KitRegistryError) {
+      return reply.status(404).send({ error: error.code, message: error.message });
+    }
+    return null;
+  }
 
   /**
    * Resolves the build a request is about. The token is the whole credential: it
@@ -1129,11 +1157,152 @@ export async function registerAgentChannelRoutes(
           sha256: sidecar.sha256,
           unpack: kitUnpackCommand(kitUrl),
           entry: KIT_ENTRY,
+          // Shell-less MCP clients (ChatGPT Apps code_execution often cannot curl
+          // storage.googleapis.com) should browse via the kit file tools instead of
+          // unpacking — keep kitUrl/unpack for agents with a writable checkout.
+          browse: {
+            list: 'list_kit_files',
+            search: 'search_kit_files',
+            read: 'read_kit_file',
+            fragment: 'read_kit_file_fragment',
+          },
         });
       } catch (error) {
         if (error instanceof KitRegistryError) {
           return reply.status(404).send({ error: error.code, message: error.message });
         }
+        throw error;
+      }
+    },
+  );
+
+  /**
+   * List files inside the current Creator Kit without downloading the tarball to the agent.
+   */
+  app.get(
+    '/api/agent/build/kit/files',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as {
+          prefix?: string;
+          glob?: string;
+          limit?: string;
+          offset?: string;
+        };
+        const tree = await kitFileStore.loadCurrentTree();
+        const limitNum = query.limit !== undefined ? Number(query.limit) : undefined;
+        const offsetNum = query.offset !== undefined ? Number(query.offset) : undefined;
+        return reply.send(
+          listKitFiles(tree, {
+            prefix: query.prefix,
+            glob: query.glob,
+            limit: limitNum !== undefined && Number.isFinite(limitNum) ? limitNum : undefined,
+            offset: offsetNum !== undefined && Number.isFinite(offsetNum) ? offsetNum : undefined,
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  /** Grep text files in the current Creator Kit. */
+  app.get(
+    '/api/agent/build/kit/search',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as { q?: string; query?: string; prefix?: string; limit?: string };
+        const tree = await kitFileStore.loadCurrentTree();
+        return reply.send(
+          searchKitFiles(tree, {
+            query: query.q ?? query.query ?? '',
+            prefix: query.prefix,
+            limit: query.limit !== undefined ? Number(query.limit) : undefined,
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  /** Read one small kit file (refuse oversized — use /fragment). */
+  app.get(
+    '/api/agent/build/kit/file',
+    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as { path?: string; encoding?: string };
+        if (!query.path?.trim()) {
+          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
+        }
+        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
+        const tree = await kitFileStore.loadCurrentTree();
+        return reply.send(readKitFile(tree, query.path, { encoding }));
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  /** Read a byte/line window of one kit file. */
+  app.get(
+    '/api/agent/build/kit/file/fragment',
+    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as {
+          path?: string;
+          offset?: string;
+          limit?: string;
+          unit?: string;
+          encoding?: string;
+        };
+        if (!query.path?.trim()) {
+          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
+        }
+        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
+        const unit = query.unit === 'bytes' || query.unit === 'lines' ? query.unit : undefined;
+        const tree = await kitFileStore.loadCurrentTree();
+        return reply.send(
+          readKitFileFragment(tree, query.path, {
+            offset: query.offset !== undefined ? Number(query.offset) : undefined,
+            limit: query.limit !== undefined ? Number(query.limit) : undefined,
+            unit,
+            encoding,
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
         throw error;
       }
     },

--- a/apps/api/src/kit-files.test.ts
+++ b/apps/api/src/kit-files.test.ts
@@ -1,0 +1,164 @@
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import type { GcsObjectStore } from './gcs-sign.js';
+import {
+  KIT_READ_MAX_BYTES,
+  createKitFileStore,
+  kitFileKind,
+  listKitFiles,
+  normalizeKitPath,
+  readKitFile,
+  readKitFileFragment,
+  searchKitFiles,
+  type KitTree,
+  KitFilesError,
+} from './kit-files.js';
+import { KIT_ROOT_DIR } from './kit-registry.js';
+
+const BLOCK = 512;
+const ENGINE = 'deadbeef0123456789abcdef0123456789abcdef';
+const SHA = 'a'.repeat(64);
+
+function entryBlocks(name: string, body: Buffer | string): Buffer {
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, 100, 'utf8');
+  header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+  header.write('0', 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  const padding = Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK);
+  return Buffer.concat([header, payload, padding]);
+}
+
+function kitTarball(files: Record<string, Buffer | string>): Buffer {
+  const entries = Object.entries(files).map(([name, body]) =>
+    entryBlocks(name.startsWith(`${KIT_ROOT_DIR}/`) ? name : `${KIT_ROOT_DIR}/${name}`, body),
+  );
+  return gzipSync(Buffer.concat([...entries, Buffer.alloc(BLOCK * 2)]));
+}
+
+function treeFrom(files: Record<string, Buffer | string>): KitTree {
+  const map = new Map<string, Buffer>();
+  for (const [name, body] of Object.entries(files)) {
+    const path = name.startsWith(`${KIT_ROOT_DIR}/`) ? name : `${KIT_ROOT_DIR}/${name}`;
+    map.set(path, Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8'));
+  }
+  return { engineRef: ENGINE, sha256: SHA, files: map };
+}
+
+describe('normalizeKitPath', () => {
+  it('accepts root-relative and kit-rooted paths; rejects traversal', () => {
+    expect(normalizeKitPath('SKILL.md')).toBe(`${KIT_ROOT_DIR}/SKILL.md`);
+    expect(normalizeKitPath(`${KIT_ROOT_DIR}/SKILL.md`)).toBe(`${KIT_ROOT_DIR}/SKILL.md`);
+    expect(normalizeKitPath('shared/modules/core.ts')).toBe(`${KIT_ROOT_DIR}/shared/modules/core.ts`);
+    expect(() => normalizeKitPath('../etc/passwd')).toThrow(KitFilesError);
+    expect(() => normalizeKitPath('/abs')).toThrow(KitFilesError);
+  });
+});
+
+describe('kit file ops', () => {
+  const tree = treeFrom({
+    'SKILL.md': '# Creator Kit\n\nStart here.\nUse GameKit.createCanvasGame.\n',
+    'kit.json': JSON.stringify({ engineRef: ENGINE }),
+    'shared/modules/core.ts': 'export const core = 1;\n// GameKit.createCanvasGame helper\n',
+    'shared/audio/beep.wav': Buffer.from([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00]),
+    'templates/game/game.ts': 'export {}\n',
+  });
+
+  it('lists with prefix and glob', () => {
+    const all = listKitFiles(tree, { limit: 10 });
+    expect(all.total).toBe(5);
+    expect(all.entry).toBe(`${KIT_ROOT_DIR}/SKILL.md`);
+    expect(all.files.map((f) => f.path)).toContain(`${KIT_ROOT_DIR}/shared/audio/beep.wav`);
+    expect(all.files.find((f) => f.path.endsWith('beep.wav'))?.kind).toBe('binary');
+
+    const shared = listKitFiles(tree, { prefix: 'shared' });
+    expect(shared.files.every((f) => f.path.includes('/shared/'))).toBe(true);
+
+    const skills = listKitFiles(tree, { glob: '**/SKILL.md' });
+    expect(skills.files.map((f) => f.path)).toEqual([`${KIT_ROOT_DIR}/SKILL.md`]);
+  });
+
+  it('searches text files and skips binaries', () => {
+    const hits = searchKitFiles(tree, { query: 'createCanvasGame' });
+    expect(hits.matches.length).toBeGreaterThanOrEqual(2);
+    expect(hits.matches.every((m) => !m.path.endsWith('.wav'))).toBe(true);
+    expect(() => searchKitFiles(tree, { query: 'x' })).toThrow(/2–120/);
+  });
+
+  it('reads small text files and refuses oversized / binary-as-utf8', () => {
+    const skill = readKitFile(tree, 'SKILL.md');
+    expect(skill.encoding).toBe('utf8');
+    expect(skill.content).toMatch(/Creator Kit/);
+
+    expect(() => readKitFile(tree, 'shared/audio/beep.wav', { encoding: 'utf8' })).toThrow(/binary/);
+    const wav = readKitFile(tree, 'shared/audio/beep.wav', { encoding: 'base64' });
+    expect(wav.encoding).toBe('base64');
+
+    const big = treeFrom({
+      'huge.md': 'x'.repeat(KIT_READ_MAX_BYTES + 1),
+    });
+    expect(() => readKitFile(big, 'huge.md')).toThrow(/read_kit_file_fragment/);
+  });
+
+  it('reads line and byte fragments', () => {
+    const lines = readKitFileFragment(tree, 'SKILL.md', { unit: 'lines', offset: 0, limit: 2 });
+    expect(lines.content.split('\n')).toHaveLength(2);
+    expect(lines.totalLines).toBeGreaterThan(2);
+    expect(lines.eof).toBe(false);
+
+    const rest = readKitFileFragment(tree, 'SKILL.md', {
+      unit: 'lines',
+      offset: 0,
+      limit: lines.totalLines ?? 99,
+    });
+    expect(rest.eof).toBe(true);
+
+    const bytes = readKitFileFragment(tree, 'shared/audio/beep.wav', {
+      unit: 'bytes',
+      offset: 0,
+      limit: 4,
+      encoding: 'base64',
+    });
+    expect(Buffer.from(bytes.content, 'base64').toString('ascii')).toBe('RIFF');
+  });
+
+  it('classifies by extension and NUL probe', () => {
+    expect(kitFileKind('a.ts', Buffer.from('export {}'))).toBe('text');
+    expect(kitFileKind('a.wav', Buffer.from('not-really'))).toBe('binary');
+    expect(kitFileKind('a.binish', Buffer.from([1, 0, 2]))).toBe('binary');
+  });
+});
+
+describe('createKitFileStore', () => {
+  it('unpacks the current kit tarball once and serves from cache', async () => {
+    const tgz = kitTarball({
+      'SKILL.md': '# hi\n',
+      'kit.json': '{"engineRef":"x"}',
+    });
+    let reads = 0;
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-03T00:00:00.000Z' })),
+      ],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA }))],
+      [`kits/${ENGINE}.tgz`, tgz],
+    ]);
+    const store: GcsObjectStore = {
+      readObject: async (name) => {
+        reads += 1;
+        return objects.get(name) ?? null;
+      },
+      objectExists: async (name) => objects.has(name),
+      signReadUrl: async () => 'https://signed.example/kit.tgz',
+    };
+    const kits = createKitFileStore(store);
+    const first = await kits.loadCurrentTree();
+    const second = await kits.loadCurrentTree();
+    expect(first.files.get(`${KIT_ROOT_DIR}/SKILL.md`)?.toString('utf8')).toBe('# hi\n');
+    expect(second).toBe(first);
+    // registry+sidecar on each loadCurrentTree, but tarball only once
+    expect(reads).toBe(5); // 2+2 registry/sidecar + 1 tgz
+  });
+});

--- a/apps/api/src/kit-files.test.ts
+++ b/apps/api/src/kit-files.test.ts
@@ -122,6 +122,7 @@ describe('kit file ops', () => {
     expect(lines.content.split('\n')).toHaveLength(2);
     expect(lines.totalLines).toBeGreaterThan(2);
     expect(lines.eof).toBe(false);
+    expect(lines.nextOffset).toBe(2);
 
     const rest = readKitFileFragment(tree, 'SKILL.md', {
       unit: 'lines',
@@ -129,14 +130,25 @@ describe('kit file ops', () => {
       limit: lines.totalLines ?? 99,
     });
     expect(rest.eof).toBe(true);
+    expect(rest.nextOffset).toBeNull();
 
     const bytes = readKitFileFragment(tree, 'shared/audio/beep.wav', {
       unit: 'bytes',
       offset: 0,
       limit: 4,
-      encoding: 'base64',
     });
+    expect(bytes.encoding).toBe('base64');
     expect(Buffer.from(bytes.content, 'base64').toString('ascii')).toBe('RIFF');
+    expect(() =>
+      readKitFileFragment(tree, 'SKILL.md', { unit: 'bytes', encoding: 'utf8', offset: 0, limit: 4 }),
+    ).toThrow(/base64/);
+  });
+
+  it('rejects overlong line windows instead of truncating', () => {
+    const big = treeFrom({
+      'wide.md': `${'x'.repeat(KIT_READ_MAX_BYTES)}\n`,
+    });
+    expect(() => readKitFileFragment(big, 'wide.md', { unit: 'lines', offset: 0, limit: 1 })).toThrow(/unit=bytes/);
   });
 
   it('classifies by extension and NUL probe', () => {
@@ -147,6 +159,9 @@ describe('kit file ops', () => {
 });
 
 describe('createKitFileStore', () => {
+  const PREV = 'cafebabe0123456789abcdef0123456789abcdef';
+  const PREV_SHA = 'b'.repeat(64);
+
   it('unpacks the current kit tarball once and serves from cache', async () => {
     const tgz = kitTarball({
       'SKILL.md': '# hi\n',
@@ -174,7 +189,34 @@ describe('createKitFileStore', () => {
     const second = await kits.loadCurrentTree();
     expect(first.files.get(`${KIT_ROOT_DIR}/SKILL.md`)?.toString('utf8')).toBe('# hi\n');
     expect(second).toBe(first);
-    // registry+sidecar on each loadCurrentTree, but tarball only once
+    // registry+sidecar on each loadTree, but tarball only once
     expect(reads).toBe(5); // 2+2 registry/sidecar + 1 tgz
+  });
+
+  it('pins browse to engineRef and rejects revisions outside N/N−1', async () => {
+    const currentTgz = kitTarball({ 'SKILL.md': '# current\n' });
+    const prevTgz = kitTarball({ 'SKILL.md': '# previous\n' });
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: PREV, updatedAt: '2026-08-03T00:00:00.000Z' })),
+      ],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA }))],
+      [`kits/${ENGINE}.tgz`, currentTgz],
+      [`kits/${PREV}.json`, Buffer.from(JSON.stringify({ sha256: PREV_SHA }))],
+      [`kits/${PREV}.tgz`, prevTgz],
+    ]);
+    const store: GcsObjectStore = {
+      readObject: async (name) => objects.get(name) ?? null,
+      objectExists: async (name) => objects.has(name),
+      signReadUrl: async () => 'https://signed.example/kit.tgz',
+    };
+    const kits = createKitFileStore(store);
+    const pinned = await kits.loadTree(PREV);
+    expect(pinned.engineRef).toBe(PREV);
+    expect(pinned.files.get(`${KIT_ROOT_DIR}/SKILL.md`)?.toString('utf8')).toBe('# previous\n');
+    await expect(kits.loadTree('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')).rejects.toMatchObject({
+      code: 'kit_revision_unsupported',
+    });
   });
 });

--- a/apps/api/src/kit-files.test.ts
+++ b/apps/api/src/kit-files.test.ts
@@ -77,6 +77,22 @@ describe('kit file ops', () => {
 
     const skills = listKitFiles(tree, { glob: '**/SKILL.md' });
     expect(skills.files.map((f) => f.path)).toEqual([`${KIT_ROOT_DIR}/SKILL.md`]);
+
+    // `?` is literal, not a single-char wildcard / regex quantifier.
+    expect(listKitFiles(tree, { glob: 'SKILL.m?' }).files).toHaveLength(0);
+    expect(listKitFiles(tree, { glob: 'SKILL.md' }).files).toHaveLength(1);
+  });
+
+  it('treats non-finite limit/offset as absent (keeps caps)', () => {
+    const tree = treeFrom({
+      'a.md': 'one\n',
+      'b.md': 'two\n',
+      'c.md': 'one again\n',
+    });
+    const listed = listKitFiles(tree, { limit: Number.NaN, offset: Number.POSITIVE_INFINITY });
+    expect(listed.files.length).toBe(3);
+    const hits = searchKitFiles(tree, { query: 'one', limit: Number.NaN });
+    expect(hits.matches.length).toBeLessThanOrEqual(40);
   });
 
   it('searches text files and skips binaries', () => {

--- a/apps/api/src/kit-files.ts
+++ b/apps/api/src/kit-files.ts
@@ -128,16 +128,22 @@ export function normalizeKitPath(raw: string): string {
 
 function matchSimpleGlob(path: string, pattern: string): boolean {
   // Escape regex metacharacters except `*`, which becomes `.*`.
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  // `?` must be escaped too — otherwise it is a regex quantifier, not a literal.
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
   return new RegExp(`^${escaped}$`, 'i').test(path);
+}
+
+/** Coerce a caller-supplied limit/offset; treat NaN/±Infinity as absent. */
+function finiteOrUndefined(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 export function listKitFiles(
   tree: KitTree,
   options: { prefix?: string; glob?: string; limit?: number; offset?: number } = {},
 ): { engineRef: string; entry: string; files: KitFileMeta[]; total: number; truncated: boolean } {
-  const limit = Math.min(Math.max(1, options.limit ?? KIT_LIST_DEFAULT_LIMIT), KIT_LIST_MAX_LIMIT);
-  const offset = Math.max(0, options.offset ?? 0);
+  const limit = Math.min(Math.max(1, finiteOrUndefined(options.limit) ?? KIT_LIST_DEFAULT_LIMIT), KIT_LIST_MAX_LIMIT);
+  const offset = Math.max(0, finiteOrUndefined(options.offset) ?? 0);
   const prefix = options.prefix?.trim() ? normalizeKitPath(options.prefix) : '';
   const glob = options.glob?.trim() ?? '';
 
@@ -175,7 +181,10 @@ export function searchKitFiles(
   if (query.length < 2 || query.length > 120) {
     throw new KitFilesError('kit_query_invalid', 'query must be 2–120 characters');
   }
-  const limit = Math.min(Math.max(1, options.limit ?? KIT_SEARCH_MAX_MATCHES), KIT_SEARCH_MAX_MATCHES);
+  const limit = Math.min(
+    Math.max(1, finiteOrUndefined(options.limit) ?? KIT_SEARCH_MAX_MATCHES),
+    KIT_SEARCH_MAX_MATCHES,
+  );
   let prefix = '';
   if (options.prefix?.trim()) {
     prefix = normalizeKitPath(options.prefix);
@@ -286,7 +295,7 @@ export function readKitFileFragment(
   }
   const kind = kitFileKind(path, bytes);
   const unit = options.unit ?? 'lines';
-  const offset = Math.max(0, options.offset ?? 0);
+  const offset = Math.max(0, finiteOrUndefined(options.offset) ?? 0);
   const encoding = options.encoding ?? (kind === 'binary' ? 'base64' : 'utf8');
 
   if (kind === 'binary' && encoding !== 'base64') {
@@ -297,7 +306,10 @@ export function readKitFileFragment(
   }
 
   if (unit === 'bytes') {
-    const limit = Math.min(Math.max(1, options.limit ?? KIT_FRAGMENT_MAX_BYTES), KIT_FRAGMENT_MAX_BYTES);
+    const limit = Math.min(
+      Math.max(1, finiteOrUndefined(options.limit) ?? KIT_FRAGMENT_MAX_BYTES),
+      KIT_FRAGMENT_MAX_BYTES,
+    );
     if (offset > bytes.length) {
       throw new KitFilesError('kit_query_invalid', `offset ${offset} is past end of file (${bytes.length} bytes)`);
     }
@@ -319,7 +331,7 @@ export function readKitFileFragment(
 
   const text = bytes.toString('utf8');
   const lines = text.split(/\r?\n/);
-  const limit = Math.min(Math.max(1, options.limit ?? 80), KIT_FRAGMENT_MAX_LINES);
+  const limit = Math.min(Math.max(1, finiteOrUndefined(options.limit) ?? 80), KIT_FRAGMENT_MAX_LINES);
   if (offset > lines.length) {
     throw new KitFilesError('kit_query_invalid', `offset ${offset} is past end of file (${lines.length} lines)`);
   }

--- a/apps/api/src/kit-files.ts
+++ b/apps/api/src/kit-files.ts
@@ -78,6 +78,7 @@ export class KitFilesError extends Error {
     | 'kit_registry_missing'
     | 'kit_registry_invalid'
     | 'kit_artifact_missing'
+    | 'kit_revision_unsupported'
     | 'kit_path_invalid'
     | 'kit_file_missing'
     | 'kit_file_too_large'
@@ -287,6 +288,8 @@ export function readKitFileFragment(
   encoding: 'utf8' | 'base64';
   content: string;
   eof: boolean;
+  /** Pass as the next call's offset; null at EOF. */
+  nextOffset: number | null;
 } {
   const path = normalizeKitPath(rawPath);
   const bytes = tree.files.get(path);
@@ -296,13 +299,21 @@ export function readKitFileFragment(
   const kind = kitFileKind(path, bytes);
   const unit = options.unit ?? 'lines';
   const offset = Math.max(0, finiteOrUndefined(options.offset) ?? 0);
-  const encoding = options.encoding ?? (kind === 'binary' ? 'base64' : 'utf8');
+  // Byte windows are opaque slices — always base64 so multi-byte UTF-8 (Polish, emoji)
+  // is never split across fragments. Line mode is the text path.
+  const encoding = options.encoding ?? (unit === 'bytes' || kind === 'binary' ? 'base64' : 'utf8');
 
   if (kind === 'binary' && encoding !== 'base64') {
     throw new KitFilesError('kit_file_binary', `${path} is binary — pass encoding=base64`);
   }
   if (kind === 'binary' && unit === 'lines') {
     throw new KitFilesError('kit_query_invalid', 'binary files only support unit=bytes');
+  }
+  if (unit === 'bytes' && encoding !== 'base64') {
+    throw new KitFilesError(
+      'kit_query_invalid',
+      'unit=bytes requires encoding=base64 (utf8 would split multi-byte characters at fragment boundaries)',
+    );
   }
 
   if (unit === 'bytes') {
@@ -323,9 +334,10 @@ export function readKitFileFragment(
       limit,
       totalBytes: bytes.length,
       totalLines: null,
-      encoding,
-      content: encoding === 'base64' ? Buffer.from(slice).toString('base64') : Buffer.from(slice).toString('utf8'),
+      encoding: 'base64',
+      content: Buffer.from(slice).toString('base64'),
       eof: offset + slice.length >= bytes.length,
+      nextOffset: offset + slice.length >= bytes.length ? null : offset + slice.length,
     };
   }
 
@@ -340,22 +352,14 @@ export function readKitFileFragment(
   // but keep interior newlines. For fragments, a trailing `\n` between lines is fine.
   const content = slice.join('\n');
   if (Buffer.byteLength(content, 'utf8') > KIT_FRAGMENT_MAX_BYTES) {
-    // Rare: few very long lines. Fall back to a byte-capped prefix of the joined text.
-    const buf = Buffer.from(content, 'utf8').subarray(0, KIT_FRAGMENT_MAX_BYTES);
-    return {
-      engineRef: tree.engineRef,
-      path,
-      kind,
-      unit,
-      offset,
-      limit: slice.length,
-      totalBytes: bytes.length,
-      totalLines: lines.length,
-      encoding: 'utf8',
-      content: buf.toString('utf8'),
-      eof: false,
-    };
+    // Do not silently drop the remainder of an overlong line — that would skip bytes
+    // on the next line-mode page. Callers must switch to byte mode.
+    throw new KitFilesError(
+      'kit_query_invalid',
+      `line window at offset ${offset} exceeds ${KIT_FRAGMENT_MAX_BYTES} bytes — use unit=bytes with encoding=base64`,
+    );
   }
+  const eof = offset + slice.length >= lines.length;
   return {
     engineRef: tree.engineRef,
     path,
@@ -367,7 +371,8 @@ export function readKitFileFragment(
     totalLines: lines.length,
     encoding: 'utf8',
     content,
-    eof: offset + slice.length >= lines.length,
+    eof,
+    nextOffset: eof ? null : offset + slice.length,
   };
 }
 
@@ -388,9 +393,16 @@ async function unpackKitTarball(tarball: Buffer): Promise<Map<string, Buffer>> {
 }
 
 export interface KitFileStore {
-  /** Metadata + signed URL path still used by get_kit — does not unpack. */
-  loadRegistry(): Promise<{ engineRef: string; sha256: string }>;
-  /** Unpack (or return cached) tree for the current registry entry. */
+  /** Metadata for the current registry entry — does not unpack. */
+  loadRegistry(): Promise<{ engineRef: string; previous: string | null; sha256: string }>;
+  /**
+   * Unpack (or return cached) tree for a kit revision.
+   * When `engineRef` is omitted, uses `kits/current.json.current`.
+   * When provided, must be current or previous (N / N−1) — pins a browse session
+   * so a mid-round registry bump cannot mix files from two kits.
+   */
+  loadTree(engineRef?: string): Promise<KitTree>;
+  /** @deprecated Prefer {@link loadTree}; alias for `loadTree()`. */
   loadCurrentTree(): Promise<KitTree>;
 }
 
@@ -399,16 +411,15 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
 
   function remember(tree: KitTree): KitTree {
     cache.set(tree.engineRef, tree);
-    if (cache.size > KIT_TREE_CACHE_CAPACITY) {
+    while (cache.size > KIT_TREE_CACHE_CAPACITY) {
       const oldest = cache.keys().next().value;
-      if (oldest !== undefined && oldest !== tree.engineRef) {
-        cache.delete(oldest);
-      }
+      if (oldest === undefined || oldest === tree.engineRef) break;
+      cache.delete(oldest);
     }
     return tree;
   }
 
-  async function loadRegistry(): Promise<{ engineRef: string; sha256: string }> {
+  async function readWindow(): Promise<{ current: string; previous: string | null }> {
     const registryBody = await objectStore.readObject('kits/current.json');
     if (!registryBody) {
       throw new KitFilesError(
@@ -416,16 +427,18 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
         'kits/current.json is not published yet — the games-repo kit publisher has not run',
       );
     }
-    let registry;
     try {
-      registry = parseKitRegistry(registryBody.toString('utf8'));
+      const registry = parseKitRegistry(registryBody.toString('utf8'));
+      return { current: registry.current, previous: registry.previous };
     } catch (error) {
       if (error instanceof KitRegistryError) {
         throw new KitFilesError(error.code, error.message, { cause: error });
       }
       throw error;
     }
-    const engineRef = registry.current;
+  }
+
+  async function loadSidecar(engineRef: string): Promise<string> {
     const sidecarBody = await objectStore.readObject(`kits/${engineRef}.json`);
     if (!sidecarBody) {
       throw new KitFilesError(
@@ -433,34 +446,52 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
         `kits/${engineRef}.json sidecar is missing for the current registry entry`,
       );
     }
-    let sidecar;
     try {
-      sidecar = parseKitSidecar(sidecarBody.toString('utf8'));
+      return parseKitSidecar(sidecarBody.toString('utf8')).sha256;
     } catch (error) {
       if (error instanceof KitRegistryError) {
         throw new KitFilesError(error.code, error.message, { cause: error });
       }
       throw error;
     }
-    return { engineRef, sha256: sidecar.sha256 };
   }
 
-  async function loadCurrentTree(): Promise<KitTree> {
-    const { engineRef, sha256 } = await loadRegistry();
-    const cached = cache.get(engineRef);
+  async function loadRegistry(): Promise<{ engineRef: string; previous: string | null; sha256: string }> {
+    const window = await readWindow();
+    const sha256 = await loadSidecar(window.current);
+    return { engineRef: window.current, previous: window.previous, sha256 };
+  }
+
+  async function loadTree(engineRef?: string): Promise<KitTree> {
+    const window = await readWindow();
+    const requested = engineRef?.trim() || window.current;
+    if (requested !== window.current && requested !== window.previous) {
+      throw new KitFilesError(
+        'kit_revision_unsupported',
+        `engineRef ${requested} is outside the supported N/N−1 window (current=${window.current}` +
+          (window.previous ? `, previous=${window.previous}` : '') +
+          ') — re-run get_kit',
+      );
+    }
+    const sha256 = await loadSidecar(requested);
+    const cached = cache.get(requested);
     if (cached && cached.sha256 === sha256) {
       return cached;
     }
-    const tarball = await objectStore.readObject(`kits/${engineRef}.tgz`);
+    const tarball = await objectStore.readObject(`kits/${requested}.tgz`);
     if (!tarball) {
       throw new KitFilesError(
         'kit_artifact_missing',
-        `kits/${engineRef}.tgz is missing for the current registry entry`,
+        `kits/${requested}.tgz is missing for the requested registry entry`,
       );
     }
     const files = await unpackKitTarball(tarball);
-    return remember({ engineRef, sha256, files });
+    return remember({ engineRef: requested, sha256, files });
   }
 
-  return { loadRegistry, loadCurrentTree };
+  return {
+    loadRegistry,
+    loadTree,
+    loadCurrentTree: () => loadTree(),
+  };
 }

--- a/apps/api/src/kit-files.ts
+++ b/apps/api/src/kit-files.ts
@@ -1,0 +1,454 @@
+/**
+ * Creator Kit as browsable files for MCP / build-channel agents.
+ *
+ * `get_kit` still returns a signed tarball URL for agents with shell egress.
+ * ChatGPT Apps (and similar) often cannot `curl` that URL from code_execution,
+ * and dumping the whole ~1.4MB tree into a tool result would wreck context —
+ * so these helpers serve list / search / read / fragment over the same pinned
+ * `kits/<engineRef>.tgz` the registry already publishes.
+ */
+
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import type { GcsObjectStore } from './gcs-sign.js';
+import { KIT_ENTRY, KIT_ROOT_DIR, KitRegistryError, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
+import { readTarEntries } from './tar.js';
+
+/** Whole-file reads above this must use fragments instead. */
+export const KIT_READ_MAX_BYTES = 48 * 1024;
+/** Cap on a single fragment response body. */
+export const KIT_FRAGMENT_MAX_BYTES = 32 * 1024;
+/** Cap on fragment line counts. */
+export const KIT_FRAGMENT_MAX_LINES = 200;
+/** Default / hard caps for list. */
+export const KIT_LIST_DEFAULT_LIMIT = 200;
+export const KIT_LIST_MAX_LIMIT = 500;
+/** Cap on search hits returned in one reply. */
+export const KIT_SEARCH_MAX_MATCHES = 40;
+/** Cap on how many files a search will open (text only). */
+export const KIT_SEARCH_MAX_FILES_SCANNED = 400;
+/** Reject absurdly large kit tarballs rather than OOM. */
+export const KIT_TREE_MAX_BYTES = 8 * 1024 * 1024;
+/** Keep current + previous trees warm (N / N−1 window). */
+const KIT_TREE_CACHE_CAPACITY = 2;
+
+const BINARY_EXTENSIONS = new Set([
+  '.wav',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.bmp',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+  '.zip',
+  '.gz',
+  '.tgz',
+  '.7z',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.ogg',
+  '.mp4',
+  '.webm',
+]);
+
+export type KitFileKind = 'text' | 'binary';
+
+export interface KitFileMeta {
+  path: string;
+  bytes: number;
+  kind: KitFileKind;
+}
+
+export interface KitTree {
+  engineRef: string;
+  sha256: string;
+  files: Map<string, Buffer>;
+}
+
+export class KitFilesError extends Error {
+  readonly code:
+    | 'kit_store_unavailable'
+    | 'kit_registry_missing'
+    | 'kit_registry_invalid'
+    | 'kit_artifact_missing'
+    | 'kit_path_invalid'
+    | 'kit_file_missing'
+    | 'kit_file_too_large'
+    | 'kit_file_binary'
+    | 'kit_query_invalid';
+
+  constructor(code: KitFilesError['code'], message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'KitFilesError';
+    this.code = code;
+  }
+}
+
+export function kitFileKind(path: string, bytes: Buffer): KitFileKind {
+  const lower = path.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  if (dot !== -1 && BINARY_EXTENSIONS.has(lower.slice(dot))) {
+    return 'binary';
+  }
+  // NUL in the first 8 KiB → binary (UTF-16 / opaque).
+  const probe = bytes.subarray(0, Math.min(bytes.length, 8 * 1024));
+  if (probe.includes(0)) return 'binary';
+  return 'text';
+}
+
+/**
+ * Normalize a caller path to the archive member path (`gamedevpl-creator-kit/...`).
+ * Accepts either the full member path or a path relative to the kit root.
+ */
+export function normalizeKitPath(raw: string): string {
+  const trimmed = raw.trim().replace(/\\/g, '/');
+  if (!trimmed) {
+    throw new KitFilesError('kit_path_invalid', 'path is required');
+  }
+  if (trimmed.startsWith('/') || trimmed.includes('\0')) {
+    throw new KitFilesError('kit_path_invalid', 'path must be a relative kit path');
+  }
+  const parts = trimmed.split('/').filter((part) => part.length > 0 && part !== '.');
+  if (parts.some((part) => part === '..')) {
+    throw new KitFilesError('kit_path_invalid', 'path must not contain .. segments');
+  }
+  const joined = parts.join('/');
+  if (joined === KIT_ROOT_DIR || joined.startsWith(`${KIT_ROOT_DIR}/`)) {
+    return joined;
+  }
+  return `${KIT_ROOT_DIR}/${joined}`;
+}
+
+function matchSimpleGlob(path: string, pattern: string): boolean {
+  // Escape regex metacharacters except `*`, which becomes `.*`.
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`, 'i').test(path);
+}
+
+export function listKitFiles(
+  tree: KitTree,
+  options: { prefix?: string; glob?: string; limit?: number; offset?: number } = {},
+): { engineRef: string; entry: string; files: KitFileMeta[]; total: number; truncated: boolean } {
+  const limit = Math.min(Math.max(1, options.limit ?? KIT_LIST_DEFAULT_LIMIT), KIT_LIST_MAX_LIMIT);
+  const offset = Math.max(0, options.offset ?? 0);
+  const prefix = options.prefix?.trim() ? normalizeKitPath(options.prefix) : '';
+  const glob = options.glob?.trim() ?? '';
+
+  const all: KitFileMeta[] = [];
+  for (const [path, bytes] of tree.files) {
+    if (prefix && path !== prefix && !path.startsWith(`${prefix}/`)) continue;
+    if (glob) {
+      const relative = path.startsWith(`${KIT_ROOT_DIR}/`) ? path.slice(KIT_ROOT_DIR.length + 1) : path;
+      if (!matchSimpleGlob(path, glob) && !matchSimpleGlob(relative, glob)) continue;
+    }
+    all.push({ path, bytes: bytes.length, kind: kitFileKind(path, bytes) });
+  }
+  all.sort((a, b) => a.path.localeCompare(b.path));
+  const slice = all.slice(offset, offset + limit);
+  return {
+    engineRef: tree.engineRef,
+    entry: KIT_ENTRY,
+    files: slice,
+    total: all.length,
+    truncated: offset + slice.length < all.length,
+  };
+}
+
+export function searchKitFiles(
+  tree: KitTree,
+  options: { query: string; prefix?: string; limit?: number },
+): {
+  engineRef: string;
+  query: string;
+  matches: Array<{ path: string; line: number; text: string }>;
+  truncated: boolean;
+  filesScanned: number;
+} {
+  const query = options.query.trim();
+  if (query.length < 2 || query.length > 120) {
+    throw new KitFilesError('kit_query_invalid', 'query must be 2–120 characters');
+  }
+  const limit = Math.min(Math.max(1, options.limit ?? KIT_SEARCH_MAX_MATCHES), KIT_SEARCH_MAX_MATCHES);
+  let prefix = '';
+  if (options.prefix?.trim()) {
+    prefix = normalizeKitPath(options.prefix);
+  }
+  const needle = query.toLowerCase();
+  const matches: Array<{ path: string; line: number; text: string }> = [];
+  let filesScanned = 0;
+  let truncated = false;
+
+  const paths = [...tree.files.keys()].sort((a, b) => a.localeCompare(b));
+  for (const path of paths) {
+    if (matches.length >= limit) {
+      truncated = true;
+      break;
+    }
+    if (prefix && path !== prefix && !path.startsWith(`${prefix}/`)) continue;
+    const bytes = tree.files.get(path)!;
+    if (kitFileKind(path, bytes) !== 'text') continue;
+    if (filesScanned >= KIT_SEARCH_MAX_FILES_SCANNED) {
+      truncated = true;
+      break;
+    }
+    filesScanned += 1;
+    const text = bytes.toString('utf8');
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      if (matches.length >= limit) {
+        truncated = true;
+        break;
+      }
+      const line = lines[i];
+      if (!line.toLowerCase().includes(needle)) continue;
+      const clipped = line.length > 240 ? `${line.slice(0, 240)}…` : line;
+      matches.push({ path, line: i + 1, text: clipped });
+    }
+  }
+
+  return { engineRef: tree.engineRef, query, matches, truncated, filesScanned };
+}
+
+export function readKitFile(
+  tree: KitTree,
+  rawPath: string,
+  options: { encoding?: 'utf8' | 'base64' } = {},
+): {
+  engineRef: string;
+  path: string;
+  bytes: number;
+  kind: KitFileKind;
+  encoding: 'utf8' | 'base64';
+  content: string;
+} {
+  const path = normalizeKitPath(rawPath);
+  const bytes = tree.files.get(path);
+  if (!bytes) {
+    throw new KitFilesError('kit_file_missing', `no kit file at ${path}`);
+  }
+  const kind = kitFileKind(path, bytes);
+  const encoding = options.encoding ?? (kind === 'binary' ? 'base64' : 'utf8');
+  if (kind === 'binary' && encoding !== 'base64') {
+    throw new KitFilesError(
+      'kit_file_binary',
+      `${path} is binary — pass encoding=base64, or use a fragment with encoding=base64`,
+    );
+  }
+  if (bytes.length > KIT_READ_MAX_BYTES) {
+    throw new KitFilesError(
+      'kit_file_too_large',
+      `${path} is ${bytes.length} bytes (max ${KIT_READ_MAX_BYTES} for read_kit_file) — use read_kit_file_fragment`,
+    );
+  }
+  return {
+    engineRef: tree.engineRef,
+    path,
+    bytes: bytes.length,
+    kind,
+    encoding,
+    content: encoding === 'base64' ? bytes.toString('base64') : bytes.toString('utf8'),
+  };
+}
+
+export function readKitFileFragment(
+  tree: KitTree,
+  rawPath: string,
+  options: {
+    offset?: number;
+    limit?: number;
+    unit?: 'bytes' | 'lines';
+    encoding?: 'utf8' | 'base64';
+  } = {},
+): {
+  engineRef: string;
+  path: string;
+  kind: KitFileKind;
+  unit: 'bytes' | 'lines';
+  offset: number;
+  limit: number;
+  totalBytes: number;
+  totalLines: number | null;
+  encoding: 'utf8' | 'base64';
+  content: string;
+  eof: boolean;
+} {
+  const path = normalizeKitPath(rawPath);
+  const bytes = tree.files.get(path);
+  if (!bytes) {
+    throw new KitFilesError('kit_file_missing', `no kit file at ${path}`);
+  }
+  const kind = kitFileKind(path, bytes);
+  const unit = options.unit ?? 'lines';
+  const offset = Math.max(0, options.offset ?? 0);
+  const encoding = options.encoding ?? (kind === 'binary' ? 'base64' : 'utf8');
+
+  if (kind === 'binary' && encoding !== 'base64') {
+    throw new KitFilesError('kit_file_binary', `${path} is binary — pass encoding=base64`);
+  }
+  if (kind === 'binary' && unit === 'lines') {
+    throw new KitFilesError('kit_query_invalid', 'binary files only support unit=bytes');
+  }
+
+  if (unit === 'bytes') {
+    const limit = Math.min(Math.max(1, options.limit ?? KIT_FRAGMENT_MAX_BYTES), KIT_FRAGMENT_MAX_BYTES);
+    if (offset > bytes.length) {
+      throw new KitFilesError('kit_query_invalid', `offset ${offset} is past end of file (${bytes.length} bytes)`);
+    }
+    const slice = bytes.subarray(offset, offset + limit);
+    return {
+      engineRef: tree.engineRef,
+      path,
+      kind,
+      unit,
+      offset,
+      limit,
+      totalBytes: bytes.length,
+      totalLines: null,
+      encoding,
+      content: encoding === 'base64' ? Buffer.from(slice).toString('base64') : Buffer.from(slice).toString('utf8'),
+      eof: offset + slice.length >= bytes.length,
+    };
+  }
+
+  const text = bytes.toString('utf8');
+  const lines = text.split(/\r?\n/);
+  const limit = Math.min(Math.max(1, options.limit ?? 80), KIT_FRAGMENT_MAX_LINES);
+  if (offset > lines.length) {
+    throw new KitFilesError('kit_query_invalid', `offset ${offset} is past end of file (${lines.length} lines)`);
+  }
+  const slice = lines.slice(offset, offset + limit);
+  // Re-join without inventing a trailing newline the source did not have at EOF…
+  // but keep interior newlines. For fragments, a trailing `\n` between lines is fine.
+  const content = slice.join('\n');
+  if (Buffer.byteLength(content, 'utf8') > KIT_FRAGMENT_MAX_BYTES) {
+    // Rare: few very long lines. Fall back to a byte-capped prefix of the joined text.
+    const buf = Buffer.from(content, 'utf8').subarray(0, KIT_FRAGMENT_MAX_BYTES);
+    return {
+      engineRef: tree.engineRef,
+      path,
+      kind,
+      unit,
+      offset,
+      limit: slice.length,
+      totalBytes: bytes.length,
+      totalLines: lines.length,
+      encoding: 'utf8',
+      content: buf.toString('utf8'),
+      eof: false,
+    };
+  }
+  return {
+    engineRef: tree.engineRef,
+    path,
+    kind,
+    unit,
+    offset,
+    limit,
+    totalBytes: bytes.length,
+    totalLines: lines.length,
+    encoding: 'utf8',
+    content,
+    eof: offset + slice.length >= lines.length,
+  };
+}
+
+async function unpackKitTarball(tarball: Buffer): Promise<Map<string, Buffer>> {
+  const files = new Map<string, Buffer>();
+  const gunzipped = Readable.from(tarball).pipe(createGunzip());
+  for await (const entry of readTarEntries(gunzipped, { maxTotalBytes: KIT_TREE_MAX_BYTES })) {
+    // Skip oddities outside the kit root (shouldn't appear in a packed kit).
+    if (entry.path !== KIT_ROOT_DIR && !entry.path.startsWith(`${KIT_ROOT_DIR}/`)) {
+      continue;
+    }
+    files.set(entry.path, Buffer.from(entry.bytes));
+  }
+  if (files.size === 0) {
+    throw new KitFilesError('kit_artifact_missing', 'kit tarball contained no files under the kit root');
+  }
+  return files;
+}
+
+export interface KitFileStore {
+  /** Metadata + signed URL path still used by get_kit — does not unpack. */
+  loadRegistry(): Promise<{ engineRef: string; sha256: string }>;
+  /** Unpack (or return cached) tree for the current registry entry. */
+  loadCurrentTree(): Promise<KitTree>;
+}
+
+export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
+  const cache = new Map<string, KitTree>();
+
+  function remember(tree: KitTree): KitTree {
+    cache.set(tree.engineRef, tree);
+    if (cache.size > KIT_TREE_CACHE_CAPACITY) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined && oldest !== tree.engineRef) {
+        cache.delete(oldest);
+      }
+    }
+    return tree;
+  }
+
+  async function loadRegistry(): Promise<{ engineRef: string; sha256: string }> {
+    const registryBody = await objectStore.readObject('kits/current.json');
+    if (!registryBody) {
+      throw new KitFilesError(
+        'kit_registry_missing',
+        'kits/current.json is not published yet — the games-repo kit publisher has not run',
+      );
+    }
+    let registry;
+    try {
+      registry = parseKitRegistry(registryBody.toString('utf8'));
+    } catch (error) {
+      if (error instanceof KitRegistryError) {
+        throw new KitFilesError(error.code, error.message, { cause: error });
+      }
+      throw error;
+    }
+    const engineRef = registry.current;
+    const sidecarBody = await objectStore.readObject(`kits/${engineRef}.json`);
+    if (!sidecarBody) {
+      throw new KitFilesError(
+        'kit_artifact_missing',
+        `kits/${engineRef}.json sidecar is missing for the current registry entry`,
+      );
+    }
+    let sidecar;
+    try {
+      sidecar = parseKitSidecar(sidecarBody.toString('utf8'));
+    } catch (error) {
+      if (error instanceof KitRegistryError) {
+        throw new KitFilesError(error.code, error.message, { cause: error });
+      }
+      throw error;
+    }
+    return { engineRef, sha256: sidecar.sha256 };
+  }
+
+  async function loadCurrentTree(): Promise<KitTree> {
+    const { engineRef, sha256 } = await loadRegistry();
+    const cached = cache.get(engineRef);
+    if (cached && cached.sha256 === sha256) {
+      return cached;
+    }
+    const tarball = await objectStore.readObject(`kits/${engineRef}.tgz`);
+    if (!tarball) {
+      throw new KitFilesError(
+        'kit_artifact_missing',
+        `kits/${engineRef}.tgz is missing for the current registry entry`,
+      );
+    }
+    const files = await unpackKitTarball(tarball);
+    return remember({ engineRef, sha256, files });
+  }
+
+  return { loadRegistry, loadCurrentTree };
+}

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -230,6 +230,10 @@ describe('POST /api/mcp (BY-05)', () => {
         'get_brief',
         'get_seed',
         'get_kit',
+        'list_kit_files',
+        'search_kit_files',
+        'read_kit_file',
+        'read_kit_file_fragment',
         'get_sources',
         'list_examples',
         'get_example',
@@ -260,6 +264,11 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
     expect(getKit?.description).toMatch(/entry=gamedevpl-creator-kit\/SKILL\.md/);
     expect(getKit?.description).toMatch(/do not assume a `cd` persists/i);
+    expect(getKit?.description).toMatch(/list_kit_files|read_kit_file/);
+    expect(tools.find((t) => t.name === 'list_kit_files')?.description).toMatch(/prefix|glob/i);
+    expect(tools.find((t) => t.name === 'search_kit_files')?.description).toMatch(/substring/i);
+    expect(tools.find((t) => t.name === 'read_kit_file')?.description).toMatch(/48 KiB|fragment/i);
+    expect(tools.find((t) => t.name === 'read_kit_file_fragment')?.description).toMatch(/lines|bytes/i);
 
     const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
     expect(gateVerdict?.description).toMatch(/2–5 minutes/);
@@ -333,6 +342,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/available:true/);
     expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
+    expect(joined).toMatch(/list_kit_files|read_kit_file/);
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/submit_sources/);
     expect(joined).toMatch(/get_gate_verdict/);
@@ -1207,7 +1217,19 @@ describe('POST /api/mcp (BY-05)', () => {
       expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(false);
     }
 
-    const readers = ['get_brief', 'get_seed', 'get_kit', 'get_sources', 'list_examples', 'get_example', 'read_inbox'];
+    const readers = [
+      'get_brief',
+      'get_seed',
+      'get_kit',
+      'list_kit_files',
+      'search_kit_files',
+      'read_kit_file',
+      'read_kit_file_fragment',
+      'get_sources',
+      'list_examples',
+      'get_example',
+      'read_inbox',
+    ];
     for (const name of readers) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(true);
     }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -231,7 +231,7 @@ function stopFromChannel(body: { control?: { stop?: boolean; reason?: string } }
 const BEHAVIOURAL_CONTRACT = [
   'Report progress before and after long steps.',
   'Send a screenshot as soon as the game draws anything playable.',
-  'Run kit checks green (at least check:static) before submit_sources.',
+  'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'Honour stop immediately — do not continue after stop:true.',
   'When get_brief.seedAvailable is true, continue the seed (get_seed) rather than scaffolding from scratch.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
@@ -253,10 +253,10 @@ const SESSION_WORKFLOW: readonly string[] = [
   // one. get_sources is cheap and answers available:false on a new game, so it is
   // unconditional rather than gated on a round type the agent cannot see.
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them.',
-  'get_kit — unpack the tarball, open entry (gamedevpl-creator-kit/SKILL.md), and follow it. Keep the engineRef it returns for submit_sources.',
+  'get_kit — keep engineRef for submit_sources. Prefer list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment (start at entry) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
-  'Run the kit checks green (at least check:static) before delivering.',
+  'Run the kit checks green (at least check:static) before delivering when you have a local kit checkout; otherwise deliver and let the gate run checks.',
   'submit_sources with the kitEngineRef get_kit returned.',
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated.',
   'red: read the report, fix, and resubmit on the SAME key.',
@@ -1226,10 +1226,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     get_kit: {
       annotations: { title: 'Fetch the Creator Kit', ...READS },
       description:
-        'Fetch the current Creator Kit: engineRef, signed kitUrl, sha256, unpack one-liner, ' +
-        'entry=gamedevpl-creator-kit/SKILL.md (path from the unpack working directory — ' +
-        'tarball roots at gamedevpl-creator-kit/; do not assume a `cd` persists across tool calls). ' +
-        'Unpack, open entry, follow SKILL.md. Run kit checks green before submit_sources. ' +
+        'Fetch Creator Kit metadata: engineRef (required for submit_sources), sha256, entry, ' +
+        'optional kitUrl/unpack for agents with shell egress, and browse tool names. ' +
+        'Prefer list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment over ' +
+        'downloading the tarball when curl/unpack is unavailable — do not pull the whole kit into context. ' +
+        'entry=gamedevpl-creator-kit/SKILL.md (tarball roots at gamedevpl-creator-kit/; ' +
+        'do not assume a `cd` persists across tool calls). ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -1243,6 +1245,168 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const body = res.json() as { error?: string; message?: string };
         if (res.statusCode !== 200) {
           return toolErr(body.message ?? body.error ?? `kit failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    list_kit_files: {
+      annotations: { title: 'List Creator Kit files', ...READS },
+      description:
+        'List paths inside the current Creator Kit (size + text/binary kind). ' +
+        'Optional prefix (e.g. shared/modules) or simple glob (*). Paginate with limit/offset. ' +
+        'Start from get_kit.entry via read_kit_file. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          prefix: { type: 'string', description: 'Path prefix under the kit root (or full gamedevpl-creator-kit/…).' },
+          glob: { type: 'string', description: 'Simple glob with * wildcards (e.g. **/*.md or shared/modules/*.ts).' },
+          limit: { type: 'integer', description: 'Max paths to return (default 200, max 500).' },
+          offset: { type: 'integer', description: 'Skip this many matching paths.' },
+        },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const params = new URLSearchParams();
+        if (typeof args.prefix === 'string' && args.prefix.trim()) params.set('prefix', args.prefix.trim());
+        if (typeof args.glob === 'string' && args.glob.trim()) params.set('glob', args.glob.trim());
+        if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
+        if (typeof args.offset === 'number' && Number.isFinite(args.offset)) params.set('offset', String(args.offset));
+        const qs = params.toString();
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/kit/files${qs ? `?${qs}` : ''}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `list_kit_files failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    search_kit_files: {
+      annotations: { title: 'Search Creator Kit files', ...READS },
+      description:
+        'Search text files in the current Creator Kit for a substring (case-insensitive). ' +
+        'Returns path + line + snippet; capped match count. Prefer this over reading many files. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          query: { type: 'string', description: 'Substring to find (2–120 chars).' },
+          prefix: { type: 'string', description: 'Optional path prefix to narrow the search.' },
+          limit: { type: 'integer', description: 'Max matches (default/max 40).' },
+        },
+        required: ['query'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const query = typeof args.query === 'string' ? args.query.trim() : '';
+        if (!query) return toolErr('query is required');
+        const params = new URLSearchParams({ q: query });
+        if (typeof args.prefix === 'string' && args.prefix.trim()) params.set('prefix', args.prefix.trim());
+        if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/kit/search?${params.toString()}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `search_kit_files failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    read_kit_file: {
+      annotations: { title: 'Read one Creator Kit file', ...READS },
+      description:
+        'Read one small Creator Kit file (≤48 KiB). Larger files return kit_file_too_large — use ' +
+        'read_kit_file_fragment. Binary files need encoding=base64. Paths may be kit-relative or ' +
+        'gamedevpl-creator-kit/…. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          path: { type: 'string', description: 'Kit file path (e.g. SKILL.md or gamedevpl-creator-kit/SKILL.md).' },
+          encoding: {
+            type: 'string',
+            enum: ['utf8', 'base64'],
+            description: 'utf8 for text (default); base64 required for binary.',
+          },
+        },
+        required: ['path'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!path) return toolErr('path is required');
+        const params = new URLSearchParams({ path });
+        if (args.encoding === 'base64' || args.encoding === 'utf8') params.set('encoding', args.encoding);
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/kit/file?${params.toString()}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `read_kit_file failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    read_kit_file_fragment: {
+      annotations: { title: 'Read a Creator Kit file fragment', ...READS },
+      description:
+        'Read a window of one Creator Kit file by lines (default) or bytes. Use for large modules/skills. ' +
+        'offset is 0-based; response includes eof, totalBytes, totalLines. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          path: { type: 'string', description: 'Kit file path.' },
+          offset: { type: 'integer', description: '0-based start line or byte.' },
+          limit: { type: 'integer', description: 'Max lines (≤200) or bytes (≤32 KiB).' },
+          unit: { type: 'string', enum: ['lines', 'bytes'], description: 'Default lines; bytes required for binary.' },
+          encoding: { type: 'string', enum: ['utf8', 'base64'], description: 'base64 required for binary.' },
+        },
+        required: ['path'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!path) return toolErr('path is required');
+        const params = new URLSearchParams({ path });
+        if (typeof args.offset === 'number' && Number.isFinite(args.offset)) params.set('offset', String(args.offset));
+        if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
+        if (args.unit === 'lines' || args.unit === 'bytes') params.set('unit', args.unit);
+        if (args.encoding === 'base64' || args.encoding === 'utf8') params.set('encoding', args.encoding);
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/kit/file/fragment?${params.toString()}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `read_kit_file_fragment failed (${res.statusCode})`, body);
         }
         return toolOk(body);
       },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -253,7 +253,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   // one. get_sources is cheap and answers available:false on a new game, so it is
   // unconditional rather than gated on a round type the agent cannot see.
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them.',
-  'get_kit — keep engineRef for submit_sources. Prefer list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment (start at entry) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
+  'get_kit — keep engineRef for submit_sources and pass it on every list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment call (start at entry) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
   'Run the kit checks green (at least check:static) before delivering when you have a local kit checkout; otherwise deliver and let the gate run checks.',
@@ -308,6 +308,13 @@ const SESSION_KEY_PROP = {
   type: 'string' as const,
   description:
     'Short-lived session capability from start(). Present this argument OR configure Authorization: Bearer <round key> — not both required. Send it with the same Mcp-Session-Id header start() used: that header alone is never authority, but a sessionKey is bound to the session that minted it, so a different one is refused. If the transport session is lost, call start() again — it re-binds and re-mints.',
+};
+
+/** Pin kit browse/read calls to the engineRef get_kit returned (N/N−1 window). */
+const KIT_ENGINE_REF_PROP = {
+  type: 'string' as const,
+  description:
+    'Creator Kit engineRef from get_kit. Pass on every browse/read call so a mid-round registry bump cannot mix kit revisions.',
 };
 
 export async function registerMcpServerRoutes(app: FastifyInstance, options: McpServerOptions = {}): Promise<void> {
@@ -1253,14 +1260,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     list_kit_files: {
       annotations: { title: 'List Creator Kit files', ...READS },
       description:
-        'List paths inside the current Creator Kit (size + text/binary kind). ' +
-        'Optional prefix (e.g. shared/modules) or simple glob (*). Paginate with limit/offset. ' +
-        'Start from get_kit.entry via read_kit_file. ' +
+        'List paths inside a pinned Creator Kit (size + text/binary kind). ' +
+        'Pass engineRef from get_kit. Optional prefix (e.g. shared/modules) or simple glob (*). ' +
+        'Paginate with limit/offset. Start from get_kit.entry via read_kit_file. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          engineRef: KIT_ENGINE_REF_PROP,
           prefix: { type: 'string', description: 'Path prefix under the kit root (or full gamedevpl-creator-kit/…).' },
           glob: { type: 'string', description: 'Simple glob with * wildcards (e.g. **/*.md or shared/modules/*.ts).' },
           limit: { type: 'integer', description: 'Max paths to return (default 200, max 500).' },
@@ -1272,6 +1280,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const params = new URLSearchParams();
+        if (typeof args.engineRef === 'string' && args.engineRef.trim()) {
+          params.set('engineRef', args.engineRef.trim());
+        }
         if (typeof args.prefix === 'string' && args.prefix.trim()) params.set('prefix', args.prefix.trim());
         if (typeof args.glob === 'string' && args.glob.trim()) params.set('glob', args.glob.trim());
         if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
@@ -1294,13 +1305,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     search_kit_files: {
       annotations: { title: 'Search Creator Kit files', ...READS },
       description:
-        'Search text files in the current Creator Kit for a substring (case-insensitive). ' +
-        'Returns path + line + snippet; capped match count. Prefer this over reading many files. ' +
+        'Search text files in a pinned Creator Kit for a substring (case-insensitive). ' +
+        'Pass engineRef from get_kit. Returns path + line + snippet; capped match count. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          engineRef: KIT_ENGINE_REF_PROP,
           query: { type: 'string', description: 'Substring to find (2–120 chars).' },
           prefix: { type: 'string', description: 'Optional path prefix to narrow the search.' },
           limit: { type: 'integer', description: 'Max matches (default/max 40).' },
@@ -1313,6 +1325,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const query = typeof args.query === 'string' ? args.query.trim() : '';
         if (!query) return toolErr('query is required');
         const params = new URLSearchParams({ q: query });
+        if (typeof args.engineRef === 'string' && args.engineRef.trim()) {
+          params.set('engineRef', args.engineRef.trim());
+        }
         if (typeof args.prefix === 'string' && args.prefix.trim()) params.set('prefix', args.prefix.trim());
         if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
         const res = await injectChannel(
@@ -1332,14 +1347,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     read_kit_file: {
       annotations: { title: 'Read one Creator Kit file', ...READS },
       description:
-        'Read one small Creator Kit file (≤48 KiB). Larger files return kit_file_too_large — use ' +
-        'read_kit_file_fragment. Binary files need encoding=base64. Paths may be kit-relative or ' +
-        'gamedevpl-creator-kit/…. ' +
+        'Read one small Creator Kit file (≤48 KiB). Pass engineRef from get_kit. Larger files return ' +
+        'kit_file_too_large — use read_kit_file_fragment. Binary files need encoding=base64. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          engineRef: KIT_ENGINE_REF_PROP,
           path: { type: 'string', description: 'Kit file path (e.g. SKILL.md or gamedevpl-creator-kit/SKILL.md).' },
           encoding: {
             type: 'string',
@@ -1355,6 +1370,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const path = typeof args.path === 'string' ? args.path.trim() : '';
         if (!path) return toolErr('path is required');
         const params = new URLSearchParams({ path });
+        if (typeof args.engineRef === 'string' && args.engineRef.trim()) {
+          params.set('engineRef', args.engineRef.trim());
+        }
         if (args.encoding === 'base64' || args.encoding === 'utf8') params.set('encoding', args.encoding);
         const res = await injectChannel(
           ctx.request,
@@ -1373,18 +1391,27 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     read_kit_file_fragment: {
       annotations: { title: 'Read a Creator Kit file fragment', ...READS },
       description:
-        'Read a window of one Creator Kit file by lines (default) or bytes. Use for large modules/skills. ' +
-        'offset is 0-based; response includes eof, totalBytes, totalLines. ' +
+        'Read a window of one Creator Kit file by lines (default) or bytes (always base64). ' +
+        'Pass engineRef from get_kit. Use nextOffset for pagination. Overlong line windows error — switch to unit=bytes. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          engineRef: KIT_ENGINE_REF_PROP,
           path: { type: 'string', description: 'Kit file path.' },
-          offset: { type: 'integer', description: '0-based start line or byte.' },
+          offset: { type: 'integer', description: '0-based start line or byte (use nextOffset from the prior reply).' },
           limit: { type: 'integer', description: 'Max lines (≤200) or bytes (≤32 KiB).' },
-          unit: { type: 'string', enum: ['lines', 'bytes'], description: 'Default lines; bytes required for binary.' },
-          encoding: { type: 'string', enum: ['utf8', 'base64'], description: 'base64 required for binary.' },
+          unit: {
+            type: 'string',
+            enum: ['lines', 'bytes'],
+            description: 'Default lines; bytes required for binary and always returns base64.',
+          },
+          encoding: {
+            type: 'string',
+            enum: ['utf8', 'base64'],
+            description: 'utf8 for lines; base64 required for unit=bytes.',
+          },
         },
         required: ['path'],
       },
@@ -1394,6 +1421,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const path = typeof args.path === 'string' ? args.path.trim() : '';
         if (!path) return toolErr('path is required');
         const params = new URLSearchParams({ path });
+        if (typeof args.engineRef === 'string' && args.engineRef.trim()) {
+          params.set('engineRef', args.engineRef.trim());
+        }
         if (typeof args.offset === 'number' && Number.isFinite(args.offset)) params.set('offset', String(args.offset));
         if (typeof args.limit === 'number' && Number.isFinite(args.limit)) params.set('limit', String(args.limit));
         if (args.unit === 'lines' || args.unit === 'bytes') params.set('unit', args.unit);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

ChatGPT Apps can call MCP successfully, but `get_kit` still points agents at a GCS signed URL (`curl | tar`). Code-execution sandboxes often cannot resolve `storage.googleapis.com`, and returning the whole ~1.4 MB kit over MCP would blow up agent context.

## Solution

Keep `get_kit` as **metadata** (`engineRef`, `sha256`, `entry`, optional `kitUrl`/`unpack`, plus a `browse` map of tool names). Add four read tools that serve the pinned kit from the server-side tarball:

| Tool | Purpose |
| --- | --- |
| `list_kit_files` | Paths + size + text/binary; `prefix` / simple `glob`, paginated |
| `search_kit_files` | Case-insensitive substring search over text files (capped hits) |
| `read_kit_file` | Whole file ≤48 KiB (binaries need `encoding=base64`) |
| `read_kit_file_fragment` | Line/byte windows for larger files (`nextOffset`; bytes → base64) |

Channel routes (same auth as other build reads):

- `GET /api/agent/build/kit/files`
- `GET /api/agent/build/kit/search`
- `GET /api/agent/build/kit/file`
- `GET /api/agent/build/kit/file/fragment`

Pass `engineRef` from `get_kit` on every browse/read call (N/N−1 pin). Caps: list ≤500, search ≤40 hits, whole-file ≤48 KiB, fragments ≤32 KiB / 200 lines.

## Review follow-ups

Addressed Copilot + Codex feedback on this branch:

- Escape `?` in simple globs; treat non-finite `limit`/`offset` as absent
- Pin browse to `engineRef` so a mid-round registry bump cannot mix kits
- Reject overlong line windows (use `unit=bytes`) instead of truncating
- Require `encoding=base64` for byte fragments (no UTF-8 split)

## Tests

- Unit coverage in `kit-files.test.ts`
- Channel coverage in `agent-build-reads.test.ts`
- MCP tool listing / workflow / readOnly annotations in `mcp-server.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

