### PR TITLE
fix(mcp): stop refusing ChatGPT when Mcp-Session-Id drifts

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -595,7 +595,9 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(JSON.stringify(res.structured)).toContain('finished');
   });
 
-  it('rejects a sessionKey presented under a mismatched Mcp-Session-Id', async () => {
+  it('accepts a valid sessionKey even when Mcp-Session-Id has drifted', async () => {
+    // ChatGPT Apps (and Cloud Run multi-instance) often present a different correlator
+    // than the one start() embedded. The sessionKey is the capability; the header is not.
     const store = new InMemoryStore();
     await seedJob(store);
     app = await createApp(store);
@@ -604,9 +606,25 @@ describe('POST /api/mcp (BY-05)', () => {
     const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionA });
     const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
 
-    const mismatch = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionB });
-    expect(mismatch.isError).toBe(true);
-    expect(JSON.stringify(mismatch.structured)).toMatch(/bound to a different Mcp-Session-Id/i);
+    const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionB });
+    expect(brief.isError).toBe(false);
+    expect(brief.structured).toMatchObject({ title: 'Comet Courier' });
+  });
+
+  it('binds start to the client Mcp-Session-Id even when this instance never saw initialize', async () => {
+    // Simulate multi-instance: client sends a well-formed id that is not in our local map.
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const foreignSessionId = 'abcdef0123456789abcdef0123456789abcd';
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': foreignSessionId });
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({ sessionId: foreignSessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': foreignSessionId });
+    expect(brief.isError).toBe(false);
+    expect(brief.structured).toMatchObject({ title: 'Comet Courier' });
   });
 
   it('reaches /api/mcp through the private-beta wall without a site session', async () => {
@@ -969,7 +987,9 @@ describe('POST /api/mcp (BY-05)', () => {
     });
   });
 
-  it('DELETE terminates the transport session (not auth)', async () => {
+  it('DELETE drops the local correlator; a well-formed id is re-adopted on the next call', async () => {
+    // Multi-instance Cloud Run cannot treat DELETE as a hard kill — the next revision
+    // would just 404 a still-valid ChatGPT session. Adopt restores the correlator.
     const store = new InMemoryStore();
     await seedJob(store);
     app = await createApp(store);
@@ -983,7 +1003,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(del.statusCode).toBe(204);
 
     const listed = await mcpCall(app, 'tools/list', {}, { 'mcp-session-id': sessionId });
-    expect(listed.statusCode).toBe(404);
+    expect(listed.statusCode).toBe(200);
   });
 
   it('list_examples and get_sources wrap the channel', async () => {
@@ -1280,10 +1300,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(good.isError).toBe(false);
   });
 
-  // The binding is real and was documented nowhere: start's own description says
-  // "Does not treat Mcp-Session-Id as authority", which reads as "the header does not
-  // matter" when in fact it is necessary, just not sufficient.
-  it('documents that a sessionKey is bound to the session that minted it', async () => {
+  it('documents that Mcp-Session-Id is a correlator and start() rebinds if lost', async () => {
     const store = new InMemoryStore();
     await seedActiveSelfJob(store);
     app = await createApp(store);
@@ -1298,7 +1315,7 @@ describe('POST /api/mcp (BY-05)', () => {
     const brief = tools.find((tool) => tool.name === 'get_brief');
     const described = brief?.inputSchema.properties?.sessionKey?.description ?? '';
 
-    expect(described).toMatch(/same Mcp-Session-Id/i);
+    expect(described).toMatch(/correlator|never authority/i);
     expect(described).toMatch(/call start\(\) again/i);
   });
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -987,9 +987,9 @@ describe('POST /api/mcp (BY-05)', () => {
     });
   });
 
-  it('DELETE drops the local correlator; a well-formed id is re-adopted on the next call', async () => {
-    // Multi-instance Cloud Run cannot treat DELETE as a hard kill — the next revision
-    // would just 404 a still-valid ChatGPT session. Adopt restores the correlator.
+  it('DELETE tombstones the correlator so it is not re-adopted on this instance', async () => {
+    // Multi-instance still cannot share tombstones, but on the instance that saw DELETE
+    // a concurrent/retry POST must not resurrect the terminated id (Codex P2).
     const store = new InMemoryStore();
     await seedJob(store);
     app = await createApp(store);
@@ -1003,6 +1003,16 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(del.statusCode).toBe(204);
 
     const listed = await mcpCall(app, 'tools/list', {}, { 'mcp-session-id': sessionId });
+    expect(listed.statusCode).toBe(404);
+  });
+
+  it('still adopts a well-formed correlator this instance never initialized or terminated', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const foreignSessionId = 'fedcba9876543210fedcba9876543210fedc';
+
+    const listed = await mcpCall(app, 'tools/list', {}, { 'mcp-session-id': foreignSessionId });
     expect(listed.statusCode).toBe(200);
   });
 

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -394,6 +394,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
   /** Transport sessions only — never consulted for authorization. */
   const transportSessions = new Map<string, { createdAt: number }>();
+  /**
+   * Correlators explicitly terminated via DELETE on this instance. Prevents the
+   * multi-instance adopt path from resurrecting a session the client just closed.
+   * Best-effort across instances (in-memory); same TTL as live correlators.
+   */
+  const terminatedTransportSessions = new Map<string, number>();
   const invalidStartsByIp = new Map<string, number[]>();
   /** Last synthetic Studio presence pulse per job — coarse MCP activity, not 1:1 tools. */
   const presencePulseByJob = new Map<number, number>();
@@ -403,6 +409,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     for (const [id, meta] of transportSessions) {
       if (currentTime - meta.createdAt > TRANSPORT_SESSION_TTL_MS) {
         transportSessions.delete(id);
+      }
+    }
+    for (const [id, terminatedAt] of terminatedTransportSessions) {
+      if (currentTime - terminatedAt > TRANSPORT_SESSION_TTL_MS) {
+        terminatedTransportSessions.delete(id);
       }
     }
     if (transportSessions.size <= MAX_TRANSPORT_SESSIONS) return;
@@ -2788,8 +2799,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     // Non-initialize requests: adopt a well-formed correlator we have not seen on this
     // instance. Cloud Run is multi-instance and ChatGPT does not pin to one revision —
     // a 404 here made every post-initialize tool call a coin flip. Inventing an id
-    // grants nothing: sessionKey / Bearer still authorize every tool.
+    // grants nothing: sessionKey / Bearer still authorize every tool. Exception:
+    // IDs this instance explicitly terminated via DELETE stay dead (tombstone).
     if (sessionHeader && !transportSessions.has(sessionHeader)) {
+      pruneTransportSessions(now());
+      if (terminatedTransportSessions.has(sessionHeader)) {
+        request.log.warn(
+          {
+            event: 'mcp_terminated_session',
+            transportSessionId: sessionHeader.slice(0, 16),
+            userAgent: headerValue(request.headers['user-agent'])?.slice(0, 120) ?? undefined,
+          },
+          'mcp terminated session refused',
+        );
+        return reply.status(404).send({ error: 'unknown MCP session' });
+      }
       if (!looksLikeMcpSessionId(sessionHeader)) {
         request.log.warn(
           {
@@ -2801,7 +2825,6 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         );
         return reply.status(404).send({ error: 'unknown MCP session' });
       }
-      pruneTransportSessions(now());
       transportSessions.set(sessionHeader, { createdAt: now() });
       request.log.info(
         {
@@ -2994,6 +3017,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return reply.status(400).send({ error: 'Mcp-Session-Id required to terminate a session' });
       }
       transportSessions.delete(sessionHeader);
+      // Tombstone so a concurrent/retry POST with the same id is not re-adopted.
+      pruneTransportSessions(now());
+      terminatedTransportSessions.set(sessionHeader, now());
       return reply.status(204).send();
     },
   );

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -49,6 +49,7 @@ import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import {
   assertMcpSessionKeyUnexpired,
+  looksLikeMcpSessionId,
   looksLikeMcpSessionKey,
   mintMcpSessionKey,
   newMcpSessionId,
@@ -368,7 +369,8 @@ const BUILD_STEP_NAMES: ReadonlySet<string> = new Set<string>(BUILD_STEPS);
 const SESSION_KEY_PROP = {
   type: 'string' as const,
   description:
-    'Short-lived session capability from start(). Present this argument OR configure Authorization: Bearer <round key> — not both required. Send it with the same Mcp-Session-Id header start() used: that header alone is never authority, but a sessionKey is bound to the session that minted it, so a different one is refused. If the transport session is lost, call start() again — it re-binds and re-mints.',
+    'Short-lived session capability from start(). Present this argument OR configure Authorization: Bearer <round key> — not both required. ' +
+    'Mcp-Session-Id is a transport correlator only (never authority). If the transport session is lost, call start() again — it re-binds and re-mints.',
 };
 
 /** Pin kit browse/read calls to the engineRef get_kit returned (N/N−1 window). */
@@ -501,11 +503,20 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         }
         throw error;
       }
-      // Enforce the sessionId binding encoded in the capability when the client
-      // presents a transport session id. A sessionKey alone from logs is not enough
-      // to ride a different correlator. Absent header is allowed (some clients drop it).
+      // Mcp-Session-Id is a correlator, not a capability. The sessionId is already
+      // inside the signed sessionKey, so requiring the header to match added no theft
+      // resistance and broke ChatGPT Apps on multi-instance Cloud Run (initialize on A,
+      // start on B remints, client keeps sending A's id). Log drift; do not refuse.
       if (ctx.sessionId && ctx.sessionId !== sessionClaims.sessionId) {
-        return toolErr('sessionKey is bound to a different Mcp-Session-Id');
+        ctx.request.log.info(
+          {
+            event: 'mcp_session_id_drift',
+            presented: ctx.sessionId.slice(0, 16),
+            bound: sessionClaims.sessionId.slice(0, 16),
+            jobId: sessionClaims.jobId,
+          },
+          'mcp sessionKey accepted despite Mcp-Session-Id drift',
+        );
       }
       claims = {
         jobId: sessionClaims.jobId,
@@ -820,7 +831,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const bindActiveRound = (active: SubmissionRecord): ToolResult => {
           pruneTransportSessions(now());
           pruneInvalidStartBuckets(now());
-          const sessionId = ctx.sessionId && transportSessions.has(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
+          // Prefer the client's correlator when well-formed — even if this instance
+          // never saw initialize (Cloud Run multi-instance). Reminting here used to
+          // embed a new id in the sessionKey while the client kept sending the old one.
+          const sessionId = ctx.sessionId && looksLikeMcpSessionId(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
           transportSessions.set(sessionId, { createdAt: now() });
 
           const jobId = active.issueNumber;
@@ -981,10 +995,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           roundGeneration = claims.roundGeneration ?? record.roundGeneration ?? 1;
         }
 
-        // Prefer the transport session id when the client already has one; otherwise mint.
+        // Prefer the client's correlator when well-formed — even across instances.
         pruneTransportSessions(now());
         pruneInvalidStartBuckets(now());
-        const sessionId = ctx.sessionId && transportSessions.has(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
+        const sessionId = ctx.sessionId && looksLikeMcpSessionId(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
         transportSessions.set(sessionId, { createdAt: now() });
 
         const sessionKey = mintMcpSessionKey(agentTokenSecret, {
@@ -2771,19 +2785,32 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       );
     }
 
-    // Non-initialize requests: require session header when we issued one (transport only).
+    // Non-initialize requests: adopt a well-formed correlator we have not seen on this
+    // instance. Cloud Run is multi-instance and ChatGPT does not pin to one revision —
+    // a 404 here made every post-initialize tool call a coin flip. Inventing an id
+    // grants nothing: sessionKey / Bearer still authorize every tool.
     if (sessionHeader && !transportSessions.has(sessionHeader)) {
-      // In-memory map miss (multi-instance, prune, or client inventing an id). ChatGPT
-      // often hides the 404 body — log so GCP can show the correlator that was refused.
-      request.log.warn(
+      if (!looksLikeMcpSessionId(sessionHeader)) {
+        request.log.warn(
+          {
+            event: 'mcp_unknown_session',
+            transportSessionId: sessionHeader.slice(0, 32),
+            userAgent: headerValue(request.headers['user-agent'])?.slice(0, 120) ?? undefined,
+          },
+          'mcp unknown session',
+        );
+        return reply.status(404).send({ error: 'unknown MCP session' });
+      }
+      pruneTransportSessions(now());
+      transportSessions.set(sessionHeader, { createdAt: now() });
+      request.log.info(
         {
-          event: 'mcp_unknown_session',
-          transportSessionId: sessionHeader,
+          event: 'mcp_session_adopted',
+          transportSessionId: sessionHeader.slice(0, 16),
           userAgent: headerValue(request.headers['user-agent'])?.slice(0, 120) ?? undefined,
         },
-        'mcp unknown session',
+        'mcp session correlator adopted on this instance',
       );
-      return reply.status(404).send({ error: 'unknown MCP session' });
     }
 
     const protocolVersion = headerValue(request.headers['mcp-protocol-version']);

--- a/apps/api/src/mcp-session-key.ts
+++ b/apps/api/src/mcp-session-key.ts
@@ -67,6 +67,11 @@ export function mcpSessionKeyTtlHours(): number {
 /** Visible ASCII without `.` — the token wire format uses `.` as a field delimiter. */
 const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
 
+/** Shape check for a transport `Mcp-Session-Id` (and the id embedded in a sessionKey). */
+export function looksLikeMcpSessionId(candidate: string): boolean {
+  return SESSION_ID_RE.test(candidate);
+}
+
 export function mintMcpSessionKey(secret: string, options: MintMcpSessionKeyOptions): string {
   if (!options.sessionId || !SESSION_ID_RE.test(options.sessionId)) {
     throw new InvalidAgentTokenError('invalid session id');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ChatGPT Apps could `create_game` / `start` but then every later tool failed with `sessionKey is bound to a different Mcp-Session-Id`. That is **not** a multi-game limit.

### Cause

1. `sessionKey` was refused when the `Mcp-Session-Id` header differed from the id embedded at mint time. The id is already inside the signed key, so the check added no theft resistance.
2. Unknown correlators 404’d when missing from this instance’s in-memory map — Cloud Run is multi-instance (`maxInstanceCount` > 1) and ChatGPT does not pin to one revision.
3. `start()` reminted a new id when the client’s header was absent from the local map, then the client kept sending the old one → guaranteed mismatch.

### Fix

- Accept a cryptographically valid `sessionKey` even if the header drifted (log `mcp_session_id_drift`).
- Adopt well-formed unknown correlators instead of 404 (multi-instance).
- Bind `start()` to the client’s presented id when well-formed, without requiring a prior local `initialize`.
- After Codex P2: `DELETE /api/mcp` tombstones the correlator on this instance so concurrent/retry POSTs get 404 instead of re-adopting the terminated id (foreign never-seen ids still adopt).

### Reproduce / verify

- ChatGPT: open `/studio/legions-real-time-battles`, `start({ slug })` then `get_brief` — should work after deploy.
- Multiple games in one chat are fine: each `start` returns a per-job `sessionKey`; use the matching key per game.

### Test plan

- [x] Accept sessionKey under drifted `Mcp-Session-Id`
- [x] Bind start to foreign well-formed correlator (no local initialize)
- [x] DELETE tombstones correlator (404 on reuse); foreign never-seen id still adopts
- [x] MCP server + session-key unit tests green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

