### PR TITLE
fix: master is red — the two new example tools owe an outputSchema

### DIFF
--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2089,6 +2089,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     list_example_files: {
       annotations: { title: 'List an exemplar’s files', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                bytes: { type: 'number' },
+                kind: { type: 'string', enum: ['text', 'binary'] },
+              },
+            },
+          },
+          total: { type: 'number' },
+          truncated: { type: 'boolean', description: 'True when the limit cut the listing short.' },
+        },
+        required: ['slug', 'files', 'total', 'truncated'],
+      },
       description:
         'List the source files inside an allowlisted exemplar game, without downloading its tarball. ' +
         'Use this (and read_example_file) when you cannot fetch URLs — get_example returns a link that ' +
@@ -2131,6 +2151,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     read_example_file: {
       annotations: { title: 'Read one exemplar file', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+          path: { type: 'string' },
+          bytes: { type: 'number' },
+          kind: { type: 'string', enum: ['text', 'binary'] },
+          encoding: { type: 'string', enum: ['utf8', 'base64'] },
+          content: { type: 'string' },
+        },
+        required: ['slug', 'path', 'bytes', 'kind', 'encoding', 'content'],
+      },
       description:
         'Read one file from an allowlisted exemplar game, inline — no fetching required. ' +
         'Paths come from list_example_files and may be given relative (game.ts) or full (games/<slug>/game.ts). ' +


### PR DESCRIPTION
## Master is red

`#517` landed a test requiring every MCP tool to declare an `outputSchema`. `#516` added `list_example_files` and `read_example_file` without one. Merged in that order, master stopped passing its own rule:

```
× POST /api/mcp (BY-05) > declares an outputSchema for every tool
  → list_example_files: expected undefined to be 'object'
```

Both PRs were green on their own; neither was tested against the other. Because the Cloud Run deploy is CI-gated, this also means **everything in #516 is merged but not live** until master goes green again.

## The fix

Both tools now declare schemas matching what their handlers actually return:

- `list_example_files` — `slug`, `files[{path, bytes, kind}]`, `total`, `truncated`
- `read_example_file` — `slug`, `path`, `bytes`, `kind`, `encoding`, `content`

`truncated` and the `kind`/`encoding` pair are included rather than trimmed, because those are the fields a caller has to branch on: a listing that was cut short reads exactly like a complete one otherwise, and a binary file needs `encoding=base64` to be requested correctly.

## Verification

Run against current master (`311623f`), not just the branch: **2117 API tests**, lint and type-check green — including the `#517` rule that is currently failing.

## Note on the pattern

Third merge-order break today, all the same shape: [#501](https://github.com/gamedevpl/www.gamedev.pl/pull/501) (`create_game` annotations vs the rule from #496), the `applySessionNudges` collision fixed inside #516, and now this. Two PRs touching `mcp-server.ts` each pass alone, merge minutes apart, and master breaks on a rule neither one violated at the time its CI ran. Worth deciding whether a rebase-and-rerun before merge is warranted when another PR touching that file has landed since — cheap guard, some friction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrXBSADXMndFNkj9FfEkMn)_