### PR TITLE
byoca: make every agent artifact readable without egress (BY-28a)

### DIFF
--- a/apps/api/src/agent-build-media.test.ts
+++ b/apps/api/src/agent-build-media.test.ts
@@ -190,8 +190,66 @@ describe('GET /api/agent/build/media (BY-28)', () => {
       expect(name).toMatch(new RegExp(`^games/${SLUG}/versions/${VERSION}/media/`));
     }
     // The inline frame is the opening shot, so a client that cannot fetch a URL still
-    // sees the game.
-    expect(body.openingShot).toEqual({ file: 'opening.png', png: PNG.toString('base64') });
+    // sees the game. Default is one frame, not all of them.
+    expect(body.frames).toEqual([{ file: 'opening.png', name: 'opening', png: PNG.toString('base64') }]);
+    // The video is URL-only, and the payload says so — the agent that needs to know is
+    // the one that cannot test a URL to find out.
+    expect(body.videoNote).toMatch(/only as a URL/i);
+  });
+
+  it('attaches every frame on frames=all, one on the default, none on frames=none', async () => {
+    // A ChatGPT-side connector can call our tools and nothing else — no shell, no fetch
+    // (owner test, 2026-08-03). For that client a signed URL is a blank experience, so
+    // the bytes have to ride the reply. Bounded, because each frame costs context.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    app = await createApp(store, stubGamesStore(), stubObjectStore().objectStore);
+
+    const all = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?frames=all',
+      headers: agentHeaders(),
+    });
+    expect(all.json().frames.map((f: { name: string }) => f.name)).toEqual(['opening', 'engagement']);
+
+    const none = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?frames=none',
+      headers: agentHeaders(),
+    });
+    expect(none.json().frames).toEqual([]);
+    // URLs are unaffected by the frame budget — a shell-capable agent still gets both.
+    expect(none.json().screenshots).toHaveLength(2);
+
+    const dflt = await app.inject({ method: 'GET', url: '/api/agent/build/media', headers: agentHeaders() });
+    expect(dflt.json().frames).toHaveLength(1);
+    expect(dflt.json().frames[0].name).toBe('opening');
+  });
+
+  it('reports frames the budget dropped rather than silently truncating', async () => {
+    // A caller told it has every frame when it has three is worse off than one that
+    // knows it is looking at a subset.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const many = {
+      captures: Object.fromEntries(
+        ['opening', 'a', 'b', 'c', 'd'].map((name) => [name, { file: `${name === 'opening' ? 'opening' : name}.png` }]),
+      ),
+    };
+    const artifacts = new Map<string, Buffer>([['media/metadata.json', Buffer.from(JSON.stringify(many))]]);
+    for (const name of ['opening', 'a', 'b', 'c', 'd']) artifacts.set(`media/${name}.png`, PNG);
+    app = await createApp(store, stubGamesStore({ artifacts }), stubObjectStore().objectStore);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?frames=all',
+      headers: agentHeaders(),
+    });
+
+    expect(res.json().frames).toHaveLength(3);
+    expect(res.json().framesOmitted).toBe(2);
+    // All five are still reachable by URL for a client that can follow one.
+    expect(res.json().screenshots).toHaveLength(5);
   });
 
   it('serves only filenames the validated metadata declares', async () => {

--- a/apps/api/src/agent-build-media.test.ts
+++ b/apps/api/src/agent-build-media.test.ts
@@ -226,6 +226,41 @@ describe('GET /api/agent/build/media (BY-28)', () => {
     expect(dflt.json().frames[0].name).toBe('opening');
   });
 
+  it('keeps the byte budget a ceiling, counting the frame it is about to add', async () => {
+    // Checking the running total *before* appending makes the budget a floor: three
+    // frames each under the per-shot cap still land ~2.1 MB together against a 1.4 MB
+    // limit. Codex #516 P2.
+    const store = new InMemoryStore();
+    await seedDeliveredJob(store);
+    const big = Buffer.alloc(600 * 1024, 7);
+    const metadata = JSON.stringify({
+      captures: { opening: { file: 'opening.png' }, a: { file: 'a.png' }, b: { file: 'b.png' } },
+    });
+    const artifacts = new Map<string, Buffer>([
+      ['media/metadata.json', Buffer.from(metadata)],
+      ['media/opening.png', big],
+      ['media/a.png', big],
+      ['media/b.png', big],
+    ]);
+    app = await createApp(store, stubGamesStore({ artifacts }), stubObjectStore().objectStore);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/agent/build/media?frames=all',
+      headers: agentHeaders(),
+    });
+
+    // Two fit inside 1.4 MB; the third would cross it and is reported, not carried.
+    const body = res.json();
+    expect(body.frames).toHaveLength(2);
+    expect(body.framesOmitted).toBe(1);
+    const decoded = body.frames.reduce(
+      (sum: number, f: { png: string }) => sum + Buffer.from(f.png, 'base64').length,
+      0,
+    );
+    expect(decoded).toBeLessThanOrEqual(1_400 * 1024);
+  });
+
   it('reports frames the budget dropped rather than silently truncating', async () => {
     // A caller told it has every frame when it has three is worse off than one that
     // knows it is looking at a subset.

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -373,4 +373,107 @@ describe('agent build reads (BY-04)', () => {
       tarballUrl: expect.stringContaining('examples%2Fblock-cascade.tgz'),
     });
   });
+
+  describe('exemplar files for fetchless agents (BY-28a)', () => {
+    const BLOCK = 512;
+
+    function entryBlocks(name: string, body: string): Buffer {
+      const payload = Buffer.from(body, 'utf8');
+      const header = Buffer.alloc(BLOCK);
+      header.write(name, 0, 100, 'utf8');
+      header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+      header.write('0', 156, 1, 'utf8');
+      header.write('ustar\0', 257, 6, 'utf8');
+      const padding = Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK);
+      return Buffer.concat([header, payload, padding]);
+    }
+
+    function exampleObjects() {
+      const tarball = gzipSync(
+        Buffer.concat([
+          entryBlocks('games/block-cascade/SPEC.md', '---\ntitle: Block Cascade\n---\n'),
+          entryBlocks('games/block-cascade/game.ts', 'export const tick = () => {};'),
+          Buffer.alloc(BLOCK * 2),
+        ]),
+      );
+      return new Map<string, Buffer>([
+        ['examples/block-cascade.tgz', tarball],
+        // Present in the bucket, absent from the allowlist — must stay unreachable.
+        ['examples/secret-creator-game.tgz', tarball],
+      ]);
+    }
+
+    it('lists and reads an allowlisted exemplar without any fetching', async () => {
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store, mockObjectStore(exampleObjects()));
+
+      const list = await app.inject({
+        method: 'GET',
+        url: '/api/agent/build/examples/block-cascade/files',
+        headers: agentHeaders(),
+      });
+      expect(list.statusCode).toBe(200);
+      expect(list.json()).toMatchObject({ slug: 'block-cascade', total: 2, truncated: false });
+      expect(list.json().files.map((f: { path: string }) => f.path)).toEqual([
+        'games/block-cascade/game.ts',
+        'games/block-cascade/SPEC.md',
+      ]);
+
+      // Relative path, as an agent would paste it from a listing.
+      const read = await app.inject({
+        method: 'GET',
+        url: '/api/agent/build/examples/block-cascade/file?path=game.ts',
+        headers: agentHeaders(),
+      });
+      expect(read.statusCode).toBe(200);
+      expect(read.json()).toMatchObject({
+        slug: 'block-cascade',
+        path: 'games/block-cascade/game.ts',
+        encoding: 'utf8',
+        content: 'export const tick = () => {};',
+      });
+    });
+
+    it('applies the same allowlist as the tarball route, and refuses traversal', async () => {
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store, mockObjectStore(exampleObjects()));
+
+      for (const url of [
+        '/api/agent/build/examples/secret-creator-game/files',
+        '/api/agent/build/examples/secret-creator-game/file?path=game.ts',
+      ]) {
+        const res = await app.inject({ method: 'GET', url, headers: agentHeaders() });
+        expect(res.statusCode, url).toBe(404);
+        expect(res.json().error).toBe('unknown_example');
+      }
+
+      const traversal = await app.inject({
+        method: 'GET',
+        url: '/api/agent/build/examples/block-cascade/file?path=../../kits/current.json',
+        headers: agentHeaders(),
+      });
+      expect(traversal.statusCode).toBe(400);
+      expect(traversal.json().error).toBe('example_path_invalid');
+    });
+
+    it('requires a build token like every other read', async () => {
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store, mockObjectStore(exampleObjects()));
+
+      for (const url of [
+        '/api/agent/build/examples/block-cascade/files',
+        '/api/agent/build/examples/block-cascade/file?path=game.ts',
+      ]) {
+        const none = await app.inject({ method: 'GET', url });
+        expect(none.statusCode, url).toBe(401);
+
+        const stale = await app.inject({ method: 'GET', url, headers: agentHeaders(ISSUE, 99) });
+        expect(stale.statusCode, url).toBe(401);
+        expect(stale.json().error).toBe(STALE_AGENT_TOKEN_REASON);
+      }
+    });
+  });
 });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1723,7 +1723,7 @@ export async function registerAgentChannelRoutes(
       let framesOmitted = 0;
       let inlineBytes = 0;
       for (const shot of wanted) {
-        if (frames.length >= MAX_INLINE_FRAMES || inlineBytes >= MAX_INLINE_FRAME_BYTES) {
+        if (frames.length >= MAX_INLINE_FRAMES) {
           framesOmitted += 1;
           continue;
         }
@@ -1731,6 +1731,16 @@ export async function registerAgentChannelRoutes(
         // An unreadable or oversized frame is skipped, not fatal: the URLs still stand
         // for clients that can use them, and a partial answer beats a 500.
         if (!body || body.length === 0 || body.length > maxShotBytes) {
+          framesOmitted += 1;
+          continue;
+        }
+        // Measured with this frame included, not before it. Checking the running total
+        // first makes the budget a floor rather than a ceiling: three frames just under
+        // the line individually still land ~2.1 MB together. A frame that would cross
+        // the line is dropped and the scan continues, so a smaller later frame can
+        // still be carried. No starvation: maxShotBytes is below the budget, so the
+        // first frame always fits.
+        if (inlineBytes + body.length > MAX_INLINE_FRAME_BYTES) {
           framesOmitted += 1;
           continue;
         }

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -100,6 +100,17 @@ const MAX_SHOT_LABEL = 120;
  * number alone or uploads pass validation and 500 at `.set()`.
  */
 const maxShotBytes = 700 * 1024;
+/**
+ * Ceilings on frames carried inline by the gate-media read.
+ *
+ * Not a bandwidth limit — a context limit. Every inlined frame is base64 in a tool
+ * reply that some model has to hold, so `frames=all` on an eight-frame capture would
+ * cost more than it informs. Two frames answer nearly every question an agent has
+ * about how its game looks; the rest stay one signed URL away for clients that can
+ * follow one.
+ */
+const MAX_INLINE_FRAMES = 3;
+const MAX_INLINE_FRAME_BYTES = 1_400 * 1024;
 /** Fastify rejects before the handler when the JSON body exceeds this. */
 const shotBodyLimit = Math.ceil((maxShotBytes * 4) / 3) + 4096;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -1481,7 +1492,7 @@ export async function registerAgentChannelRoutes(
         return reply.status(503).send({ error: 'the media store is not configured' });
       }
 
-      const query = request.query as { version?: string };
+      const query = request.query as { version?: string; frames?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
       const version = requestedVersion ?? record.deliveredVersion ?? null;
 
@@ -1592,17 +1603,47 @@ export async function registerAgentChannelRoutes(
           }
         : null;
 
-      // One frame inline, for clients that can render an image but not fetch a URL.
-      // Best effort and bounded: an absent or oversized frame degrades to URLs-only.
-      const openingFile = (storedShots.find((shot) => shot.name === 'opening') ?? storedShots[0])?.file;
-      let openingShot: { file: string; png: string } | null = null;
-      if (openingFile) {
-        const body = await options.gamesStore
-          .getDerivedArtifact(slug, version, `media/${openingFile}`)
-          .catch(() => null);
-        if (body && body.length > 0 && body.length <= maxShotBytes) {
-          openingShot = { file: openingFile, png: body.toString('base64') };
+      // Frames carried *through* the channel, not pointed at.
+      //
+      // A signed URL assumes the reader can open a socket. The agent this endpoint was
+      // built for cannot: a ChatGPT-side connector runs our tools and nothing else — no
+      // shell, no fetch, no egress at all (owner test, 2026-08-03). For that client a
+      // URL is not a degraded experience, it is a blank one, and the same is true of
+      // `get_kit`'s tarball (which is why #510 added file-reading tools rather than
+      // another link). So the bytes ride the reply.
+      //
+      // Bounded, because context is the cost here rather than bandwidth: capture stores
+      // up to eight frames and each may be ~700 KB, which no client should be made to
+      // swallow by default. `opening` answers "did it draw"; `all` is for "show the
+      // creator what it looks like". Whatever the budget drops is reported — a caller
+      // told it has every frame when it has three is worse off than one that knows.
+      const requestedFrames = typeof query.frames === 'string' ? query.frames : 'opening';
+      const frameMode: 'opening' | 'all' | 'none' =
+        requestedFrames === 'all' || requestedFrames === 'none' ? requestedFrames : 'opening';
+
+      const openingFirst = [
+        ...storedShots.filter((shot) => shot.name === 'opening'),
+        ...storedShots.filter((shot) => shot.name !== 'opening'),
+      ];
+      const wanted = frameMode === 'none' ? [] : frameMode === 'all' ? openingFirst : openingFirst.slice(0, 1);
+
+      const frames: Array<{ file: string; name: string; png: string }> = [];
+      let framesOmitted = 0;
+      let inlineBytes = 0;
+      for (const shot of wanted) {
+        if (frames.length >= MAX_INLINE_FRAMES || inlineBytes >= MAX_INLINE_FRAME_BYTES) {
+          framesOmitted += 1;
+          continue;
         }
+        const body = await options.gamesStore.getDerivedArtifact(slug, version, `media/${shot.file}`).catch(() => null);
+        // An unreadable or oversized frame is skipped, not fatal: the URLs still stand
+        // for clients that can use them, and a partial answer beats a 500.
+        if (!body || body.length === 0 || body.length > maxShotBytes) {
+          framesOmitted += 1;
+          continue;
+        }
+        inlineBytes += body.length;
+        frames.push({ file: shot.file, name: shot.name, png: body.toString('base64') });
       }
 
       return reply.send({
@@ -1619,7 +1660,17 @@ export async function registerAgentChannelRoutes(
           : {}),
         screenshots,
         video,
-        ...(openingShot ? { openingShot } : {}),
+        frames,
+        ...(framesOmitted > 0 ? { framesOmitted } : {}),
+        // Said in the payload, not only in the tool description, because the agent that
+        // needs to know is the one that cannot test a URL to find out.
+        ...(video
+          ? {
+              videoNote:
+                'The video is available only as a URL. If you cannot fetch URLs, do not try — ' +
+                'give the link to the creator, who can open it, and describe the game from the frames.',
+            }
+          : {}),
         expiresInSeconds: DEFAULT_SIGNED_URL_TTL_SECONDS,
         access,
       });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_BUILD_ORIENTATION,
 } from './agent-build-brief.js';
 import { getAgentBuildExample, listAgentBuildExamples } from './agent-build-examples.js';
+import { ExampleFilesError, createExampleFileStore, listExampleFiles, readExampleFile } from './example-files.js';
 import {
   assertAgentTokenActive,
   classifyAgentTokenAccess,
@@ -323,11 +324,25 @@ export async function registerAgentChannelRoutes(
   const previewsByBuild = new Map<number, number[]>();
   const submitsByBuild = new Map<number, number[]>();
   const kitFileStore = options.objectStore ? createKitFileStore(options.objectStore) : null;
+  const exampleFileStore = options.objectStore ? createExampleFileStore(options.objectStore) : null;
 
   function optionalFiniteQuery(raw: string | undefined): number | undefined {
     if (raw === undefined) return undefined;
     const value = Number(raw);
     return Number.isFinite(value) ? value : undefined;
+  }
+
+  function sendExampleFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
+    if (error instanceof ExampleFilesError) {
+      const status =
+        error.code === 'example_store_unavailable'
+          ? 503
+          : error.code === 'example_unavailable' || error.code === 'example_file_missing'
+            ? 404
+            : 400;
+      return reply.status(status).send({ error: error.code, message: error.message });
+    }
+    return null;
   }
 
   function sendKitFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
@@ -1398,6 +1413,83 @@ export async function registerAgentChannelRoutes(
         ...(sha256 ? { sha256 } : {}),
         unpack: exampleUnpackCommand(tarballUrl),
       });
+    },
+  );
+
+  /**
+   * Exemplar sources as files, for agents that cannot fetch the tarball.
+   *
+   * Same allowlist gate as the signed-URL route above — the exemplar catalog is a
+   * hand-curated list of first-party slugs, and a slug that is not on it does not
+   * become readable just because a different verb reaches the same bucket. What
+   * changes is only the transport: bytes through the tool instead of a link.
+   */
+  app.get(
+    '/api/agent/build/examples/:slug/files',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
+      if (!example) {
+        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
+      }
+      if (!exampleFileStore) {
+        return reply
+          .status(503)
+          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
+      }
+
+      try {
+        const query = request.query as { prefix?: string; limit?: string; offset?: string };
+        const tree = await exampleFileStore.loadTree(example.slug);
+        return reply.send(
+          listExampleFiles(tree, {
+            prefix: query.prefix,
+            limit: optionalFiniteQuery(query.limit),
+            offset: optionalFiniteQuery(query.offset),
+          }),
+        );
+      } catch (error) {
+        const sent = sendExampleFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  /** One file from an allowlisted exemplar, inline. */
+  app.get(
+    '/api/agent/build/examples/:slug/file',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
+      if (!example) {
+        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
+      }
+      if (!exampleFileStore) {
+        return reply
+          .status(503)
+          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
+      }
+
+      try {
+        const query = request.query as { path?: string; encoding?: string };
+        const encoding = query.encoding === 'base64' ? 'base64' : query.encoding === 'utf8' ? 'utf8' : undefined;
+        if (query.encoding && !encoding) {
+          return reply.status(400).send({ error: 'example_query_invalid', message: 'encoding must be utf8 or base64' });
+        }
+        const tree = await exampleFileStore.loadTree(example.slug);
+        return reply.send(readExampleFile(tree, query.path ?? '', { ...(encoding ? { encoding } : {}) }));
+      } catch (error) {
+        const sent = sendExampleFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
     },
   );
 

--- a/apps/api/src/example-files.test.ts
+++ b/apps/api/src/example-files.test.ts
@@ -1,0 +1,166 @@
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import type { GcsObjectStore } from './gcs-sign.js';
+import {
+  EXAMPLE_READ_MAX_BYTES,
+  ExampleFilesError,
+  createExampleFileStore,
+  exampleRootDir,
+  listExampleFiles,
+  normalizeExamplePath,
+  readExampleFile,
+  type ExampleTree,
+} from './example-files.js';
+
+/**
+ * BY-28a — exemplar sources readable without fetching.
+ *
+ * `get_example` hands back a signed tarball, which assumes the reader can open a
+ * socket. A ChatGPT-side connector cannot, so these are the reads that make the
+ * curated exemplars reachable for that client at all.
+ */
+
+const BLOCK = 512;
+const SLUG = 'block-cascade';
+const ROOT = exampleRootDir(SLUG);
+
+function entryBlocks(name: string, body: Buffer | string): Buffer {
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, 100, 'utf8');
+  header.write(`${payload.length.toString(8).padStart(11, '0')} `, 124, 12, 'utf8');
+  header.write('0', 156, 1, 'utf8');
+  header.write('ustar\0', 257, 6, 'utf8');
+  const padding = Buffer.alloc((BLOCK - (payload.length % BLOCK)) % BLOCK);
+  return Buffer.concat([header, payload, padding]);
+}
+
+function exampleTarball(files: Record<string, Buffer | string>): Buffer {
+  const entries = Object.entries(files).map(([name, body]) => entryBlocks(name, body));
+  return gzipSync(Buffer.concat([...entries, Buffer.alloc(BLOCK * 2)]));
+}
+
+function treeFrom(files: Record<string, Buffer | string>): ExampleTree {
+  const map = new Map<string, Buffer>();
+  for (const [name, body] of Object.entries(files)) {
+    map.set(name, Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8'));
+  }
+  return { slug: SLUG, files: map };
+}
+
+function objectStoreWith(objects: Map<string, Buffer>): GcsObjectStore {
+  return {
+    readObject: async (name) => objects.get(name) ?? null,
+    objectExists: async (name) => objects.has(name),
+    signReadUrl: async (name) => `https://signed.example/${name}`,
+  };
+}
+
+describe('example files (BY-28a)', () => {
+  it('accepts relative and full paths as the same file, and refuses traversal', () => {
+    expect(normalizeExamplePath(SLUG, 'game.ts')).toBe(`${ROOT}/game.ts`);
+    expect(normalizeExamplePath(SLUG, `${ROOT}/game.ts`)).toBe(`${ROOT}/game.ts`);
+    expect(normalizeExamplePath(SLUG, './SPEC.md')).toBe(`${ROOT}/SPEC.md`);
+
+    // A `..` from an untrusted round is a probe, not a typo — refused, not normalized.
+    for (const bad of ['../secret', 'a/../../b', '/etc/passwd', 'a\\b', '']) {
+      expect(() => normalizeExamplePath(SLUG, bad), bad).toThrow(ExampleFilesError);
+    }
+  });
+
+  it('lists files with sizes and kinds, and says when it truncated', () => {
+    const tree = treeFrom({
+      [`${ROOT}/SPEC.md`]: '# Block Cascade',
+      [`${ROOT}/game.ts`]: 'export {};',
+      [`${ROOT}/assets/blip.wav`]: Buffer.from([0, 1, 2, 3]),
+    });
+
+    const all = listExampleFiles(tree);
+    expect(all.slug).toBe(SLUG);
+    expect(all.total).toBe(3);
+    expect(all.truncated).toBe(false);
+    // localeCompare, same ordering rule as the kit listing (case-insensitive, so
+    // SPEC.md sorts after the lowercase names rather than before them).
+    expect(all.files.map((f) => f.path)).toEqual([`${ROOT}/assets/blip.wav`, `${ROOT}/game.ts`, `${ROOT}/SPEC.md`]);
+    expect(all.files.find((f) => f.path.endsWith('.wav'))?.kind).toBe('binary');
+
+    const page = listExampleFiles(tree, { limit: 2 });
+    expect(page.files).toHaveLength(2);
+    // A caller that believes it saw everything will reason about a game it half read.
+    expect(page.truncated).toBe(true);
+
+    const scoped = listExampleFiles(tree, { prefix: 'assets' });
+    expect(scoped.files.map((f) => f.path)).toEqual([`${ROOT}/assets/blip.wav`]);
+  });
+
+  it('reads text inline, requires base64 for binary, and refuses oversized files', () => {
+    const tree = treeFrom({
+      [`${ROOT}/game.ts`]: 'export const tick = () => {};',
+      [`${ROOT}/assets/blip.wav`]: Buffer.from([1, 2, 3]),
+      [`${ROOT}/huge.ts`]: 'x'.repeat(EXAMPLE_READ_MAX_BYTES + 1),
+    });
+
+    expect(readExampleFile(tree, 'game.ts')).toMatchObject({
+      slug: SLUG,
+      path: `${ROOT}/game.ts`,
+      kind: 'text',
+      encoding: 'utf8',
+      content: 'export const tick = () => {};',
+    });
+
+    // Binary defaults to base64 rather than mangling bytes into a string.
+    expect(readExampleFile(tree, 'assets/blip.wav')).toMatchObject({ kind: 'binary', encoding: 'base64' });
+    expect(() => readExampleFile(tree, 'assets/blip.wav', { encoding: 'utf8' })).toThrow(/binary/i);
+
+    expect(() => readExampleFile(tree, 'missing.ts')).toThrow(/no file at/i);
+    // Refused, not silently truncated — a half file reads as a whole one.
+    expect(() => readExampleFile(tree, 'huge.ts')).toThrow(/max/i);
+  });
+
+  it('unpacks a published tarball and caches it', async () => {
+    const objects = new Map<string, Buffer>([
+      [
+        `examples/${SLUG}.tgz`,
+        exampleTarball({ [`${ROOT}/SPEC.md`]: '# Block Cascade', [`${ROOT}/game.ts`]: 'export {};' }),
+      ],
+    ]);
+    let reads = 0;
+    const store = createExampleFileStore({
+      ...objectStoreWith(objects),
+      readObject: async (name) => {
+        reads += 1;
+        return objects.get(name) ?? null;
+      },
+    });
+
+    const tree = await store.loadTree(SLUG);
+    expect([...tree.files.keys()].sort()).toEqual([`${ROOT}/SPEC.md`, `${ROOT}/game.ts`]);
+    await store.loadTree(SLUG);
+    expect(reads).toBe(1);
+  });
+
+  it('drops members outside the exemplar root', async () => {
+    // A tool scoped to one slug must not become a reader for whatever else a future
+    // packer happens to put in the archive.
+    const objects = new Map<string, Buffer>([
+      [
+        `examples/${SLUG}.tgz`,
+        exampleTarball({
+          [`${ROOT}/game.ts`]: 'export {};',
+          'games/some-other-game/game.ts': 'export const leaked = true;',
+          'kits/secret.txt': 'nope',
+        }),
+      ],
+    ]);
+    const store = createExampleFileStore(objectStoreWith(objects));
+
+    const tree = await store.loadTree(SLUG);
+
+    expect([...tree.files.keys()]).toEqual([`${ROOT}/game.ts`]);
+  });
+
+  it('reports an unpublished exemplar rather than throwing something opaque', async () => {
+    const store = createExampleFileStore(objectStoreWith(new Map()));
+    await expect(store.loadTree(SLUG)).rejects.toThrow(/no packed sources/i);
+  });
+});

--- a/apps/api/src/example-files.ts
+++ b/apps/api/src/example-files.ts
@@ -1,0 +1,198 @@
+/**
+ * Exemplar sources as browsable files for MCP / build-channel agents.
+ *
+ * The sibling of `kit-files.ts`, for the same reason and against the same finding:
+ * `get_example` hands back a signed tarball and a `curl … | tar -xz` line, which
+ * assumes the reader can open a socket. A ChatGPT-side connector cannot — it calls
+ * MCP tools and nothing else (owner test, 2026-08-03) — so for that agent the
+ * curated exemplars, the one piece of "here is how a good game is written" context
+ * we offer, were unreachable. This serves list / read over the same
+ * `examples/<slug>.tgz` the publisher already writes.
+ *
+ * Narrower than the kit deliberately. A kit is a whole toolchain (~1.4 MB, hundreds
+ * of files) and needs search and fragments to be navigable; an exemplar is one game
+ * directory — a spec, a handful of modules, some JSON — so list + read covers it,
+ * and a caller that wants to grep can list and read. Members are rooted at
+ * `games/<slug>/` (games-repo `pack-example.ts`), not at a kit root.
+ */
+
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import type { GcsObjectStore } from './gcs-sign.js';
+import { kitFileKind, type KitFileKind } from './kit-files.js';
+import { readTarEntries } from './tar.js';
+
+/** Whole-file reads above this are refused — an exemplar module is never this big. */
+export const EXAMPLE_READ_MAX_BYTES = 64 * 1024;
+/** Default / hard caps for list. */
+export const EXAMPLE_LIST_DEFAULT_LIMIT = 200;
+export const EXAMPLE_LIST_MAX_LIMIT = 500;
+/** Reject an absurdly large exemplar tarball rather than OOM. */
+export const EXAMPLE_TREE_MAX_BYTES = 4 * 1024 * 1024;
+/** Exemplars are small and re-read across a round; keep a few warm. */
+const EXAMPLE_TREE_CACHE_CAPACITY = 3;
+
+export class ExampleFilesError extends Error {
+  readonly code:
+    | 'example_store_unavailable'
+    | 'example_unavailable'
+    | 'example_path_invalid'
+    | 'example_file_missing'
+    | 'example_file_too_large'
+    | 'example_file_binary'
+    | 'example_query_invalid';
+
+  constructor(code: ExampleFilesError['code'], message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.code = code;
+    this.name = 'ExampleFilesError';
+  }
+}
+
+export interface ExampleFileMeta {
+  path: string;
+  bytes: number;
+  kind: KitFileKind;
+}
+
+export interface ExampleTree {
+  slug: string;
+  /** Keyed by full member path (`games/<slug>/…`). */
+  files: Map<string, Buffer>;
+}
+
+/** The archive root for one exemplar, matching the games-repo packer. */
+export function exampleRootDir(slug: string): string {
+  return `games/${slug}`;
+}
+
+/**
+ * Resolve a caller-supplied path against the exemplar root.
+ *
+ * Accepts both `game.ts` and `games/<slug>/game.ts` so an agent that pasted a path
+ * out of a list reply gets the same file as one that typed a relative name. Traversal
+ * is refused rather than normalized away: `..` in a path handed to us by an untrusted
+ * round is a probe, not a typo.
+ */
+export function normalizeExamplePath(slug: string, raw: string): string {
+  const trimmed = (raw ?? '').trim().replace(/^\.\//, '');
+  if (!trimmed) {
+    throw new ExampleFilesError('example_path_invalid', 'path is required');
+  }
+  if (trimmed.startsWith('/') || trimmed.includes('\\')) {
+    throw new ExampleFilesError('example_path_invalid', `invalid path: ${raw}`);
+  }
+  const segments = trimmed.split('/');
+  if (segments.some((segment) => segment === '..' || segment === '.')) {
+    throw new ExampleFilesError('example_path_invalid', `invalid path: ${raw}`);
+  }
+  const root = exampleRootDir(slug);
+  if (trimmed === root || trimmed.startsWith(`${root}/`)) return trimmed;
+  return `${root}/${trimmed}`;
+}
+
+export function listExampleFiles(
+  tree: ExampleTree,
+  options: { prefix?: string; limit?: number; offset?: number } = {},
+): { slug: string; files: ExampleFileMeta[]; total: number; truncated: boolean } {
+  const limit = Math.min(
+    Math.max(1, Number.isFinite(options.limit) ? (options.limit as number) : EXAMPLE_LIST_DEFAULT_LIMIT),
+    EXAMPLE_LIST_MAX_LIMIT,
+  );
+  const offset = Math.max(0, Number.isFinite(options.offset) ? (options.offset as number) : 0);
+  const prefix = options.prefix?.trim() ? normalizeExamplePath(tree.slug, options.prefix) : '';
+
+  const all: ExampleFileMeta[] = [];
+  for (const [path, bytes] of tree.files) {
+    if (prefix && path !== prefix && !path.startsWith(`${prefix}/`)) continue;
+    all.push({ path, bytes: bytes.length, kind: kitFileKind(path, bytes) });
+  }
+  all.sort((a, b) => a.path.localeCompare(b.path));
+  const slice = all.slice(offset, offset + limit);
+  return {
+    slug: tree.slug,
+    files: slice,
+    total: all.length,
+    // Said rather than implied: a caller that believes it listed everything will
+    // reason about an exemplar it has only partly seen.
+    truncated: offset + slice.length < all.length,
+  };
+}
+
+export function readExampleFile(
+  tree: ExampleTree,
+  rawPath: string,
+  options: { encoding?: 'utf8' | 'base64' } = {},
+): { slug: string; path: string; bytes: number; kind: KitFileKind; encoding: 'utf8' | 'base64'; content: string } {
+  const path = normalizeExamplePath(tree.slug, rawPath);
+  const bytes = tree.files.get(path);
+  if (!bytes) {
+    throw new ExampleFilesError('example_file_missing', `no file at ${path} in exemplar ${tree.slug}`);
+  }
+  const kind = kitFileKind(path, bytes);
+  const encoding = options.encoding ?? (kind === 'binary' ? 'base64' : 'utf8');
+  if (kind === 'binary' && encoding !== 'base64') {
+    throw new ExampleFilesError('example_file_binary', `${path} is binary — pass encoding=base64`);
+  }
+  if (bytes.length > EXAMPLE_READ_MAX_BYTES) {
+    throw new ExampleFilesError(
+      'example_file_too_large',
+      `${path} is ${bytes.length} bytes (max ${EXAMPLE_READ_MAX_BYTES}) — read a smaller file`,
+    );
+  }
+  return {
+    slug: tree.slug,
+    path,
+    bytes: bytes.length,
+    kind,
+    encoding,
+    content: encoding === 'base64' ? bytes.toString('base64') : bytes.toString('utf8'),
+  };
+}
+
+async function unpackExampleTarball(slug: string, tarball: Buffer): Promise<Map<string, Buffer>> {
+  const files = new Map<string, Buffer>();
+  const root = exampleRootDir(slug);
+  const gunzipped = Readable.from(tarball).pipe(createGunzip());
+  for await (const entry of readTarEntries(gunzipped, { maxTotalBytes: EXAMPLE_TREE_MAX_BYTES })) {
+    // Anything outside this exemplar's own directory is dropped. The packer should
+    // never produce such a member; if a future one does, it must not become readable
+    // through a tool scoped to one slug.
+    if (entry.path !== root && !entry.path.startsWith(`${root}/`)) continue;
+    files.set(entry.path, Buffer.from(entry.bytes));
+  }
+  if (files.size === 0) {
+    throw new ExampleFilesError('example_unavailable', `exemplar ${slug} contained no files under ${root}`);
+  }
+  return files;
+}
+
+export interface ExampleFileStore {
+  loadTree(slug: string): Promise<ExampleTree>;
+}
+
+export function createExampleFileStore(objectStore: GcsObjectStore): ExampleFileStore {
+  const cache = new Map<string, ExampleTree>();
+
+  function remember(tree: ExampleTree): ExampleTree {
+    cache.set(tree.slug, tree);
+    while (cache.size > EXAMPLE_TREE_CACHE_CAPACITY) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined || oldest === tree.slug) break;
+      cache.delete(oldest);
+    }
+    return tree;
+  }
+
+  return {
+    async loadTree(slug) {
+      const cached = cache.get(slug);
+      if (cached) return cached;
+      const body = await objectStore.readObject(`examples/${slug}.tgz`);
+      if (!body) {
+        throw new ExampleFilesError('example_unavailable', `no packed sources for exemplar ${slug}`);
+      }
+      return remember({ slug, files: await unpackExampleTarball(slug, body) });
+    },
+  };
+}

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1393,7 +1393,7 @@ describe('POST /api/mcp (BY-05)', () => {
           deliveryId: string;
           screenshots: Array<{ file: string; url: string }>;
           video: { file: string; url: string };
-          openingShot?: { file: string; attached: boolean };
+          frames?: Array<{ file: string; name: string; attached: boolean }>;
         };
         isError?: boolean;
       };
@@ -1411,7 +1411,7 @@ describe('POST /api/mcp (BY-05)', () => {
           file: 'gameplay.mp4',
           url: 'https://signed.example/games/comet-courier/versions/v1/media/gameplay.mp4?sig=1',
         },
-        openingShot: { file: 'opening.png', attached: true },
+        frames: [{ file: 'opening.png', name: 'opening', attached: true }],
       });
 
       const image = result.content.find((part) => part.type === 'image');

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1439,22 +1439,23 @@ describe('POST /api/mcp (BY-05)', () => {
       const res = await mcpCall(
         app,
         'tools/call',
-        { name: 'get_gate_media', arguments: { sessionKey } },
+        // frames=all so this covers the plural case too: the nudge rebuild must keep
+        // *every* image block, not merely the first one.
+        { name: 'get_gate_media', arguments: { sessionKey, frames: 'all' } },
         { 'mcp-session-id': sessionId },
       );
       expect(res.statusCode).toBe(200);
       const result = res.json().result as {
         content: Array<{ type: string; data?: string; mimeType?: string }>;
-        structuredContent: { warnings?: Array<{ code: string }>; openingShot?: { attached: boolean } };
+        structuredContent: { warnings?: Array<{ code: string }>; frames?: Array<{ attached: boolean }> };
         isError?: boolean;
       };
       expect(result.isError).toBeFalsy();
       expect(result.structuredContent.warnings?.map((w) => w.code)).toContain('progress_stale');
-      expect(result.structuredContent.openingShot?.attached).toBe(true);
-      expect(result.content.find((part) => part.type === 'image')).toMatchObject({
-        mimeType: 'image/png',
-        data: TINY_PNG,
-      });
+      expect(result.structuredContent.frames?.every((frame) => frame.attached)).toBe(true);
+      const images = result.content.filter((part) => part.type === 'image');
+      expect(images).toHaveLength(result.structuredContent.frames?.length ?? 0);
+      expect(images[0]).toMatchObject({ mimeType: 'image/png', data: TINY_PNG });
     });
 
     it('reports available:false instead of erroring before anything is delivered', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1896,6 +1896,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       annotations: { title: 'Fetch one exemplar', ...READS },
       description:
         'Fetch one allowlisted exemplar as a signed tarball URL. Unknown or non-allowlisted slugs fail. ' +
+        'Requires a client that can fetch a URL — if yours cannot, use list_example_files and ' +
+        'read_example_file instead, which return the same sources inline. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -1919,6 +1921,88 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const body = res.json() as { error?: string; message?: string };
         if (res.statusCode !== 200) {
           return toolErr(body.message ?? body.error ?? `example failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    list_example_files: {
+      annotations: { title: 'List an exemplar’s files', ...READS },
+      description:
+        'List the source files inside an allowlisted exemplar game, without downloading its tarball. ' +
+        'Use this (and read_example_file) when you cannot fetch URLs — get_example returns a link that ' +
+        'a client without shell or network access cannot follow. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          slug: { type: 'string', description: 'Allowlisted exemplar slug from list_examples.' },
+          prefix: { type: 'string', description: 'Optional path prefix to narrow the listing.' },
+          limit: { type: 'integer', description: 'Max paths to return (default 200, max 500).' },
+          offset: { type: 'integer', description: 'Skip this many matching paths.' },
+        },
+        required: ['slug'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const slug = typeof args.slug === 'string' ? args.slug.trim() : '';
+        if (!slug) return toolErr('slug is required');
+        const query = new URLSearchParams();
+        if (typeof args.prefix === 'string' && args.prefix.trim()) query.set('prefix', args.prefix.trim());
+        if (typeof args.limit === 'number') query.set('limit', String(args.limit));
+        if (typeof args.offset === 'number') query.set('offset', String(args.offset));
+        const suffix = query.toString() ? `?${query.toString()}` : '';
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/examples/${encodeURIComponent(slug)}/files${suffix}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `example files failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
+      },
+    },
+
+    read_example_file: {
+      annotations: { title: 'Read one exemplar file', ...READS },
+      description:
+        'Read one file from an allowlisted exemplar game, inline — no fetching required. ' +
+        'Paths come from list_example_files and may be given relative (game.ts) or full (games/<slug>/game.ts). ' +
+        'Binary files need encoding=base64. Large files are refused rather than truncated. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          slug: { type: 'string', description: 'Allowlisted exemplar slug from list_examples.' },
+          path: { type: 'string', description: 'File path within the exemplar (e.g. SPEC.md or game.ts).' },
+          encoding: { type: 'string', enum: ['utf8', 'base64'], description: 'utf8 for text (default).' },
+        },
+        required: ['slug', 'path'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const slug = typeof args.slug === 'string' ? args.slug.trim() : '';
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!slug) return toolErr('slug is required');
+        if (!path) return toolErr('path is required — call list_example_files to see what an exemplar contains');
+        const query = new URLSearchParams({ path });
+        if (args.encoding === 'utf8' || args.encoding === 'base64') query.set('encoding', args.encoding);
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/examples/${encodeURIComponent(slug)}/file?${query.toString()}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `example file failed (${res.statusCode})`, body);
         }
         return toolOk(body);
       },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2209,10 +2209,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     get_gate_media: {
       annotations: { title: "Fetch the gate's screenshots and video", ...READS },
       description:
-        'Fetch the media the gate itself produced for a delivery (default: latest): capture screenshots and a ' +
-        'gameplay MP4 as short-lived signed URLs, plus the opening frame attached inline as an image. ' +
-        'Use it when you cannot run the game yourself — check the frames for visual defects (blank canvas, ' +
-        'missing sprites) before resubmitting, and share the screenshots/video with the creator. ' +
+        'Fetch the media the gate itself produced for a delivery (default: latest). Screenshots come back ' +
+        'BOTH as attached images (no fetching needed — use these) and as short-lived signed URLs; the ' +
+        'gameplay MP4 is a URL only. ' +
+        'Use it when you cannot run the game yourself — look at the attached frames for visual defects ' +
+        '(blank canvas, missing sprites) before resubmitting, and show them to the creator. ' +
+        'frames=opening (default) attaches one frame; frames=all attaches up to 3; frames=none skips them ' +
+        'when you only want the URLs. ' +
+        'If your client cannot open URLs, do not try and do not report the video as broken — hand the link ' +
+        'to the creator, who can, and describe the game from the attached frames. ' +
         'Read-only over the gate run that already happened; it never triggers a build, and media exists only ' +
         'after a delivery has been gated. Terminal receipt: like get_gate_verdict, the latest delivery stays ' +
         'readable after green closes the round. ' +
@@ -2222,6 +2227,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: {
           sessionKey: SESSION_KEY_PROP,
           deliveryId: { type: 'string', description: "Delivery version id; default is the job's latest." },
+          frames: {
+            type: 'string',
+            enum: ['opening', 'all', 'none'],
+            description:
+              'How many screenshots to attach as images: opening (default, one), all (up to 3), none (URLs only).',
+          },
         },
         required: [],
       },
@@ -2231,28 +2242,34 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
         const deliveryId =
           typeof args.deliveryId === 'string' && args.deliveryId.trim() ? args.deliveryId.trim() : null;
-        const path = deliveryId
-          ? `/api/agent/build/media?version=${encodeURIComponent(deliveryId)}`
-          : '/api/agent/build/media';
-        const res = await injectChannel(ctx.request, 'GET', path, auth.channelToken);
+        const frames = args.frames === 'all' || args.frames === 'none' ? args.frames : 'opening';
+        const query = new URLSearchParams({ frames });
+        if (deliveryId) query.set('version', deliveryId);
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/media?${query.toString()}`,
+          auth.channelToken,
+        );
         const body = res.json() as Record<string, unknown> & {
           error?: string;
-          openingShot?: { file?: string; png?: string };
+          frames?: Array<{ file?: string; name?: string; png?: string }>;
         };
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `gate media failed (${res.statusCode})`);
         }
-        // The inline frame travels as an MCP image block, not inside the JSON body —
-        // duplicating ~700 KB of base64 into the text content would bloat every client's
-        // context for no benefit, and image blocks are the shape chat surfaces render.
-        const { openingShot, ...rest } = body;
+        // Frames travel as MCP image blocks, never inside the JSON body: base64 in the
+        // text content would double the cost and no client renders it. The structured
+        // half keeps the names so the model can talk about what it was shown.
+        const { frames: inlineFrames, ...rest } = body;
+        const attached = (inlineFrames ?? []).filter((frame) => typeof frame.png === 'string' && frame.png);
         const structured = {
           ...rest,
-          ...(openingShot?.file ? { openingShot: { file: openingShot.file, attached: Boolean(openingShot.png) } } : {}),
+          frames: attached.map((frame) => ({ file: frame.file, name: frame.name, attached: true })),
         };
         const result = toolOk(structured);
-        if (openingShot?.png) {
-          result.content.push({ type: 'image', data: openingShot.png, mimeType: 'image/png' });
+        for (const frame of attached) {
+          result.content.push({ type: 'image', data: frame.png as string, mimeType: 'image/png' });
         }
         return result;
       },


### PR DESCRIPTION
## Why

Owner test, 2026-08-03: **a ChatGPT-side connector agent cannot reach external hosts at all.** It can call our MCP tools and nothing else — no shell, no `curl`, no fetch.

That falsifies an assumption running through the whole WS3 tool contract, which says "signed URL" in five places and never asks whether the reader can follow one. For a fetchless client a URL is not a degraded experience — it is a blank one. Three tools were affected:

| Artifact | Before | Now |
| --- | --- | --- |
| Creator Kit | tarball URL only | `list_kit_files` / `read_kit_file` / `search_kit_files` (**#510**, already merged) |
| Gate media | one frame inline, rest by URL | frames as MCP image blocks (**this PR**) |
| Exemplar games | tarball URL only | `list_example_files` / `read_example_file` (**this PR**) |

## What changed

**Gate media — carry the frames, don't point at them**
- `frames` argument: `opening` (default, one), `all` (up to 3), `none` (URLs only).
- Budget ≤3 frames / ≤1.4 MB decoded; anything dropped is reported as `framesOmitted` rather than silently truncated.
- URLs stay for everyone — shell-capable agents want them, and the fetchless agent can still hand one to the *creator*, who has a browser.
- The mp4 stays URL-only (nothing renders an inlined video) with a `videoNote` saying so, so an agent that cannot fetch doesn't report it broken.

**Exemplars — the last link-only tool**
- `list_example_files` / `read_example_file` serve the same `examples/<slug>.tgz` the publisher already writes, through the tool.
- Narrower than the kit browser on purpose: a kit is a toolchain needing search and fragments; an exemplar is one game directory, so list + read covers it.
- Same allowlist, now enforced on three verbs instead of one — a slug sitting in the bucket doesn't become readable because a different route reaches the same object. Members outside `games/<slug>/` are dropped at unpack; `..` is refused rather than normalized; oversized files are refused rather than truncated.

## On context cost

Deliberately bounded, since inlined bytes *are* context:
- capture frames are 900×900 (`deviceScaleFactor: 1`) ≈ **1k image tokens each** — cheap for a few, not for all eight by default;
- base64 rides a typed `image` content block and **never the JSON body** — as text the same bytes cost ~100× more. A test asserts the base64 does not appear in the text content so nobody merges it back in later.

## Verification

`type-check`, `lint`, `build -w @gamedevpl/api` (the production build that caught the last merge-tree break) and the full API suite: **2096 tests green**. New coverage for frame modes and omission reporting, exemplar path normalization/traversal, allowlist parity across the three example verbs, root-escape at unpack, and token requirements.

Branch restarted from `master` after #506 merged, rather than stacked on merged history.

Docs: [ops#58](https://github.com/gamedevpl/www.gamedev.pl-ops/pull/58) records the finding as **BY-28a** plus a standing rule — *a URL may be an optimisation, never the only path to content an agent must read* — so a future tool gets checked against it rather than rediscovering this one at a time.