### PR TITLE
feat(mcp): preview deliveries without TRACE; publish seals later

### DIFF
--- a/apps/api/scripts/run-gate.ts
+++ b/apps/api/scripts/run-gate.ts
@@ -94,6 +94,11 @@ async function main(): Promise<void> {
   const store = createGcsGamesStore({ bucket });
   const harnesses: string[] = [];
   const health = process.argv.includes('--health');
+  const preview = process.argv.includes('--preview');
+  if (health && preview) {
+    console.error('--health and --preview are mutually exclusive');
+    process.exit(2);
+  }
 
   const outcome = await runGate(
     slug,
@@ -127,7 +132,7 @@ async function main(): Promise<void> {
     },
     // Health asks about today's engine, so the manifest's pin is exactly the thing to
     // ignore. An acceptance run passes nothing and lets the pin (or `main`) decide.
-    health ? { engineRef: 'main' } : {},
+    health ? { engineRef: 'main' } : preview ? { preview: true } : {},
   );
 
   if (health) {
@@ -135,6 +140,12 @@ async function main(): Promise<void> {
       green: outcome.green,
       report: outcome.report,
       engineRef: outcome.engineCommit,
+    });
+  } else if (preview) {
+    // Never putGateResult — preview passes must not look publishable.
+    await store.putPreviewGateResult(slug, version, {
+      green: outcome.green,
+      report: outcome.report,
     });
   } else {
     // The resolved sha rides along so the manifest ends up pinned to what was actually
@@ -155,7 +166,7 @@ async function main(): Promise<void> {
   }
 
   console.log(
-    `\n${health ? 'health check' : 'gate'} ${outcome.green ? 'PASSED' : 'FAILED'} for ${slug}@${version} ` +
+    `\n${health ? 'health check' : preview ? 'preview check' : 'gate'} ${outcome.green ? 'PASSED' : 'FAILED'} for ${slug}@${version} ` +
       `in ${Math.round(outcome.durationMs / 1000)}s`,
   );
   if (outcome.artifacts.length) console.log(`stored: ${outcome.artifacts.join(', ')}`);

--- a/apps/api/scripts/run-gate.ts
+++ b/apps/api/scripts/run-gate.ts
@@ -142,10 +142,12 @@ async function main(): Promise<void> {
       engineRef: outcome.engineCommit,
     });
   } else if (preview) {
-    // Never putGateResult — preview passes must not look publishable.
+    // Never putGateResult — preview passes must not look publishable. kit_outdated still
+    // rides along so the channel can tell the agent to refresh the kit, not chase smoke.
     await store.putPreviewGateResult(slug, version, {
       green: outcome.green,
       report: outcome.report,
+      ...(outcome.status ? { status: outcome.status } : {}),
     });
   } else {
     // The resolved sha rides along so the manifest ends up pinned to what was actually

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -39,7 +39,12 @@ async function createApp(
     maxEventsPerWindow?: number;
     gamesStore?: GamesStore;
     maxSubmitsPerWindow?: number;
-    onSourcesDelivered?: (input: { issueNumber: number; slug: string; version: string }) => void;
+    onSourcesDelivered?: (input: {
+      issueNumber: number;
+      slug: string;
+      version: string;
+      mode?: 'health' | 'preview';
+    }) => void;
   },
 ) {
   await store.upsertUser({ uid: 'g:owner' });
@@ -689,22 +694,30 @@ describe('agent build channel', () => {
     ];
 
     function stubGamesStore() {
-      const stored: Array<{ slug: string; issueNumber: number; files: unknown[]; kitEngineRef?: string }> = [];
+      const stored: Array<{
+        slug: string;
+        issueNumber: number;
+        files: unknown[];
+        kitEngineRef?: string;
+        mode?: string;
+      }> = [];
       const gamesStore = {
         putCandidateSources: async (input: {
           slug: string;
           issueNumber: number;
           files: unknown[];
           kitEngineRef?: string;
+          mode?: 'preview' | 'publish';
         }) => {
           stored.push(input);
           const { validateSourceUpload } = await import('./games-store.js');
-          validateSourceUpload(input.files as Array<{ path: string; content: string }>);
+          validateSourceUpload(input.files as Array<{ path: string; content: string }>, input.mode ?? 'publish');
           return { version: 'v1', manifest: {} as never };
         },
         getManifest: async () => null,
         getSourceFile: async () => null,
         putGateResult: async () => {},
+        putPreviewGateResult: async () => {},
         putDerivedArtifact: async () => {},
         getDerivedArtifact: async () => null,
         getKitRegistry: async () => null,
@@ -977,7 +990,7 @@ describe('agent build channel', () => {
       const store = new InMemoryStore();
       await seedSubmission(store);
       const { gamesStore } = stubGamesStore();
-      const delivered: Array<{ slug: string; version: string }> = [];
+      const delivered: Array<{ slug: string; version: string; mode?: string }> = [];
       app = await createApp(store, { gamesStore });
       // Re-create with the hook wired, since createApp builds options once.
       await app.close();
@@ -991,8 +1004,8 @@ describe('agent build channel', () => {
           translator: new NoopTranslator(),
           agentChannel: {
             gamesStore,
-            onSourcesDelivered: ({ slug, version }) => {
-              delivered.push({ slug, version });
+            onSourcesDelivered: ({ slug, version, mode }) => {
+              delivered.push({ slug, version, ...(mode ? { mode } : {}) });
             },
           },
         },
@@ -1006,6 +1019,51 @@ describe('agent build channel', () => {
       });
 
       expect(delivered).toEqual([{ slug: 'comet-courier', version: 'v1' }]);
+    });
+
+    it('preview mode accepts TRACE-less drafts and does not seal deliveredVersion', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, stored } = stubGamesStore();
+      const delivered: Array<{ mode?: string }> = [];
+      app = await buildApp({
+        store,
+        sessionSecret,
+        submissionRoutes: {
+          githubClient: stubGitHub(),
+          githubToken: 'gh-token',
+          submissionTokenSecret: secret,
+          translator: new NoopTranslator(),
+          agentChannel: {
+            gamesStore,
+            onSourcesDelivered: (input) => {
+              delivered.push({ mode: input.mode });
+            },
+          },
+        },
+      });
+
+      const draft = MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          files: draft,
+          kitEngineRef: 'abcdef1234567890',
+          mode: 'preview',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ accepted: true, mode: 'preview' });
+      expect(stored[0]?.mode).toBe('preview');
+      expect(delivered).toEqual([{ mode: 'preview' }]);
+
+      const record = await store.getSubmission(ISSUE);
+      expect(record?.previewVersion).toBe('v1');
+      expect(record?.deliveredVersion).toBeUndefined();
+      expect(record?.state).not.toBe('submitted');
     });
   });
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -845,6 +845,80 @@ describe('agent build channel', () => {
       expect(response.json().control.mustFixGate).toBeUndefined();
     });
 
+    it('prefers a newer preview verdict over a stale red publish', async () => {
+      // Publish set deliveredVersion=v1 (and previewVersion=v1). A later mode=preview
+      // only advances previewVersion — delivered-first would keep reporting the old red.
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v2');
+      const { gamesStore } = stubGamesStore();
+      app = await createApp(store, {
+        gamesStore: {
+          ...gamesStore,
+          getManifest: async (_slug: string, version: string) => {
+            if (version === 'v2') {
+              return {
+                previewGate: {
+                  green: false,
+                  ranAt: '2026-08-03T22:00:00Z',
+                  report: 'typecheck failed: missing export',
+                },
+              };
+            }
+            return {
+              gate: {
+                green: false,
+                ranAt: '2026-08-03T21:00:00Z',
+                report: 'trace stage refused: TRACE.json missing',
+              },
+            };
+          },
+        } as unknown as GamesStore,
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/inbox', headers: agentHeaders() });
+
+      expect(response.json()).toMatchObject({
+        gate: {
+          version: 'v2',
+          lane: 'preview',
+          status: 'preview_failed',
+          report: 'typecheck failed: missing export',
+        },
+      });
+      expect(response.json().control.mustFixGate).toMatch(/mode=preview/);
+    });
+
+    it('surfaces kit_outdated from a preview-lane check', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      const { gamesStore } = stubGamesStore();
+      app = await createApp(store, {
+        gamesStore: {
+          ...gamesStore,
+          getManifest: async () => ({
+            previewGate: {
+              green: false,
+              ranAt: '2026-08-03T22:00:00Z',
+              report: 'kitEngineRef outside supported window',
+              status: 'kit_outdated',
+            },
+          }),
+        } as unknown as GamesStore,
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/inbox', headers: agentHeaders() });
+
+      expect(response.json()).toMatchObject({
+        gate: { version: 'v1', lane: 'preview', status: 'kit_outdated' },
+      });
+      expect(response.json().control.mustFixGate).toMatch(/kit_outdated|Creator Kit/i);
+    });
+
     it('keeps the channel working when the gate verdict cannot be read', async () => {
       // The channel is how an agent reports progress and reads its creator's messages.
       // A store that will not answer must cost it the verdict, not both.
@@ -1103,6 +1177,60 @@ describe('agent build channel', () => {
           { path: 'SPEC.md', content: '# Comet Courier' },
           { path: 'game.ts', content: 'export const tick = () => {};' },
         ],
+      });
+    });
+
+    it('restores a preview-only delivery when nothing has been published yet', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      app = await createApp(store, {
+        gamesStore: storeWithVersion({ 'SPEC.md': '# Draft', 'game.ts': 'export {};' }),
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/sources', headers: agentHeaders() });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        delivery: { slug: 'comet-courier', version: 'v1' },
+        files: [
+          { path: 'SPEC.md', content: '# Draft' },
+          { path: 'game.ts', content: 'export {};' },
+        ],
+      });
+    });
+
+    it('restores the newer preview when a red publish pointer is still on the job', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v2');
+      const filesByVersion: Record<string, Record<string, string>> = {
+        v1: { 'SPEC.md': '# Publish attempt' },
+        v2: { 'SPEC.md': '# Preview fix' },
+      };
+      app = await createApp(store, {
+        gamesStore: {
+          putCandidateSources: async () => ({ version: 'v1', manifest: {} as never }),
+          getManifest: async (_slug: string, version: string) => ({
+            sourceFiles: Object.keys(filesByVersion[version] ?? {}),
+          }),
+          getSourceFile: async (_slug: string, version: string, path: string) =>
+            filesByVersion[version]?.[path] ?? null,
+          putGateResult: async () => {},
+          putDerivedArtifact: async () => {},
+          getDerivedArtifact: async () => null,
+        } as unknown as GamesStore,
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/agent/build/sources', headers: agentHeaders() });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        delivery: { slug: 'comet-courier', version: 'v2' },
+        files: [{ path: 'SPEC.md', content: '# Preview fix' }],
       });
     });
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -19,7 +19,7 @@ import {
 } from './agent-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
-import { InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
+import { InvalidUploadError, MAX_UPLOAD_FILES, type DeliveryMode, type GamesStore } from './games-store.js';
 import { parseGameMedia, parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import {
@@ -189,6 +189,11 @@ const BuildSourcesInputSchema = z.object({
     .max(64)
     .regex(/^[0-9a-f]+$/i, 'kitEngineRef must be a hex commit sha')
     .optional(),
+  /**
+   * Preview: typecheck→smoke→build, TRACE/PLAYTEST optional, Studio-playable only.
+   * Publish (default): full gate; TRACE/PLAYTEST required. Keeps `npm run submit` safe.
+   */
+  mode: z.enum(['preview', 'publish']).default('publish'),
 });
 
 const BuildPreviewInputSchema = z.object({
@@ -269,11 +274,10 @@ export interface AgentChannelOptions {
     slug: string;
     version: string;
     /**
-     * The delivery path never sets this; it exists so the operator's health re-gate can
-     * reuse the same configured trigger (see gate-trigger.ts) instead of a second one
-     * that would drift.
+     * `preview` runs `check:game --preview`. `health` is the operator re-gate.
+     * Omitted means the acceptance (publish) gate.
      */
-    mode?: 'health';
+    mode?: 'health' | 'preview';
   }) => Promise<{ buildId?: string } | void> | void;
 }
 
@@ -493,23 +497,39 @@ export async function registerAgentChannelRoutes(
    * yet", which is what the agent would have seen a moment earlier anyway.
    */
   async function gateVerdict(record: SubmissionRecord) {
-    const { slug, deliveredVersion } = record;
-    if (!options.gamesStore || !slug || !deliveredVersion) return null;
+    const { slug } = record;
+    const version = record.deliveredVersion ?? record.previewVersion;
+    if (!options.gamesStore || !slug || !version) return null;
     try {
-      const manifest = await options.gamesStore.getManifest(slug, deliveredVersion);
-      if (!manifest?.gate) return null;
-      return {
-        // Named so the agent can tell a verdict about *this* delivery from a stale one
-        // about the previous round — the difference between "fix it" and "already fixed".
-        version: deliveredVersion,
-        green: manifest.gate.green,
-        ranAt: manifest.gate.ranAt,
-        // The tail is where the chain names the check that stopped it; the runner has
-        // already trimmed to 4000 characters for exactly this reason.
-        ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
-        // `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game.
-        ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
-      };
+      const manifest = await options.gamesStore.getManifest(slug, version);
+      if (manifest?.gate) {
+        return {
+          // Named so the agent can tell a verdict about *this* delivery from a stale one
+          // about the previous round — the difference between "fix it" and "already fixed".
+          version,
+          lane: 'publish' as const,
+          green: manifest.gate.green,
+          ranAt: manifest.gate.ranAt,
+          // The tail is where the chain names the check that stopped it; the runner has
+          // already trimmed to 4000 characters for exactly this reason.
+          ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
+          // `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game.
+          ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
+        };
+      }
+      // Preview-lane check: never report as publishable green (that ends the MCP round).
+      if (manifest?.previewGate) {
+        return {
+          version,
+          lane: 'preview' as const,
+          green: false,
+          previewPassed: manifest.previewGate.green,
+          ranAt: manifest.previewGate.ranAt,
+          ...(manifest.previewGate.report ? { report: manifest.previewGate.report } : {}),
+          status: manifest.previewGate.green ? ('preview_passed' as const) : ('preview_failed' as const),
+        };
+      }
+      return null;
     } catch (error) {
       app.log.warn({ err: error, issueNumber: record.issueNumber, slug }, 'could not read the gate verdict');
       return null;
@@ -550,18 +570,21 @@ export async function registerAgentChannelRoutes(
         // and will never know why. This is the same trick as `mustDeliver` above: say it
         // on every call, derived from what we stored, rather than once in a brief read
         // thousands of tokens ago.
-        ...(gate && !gate.green
+        ...(gate && !gate.green && gate.status !== 'preview_passed'
           ? {
               mustFixGate:
                 gate.status === 'kit_outdated'
                   ? `The gate refused your delivery (${gate.version}) because the Creator Kit is ` +
                     'outdated (`kit_outdated`). Refresh the kit (re-run get_kit), rebuild against ' +
                     'it, and deliver again with the new kitEngineRef.'
-                  : `The gate ran against your delivery and refused it (${gate.version}). You are not ` +
-                    'done: nothing can be published until it passes. Read `gate.report` below — it ends ' +
-                    'with the check that stopped the chain — fix the cause in your game, and deliver ' +
-                    'again with `npm run submit -- <slug>`. Re-delivering without a fix just stores ' +
-                    'another version that fails the same way.',
+                  : gate.status === 'preview_failed'
+                    ? `The preview check refused your delivery (${gate.version}). Fix typecheck/smoke/build, ` +
+                      'then submit_sources again with mode=preview. TRACE.json is not required until mode=publish.'
+                    : `The gate ran against your delivery and refused it (${gate.version}). You are not ` +
+                      'done: nothing can be published until it passes. Read `gate.report` below — it ends ' +
+                      'with the check that stopped the chain — fix the cause in your game, and deliver ' +
+                      'again with `npm run submit -- <slug>` (or submit_sources mode=publish). Re-delivering ' +
+                      'without a fix just stores another version that fails the same way.',
             }
           : {}),
         ...(record.deliveredVersion
@@ -886,6 +909,7 @@ export async function registerAgentChannelRoutes(
         // and `canTransition('queued','submitted')` is false, so the protective
         // transition was skipped and the job stayed `building` (CP-1 double-close).
         const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
+        const mode: DeliveryMode = parsed.data.mode === 'preview' ? 'preview' : 'publish';
         const { version } = await options.gamesStore.putCandidateSources({
           slug,
           issueNumber,
@@ -893,13 +917,17 @@ export async function registerAgentChannelRoutes(
           // Provenance: which backend built this version. Backend name on the dispatch
           // ('copilot' / 'self') is the durable record; builder is the round selector.
           backend: record.dispatch?.backend ?? record.builder,
+          mode,
           ...(parsed.data.kitEngineRef ? { kitEngineRef: parsed.data.kitEngineRef } : {}),
         });
-        // Recorded before the gate is asked to run: this is what the creator's preview
-        // reads, and a delivered game should be playable on the status page whether or
-        // not anything ever verifies it. The gate decides whether it may be *published*,
-        // which is a different question from whether its author can watch it.
-        await store?.setSubmissionDeliveredVersion(issueNumber, version);
+        // Preview updates Studio's playable pointer without marking a sealed delivery —
+        // control.delivered / publication reconciliation still wait for mode=publish.
+        // Publish sets both (setSubmissionDeliveredVersion also refreshes previewVersion).
+        if (mode === 'preview') {
+          await store?.setSubmissionPreviewVersion(issueNumber, version);
+        } else {
+          await store?.setSubmissionDeliveredVersion(issueNumber, version);
+        }
         if (store && record.builder === 'self') {
           await store.incrementRoundDeliveryCount(issueNumber);
         }
@@ -918,13 +946,11 @@ export async function registerAgentChannelRoutes(
             }
           }
         }
-        // Past the agent, and recorded as such. Without this the job stays `building`,
-        // and the agent's own session then reports `completed` with a candidate present
-        // — which the reconciler reads as "done, ready for review". That would promote a
-        // game to the review queue on the agent's say-so, before our gate had run and
-        // whatever it might have said. `submitted` is the state the reconciler refuses
-        // to move, which is exactly the protection this needs.
-        if (store) {
+        // Publish only: without this the job stays `building`, and the agent's own
+        // session then reports `completed` with a candidate present — which the
+        // reconciler reads as "done, ready for review". Preview stays in building so a
+        // vibe-coding loop never looks like a sealed candidate.
+        if (store && mode === 'publish') {
           if (canTransition(stateAfterSignal, 'submitted')) {
             await store.recordJobTransition(issueNumber, {
               to: 'submitted',
@@ -934,7 +960,12 @@ export async function registerAgentChannelRoutes(
             });
           }
         }
-        const gate = await options.onSourcesDelivered?.({ issueNumber, slug, version });
+        const gate = await options.onSourcesDelivered?.({
+          issueNumber,
+          slug,
+          version,
+          ...(mode === 'preview' ? { mode: 'preview' as const } : {}),
+        });
         // Booked here rather than inside the trigger because this is where the job is
         // known: the trigger takes a slug and a version and has no idea whose ledger to
         // write to. Best-effort like every other write in this handler — the delivery has
@@ -954,6 +985,7 @@ export async function registerAgentChannelRoutes(
         const fresh = store ? ((await store.getSubmission(issueNumber)) ?? record) : record;
         return reply.send({
           accepted: true,
+          mode,
           delivery: { slug, version },
           ...(await channelState(issueNumber, fresh)),
         });
@@ -1511,7 +1543,7 @@ export async function registerAgentChannelRoutes(
 
       const query = request.query as { version?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
-      const version = requestedVersion ?? record.deliveredVersion ?? null;
+      const version = requestedVersion ?? record.deliveredVersion ?? record.previewVersion ?? null;
 
       if (!version || !record.slug) {
         return reply.send({
@@ -1528,7 +1560,11 @@ export async function registerAgentChannelRoutes(
         return reply.status(401).send({ error: STALE_AGENT_TOKEN_REASON });
       }
 
-      const gate = await gateVerdict({ ...record, deliveredVersion: version });
+      const gate = await gateVerdict({
+        ...record,
+        deliveredVersion: record.deliveredVersion === version ? version : undefined,
+        previewVersion: version,
+      });
       if (!gate) {
         return reply.send({
           status: 'pending',
@@ -1538,18 +1574,32 @@ export async function registerAgentChannelRoutes(
         });
       }
 
-      const status = gate.green ? 'green' : gate.status === 'kit_outdated' ? 'kit_outdated' : 'red';
+      const status = gate.green
+        ? 'green'
+        : gate.status === 'kit_outdated'
+          ? 'kit_outdated'
+          : gate.status === 'preview_passed'
+            ? 'preview_passed'
+            : gate.status === 'preview_failed'
+              ? 'preview_failed'
+              : 'red';
       return reply.send({
         status,
         deliveryId: version,
         version: gate.version,
         green: gate.green,
+        lane: gate.lane,
         ranAt: gate.ranAt,
         summary: gate.green
           ? 'gate accepted this delivery'
-          : (gate.report?.split('\n').at(-1) ?? 'gate refused this delivery'),
+          : gate.status === 'preview_passed'
+            ? 'preview check passed — continue iterating, then submit_sources with mode=publish (TRACE required)'
+            : gate.status === 'preview_failed'
+              ? (gate.report?.split('\n').at(-1) ?? 'preview check refused this delivery')
+              : (gate.report?.split('\n').at(-1) ?? 'gate refused this delivery'),
         ...(gate.report ? { report: gate.report } : {}),
         ...(gate.status ? { gateStatus: gate.status } : {}),
+        ...('previewPassed' in gate && gate.previewPassed !== undefined ? { previewPassed: gate.previewPassed } : {}),
         access,
       });
     },
@@ -1586,7 +1636,7 @@ export async function registerAgentChannelRoutes(
 
       const query = request.query as { version?: string; frames?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
-      const version = requestedVersion ?? record.deliveredVersion ?? null;
+      const version = requestedVersion ?? record.deliveredVersion ?? record.previewVersion ?? null;
 
       if (!version || !record.slug) {
         return reply.send({

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -498,7 +498,10 @@ export async function registerAgentChannelRoutes(
    */
   async function gateVerdict(record: SubmissionRecord) {
     const { slug } = record;
-    const version = record.deliveredVersion ?? record.previewVersion;
+    // Prefer previewVersion: publish writes both pointers to the same id, while a later
+    // mode=preview only advances previewVersion. delivered-first would keep reporting the
+    // stale publish red after the agent already fixed and re-previewed.
+    const version = record.previewVersion ?? record.deliveredVersion;
     if (!options.gamesStore || !slug || !version) return null;
     try {
       const manifest = await options.gamesStore.getManifest(slug, version);
@@ -519,6 +522,7 @@ export async function registerAgentChannelRoutes(
       }
       // Preview-lane check: never report as publishable green (that ends the MCP round).
       if (manifest?.previewGate) {
+        const kitOutdated = manifest.previewGate.status === 'kit_outdated';
         return {
           version,
           lane: 'preview' as const,
@@ -526,7 +530,11 @@ export async function registerAgentChannelRoutes(
           previewPassed: manifest.previewGate.green,
           ranAt: manifest.previewGate.ranAt,
           ...(manifest.previewGate.report ? { report: manifest.previewGate.report } : {}),
-          status: manifest.previewGate.green ? ('preview_passed' as const) : ('preview_failed' as const),
+          status: kitOutdated
+            ? ('kit_outdated' as const)
+            : manifest.previewGate.green
+              ? ('preview_passed' as const)
+              : ('preview_failed' as const),
         };
       }
       return null;
@@ -1011,11 +1019,13 @@ export async function registerAgentChannelRoutes(
    * The store already holds every delivered version, immutably; this is the read that
    * makes it the source of truth rather than a copy nobody can get back.
    *
-   * Prefer the job's own last delivery. When this job has not delivered yet but its
-   * slug is already published — the shape of every post-publish improvement, which is a
-   * *new* job on an existing game — fall back to the live publication. Without that,
-   * `npm run restore` reports nothing to restore and the agent rebuilds a stranger's
-   * game instead of revising the one the creator asked to change.
+   * Prefer the job's own latest candidate — previewVersion first (mode=preview may be
+   * the only upload so far, or a fix after a red publish), then deliveredVersion. When
+   * this job has neither but its slug is already published — the shape of every
+   * post-publish improvement, which is a *new* job on an existing game — fall back to
+   * the live publication. Without that, `npm run restore` reports nothing to restore
+   * and the agent rebuilds a stranger's game instead of revising the one the creator
+   * asked to change.
    *
    * Scoped to the job's own game by the same token that authorizes its delivery, so a
    * build can restore what it (or its published predecessor) delivered and nothing else.
@@ -1033,7 +1043,7 @@ export async function registerAgentChannelRoutes(
       }
 
       const slug = record.slug;
-      let version = record.deliveredVersion;
+      let version = record.previewVersion ?? record.deliveredVersion;
       // An improvement job inherits the slug before it has delivered anything of its
       // own. The publication pointer is what is live — the version the creator played.
       if (slug && !version) {
@@ -1531,7 +1541,8 @@ export async function registerAgentChannelRoutes(
    * Unlike every other channel read, a capability whose generation is exactly one
    * behind current is accepted — limited to this delivery's own verdict — so an agent
    * can observe the green that closed its round. Writes and other reads still 401.
-   * Query `?version=` to name a delivery; default is the job's latest `deliveredVersion`.
+   * Query `?version=` to name a delivery; default is the job's latest playable pointer
+   * (`previewVersion`, then `deliveredVersion`) — same order as Studio and restore.
    */
   app.get(
     '/api/agent/build/gate',
@@ -1543,7 +1554,7 @@ export async function registerAgentChannelRoutes(
 
       const query = request.query as { version?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
-      const version = requestedVersion ?? record.deliveredVersion ?? record.previewVersion ?? null;
+      const version = requestedVersion ?? record.previewVersion ?? record.deliveredVersion ?? null;
 
       if (!version || !record.slug) {
         return reply.send({
@@ -1636,7 +1647,7 @@ export async function registerAgentChannelRoutes(
 
       const query = request.query as { version?: string; frames?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
-      const version = requestedVersion ?? record.deliveredVersion ?? record.previewVersion ?? null;
+      const version = requestedVersion ?? record.previewVersion ?? record.deliveredVersion ?? null;
 
       if (!version || !record.slug) {
         return reply.send({

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -277,6 +277,32 @@ describe('GCS games store', () => {
     expect((await store.getManifest('g', version))?.gate).toMatchObject({ green: false, report: '3 checks failed' });
   });
 
+  it('records kit_outdated on a preview-lane check without touching gate', async () => {
+    const { impl } = stubGcs();
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+    const draft = MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+    const { version } = await store.putCandidateSources({
+      slug: 'g',
+      issueNumber: 1,
+      files: draft,
+      mode: 'preview',
+    });
+
+    await store.putPreviewGateResult('g', version, {
+      green: false,
+      report: 'kitEngineRef outside supported window',
+      status: 'kit_outdated',
+    });
+
+    const manifest = await store.getManifest('g', version);
+    expect(manifest?.gate).toBeUndefined();
+    expect(manifest?.previewGate).toMatchObject({
+      green: false,
+      report: 'kitEngineRef outside supported window',
+      status: 'kit_outdated',
+    });
+  });
+
   it('pins the engine the first gate run checked against, and never repins', async () => {
     const { impl } = stubGcs();
     const store = createGcsGamesStore({ ...base, fetchImpl: impl });

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -94,6 +94,13 @@ describe('validateSourceUpload — the delivery contract', () => {
     );
   });
 
+  it('preview mode allows iterating without TRACE/PLAYTEST seals', () => {
+    const draft = MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+    expect(() => validateSourceUpload(draft, 'publish')).toThrow(/TRACE\.json is required/);
+    expect(validateSourceUpload(draft, 'preview').map((f) => f.path)).not.toContain('TRACE.json');
+    expect(validateSourceUpload(draft, 'preview').map((f) => f.path)).toContain('game.ts');
+  });
+
   it('accepts the agent-play contract without blocking pre-companion submit tools', () => {
     // The bug this PR fixes is "path not deliverable" for AGENT.json — accepting the
     // file is the unblock. Hard-requiring it would 400 in-flight workspaces that still

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -128,6 +128,12 @@ export interface SourceFile {
   content: string;
 }
 
+/**
+ * Delivery lane. Preview is the vibe-coding loop (typecheck→smoke→build, no TRACE).
+ * Publish is the sealed candidate the full gate judges for ready_for_review.
+ */
+export type DeliveryMode = 'preview' | 'publish';
+
 export class InvalidUploadError extends Error {
   constructor(message: string) {
     super(message);
@@ -174,8 +180,12 @@ export function forbiddenDeliveryPathReason(path: string): string | null {
  * Returns the files to store; throws {@link InvalidUploadError} with a message meant for
  * the agent, since the agent is the only one who can fix it and a vague rejection costs a
  * whole session.
+ *
+ * `mode: 'preview'` skips publish-stage seals (TRACE / PLAYTEST) so a first playable
+ * draft can land without burning the agent on capture tooling. Publish (default) keeps
+ * the hard requirements — a TRACE-less publishable candidate is still dead on arrival.
  */
-export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
+export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = 'publish'): SourceFile[] {
   if (files.length === 0) throw new InvalidUploadError('no files in upload');
   if (files.length > MAX_UPLOAD_FILES) {
     throw new InvalidUploadError(`too many files: ${files.length} > ${MAX_UPLOAD_FILES}`);
@@ -225,28 +235,34 @@ export function validateSourceUpload(files: SourceFile[]): SourceFile[] {
   if (!seen.has('index.html') || !seen.has('game.ts')) {
     throw new InvalidUploadError('index.html and game.ts are required — a game must be playable');
   }
-  // Refused here rather than stored and failed later. Without the golden the gate cannot
-  // reach a verdict at all — it stops at the trace stage having proved nothing — so
-  // accepting the upload would mean storing a version that is dead on arrival, and
-  // telling the agent it had succeeded. It is still running at this moment and can
-  // record the golden and retry; twenty minutes later it is gone.
-  if (!seen.has('TRACE.json')) {
-    throw new InvalidUploadError(
-      'TRACE.json is required — the gate diffs your game against it and cannot verify a ' +
-        'delivery without one. Record it with `npm run trace -- <slug> --accept`, read what ' +
-        'it captured, then deliver again.',
-    );
-  }
-  // Same reasoning as TRACE.json, and the same failure without it: the harness's Check
-  // 26 refuses a game that does not declare its progress landmarks, so a delivery
-  // missing this one is stored, reported as accepted, and then stops at validate having
-  // produced no bundle at all. Told now, while the agent still exists to act on it.
-  if (!seen.has('PLAYTEST.json')) {
-    throw new InvalidUploadError(
-      'PLAYTEST.json is required — it declares the progress landmarks your CAPTURE.json ' +
-        'run must reach, and the gate refuses a game without one. The minimum is ' +
-        '{"expectProgress": ["round-start"]}; list richer landmarks if your capture reaches them.',
-    );
+  if (mode === 'publish') {
+    // Refused here rather than stored and failed later. Without the golden the gate cannot
+    // reach a verdict at all — it stops at the trace stage having proved nothing — so
+    // accepting the upload would mean storing a version that is dead on arrival, and
+    // telling the agent it had succeeded. It is still running at this moment and can
+    // record the golden and retry; twenty minutes later it is gone.
+    //
+    // Preview deliveries skip this: they run `check:game --preview` (typecheck→smoke→build)
+    // and only produce Studio-playable preview.html — never a publishable green.
+    if (!seen.has('TRACE.json')) {
+      throw new InvalidUploadError(
+        'TRACE.json is required for publish — the gate diffs your game against it and cannot ' +
+          'verify a publishable delivery without one. Record it with `npm run trace -- <slug> --accept`, ' +
+          'or deliver mode=preview first while iterating. Read what TRACE captured, then deliver again.',
+      );
+    }
+    // Same reasoning as TRACE.json, and the same failure without it: the harness's Check
+    // 26 refuses a game that does not declare its progress landmarks, so a delivery
+    // missing this one is stored, reported as accepted, and then stops at validate having
+    // produced no bundle at all. Told now, while the agent still exists to act on it.
+    if (!seen.has('PLAYTEST.json')) {
+      throw new InvalidUploadError(
+        'PLAYTEST.json is required for publish — it declares the progress landmarks your CAPTURE.json ' +
+          'run must reach, and the gate refuses a publishable game without one. The minimum is ' +
+          '{"expectProgress": ["round-start"]}; list richer landmarks if your capture reaches them. ' +
+          'Or deliver mode=preview while iterating without it.',
+      );
+    }
   }
   // AGENT.json is allowed above but deliberately not required here yet — see the
   // ALLOWED_SOURCE_FILES note. Missing file → Check 28 on the gate, not a 400 at upload.
@@ -288,8 +304,18 @@ export interface VersionManifest {
    * (`npm run trace -- --accept`) before `check:game` replays it.
    */
   origin?: 'editor';
+  /**
+   * Which lane produced this version. Absent on legacy manifests (= publish).
+   * Preview versions must never carry a publishable {@link gate}.green.
+   */
+  deliveryMode?: DeliveryMode;
   /** Verdict of our own gate. A version without a green one is never publishable. */
   gate?: GateVerdict;
+  /**
+   * Preview-lane check (`check:game --preview`). Separate from {@link gate} so a
+   * typecheck/smoke/build pass never looks publishable to reconciliation or the catalog.
+   */
+  previewGate?: { green: boolean; ranAt: string; report?: string };
   /**
    * The most recent *health* verdict: the same check re-run later against the current
    * engine, asking "does this game still work on today's GameKit".
@@ -372,6 +398,8 @@ export interface GamesStore {
     kitEngineRef?: string;
     /** Content-only Studio publish — see {@link VersionManifest.origin}. */
     origin?: 'editor';
+    /** Preview skips TRACE/PLAYTEST; default publish. */
+    mode?: DeliveryMode;
   }): Promise<{ version: string; manifest: VersionManifest }>;
   getManifest(slug: string, version: string): Promise<VersionManifest | null>;
   getSourceFile(slug: string, version: string, path: string): Promise<string | null>;
@@ -394,6 +422,11 @@ export interface GamesStore {
       screenshot?: string;
     },
   ): Promise<void>;
+  /**
+   * Records a preview-lane check. Never touches {@link VersionManifest.gate} — a preview
+   * pass must not make the version publishable.
+   */
+  putPreviewGateResult(slug: string, version: string, result: { green: boolean; report?: string }): Promise<void>;
   /**
    * Records a *health* verdict — the check re-run against the current engine, long
    * after acceptance. Never touches `gate` or `engineRef`: health answers "does it
@@ -494,7 +527,8 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
   return {
     async putCandidateSources(input) {
       assertSlug(input.slug);
-      const files = validateSourceUpload(input.files);
+      const mode: DeliveryMode = input.mode === 'preview' ? 'preview' : 'publish';
+      const files = validateSourceUpload(input.files, mode);
       const at = new Date(now());
       const version = versionId(at);
       const prefix = versionPrefix(input.slug, version);
@@ -513,6 +547,7 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
         backend: input.backend,
         model: input.model,
         engineRef: input.engineRef,
+        deliveryMode: mode,
         ...(input.kitEngineRef ? { kitEngineRef: input.kitEngineRef } : {}),
         ...(input.origin ? { origin: input.origin } : {}),
         sourceFiles: files.map((file) => file.path),
@@ -550,6 +585,19 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       // First writer wins: the ref the *first* gate run checked against is the one the
       // verdict is reproducible against, and a re-run must not quietly repin it.
       if (result.engineRef && !manifest.engineRef) manifest.engineRef = result.engineRef;
+      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
+    },
+
+    async putPreviewGateResult(slug, version, result) {
+      const prefix = versionPrefix(slug, version);
+      const existing = await readObject(`${prefix}/manifest.json`);
+      if (!existing) throw new Error(`no manifest for ${slug}@${version}`);
+      const manifest = JSON.parse(existing.toString('utf8')) as VersionManifest;
+      manifest.previewGate = {
+        green: result.green,
+        ranAt: new Date(now()).toISOString(),
+        ...(result.report ? { report: result.report } : {}),
+      };
       await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
     },
 

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -314,8 +314,10 @@ export interface VersionManifest {
   /**
    * Preview-lane check (`check:game --preview`). Separate from {@link gate} so a
    * typecheck/smoke/build pass never looks publishable to reconciliation or the catalog.
+   * `status: 'kit_outdated'` is preserved so agents refresh the kit instead of retrying
+   * typecheck/smoke/build against an unsupported engine pin.
    */
-  previewGate?: { green: boolean; ranAt: string; report?: string };
+  previewGate?: { green: boolean; ranAt: string; report?: string; status?: 'kit_outdated' };
   /**
    * The most recent *health* verdict: the same check re-run later against the current
    * engine, asking "does this game still work on today's GameKit".
@@ -426,7 +428,11 @@ export interface GamesStore {
    * Records a preview-lane check. Never touches {@link VersionManifest.gate} — a preview
    * pass must not make the version publishable.
    */
-  putPreviewGateResult(slug: string, version: string, result: { green: boolean; report?: string }): Promise<void>;
+  putPreviewGateResult(
+    slug: string,
+    version: string,
+    result: { green: boolean; report?: string; status?: 'kit_outdated' },
+  ): Promise<void>;
   /**
    * Records a *health* verdict — the check re-run against the current engine, long
    * after acceptance. Never touches `gate` or `engineRef`: health answers "does it
@@ -597,6 +603,7 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
         green: result.green,
         ranAt: new Date(now()).toISOString(),
         ...(result.report ? { report: result.report } : {}),
+        ...(result.status ? { status: result.status } : {}),
       };
       await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
     },

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -82,6 +82,30 @@ describe('runGate', () => {
     expect(check?.[1]).not.toContain('--accept');
   });
 
+  it('preview lane runs check:game --preview and stores only preview.html', async () => {
+    const harness = await harnessDir();
+    const { store, derived } = stubStore();
+    const run = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'npm' && args.includes('check:game')) {
+        return { code: 0, output: 'preview ok' };
+      }
+      return { code: 0, output: 'deadbeef' };
+    });
+
+    const outcome = await runGate(
+      'comet-courier',
+      'v1',
+      { store, prepareHarness: async () => harness, run, assembleBundle: stubAssemble },
+      { preview: true },
+    );
+
+    expect(outcome.green).toBe(true);
+    expect(run).toHaveBeenCalledWith('npm', ['run', 'check:game', '--', 'comet-courier', '--preview'], harness);
+    expect(derived.map((d) => d.name)).toEqual(['preview.html']);
+    expect(outcome.artifacts).toEqual(['preview.html']);
+    expect(outcome.artifacts).not.toContain('bundle.html');
+  });
+
   it('reports the engine commit it actually checked against, from the harness itself', async () => {
     const { store } = stubStore();
     const run = vi.fn(async (command: string) =>

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -56,6 +56,11 @@ export interface GateRunOptions {
    * not the one it was accepted against".
    */
   engineRef?: string;
+  /**
+   * Preview lane: `check:game --preview` (typecheck→smoke→build). Never stores
+   * bundle.html / publishable green — only preview.html.
+   */
+  preview?: boolean;
 }
 
 export interface GateRunnerDeps {
@@ -156,6 +161,7 @@ export async function runGate(
   // check:game run. Health re-gates skip this — they ask about today's engine, not
   // whether the original kit claim was still supported.
   const healthRun = Boolean(options.engineRef);
+  const previewRun = Boolean(options.preview);
   if (!healthRun && manifest.kitEngineRef) {
     const registry = await (deps.readKitRegistry ?? (() => deps.store.getKitRegistry()))().catch(() => null);
     if (registry && !isKitEngineRefSupported(manifest.kitEngineRef, registry)) {
@@ -197,7 +203,8 @@ export async function runGate(
     // validate including Check 31, accept, playtest) still judges the edited
     // content for real; `--accept` here only retires the has-it-changed question,
     // which for a content edit is always answered "yes, that was the point".
-    if (manifest.origin === 'editor') {
+    // Preview lane skips this: it never reaches the trace stage.
+    if (!previewRun && manifest.origin === 'editor') {
       const trace = await deps.run('npm', ['run', 'trace', '--', slug, '--accept'], harness);
       if (trace.code !== 0) {
         return {
@@ -216,18 +223,19 @@ export async function runGate(
       }
     }
 
-    // Deliberately without `--accept`. That flag re-records the behavioural golden
-    // instead of checking against it, which would make the trace stage unconditionally
-    // pass and quietly retire the one check that can catch a game behaving differently
-    // here than it did for the agent. The candidate ships its own `TRACE.json`, and the
-    // gate replays it against *our* engine: a golden recorded against a locally
-    // modified GameKit fails here, which is precisely the thing worth catching.
-    const check = await deps.run('npm', ['run', 'check:game', '--', slug], harness);
+    // Preview: typecheck→smoke→build only. Publish: full check:game without `--accept`
+    // (that flag re-records the behavioural golden instead of checking against it).
+    const check = await deps.run(
+      'npm',
+      previewRun ? ['run', 'check:game', '--', slug, '--preview'] : ['run', 'check:game', '--', slug],
+      harness,
+    );
     if (check.code !== 0) {
       // Preview for the creator; media when capture got far enough — both best-effort.
+      // Preview lane never runs capture, so media store is a no-op there.
       const artifacts = [
         ...(await storePreview(deps, slug, version, harness)),
-        ...(await storeCaptureMedia(deps, slug, version, harness, roots)),
+        ...(previewRun ? [] : await storeCaptureMedia(deps, slug, version, harness, roots)),
       ];
       const screenshot = firstGateScreenshotPath(artifacts);
       return {
@@ -246,6 +254,19 @@ export async function runGate(
         durationMs: now() - startedAt,
         ...(engineCommit ? { engineCommit } : {}),
         ...(screenshot ? { screenshot } : {}),
+      };
+    }
+
+    if (previewRun) {
+      // Preview pass: Studio-playable document only. Never bundle.html / media — those
+      // are publish seals. Caller writes previewGate, not gate.
+      const artifacts = await storePreview(deps, slug, version, harness);
+      return {
+        green: true,
+        report: `check:game --preview passed against engine ${engineCommit ?? engineRef}; preview.html stored`,
+        artifacts,
+        durationMs: now() - startedAt,
+        ...(engineCommit ? { engineCommit } : {}),
       };
     }
 

--- a/apps/api/src/gate-trigger.ts
+++ b/apps/api/src/gate-trigger.ts
@@ -48,10 +48,11 @@ export interface GateTriggerInput {
   version: string;
   /**
    * `health` re-runs the check against the current engine and records the verdict as
-   * `manifest.health`, leaving the acceptance verdict alone. Omitted means the
-   * acceptance gate, exactly as before.
+   * `manifest.health`, leaving the acceptance verdict alone. `preview` runs
+   * `check:game --preview` and records `manifest.previewGate` (never publishable).
+   * Omitted means the acceptance (publish) gate, exactly as before.
    */
-  mode?: 'health';
+  mode?: 'health' | 'preview';
 }
 
 const DEFAULTS = {
@@ -126,7 +127,7 @@ function buildSpec(
             // `--health` is our own constant, appended from a two-value union, never
             // from input text.
             `npm run gate:run -w @gamedevpl/api -- --slug '${input.slug}' --version '${input.version}'` +
-              (input.mode === 'health' ? ' --health' : ''),
+              (input.mode === 'health' ? ' --health' : input.mode === 'preview' ? ' --preview' : ''),
           ].join('\n'),
         ],
       },
@@ -148,9 +149,14 @@ function buildSpec(
     },
     timeout: GATE_TIMEOUT,
     // Searchable in the Cloud Build history: "show me every gate run for this game" —
-    // and health runs carry their own tag so a fleet re-check reads as one, not as a
+    // and health/preview runs carry their own tag so a fleet re-check reads as one, not as a
     // wave of failing acceptance gates.
-    tags: ['gate', ...(input.mode === 'health' ? ['health'] : []), `slug-${input.slug}`],
+    tags: [
+      'gate',
+      ...(input.mode === 'health' ? ['health'] : []),
+      ...(input.mode === 'preview' ? ['preview'] : []),
+      `slug-${input.slug}`,
+    ],
   };
 }
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -327,7 +327,9 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(start?.description).toMatch(/pendingMessages/);
     expect(start?.description).toMatch(/array is non-empty/i);
     expect(start?.description).toMatch(/do not schedule background/i);
-    expect(start?.description).toMatch(/green gate verdict ends the round/i);
+    expect(start?.description).toMatch(
+      /green \*publish\* gate verdict ends the round|green publish gate verdict ends the round/i,
+    );
     expect(start?.description).toMatch(/END immediately/i);
 
     const getKit = tools.find((t) => t.name === 'get_kit');
@@ -415,15 +417,17 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/list_kit_files|read_kit_file/);
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/submit_sources/);
+    expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
+    expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);
     expect(joined).toMatch(/get_gate_verdict/);
     // The stop condition is explicit: green means done — END immediately; no post-green
     // tools (key retires; get_gate_verdict may still answer via terminal receipt).
-    expect(joined).toMatch(/green: the round is complete/i);
+    expect(joined).toMatch(/green \(publish only\): the round is complete/i);
     expect(joined).toMatch(/END the session immediately/i);
     expect(joined).toMatch(/Do not report_progress, read_inbox, or ack after green/i);
     expect(joined).toMatch(/terminal receipt/i);
     // Both failure branches are covered.
-    expect(joined).toMatch(/red:.*resubmit on the SAME key/i);
+    expect(joined).toMatch(/red \/ preview_failed:.*resubmit on the SAME key/i);
     expect(joined).toMatch(/kit_outdated: re-run get_kit/i);
 
     // Inbox policy: no scheduled polling; drain non-empty pendingMessages from write replies.

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -290,12 +290,13 @@ function stopFromChannel(body: { control?: { stop?: boolean; reason?: string } }
 const BEHAVIOURAL_CONTRACT = [
   'Report progress before and after long steps (and whenever a reply carries warnings with code progress_stale).',
   'Send a screenshot as soon as the game draws anything playable.',
+  'While iterating, submit_sources with mode=preview (no TRACE required). Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'Honour stop immediately — do not continue after stop:true.',
   'When get_brief.seedAvailable is true, continue the seed (get_seed) rather than scaffolding from scratch.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
-  'A green gate verdict ends the round — END immediately; the key retires and new work arrives as a fresh kickoff.',
+  'A green *publish* gate verdict ends the round — END immediately; preview_passed does not end the round. The key retires on green and new work arrives as a fresh kickoff.',
 ].join(' ');
 
 /**
@@ -315,16 +316,17 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources and pass it on every list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment call (start at entry) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
-  'Run the kit checks green (at least check:static) before delivering when you have a local kit checkout; otherwise deliver and let the gate run checks.',
-  'submit_sources with the kitEngineRef get_kit returned.',
-  'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated.',
-  'Once a verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
-  'red: read the report, fix, and resubmit on the SAME key.',
+  'While iterating: submit_sources({ mode: "preview", kitEngineRef, files }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build.',
+  'Poll get_gate_verdict until preview_passed or preview_failed; fix and re-preview on the SAME key. preview_passed does NOT end the round.',
+  'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), include PLAYTEST.json, then submit_sources({ mode: "publish", … }).',
+  'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated (publish lane).',
+  'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
+  'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
   'kit_outdated: re-run get_kit, rebuild against the new kit, and resubmit.',
   // Green closes the round before the next tool call; writes and non-receipt reads then
   // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
   // happen on earlier write replies — do not instruct post-green tools (Codex P1).
-  'green: the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict and get_gate_media may still answer via terminal receipt). ' +
+  'green (publish only): the round is complete — END the session immediately. Do not report_progress, read_inbox, or ack after green; the key retired with that transition (get_gate_verdict and get_gate_media may still answer via terminal receipt). ' +
     'If the creator wants more changes before publish, call continue_draft({ feedback }) then start() — do not call open_round on an unpublished draft.',
 ];
 
@@ -2366,6 +2368,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         properties: {
           ok: { type: 'boolean' },
           rejected: { type: 'string' },
+          mode: { type: 'string', enum: ['preview', 'publish'] },
           deliveryId: { type: ['string', 'null'] },
           delivery: {
             type: ['object', 'null'],
@@ -2378,11 +2381,22 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           deliveriesRemaining: { type: ['number', 'null'] },
           ...REPLY_CONTROL,
         },
-        required: ['ok', 'deliveryId', 'delivery', 'gateStarted', 'deliveriesRemaining', 'stop', 'pendingMessages'],
+        required: [
+          'ok',
+          'mode',
+          'deliveryId',
+          'delivery',
+          'gateStarted',
+          'deliveriesRemaining',
+          'stop',
+          'pendingMessages',
+        ],
       },
       description:
-        `Deliver game sources for the gate. files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES} items; kitEngineRef required (from get_kit / kit.json). ` +
-        'Subject to delivery cap and filename allowlist. Run kit checks green before submitting. Reply includes stop and pendingMessages. ' +
+        `Deliver game sources. mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
+        `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
+        `files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES}; kitEngineRef required (from get_kit / kit.json). ` +
+        'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -2404,6 +2418,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           kitEngineRef: {
             type: 'string',
             description: 'Creator Kit engineRef the sources were built against (from get_kit / kit.json).',
+          },
+          mode: {
+            type: 'string',
+            enum: ['preview', 'publish'],
+            description:
+              'preview = iterate without TRACE (Studio draft). publish = sealed candidate (TRACE required; default).',
           },
           slug: { type: 'string' },
           note: { type: 'string' },
@@ -2437,6 +2457,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('kitEngineRef is required — send the engineRef from get_kit / kit.json');
         }
 
+        const mode = args.mode === 'preview' ? 'preview' : 'publish';
+
         const decodedFiles: Array<{ path: string; content: string }> = [];
         for (const file of filesParse.data) {
           if (file.encoding === 'base64') {
@@ -2457,12 +2479,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           slug,
           files: decodedFiles,
           kitEngineRef,
+          mode,
         });
         const body = res.json() as {
           error?: string;
           reason?: string;
           accepted?: boolean;
           rejected?: string;
+          mode?: string;
           delivery?: { slug: string; version: string };
           deliveryCap?: number;
           deliveriesUsed?: number;
@@ -2479,6 +2503,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
         return toolOk({
           ok: body.accepted !== false,
+          mode: body.mode === 'preview' ? 'preview' : 'publish',
           ...(body.rejected ? { rejected: body.rejected } : {}),
           deliveryId: body.delivery?.version ?? null,
           delivery: body.delivery ?? null,
@@ -2495,26 +2520,32 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       outputSchema: {
         type: 'object',
         properties: {
-          status: { type: 'string', enum: ['pending', 'green', 'red', 'kit_outdated'] },
+          status: {
+            type: 'string',
+            enum: ['pending', 'green', 'red', 'kit_outdated', 'preview_passed', 'preview_failed'],
+          },
           deliveryId: { type: ['string', 'null'] },
           summary: { type: 'string' },
           access: { type: 'string' },
           version: { type: 'string' },
           green: { type: 'boolean' },
+          lane: { type: 'string', enum: ['preview', 'publish'] },
           ranAt: { type: 'string' },
           report: { type: 'string' },
           gateStatus: { type: 'string' },
+          previewPassed: { type: 'boolean' },
         },
         required: ['status', 'deliveryId', 'summary', 'access'],
       },
       description:
-        'Poll the gate verdict for a delivery (default: latest). Verdicts typically land in 2–5 minutes; ' +
-        'poll every ~30s until green, red, or kit_outdated. kit_outdated is terminal — stop polling, ' +
+        'Poll the gate verdict for a delivery (default: latest). Preview lane: preview_passed / preview_failed ' +
+        '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
+        'Verdicts typically land in 2–5 minutes; poll every ~30s. kit_outdated is terminal — stop polling, ' +
         're-run get_kit, rebuild against the new kit, and deliver again (do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
         "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
         'so the verdict stays readable if the round closes between polls. ' +
-        'Expiry still applies. Wait for green before considering the round done. ' +
+        'Expiry still applies. Wait for publish green before considering the round done. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -124,6 +124,12 @@ export interface SubmissionRecord {
    */
   deliveredVersion?: string;
   /**
+   * Latest Studio-playable delivery (preview or publish). Preview-only rounds update
+   * this without setting {@link deliveredVersion}, so control.delivered / publication
+   * reconciliation still wait for a sealed publish delivery.
+   */
+  previewVersion?: string;
+  /**
    * How many times this job has been sent back for finishing without delivering.
    *
    * Counted rather than inferred from the transition history, which is capped and drops
@@ -1457,6 +1463,8 @@ export interface Store {
   setSubmissionTitle(issueNumber: number, title: string): Promise<void>;
   /** Records the candidate version a delivery just stored, for the preview to read. */
   setSubmissionDeliveredVersion(issueNumber: number, version: string): Promise<void>;
+  /** Latest playable version for Studio (preview or publish). */
+  setSubmissionPreviewVersion(issueNumber: number, version: string): Promise<void>;
   /** Counts a send-back for finishing without delivering. Returns the new total. */
   recordDeliveryNudge(issueNumber: number): Promise<number>;
   /** Stamps the moment a submission was first seen published (for build-time stats). */
@@ -2515,7 +2523,12 @@ export class InMemoryStore implements Store {
 
   async setSubmissionDeliveredVersion(issueNumber: number, version: string): Promise<void> {
     const sub = this.submissions.get(issueNumber);
-    if (sub) this.submissions.set(issueNumber, { ...sub, deliveredVersion: version });
+    if (sub) this.submissions.set(issueNumber, { ...sub, deliveredVersion: version, previewVersion: version });
+  }
+
+  async setSubmissionPreviewVersion(issueNumber: number, version: string): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (sub) this.submissions.set(issueNumber, { ...sub, previewVersion: version });
   }
 
   async recordDeliveryNudge(issueNumber: number): Promise<number> {
@@ -4235,7 +4248,11 @@ export class FirestoreStore implements Store {
     await this.db
       .collection('submissions')
       .doc(String(issueNumber))
-      .set({ deliveredVersion: version }, { merge: true });
+      .set({ deliveredVersion: version, previewVersion: version }, { merge: true });
+  }
+
+  async setSubmissionPreviewVersion(issueNumber: number, version: string): Promise<void> {
+    await this.db.collection('submissions').doc(String(issueNumber)).set({ previewVersion: version }, { merge: true });
   }
 
   async recordDeliveryNudge(issueNumber: number): Promise<number> {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1737,13 +1737,14 @@ export async function registerSubmissionRoutes(
     // stay unchanged (Codex P1). Presence of `preview.slug` is therefore a readiness
     // signal to attempt loading, not a promise that the route is warm on the same
     // tick — but it must not flip on until something is actually storable.
-    if (record.slug && record.deliveredVersion) {
+    const playableVersion = record.previewVersion ?? record.deliveredVersion;
+    if (record.slug && playableVersion) {
       const gamesStore = options.agentChannel?.gamesStore;
       if (gamesStore?.getDerivedArtifact) {
         try {
           const [bundle, previewHtml] = await Promise.all([
-            gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'bundle.html'),
-            gamesStore.getDerivedArtifact(record.slug, record.deliveredVersion, 'preview.html'),
+            gamesStore.getDerivedArtifact(record.slug, playableVersion, 'bundle.html'),
+            gamesStore.getDerivedArtifact(record.slug, playableVersion, 'preview.html'),
           ]);
           if (bundle || previewHtml) {
             status.preview = { slug: record.slug };
@@ -1770,11 +1771,12 @@ export async function registerSubmissionRoutes(
     // these from its own unsent-state memory, so they vanished on the first reload.
     if (store) {
       const messages = await store.listCreatorMessages(record.issueNumber, { limit: 20 });
-      if (messages.length > 0 || record.deliveredVersion) {
+      if (messages.length > 0 || playableVersion) {
         status.progress = {
           // The preview refreshes when headSha changes; for a native job the moment
           // with something new to show is a delivery, so the version plays that role.
-          headSha: record.deliveredVersion ?? '',
+          // Prefer previewVersion so mode=preview iterations reload Studio.
+          headSha: playableVersion ?? '',
           commits: [],
           checklist: [],
           revisions: messages.map((message) => ({
@@ -3690,24 +3692,25 @@ export async function registerSubmissionRoutes(
     record: SubmissionRecord,
   ): Promise<FastifyReply | null> {
     const gamesStore = options.agentChannel?.gamesStore;
-    const { slug, deliveredVersion } = record;
-    if (!gamesStore || !slug || !deliveredVersion) return null;
+    const { slug } = record;
+    const playableVersion = record.previewVersion ?? record.deliveredVersion;
+    if (!gamesStore || !slug || !playableVersion) return null;
 
     const cached = draftPreviewCache.get(record.issueNumber);
-    if (cached && cached.revision === deliveredVersion && cached.expiresAt > now()) {
+    if (cached && cached.revision === playableVersion && cached.expiresAt > now()) {
       return reply.send(cached.value);
     }
 
-    // The verified bundle first, then the gate's red-run preview. Both are assembled by
-    // the same code from the same sources, so this is not a choice between a good and a
-    // degraded document — it is only about whether the run that produced it also passed.
-    // Falling back is the point: a creator being unable to look at their own build
-    // because it failed a check is the least useful moment to hide it from them, and for
-    // a while that is what happened — a red gate stored nothing, so the studio showed an
-    // empty panel and said nothing about why.
-    let bundle = await gamesStore.getDerivedArtifact(slug, deliveredVersion, 'bundle.html');
+    // The verified bundle first, then the gate's red-run / preview-lane document. Both
+    // are assembled by the same code from the same sources, so this is not a choice
+    // between a good and a degraded document — it is only about whether the run that
+    // produced it also passed. Falling back is the point: a creator being unable to
+    // look at their own build because it failed a check is the least useful moment to
+    // hide it from them, and for a while that is what happened — a red gate stored
+    // nothing, so the studio showed an empty panel and said nothing about why.
+    let bundle = await gamesStore.getDerivedArtifact(slug, playableVersion, 'bundle.html');
     const artifact = bundle ? 'bundle.html' : 'preview.html';
-    bundle ??= await gamesStore.getDerivedArtifact(slug, deliveredVersion, 'preview.html');
+    bundle ??= await gamesStore.getDerivedArtifact(slug, playableVersion, 'preview.html');
     // Absent rather than broken: the gate has not finished, or it went red early enough
     // that there was nothing assemblable to keep. Both are "not ready", and the channel's
     // own pushed previews cover the window. A store that *errors* throws out of here
@@ -3717,11 +3720,11 @@ export async function registerSubmissionRoutes(
     const value: DraftPreviewValue = { slug, title: record.title || slug, html: bundle.toString('utf8') };
     rememberDraftPreview(record.issueNumber, {
       value,
-      revision: deliveredVersion,
+      revision: playableVersion,
       expiresAt: now() + draftPreviewTtlMs,
     });
     request.log.info(
-      { issueNumber: record.issueNumber, slug, version: deliveredVersion, artifact },
+      { issueNumber: record.issueNumber, slug, version: playableVersion, artifact },
       'served gate-built preview for a delivered version',
     );
     return reply.send(value);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vibe-coding was blocked at upload because `submit_sources` hard-required `TRACE.json` before any gate stage. Add `mode=preview|publish` (default **publish** for `npm run submit` compat):

- **preview**: TRACE/PLAYTEST optional; `check:game --preview`; `preview.html` only; `previewVersion` for Studio; stays `building` (not ready_for_review)
- **publish**: existing TRACE/PLAYTEST + full gate + `deliveredVersion`

MCP workflow and `get_gate_verdict` expose `preview_passed` / `preview_failed` so agents iterate without ending the round on a draft check.

### Codex follow-up (`1c3e36c5`)

- Prefer `previewVersion` over a stale `deliveredVersion` for gate/media defaults and channel verdicts (red publish → fix → preview can observe the latest result).
- Restore sources from `previewVersion` when that is the latest candidate.
- Persist `kit_outdated` on `previewGate` so agents refresh the kit instead of retrying smoke.

### Test plan

- [x] Preview upload without TRACE; publish still requires TRACE/PLAYTEST
- [x] Preview does not set `deliveredVersion` / does not transition to `submitted`
- [x] Newer preview verdict wins over stale red publish
- [x] Restore returns preview-only and newer-preview candidates
- [x] `kit_outdated` survives on `previewGate` and surfaces on the channel
- [x] API suite + root green gate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

