### PR TITLE
Assemble the arcade-football GameKit vertical

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -12,6 +12,7 @@
     "gfx",
     "gfx3d",
     "racing",
+    "football",
     "effects",
     "audio",
     "party",

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -78,10 +78,10 @@ describe('runGamesRepoContractCheck', () => {
     expect(outcome.kind === 'drift' && outcome.reason).toContain('GAME_KIT_MODULES mismatch');
   });
 
-  it('allows the website to list modules the games tip has not shipped yet', async () => {
+  it('allows a short-lived website-first module rollout', async () => {
     // Website-first adds: GAME_KIT_MODULES here already includes these modules, but
     // main's assemble.ts may still list the older order. That window must stay green.
-    const aheadModules = new Set(['voice', 'racing']);
+    const aheadModules = new Set(['football']);
     const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => !aheadModules.has(name));
     const olderAssemble = `
       const GAME_KIT_MODULES = [${withoutAheadExtras.map((name) => `'${name}'`).join(', ')}];
@@ -94,7 +94,31 @@ describe('runGamesRepoContractCheck', () => {
       'tools/validate.ts': [ok(VALIDATE_SOURCE)],
     });
 
-    await expect(runGamesRepoContractCheck({ ...BASE, fetchImpl })).resolves.toEqual({ kind: 'ok' });
+    await expect(
+      runGamesRepoContractCheck({ ...BASE, fetchImpl, now: () => Date.parse('2026-08-04T00:00:00.000Z') }),
+    ).resolves.toEqual({ kind: 'ok' });
+  });
+
+  it('fails closed when a website-first module rollout expires', async () => {
+    const remoteWithoutFootball = GAME_KIT_MODULES.filter((name) => name !== 'football');
+    const olderAssemble = `
+      const GAME_KIT_MODULES = [${remoteWithoutFootball.map((name) => `'${name}'`).join(', ')}];
+      const catalog = readMusicCatalog();
+      const track = catalog.tracks[name];
+      out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
+    `;
+    const { fetchImpl } = createFetch({
+      'tools/lib/assemble.ts': [ok(olderAssemble)],
+      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
+    });
+
+    const outcome = await runGamesRepoContractCheck({
+      ...BASE,
+      fetchImpl,
+      now: () => Date.parse('2026-08-10T00:00:00.000Z'),
+    });
+    expect(outcome.kind).toBe('drift');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('expired website-ahead modules: football');
   });
 
   it('reports drift when a local-only module is not in the declared-ahead list', async () => {
@@ -114,7 +138,7 @@ describe('runGamesRepoContractCheck', () => {
 
     const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
     expect(outcome.kind).toBe('drift');
-    expect(outcome.kind === 'drift' && outcome.reason).toContain('Undeclared website-ahead modules');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('Undeclared or expired website-ahead modules');
     expect(outcome.kind === 'drift' && outcome.reason).toContain('collision');
   });
 

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -243,7 +243,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   // before the games-repo tip merges them. If a local-only module is NOT in this
   // list, it means games-repo dropped or rolled it back — that is drift, not an
   // intentional lead. (Codex review — PR #379.)
-  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice', 'editor', 'racing']);
+  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice', 'editor', 'racing', 'football']);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const undeclaredExtras = websiteExtras.filter((m) => !DECLARED_AHEAD_MODULES.has(m));
   if (undeclaredExtras.length > 0) {

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -49,6 +49,8 @@ export interface ContractCheckOptions {
   log?: (message: string) => void;
   /** Test seam — replaced so retry backoff does not slow the suite. */
   sleep?: (ms: number) => Promise<void>;
+  /** Test seam for expiring website-first module rollout exceptions. */
+  now?: () => number;
 }
 
 /** Attempts per file, including the first. Bounded so a dead remote fails fast. */
@@ -239,20 +241,26 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     };
   }
 
-  // Declared website-ahead modules: explicitly list modules this side has added
-  // before the games-repo tip merges them. If a local-only module is NOT in this
-  // list, it means games-repo dropped or rolled it back — that is drift, not an
-  // intentional lead. (Codex review — PR #379.)
-  const DECLARED_AHEAD_MODULES: ReadonlySet<string> = new Set(['sensing', 'voice', 'editor', 'racing', 'football']);
+  // Website-first exceptions must expire. A permanent allowlist would turn a later
+  // games-repo rollback into an apparently intentional rollout state. Remove an entry
+  // as soon as its paired games change lands; the deadline is the fail-closed backstop.
+  const WEBSITE_AHEAD_EXPIRY: ReadonlyMap<string, number> = new Map([
+    ['football', Date.parse('2026-08-10T00:00:00.000Z')],
+  ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
-  const undeclaredExtras = websiteExtras.filter((m) => !DECLARED_AHEAD_MODULES.has(m));
-  if (undeclaredExtras.length > 0) {
+  const now = options.now?.() ?? Date.now();
+  const invalidExtras = websiteExtras.filter((m) => {
+    const expiry = WEBSITE_AHEAD_EXPIRY.get(m);
+    return expiry === undefined || now >= expiry;
+  });
+  if (invalidExtras.length > 0) {
     return {
       kind: 'drift',
       reason:
-        `Undeclared website-ahead modules: ${undeclaredExtras.join(', ')}.\n` +
-        `  If these are intentional new modules, add them to DECLARED_AHEAD_MODULES in ` +
-        `games-repo-contract-check.ts. If games-repo removed them, update GAME_KIT_MODULES.`,
+        `Undeclared or expired website-ahead modules: ${invalidExtras.join(', ')}.\n` +
+        `  If these are intentional new modules, add a short-lived deadline to ` +
+        `WEBSITE_AHEAD_EXPIRY in games-repo-contract-check.ts. Remove it as soon as the paired ` +
+        `games change lands; if games-repo removed the module, update GAME_KIT_MODULES.`,
     };
   }
   if (remoteModules.join(',') !== localModules.join(',')) {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -53,6 +53,7 @@ describe('games-repo-contract (website half)', () => {
       'gfx',
       'gfx3d',
       'racing',
+      'football',
       'effects',
       'audio',
       'party',
@@ -79,7 +80,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'ai', 'gameplay',
-        'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
+        'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;
     `;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -31,8 +31,9 @@ export const GAME_KIT_MODULES = [
   'actors',
   'gfx',
   'gfx3d',
-  // Genre vertical: the GitHub client bundles its private shared/verticals/racing graph.
+  // Genre verticals: the GitHub client bundles their private shared/verticals graphs.
   'racing',
+  'football',
   'effects',
   'audio',
   'party',

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -727,13 +727,13 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
-  it('bundles an opt-in GameKit vertical from its private TypeScript graph', async () => {
+  it('bundles opt-in GameKit verticals from their private TypeScript graphs', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/racer/index.html', '<canvas id="game"></canvas>'],
-      ['games/racer/game.ts', 'GameKit.mount({ vertical: GameKit.circuitRacer });'],
+      ['games/racer/game.ts', 'GameKit.mount({ verticals: [GameKit.circuitRacer, GameKit.arcadeFootball] });'],
       ['games/racer/style.css', '.game {}'],
       ['games/racer/SPEC.md', specMd({ title: 'Racer' })],
-      ['games/racer/GAME.json', JSON.stringify({ engine: { modules: ['racing'] } })],
+      ['games/racer/GAME.json', JSON.stringify({ engine: { modules: ['racing', 'football'] } })],
       ['shared/game-shell.css', '.shell {}'],
       ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
       [
@@ -741,6 +741,14 @@ describe('getGameSources', () => {
         "import { createRace } from './simulation.ts'; Object.assign(GameKit, { circuitRacer: { createRace } });",
       ],
       ['shared/verticals/racing/simulation.ts', "export function createRace(): string { return 'vertical-loaded'; }"],
+      [
+        'shared/verticals/football/index.ts',
+        "import { createMatch } from './simulation.ts'; Object.assign(GameKit, { arcadeFootball: { createMatch } });",
+      ],
+      [
+        'shared/verticals/football/simulation.ts',
+        "export function createMatch(): string { return 'football-vertical-loaded'; }",
+      ],
     ]);
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const pathname = new URL(String(input)).pathname;
@@ -754,6 +762,7 @@ describe('getGameSources', () => {
     const sources = await client.getGameSources('main', 'racer');
 
     expect(sources?.gameJs).toContain('vertical-loaded');
+    expect(sources?.gameJs).toContain('football-vertical-loaded');
     expect(sources?.gameJs).not.toContain('import ');
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -73,6 +73,7 @@ const MAX_SOURCE_GRAPH_MODULES = 64;
 const MAX_SOURCE_GRAPH_BYTES = 200 * 1024;
 const GAME_KIT_MODULE_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
   racing: 'shared/verticals/racing/index.ts',
+  football: 'shared/verticals/football/index.ts',
 };
 
 /**


### PR DESCRIPTION
## What changed

- add `football` to the canonical GameKit module contract
- bundle `shared/verticals/football/index.ts` and its private TypeScript graph for GitHub-served games
- update the games-repo contract fixture and website-ahead compatibility list
- cover the new vertical entry in contract and GitHub assembler tests

## Why

The games repository now has a reusable opt-in arcade-football vertical used by three games. The website assembler must recognize and bundle that module before those game changes can merge.

## Impact

This is compatibility-only for existing games. Games selecting `football` can be assembled for previews and serving once the paired games-repo PR lands.

Merge this PR before the paired games-repo PR.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` (2,085 API tests plus all other workspaces)
- `npm run build`
