### PR TITLE
feat: continue_draft, Studio honesty after green, MCP presence pulses

### DIFF
--- a/apps/api/src/agent-game-key-resolve.ts
+++ b/apps/api/src/agent-game-key-resolve.ts
@@ -64,6 +64,19 @@ export async function findActiveRoundForSlug(
 }
 
 /**
+ * Newest unpublished draft job for this slug owned by the creator, or null.
+ * Used by MCP `continue_draft` — post-publish work uses `open_round` instead.
+ */
+export async function findDraftJobForSlug(
+  store: Store,
+  slug: string,
+  creatorUid: string,
+): Promise<SubmissionRecord | null> {
+  const bySlug = await store.listSubmissionsBySlug(slug);
+  return bySlug.find((job) => job.ownerUid === creatorUid && !job.abandonedAt && !job.publishedAt) ?? null;
+}
+
+/**
  * Signature, generation, expiry, and slug ownership — shared by `start` and `open_round`.
  * Does not require an open round or a published game.
  */

--- a/apps/api/src/agent-game-key.ts
+++ b/apps/api/src/agent-game-key.ts
@@ -27,7 +27,8 @@ export const DEFAULT_GAME_AGENT_KEY_TTL_DAYS = 90;
  * there is simply no self-build round open for the agent to join.
  */
 export const NO_OPEN_ROUND_REASON =
-  'no build round is open for this game; ask the creator to request a change in their Studio thread';
+  'no build round is open for this game; for an unpublished draft call continue_draft({ feedback }) then start(), ' +
+  'or ask the creator to request a change in their Studio thread';
 
 /** Active round exists but is platform-built — not the creator's agent's turn. */
 export const PLATFORM_ROUND_REASON =
@@ -65,7 +66,17 @@ export const ROTATED_GAME_KEY_REASON =
   'this game key was rotated — get a fresh prompt from the Studio thread for this game';
 
 /** `open_round` only applies after the game has shipped. */
-export const GAME_NOT_PUBLISHED_REASON = 'this game is not published yet — improvement rounds open only after publish';
+export const GAME_NOT_PUBLISHED_REASON =
+  'this game is not published yet — improvement rounds open only after publish; ' +
+  'to keep iterating on the draft call continue_draft({ feedback }) then start()';
+
+/** `continue_draft` only applies before the game has shipped. */
+export const GAME_ALREADY_PUBLISHED_REASON =
+  'this game is already published — call open_round({ feedback }) then start() for an improvement round';
+
+/** Draft job exists but cannot be reopened from its current state. */
+export const DRAFT_NOT_CONTINUABLE_REASON =
+  'this draft cannot be continued right now — wait for the current step to finish, or ask the creator in Studio';
 
 /** Creator daily improvement quota exhausted on the agent-open path. */
 export const IMPROVEMENT_QUOTA_EXHAUSTED_REASON =

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -101,6 +101,16 @@ describe('transition rules', () => {
     expect(canTransition('ready_for_review', 'needs_changes')).toBe(true);
   });
 
+  it('lets a green draft reopen into another build round before publish', () => {
+    // Studio feedback and MCP continue_draft resume the same job; without this the
+    // dispatch succeeds and the state stays ready_for_review forever.
+    expect(canTransition('ready_for_review', 'building')).toBe(true);
+    expect(canTransition('ready_for_review', 'queued')).toBe(true);
+    expect(canTransition('ready_for_review', 'dispatched')).toBe(true);
+    // Still no shortcut past moderation into a live game.
+    expect(canTransition('ready_for_review', 'published')).toBe(false);
+  });
+
   // A gate-red round is not always over: `mustFixGate` tells the live session to fix the
   // cause and deliver again without a new dispatch. agent-channel records that upload
   // only when this holds, so refusing it stranded a game the agent had already repaired.

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -88,7 +88,11 @@ const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   // long as the creator kept the page open.
   submitted: ['gating', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
   gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
-  ready_for_review: ['publishing', 'needs_changes', 'canceled', 'abandoned'],
+  // `building` (and the queue/dispatch that precede a fresh round) let a creator or
+  // their agent continue iterating after a green gate without waiting on publish —
+  // Studio feedback and MCP `continue_draft` both land here. Reviewer reject still
+  // goes through `needs_changes`; publish still goes through `publishing`.
+  ready_for_review: ['publishing', 'needs_changes', 'building', 'queued', 'dispatched', 'canceled', 'abandoned'],
   // A failed bake must be able to fall back, or a job strands with no way home.
   publishing: ['published', 'needs_changes', 'failed'],
   // Improvements start a *new* job, so publishing is terminal for this one.

--- a/apps/api/src/mcp-continue-draft.test.ts
+++ b/apps/api/src/mcp-continue-draft.test.ts
@@ -255,4 +255,24 @@ describe('MCP continue_draft', () => {
     expect((structured as { error: string }).error).toMatch(/publishing/i);
     expect((structured as { error: string }).error).not.toBe(DRAFT_NOT_CONTINUABLE_REASON);
   });
+
+  it('adopts a legacy draft with no state into building', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(DRAFT_ISSUE, OWNER, 'Legacy Draft');
+    await store.setSubmissionSlug(DRAFT_ISSUE, SLUG);
+    await store.setRoundBuilder(DRAFT_ISSUE, 'self');
+    await store.ensureGameAgentKey(SLUG, OWNER, '2026-08-01T12:00:00.000Z');
+    // No recordJobTransition — state stays undefined (pre-job-model shape).
+    expect((await store.getSubmission(DRAFT_ISSUE))?.state).toBeUndefined();
+    app = await createApp(store);
+
+    const { structured, isError } = await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'Pick up this legacy draft and keep going.',
+    });
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ jobId: DRAFT_ISSUE, alreadyOpen: false });
+    const job = await store.getSubmission(DRAFT_ISSUE);
+    expect(job?.state).toBe('building');
+  });
 });

--- a/apps/api/src/mcp-continue-draft.test.ts
+++ b/apps/api/src/mcp-continue-draft.test.ts
@@ -1,0 +1,258 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mintCreatorAgentKey } from './agent-creator-key.js';
+import {
+  DRAFT_NOT_CONTINUABLE_REASON,
+  GAME_ALREADY_PUBLISHED_REASON,
+  mintGameAgentKey,
+  NO_OPEN_ROUND_REASON,
+  SLUG_NOT_ON_ACCOUNT_REASON,
+} from './agent-game-key.js';
+import { buildApp } from './app.js';
+import type { ContentChecker } from './moderation.js';
+import type { GamesStore } from './games-store.js';
+import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import { InMemoryStore } from './store.js';
+import { NoopTranslator } from './translate.js';
+
+const secret = 'continue-draft-test-secret';
+const OWNER = 'g:owner';
+const SLUG = 'pong-draft';
+const DRAFT_ISSUE = 1000018;
+
+function stubGitHub(): GitHubClient {
+  return {
+    createIssue: async () => ({ number: DRAFT_ISSUE }),
+    getIssueState: async () => ({ state: 'open' as const }),
+    findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
+    createIssueComment: async () => ({ id: 1 }),
+    updateIssueBody: async () => {},
+    closeIssue: async () => {},
+    closePullRequest: async () => {},
+    ensureOpenPullRequest: async () => ({ number: 1 }),
+    deleteBranch: async () => {},
+    getGameSources: async (): Promise<GameSources | null> => null,
+    getGameMedia: async () => null,
+    getCatalog: async (): Promise<CatalogGameEntry[]> => [],
+    getProgressNotes: async () => null,
+  };
+}
+
+async function createApp(store: InMemoryStore, contentChecker?: ContentChecker) {
+  return buildApp({
+    store,
+    sessionSecret: 'dev-session-secret-change-me',
+    ...(contentChecker ? { contentChecker } : {}),
+    submissionRoutes: {
+      githubClient: stubGitHub(),
+      githubToken: 'gh-token',
+      submissionTokenSecret: secret,
+      translator: new NoopTranslator(),
+      agentChannel: {} as { gamesStore?: GamesStore },
+    },
+  });
+}
+
+async function seedGreenDraft(store: InMemoryStore) {
+  await store.createSubmission(DRAFT_ISSUE, OWNER, 'Pong Draft');
+  await store.setSubmissionSlug(DRAFT_ISSUE, SLUG);
+  await store.setRoundBuilder(DRAFT_ISSUE, 'self');
+  await store.setSubmissionDeliveredVersion(DRAFT_ISSUE, 'v1');
+  await store.recordJobTransition(DRAFT_ISSUE, {
+    to: 'ready_for_review',
+    at: '2026-08-01T12:00:00.000Z',
+    by: 'gate',
+    reason: 'gate_green',
+  });
+  await store.ensureGameAgentKey(SLUG, OWNER, '2026-08-01T12:00:00.000Z');
+}
+
+function gameKey(generation = 1) {
+  return mintGameAgentKey(secret, {
+    slug: SLUG,
+    creatorUid: OWNER,
+    keyGeneration: generation,
+    now: Date.parse('2026-08-01T12:00:00.000Z'),
+  });
+}
+
+async function mcpCall(
+  app: FastifyInstance,
+  method: string,
+  params?: unknown,
+  headers: Record<string, string> = {},
+  id: string | number = 1,
+) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/mcp',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    payload: { jsonrpc: '2.0', id, method, ...(params !== undefined ? { params } : {}) },
+  });
+}
+
+async function callTool(
+  app: FastifyInstance,
+  name: string,
+  args: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const res = await mcpCall(app, 'tools/call', { name, arguments: args }, headers);
+  expect(res.statusCode).toBe(200);
+  const body = res.json() as {
+    result?: { content?: Array<{ text: string }>; structuredContent?: unknown; isError?: boolean };
+  };
+  const structured =
+    body.result?.structuredContent ??
+    (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
+  return { structured, isError: Boolean(body.result?.isError) };
+}
+
+describe('MCP continue_draft', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  it('reopens a ready_for_review draft into building and lets start join', async () => {
+    const store = new InMemoryStore();
+    await seedGreenDraft(store);
+    app = await createApp(store);
+
+    const startBefore = await callTool(app, 'start', { key: gameKey() });
+    expect(startBefore.isError).toBe(true);
+    expect((startBefore.structured as { error: string }).error).toMatch(/continue_draft/i);
+    expect((startBefore.structured as { error: string }).error).toBe(NO_OPEN_ROUND_REASON);
+
+    const { structured, isError } = await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'Make the paddle wider and add a second ball.',
+    });
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({
+      jobId: DRAFT_ISSUE,
+      slug: SLUG,
+      alreadyOpen: false,
+    });
+
+    const job = await store.getSubmission(DRAFT_ISSUE);
+    expect(job?.state).toBe('building');
+    expect(job?.transitions?.at(-1)).toMatchObject({
+      to: 'building',
+      by: 'agent',
+      reason: 'continue_draft',
+    });
+
+    const started = await callTool(app, 'start', { key: gameKey() });
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({ jobId: DRAFT_ISSUE, slug: SLUG });
+  });
+
+  it('is idempotent while a round is already open', async () => {
+    const store = new InMemoryStore();
+    await seedGreenDraft(store);
+    app = await createApp(store);
+
+    await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'First continue.',
+    });
+    const again = await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'Second continue should not reopen.',
+    });
+    expect(again.isError).toBe(false);
+    expect(again.structured).toMatchObject({ jobId: DRAFT_ISSUE, alreadyOpen: true });
+  });
+
+  it('refuses a published game and points at open_round', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(DRAFT_ISSUE, OWNER, 'Live Game');
+    await store.setSubmissionSlug(DRAFT_ISSUE, SLUG);
+    await store.setSubmissionPublishedAt(DRAFT_ISSUE, '2026-07-01T00:00:00.000Z');
+    await store.recordJobTransition(DRAFT_ISSUE, {
+      to: 'published',
+      at: '2026-07-01T00:00:00.000Z',
+      by: 'operator',
+      reason: 'published',
+    });
+    await store.ensureGameAgentKey(SLUG, OWNER, '2026-08-01T12:00:00.000Z');
+    app = await createApp(store);
+
+    const { structured, isError } = await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'Post-publish work belongs on open_round.',
+    });
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toBe(GAME_ALREADY_PUBLISHED_REASON);
+  });
+
+  it('opens via creator-key Bearer + slug', async () => {
+    const store = new InMemoryStore();
+    await seedGreenDraft(store);
+    await store.ensureCreatorAgentKey(OWNER, new Date().toISOString());
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callTool(
+      app,
+      'continue_draft',
+      { slug: SLUG, feedback: 'Tighten the serve angle.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(false);
+    expect(structured).toMatchObject({ jobId: DRAFT_ISSUE, alreadyOpen: false });
+  });
+
+  it('refuses an unowned slug without blaming the key', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(DRAFT_ISSUE, 'g:other', 'Other');
+    await store.setSubmissionSlug(DRAFT_ISSUE, 'other-slug');
+    await store.ensureCreatorAgentKey(OWNER, new Date().toISOString());
+    const creatorKey = mintCreatorAgentKey(secret, {
+      creatorUid: OWNER,
+      keyGeneration: 1,
+      now: Date.parse('2026-08-01T12:00:00.000Z'),
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callTool(
+      app,
+      'continue_draft',
+      { slug: 'other-slug', feedback: 'Do not rotate for a typo.' },
+      { authorization: `Bearer ${creatorKey}` },
+    );
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toBe(SLUG_NOT_ON_ACCOUNT_REASON);
+  });
+
+  it('refuses a draft that is mid-publish', async () => {
+    const store = new InMemoryStore();
+    await seedGreenDraft(store);
+    await store.recordJobTransition(DRAFT_ISSUE, {
+      to: 'publishing',
+      at: '2026-08-01T12:05:00.000Z',
+      by: 'operator',
+      reason: 'publish_started',
+    });
+    app = await createApp(store);
+
+    const { structured, isError } = await callTool(app, 'continue_draft', {
+      key: gameKey(),
+      feedback: 'Too late — bake is in flight.',
+    });
+    expect(isError).toBe(true);
+    expect((structured as { error: string }).error).toMatch(/publishing/i);
+    expect((structured as { error: string }).error).not.toBe(DRAFT_NOT_CONTINUABLE_REASON);
+  });
+});

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -74,7 +74,10 @@ export function mcpRequestLacksCredential(request: FastifyRequest, message: Json
   if (nonEmptyString(args.sessionKey)) return false;
 
   const toolName = nonEmptyString(toolParams.name);
-  if ((toolName === 'start' || toolName === 'open_round') && nonEmptyString(args.key)) {
+  if (
+    (toolName === 'start' || toolName === 'open_round' || toolName === 'continue_draft') &&
+    nonEmptyString(args.key)
+  ) {
     return false;
   }
 

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   mcpPresenceText,
   MCP_PRESENCE_MIN_GAP_MS,
+  noteMcpPresencePulse,
   shouldEmitMcpPresencePulse,
   shouldPulseMcpPresence,
 } from './mcp-presence.js';
@@ -15,6 +16,10 @@ describe('mcp presence pulses', () => {
     expect(shouldPulseMcpPresence('start')).toBe(false);
     expect(shouldPulseMcpPresence('continue_draft')).toBe(false);
     expect(shouldPulseMcpPresence('open_round')).toBe(false);
+    // Inherited Object keys must not count as tools.
+    expect(shouldPulseMcpPresence('toString')).toBe(false);
+    expect(shouldPulseMcpPresence('constructor')).toBe(false);
+    expect(mcpPresenceText('toString')).toBeNull();
   });
 
   it('maps tools to short Studio-facing copy', () => {
@@ -28,5 +33,15 @@ describe('mcp presence pulses', () => {
     expect(shouldEmitMcpPresencePulse(undefined, t0)).toBe(true);
     expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS - 1)).toBe(false);
     expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS)).toBe(true);
+  });
+
+  it('caps the per-job pulse map by dropping the oldest entries', () => {
+    const pulses = new Map<number, number>();
+    noteMcpPresencePulse(pulses, 1, 100, 2);
+    noteMcpPresencePulse(pulses, 2, 200, 2);
+    noteMcpPresencePulse(pulses, 3, 300, 2);
+    expect([...pulses.keys()]).toEqual([2, 3]);
+    noteMcpPresencePulse(pulses, 2, 400, 2);
+    expect([...pulses.keys()]).toEqual([3, 2]);
   });
 });

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mcpPresenceText,
+  MCP_PRESENCE_MIN_GAP_MS,
+  shouldEmitMcpPresencePulse,
+  shouldPulseMcpPresence,
+} from './mcp-presence.js';
+
+describe('mcp presence pulses', () => {
+  it('pulses kit browse and brief reads, not openers or report_progress', () => {
+    expect(shouldPulseMcpPresence('list_kit_files')).toBe(true);
+    expect(shouldPulseMcpPresence('read_kit_file')).toBe(true);
+    expect(shouldPulseMcpPresence('get_brief')).toBe(true);
+    expect(shouldPulseMcpPresence('report_progress')).toBe(false);
+    expect(shouldPulseMcpPresence('start')).toBe(false);
+    expect(shouldPulseMcpPresence('continue_draft')).toBe(false);
+    expect(shouldPulseMcpPresence('open_round')).toBe(false);
+  });
+
+  it('maps tools to short Studio-facing copy', () => {
+    expect(mcpPresenceText('list_kit_files')).toMatch(/Creator Kit/i);
+    expect(mcpPresenceText('get_gate_verdict')).toMatch(/checks/i);
+    expect(mcpPresenceText('start')).toBeNull();
+  });
+
+  it('rate-limits pulses per job', () => {
+    const t0 = 1_000_000;
+    expect(shouldEmitMcpPresencePulse(undefined, t0)).toBe(true);
+    expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS - 1)).toBe(false);
+    expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS)).toBe(true);
+  });
+});

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -1,0 +1,61 @@
+/**
+ * Coarse Studio presence pulses from MCP tool activity.
+ *
+ * ChatGPT Apps (and similar) often browse the kit for many turns with few
+ * `report_progress` writes. Studio then looks idle even though the agent is busy.
+ * These pulses ride successful session-authenticated tool calls — not 1:1 tool
+ * logging — and are rate-limited so the build-event cap stays healthy.
+ */
+
+/** Minimum gap between synthetic presence events for one job. */
+export const MCP_PRESENCE_MIN_GAP_MS = 60_000;
+
+/** Tools that already write real progress / open rounds — never synthesize for these. */
+const NO_PULSE = new Set([
+  'start',
+  'create_game',
+  'open_round',
+  'continue_draft',
+  'report_progress',
+  'send_screenshot',
+  'submit_sources',
+  'ack_inbox',
+]);
+
+const PRESENCE_COPY: Record<string, string> = {
+  get_brief: 'Reading the build brief…',
+  get_seed: 'Loading the seed draft…',
+  get_kit: 'Fetching Creator Kit metadata…',
+  list_kit_files: 'Browsing the Creator Kit…',
+  search_kit_files: 'Searching the Creator Kit…',
+  read_kit_file: 'Reading Creator Kit files…',
+  read_kit_file_fragment: 'Reading Creator Kit files…',
+  get_sources: 'Loading existing game sources…',
+  list_examples: 'Browsing example games…',
+  get_example: 'Reading an example game…',
+  read_inbox: 'Checking creator notes…',
+  get_gate_verdict: 'Waiting on automated checks…',
+  get_gate_media: 'Reviewing gate captures…',
+};
+
+export function shouldPulseMcpPresence(toolName: string): boolean {
+  if (NO_PULSE.has(toolName)) return false;
+  return toolName in PRESENCE_COPY;
+}
+
+export function mcpPresenceText(toolName: string): string | null {
+  return PRESENCE_COPY[toolName] ?? null;
+}
+
+/**
+ * Whether enough time has passed since the last pulse for this job.
+ * Pure so tests can drive the clock; callers own the last-pulse map.
+ */
+export function shouldEmitMcpPresencePulse(
+  lastPulseAtMs: number | undefined,
+  nowMs: number,
+  minGapMs: number = MCP_PRESENCE_MIN_GAP_MS,
+): boolean {
+  if (lastPulseAtMs === undefined) return true;
+  return nowMs - lastPulseAtMs >= minGapMs;
+}

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -40,11 +40,34 @@ const PRESENCE_COPY: Record<string, string> = {
 
 export function shouldPulseMcpPresence(toolName: string): boolean {
   if (NO_PULSE.has(toolName)) return false;
-  return toolName in PRESENCE_COPY;
+  // Own-property only — `in` would also match inherited keys like `toString`.
+  return Object.hasOwn(PRESENCE_COPY, toolName);
 }
 
 export function mcpPresenceText(toolName: string): string | null {
-  return PRESENCE_COPY[toolName] ?? null;
+  return Object.hasOwn(PRESENCE_COPY, toolName) ? PRESENCE_COPY[toolName]! : null;
+}
+
+/** Cap for the in-process last-pulse map — oldest entries drop first (insertion order). */
+export const MAX_PRESENCE_PULSE_JOBS = 2_000;
+
+/**
+ * Record a pulse timestamp with a simple LRU cap so long-lived instances cannot grow
+ * the map without bound. Pure aside from mutating `pulses`.
+ */
+export function noteMcpPresencePulse(
+  pulses: Map<number, number>,
+  jobId: number,
+  atMs: number,
+  maxJobs: number = MAX_PRESENCE_PULSE_JOBS,
+): void {
+  pulses.delete(jobId);
+  pulses.set(jobId, atMs);
+  while (pulses.size > maxJobs) {
+    const oldest = pulses.keys().next().value;
+    if (oldest === undefined) break;
+    pulses.delete(oldest);
+  }
 }
 
 /**

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1214,7 +1214,7 @@ describe('POST /api/mcp (BY-05)', () => {
     for (const name of ['submit_sources', 'ack_inbox']) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(true);
     }
-    for (const name of ['get_brief', 'list_examples', 'start', 'open_round', 'report_progress']) {
+    for (const name of ['get_brief', 'list_examples', 'start', 'open_round', 'continue_draft', 'report_progress']) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(false);
     }
 
@@ -1234,7 +1234,15 @@ describe('POST /api/mcp (BY-05)', () => {
     for (const name of readers) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(true);
     }
-    const writers = ['start', 'open_round', 'report_progress', 'send_screenshot', 'submit_sources', 'ack_inbox'];
+    const writers = [
+      'start',
+      'open_round',
+      'continue_draft',
+      'report_progress',
+      'send_screenshot',
+      'submit_sources',
+      'ack_inbox',
+    ];
     for (const name of writers) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(false);
     }
@@ -1251,7 +1259,15 @@ describe('POST /api/mcp (BY-05)', () => {
 
     // Only these: the rest return the channel's body verbatim, and declaring a shape
     // this file does not construct would be asserting a contract it cannot keep.
-    for (const name of ['start', 'create_game', 'open_round', 'get_sources', 'list_examples', 'report_progress']) {
+    for (const name of [
+      'start',
+      'create_game',
+      'open_round',
+      'continue_draft',
+      'get_sources',
+      'list_examples',
+      'report_progress',
+    ]) {
       expect(tools.find((tool) => tool.name === name)?.outputSchema?.type, name).toBe('object');
     }
     const startSchema = tools.find((tool) => tool.name === 'start')?.outputSchema as {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -27,7 +27,12 @@ import {
   resolveGameAgentKeyForStart,
   verifyDurableGameAgentKey,
 } from './agent-game-key-resolve.js';
-import { mcpPresenceText, shouldEmitMcpPresencePulse, shouldPulseMcpPresence } from './mcp-presence.js';
+import {
+  mcpPresenceText,
+  noteMcpPresencePulse,
+  shouldEmitMcpPresencePulse,
+  shouldPulseMcpPresence,
+} from './mcp-presence.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -2387,7 +2392,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           if (presenceText && jobId !== null) {
             const at = now();
             if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
-              presencePulseByJob.set(jobId, at);
+              noteMcpPresencePulse(presencePulseByJob, jobId, at);
               try {
                 await store.appendBuildEvent(jobId, { kind: 'step', text: presenceText });
               } catch (pulseError) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -9,6 +9,8 @@ import {
 } from './agent-creator-key-resolve.js';
 import {
   looksLikeGameAgentKey,
+  DRAFT_NOT_CONTINUABLE_REASON,
+  GAME_ALREADY_PUBLISHED_REASON,
   GAME_KEY_GOES_IN_KEY_ARG_REASON,
   IMPROVEMENT_QUOTA_EXHAUSTED_REASON,
   NO_OPEN_ROUND_REASON,
@@ -20,9 +22,12 @@ import {
 import {
   creatorOwnsSlug,
   findActiveRoundForSlug,
+  findDraftJobForSlug,
   resolveGameAgentKeyForOpenRound,
   resolveGameAgentKeyForStart,
+  verifyDurableGameAgentKey,
 } from './agent-game-key-resolve.js';
+import { mcpPresenceText, shouldEmitMcpPresencePulse, shouldPulseMcpPresence } from './mcp-presence.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -115,6 +120,17 @@ export interface McpServerOptions {
     ownerUid?: string;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
   /**
+   * Reopens an unpublished draft after a closed round (gate-green ready_for_review, etc.).
+   * Injected from submissions so MCP and Studio feedback share the same resume path.
+   */
+  continueDraftRound?: (input: {
+    issueNumber: number;
+    feedback: string;
+    locale: string;
+    log: { error: (context: object, message: string) => void };
+    openedBy?: 'creator' | 'agent';
+  }) => Promise<{ ok: true; jobId: number; alreadyOpen: boolean } | { ok: false; reason: string }>;
+  /**
    * Creates a game, running the identical sequence Studio's POST /api/submissions runs.
    * Injected rather than reimplemented so the two surfaces cannot drift on beta gating,
    * moderation, the creation circuit-breaker or quota.
@@ -131,6 +147,7 @@ export interface McpServerOptions {
   >;
   contentChecker?: ContentChecker;
   dailyImprovementQuota?: number;
+  dailyFeedbackQuota?: number;
 }
 
 interface JsonRpcRequest {
@@ -195,6 +212,25 @@ function toolErr(message: string, data?: unknown): ToolResult {
     structuredContent: payload,
     isError: true,
   };
+}
+
+/** Job id for a coarse presence pulse — sessionKey preferred, else round Bearer. */
+function resolvePresenceJobId(sessionKey: string, bearer: string | null, secret: string): number | null {
+  if (sessionKey && looksLikeMcpSessionKey(sessionKey)) {
+    try {
+      return verifyMcpSessionKey(sessionKey, secret).jobId;
+    } catch {
+      return null;
+    }
+  }
+  if (bearer) {
+    try {
+      return verifyAgentToken(bearer, secret).jobId;
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 function pruneHits(buckets: Map<string, number[]>, key: string, currentTime: number): number[] {
@@ -271,7 +307,8 @@ const SESSION_WORKFLOW: readonly string[] = [
   // Green closes the round before the next tool call; writes and non-receipt reads then
   // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
   // happen on earlier write replies — do not instruct post-green tools (Codex P1).
-  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict and get_gate_media may still answer via terminal receipt).',
+  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict and get_gate_media may still answer via terminal receipt). ' +
+    'If the creator wants more changes before publish, call continue_draft({ feedback }) then start() — do not call open_round on an unpublished draft.',
 ];
 
 /**
@@ -290,8 +327,9 @@ const INBOX_POLICY =
  */
 const RETIRED_KEY_ETIQUETTE =
   'If a call is refused because the round finished, no round is open, or the key was rotated, do not retry and do not ' +
-  "report an outage. Tell the creator to open the game's Studio thread — start a new round if none is open, or copy " +
-  'the current kickoff only if they rotated the key; the gamedev.pl MCP connection itself is unchanged.';
+  'report an outage. For an unpublished draft call continue_draft({ feedback }) then start(); for a published game ' +
+  "call open_round({ feedback }) then start(); or tell the creator to open the game's Studio thread. Copy the " +
+  'current kickoff only if they rotated the key — the gamedev.pl MCP connection itself is unchanged.';
 
 /** Human-readable session loop for the text body of `start`. */
 const SESSION_WORKFLOW_TEXT = [
@@ -330,13 +368,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   const now = options.now ?? Date.now;
   const allowedOrigins = options.allowedOrigins ?? parseAllowedOrigins();
   const startImprovementRound = options.startImprovementRound;
+  const continueDraftRound = options.continueDraftRound;
   const createGame = options.createGame;
   const contentChecker = options.contentChecker;
   const dailyImprovementQuota = options.dailyImprovementQuota ?? Number(process.env.DAILY_IMPROVEMENT_QUOTA ?? '2');
+  const dailyFeedbackQuota = options.dailyFeedbackQuota ?? 20;
 
   /** Transport sessions only — never consulted for authorization. */
   const transportSessions = new Map<string, { createdAt: number }>();
   const invalidStartsByIp = new Map<string, number[]>();
+  /** Last synthetic Studio presence pulse per job — coarse MCP activity, not 1:1 tools. */
+  const presencePulseByJob = new Map<number, number>();
 
   function pruneTransportSessions(currentTime: number): void {
     for (const [id, meta] of transportSessions) {
@@ -1186,6 +1228,180 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         } finally {
           await store.finishAgentOpenRound(resolved.slug, at);
         }
+      },
+    },
+
+    continue_draft: {
+      annotations: { title: 'Continue an unpublished draft', ...WRITES_ONCE },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'number' },
+          slug: { type: 'string' },
+          alreadyOpen: { type: 'boolean', description: 'True when a round was already open; not an error.' },
+          next: { type: 'string' },
+        },
+        required: ['jobId', 'slug', 'alreadyOpen'],
+      },
+      description:
+        'Reopen an unpublished draft after a closed round (typically after a green gate). ' +
+        'Accepts a durable per-game key, or Authorization: Bearer (creator key or OAuth access) + slug. ' +
+        'Not for published games — use open_round after publish. ' +
+        'Returns jobId only — call start() next for a sessionKey. Idempotent while a round is already open.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: {
+            type: 'string',
+            description:
+              'Durable per-game key. Optional when using Authorization Bearer (creator key or OAuth) + slug.',
+          },
+          slug: {
+            type: 'string',
+            description: 'Game slug. Required with a creator-key or OAuth Bearer; ignored with a per-game key.',
+          },
+          feedback: {
+            type: 'string',
+            description:
+              'Creator change request for this draft round (≤2000 chars). Treated as untrusted creator text.',
+          },
+        },
+        required: ['feedback'],
+      },
+      handler: async (args, ctx) => {
+        if (!store || !agentTokenSecret || !continueDraftRound || !contentChecker) {
+          return toolErr('the MCP build endpoint is not configured');
+        }
+
+        const key = typeof args.key === 'string' ? args.key.trim() : '';
+        const slugArg = typeof args.slug === 'string' ? args.slug.trim() : '';
+        const bearer = ctx.bearerToken;
+
+        const feedbackRaw = typeof args.feedback === 'string' ? args.feedback.trim() : '';
+        if (!feedbackRaw) {
+          return toolErr('feedback is required — relay what the creator wants changed');
+        }
+        if (feedbackRaw.length > 2000) {
+          return toolErr('feedback is too long (max 2000 characters)');
+        }
+
+        type ContinueResolved = { creatorUid: string; slug: string; draft: SubmissionRecord };
+
+        let resolved: ContinueResolved;
+
+        if (!key && bearer && looksLikeCreatorAgentKey(bearer)) {
+          if (!slugArg) {
+            return toolErr('slug is required when using a creator key — pass the game slug to continue');
+          }
+          const verified = await verifyDurableCreatorAgentKey(store, bearer, agentTokenSecret, now());
+          if (!verified.ok) return toolErr(verified.reason);
+          if (!(await creatorOwnsSlug(store, slugArg, verified.claims.creatorUid))) {
+            return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+          }
+          if (await store.getPublishedSubmissionBySlug(slugArg)) {
+            return toolErr(GAME_ALREADY_PUBLISHED_REASON);
+          }
+          const draft = await findDraftJobForSlug(store, slugArg, verified.claims.creatorUid);
+          if (!draft) return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+          resolved = { creatorUid: verified.claims.creatorUid, slug: slugArg, draft };
+        } else if (!key && bearer && looksLikeAsAccessToken(bearer)) {
+          const asAccess = await verifyAsAccessToken(store, bearer, now());
+          if (!asAccess) {
+            return toolErr('invalid OAuth access — sign in again from your coding agent');
+          }
+          if (!slugArg) {
+            return toolErr('slug is required when using OAuth — pass the game slug to continue');
+          }
+          if (!(await creatorOwnsSlug(store, slugArg, asAccess.ownerUid))) {
+            return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+          }
+          if (await store.getPublishedSubmissionBySlug(slugArg)) {
+            return toolErr(GAME_ALREADY_PUBLISHED_REASON);
+          }
+          const draft = await findDraftJobForSlug(store, slugArg, asAccess.ownerUid);
+          if (!draft) return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+          resolved = { creatorUid: asAccess.ownerUid, slug: slugArg, draft };
+        } else if (key && looksLikeGameAgentKey(key)) {
+          const verified = await verifyDurableGameAgentKey(store, key, agentTokenSecret, now());
+          if (!verified.ok) return toolErr(verified.reason);
+          if (await store.getPublishedSubmissionBySlug(verified.claims.slug)) {
+            return toolErr(GAME_ALREADY_PUBLISHED_REASON);
+          }
+          const draft = await findDraftJobForSlug(store, verified.claims.slug, verified.claims.creatorUid);
+          if (!draft) return toolErr(SLUG_NOT_ON_ACCOUNT_REASON);
+          resolved = {
+            creatorUid: verified.claims.creatorUid,
+            slug: verified.claims.slug,
+            draft,
+          };
+        } else if (key && looksLikeCreatorAgentKey(key)) {
+          return toolErr('creator key must be sent as Authorization Bearer, not as the key argument');
+        } else if (key) {
+          return toolErr(
+            'continue_draft requires a durable per-game key, or Authorization Bearer (creator key or OAuth) + slug',
+          );
+        } else {
+          return toolErr('pass a durable per-game key, or Authorization Bearer (creator key or OAuth) + slug');
+        }
+
+        // Publishing is still an "active round" for inbox steering, but it must not be
+        // rejoined — the bake owns the job until it finishes or falls back.
+        if (resolved.draft.state === 'publishing') {
+          return toolErr('this game is currently publishing — try again in a moment');
+        }
+
+        const active = await findActiveRoundForSlug(store, resolved.slug, resolved.creatorUid);
+        if (active) {
+          return toolOk({
+            jobId: active.issueNumber,
+            slug: resolved.slug,
+            alreadyOpen: true,
+            next: 'call start({ slug }) to join the build round',
+          });
+        }
+
+        const moderation = await contentChecker.checkFields([feedbackRaw]);
+        if (!moderation.allowed) {
+          logModerationRejection(ctx.request.log, {
+            surface: 'creator_feedback',
+            uid: resolved.creatorUid,
+            category: moderation.category,
+          });
+          return toolErr('content_rejected', { category: moderation.category ?? 'other' });
+        }
+
+        const dateStr = new Date(now()).toISOString().slice(0, 10);
+        const quota = await store.checkAndIncrementQuota(resolved.creatorUid, dateStr, dailyFeedbackQuota, 'feedback');
+        if (!quota.allowed) {
+          if (quota.tier === 'blocked') {
+            return toolErr('account is blocked');
+          }
+          return toolErr("today's feedback limit is used up — try again tomorrow, or from the Studio");
+        }
+
+        const sanitizedFeedback = sanitizeCreatorText(feedbackRaw, { singleLine: false });
+        const continued = await continueDraftRound({
+          issueNumber: resolved.draft.issueNumber,
+          feedback: sanitizedFeedback,
+          locale: resolved.draft.locale ?? 'en',
+          log: ctx.request.log,
+          openedBy: 'agent',
+        });
+        if (!continued.ok) {
+          if (continued.reason === 'already_published') return toolErr(GAME_ALREADY_PUBLISHED_REASON);
+          if (continued.reason === 'publishing') {
+            return toolErr('this game is currently publishing — try again in a moment');
+          }
+          if (continued.reason === 'not_continuable') return toolErr(DRAFT_NOT_CONTINUABLE_REASON);
+          return toolErr('could not continue this draft — try again shortly, or ask the creator in Studio');
+        }
+
+        return toolOk({
+          jobId: continued.jobId,
+          slug: resolved.slug,
+          alreadyOpen: continued.alreadyOpen,
+          next: 'call start({ slug }) to join the build round',
+        });
       },
     },
 
@@ -2163,6 +2379,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               }),
               'mcp session started',
             );
+          }
+        } else if (store && agentTokenSecret && shouldPulseMcpPresence(name)) {
+          // Coarse Studio presence for read-heavy Apps loops that skip report_progress.
+          const presenceText = mcpPresenceText(name);
+          const jobId = resolvePresenceJobId(sessionKeyArg, bearerToken, agentTokenSecret);
+          if (presenceText && jobId !== null) {
+            const at = now();
+            if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
+              presencePulseByJob.set(jobId, at);
+              try {
+                await store.appendBuildEvent(jobId, { kind: 'step', text: presenceText });
+              } catch (pulseError) {
+                request.log.warn({ err: pulseError, jobId, tool: name }, 'mcp presence pulse failed');
+              }
+            }
           }
         }
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2330,7 +2330,12 @@ export class InMemoryStore implements Store {
       transitions: [...(sub.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
       ...(closes ? { roundGeneration: nextRoundGeneration(sub.roundGeneration), roundDeliveryCount: 0 } : {}),
     };
-    if (closes) delete next.seed;
+    if (closes) {
+      delete next.seed;
+      // Signals belong to the round that closed — keeping them makes the next self
+      // round look "connected" before any agent has joined.
+      delete next.lastAgentSignalAt;
+    }
     this.submissions.set(issueNumber, next);
     return true;
   }
@@ -2341,6 +2346,7 @@ export class InMemoryStore implements Store {
     const roundGeneration = nextRoundGeneration(sub.roundGeneration);
     const next: SubmissionRecord = { ...sub, roundGeneration, roundDeliveryCount: 0 };
     delete next.seed;
+    delete next.lastAgentSignalAt;
     this.submissions.set(issueNumber, next);
     return roundGeneration;
   }
@@ -3942,6 +3948,7 @@ export class FirestoreStore implements Store {
           roundDeliveryCount: 0,
         };
         delete next.seed;
+        delete next.lastAgentSignalAt;
         tx.set(ref, next);
       } else {
         tx.set(
@@ -3967,6 +3974,7 @@ export class FirestoreStore implements Store {
       const roundGeneration = nextRoundGeneration(current.roundGeneration);
       const next: SubmissionRecord = { ...current, roundGeneration, roundDeliveryCount: 0 };
       delete next.seed;
+      delete next.lastAgentSignalAt;
       tx.set(ref, next);
       return roundGeneration;
     });

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1063,6 +1063,15 @@ describe('submission routes', () => {
     expect(response.statusCode).toBe(200);
     expect(briefs.at(-1)?.undelivered).toBeUndefined();
     expect(briefs.at(-1)?.feedback).toContain('Make the parcels bigger');
+    // Gate-green closed the round; feedback must reopen the job, not leave it stuck
+    // in ready_for_review while a session quietly starts underneath.
+    const after = await store.getSubmission(job.issueNumber);
+    expect(after?.state).toBe('building');
+    expect(after?.transitions?.at(-1)).toMatchObject({
+      to: 'building',
+      by: 'creator',
+      reason: 'creator_feedback',
+    });
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1044,7 +1044,10 @@ export async function registerSubmissionRoutes(
       if (!input.undelivered && previous?.workspace && previous.workspace !== result.workspace) {
         await releaseWorkspace(input.issueNumber, previous.workspace, input.log);
       }
-      const transition = record?.state
+      // Pass `record.state` even when undefined — planObservedStatusTransition adopts
+      // legacy/partial records into `building`. Guarding on truthy state skipped that
+      // and left continue_draft / feedback with a live dispatch but no durable move.
+      const transition = record
         ? planObservedStatusTransition(
             record.state,
             'building',
@@ -1186,6 +1189,7 @@ export async function registerSubmissionRoutes(
       return { ok: true, jobId: input.issueNumber, alreadyOpen: true };
     }
     // Only states where a new round is the honest next step. Canceled/abandoned stay dead.
+    // `undefined` is a legacy/partial record — resumeBuild adopts it into `building`.
     const state = record.state;
     const continuable =
       state === 'ready_for_review' ||

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1158,6 +1158,71 @@ export async function registerSubmissionRoutes(
   }
 
   /**
+   * Reopens an unpublished draft after the previous round closed (typically gate-green
+   * `ready_for_review`). Same job, new round — not a post-publish improvement.
+   *
+   * Shared by MCP `continue_draft` so Studio feedback and the agent path cannot disagree
+   * about how a closed green draft starts moving again.
+   */
+  async function continueDraftRound(input: {
+    issueNumber: number;
+    feedback: string;
+    locale: string;
+    log: { error: (context: object, message: string) => void };
+    openedBy?: 'creator' | 'agent';
+  }): Promise<{ ok: true; jobId: number; alreadyOpen: boolean } | { ok: false; reason: string }> {
+    if (!store) return { ok: false, reason: 'not_configured' };
+    const record = await store.getSubmission(input.issueNumber);
+    if (!record || record.abandonedAt) {
+      return { ok: false, reason: 'draft_not_found' };
+    }
+    if (record.publishedAt) {
+      return { ok: false, reason: 'already_published' };
+    }
+    if (record.state === 'publishing') {
+      return { ok: false, reason: 'publishing' };
+    }
+    if (isActiveBuildRound(record)) {
+      return { ok: true, jobId: input.issueNumber, alreadyOpen: true };
+    }
+    // Only states where a new round is the honest next step. Canceled/abandoned stay dead.
+    const state = record.state;
+    const continuable =
+      state === 'ready_for_review' ||
+      state === 'failed' ||
+      state === 'needs_changes' ||
+      state === 'queued' ||
+      state === undefined;
+    if (!continuable) {
+      return { ok: false, reason: 'not_continuable' };
+    }
+
+    try {
+      await store.appendCreatorMessage(input.issueNumber, input.feedback);
+    } catch (queueError) {
+      input.log.error({ err: queueError, issueNumber: input.issueNumber }, 'failed to queue continue_draft feedback');
+      return { ok: false, reason: 'queue_failed' };
+    }
+
+    const outcome = await resumeBuild({
+      issueNumber: input.issueNumber,
+      feedback: input.feedback,
+      locale: input.locale,
+      log: input.log,
+      ...(record.deliveredVersion ? {} : { undelivered: true }),
+      builder: 'self',
+      transition: {
+        by: input.openedBy === 'agent' ? 'agent' : 'creator',
+        reason: 'continue_draft',
+      },
+    });
+    if (!outcome.started) {
+      return { ok: false, reason: outcome.reason ?? 'resume_failed' };
+    }
+    return { ok: true, jobId: input.issueNumber, alreadyOpen: false };
+  }
+
+  /**
    * Drops a workspace the job is finished with.
    *
    * Best effort on purpose: the branch holds nothing authoritative — the game is in the
@@ -2887,6 +2952,9 @@ export async function registerSubmissionRoutes(
         log: request.log,
         ...(record?.deliveredVersion ? {} : { undelivered: true }),
         ...(requestedBuilder && isBuilderKind(requestedBuilder) ? { builder: requestedBuilder } : {}),
+        // Name the actor so a ready_for_review → building reopen does not look like a
+        // GitHub-derived observation in the job history.
+        transition: { by: 'creator', reason: 'creator_feedback' },
       });
 
       // Accepted, and honest about what it bought. The message is kept either way — it is
@@ -4295,9 +4363,11 @@ export async function registerSubmissionRoutes(
     gamesStore: options.agentChannel?.gamesStore,
     objectStore: options.agentChannel?.objectStore,
     startImprovementRound,
+    continueDraftRound,
     createGame,
     contentChecker,
     dailyImprovementQuota,
+    dailyFeedbackQuota,
   });
 
   return { githubClient, startImprovementRound };

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -32,6 +32,7 @@ function copyInputFromStatus(status: SubmissionStatus | null | undefined) {
     builder: status?.builder,
     stall: status?.stall,
     failureReason: status?.failure?.reason,
+    phase: status?.phase,
   };
 }
 
@@ -712,6 +713,7 @@ export function SubmissionStatusView({
                     roundBuilder={status.builder && isBuilderKind(status.builder) ? status.builder : undefined}
                     stall={status.stall}
                     failureReason={status.failure?.reason}
+                    phase={status.phase}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                     onPublishedImprove={handleImproved}
                   />
@@ -888,6 +890,7 @@ export function SubmissionStatusView({
                 roundBuilder={status.builder && isBuilderKind(status.builder) ? status.builder : undefined}
                 stall={status.stall}
                 failureReason={status.failure?.reason}
+                phase={status.phase}
                 onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                 onPublishedImprove={handleImproved}
               />
@@ -1093,6 +1096,7 @@ function FeedbackPanel({
   roundBuilder,
   stall,
   failureReason,
+  phase,
   onSent,
   onPublishedImprove,
 }: {
@@ -1109,6 +1113,8 @@ function FeedbackPanel({
   roundBuilder?: BuilderKind;
   stall?: SubmissionStatus['stall'];
   failureReason?: string;
+  /** Internal job phase — gate-green drafts need honest "start your agent" routing. */
+  phase?: SubmissionStatus['phase'];
   onSent: (text: string) => void;
   /**
    * A published-game improvement opened a new job; called with its token so the view
@@ -1151,6 +1157,7 @@ function FeedbackPanel({
     builder: routeBuilder,
     stall: chooseBuilder ? null : stall,
     failureReason: chooseBuilder ? null : failureReason,
+    phase: chooseBuilder ? null : phase,
   });
   const sentSelfKey =
     composerRoute === 'active'

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -79,6 +79,11 @@ describe('selfComposerRoute', () => {
       }),
     ).toBe('waiting');
   });
+
+  it('is waiting after a green gate closes the round', () => {
+    expect(selfComposerRoute({ builder: 'self', phase: 'ready_for_review', stall: null })).toBe('waiting');
+    expect(shouldShowConnectCard({ builder: 'self', phase: 'ready_for_review' })).toBe(true);
+  });
 });
 
 // CP-2 confirmed this pair on a live failed round: the banner told the creator that

--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -18,6 +18,11 @@ export type SelfBuildCopyInput = {
   builder?: 'platform' | 'self' | null;
   stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'gate_not_started' | 'no_agent_yet' | null;
   failureReason?: string | null;
+  /**
+   * Internal job phase when the coarse status is lossy. Gate-green drafts project as
+   * `in_review` / `ready_for_review` with no live session — copy must not claim a check-in.
+   */
+  phase?: string | null;
 };
 
 /**
@@ -39,10 +44,13 @@ export function selfStatusCopy(input: SelfBuildCopyInput): SelfStatusCopy | null
  *
  * Shown before the first agent signal, and again when a connected agent has gone
  * quiet — gamedev.pl cannot wake it, so the paste-ready prompt is the resume path.
+ * Also shown after a green gate closes the round: Studio still looks "live", but no
+ * session will check the inbox until the creator starts their agent again.
  */
 export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
   const copy = selfStatusCopy(input);
-  return copy === 'no_agent_yet' || copy === 'quiet_agent';
+  if (copy === 'no_agent_yet' || copy === 'quiet_agent') return true;
+  return input.builder === 'self' && input.phase === 'ready_for_review';
 }
 
 /**
@@ -51,10 +59,14 @@ export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
  * `waiting` covers both pre-first-signal and quiet — the message is saved, but no
  * agent will see it until the creator starts theirs. `active` means a recent signal
  * so the next check-in will pick the inbox up.
+ *
+ * Gate-green (`ready_for_review`) closes the round and retires the session key, so
+ * claiming a next check-in would be a lie — route as waiting even with a stale stall.
  */
 export function selfComposerRoute(input: SelfBuildCopyInput): SelfComposerRoute | null {
   if (input.builder !== 'self') return null;
   if (input.failureReason === 'self_build_delivery_cap') return 'waiting';
+  if (input.phase === 'ready_for_review') return 'waiting';
   if (input.stall === 'no_agent_yet' || input.stall === 'quiet') return 'waiting';
   return 'active';
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the post-green draft trap seen with ChatGPT Apps (`pong-3` / job `1000018`): after gate green closes the round, `open_round` refuses (unpublished) and `start` refuses (no open round), while Studio still implied the agent would pick up inbox on the next check-in.

### Changes

1. **`continue_draft` MCP tool** — reopen an unpublished draft (typically `ready_for_review`) with feedback, then call `start()`. Same opener auth as `open_round` (game key / creator Bearer+slug / OAuth+slug). Not for published games (`open_round` stays that path).

2. **State machine + Studio feedback** — allow `ready_for_review → building` (and queue/dispatch). `resumeBuild` / feedback now actually move the job; round bump clears `lastAgentSignalAt` so a new self round shows as waiting to connect.

3. **Studio honesty** — self composer routes as `waiting` when `phase === 'ready_for_review'`, and the connect card resurfaces. No more “picks this up on its next check-in” with no live session.

4. **Synthetic Studio presence** — successful session-authenticated MCP reads (kit browse, brief, etc.) append coarse, rate-limited build events so long Apps loops without `report_progress` still show activity in Studio.

### Related

- Soft MCP nudges: #511 (ready for review; still separate).
- Kit browse over MCP: #510 (merged).

### Test plan

- [x] `mcp-continue-draft.test.ts` — reopen, idempotent, published refuse, creator-key path
- [x] `job-state.test.ts` — `ready_for_review → building`
- [x] submissions feedback from `ready_for_review` → `building` + `creator_feedback`
- [x] `selfBuildCopy` waiting/connect for `ready_for_review`
- [x] `mcp-presence` unit tests
- [ ] Full green gate (`type-check`, `lint`, `test`, `build`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

