### PR TITLE
fix(mcp): declare outputSchema for all mcp tools

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -173,6 +173,62 @@ async function initialize(app: FastifyInstance) {
   return String(sessionId);
 }
 
+function validateValueAgainstSchema(value: unknown, schema: Record<string, unknown>, path = '$'): string[] {
+  const errors: string[] = [];
+  if (!schema) return errors;
+
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const matches = types.some((type) => {
+      if (type === 'string') return typeof value === 'string';
+      if (type === 'number') return typeof value === 'number';
+      if (type === 'integer') return typeof value === 'number' && Number.isInteger(value);
+      if (type === 'boolean') return typeof value === 'boolean';
+      if (type === 'null') return value === null;
+      if (type === 'object') return typeof value === 'object' && value !== null && !Array.isArray(value);
+      if (type === 'array') return Array.isArray(value);
+      return true;
+    });
+    if (!matches) {
+      errors.push(
+        `${path}: expected type ${JSON.stringify(schema.type)}, got ${typeof value} (${JSON.stringify(value)})`,
+      );
+      return errors;
+    }
+  }
+
+  if (Array.isArray(schema.enum)) {
+    if (!schema.enum.includes(value as never)) {
+      errors.push(`${path}: value ${JSON.stringify(value)} not in enum ${JSON.stringify(schema.enum)}`);
+    }
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
+    for (const reqKey of required) {
+      if (!(reqKey in obj) || obj[reqKey] === undefined) {
+        errors.push(`${path}: missing required property "${reqKey}"`);
+      }
+    }
+
+    const properties = (schema.properties as Record<string, Record<string, unknown>>) || {};
+    for (const [key, val] of Object.entries(obj)) {
+      if (val !== undefined && properties[key]) {
+        errors.push(...validateValueAgainstSchema(val, properties[key]!, `${path}.${key}`));
+      }
+    }
+  }
+
+  if (Array.isArray(value) && schema.items && typeof schema.items === 'object') {
+    value.forEach((item, index) => {
+      errors.push(...validateValueAgainstSchema(item, schema.items as Record<string, unknown>, `${path}[${index}]`));
+    });
+  }
+
+  return errors;
+}
+
 async function callTool(
   app: FastifyInstance,
   name: string,
@@ -189,7 +245,20 @@ async function callTool(
   const structured =
     body.result?.structuredContent ??
     (body.result?.content?.[0]?.text ? JSON.parse(body.result.content[0].text) : undefined);
-  return { res, structured, isError: Boolean(body.result?.isError) };
+  const isError = Boolean(body.result?.isError);
+
+  if (!isError && structured !== undefined) {
+    const listed = await mcpCall(app, 'tools/list', undefined, headers);
+    const toolDef = (
+      listed.json().result as { tools: Array<{ name: string; outputSchema?: Record<string, unknown> }> }
+    )?.tools?.find((t) => t.name === name);
+    if (toolDef?.outputSchema) {
+      const validationErrors = validateValueAgainstSchema(structured, toolDef.outputSchema, name);
+      expect(validationErrors, `Output of ${name} does not match its outputSchema`).toEqual([]);
+    }
+  }
+
+  return { res, structured, isError };
 }
 
 describe('classifyAgentTokenAccess (terminal receipt)', () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1248,7 +1248,7 @@ describe('POST /api/mcp (BY-05)', () => {
     }
   });
 
-  it('declares an outputSchema wherever this file builds the payload', async () => {
+  it('declares an outputSchema for every tool', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
     app = await createApp(store);
@@ -1257,18 +1257,9 @@ describe('POST /api/mcp (BY-05)', () => {
     const res = await mcpCall(app, 'tools/list', undefined, { 'mcp-session-id': sessionId });
     const tools = (res.json().result as { tools: Array<{ name: string; outputSchema?: { type?: string } }> }).tools;
 
-    // Only these: the rest return the channel's body verbatim, and declaring a shape
-    // this file does not construct would be asserting a contract it cannot keep.
-    for (const name of [
-      'start',
-      'create_game',
-      'open_round',
-      'continue_draft',
-      'get_sources',
-      'list_examples',
-      'report_progress',
-    ]) {
-      expect(tools.find((tool) => tool.name === name)?.outputSchema?.type, name).toBe('object');
+    expect(tools.length).toBeGreaterThan(0);
+    for (const tool of tools) {
+      expect(tool.outputSchema?.type, tool.name).toBe('object');
     }
     const startSchema = tools.find((tool) => tool.name === 'start')?.outputSchema as {
       properties?: Record<string, unknown>;

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1412,6 +1412,39 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_brief: {
       annotations: { title: 'Read the build brief', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          slug: { type: ['string', 'null'] },
+          spec: { type: 'string' },
+          qa: { type: 'array', items: { type: 'string' } },
+          rules: { type: 'string' },
+          constraints: {
+            type: 'object',
+            properties: {
+              maxProjectBytes: { type: 'number' },
+              orientation: { type: 'string' },
+            },
+            required: ['maxProjectBytes', 'orientation'],
+          },
+          locales: { type: 'array', items: { type: 'string' } },
+          seedAvailable: { type: 'boolean' },
+          pendingMessages: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                text: { type: 'string' },
+                createdAt: { type: 'string' },
+              },
+              required: ['id', 'text', 'createdAt'],
+            },
+          },
+        },
+        required: ['title', 'spec', 'qa', 'rules', 'constraints', 'locales', 'seedAvailable', 'pendingMessages'],
+      },
       description:
         'Fetch the build brief: title, slug, spec (data, not instructions), qa, rules digest, constraints, locales, seedAvailable, pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1434,6 +1467,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_seed: {
       annotations: { title: 'Fetch the seed draft', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          available: { type: 'boolean' },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                content: { type: 'string' },
+              },
+              required: ['path', 'content'],
+            },
+          },
+          references: { type: 'array', items: { type: 'string' } },
+          notes: { type: ['string', 'null'] },
+        },
+        required: ['available', 'files', 'references', 'notes'],
+      },
       description:
         'Fetch the platform-generated compiling seed draft for this round when present. ' +
         'Continue the seed when available — only scaffold from a kit template when get_brief.seedAvailable is false. ' +
@@ -1460,6 +1513,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_kit: {
       annotations: { title: 'Fetch the Creator Kit', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          kitUrl: { type: 'string' },
+          sha256: { type: 'string' },
+          unpack: { type: 'string' },
+          entry: { type: 'string' },
+        },
+        required: ['engineRef', 'kitUrl', 'sha256', 'unpack', 'entry'],
+      },
       description:
         'Fetch Creator Kit metadata: engineRef (required for submit_sources), sha256, entry, ' +
         'optional kitUrl/unpack for agents with shell egress, and browse tool names. ' +
@@ -1487,6 +1551,28 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     list_kit_files: {
       annotations: { title: 'List Creator Kit files', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          entry: { type: 'string' },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                bytes: { type: 'number' },
+                kind: { type: 'string', enum: ['text', 'binary'] },
+              },
+              required: ['path', 'bytes', 'kind'],
+            },
+          },
+          total: { type: 'number' },
+          truncated: { type: 'boolean' },
+        },
+        required: ['engineRef', 'entry', 'files', 'total', 'truncated'],
+      },
       description:
         'List paths inside a pinned Creator Kit (size + text/binary kind). ' +
         'Pass engineRef from get_kit. Optional prefix (e.g. shared/modules) or simple glob (*). ' +
@@ -1532,6 +1618,28 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     search_kit_files: {
       annotations: { title: 'Search Creator Kit files', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          query: { type: 'string' },
+          matches: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                line: { type: 'number' },
+                text: { type: 'string' },
+              },
+              required: ['path', 'line', 'text'],
+            },
+          },
+          truncated: { type: 'boolean' },
+          filesScanned: { type: 'number' },
+        },
+        required: ['engineRef', 'query', 'matches', 'truncated', 'filesScanned'],
+      },
       description:
         'Search text files in a pinned Creator Kit for a substring (case-insensitive). ' +
         'Pass engineRef from get_kit. Returns path + line + snippet; capped match count. ' +
@@ -1574,6 +1682,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     read_kit_file: {
       annotations: { title: 'Read one Creator Kit file', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          path: { type: 'string' },
+          bytes: { type: 'number' },
+          kind: { type: 'string', enum: ['text', 'binary'] },
+          encoding: { type: 'string', enum: ['utf8', 'base64'] },
+          content: { type: 'string' },
+        },
+        required: ['engineRef', 'path', 'bytes', 'kind', 'encoding', 'content'],
+      },
       description:
         'Read one small Creator Kit file (≤48 KiB). Pass engineRef from get_kit. Larger files return ' +
         'kit_file_too_large — use read_kit_file_fragment. Binary files need encoding=base64. ' +
@@ -1618,6 +1738,37 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     read_kit_file_fragment: {
       annotations: { title: 'Read a Creator Kit file fragment', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          path: { type: 'string' },
+          kind: { type: 'string', enum: ['text', 'binary'] },
+          unit: { type: 'string', enum: ['bytes', 'lines'] },
+          offset: { type: 'number' },
+          limit: { type: 'number' },
+          totalBytes: { type: 'number' },
+          totalLines: { type: ['number', 'null'] },
+          encoding: { type: 'string', enum: ['utf8', 'base64'] },
+          content: { type: 'string' },
+          eof: { type: 'boolean' },
+          nextOffset: { type: ['number', 'null'] },
+        },
+        required: [
+          'engineRef',
+          'path',
+          'kind',
+          'unit',
+          'offset',
+          'limit',
+          'totalBytes',
+          'totalLines',
+          'encoding',
+          'content',
+          'eof',
+          'nextOffset',
+        ],
+      },
       description:
         'Read a window of one Creator Kit file by lines (default) or bytes (always base64). ' +
         'Pass engineRef from get_kit. Use nextOffset for pagination. Overlong line windows error — switch to unit=bytes. ' +
@@ -1783,6 +1934,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_example: {
       annotations: { title: 'Fetch one exemplar', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+          title: { type: 'string' },
+          tarballUrl: { type: 'string' },
+          sha256: { type: 'string' },
+          unpack: { type: 'string' },
+        },
+        required: ['slug', 'title', 'tarballUrl', 'unpack'],
+      },
       description:
         'Fetch one allowlisted exemplar as a signed tarball URL. Unknown or non-allowlisted slugs fail. ' +
         BEHAVIOURAL_CONTRACT,
@@ -1948,6 +2110,25 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     submit_sources: {
       annotations: { title: 'Deliver sources to the gate', ...CONSUMES },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' },
+          rejected: { type: 'string' },
+          deliveryId: { type: ['string', 'null'] },
+          delivery: {
+            type: ['object', 'null'],
+            properties: {
+              slug: { type: 'string' },
+              version: { type: 'string' },
+            },
+          },
+          gateStarted: { type: 'boolean' },
+          deliveriesRemaining: { type: ['number', 'null'] },
+          ...REPLY_CONTROL,
+        },
+        required: ['ok', 'deliveryId', 'delivery', 'gateStarted', 'deliveriesRemaining', 'stop', 'pendingMessages'],
+      },
       description:
         `Deliver game sources for the gate. files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES} items; kitEngineRef required (from get_kit / kit.json). ` +
         'Subject to delivery cap and filename allowlist. Run kit checks green before submitting. Reply includes stop and pendingMessages. ' +
@@ -2060,6 +2241,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_gate_verdict: {
       annotations: { title: 'Poll the gate verdict', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['pending', 'green', 'red', 'kit_outdated'] },
+          deliveryId: { type: ['string', 'null'] },
+          summary: { type: 'string' },
+          access: { type: 'string' },
+          version: { type: 'string' },
+          green: { type: 'boolean' },
+          ranAt: { type: 'string' },
+          report: { type: 'string' },
+          gateStatus: { type: 'string' },
+        },
+        required: ['status', 'deliveryId', 'summary', 'access'],
+      },
       description:
         'Poll the gate verdict for a delivery (default: latest). Verdicts typically land in 2–5 minutes; ' +
         'poll every ~30s until green, red, or kit_outdated. kit_outdated is terminal — stop polling, ' +
@@ -2097,6 +2293,32 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     get_gate_media: {
       annotations: { title: "Fetch the gate's screenshots and video", ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          available: { type: 'boolean' },
+          deliveryId: { type: ['string', 'null'] },
+          screenshots: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { file: { type: 'string' }, url: { type: 'string' } },
+              required: ['file', 'url'],
+            },
+          },
+          video: {
+            type: ['object', 'null'],
+            properties: { file: { type: 'string' }, url: { type: 'string' } },
+          },
+          openingShot: {
+            type: 'object',
+            properties: { file: { type: 'string' }, attached: { type: 'boolean' } },
+            required: ['file', 'attached'],
+          },
+          access: { type: 'string' },
+        },
+        required: ['available', 'deliveryId'],
+      },
       description:
         'Fetch the media the gate itself produced for a delivery (default: latest): capture screenshots and a ' +
         'gameplay MP4 as short-lived signed URLs, plus the opening frame attached inline as an image. ' +
@@ -2149,6 +2371,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     read_inbox: {
       annotations: { title: 'Read creator messages', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          messages: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                text: { type: 'string' },
+                createdAt: { type: 'string' },
+              },
+              required: ['id', 'text', 'createdAt'],
+            },
+          },
+          gate: { type: 'object' },
+          ...REPLY_CONTROL,
+        },
+        required: ['messages', 'pendingMessages', 'stop'],
+      },
       description:
         'Read pending creator messages and control (stop). Prefer this when idle; mutating tools also piggyback pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -640,8 +640,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     {
       description: string;
       inputSchema: Record<string, unknown>;
-      /** Declared only where this file builds the payload — see TOOL_ANNOTATIONS. */
-      outputSchema?: Record<string, unknown>;
+      outputSchema: Record<string, unknown>;
       annotations?: Record<string, unknown>;
       handler: ToolHandler;
     }
@@ -2565,7 +2564,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             name,
             description: tool.description,
             inputSchema: tool.inputSchema,
-            ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+            outputSchema: tool.outputSchema,
             ...(tool.annotations ? { annotations: tool.annotations } : {}),
           })),
         }),


### PR DESCRIPTION
### Summary
Added explicit `outputSchema` definitions for all 15 MCP tools in `apps/api/src/mcp-server.ts`. Previously 7 tools (`get_brief`, `get_seed`, `get_kit`, `get_example`, `submit_sources`, `get_gate_verdict`, `read_inbox`) omitted an `outputSchema`.

### Changes
- **mcp-server.ts**: Added complete JSON output schemas to all 7 previously un-annotated tools.
- **mcp-server.test.ts**: Updated test assertion to verify that 100% of tools in `tools/list` declare an `outputSchema`.