### PR TITLE
Stabilize catalog order and calm phone card chrome

### DIFF
--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -111,9 +111,19 @@ async function flushEffects() {
   await Promise.resolve();
 }
 
+/** Default AuthContext is `loading: true` — resolve auth so the shelf gate can finish. */
+function mockSignedOutAuth() {
+  vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    user: null,
+    loading: false,
+    privateBeta: false,
+  } as ReturnType<typeof AuthContextModule.useAuth>);
+}
+
 describe('ArcadeCatalog lazy media', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
+    mockSignedOutAuth();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
       JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
@@ -410,6 +420,7 @@ describe('ArcadeCatalog lazy media', () => {
 describe('ArcadeCatalog shared-world badge', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
+    mockSignedOutAuth();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
       JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
@@ -469,6 +480,7 @@ describe('ArcadeCatalog shared-world badge', () => {
 describe('ArcadeCatalog soft-refresh failure', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
+    mockSignedOutAuth();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
       JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
@@ -525,6 +537,7 @@ describe('ArcadeCatalog soft-refresh failure', () => {
 describe('ArcadeCatalog Studio chip', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
+    mockSignedOutAuth();
     sessionStorage.setItem(
       'gdpl.catalogSortSignals',
       JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -582,9 +582,9 @@ describe('ArcadeCatalog Studio chip', () => {
       await flushEffects();
     });
 
-    // Published grid paints without waiting on the shelf — no shove when builds arrive.
-    expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
-    expect(container.querySelector('.catalog-studio-chip')).toBeNull();
+    // Signed-in paint waits for the shelf so Yours pins + Studio chip land with the grid.
+    expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
+    expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
 
     await act(async () => {
       resolveMine?.(
@@ -624,6 +624,84 @@ describe('ArcadeCatalog Studio chip', () => {
       chip?.click();
     });
     expect(onOpenStudio).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('does not reshuffle the grid when the network recommendations differ from the cache', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    sessionStorage.setItem(
+      'gdpl.catalogSortSignals',
+      JSON.stringify({
+        viewer: '',
+        items: [
+          { slug: 'above-fold', reason: 'popular' },
+          { slug: 'below-fold', reason: 'popular' },
+        ],
+        popularity: [],
+        lastPlayed: [],
+        newest: ['above-fold', 'below-fold'],
+      }),
+    );
+
+    let resolveSignals: ((value: Response) => void) | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/recommendations')) {
+        return new Promise<Response>((resolve) => {
+          resolveSignals = resolve;
+        });
+      }
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entries,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // Cache is enough for first paint.
+    const firstOrder = [...container.querySelectorAll('.card-title')].map((el) => el.textContent);
+    expect(firstOrder[0]).toMatch(/Above Fold/);
+
+    await act(async () => {
+      resolveSignals?.(
+        new Response(
+          JSON.stringify({
+            items: [
+              { slug: 'below-fold', reason: 'popular' },
+              { slug: 'above-fold', reason: 'popular' },
+            ],
+            popularity: [],
+            lastPlayed: [],
+            newest: ['below-fold', 'above-fold'],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+      await flushEffects();
+    });
+
+    const secondOrder = [...container.querySelectorAll('.card-title')].map((el) => el.textContent);
+    expect(secondOrder).toEqual(firstOrder);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -510,7 +510,7 @@ export function ArcadeCatalog({
   onOpenStudio,
 }: ArcadeCatalogProps) {
   const { t, i18n } = useTranslation();
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const viewerUid = user?.uid ?? null;
   const locale = i18n.language;
   const [sortMode, setSortMode] = useState<CatalogSortMode>(() =>
@@ -524,10 +524,9 @@ export function ArcadeCatalog({
   const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
   const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
-  // Signed-in "Yours" pins + Studio chip land with the first grid paint — waiting for
-  // the shelf (in parallel with catalog/signals) avoids pinning mid-scroll after the
-  // published order was already on screen.
-  const [creatorGamesReady, setCreatorGamesReady] = useState(() => !viewerUid);
+  // Starts false until auth resolves: a null→uid transition must not paint an
+  // unpinned grid first and then flip back to loading when the shelf gate applies.
+  const [creatorGamesReady, setCreatorGamesReady] = useState(false);
   /** Grid order committed for the current sort/filter/viewer; later signal refresh must not reshuffle. */
   const [displayedEntries, setDisplayedEntries] = useState<CatalogEntry[]>([]);
   const desiredOrderRef = useRef<CatalogEntry[]>([]);
@@ -572,17 +571,20 @@ export function ArcadeCatalog({
   }, [recommendationsRefreshKey, viewerUid]);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!viewerUid) {
       setCreatorItems([]);
       setCreatorGamesReady(true);
       return;
     }
+    // Drop the previous viewer's shelf immediately on account switch.
+    setCreatorItems([]);
     setCreatorGamesReady(false);
-  }, [viewerUid, locale]);
+  }, [authLoading, viewerUid, locale]);
 
   // Creator shelf feeds the Studio chip and "Yours" pins — never the grid itself.
   useEffect(() => {
-    if (!viewerUid) return;
+    if (authLoading || !viewerUid) return;
     let cancelled = false;
     void loadCreatorGames(locale).then((items) => {
       if (cancelled) return;
@@ -598,7 +600,7 @@ export function ArcadeCatalog({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [viewerUid, creatorGamesRefreshKey, locale]);
+  }, [authLoading, viewerUid, creatorGamesRefreshKey, locale]);
 
   // Close the sort menu on outside tap or Escape — phones have no hover to dismiss it.
   useEffect(() => {
@@ -653,7 +655,8 @@ export function ArcadeCatalog({
 
   const awaitingSignals =
     catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
-  const awaitingCreatorShelf = Boolean(viewerUid) && !creatorGamesReady;
+  // Hold the grid while auth is unknown, and while a signed-in shelf is still loading.
+  const awaitingCreatorShelf = authLoading || (Boolean(viewerUid) && !creatorGamesReady);
   const layoutReady = catalogStatus === 'ready' && !awaitingSignals && !awaitingCreatorShelf;
 
   // Commit order once per sort/filter/viewer (and when the shelf/signals first land).

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
@@ -524,6 +524,14 @@ export function ArcadeCatalog({
   const [signals, setSignals] = useState<CatalogSortSignals>(() => initialSignals(viewerUid).signals);
   const [signalsReady, setSignalsReady] = useState(() => initialSignals(viewerUid).ready);
   const [creatorItems, setCreatorItems] = useState<CreatorGameItem[]>([]);
+  // Signed-in "Yours" pins + Studio chip land with the first grid paint — waiting for
+  // the shelf (in parallel with catalog/signals) avoids pinning mid-scroll after the
+  // published order was already on screen.
+  const [creatorGamesReady, setCreatorGamesReady] = useState(() => !viewerUid);
+  /** Grid order committed for the current sort/filter/viewer; later signal refresh must not reshuffle. */
+  const [displayedEntries, setDisplayedEntries] = useState<CatalogEntry[]>([]);
+  const desiredOrderRef = useRef<CatalogEntry[]>([]);
+  const paintedOrderKeyRef = useRef<string | null>(null);
 
   useEffect(() => watchCatalogScrollIdle(), []);
 
@@ -563,16 +571,23 @@ export function ArcadeCatalog({
     };
   }, [recommendationsRefreshKey, viewerUid]);
 
-  // Creator shelf feeds the Studio chip and "Yours" pins — never the grid itself.
-  // Fetch in parallel; when it lands the chip appears without shoving published cards.
   useEffect(() => {
     if (!viewerUid) {
       setCreatorItems([]);
+      setCreatorGamesReady(true);
       return;
     }
+    setCreatorGamesReady(false);
+  }, [viewerUid, locale]);
+
+  // Creator shelf feeds the Studio chip and "Yours" pins — never the grid itself.
+  useEffect(() => {
+    if (!viewerUid) return;
     let cancelled = false;
     void loadCreatorGames(locale).then((items) => {
-      if (!cancelled) setCreatorItems(items);
+      if (cancelled) return;
+      setCreatorItems(items);
+      setCreatorGamesReady(true);
     });
     const timer = window.setInterval(() => {
       void loadCreatorGames(locale).then((items) => {
@@ -623,13 +638,36 @@ export function ArcadeCatalog({
   const notPlayedOnly = filters.has('not_played');
   const filtersActive = yourGamesOnly || notPlayedOnly;
 
-  const orderedEntries = useMemo(() => {
+  const desiredOrder = useMemo(() => {
     // Ignore a sticky your_games pref when signed out or you have nothing yours —
     // otherwise the whole catalog would look empty for no good reason.
     const activeFilters = canFilterYourGames ? filters : new Set([...filters].filter((id) => id !== 'your_games'));
     const filtered = applyCatalogFilters(catalogEntries, activeFilters, signals.affinityLastPlayed, mySlugs);
     return orderCatalogEntries(filtered, sortMode, signals, mySlugs);
   }, [catalogEntries, sortMode, filters, signals, mySlugs, canFilterYourGames]);
+  desiredOrderRef.current = desiredOrder;
+
+  const filterKey = [...filters].sort().join(',');
+  // recommendationsRefreshKey: post-play re-rank is deliberate user-visible intent.
+  const userOrderKey = `${sortMode}|${filterKey}|${viewerUid ?? ''}|r${recommendationsRefreshKey}`;
+
+  const awaitingSignals =
+    catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
+  const awaitingCreatorShelf = Boolean(viewerUid) && !creatorGamesReady;
+  const layoutReady = catalogStatus === 'ready' && !awaitingSignals && !awaitingCreatorShelf;
+
+  // Commit order once per sort/filter/viewer (and when the shelf/signals first land).
+  // A later recommendations refresh that differs from the sessionStorage cache must
+  // not reshuffle cards under the reader's thumb.
+  useLayoutEffect(() => {
+    if (!layoutReady) {
+      paintedOrderKeyRef.current = null;
+      return;
+    }
+    if (paintedOrderKeyRef.current === userOrderKey) return;
+    paintedOrderKeyRef.current = userOrderKey;
+    setDisplayedEntries(desiredOrderRef.current);
+  }, [layoutReady, userOrderKey]);
 
   function handleSortChange(mode: CatalogSortMode) {
     setSortMode(mode);
@@ -654,8 +692,6 @@ export function ArcadeCatalog({
       return next;
     });
   }
-  const awaitingSignals =
-    catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
 
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
@@ -665,8 +701,7 @@ export function ArcadeCatalog({
         : notPlayedOnly && catalogEntries.length > 0
           ? t('catalog.emptyNotPlayed')
           : t('catalog.empty');
-  const showEmpty =
-    !awaitingSignals && catalogStatus !== 'loading' && catalogStatus !== 'error' && orderedEntries.length === 0;
+  const showEmpty = layoutReady && displayedEntries.length === 0;
 
   const studioChipLabel =
     liveCount > 0
@@ -766,7 +801,7 @@ export function ArcadeCatalog({
         </div>
       ) : null}
 
-      {catalogStatus === 'loading' || awaitingSignals ? (
+      {catalogStatus === 'loading' || awaitingSignals || awaitingCreatorShelf ? (
         <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
           <p>{t('catalog.loading')}</p>
         </MascotMoment>
@@ -790,7 +825,7 @@ export function ArcadeCatalog({
         </MascotMoment>
       ) : (
         <div className="catalog-grid">
-          {orderedEntries.map((entry) => (
+          {displayedEntries.map((entry) => (
             <CatalogCard
               key={entry.slug}
               entry={entry}

--- a/apps/web/src/styles.catalogGrid.test.ts
+++ b/apps/web/src/styles.catalogGrid.test.ts
@@ -28,4 +28,10 @@ describe('catalog grid layout', () => {
   it('keeps published cards as a single 16:9 media box', () => {
     expect(ruleBody('.catalog-media')).toMatch(/aspect-ratio:\s*16\s*\/\s*9/);
   });
+
+  it('hides trailer/moment chrome on coarse pointers so cards keep one Play CTA', () => {
+    expect(css).toMatch(
+      /@media\s*\(\s*pointer:\s*coarse\s*\)\s*,\s*\(\s*max-width:\s*768px\s*\)\s*\{[^}]*\.preview-toggle\s*,\s*\.catalog-moments\s*\{[^}]*display:\s*none/s,
+    );
+  });
 });

--- a/apps/web/src/styles.catalogGrid.test.ts
+++ b/apps/web/src/styles.catalogGrid.test.ts
@@ -30,8 +30,13 @@ describe('catalog grid layout', () => {
   });
 
   it('hides trailer/moment chrome on coarse pointers so cards keep one Play CTA', () => {
-    expect(css).toMatch(
-      /@media\s*\(\s*pointer:\s*coarse\s*\)\s*,\s*\(\s*max-width:\s*768px\s*\)\s*\{[^}]*\.preview-toggle\s*,\s*\.catalog-moments\s*\{[^}]*display:\s*none/s,
+    const rule = css.match(/\.preview-toggle\s*,\s*\.catalog-moments\s*\{([\s\S]*?)\}/);
+    expect(rule, 'missing combined preview-toggle/catalog-moments hide rule').not.toBeNull();
+    expect(rule![1]).toMatch(/display:\s*none/);
+    // Same rule lives under the coarse/phone media query (look behind a short window).
+    const at = css.indexOf(rule![0]!);
+    expect(css.slice(Math.max(0, at - 240), at)).toMatch(
+      /@media\s*\(\s*pointer:\s*coarse\s*\)\s*,\s*\(\s*max-width:\s*768px\s*\)/,
     );
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1343,74 +1343,29 @@ button:disabled {
   text-transform: uppercase;
 }
 
-/* The two overlay controls on a card are sized for a mouse: the preview toggle is a
-   28px pill and each moment thumbnail is 42x26. Both are real tap targets, so on a
-   finger they grow to the 44px iOS HIG floor. Gated rather than applied everywhere
-   because at grid density a 44px pill and four 44px thumbnails on top of every
-   preview is a lot of furniture for a pointer that doesn't need it. Both conditions
-   are listed: `pointer: coarse` catches a large tablet, the width catches a phone
-   (and a narrow desktop window, harmlessly). */
+/* Phone / coarse pointer: the card already has a primary Zagraj CTA. A second 44px
+   play circle for trailer preview (plus moment thumbs) stacked the AI disclosure over
+   gameplay HUDs and read as two competing Play affordances. Hover-to-preview is a
+   mouse behaviour — on a finger, leave the art alone and keep only the disclosures. */
 @media (pointer: coarse), (max-width: 768px) {
-  /* Icon-only, because the labelled pill at 44px tall is 127px wide in English and
-     wider in Polish — enough to reach the moment thumbnails on the far side of a
-     351px card. A round 44px button clears them at every label length. */
-  .preview-toggle {
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    padding: 0;
-  }
-
-  .preview-toggle .btn-label {
+  .preview-toggle,
+  .catalog-moments {
     display: none;
   }
 
-  .catalog-moment {
-    width: 48px;
-    height: 44px;
-  }
-
-  /* A 320px card is only 167px tall, and the row growing from 26px to 44px pushed
-     its bottom edge into the title. Tuck it up against the genre chip instead: the
-     free band runs from that chip's bottom (29px) to the title's top (79px on the
-     shortest card), and 33px puts the row inside it with the narrowest card as the
-     binding case — every wider card has more room below. */
-  .catalog-moments {
-    top: 33px;
+  .catalog-badges-top-left {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    max-width: calc(100% - 8.5rem);
   }
 
   .touch-warning-pill {
     display: inline-flex;
   }
-}
 
-/* Below 360px the card is a 296x167 box already carrying a 44px preview toggle, the
-   AI disclosure, a genre chip, a title that wraps to two lines, and a 44px Play
-   button. Two things give way rather than fight over it. */
-@media (max-width: 360px) {
-  /* The frame picker is the only thing on the card that is a convenience rather than
-     information, and at thumb size it covers the gameplay it is advertising — so the
-     smallest phones lose it instead of gaining four more 44px boxes stacked on the
-     art. It comes back above 360px, where the taller card has the room. */
-  .catalog-moments {
-    display: none;
-  }
-
-  /* Side by side, not stacked: at 44px the toggle made this column 68px tall, and a
-     title that wrapped to two lines climbed under it — the AI disclosure ended up
-     drawn over the first word of the title, which is exactly the thing a mandatory
-     disclosure must never do. A row ends 103px in, which clears both a two-line title
-     below it and the genre chip, which the 40% cap keeps to the right of that. */
-  .catalog-badges-top-left {
-    flex-direction: row;
-    align-items: center;
-  }
-
-  /* A card carrying the keyboard-only warning has a third badge in that row, which
-     at 320px reaches across to where the genre chip starts. Genre is the least
-     important thing on a card — the art and the title say more — and it is the only
-     other claimant on that corner, so on the rare card that has to warn somebody, it
-     is what gives way. Scoped with :has() so every other card keeps its chip. */
+  /* Keyboard-only + AI + Yours can crowd the genre chip on a narrow card. Genre is
+     the least important corner claim — drop it when the warning is present. */
   .catalog-media:has(.touch-warning-pill) .genre-pill {
     display: none;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two leftover catalog pain points after #500:

1. **Re-sort / jump** — the grid could still reshuffle when (a) signed-in “Yours” pins arrived after first paint, or (b) the network recommendations payload differed from the sessionStorage cache. Fix: wait for the creator shelf when signed in (parallel with catalog/signals), then **freeze** the painted order until the user changes sort/filter (or a deliberate post-play refresh).
2. **Chaotic phone chrome** — the 44px trailer “play” circle + AI stack sat on top of gameplay HUDs and read as a second Play next to Zagraj. On coarse/phone viewports, hide the preview toggle and moment strip; keep AI / Yours / genre only.

## Test plan

- [x] `npm run type-check && npm run lint`
- [x] ArcadeCatalog + catalog grid CSS tests
- [ ] Phone: cards show art + AI + genre + Zagraj only (no circular preview play)
- [ ] Signed in: one paint with stable order; no mid-scroll reshuffle when recommendations return
- [ ] Changing sort/filter still reorders intentionally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb05ef3-d984-43f7-acdf-5cbf729c728e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

