### PR TITLE
feat: soft MCP warnings for stale progress and pending inbox

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1422,6 +1422,41 @@ describe('POST /api/mcp (BY-05)', () => {
       expect(text).not.toContain(TINY_PNG);
     });
 
+    it('keeps the opening image when session nudges add warnings', async () => {
+      // applySessionNudges must not rebuild via toolOk alone — that dropped image blocks.
+      const store = new InMemoryStore();
+      await seedJob(store);
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+      app = await createApp(store, mediaGamesStore(), mediaObjectStore());
+      const sessionId = await initialize(app);
+      const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      for (let i = 0; i < 6; i += 1) {
+        await callTool(app, 'list_examples', { sessionKey }, { 'mcp-session-id': sessionId });
+      }
+
+      const res = await mcpCall(
+        app,
+        'tools/call',
+        { name: 'get_gate_media', arguments: { sessionKey } },
+        { 'mcp-session-id': sessionId },
+      );
+      expect(res.statusCode).toBe(200);
+      const result = res.json().result as {
+        content: Array<{ type: string; data?: string; mimeType?: string }>;
+        structuredContent: { warnings?: Array<{ code: string }>; openingShot?: { attached: boolean } };
+        isError?: boolean;
+      };
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent.warnings?.map((w) => w.code)).toContain('progress_stale');
+      expect(result.structuredContent.openingShot?.attached).toBe(true);
+      expect(result.content.find((part) => part.type === 'image')).toMatchObject({
+        mimeType: 'image/png',
+        data: TINY_PNG,
+      });
+    });
+
     it('reports available:false instead of erroring before anything is delivered', async () => {
       const store = new InMemoryStore();
       await seedJob(store);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -633,6 +633,11 @@ describe('POST /api/mcp (BY-05)', () => {
       stop: false,
       pendingMessages: [expect.objectContaining({ text: 'Make it faster' })],
     });
+    // Soft nudge while creator notes are waiting — never isError.
+    expect(progress.isError).toBe(false);
+    expect((progress.structured as { warnings?: Array<{ code: string }> }).warnings?.map((w) => w.code)).toContain(
+      'inbox_pending',
+    );
 
     const acked = await callTool(app, 'ack_inbox', { sessionKey, ids: [msg.id] }, { 'mcp-session-id': sessionId });
     expect(acked.structured).toMatchObject({
@@ -643,6 +648,54 @@ describe('POST /api/mcp (BY-05)', () => {
     // stop/pendingMessages keys must be present on the write reply.
     expect(acked.structured).toHaveProperty('stop');
     expect(acked.structured).toHaveProperty('pendingMessages');
+  });
+
+  it('soft-nudges progress_stale after several tools without report_progress', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    let last: { structured: unknown; isError: boolean } | undefined;
+    for (let i = 0; i < 6; i += 1) {
+      last = await callTool(app, 'list_examples', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(last.isError).toBe(false);
+    }
+    const warnings = (last?.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? [];
+    expect(warnings.map((w) => w.code)).toContain('progress_stale');
+    expect(warnings.find((w) => w.code === 'progress_stale')?.message).toMatch(/report_progress/);
+
+    const progress = await callTool(
+      app,
+      'report_progress',
+      { sessionKey, text: 'Still building.', step: 'mechanics' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(progress.isError).toBe(false);
+    const cleared = await callTool(app, 'list_examples', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(
+      ((cleared.structured as { warnings?: Array<{ code: string }> }).warnings ?? []).map((w) => w.code),
+    ).not.toContain('progress_stale');
+  });
+
+  it('piggybacks pendingMessages on kit/browse-style reads and warns inbox_pending', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    await store.appendCreatorMessage(ISSUE, 'Add a power-up');
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    // list_examples is a hot read — should carry inbox piggyback without a separate read_inbox.
+    const examples = await callTool(app, 'list_examples', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(examples.isError).toBe(false);
+    expect(examples.structured).toMatchObject({
+      pendingMessages: [expect.objectContaining({ text: 'Add a power-up' })],
+      warnings: [expect.objectContaining({ code: 'inbox_pending' })],
+    });
   });
 
   it('rejects oversized screenshots at the MCP layer', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -54,12 +54,23 @@ import {
   newMcpSessionId,
   verifyMcpSessionKey,
 } from './mcp-session-key.js';
-import { mcpSessionStartedFields, mcpToolRefusalFields, toolErrorReason } from './mcp-debug-log.js';
+import {
+  mcpSessionStartedFields,
+  mcpToolRefusalFields,
+  peekMcpSessionKeyForLog,
+  toolErrorReason,
+} from './mcp-debug-log.js';
 import {
   MCP_MISSING_CREDENTIAL_HINT,
   sendMcpOAuthChallenge,
   shouldIssueMcpOAuthChallenge,
 } from './mcp-oauth-metadata.js';
+import {
+  INBOX_PIGGYBACK_TOOLS,
+  createMcpNudgeTracker,
+  pendingCountFromPayload,
+  type NudgeWarning,
+} from './mcp-session-nudges.js';
 import { looksLikeAsAccessToken, verifyAsAccessToken } from './oauth-tokens.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
 import { BUILD_STEPS, sanitizeCreatorText } from './submission-status.js';
@@ -276,13 +287,13 @@ function stopFromChannel(body: { control?: { stop?: boolean; reason?: string } }
 }
 
 const BEHAVIOURAL_CONTRACT = [
-  'Report progress before and after long steps.',
+  'Report progress before and after long steps (and whenever a reply carries warnings with code progress_stale).',
   'Send a screenshot as soon as the game draws anything playable.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'Honour stop immediately — do not continue after stop:true.',
   'When get_brief.seedAvailable is true, continue the seed (get_seed) rather than scaffolding from scratch.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
-  'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies as you go.',
+  'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
   'A green gate verdict ends the round — END immediately; the key retires and new work arrives as a fresh kickoff.',
 ].join(' ');
 
@@ -384,6 +395,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   const invalidStartsByIp = new Map<string, number[]>();
   /** Last synthetic Studio presence pulse per job — coarse MCP activity, not 1:1 tools. */
   const presencePulseByJob = new Map<number, number>();
+  const nudgeTracker = createMcpNudgeTracker();
 
   function pruneTransportSessions(currentTime: number): void {
     for (const [id, meta] of transportSessions) {
@@ -581,6 +593,79 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     };
   }
 
+  function resolveNudgeJobId(
+    args: Record<string, unknown>,
+    ctx: ToolContext,
+    payload: Record<string, unknown>,
+  ): number | null {
+    if (typeof payload.jobId === 'number' && Number.isFinite(payload.jobId)) {
+      return payload.jobId;
+    }
+    const sessionKeyArg = typeof args.sessionKey === 'string' ? args.sessionKey.trim() : '';
+    const peeked = peekMcpSessionKeyForLog(sessionKeyArg, agentTokenSecret);
+    if (peeked) return peeked.jobId;
+    if (ctx.bearerToken && agentTokenSecret) {
+      try {
+        return verifyAgentToken(ctx.bearerToken, agentTokenSecret).jobId;
+      } catch {
+        // Not a round token — ignore.
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Merge soft warnings (and inbox piggyback on hot reads) into a successful tool result.
+   * Never flips isError — ChatGPT already mishandles hard errors in the transcript.
+   */
+  async function applySessionNudges(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: ToolContext,
+    result: ToolResult,
+  ): Promise<ToolResult> {
+    if (result.isError) return result;
+    if (!result.structuredContent || typeof result.structuredContent !== 'object') return result;
+    if (Array.isArray(result.structuredContent)) return result;
+
+    let data: Record<string, unknown> = { ...(result.structuredContent as Record<string, unknown>) };
+    const jobId = resolveNudgeJobId(args, ctx, data);
+    if (jobId === null) return result;
+
+    const nowMs = now();
+    nudgeTracker.ensure(jobId, nowMs);
+
+    let piggybacked = false;
+    if (INBOX_PIGGYBACK_TOOLS.has(toolName) && !Array.isArray(data.pendingMessages)) {
+      const auth = await resolveAuth(ctx, args);
+      if ('channelToken' in auth) {
+        const piggy = await writePiggyback(ctx.request, auth.channelToken);
+        data = {
+          ...data,
+          pendingMessages: piggy.pendingMessages,
+          stop: piggy.stop,
+          ...(piggy.reason ? { reason: piggy.reason } : {}),
+        };
+        piggybacked = true;
+      }
+    }
+
+    const pending = pendingCountFromPayload(data);
+    if (pending !== null) {
+      nudgeTracker.notePendingCount(jobId, pending);
+    }
+
+    nudgeTracker.noteToolSuccess(jobId, toolName, nowMs);
+    const warnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs);
+    if (warnings.length === 0 && !piggybacked) {
+      return result;
+    }
+    if (warnings.length > 0) {
+      data = { ...data, warnings };
+    }
+    return toolOk(data);
+  }
+
   /**
    * Tool annotations, and why every tool needs them.
    *
@@ -622,6 +707,23 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     openWorldHint: false,
   } as const;
 
+  /** Soft nudges — advisory, never isError. */
+  const WARNINGS_PROP = {
+    warnings: {
+      type: 'array',
+      description:
+        'Soft session nudges (progress_stale, inbox_pending). Not errors — act on them, then continue the workflow.',
+      items: {
+        type: 'object',
+        properties: {
+          code: { type: 'string', enum: ['progress_stale', 'inbox_pending'] },
+          message: { type: 'string' },
+        },
+        required: ['code', 'message'],
+      },
+    },
+  } as const;
+
   /** Every mutating reply carries these two, so the model can plan around them. */
   const REPLY_CONTROL = {
     stop: { type: 'boolean', description: 'When true, stop immediately.' },
@@ -633,6 +735,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: { id: { type: 'string' }, text: { type: 'string' }, createdAt: { type: 'string' } },
       },
     },
+    ...WARNINGS_PROP,
   } as const;
 
   const tools: Record<
@@ -2341,7 +2444,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       const sessionKeyArg = typeof args.sessionKey === 'string' ? args.sessionKey.trim() : '';
       const userAgent = headerValue(request.headers['user-agent']);
       try {
-        const result = await tool.handler(args, ctx);
+        const rawResult = await tool.handler(args, ctx);
+        const result = await applySessionNudges(name, args, ctx, rawResult);
         // Echo session id on tool responses when we have one (transport correlator).
         if (sessionHeader) {
           reply.header('Mcp-Session-Id', sessionHeader);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -652,7 +652,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     const pending = pendingCountFromPayload(data);
     if (pending !== null) {
-      nudgeTracker.notePendingCount(jobId, pending);
+      nudgeTracker.notePendingCount(jobId, pending, nowMs);
     }
 
     nudgeTracker.noteToolSuccess(jobId, toolName, nowMs);
@@ -663,7 +663,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     if (warnings.length > 0) {
       data = { ...data, warnings };
     }
-    return toolOk(data);
+    // Keep non-text content (e.g. get_gate_media's inline opening screenshot). Rebuilding
+    // via toolOk() would drop those blocks whenever a warning or piggyback lands.
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(data) },
+        ...result.content.filter((block) => block.type !== 'text'),
+      ],
+      structuredContent: data,
+    };
   }
 
   /**

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -43,12 +43,12 @@ describe('mcp-session-nudges', () => {
   it('warns inbox_pending only while count > 0 (not on read_inbox itself)', () => {
     const nudges = createMcpNudgeTracker();
     const t0 = 1_000_000;
-    nudges.ensure(1, t0);
-    nudges.notePendingCount(1, 2);
+    nudges.notePendingCount(1, 2, t0);
+    expect(nudges.peek(1)?.startedAt).toBe(t0);
     expect(nudges.warningsFor(1, 'read_kit_file', t0).map((w) => w.code)).toContain('inbox_pending');
     expect(nudges.warningsFor(1, 'read_inbox', t0).map((w) => w.code)).not.toContain('inbox_pending');
     nudges.noteInboxCheck(1, t0);
-    nudges.notePendingCount(1, 0);
+    nudges.notePendingCount(1, 0, t0);
     expect(nudges.warningsFor(1, 'read_kit_file', t0 + 1)).toEqual([]);
   });
 

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROGRESS_STALE_CALLS,
+  PROGRESS_STALE_MS,
+  createMcpNudgeTracker,
+  pendingCountFromPayload,
+} from './mcp-session-nudges.js';
+
+describe('mcp-session-nudges', () => {
+  it('warns progress_stale after wall-clock silence', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.ensure(1, t0);
+    nudges.noteProgress(1, t0);
+    expect(nudges.warningsFor(1, 'read_kit_file', t0 + 10_000)).toEqual([]);
+    const warnings = nudges.warningsFor(1, 'read_kit_file', t0 + PROGRESS_STALE_MS);
+    expect(warnings.map((w) => w.code)).toContain('progress_stale');
+  });
+
+  it('warns progress_stale after enough tool calls without report_progress', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.ensure(1, t0);
+    nudges.noteProgress(1, t0);
+    for (let i = 0; i < PROGRESS_STALE_CALLS; i += 1) {
+      nudges.noteToolSuccess(1, 'read_kit_file', t0 + i * 100);
+    }
+    expect(nudges.warningsFor(1, 'read_kit_file', t0 + 1_000).map((w) => w.code)).toContain('progress_stale');
+  });
+
+  it('does not progress-nudge exempt tools; report_progress clears the clock', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.ensure(1, t0);
+    for (let i = 0; i < PROGRESS_STALE_CALLS + 2; i += 1) {
+      nudges.noteToolSuccess(1, 'read_kit_file', t0 + i);
+    }
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 50_000).map((w) => w.code)).not.toContain('progress_stale');
+    nudges.noteToolSuccess(1, 'report_progress', t0 + 60_000);
+    expect(nudges.warningsFor(1, 'read_kit_file', t0 + 61_000)).toEqual([]);
+  });
+
+  it('warns inbox_pending only while count > 0 (not on read_inbox itself)', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.ensure(1, t0);
+    nudges.notePendingCount(1, 2);
+    expect(nudges.warningsFor(1, 'read_kit_file', t0).map((w) => w.code)).toContain('inbox_pending');
+    expect(nudges.warningsFor(1, 'read_inbox', t0).map((w) => w.code)).not.toContain('inbox_pending');
+    nudges.noteInboxCheck(1, t0);
+    nudges.notePendingCount(1, 0);
+    expect(nudges.warningsFor(1, 'read_kit_file', t0 + 1)).toEqual([]);
+  });
+
+  it('reads pending counts from common payload shapes', () => {
+    expect(pendingCountFromPayload({ pendingMessages: [{ id: 'a' }] })).toBe(1);
+    expect(pendingCountFromPayload({ pending: [] })).toBe(0);
+    expect(pendingCountFromPayload({ messages: [{}, {}] })).toBe(2);
+    expect(pendingCountFromPayload({ ok: true })).toBeNull();
+  });
+});

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -58,7 +58,8 @@ export interface McpNudgeTracker {
   ensure(jobId: number, nowMs: number): JobNudgeState;
   noteProgress(jobId: number, nowMs: number): void;
   noteInboxCheck(jobId: number, nowMs: number): void;
-  notePendingCount(jobId: number, count: number): void;
+  /** `nowMs` is only used if the job has never been ensured — callers should pass the injected clock. */
+  notePendingCount(jobId: number, count: number, nowMs: number): void;
   noteToolSuccess(jobId: number, toolName: string, nowMs: number): void;
   warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[];
   /** Test helper. */
@@ -98,8 +99,8 @@ export function createMcpNudgeTracker(
     state.lastInboxCheckAt = nowMs;
   }
 
-  function notePendingCount(jobId: number, count: number): void {
-    const state = ensure(jobId, Date.now());
+  function notePendingCount(jobId: number, count: number, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
     state.pendingCount = Math.max(0, count);
   }
 

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -1,0 +1,165 @@
+/**
+ * Soft session nudges for MCP tools — progress heartbeat + pending inbox.
+ *
+ * ChatGPT Apps (and similar) can spend many turns on read-only kit tools without
+ * `report_progress`, so the Studio UI looks frozen; creator notes only ride writes.
+ * These warnings are advisory (never `isError`) and are merged into successful tool
+ * results by the MCP dispatcher.
+ */
+
+export type NudgeCode = 'progress_stale' | 'inbox_pending';
+
+export interface NudgeWarning {
+  code: NudgeCode;
+  message: string;
+}
+
+export interface JobNudgeState {
+  startedAt: number;
+  lastProgressAt: number | null;
+  callsSinceProgress: number;
+  pendingCount: number;
+  lastInboxCheckAt: number | null;
+}
+
+/** No progress for this long (wall clock) → `progress_stale`. */
+export const PROGRESS_STALE_MS = 90_000;
+/** Or this many successful tools since the last progress report. */
+export const PROGRESS_STALE_CALLS = 6;
+
+/** Tools that should not emit a progress_stale warning. */
+export const PROGRESS_NUDGE_EXEMPT = new Set([
+  'start',
+  'create_game',
+  'open_round',
+  'report_progress',
+  'get_gate_verdict',
+  'read_inbox',
+  'ack_inbox',
+]);
+
+/**
+ * Read tools that otherwise never see `pendingMessages`. The dispatcher piggybacks
+ * a fresh inbox peek onto these so a read-heavy loop still learns about creator notes.
+ */
+export const INBOX_PIGGYBACK_TOOLS = new Set([
+  'get_kit',
+  'list_kit_files',
+  'search_kit_files',
+  'read_kit_file',
+  'read_kit_file_fragment',
+  'get_sources',
+  'list_examples',
+  'get_example',
+  'get_seed',
+]);
+
+export interface McpNudgeTracker {
+  ensure(jobId: number, nowMs: number): JobNudgeState;
+  noteProgress(jobId: number, nowMs: number): void;
+  noteInboxCheck(jobId: number, nowMs: number): void;
+  notePendingCount(jobId: number, count: number): void;
+  noteToolSuccess(jobId: number, toolName: string, nowMs: number): void;
+  warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[];
+  /** Test helper. */
+  peek(jobId: number): JobNudgeState | undefined;
+}
+
+export function createMcpNudgeTracker(
+  options: { progressStaleMs?: number; progressStaleCalls?: number } = {},
+): McpNudgeTracker {
+  const progressStaleMs = options.progressStaleMs ?? PROGRESS_STALE_MS;
+  const progressStaleCalls = options.progressStaleCalls ?? PROGRESS_STALE_CALLS;
+  const states = new Map<number, JobNudgeState>();
+
+  function ensure(jobId: number, nowMs: number): JobNudgeState {
+    let state = states.get(jobId);
+    if (!state) {
+      state = {
+        startedAt: nowMs,
+        lastProgressAt: null,
+        callsSinceProgress: 0,
+        pendingCount: 0,
+        lastInboxCheckAt: null,
+      };
+      states.set(jobId, state);
+    }
+    return state;
+  }
+
+  function noteProgress(jobId: number, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
+    state.lastProgressAt = nowMs;
+    state.callsSinceProgress = 0;
+  }
+
+  function noteInboxCheck(jobId: number, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
+    state.lastInboxCheckAt = nowMs;
+  }
+
+  function notePendingCount(jobId: number, count: number): void {
+    const state = ensure(jobId, Date.now());
+    state.pendingCount = Math.max(0, count);
+  }
+
+  function noteToolSuccess(jobId: number, toolName: string, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
+    if (toolName === 'report_progress') {
+      noteProgress(jobId, nowMs);
+      return;
+    }
+    if (toolName === 'read_inbox' || toolName === 'ack_inbox') {
+      noteInboxCheck(jobId, nowMs);
+    }
+    if (!PROGRESS_NUDGE_EXEMPT.has(toolName)) {
+      state.callsSinceProgress += 1;
+    }
+  }
+
+  function warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[] {
+    const state = ensure(jobId, nowMs);
+    const warnings: NudgeWarning[] = [];
+
+    if (!PROGRESS_NUDGE_EXEMPT.has(toolName)) {
+      const anchor = state.lastProgressAt ?? state.startedAt;
+      const staleByTime = nowMs - anchor >= progressStaleMs;
+      const staleByCalls = state.callsSinceProgress >= progressStaleCalls;
+      if (staleByTime || staleByCalls) {
+        warnings.push({
+          code: 'progress_stale',
+          message:
+            'No recent report_progress — call report_progress with a short status so the creator sees you are still working, then continue.',
+        });
+      }
+    }
+
+    if (state.pendingCount > 0 && toolName !== 'read_inbox') {
+      warnings.push({
+        code: 'inbox_pending',
+        message: `Creator inbox has ${state.pendingCount} pending message(s) — call read_inbox, apply them, ack_inbox, then continue.`,
+      });
+    }
+
+    return warnings;
+  }
+
+  return {
+    ensure,
+    noteProgress,
+    noteInboxCheck,
+    notePendingCount,
+    noteToolSuccess,
+    warningsFor,
+    peek: (jobId) => states.get(jobId),
+  };
+}
+
+/** Pull pendingMessages / pending arrays out of a tool result payload. */
+export function pendingCountFromPayload(payload: unknown): number | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const obj = payload as Record<string, unknown>;
+  const list = obj.pendingMessages ?? obj.pending ?? obj.messages;
+  if (!Array.isArray(list)) return null;
+  return list.length;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

ChatGPT Apps can spend many turns on read-only kit tools without `report_progress`, so Studio looks frozen. Creator inbox notes only ride writes, so a read-heavy loop can miss them entirely.

Hard-erroring every endpoint would break the kit browse path and re-hit ChatGPT’s weak `isError` handling.

## Solution

Soft, advisory `warnings` on successful tool results (never `isError`):

| Code | When |
| --- | --- |
| `progress_stale` | No `report_progress` for ~90s **or** ≥6 successful work tools since the last one |
| `inbox_pending` | `pendingCount > 0` (skipped on `read_inbox` itself) |

Also piggyback `pendingMessages` (+ `stop`) onto hot reads: `get_kit`, `list_kit_files`, `search_kit_files`, `read_kit_file`, `read_kit_file_fragment`, `get_sources`, `list_examples`, `get_example`, `get_seed`.

Exempt from progress nudges: `start`, `create_game`, `open_round`, `report_progress`, `get_gate_verdict`, `read_inbox`, `ack_inbox`.

Behavioural contract text updated to honour these warning codes.

## Tests

- Unit: `mcp-session-nudges.test.ts`
- MCP integration: progress_stale after 6× `list_examples`; inbox piggyback + `inbox_pending` on hot reads; existing write piggyback asserts soft `inbox_pending` without `isError`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

