### PR TITLE
Ignore GSI report-only frame-ancestors noise in e2e

### DIFF
--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -212,6 +212,24 @@ const EXPECTED_NOISE: { pattern: RegExp; why: string }[] = [
     pattern: /Provider's accounts list is empty|\[GSI_LOGGER\]: FedCM get\(\) rejects with NetworkError/,
     why: 'a fresh CI browser has no Google session, so FedCM cannot mint a token',
   },
+  {
+    // Newer Chromium also surfaces Google's own report-only frame-ancestors CSP when
+    // GSI briefly frames accounts.google.com during button init. The directive is
+    // report-only ("violation has been logged, but no further action has been taken"),
+    // so the splash still works — confirmed on the 2026-08-03 #500 deploy where the
+    // anonymous splash assertions passed and only this console line failed the gate.
+    // Narrow to accounts.google.com + report-only wording so a real frame-ancestors
+    // block on our own origin would still fail loudly.
+    pattern: /Framing 'https:\/\/accounts\.google\.com\/' violates the following report-only Content Security Policy/,
+    why: "GSI's report-only frame-ancestors probe on accounts.google.com; not enforced",
+  },
+  {
+    // The companion report POST to Google's CSP collector is blocked by ORB in headless
+    // Chromium (opaque cross-origin response). Same GSI init path as above; the report
+    // never needed to succeed for sign-in to work.
+    pattern: /csp\.withgoogle\.com\/csp\/frame-ancestors\/\S+ :: net::ERR_BLOCKED_BY_ORB/,
+    why: 'Chromium ORB blocks Google CSP report beacons from headless CI',
+  },
 ];
 
 function isExpected(text: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy for #500 ([run](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30837669294)) failed the browser gate on `anonymous-and-mobile.test.ts`, not on the Studio chip change.

The splash itself passed (`.beta-splash`, sign-in present, no catalog cards). The gate then failed because Chromium logged Google’s **report-only** `frame-ancestors` probe while GSI framed `accounts.google.com`, plus an ORB-blocked POST to `csp.withgoogle.com/csp/frame-ancestors/…`.

Same class of noise as the existing FedCM empty-accounts allowlist in `EXPECTED_NOISE`. Prod traffic stayed on the previous revision (`gamedev-app-00749-tiz`); the #500 candidate was never promoted.

## Test plan

- [x] Patterns match the exact log lines from the failed run
- [ ] Merge → deploy should promote #500 + this fix (or re-run after merge)
- [ ] Confirm live traffic moves off `00749-tiz` after a green deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

