### PR TITLE
fix(web): streamline Studio self-build chrome and quiet resume

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -151,7 +151,8 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     sign-in wall, so there is no separate `signin_required` rung (that name already means
     the creation wall).
   - ~~BYOCA / self-build funnel unmeasured~~ — **closed 2026-08-01 (BY-08)**: `studio_step`
-    on the visit stream records `builder_chosen` → `connect_copied` → `agent_signaled` →
+    on the visit stream records `builder_chosen` → `connect_copied` (also `connect_deeplink`,
+    `connect_dismissed`, `connect_restored`) → `agent_signaled` →
     `gate_verdict`, each with a required `builder` dimension (`platform` | `self`). Optional
     `detail` is a closed enum (`install` | `kickoff` | `header` | `cursor` | `vscode` |
     `green` | `red` | `kit_outdated` | `creator` | `agent`). BY-18c adds sibling step

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -290,6 +290,8 @@ describe('POST /api/telemetry/visit', () => {
           detail: 'header',
           msSinceStart: 260,
         },
+        { type: 'studio_step', step: 'connect_dismissed', builder: 'self', msSinceStart: 270 },
+        { type: 'studio_step', step: 'connect_restored', builder: 'self', msSinceStart: 280 },
         { type: 'studio_step', step: 'agent_signaled', builder: 'self', msSinceStart: 12_000 },
         {
           type: 'studio_step',
@@ -328,6 +330,16 @@ describe('POST /api/telemetry/visit', () => {
           step: 'connect_copied',
           builder: 'self',
           detail: 'header',
+        }),
+        expect.objectContaining({
+          type: 'studio_step',
+          step: 'connect_dismissed',
+          builder: 'self',
+        }),
+        expect.objectContaining({
+          type: 'studio_step',
+          step: 'connect_restored',
+          builder: 'self',
         }),
         expect.objectContaining({
           type: 'studio_step',

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -66,6 +66,8 @@ const StudioStepSchema = z.enum([
   'builder_chosen',
   'connect_copied',
   'connect_deeplink',
+  'connect_dismissed',
+  'connect_restored',
   'agent_signaled',
   'gate_verdict',
   'round_opened',

--- a/apps/web/src/CreatorStudioView.handoff.test.tsx
+++ b/apps/web/src/CreatorStudioView.handoff.test.tsx
@@ -196,14 +196,12 @@ describe('CreatorStudioView publish→improve handoff', () => {
         expect.objectContaining({ credentials: 'include' }),
       );
 
-      // Playtest must follow the handoff token too — otherwise pause-feedback would
+      // Play must follow the handoff token too — otherwise pause-feedback would
       // call submitImprovement on the published job and open a second concurrent round.
       await act(async () => {
-        const playtestTab = Array.from(container.querySelectorAll('button')).find((btn) =>
-          /playtest/i.test(btn.textContent ?? ''),
-        );
-        expect(playtestTab).toBeTruthy();
-        playtestTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        const playTab = Array.from(container.querySelectorAll('.studio-head-action.is-primary')).find(Boolean);
+        expect(playTab).toBeTruthy();
+        playTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         await flushEffects();
         await flushEffects();
       });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -402,7 +402,7 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
-  it('makes Playtest the primary head action, not a peer of Details', async () => {
+  it('makes Play the primary head action, with Details as an icon peer', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -411,19 +411,21 @@ describe('CreatorStudioView', () => {
 
     const { container, root } = await renderStudio({ selectedGame: 'token-0' });
 
-    const playtest = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
-      button.textContent?.includes('Playtest'),
+    const play = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.classList.contains('is-primary'),
     );
     const details = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
       button.textContent?.includes('Details'),
     );
-    expect(playtest?.classList.contains('is-primary')).toBe(true);
+    expect(play?.textContent).toMatch(/Play/);
+    expect(play?.classList.contains('is-primary')).toBe(true);
     expect(details?.classList.contains('is-primary')).toBe(false);
+    expect(details?.classList.contains('is-icon-only')).toBe(true);
 
     root.unmount();
   });
 
-  it('lets Playtest toggle back to the thread when already open', async () => {
+  it('lets Play toggle back to the thread when already open', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -435,15 +437,15 @@ describe('CreatorStudioView', () => {
       selectedTab: 'playtest',
     });
 
-    const playtest = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
-      button.textContent?.includes('Playtest'),
+    const play = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.classList.contains('is-primary'),
     );
-    expect(playtest?.getAttribute('aria-pressed')).toBe('true');
+    expect(play?.getAttribute('aria-pressed')).toBe('true');
     expect(container.querySelector('.studio-playtest')).not.toBeNull();
     expect(container.querySelector('.studio-build')).toBeNull();
 
     await act(async () => {
-      playtest!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      play!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(onNavigate).toHaveBeenCalledWith('/studio/token-0/thread');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -676,10 +676,9 @@ export function CreatorStudioView({
                           <span className="studio-head-action-label">{t('studioPanel.tabs.edit')}</span>
                         </button>
                       ) : null}
-                      {/* Playtest is the next action after a build — same weight as Send
-                        feedback, not a peer of the Details toggle beside it. When already
-                        open (empty/error keeps chrome visible), clicking again returns to
-                        the thread so creators are never stuck without a Build tab. */}
+                      {/* Play is the next action after a build — one verb with Details as
+                        the side-panel toggle beside it. When already open (empty/error
+                        keeps chrome visible), clicking again returns to the thread. */}
                       {/* Labels are wrapped rather than left as bare text so a phone can
                         hide the word and keep the icon — and hide it the way that leaves
                         the button still named for a screen reader, not display: none. */}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -25,6 +25,7 @@ import {
 import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
+import { StudioDetailsBuildProgress } from './StudioDetailsBuildProgress.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
@@ -1049,6 +1050,12 @@ function DetailsPanel({
       {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
           public play link — offering a second "share the draft" switch would lie. */}
       {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+
+      {/* Checklist fraction left the thread foot — Details is where Claude-style chrome
+          keeps build meta without crowding the composer. */}
+      {game.lastKnownStatus !== 'abandoned' && game.lastKnownStatus !== 'published' ? (
+        <StudioDetailsBuildProgress token={game.token} />
+      ) : null}
 
       {/* Self-build connect steps live here too so the thread can dismiss them without
           losing the path back — hideIfUnavailable keeps platform rounds silent. */}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -669,25 +669,22 @@ export function CreatorStudioView({
                       {tabAvailable(activeGame, 'edit') ? (
                         <button
                           type="button"
-                          className={`studio-head-action${tab === 'edit' ? ' is-active' : ''}`}
+                          className={`studio-head-action is-icon-only${tab === 'edit' ? ' is-active' : ''}`}
                           aria-pressed={tab === 'edit'}
+                          aria-label={t('studioPanel.tabs.edit')}
                           onClick={() => openTab(tab === 'edit' ? 'thread' : 'edit')}
                         >
                           <PixelIcon name="pencil" size={12} />{' '}
                           <span className="studio-head-action-label">{t('studioPanel.tabs.edit')}</span>
                         </button>
                       ) : null}
-                      {/* Play is the next action after a build — one verb with Details as
-                        the side-panel toggle beside it. When already open (empty/error
-                        keeps chrome visible), clicking again returns to the thread. */}
-                      {/* Labels are wrapped rather than left as bare text so a phone can
-                        hide the word and keep the icon — and hide it the way that leaves
-                        the button still named for a screen reader, not display: none. */}
+                      {/* Claude-shaped cluster: one primary Play verb, icon-only peers for
+                        Edit / Details (side panel). Labels stay in the DOM for AT. */}
                       {!user?.handle &&
                       (activeGame.lastKnownStatus === 'in_review' || activeGame.lastKnownStatus === 'publishing') ? (
                         <button
                           type="button"
-                          className="studio-head-action studio-head-action--claim"
+                          className="studio-head-action is-icon-only studio-head-action--claim"
                           onClick={() => setClaimOpen(true)}
                           aria-label={t('creatorProfile.publishGateTitle')}
                         >
@@ -706,8 +703,9 @@ export function CreatorStudioView({
                       </button>
                       <button
                         type="button"
-                        className={`studio-head-action${tab === 'details' ? ' is-active' : ''}`}
+                        className={`studio-head-action is-icon-only${tab === 'details' ? ' is-active' : ''}`}
                         aria-pressed={tab === 'details'}
+                        aria-label={t('studioPanel.tabs.details')}
                         onClick={() => openTab(tab === 'details' ? 'thread' : 'details')}
                       >
                         <PixelIcon name="expand" size={12} />{' '}

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -23,6 +23,7 @@ import {
   type StudioShelfGame,
 } from './studioShelf.js';
 import { StudioAgentKeyPanel } from './StudioAgentKeyPanel.js';
+import { StudioConnectCard } from './StudioConnectCard.js';
 import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
@@ -1050,6 +1051,12 @@ function DetailsPanel({
       {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
           public play link — offering a second "share the draft" switch would lie. */}
       {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
+
+      {/* Self-build connect steps live here too so the thread can dismiss them without
+          losing the path back — hideIfUnavailable keeps platform rounds silent. */}
+      {game.lastKnownStatus !== 'abandoned' && game.lastKnownStatus !== 'published' ? (
+        <StudioConnectCard token={game.token} collapsible={false} hideIfUnavailable />
+      ) : null}
 
       {game.slug && game.lastKnownStatus !== 'abandoned' ? <StudioAgentKeyPanel token={game.token} /> : null}
 

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -447,6 +447,10 @@ describe('StudioConnectCard', () => {
     expect(container.querySelector('[data-testid="connect-expanded"]')).not.toBeNull();
     const hide = container.querySelector<HTMLButtonElement>('[data-testid="connect-hide"]');
     expect(hide?.textContent).toContain('Hide for now');
+    // Chip affordance — not a muted underline that disappears into the title row.
+    expect(hide?.classList.contains('studio-connect-hide')).toBe(true);
+    // End-of-card twin: title wrap on phones buries the header control.
+    expect(container.querySelector('[data-testid="connect-hide-foot"]')?.textContent).toContain('Hide for now');
 
     await act(async () => {
       hide?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -455,15 +459,14 @@ describe('StudioConnectCard', () => {
 
     expect(container.querySelector('[data-testid="connect-expanded"]')).toBeNull();
     expect(container.querySelector('[data-testid="connect-collapsed"]')).not.toBeNull();
-    expect(container.textContent).toContain('Show connect steps');
+    expect(container.querySelector('[data-testid="connect-show"]')?.textContent).toContain('Show connect steps');
     expect(container.textContent).toContain('Also in Details anytime');
     expect(localStorage.getItem('gamedev_connect_collapsed:status-tok')).toBe('1');
 
     await act(async () => {
-      const show = [...container.querySelectorAll<HTMLButtonElement>('button')].find((btn) =>
-        btn.textContent?.includes('Show connect steps'),
-      );
-      show?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="connect-show"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
     });
 

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -426,4 +426,36 @@ describe('StudioConnectCard', () => {
       await act(async () => root.unmount());
     }
   });
+
+  it('resume mode leads with the kickoff and tucks MCP install under details', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok', mode: 'resume' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-connect-mode="resume"]')).not.toBeNull();
+    expect(container.querySelector('.studio-connect-title')?.textContent).toContain('Continue with your agent');
+    expect(container.textContent).not.toContain('Connect your coding agent');
+    expect(container.querySelector('[data-testid="connect-kickoff"]')?.textContent).toContain('slug: sky-dodge');
+    // Install stays under a closed disclosure — still in the DOM (jsdom keeps details
+    // content), but not the primary chrome a quiet mid-round should lead with.
+    const details = container.querySelector<HTMLDetailsElement>('[data-testid="connect-setup-details"]');
+    expect(details).not.toBeNull();
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain('Need to reconnect MCP?');
+    expect(details?.querySelector('[data-testid="connect-install-cursor"]')).not.toBeNull();
+    expect(container.innerHTML).not.toContain(FULL_KEY);
+
+    await act(async () => root.unmount());
+  });
 });

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -427,6 +427,106 @@ describe('StudioConnectCard', () => {
     }
   });
 
+  it('hides the tall card behind a one-line strip and restores it on demand', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    localStorage.clear();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="connect-expanded"]')).not.toBeNull();
+    const hide = container.querySelector<HTMLButtonElement>('[data-testid="connect-hide"]');
+    expect(hide?.textContent).toContain('Hide for now');
+
+    await act(async () => {
+      hide?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="connect-expanded"]')).toBeNull();
+    expect(container.querySelector('[data-testid="connect-collapsed"]')).not.toBeNull();
+    expect(container.textContent).toContain('Show connect steps');
+    expect(container.textContent).toContain('Also in Details anytime');
+    expect(localStorage.getItem('gamedev_connect_collapsed:status-tok')).toBe('1');
+
+    await act(async () => {
+      const show = [...container.querySelectorAll<HTMLButtonElement>('button')].find((btn) =>
+        btn.textContent?.includes('Show connect steps'),
+      );
+      show?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="connect-expanded"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="connect-kickoff"]')).not.toBeNull();
+    expect(localStorage.getItem('gamedev_connect_collapsed:status-tok')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('stays collapsed across remount when the preference is set', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    localStorage.setItem('gamedev_connect_collapsed:status-tok', '1');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok' }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="connect-collapsed"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="connect-kickoff"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('returns nothing when hideIfUnavailable and the round is not self', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: 'connect_unavailable', reason: 'not_self_round', builder: 'platform' }),
+      })),
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'plat-tok', hideIfUnavailable: true, collapsible: false }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('.studio-connect')).toBeNull();
+    expect(container.textContent).toBe('');
+
+    await act(async () => root.unmount());
+  });
+
   it('resume mode leads with the kickoff and tucks MCP install under details', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -530,6 +530,36 @@ describe('StudioConnectCard', () => {
     await act(async () => root.unmount());
   });
 
+  it('surfaces missing_slug instead of hiding when hideIfUnavailable', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: 'connect_unavailable', reason: 'missing_slug', builder: 'self' }),
+      })),
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'slugless', hideIfUnavailable: true, collapsible: false }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('.studio-connect.is-error')).not.toBeNull();
+    expect(container.textContent).toContain("couldn't load the connect steps");
+
+    await act(async () => root.unmount());
+  });
+
   it('resume mode leads with the kickoff and tucks MCP install under details', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -162,11 +162,13 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
   const showInstallLinks = Boolean(installLinks?.cursor && installLinks?.vscode);
 
   return (
-    <section className="studio-connect" aria-labelledby={`${baseId}-title`}>
+    <section className={`studio-connect${error ? ' is-error' : ''}`} aria-labelledby={`${baseId}-title`}>
       <h3 id={`${baseId}-title`} className="studio-connect-title">
         {t('connect.title')}
       </h3>
-      <p className="studio-connect-lead">{t('connect.lead')}</p>
+      {/* Lead is setup guidance — drop it once we only have an error, so a phone foot/thread
+          is not mostly paragraph + red line. */}
+      {!error ? <p className="studio-connect-lead">{t('connect.lead')}</p> : null}
 
       {loading ? <p className="studio-connect-state">{t('connect.loading')}</p> : null}
       {error ? <p className="error">{error}</p> : null}

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 import {
@@ -21,6 +21,9 @@ const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
 const AUTH_MODE_STORAGE_KEY = 'gamedev_connect_auth_mode';
 
 type ConnectAuthMode = 'key' | 'oauth';
+
+/** First attach vs mid-round re-attach after quiet / gate green. */
+export type ConnectCardMode = 'setup' | 'resume';
 
 function loadAuthMode(): ConnectAuthMode {
   try {
@@ -47,6 +50,12 @@ type StudioConnectCardProps = {
    * status poll.
    */
   agentConnected?: boolean;
+  /**
+   * `setup` (default): full MCP install + kickoff for the first connect.
+   * `resume`: kickoff-first after quiet / gate-green — install stays under a details
+   * disclosure so a mid-round stall does not look like a project reset.
+   */
+  mode?: ConnectCardMode;
 };
 
 /**
@@ -57,7 +66,7 @@ type StudioConnectCardProps = {
  * Step 2: paste the keyless kickoff prompt (slug only; never a secret).
  * The full Authorization value is held in memory for Copy and never rendered.
  */
-export function StudioConnectCard({ token, agentConnected = false }: StudioConnectCardProps) {
+export function StudioConnectCard({ token, agentConnected = false, mode = 'setup' }: StudioConnectCardProps) {
   const { t, i18n } = useTranslation();
   const baseId = useId();
   const authHeaderRef = useRef<string | null>(null);
@@ -70,6 +79,8 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
   const [rotateArmed, setRotateArmed] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
+
+  const isResume = mode === 'resume';
 
   useEffect(() => {
     let cancelled = false;
@@ -98,9 +109,9 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
     return null;
   }
 
-  const chooseAuthMode = (mode: ConnectAuthMode) => {
-    setAuthMode(mode);
-    saveAuthMode(mode);
+  const chooseAuthMode = (next: ConnectAuthMode) => {
+    setAuthMode(next);
+    saveAuthMode(next);
   };
 
   const copyText = async (text: string, which: 'config' | 'kickoff') => {
@@ -161,206 +172,219 @@ export function StudioConnectCard({ token, agentConnected = false }: StudioConne
   const installLinks = payload?.installLinks;
   const showInstallLinks = Boolean(installLinks?.cursor && installLinks?.vscode);
 
+  const installLinksBlock =
+    showInstallLinks && installLinks ? (
+      <>
+        <p className="studio-connect-same">{t('connect.installLinks.hint')}</p>
+        <div className="studio-connect-install-links" data-testid="connect-install-links">
+          <a
+            className="studio-connect-install-link"
+            href={installLinks.cursor}
+            data-testid="connect-install-cursor"
+            onClick={() => recordDeeplinkClick('cursor')}
+          >
+            {t('connect.installLinks.cursor')}
+          </a>
+          <a
+            className="studio-connect-install-link"
+            href={installLinks.vscode}
+            data-testid="connect-install-vscode"
+            onClick={() => recordDeeplinkClick('vscode')}
+          >
+            {t('connect.installLinks.vscode')}
+          </a>
+        </div>
+      </>
+    ) : null;
+
+  const installPanel: ReactNode = payload ? (
+    <>
+      <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.authMode.label')}>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={authMode === 'key'}
+          className={`studio-connect-tab${authMode === 'key' ? ' is-active' : ''}`}
+          onClick={() => chooseAuthMode('key')}
+        >
+          {t('connect.authMode.key')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={authMode === 'oauth'}
+          className={`studio-connect-tab${authMode === 'oauth' ? ' is-active' : ''}`}
+          onClick={() => chooseAuthMode('oauth')}
+        >
+          {t('connect.authMode.oauth')}
+        </button>
+      </div>
+
+      {authMode === 'key' ? (
+        <div className="studio-connect-step">
+          <div className="studio-connect-step-head">
+            {!isResume ? (
+              <span className="studio-connect-step-num" aria-hidden="true">
+                1
+              </span>
+            ) : null}
+            <h4 className="studio-connect-step-title">{t('connect.step1.title')}</h4>
+          </div>
+          {installLinksBlock}
+          <p className="studio-connect-same">{t('connect.step1.configHint')}</p>
+          <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.step1.clients')}>
+            {CONNECT_CLIENTS.map((id) => (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={client === id}
+                className={`studio-connect-tab${client === id ? ' is-active' : ''}`}
+                onClick={() => setClient(id)}
+              >
+                {t(CLIENT_LABEL_KEY[id])}
+              </button>
+            ))}
+          </div>
+          <pre className="studio-connect-snippet" tabIndex={0} data-testid="connect-config-snippet">
+            {installSnippet}
+          </pre>
+          <p className="studio-connect-expiry" data-testid="connect-key-meta">
+            {t('connect.step1.meta', {
+              fingerprint: payload.fingerprint,
+              when: expiresLabel,
+              generation: payload.keyGeneration,
+            })}
+          </p>
+          <div className="studio-connect-actions">
+            <button type="button" className="status-share-copy" onClick={() => void copyConfig()}>
+              <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
+              {copied === 'config' ? t('connect.copied') : t('connect.copyConfig')}
+            </button>
+            {!rotateArmed ? (
+              <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
+                {t('connect.rotate.start')}
+              </button>
+            ) : (
+              <span className="studio-connect-rotate-confirm">
+                <span>{t('connect.rotate.confirm')}</span>
+                <button
+                  type="button"
+                  className="studio-connect-skip is-danger"
+                  disabled={rotating}
+                  onClick={() => void handleRotate()}
+                >
+                  {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
+                </button>
+                <button
+                  type="button"
+                  className="studio-connect-skip"
+                  disabled={rotating}
+                  onClick={() => setRotateArmed(false)}
+                >
+                  {t('connect.rotate.no')}
+                </button>
+              </span>
+            )}
+          </div>
+          {rotateError ? <p className="error">{rotateError}</p> : null}
+        </div>
+      ) : (
+        <div className="studio-connect-step">
+          <div className="studio-connect-step-head">
+            {!isResume ? (
+              <span className="studio-connect-step-num" aria-hidden="true">
+                1
+              </span>
+            ) : null}
+            <h4 className="studio-connect-step-title">{t('connect.oauth.title')}</h4>
+          </div>
+          {installLinksBlock}
+          <p className="studio-connect-same">{t('connect.oauth.hint')}</p>
+          <pre className="studio-connect-snippet" tabIndex={0}>
+            {payload.mcpUrl}
+          </pre>
+          <div className="studio-connect-actions">
+            <button type="button" className="status-share-copy" onClick={() => void copyText(payload.mcpUrl, 'config')}>
+              <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
+              {copied === 'config' ? t('connect.copied') : t('connect.copyUrl')}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  ) : null;
+
+  const kickoffPanel: ReactNode = payload ? (
+    <div className="studio-connect-step">
+      <div className="studio-connect-step-head">
+        {!isResume ? (
+          <span className="studio-connect-step-num" aria-hidden="true">
+            2
+          </span>
+        ) : null}
+        <h4 className="studio-connect-step-title">
+          {isResume ? t('connect.resume.kickoffTitle') : t('connect.step2.title')}
+        </h4>
+      </div>
+      <p className="studio-connect-same">
+        {isResume ? t('connect.resume.kickoffHint') : t('connect.step2.sameConnection')}
+      </p>
+      <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0} data-testid="connect-kickoff">
+        {payload.kickoffPrompt}
+      </pre>
+      <div className="studio-connect-actions">
+        <button
+          type="button"
+          className="status-share-copy"
+          onClick={() => void copyText(payload.kickoffPrompt, 'kickoff')}
+        >
+          <PixelIcon name={copied === 'kickoff' ? 'check' : 'sparkle'} size={12} />{' '}
+          {copied === 'kickoff' ? t('connect.copied') : t('connect.copyKickoff')}
+        </button>
+      </div>
+    </div>
+  ) : null;
+
   return (
-    <section className={`studio-connect${error ? ' is-error' : ''}`} aria-labelledby={`${baseId}-title`}>
+    <section
+      className={`studio-connect${error ? ' is-error' : ''}${isResume ? ' is-resume' : ''}`}
+      aria-labelledby={`${baseId}-title`}
+      data-connect-mode={mode}
+    >
       <h3 id={`${baseId}-title`} className="studio-connect-title">
-        {t('connect.title')}
+        {isResume ? t('connect.resume.title') : t('connect.title')}
       </h3>
       {/* Lead is setup guidance — drop it once we only have an error, so a phone foot/thread
           is not mostly paragraph + red line. */}
-      {!error ? <p className="studio-connect-lead">{t('connect.lead')}</p> : null}
+      {!error ? <p className="studio-connect-lead">{isResume ? t('connect.resume.lead') : t('connect.lead')}</p> : null}
 
       {loading ? <p className="studio-connect-state">{t('connect.loading')}</p> : null}
       {error ? <p className="error">{error}</p> : null}
 
       {payload && !loading ? (
-        <>
-          <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.authMode.label')}>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={authMode === 'key'}
-              className={`studio-connect-tab${authMode === 'key' ? ' is-active' : ''}`}
-              onClick={() => chooseAuthMode('key')}
-            >
-              {t('connect.authMode.key')}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={authMode === 'oauth'}
-              className={`studio-connect-tab${authMode === 'oauth' ? ' is-active' : ''}`}
-              onClick={() => chooseAuthMode('oauth')}
-            >
-              {t('connect.authMode.oauth')}
-            </button>
-          </div>
-
-          {authMode === 'key' ? (
-            <div className="studio-connect-step">
-              <div className="studio-connect-step-head">
-                <span className="studio-connect-step-num" aria-hidden="true">
-                  1
-                </span>
-                <h4 className="studio-connect-step-title">{t('connect.step1.title')}</h4>
-              </div>
-              {showInstallLinks && installLinks ? (
-                <>
-                  <p className="studio-connect-same">{t('connect.installLinks.hint')}</p>
-                  <div className="studio-connect-install-links" data-testid="connect-install-links">
-                    <a
-                      className="studio-connect-install-link"
-                      href={installLinks.cursor}
-                      data-testid="connect-install-cursor"
-                      onClick={() => recordDeeplinkClick('cursor')}
-                    >
-                      {t('connect.installLinks.cursor')}
-                    </a>
-                    <a
-                      className="studio-connect-install-link"
-                      href={installLinks.vscode}
-                      data-testid="connect-install-vscode"
-                      onClick={() => recordDeeplinkClick('vscode')}
-                    >
-                      {t('connect.installLinks.vscode')}
-                    </a>
-                  </div>
-                </>
-              ) : null}
-              <p className="studio-connect-same">{t('connect.step1.configHint')}</p>
-              <div className="studio-connect-tabs" role="tablist" aria-label={t('connect.step1.clients')}>
-                {CONNECT_CLIENTS.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    role="tab"
-                    aria-selected={client === id}
-                    className={`studio-connect-tab${client === id ? ' is-active' : ''}`}
-                    onClick={() => setClient(id)}
-                  >
-                    {t(CLIENT_LABEL_KEY[id])}
-                  </button>
-                ))}
-              </div>
-              <pre className="studio-connect-snippet" tabIndex={0} data-testid="connect-config-snippet">
-                {installSnippet}
-              </pre>
-              <p className="studio-connect-expiry" data-testid="connect-key-meta">
-                {t('connect.step1.meta', {
-                  fingerprint: payload.fingerprint,
-                  when: expiresLabel,
-                  generation: payload.keyGeneration,
-                })}
-              </p>
-              <div className="studio-connect-actions">
-                <button type="button" className="status-share-copy" onClick={() => void copyConfig()}>
-                  <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
-                  {copied === 'config' ? t('connect.copied') : t('connect.copyConfig')}
-                </button>
-                {!rotateArmed ? (
-                  <button type="button" className="studio-connect-skip" onClick={() => setRotateArmed(true)}>
-                    {t('connect.rotate.start')}
-                  </button>
-                ) : (
-                  <span className="studio-connect-rotate-confirm">
-                    <span>{t('connect.rotate.confirm')}</span>
-                    <button
-                      type="button"
-                      className="studio-connect-skip is-danger"
-                      disabled={rotating}
-                      onClick={() => void handleRotate()}
-                    >
-                      {rotating ? t('connect.rotate.sending') : t('connect.rotate.yes')}
-                    </button>
-                    <button
-                      type="button"
-                      className="studio-connect-skip"
-                      disabled={rotating}
-                      onClick={() => setRotateArmed(false)}
-                    >
-                      {t('connect.rotate.no')}
-                    </button>
-                  </span>
-                )}
-              </div>
-              {rotateError ? <p className="error">{rotateError}</p> : null}
-            </div>
-          ) : (
-            <div className="studio-connect-step">
-              <div className="studio-connect-step-head">
-                <span className="studio-connect-step-num" aria-hidden="true">
-                  1
-                </span>
-                <h4 className="studio-connect-step-title">{t('connect.oauth.title')}</h4>
-              </div>
-              {showInstallLinks && installLinks ? (
-                <>
-                  <p className="studio-connect-same">{t('connect.installLinks.hint')}</p>
-                  <div className="studio-connect-install-links" data-testid="connect-install-links">
-                    <a
-                      className="studio-connect-install-link"
-                      href={installLinks.cursor}
-                      data-testid="connect-install-cursor"
-                      onClick={() => recordDeeplinkClick('cursor')}
-                    >
-                      {t('connect.installLinks.cursor')}
-                    </a>
-                    <a
-                      className="studio-connect-install-link"
-                      href={installLinks.vscode}
-                      data-testid="connect-install-vscode"
-                      onClick={() => recordDeeplinkClick('vscode')}
-                    >
-                      {t('connect.installLinks.vscode')}
-                    </a>
-                  </div>
-                </>
-              ) : null}
-              <p className="studio-connect-same">{t('connect.oauth.hint')}</p>
-              <pre className="studio-connect-snippet" tabIndex={0}>
-                {payload.mcpUrl}
-              </pre>
-              <div className="studio-connect-actions">
-                <button
-                  type="button"
-                  className="status-share-copy"
-                  onClick={() => void copyText(payload.mcpUrl, 'config')}
-                >
-                  <PixelIcon name={copied === 'config' ? 'check' : 'sparkle'} size={12} />{' '}
-                  {copied === 'config' ? t('connect.copied') : t('connect.copyUrl')}
-                </button>
-              </div>
-            </div>
-          )}
-
-          <div className="studio-connect-step">
-            <div className="studio-connect-step-head">
-              <span className="studio-connect-step-num" aria-hidden="true">
-                2
-              </span>
-              <h4 className="studio-connect-step-title">{t('connect.step2.title')}</h4>
-            </div>
-            <p className="studio-connect-same">{t('connect.step2.sameConnection')}</p>
-            <pre className="studio-connect-snippet studio-connect-kickoff" tabIndex={0} data-testid="connect-kickoff">
-              {payload.kickoffPrompt}
-            </pre>
-            <div className="studio-connect-actions">
-              <button
-                type="button"
-                className="status-share-copy"
-                onClick={() => void copyText(payload.kickoffPrompt, 'kickoff')}
-              >
-                <PixelIcon name={copied === 'kickoff' ? 'check' : 'sparkle'} size={12} />{' '}
-                {copied === 'kickoff' ? t('connect.copied') : t('connect.copyKickoff')}
-              </button>
-            </div>
-          </div>
-
-          <p className="studio-connect-waiting" aria-live="polite">
-            <span className="studio-connect-pulse" aria-hidden="true" />
-            {t('connect.waiting')}
-          </p>
-        </>
+        isResume ? (
+          <>
+            {kickoffPanel}
+            <p className="studio-connect-waiting" aria-live="polite">
+              <span className="studio-connect-pulse" aria-hidden="true" />
+              {t('connect.resume.waiting')}
+            </p>
+            <details className="studio-connect-setup-details" data-testid="connect-setup-details">
+              <summary>{t('connect.resume.setupDetails')}</summary>
+              <div className="studio-connect-setup-body">{installPanel}</div>
+            </details>
+          </>
+        ) : (
+          <>
+            {installPanel}
+            {kickoffPanel}
+            <p className="studio-connect-waiting" aria-live="polite">
+              <span className="studio-connect-pulse" aria-hidden="true" />
+              {t('connect.waiting')}
+            </p>
+          </>
+        )
       ) : null}
     </section>
   );

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -10,7 +10,10 @@ import {
   type ConnectPayload,
 } from './connectApi.js';
 import { isConnectCollapsed, setConnectCollapsed } from './connectCollapse.js';
+import type { ConnectCardMode } from './selfBuildCopy.js';
 import { recordStudioStep } from './visitTelemetry.js';
+
+export type { ConnectCardMode };
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
   claudeCode: 'connect.clients.claudeCode',
@@ -24,8 +27,8 @@ const AUTH_MODE_STORAGE_KEY = 'gamedev_connect_auth_mode';
 
 type ConnectAuthMode = 'key' | 'oauth';
 
-/** First attach vs mid-round re-attach after quiet / gate green. */
-export type ConnectCardMode = 'setup' | 'resume';
+/** Reasons the connect endpoint returns 409 that mean "no card belongs here". */
+const QUIET_UNAVAILABLE = new Set(['not_self_round', 'inactive_round']);
 
 function loadAuthMode(): ConnectAuthMode {
   try {
@@ -122,9 +125,15 @@ export function StudioConnectCard({
       .catch((err: unknown) => {
         if (cancelled) return;
         const apiErr = err as ConnectApiError;
-        // 409 connect_unavailable = platform / inactive round — Details mounts us
-        // opportunistically and should stay quiet. Other failures still surface.
-        if (hideIfUnavailable && (apiErr.status === 409 || apiErr.message === 'connect_unavailable')) {
+        // Details mounts us for every open draft — stay quiet only when the round is
+        // plainly not a self connect (platform / inactive). missing_slug and other
+        // 409s still surface so a broken self round is not silently empty.
+        if (
+          hideIfUnavailable &&
+          apiErr.message === 'connect_unavailable' &&
+          apiErr.reason != null &&
+          QUIET_UNAVAILABLE.has(apiErr.reason)
+        ) {
           setUnavailable(true);
           setLoading(false);
           return;

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -5,9 +5,11 @@ import {
   CONNECT_CLIENTS,
   getConnectPayload,
   rotateCreatorAgentKey,
+  type ConnectApiError,
   type ConnectClient,
   type ConnectPayload,
 } from './connectApi.js';
+import { isConnectCollapsed, setConnectCollapsed } from './connectCollapse.js';
 import { recordStudioStep } from './visitTelemetry.js';
 
 const CLIENT_LABEL_KEY: Record<ConnectClient, string> = {
@@ -56,6 +58,16 @@ type StudioConnectCardProps = {
    * disclosure so a mid-round stall does not look like a project reset.
    */
   mode?: ConnectCardMode;
+  /**
+   * When true (default), the creator can hide the tall card and restore it from a
+   * one-line strip — so connect steps do not own the whole thread after first look.
+   */
+  collapsible?: boolean;
+  /**
+   * When true, a non-self / inactive round yields nothing instead of an error
+   * (Details mounts this for every open game; only self rounds have a payload).
+   */
+  hideIfUnavailable?: boolean;
 };
 
 /**
@@ -66,12 +78,19 @@ type StudioConnectCardProps = {
  * Step 2: paste the keyless kickoff prompt (slug only; never a secret).
  * The full Authorization value is held in memory for Copy and never rendered.
  */
-export function StudioConnectCard({ token, agentConnected = false, mode = 'setup' }: StudioConnectCardProps) {
+export function StudioConnectCard({
+  token,
+  agentConnected = false,
+  mode = 'setup',
+  collapsible = true,
+  hideIfUnavailable = false,
+}: StudioConnectCardProps) {
   const { t, i18n } = useTranslation();
   const baseId = useId();
   const authHeaderRef = useRef<string | null>(null);
   const [payload, setPayload] = useState<ConnectPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
   const [loading, setLoading] = useState(true);
   const [client, setClient] = useState<ConnectClient>('claudeCode');
   const [authMode, setAuthMode] = useState<ConnectAuthMode>(() => loadAuthMode());
@@ -79,13 +98,19 @@ export function StudioConnectCard({ token, agentConnected = false, mode = 'setup
   const [rotateArmed, setRotateArmed] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(() => (collapsible ? isConnectCollapsed(token) : false));
 
   const isResume = mode === 'resume';
+
+  useEffect(() => {
+    setCollapsed(collapsible ? isConnectCollapsed(token) : false);
+  }, [token, collapsible]);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setUnavailable(false);
     getConnectPayload(token)
       .then((next) => {
         if (!cancelled) {
@@ -94,19 +119,60 @@ export function StudioConnectCard({ token, agentConnected = false, mode = 'setup
           setLoading(false);
         }
       })
-      .catch(() => {
-        if (!cancelled) {
-          setError(t('connect.loadError'));
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const apiErr = err as ConnectApiError;
+        // 409 connect_unavailable = platform / inactive round — Details mounts us
+        // opportunistically and should stay quiet. Other failures still surface.
+        if (hideIfUnavailable && (apiErr.status === 409 || apiErr.message === 'connect_unavailable')) {
+          setUnavailable(true);
           setLoading(false);
+          return;
         }
+        setError(t('connect.loadError'));
+        setLoading(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [token, t]);
+  }, [token, t, hideIfUnavailable]);
 
-  if (agentConnected) {
+  if (agentConnected || unavailable) {
     return null;
+  }
+
+  const hideCard = () => {
+    setConnectCollapsed(token, true);
+    setCollapsed(true);
+    recordStudioStep('connect_dismissed', 'self');
+  };
+
+  const showCard = () => {
+    setConnectCollapsed(token, false);
+    setCollapsed(false);
+    recordStudioStep('connect_restored', 'self');
+  };
+
+  if (collapsible && collapsed && !loading && !error) {
+    return (
+      <aside
+        className="studio-connect is-collapsed"
+        aria-label={t('connect.collapsed.title')}
+        data-connect-mode={mode}
+        data-testid="connect-collapsed"
+      >
+        <p className="studio-connect-waiting" aria-live="polite">
+          <span className="studio-connect-pulse" aria-hidden="true" />
+          {isResume ? t('connect.resume.waiting') : t('connect.waiting')}
+        </p>
+        <div className="studio-connect-collapsed-actions">
+          <button type="button" className="studio-connect-show" onClick={showCard}>
+            {t('connect.show')}
+          </button>
+          <span className="studio-connect-collapsed-hint">{t('connect.collapsed.hint')}</span>
+        </div>
+      </aside>
+    );
   }
 
   const chooseAuthMode = (next: ConnectAuthMode) => {
@@ -351,10 +417,18 @@ export function StudioConnectCard({ token, agentConnected = false, mode = 'setup
       className={`studio-connect${error ? ' is-error' : ''}${isResume ? ' is-resume' : ''}`}
       aria-labelledby={`${baseId}-title`}
       data-connect-mode={mode}
+      data-testid="connect-expanded"
     >
-      <h3 id={`${baseId}-title`} className="studio-connect-title">
-        {isResume ? t('connect.resume.title') : t('connect.title')}
-      </h3>
+      <div className="studio-connect-title-row">
+        <h3 id={`${baseId}-title`} className="studio-connect-title">
+          {isResume ? t('connect.resume.title') : t('connect.title')}
+        </h3>
+        {collapsible && !error ? (
+          <button type="button" className="studio-connect-hide" onClick={hideCard} data-testid="connect-hide">
+            {t('connect.hide')}
+          </button>
+        ) : null}
+      </div>
       {/* Lead is setup guidance — drop it once we only have an error, so a phone foot/thread
           is not mostly paragraph + red line. */}
       {!error ? <p className="studio-connect-lead">{isResume ? t('connect.resume.lead') : t('connect.lead')}</p> : null}

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -166,8 +166,8 @@ export function StudioConnectCard({
           {isResume ? t('connect.resume.waiting') : t('connect.waiting')}
         </p>
         <div className="studio-connect-collapsed-actions">
-          <button type="button" className="studio-connect-show" onClick={showCard}>
-            {t('connect.show')}
+          <button type="button" className="studio-connect-show" onClick={showCard} data-testid="connect-show">
+            <PixelIcon name="expand" size={12} /> {t('connect.show')}
           </button>
           <span className="studio-connect-collapsed-hint">{t('connect.collapsed.hint')}</span>
         </div>
@@ -424,8 +424,14 @@ export function StudioConnectCard({
           {isResume ? t('connect.resume.title') : t('connect.title')}
         </h3>
         {collapsible && !error ? (
-          <button type="button" className="studio-connect-hide" onClick={hideCard} data-testid="connect-hide">
-            {t('connect.hide')}
+          <button
+            type="button"
+            className="studio-connect-hide"
+            onClick={hideCard}
+            data-testid="connect-hide"
+            title={t('connect.hide')}
+          >
+            <PixelIcon name="close" size={11} /> {t('connect.hide')}
           </button>
         ) : null}
       </div>
@@ -459,6 +465,21 @@ export function StudioConnectCard({
             </p>
           </>
         )
+      ) : null}
+
+      {/* End-of-card dismiss: the title-row chip is easy to miss once the title wraps on
+          a phone; readers finish at the waiting line and need a clear exit there. */}
+      {collapsible && !error && payload && !loading ? (
+        <div className="studio-connect-foot-dismiss">
+          <button
+            type="button"
+            className="studio-connect-hide is-foot"
+            onClick={hideCard}
+            data-testid="connect-hide-foot"
+          >
+            <PixelIcon name="close" size={11} /> {t('connect.hide')}
+          </button>
+        </div>
       ) : null}
     </section>
   );

--- a/apps/web/src/StudioDetailsBuildProgress.test.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StudioDetailsBuildProgress } from './StudioDetailsBuildProgress.js';
+import i18n from './i18n/index.js';
+import { getSubmissionStatus } from './submissionApi.js';
+
+vi.mock('./submissionApi', async () => {
+  const actual = await vi.importActual<typeof import('./submissionApi.js')>('./submissionApi.js');
+  return {
+    ...actual,
+    getSubmissionStatus: vi.fn(),
+  };
+});
+
+const mockedGetSubmissionStatus = vi.mocked(getSubmissionStatus);
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('StudioDetailsBuildProgress', () => {
+  afterEach(() => {
+    mockedGetSubmissionStatus.mockReset();
+  });
+
+  it('renders the checklist fraction relocated from the thread foot', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      progress: {
+        headSha: 'sha-1',
+        commits: [],
+        checklist: [
+          { text: 'Collision', checked: true },
+          { text: 'Sprites', checked: true },
+          { text: 'Audio', checked: false },
+        ],
+      },
+    });
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioDetailsBuildProgress, { token: 'progress-token' }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const panel = container.querySelector('[data-testid="studio-details-progress"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toContain('2 of 3 done');
+    expect(panel?.textContent).toContain('Collision');
+    expect(panel?.textContent).toContain('Audio');
+    expect(panel?.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('2');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('renders nothing when the round has no checklist yet', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      progress: { headSha: 'sha-1', commits: [], checklist: [] },
+    });
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioDetailsBuildProgress, { token: 'empty-progress' }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('[data-testid="studio-details-progress"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
+import { getSubmissionStatus, type BuildEvent, type BuildProgress } from './submissionApi.js';
+
+/** Details refreshes slower than the thread — the thread already owns the live pulse. */
+const DETAILS_POLL_MS = 10_000;
+
+/**
+ * Checklist + fraction for the Details rail — the progress that used to sit in the
+ * thread foot. Kept out of the composer strip so the conversation stays Claude-quiet;
+ * open Details when you want the count.
+ */
+export function StudioDetailsBuildProgress({ token }: { token: string }) {
+  const { t, i18n } = useTranslation();
+  const [progress, setProgress] = useState<BuildProgress | null>(null);
+  const [events, setEvents] = useState<BuildEvent[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const status = await getSubmissionStatus(token, i18n.language);
+        if (cancelled) return;
+        setProgress(status.progress ?? null);
+        setEvents(status.events ?? []);
+      } catch {
+        // Secondary chrome — a failed poll must not toast over the thread.
+      }
+    };
+
+    void load();
+    const timer = window.setInterval(() => void load(), DETAILS_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [token, i18n.language]);
+
+  const checklist = progress?.checklist ?? [];
+  const reported = events.find((event) => event.progress)?.progress;
+  const doneCount = reported?.done ?? checklist.filter((item) => item.checked).length;
+  const totalCount = reported?.total ?? checklist.length;
+
+  if (totalCount === 0) return null;
+
+  const donePercent = (doneCount / totalCount) * 100;
+  const currentStep = checklist.find((item) => !item.checked);
+  const note = events[0]?.text ?? progress?.note;
+
+  return (
+    <div className="studio-details-progress" data-testid="studio-details-progress">
+      <div className="build-progress-heading-row">
+        <h3 className="build-progress-heading">{t('statusView.progress.checklistTitle')}</h3>
+        <span className="build-progress-count">
+          {t('statusView.progress.checklistCount', { done: doneCount, total: totalCount })}
+        </span>
+      </div>
+      <div
+        className="build-progress-bar"
+        role="progressbar"
+        aria-valuenow={doneCount}
+        aria-valuemin={0}
+        aria-valuemax={totalCount}
+      >
+        <div className="build-progress-bar-fill" style={{ width: `${donePercent}%` }} />
+      </div>
+      {note ? (
+        <p className="studio-details-progress-note">
+          <span className="build-progress-note-label">
+            {events[0]?.step ? t(`statusView.progress.steps.${events[0].step}`) : t('statusView.progress.agentSays')}
+          </span>
+          <span className="build-progress-note-text">{note}</span>
+        </p>
+      ) : currentStep ? (
+        <p className="build-progress-current">
+          <span className="build-progress-current-spinner" aria-hidden="true" />
+          {t('statusView.progress.currentStep', { step: currentStep.text })}
+        </p>
+      ) : null}
+      {checklist.length > 0 ? (
+        <ul className="studio-details-checklist">
+          {checklist.map((item, index) => (
+            <li key={index} className={item.checked ? 'checklist-done' : 'checklist-pending'}>
+              <span aria-hidden="true">
+                <PixelIcon name={item.checked ? 'check' : 'checkbox'} size={12} />
+              </span>{' '}
+              {item.text}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -142,7 +142,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('routes the one Play verb to playtest when Studio provides that surface', async () => {
+  it('keeps Play out of the embedded foot — the Studio header owns that verb', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -163,16 +163,10 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    // Header and foot share one Play verb — no second "play with a note" peer.
-    const play = container.querySelector<HTMLButtonElement>('.status-play-cta');
-    expect(play?.textContent?.trim()).toMatch(/^Play$/);
+    // Thread foot is phase/heartbeat only — no Play peer of the composer.
+    expect(container.querySelector('.status-play-cta')).toBeNull();
     expect(container.querySelector('.status-playtest-cta')).toBeNull();
-
-    await act(async () => {
-      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
-    expect(onPlaytest).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.studio-context-progress')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -451,17 +445,10 @@ describe('SubmissionStatusView', () => {
 
     expect(mockedGetSubmissionPreview).toHaveBeenCalledWith('self-ready-token');
     expect(mockedGetChannelPlayable).not.toHaveBeenCalled();
-    const playDraft = container.querySelector<HTMLButtonElement>('.studio-thread-context .status-play-cta');
-    // Foot uses the short play verb; phase already says this is still a draft.
-    expect(playDraft?.textContent?.trim()).toMatch(/^Play$/);
-
-    await act(async () => {
-      playDraft?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
-    const iframe = container.querySelector('iframe');
-    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-pointer-lock');
-    expect(iframe?.getAttribute('srcdoc') ?? '').toContain('id="game"');
+    // Embedded foot no longer carries Play — open the draft from a thread media/version
+    // path is covered elsewhere; here we only assert the preview loaded for Studio.
+    expect(container.querySelector('.studio-thread-context .status-play-cta')).toBeNull();
+    expect(mockedGetSubmissionPreview.mock.results[0]?.value).toBeTruthy();
 
     await act(async () => {
       root.unmount();
@@ -570,6 +557,7 @@ describe('SubmissionStatusView', () => {
 
   it('shows the connect card while a self round awaits its agent, then hides it on signal', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.clear();
     vi.useFakeTimers();
     const connectFetch = vi.fn(async () => ({
       ok: true,
@@ -1247,10 +1235,10 @@ describe('SubmissionStatusView', () => {
 
     expect(container.querySelector('.studio-thread-context.is-active')).not.toBeNull();
     expect(container.querySelector('.studio-context-phase-spinner')).not.toBeNull();
-    // Abandon is Details-only — not a destructive peer of the composer.
+    // Abandon / checklist / Play stay out of the foot — Claude-shaped chrome.
     expect(container.querySelector('.studio-context-stop')).toBeNull();
-    // Incomplete checklist still shows; slug does not (header owns identity).
-    expect(container.querySelector('.studio-context-progress')?.textContent).toContain('4 of 6 done');
+    expect(container.querySelector('.studio-context-progress')).toBeNull();
+    expect(container.querySelector('.status-play-cta')).toBeNull();
     expect(container.querySelector('.studio-thread-context .studio-slug')).toBeNull();
 
     await act(async () => {
@@ -1287,7 +1275,7 @@ describe('SubmissionStatusView', () => {
 
     expect(container.querySelector('.studio-context-progress')).toBeNull();
     expect(container.querySelector('.studio-thread-context .studio-slug')).toBeNull();
-    expect(container.querySelector('.status-play-cta')?.textContent?.trim()).toMatch(/Play$/);
+    expect(container.querySelector('.status-play-cta')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -142,7 +142,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('offers playtesting as a quiet link next to Play, once there is something to play', async () => {
+  it('routes the one Play verb to playtest when Studio provides that surface', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -163,15 +163,13 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    // One play verb in the foot; playtest is a quieter path, not a peer button.
+    // Header and foot share one Play verb — no second "play with a note" peer.
     const play = container.querySelector<HTMLButtonElement>('.status-play-cta');
     expect(play?.textContent?.trim()).toMatch(/^Play$/);
-    const playtest = container.querySelector<HTMLButtonElement>('.status-playtest-cta');
-    expect(playtest?.classList.contains('studio-context-link')).toBe(true);
-    expect(playtest?.textContent).toContain('Play with a note');
+    expect(container.querySelector('.status-playtest-cta')).toBeNull();
 
     await act(async () => {
-      playtest?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
     expect(onPlaytest).toHaveBeenCalledTimes(1);
@@ -645,8 +643,10 @@ describe('SubmissionStatusView', () => {
       });
 
       expect(container.querySelector('.studio-connect')).toBeNull();
-      // Active self round: composer routing says the agent will pick the note up.
-      expect(container.textContent).toContain('picks this up on its next check-in');
+      // Active self round: composer is back; the always-on "picks this up" line is gone —
+      // that was chrome noise once an agent is already listening.
+      expect(container.querySelector('.status-composer')).not.toBeNull();
+      expect(container.querySelector('.status-feedback-route')).toBeNull();
     } finally {
       await act(async () => {
         root.unmount();
@@ -707,7 +707,13 @@ describe('SubmissionStatusView', () => {
       });
 
       expect(container.querySelector('.status-warning')?.textContent).toContain("can't start it from here");
-      expect(container.querySelector('.studio-connect')).not.toBeNull();
+      expect(container.querySelector('.studio-connect.is-resume')).not.toBeNull();
+      expect(container.textContent).toContain('Continue with your agent');
+      expect(container.textContent).not.toContain('Connect your coding agent');
+      // Full first-time install stays under a closed disclosure — continue, not a reset.
+      const details = container.querySelector<HTMLDetailsElement>('[data-testid="connect-setup-details"]');
+      expect(details).not.toBeNull();
+      expect(details?.open).toBe(false);
       expect(container.textContent).toContain('your agent will get this when you start it');
       expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
     } finally {
@@ -1208,7 +1214,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('shows a build pulse and a stop control on the studio thread bar while building', async () => {
+  it('shows a build pulse and checklist fraction on the studio thread bar while building', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -1241,7 +1247,8 @@ describe('SubmissionStatusView', () => {
 
     expect(container.querySelector('.studio-thread-context.is-active')).not.toBeNull();
     expect(container.querySelector('.studio-context-phase-spinner')).not.toBeNull();
-    expect(container.querySelector('.studio-context-stop')?.textContent).toContain('Stop');
+    // Abandon is Details-only — not a destructive peer of the composer.
+    expect(container.querySelector('.studio-context-stop')).toBeNull();
     // Incomplete checklist still shows; slug does not (header owns identity).
     expect(container.querySelector('.studio-context-progress')?.textContent).toContain('4 of 6 done');
     expect(container.querySelector('.studio-thread-context .studio-slug')).toBeNull();
@@ -1655,7 +1662,7 @@ describe('SubmissionStatusView stop & retry', () => {
     });
 
     const arm = container.querySelector<HTMLButtonElement>('.status-abandon');
-    expect(arm?.textContent).toContain('Stop this build');
+    expect(arm?.textContent).toContain('Abandon this build');
 
     // Arming must not call the API — this is the mis-tap guard.
     await act(async () => {
@@ -1663,7 +1670,7 @@ describe('SubmissionStatusView stop & retry', () => {
       await flushEffects();
     });
     expect(mockedAbandonSubmission).not.toHaveBeenCalled();
-    expect(container.textContent).toContain('Stop building this game?');
+    expect(container.textContent).toContain('Abandon this round?');
 
     await act(async () => {
       container

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1202,7 +1202,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('shows a build pulse and checklist fraction on the studio thread bar while building', async () => {
+  it('keeps build pulse in the foot without checklist fraction, stop, or Play', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -1240,6 +1240,43 @@ describe('SubmissionStatusView', () => {
     expect(container.querySelector('.studio-context-progress')).toBeNull();
     expect(container.querySelector('.status-play-cta')).toBeNull();
     expect(container.querySelector('.studio-thread-context .studio-slug')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('lets the creator dismiss a stall chip above the composer', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      stall: 'quiet',
+      builder: 'platform',
+      progress: { headSha: 'sha-1', commits: [], checklist: [] },
+    });
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'chip-dismiss', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const chip = container.querySelector('.studio-status-chip');
+    expect(chip?.textContent).toContain('quiet for a while');
+    const dismiss = container.querySelector<HTMLButtonElement>('.studio-status-chip-dismiss');
+    expect(dismiss).not.toBeNull();
+
+    await act(async () => {
+      dismiss?.click();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.studio-status-chip')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -628,6 +628,9 @@ describe('SubmissionStatusView', () => {
       // the conversation to a sliver on a phone (connect + play CTAs + composer).
       expect(container.querySelector('.studio-thread-scroll .studio-connect')).not.toBeNull();
       expect(container.querySelector('.studio-thread-foot .studio-connect')).toBeNull();
+      // Nobody is listening yet — a composer that "saves for later" is just noise beside
+      // the connect steps. It returns once the agent has checked in.
+      expect(container.querySelector('.status-composer')).toBeNull();
       expect(connectFetch).toHaveBeenCalledWith(
         expect.stringContaining('/api/submissions/await-token/connect'),
         expect.objectContaining({ credentials: 'include' }),

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -624,6 +624,10 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.studio-connect')).not.toBeNull();
       expect(container.textContent).toContain('Connect your coding agent');
       expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
+      // Tall connect UI scrolls with the transcript — pinning it in the foot crushed
+      // the conversation to a sliver on a phone (connect + play CTAs + composer).
+      expect(container.querySelector('.studio-thread-scroll .studio-connect')).not.toBeNull();
+      expect(container.querySelector('.studio-thread-foot .studio-connect')).toBeNull();
       expect(connectFetch).toHaveBeenCalledWith(
         expect.stringContaining('/api/submissions/await-token/connect'),
         expect.objectContaining({ credentials: 'include' }),

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -205,6 +205,35 @@ function failureCopyKey(reason: string): string {
   return FAILURE_COPY_KEYS.has(reason) ? reason : 'generic';
 }
 
+/**
+ * Claude-shaped status chip above the composer: one sentence, dismissible with ×.
+ * Reappears when the underlying condition changes (`chipKey`).
+ */
+function ThreadStatusChip({ chipKey, children }: { chipKey: string; children: ReactNode }) {
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setDismissed(false);
+  }, [chipKey]);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="studio-status-chip status-warning" role="status" data-chip-key={chipKey}>
+      <span className="studio-status-chip-body">{children}</span>
+      <button
+        type="button"
+        className="studio-status-chip-dismiss"
+        onClick={() => setDismissed(true)}
+        aria-label={t('notifications.dismiss')}
+      >
+        <PixelIcon name="close" size={12} />
+      </button>
+    </div>
+  );
+}
+
 type SubmissionStatusViewProps = {
   token: string;
   submittedTitle?: string;
@@ -648,26 +677,30 @@ export function SubmissionStatusView({
                     card inside the transcript scroller (not this foot) so a phone still
                     has room for the conversation. Delivery-cap is a failure sentence. */}
                 {status.failure ? (
-                  <p className="status-warning">
-                    <PixelIcon name="signal" size={13} />{' '}
-                    {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
-                  </p>
+                  <ThreadStatusChip chipKey={`failure:${status.failure.reason}`}>
+                    <PixelIcon name="signal" size={13} />
+                    <span>{t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}</span>
+                  </ThreadStatusChip>
                 ) : status.status === 'needs_changes' ? (
-                  <p className="status-warning">
-                    <PixelIcon name="signal" size={13} /> {t('statusView.states.needs_changes.description')}
-                  </p>
+                  <ThreadStatusChip chipKey="needs_changes">
+                    <PixelIcon name="signal" size={13} />
+                    <span>{t('statusView.states.needs_changes.description')}</span>
+                  </ThreadStatusChip>
                 ) : selfCopy === 'no_agent_yet' ? null : selfCopy === 'quiet_agent' ? (
-                  <p className="status-warning">
-                    <PixelIcon name="signal" size={13} /> {t('statusView.stall.quietSelf')}
-                  </p>
+                  <ThreadStatusChip chipKey="quiet_self">
+                    <PixelIcon name="signal" size={13} />
+                    <span>{t('statusView.stall.quietSelf')}</span>
+                  </ThreadStatusChip>
                 ) : status.stall ? (
-                  <p className="status-warning">
-                    <PixelIcon name="signal" size={13} /> {t(`statusView.stall.${status.stall}`)}
-                  </p>
+                  <ThreadStatusChip chipKey={`stall:${status.stall}`}>
+                    <PixelIcon name="signal" size={13} />
+                    <span>{t(`statusView.stall.${status.stall}`)}</span>
+                  </ThreadStatusChip>
                 ) : status.progress?.checks === 'FAILURE' ? (
-                  <p className="status-warning">
-                    <PixelIcon name="signal" size={13} /> {t('statusView.checksFailed')}
-                  </p>
+                  <ThreadStatusChip chipKey="checks_failure">
+                    <PixelIcon name="signal" size={13} />
+                    <span>{t('statusView.checksFailed')}</span>
+                  </ThreadStatusChip>
                 ) : null}
 
                 {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -22,7 +22,7 @@ import {
 } from './submissionApi.js';
 import { NAVIGATE_EVENT, statusPath, studioPath } from './router.js';
 import { formatRelativeTime } from './relativeTime.js';
-import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
+import { connectCardMode, selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { submitImprovement } from './studioApi.js';
 import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
@@ -643,7 +643,11 @@ export function SubmissionStatusView({
                 stickNonce={isAwaitingOwnAgent(status) ? pendingRevisions.length + 1 : 0}
                 after={
                   isAwaitingOwnAgent(status) ? (
-                    <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
+                    <StudioConnectCard
+                      key={`connect-${pendingRevisions.length}`}
+                      token={token}
+                      mode={connectCardMode(copyInputFromStatus(status)) ?? 'setup'}
+                    />
                   ) : null
                 }
               />
@@ -695,16 +699,19 @@ export function SubmissionStatusView({
 
                 {/* Checklist fraction earns its keep while work remains; once every
                     item is checked it only restates the phase. Slug lives in the studio
-                    header — repeating it here is infra chrome. */}
+                    header — repeating it here is infra chrome.
+                    Abandon lives in Details (Claude-Code side panel), not beside the
+                    composer. When Studio provides playtest, that is the one Play verb —
+                    the header already owns the same action; no second "play with a note". */}
                 <ThreadContextBar
                   phase={t(`statusView.states.${status.status}.label`)}
                   heartbeatAt={heartbeatAt}
                   active={!TERMINAL_STATUSES.has(status.status)}
-                  {...(!TERMINAL_STATUSES.has(status.status) ? { stopToken: token } : {})}
                   {...(total > 0 && done < total ? { progress: { done, total } } : {})}
-                  {...(playable ? { primary: playable } : {})}
-                  {...(onPlaytest && playable
-                    ? { secondary: { label: t('statusView.playtestCta'), onClick: onPlaytest } }
+                  {...(playable
+                    ? {
+                        primary: onPlaytest ? { label: t('statusView.playShort'), onClick: onPlaytest } : playable,
+                      }
                     : {})}
                 />
 
@@ -817,7 +824,11 @@ export function SubmissionStatusView({
             ) : null}
 
             {isAwaitingOwnAgent(status) ? (
-              <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
+              <StudioConnectCard
+                key={`connect-${pendingRevisions.length}`}
+                token={token}
+                mode={connectCardMode(copyInputFromStatus(status)) ?? 'setup'}
+              />
             ) : null}
 
             {TERMINAL_STATUSES.has(status.status) && status.status !== 'published' && submittedConcept && onRetry ? (
@@ -1174,12 +1185,11 @@ function FeedbackPanel({
       : composerRoute === 'waiting'
         ? 'statusView.feedback.sentSelfWaiting'
         : null;
-  const routeNoteKey =
-    composerRoute === 'active'
-      ? 'statusView.feedback.routeSelfActive'
-      : composerRoute === 'waiting'
-        ? 'statusView.feedback.routeSelfWaiting'
-        : null;
+  // Active self rounds already imply a listening agent — repeating that above the
+  // box is chrome noise (the placeholder covers "what to write"). Waiting is the
+  // case that still needs a sentence: the note will not be read until they start
+  // their agent again.
+  const routeNoteKey = composerRoute === 'waiting' ? 'statusView.feedback.routeSelfWaiting' : null;
 
   // The composer grows with what is typed, which is what replaced the resize grip: once
   // the send button moved inside the box, a drag handle in the middle of its right edge
@@ -1539,19 +1549,14 @@ function ThreadContextBar({
   heartbeatAt,
   progress,
   primary,
-  secondary,
   active = false,
-  stopToken,
 }: {
   phase: string;
   heartbeatAt: number | null;
   progress?: { done: number; total: number };
   primary?: { label: string; onClick: () => void };
-  secondary?: { label: string; onClick: () => void };
   /** Agent is mid-build — show motion so "Writing code" does not read as stuck text. */
   active?: boolean;
-  /** When set, offer a two-step stop control for the running build. */
-  stopToken?: string;
 }) {
   const { t } = useTranslation();
 
@@ -1573,12 +1578,6 @@ function ThreadContextBar({
           <span className="studio-context-progress">
             {t('statusView.progress.checklistCount', { done: progress.done, total: progress.total })}
           </span>
-        ) : null}
-        {stopToken ? <AbandonControl token={stopToken} compact /> : null}
-        {secondary ? (
-          <button type="button" className="studio-context-link status-playtest-cta" onClick={secondary.onClick}>
-            {secondary.label}
-          </button>
         ) : null}
         {primary ? (
           <button type="button" className="primary-btn status-play-cta" onClick={primary.onClick}>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -708,7 +708,10 @@ export function SubmissionStatusView({
                     : {})}
                 />
 
-                {status.status !== 'abandoned' ? (
+                {/* Before the first agent signal there is nobody to receive a note — the
+                    connect card is the only move. Quiet / gate-green still keep the box
+                    so a creator can leave work for the next start. */}
+                {status.status !== 'abandoned' && selfCopy !== 'no_agent_yet' ? (
                   <FeedbackPanel
                     token={token}
                     published={status.status === 'published'}
@@ -886,7 +889,7 @@ export function SubmissionStatusView({
 
                 No mode to pick, either: a game is either published or it is not, and
                 there is only ever the current version to work on. */}
-            {status.status !== 'abandoned' ? (
+            {status.status !== 'abandoned' && selfCopy !== 'no_agent_yet' ? (
               <FeedbackPanel
                 token={token}
                 published={status.status === 'published'}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -636,7 +636,17 @@ export function SubmissionStatusView({
             </div>
           ) : status ? (
             <>
-              <ThreadStream token={token} entries={activity} emptyLabel={stateDescription} />
+              <ThreadStream
+                token={token}
+                entries={activity}
+                emptyLabel={stateDescription}
+                stickNonce={isAwaitingOwnAgent(status) ? pendingRevisions.length + 1 : 0}
+                after={
+                  isAwaitingOwnAgent(status) ? (
+                    <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
+                  ) : null
+                }
+              />
 
               <div className="studio-thread-foot">
                 {/* Trouble is said once, immediately above the box the creator would use
@@ -646,9 +656,9 @@ export function SubmissionStatusView({
                     needs a sentence here — the thread's emptyLabel only shows when there
                     are no turns, which is exactly when a bounced build still has planning
                     notes and used to look like nothing was wrong.
-                    Self rounds: no-agent-yet is the connect card alone; quiet keeps a
-                    self-specific warning *and* resurfaces the card (we cannot wake the
-                    agent). Delivery-cap is a failure sentence, not a stall. */}
+                    Self rounds: no-agent-yet / quiet / gate-green resurface the connect
+                    card inside the transcript scroller (not this foot) so a phone still
+                    has room for the conversation. Delivery-cap is a failure sentence. */}
                 {status.failure ? (
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} />{' '}
@@ -670,10 +680,6 @@ export function SubmissionStatusView({
                   <p className="status-warning">
                     <PixelIcon name="signal" size={13} /> {t('statusView.checksFailed')}
                   </p>
-                ) : null}
-
-                {isAwaitingOwnAgent(status) ? (
-                  <StudioConnectCard key={`connect-${pendingRevisions.length}`} token={token} />
                 ) : null}
 
                 {previewError && !preview && !channelHtml ? <p className="error">{previewError}</p> : null}
@@ -1425,7 +1431,22 @@ function FeedbackPanel({
  * bottom as the agent talks — unless the reader has scrolled up, which is them saying
  * they are reading something and would like it to stay put.
  */
-function ThreadStream({ token, entries, emptyLabel }: { token: string; entries: ActivityEntry[]; emptyLabel: string }) {
+function ThreadStream({
+  token,
+  entries,
+  emptyLabel,
+  after,
+  stickNonce = 0,
+}: {
+  token: string;
+  entries: ActivityEntry[];
+  emptyLabel: string;
+  /** Renders inside the scroller after the turns — tall surfaces (connect card) belong
+   *  here, not in the pinned foot, or a phone has no room left for the conversation. */
+  after?: ReactNode;
+  /** Bump when `after` appears/disappears so a stick-to-bottom reader still sees it. */
+  stickNonce?: number;
+}) {
   const { t, i18n } = useTranslation();
   const [zoomed, setZoomed] = useState<BuildMediaItem | null>(null);
   const [broken, setBroken] = useState<string[]>([]);
@@ -1444,7 +1465,7 @@ function ThreadStream({ token, entries, emptyLabel }: { token: string; entries: 
     const pane = scrollRef.current;
     if (!pane || !stickToBottomRef.current) return;
     pane.scrollTop = pane.scrollHeight;
-  }, [entries.length]);
+  }, [entries.length, stickNonce]);
 
   return (
     <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
@@ -1495,6 +1516,7 @@ function ThreadStream({ token, entries, emptyLabel }: { token: string; entries: 
           );
         })}
       </ol>
+      {after}
       {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}
     </div>
   );

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -597,22 +597,6 @@ export function SubmissionStatusView({
           t('statusView.gallery.caption'),
         )
       : [];
-    const reported = status?.events?.find((event) => event.progress)?.progress;
-    const checklist = status?.progress?.checklist ?? [];
-    const done = reported?.done ?? checklist.filter((item) => item.checked).length;
-    const total = reported?.total ?? checklist.length;
-
-    // Short play verb in the foot — the phase already says live vs draft, so
-    // "Play your game" / "Play the draft" were two long peers of the quieter playtest path.
-    const playable =
-      status?.status === 'published' && status.slug
-        ? { label: t('statusView.playShort'), onClick: () => setPlaying('published') }
-        : preview
-          ? { label: t('statusView.playShort'), onClick: openDraft }
-          : channelHtml
-            ? { label: t('statusView.playShort'), onClick: openChannel }
-            : undefined;
-
     return (
       <>
         <div className="studio-thread">
@@ -697,22 +681,12 @@ export function SubmissionStatusView({
                   </button>
                 ) : null}
 
-                {/* Checklist fraction earns its keep while work remains; once every
-                    item is checked it only restates the phase. Slug lives in the studio
-                    header — repeating it here is infra chrome.
-                    Abandon lives in Details (Claude-Code side panel), not beside the
-                    composer. When Studio provides playtest, that is the one Play verb —
-                    the header already owns the same action; no second "play with a note". */}
+                {/* Claude-shaped foot: phase + heartbeat only. Play lives in the header
+                    icon cluster; abandon / checklist / connect live in Details. */}
                 <ThreadContextBar
                   phase={t(`statusView.states.${status.status}.label`)}
                   heartbeatAt={heartbeatAt}
                   active={!TERMINAL_STATUSES.has(status.status)}
-                  {...(total > 0 && done < total ? { progress: { done, total } } : {})}
-                  {...(playable
-                    ? {
-                        primary: onPlaytest ? { label: t('statusView.playShort'), onClick: onPlaytest } : playable,
-                      }
-                    : {})}
                 />
 
                 {/* Before the first agent signal there is nobody to receive a note — the

--- a/apps/web/src/connectCollapse.ts
+++ b/apps/web/src/connectCollapse.ts
@@ -1,0 +1,24 @@
+/**
+ * Per-round preference: hide the tall MCP connect card so it does not own the
+ * thread. Expand restores it; Details also mounts the card when available.
+ */
+
+const STORAGE_PREFIX = 'gamedev_connect_collapsed:';
+
+export function isConnectCollapsed(token: string): boolean {
+  try {
+    return localStorage.getItem(`${STORAGE_PREFIX}${token}`) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setConnectCollapsed(token: string, collapsed: boolean): void {
+  try {
+    const key = `${STORAGE_PREFIX}${token}`;
+    if (collapsed) localStorage.setItem(key, '1');
+    else localStorage.removeItem(key);
+  } catch {
+    // Preference only — a private mode block must not break the thread.
+  }
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -274,7 +274,7 @@
     "tabs": {
       "thread": "Thread",
       "details": "Details",
-      "playtest": "Playtest",
+      "playtest": "Play",
       "edit": "Edit"
     },
     "editor": {
@@ -323,9 +323,9 @@
       "sessions": "Recent play",
       "play": "played",
       "openBuild": "Open build",
-      "playtest": "Playtest & prompt",
-      "abandon": "Stop build",
-      "abandonConfirm": "Confirm stop"
+      "playtest": "Play & note",
+      "abandon": "Abandon this build",
+      "abandonConfirm": "Yes, abandon — discard this round"
     },
     "share": {
       "title": "Share the draft",
@@ -644,13 +644,13 @@
     },
     "tryAgain": "Try this idea again",
     "abandon": {
-      "start": "Stop this build",
-      "compact": "Stop",
-      "confirm": "Stop building this game?",
-      "yes": "Yes, stop it",
+      "start": "Abandon this build",
+      "compact": "Abandon",
+      "confirm": "Abandon this round? Agent work so far is discarded.",
+      "yes": "Yes, abandon it",
       "no": "Keep building",
-      "sending": "Stopping…",
-      "error": "We couldn't stop this build right now. Please try again in a moment."
+      "sending": "Abandoning…",
+      "error": "We couldn't abandon this build right now. Please try again in a moment."
     },
     "playableHint": "An early build, straight from the workshop — rough, unfinished, and already playable. Tell them what to change while it is easy."
   },
@@ -960,6 +960,14 @@
       "no": "Cancel",
       "sending": "Rotating…",
       "error": "We couldn't rotate the key right now. Try again in a moment."
+    },
+    "resume": {
+      "title": "Continue with your agent",
+      "lead": "Your agent went quiet. Paste this prompt into the same session — or start a new one with your existing gamedev.pl connection.",
+      "kickoffTitle": "Continue prompt",
+      "kickoffHint": "This prompt carries only the game slug. Your MCP connection stays in the agent config.",
+      "setupDetails": "Need to reconnect MCP?",
+      "waiting": "Waiting for your agent to check in again…"
     }
   },
   "agentKey": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -918,6 +918,12 @@
     "copyInstall": "Copy",
     "copyKickoff": "Copy prompt",
     "waiting": "Waiting for your agent to check in…",
+    "hide": "Hide for now",
+    "show": "Show connect steps",
+    "collapsed": {
+      "title": "Waiting for your coding agent",
+      "hint": "Also in Details anytime."
+    },
     "authMode": {
       "label": "How to connect",
       "key": "Paste header",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -276,7 +276,7 @@
     "tabs": {
       "thread": "Wątek",
       "details": "Szczegóły",
-      "playtest": "Testuj",
+      "playtest": "Zagraj",
       "edit": "Edytuj"
     },
     "editor": {
@@ -325,9 +325,9 @@
       "sessions": "Ostatnia gra",
       "play": "gry",
       "openBuild": "Otwórz build",
-      "playtest": "Playtest i prompt",
-      "abandon": "Zatrzymaj build",
-      "abandonConfirm": "Potwierdź zatrzymanie"
+      "playtest": "Zagraj i notatka",
+      "abandon": "Porzuć ten build",
+      "abandonConfirm": "Tak, porzuć — odrzuć tę rundę"
     },
     "share": {
       "title": "Udostępnij wersję roboczą",
@@ -648,13 +648,13 @@
     },
     "tryAgain": "Spróbuj z tym pomysłem jeszcze raz",
     "abandon": {
-      "start": "Zatrzymaj tę grę",
-      "compact": "Zatrzymaj",
-      "confirm": "Zatrzymać tworzenie tej gry?",
-      "yes": "Tak, zatrzymaj",
+      "start": "Porzuć ten build",
+      "compact": "Porzuć",
+      "confirm": "Porzucić tę rundę? Dotychczasowa praca agenta zostanie odrzucona.",
+      "yes": "Tak, porzuć",
       "no": "Twórz dalej",
-      "sending": "Zatrzymuję…",
-      "error": "Nie udało się teraz zatrzymać tej gry. Spróbuj ponownie za chwilę."
+      "sending": "Porzucam…",
+      "error": "Nie udało się teraz porzucić tego buildu. Spróbuj ponownie za chwilę."
     },
     "playableHint": "Wczesna wersja prosto z warsztatu — surowa, niedokończona i już grywalna. Powiedz, co zmienić, póki to łatwe."
   },
@@ -964,6 +964,14 @@
       "no": "Anuluj",
       "sending": "Obracanie…",
       "error": "Nie udało się teraz obrócić klucza. Spróbuj za chwilę."
+    },
+    "resume": {
+      "title": "Wznów pracę z agentem",
+      "lead": "Twój agent umilkł. Wklej ten prompt do tej samej sesji — albo uruchom nową z istniejącym połączeniem gamedev.pl.",
+      "kickoffTitle": "Prompt wznowienia",
+      "kickoffHint": "Ten prompt niesie tylko slug gry. Połączenie MCP zostaje w konfiguracji agenta.",
+      "setupDetails": "Trzeba ponownie podłączyć MCP?",
+      "waiting": "Czekamy, aż Twój agent znów się odezwie…"
     }
   },
   "agentKey": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -922,6 +922,12 @@
     "copyInstall": "Kopiuj",
     "copyKickoff": "Kopiuj prompt",
     "waiting": "Czekamy, aż Twój agent się odezwie…",
+    "hide": "Ukryj na razie",
+    "show": "Pokaż kroki połączenia",
+    "collapsed": {
+      "title": "Czekamy na Twojego agenta",
+      "hint": "Zawsze też w Szczegółach."
+    },
     "authMode": {
       "label": "Jak się połączyć",
       "key": "Wklej nagłówek",

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import enLocale from './i18n/locales/en.json';
 import plLocale from './i18n/locales/pl.json';
-import { selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
+import { connectCardMode, selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 
 describe('selfStatusCopy', () => {
   it('is null for platform rounds', () => {
@@ -55,6 +55,22 @@ describe('shouldShowConnectCard', () => {
     ).toBe(false);
     expect(shouldShowConnectCard({ builder: 'self', stall: null })).toBe(false);
     expect(shouldShowConnectCard({ builder: 'platform', stall: 'quiet' })).toBe(false);
+  });
+});
+
+describe('connectCardMode', () => {
+  it('is setup before the first agent signal', () => {
+    expect(connectCardMode({ builder: 'self', stall: 'no_agent_yet' })).toBe('setup');
+  });
+
+  it('is resume after quiet or gate-green — not a full first-time install', () => {
+    expect(connectCardMode({ builder: 'self', stall: 'quiet' })).toBe('resume');
+    expect(connectCardMode({ builder: 'self', phase: 'ready_for_review' })).toBe('resume');
+  });
+
+  it('is null when the connect card should not show', () => {
+    expect(connectCardMode({ builder: 'self', stall: null })).toBeNull();
+    expect(connectCardMode({ builder: 'platform', stall: 'quiet' })).toBeNull();
   });
 });
 

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -69,8 +69,8 @@ describe('selfComposerRoute', () => {
     expect(selfComposerRoute({ builder: 'self' })).toBe('active');
   });
 
-  it('is waiting before first signal, when quiet, or at the delivery cap', () => {
-    expect(selfComposerRoute({ builder: 'self', stall: 'no_agent_yet' })).toBe('waiting');
+  it('hides the composer before first signal; waits when quiet or at the delivery cap', () => {
+    expect(selfComposerRoute({ builder: 'self', stall: 'no_agent_yet' })).toBeNull();
     expect(selfComposerRoute({ builder: 'self', stall: 'quiet' })).toBe('waiting');
     expect(
       selfComposerRoute({

--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -46,11 +46,27 @@ export function selfStatusCopy(input: SelfBuildCopyInput): SelfStatusCopy | null
  * quiet — gamedev.pl cannot wake it, so the paste-ready prompt is the resume path.
  * Also shown after a green gate closes the round: Studio still looks "live", but no
  * session will check the inbox until the creator starts their agent again.
+ *
+ * Quiet / gate-green use {@link connectCardMode} `resume` (kickoff-first), not the
+ * full first-time MCP install chrome.
  */
 export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
   const copy = selfStatusCopy(input);
   if (copy === 'no_agent_yet' || copy === 'quiet_agent') return true;
   return input.builder === 'self' && input.phase === 'ready_for_review';
+}
+
+/** Shape of the connect card when it is on screen, or null when it should not show. */
+export type ConnectCardMode = 'setup' | 'resume';
+
+/**
+ * First attach gets the full install + kickoff. Quiet / gate-green already had a
+ * connection — show the continue prompt first and tuck MCP re-install under details.
+ */
+export function connectCardMode(input: SelfBuildCopyInput): ConnectCardMode | null {
+  if (!shouldShowConnectCard(input)) return null;
+  if (selfStatusCopy(input) === 'no_agent_yet') return 'setup';
+  return 'resume';
 }
 
 /**

--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -54,19 +54,22 @@ export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
 }
 
 /**
- * Composer routing for a self round, or null when the platform is building.
+ * Composer routing for a self round, or null when the platform is building / the
+ * composer should not be on screen.
  *
- * `waiting` covers both pre-first-signal and quiet — the message is saved, but no
- * agent will see it until the creator starts theirs. `active` means a recent signal
- * so the next check-in will pick the inbox up.
+ * Pre-first-signal (`no_agent_yet`): returns null — Studio hides the composer; the
+ * connect card is the only action. `waiting` is for quiet / gate-green / delivery-cap,
+ * where a note can still be left for the next start. `active` means a recent signal so
+ * the next check-in will pick the inbox up.
  *
  * Gate-green (`ready_for_review`) closes the round and retires the session key, so
  * claiming a next check-in would be a lie — route as waiting even with a stale stall.
  */
 export function selfComposerRoute(input: SelfBuildCopyInput): SelfComposerRoute | null {
   if (input.builder !== 'self') return null;
+  if (input.stall === 'no_agent_yet') return null;
   if (input.failureReason === 'self_build_delivery_cap') return 'waiting';
   if (input.phase === 'ready_for_review') return 'waiting';
-  if (input.stall === 'no_agent_yet' || input.stall === 'quiet') return 'waiting';
+  if (input.stall === 'quiet') return 'waiting';
   return 'active';
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3370,6 +3370,89 @@ body.player-open {
   border: 1px solid rgba(251, 191, 36, 0.28);
 }
 
+/* Claude-shaped: one dismissible chip above the composer, not a sticky banner. */
+.studio-status-chip {
+  margin: 0;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  font-size: 0.82rem;
+}
+
+.studio-status-chip-body {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.studio-status-chip-body > span {
+  min-width: 0;
+}
+
+.studio-status-chip-dismiss {
+  appearance: none;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin: -4px -2px -4px 0;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.studio-status-chip-dismiss:hover {
+  opacity: 1;
+  background: rgba(251, 191, 36, 0.12);
+}
+
+.studio-details-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 10px;
+  background: var(--panel-card);
+  border: 1px solid var(--panel-border);
+}
+
+.studio-details-progress-note {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  font-size: 0.82rem;
+}
+
+.studio-details-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.82rem;
+}
+
+.studio-details-checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  color: var(--text);
+}
+
+.studio-details-checklist li.checklist-done {
+  color: var(--muted);
+}
+
 .status-retry {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5113,12 +5113,17 @@ a.user-name--profile:focus-visible {
 
   .app:has(.studio-layout.is-game-open) .studio-head-actions {
     flex: none;
+    flex-wrap: nowrap;
   }
 
-  /* Details keeps its icon and loses its word. Clipped rather than display: none, so the
-     button is still called "Details" by a screen reader. Playtest keeps both — it is the
-     thing most people came to do. */
-  .app:has(.studio-layout.is-game-open) .studio-head-action:not(.is-primary) .studio-head-action-label {
+  .app:has(.studio-layout.is-game-open) .studio-head-action {
+    padding: 6px 10px;
+  }
+
+  /* Icon-only in the title row — Playtest's word plus Details (and Claim) was enough to
+     shove the trailing control past the right edge on a 390px phone with a long title.
+     Clipped rather than display: none so the button keeps its accessible name. */
+  .app:has(.studio-layout.is-game-open) .studio-head-action .studio-head-action-label {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -5391,14 +5396,21 @@ a.user-name--profile:focus-visible {
   }
 }
 
-/* Self-build connect steps in the Studio thread. Interaction container, not card chrome. */
+/* Self-build connect steps in the Studio thread. Interaction container, not card chrome.
+   Lives inside `.studio-thread-scroll` so a tall connect surface scrolls with the
+   conversation instead of pinning the composer halfway up a phone. */
 .studio-connect {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  margin: 0 0 10px;
-  padding: 14px 0 4px;
+  margin: 12px 0 4px;
+  padding: 14px 0 8px;
   border-top: 1px solid var(--panel-border, #33383d);
+}
+
+.studio-connect.is-error {
+  gap: 8px;
+  padding-bottom: 4px;
 }
 
 .studio-connect-title {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4502,12 +4502,26 @@ a.user-name--profile:focus-visible {
   background: rgba(0, 228, 172, 0.1);
 }
 
-/* Solid turquoise CTA — Playtest must read louder than the outlined Details toggle. */
+/* Solid turquoise CTA — Play must read louder than the icon-only Details toggle. */
 .studio-head-action.is-primary {
   background: var(--turquoise);
   border-color: var(--turquoise);
   color: #08241d;
   font-weight: 700;
+}
+
+/* Claude-shaped cluster: Edit / Details / Claim are icons; the accessible name stays
+   in a clipped label so AT and tests that read textContent still see the word. */
+.studio-head-action.is-icon-only .studio-head-action-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .studio-head-action--claim {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5413,11 +5413,57 @@ a.user-name--profile:focus-visible {
   padding-bottom: 4px;
 }
 
+.studio-connect-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .studio-connect-title {
   margin: 0;
   font-size: 1rem;
   font-weight: 700;
   color: var(--text-heading, #fff);
+}
+
+.studio-connect-hide,
+.studio-connect-show {
+  appearance: none;
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--muted, #94a3b8);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.studio-connect-hide:hover,
+.studio-connect-show:hover {
+  color: var(--text, #e2e8f0);
+}
+
+.studio-connect.is-collapsed {
+  gap: 8px;
+  padding-top: 10px;
+  padding-bottom: 4px;
+}
+
+.studio-connect-collapsed-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 12px;
+}
+
+.studio-connect-collapsed-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted, #94a3b8);
 }
 
 .studio-connect-lead,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5415,36 +5415,62 @@ a.user-name--profile:focus-visible {
 
 .studio-connect-title-row {
   display: flex;
-  align-items: baseline;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px 12px;
 }
 
 .studio-connect-title {
   margin: 0;
+  flex: 1 1 12rem;
   font-size: 1rem;
   font-weight: 700;
   color: var(--text-heading, #fff);
 }
 
+/* Peer of Copy config / install chips — not a muted underline that vanishes into
+   a wrapping title on a phone. */
 .studio-connect-hide,
 .studio-connect-show {
-  appearance: none;
-  border: 0;
-  background: none;
-  padding: 0;
-  font: inherit;
-  font-size: 0.8rem;
-  color: var(--muted, #94a3b8);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
   flex-shrink: 0;
+  padding: 0.4rem 0.85rem;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--turquoise, #00e4ac) 45%, var(--panel-border, #33383d));
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 12%, transparent);
+  color: var(--text-heading, #fff);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 .studio-connect-hide:hover,
 .studio-connect-show:hover {
-  color: var(--text, #e2e8f0);
+  border-color: var(--turquoise, #00e4ac);
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 20%, transparent);
+}
+
+/* Phone: title wraps and buries the header chip — repeat dismiss where reading ends.
+   Desktop keeps the header control only so the card does not grow two exits. */
+.studio-connect-foot-dismiss {
+  display: none;
+}
+
+.studio-connect-hide.is-foot {
+  width: 100%;
+}
+
+@media (max-width: 800px) {
+  .studio-connect-foot-dismiss {
+    display: flex;
+    justify-content: stretch;
+    padding-top: 2px;
+  }
 }
 
 .studio-connect.is-collapsed {
@@ -5456,7 +5482,7 @@ a.user-name--profile:focus-visible {
 .studio-connect-collapsed-actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: 8px 12px;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5463,6 +5463,9 @@ a.user-name--profile:focus-visible {
 
 .studio-connect-hide.is-foot {
   width: 100%;
+  padding: 0.55rem 0.85rem;
+  border-color: var(--turquoise, #00e4ac);
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 18%, transparent);
 }
 
 @media (max-width: 800px) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5584,6 +5584,42 @@ a.user-name--profile:focus-visible {
   }
 }
 
+/* Mid-round resume: kickoff first; full MCP install tucked under a disclosure so a
+   quiet stall does not look like first-time onboarding. */
+.studio-connect.is-resume {
+  gap: 12px;
+}
+
+.studio-connect-setup-details {
+  margin: 0;
+  padding-top: 4px;
+  border-top: 1px solid var(--panel-border, #33383d);
+}
+
+.studio-connect-setup-details > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.82rem;
+  color: var(--muted, #94a3b8);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.studio-connect-setup-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.studio-connect-setup-details > summary:hover {
+  color: var(--text, #e2e8f0);
+}
+
+.studio-connect-setup-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 12px;
+}
+
 /* Naming the game — the step the build waits on, so it leads the panel and is sized
    like a decision rather than like one more field among the clarifying questions. */
 .qa-name {

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -129,7 +129,14 @@ export type BuilderDimension = 'platform' | 'self';
  * agent signal (`msSinceStart` on `agent_signaled`), and gate verdict per visit.
  */
 export type StudioStep =
-  'builder_chosen' | 'connect_copied' | 'connect_deeplink' | 'agent_signaled' | 'gate_verdict' | 'round_opened';
+  | 'builder_chosen'
+  | 'connect_copied'
+  | 'connect_deeplink'
+  | 'connect_dismissed'
+  | 'connect_restored'
+  | 'agent_signaled'
+  | 'gate_verdict'
+  | 'round_opened';
 
 /**
  * Closed detail for studio steps that need one. `install` / `kickoff` are connect-card


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Self-build Studio UX was fighting the creator mid-round: a quiet agent resurfaced the full MCP install card (felt like a reset), tall connect steps owned the whole thread, the foot stacked Stop + progress + Test/Play peers, and an always-on “your agent will pick this up…” line sat above the composer.

This PR moves Studio toward Claude-shaped chrome: thread center, icons open side panels, light dismissible status above the composer.

## Screenshots

### Desktop thread (quiet foot + Zagraj + icon Details)
[Desktop Studio thread](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-thread-desktop.png)

### Mobile thread
[Mobile Studio thread](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-thread-mobile.png)

### Dismissible stall chip + Details checklist
[Status chip and Details progress](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-gaps-chip-and-details.webp)

### After dismissing the chip
[Chip dismissed](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-gaps-chip-dismissed.webp)

[studio-gaps-chip-dismiss-demo.mp4](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio-gaps-chip-dismiss-demo.mp4)

### Connect card (Hide chip)
[Desktop connect expanded](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-connect-desktop.png)
[Desktop connect collapsed](https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-connect-desktop-collapsed.png)

## Change

### Claude-shaped chrome
- Header: one primary **Play** + icon-only Details/Edit
- Thread foot: phase + heartbeat only (no Stop / progress / Play peers)
- Checklist fraction lives in **Details** (`StudioDetailsBuildProgress`)
- Stall / failure copy above the composer is a dismissible chip (×)

### Dismissable connect steps
- **Hide for now** chip; preference persists per round; restore via strip / Details
- Quiet / gate-green use `resume` mode (kickoff-first, not full MCP reset)

### Composer honesty
- Composer hidden until first agent check-in
- Always-on “agent will pick this up” route note removed for active self rounds

## Verification
- `npm run type-check && npm run lint` green
- Unit tests: SubmissionStatusView, StudioDetailsBuildProgress, CreatorStudioView


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

