### PR TITLE
fix(web): quiet Studio connect — OAuth default, Details install, gate-green Done

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -738,6 +738,7 @@ export function CreatorStudioView({
                         justHandedOff={handoffToken != null}
                         onImproved={(newToken) => setHandoffToken(newToken)}
                         onPlaytest={() => openTab('playtest')}
+                        onOpenConnect={() => openTab('details')}
                         onRetry={
                           onRetryConcept
                             ? (concept) => {

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -92,7 +92,7 @@ describe('StudioConnectCard', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders masked config + keyless kickoff and never puts the full key in markup', async () => {
+  it('defaults to Sign in and never puts the full key in markup', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -113,15 +113,12 @@ describe('StudioConnectCard', () => {
       expect.objectContaining({ credentials: 'include' }),
     );
     expect(container.querySelector('.studio-connect-title')?.textContent).toContain('Connect your coding agent');
-    expect(container.textContent).toContain('Add gamedev.pl to your agent');
+    expect(container.textContent).toMatch(/Sign in from your agent/i);
     expect(container.textContent).toContain('Tell your agent what to build');
     expect(container.textContent).toContain('slug: sky-dodge');
     expect(container.textContent).not.toContain('key:');
-    expect(container.innerHTML).toContain(MASKED);
     expect(container.innerHTML).not.toContain(FULL_KEY);
-    expect(container.querySelector('[data-testid="connect-config-snippet"]')?.textContent).not.toContain(FULL_KEY);
     expect(container.querySelector('[data-testid="connect-kickoff"]')?.textContent).toContain('slug: sky-dodge');
-    expect(container.textContent).toMatch(/Ends in 9a10e/);
     expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
     expect(container.querySelector('.studio-connect-waiting')).not.toBeNull();
 
@@ -134,8 +131,19 @@ describe('StudioConnectCard', () => {
     expect(vscodeLink?.getAttribute('href')).not.toContain(FULL_KEY);
     expect(cursorLink?.getAttribute('href')).not.toMatch(/Authorization|Bearer|headers/i);
     expect(vscodeLink?.getAttribute('href')).not.toMatch(/Authorization|Bearer|headers/i);
-    // Hand-copy config path stays for clients without a deep link.
-    expect(container.querySelector('[data-testid="connect-config-snippet"]')).not.toBeNull();
+
+    // Paste-header path still available as the escape hatch.
+    const keyTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
+      tab.textContent?.includes('Paste header'),
+    );
+    await act(async () => {
+      keyTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(container.textContent).toContain('Add gamedev.pl to your agent');
+    expect(container.innerHTML).toContain(MASKED);
+    expect(container.querySelector('[data-testid="connect-config-snippet"]')?.textContent).not.toContain(FULL_KEY);
+    expect(container.textContent).toMatch(/Ends in 9a10e/);
     expect(container.textContent).toContain('Claude Code');
 
     await act(async () => root.unmount());
@@ -144,6 +152,7 @@ describe('StudioConnectCard', () => {
   it('Copy config puts the real Authorization header on the clipboard', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
+    localStorage.setItem('gamedev_connect_auth_mode', 'key');
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -174,6 +183,7 @@ describe('StudioConnectCard', () => {
   it('Copy config replaces Bearer-only masks in Codex and Cursor snippets', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
+    localStorage.setItem('gamedev_connect_auth_mode', 'key');
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -219,7 +229,7 @@ describe('StudioConnectCard', () => {
     await act(async () => root.unmount());
   });
 
-  it('remembers auth mode choice between Paste header and Sign in', async () => {
+  it('defaults to Sign in and remembers a Paste header choice', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -235,15 +245,17 @@ describe('StudioConnectCard', () => {
       await flush();
     });
 
-    const oauthTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
-      tab.textContent?.includes('Sign in'),
+    expect(container.textContent).toMatch(/Sign in from your agent/i);
+
+    const keyTab = [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((tab) =>
+      tab.textContent?.includes('Paste header'),
     );
     await act(async () => {
-      oauthTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      keyTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
     });
-    expect(localStorage.getItem('gamedev_connect_auth_mode')).toBe('oauth');
-    expect(container.textContent).toMatch(/Sign in from your agent/i);
+    expect(localStorage.getItem('gamedev_connect_auth_mode')).toBe('key');
+    expect(container.textContent).toContain('Add gamedev.pl to your agent');
 
     await act(async () => root.unmount());
   });
@@ -251,6 +263,7 @@ describe('StudioConnectCard', () => {
   it('rotate uses the creator-key rotate endpoint', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
+    localStorage.setItem('gamedev_connect_auth_mode', 'key');
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -588,6 +601,36 @@ describe('StudioConnectCard', () => {
     expect(details?.textContent).toContain('Need to reconnect MCP?');
     expect(details?.querySelector('[data-testid="connect-install-cursor"]')).not.toBeNull();
     expect(container.innerHTML).not.toContain(FULL_KEY);
+
+    await act(async () => root.unmount());
+  });
+
+  it('Studio resume sends MCP install to Details instead of expanding inline', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const onOpenInstall = vi.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(StudioConnectCard, { token: 'status-tok', mode: 'resume', onOpenInstall }));
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="connect-setup-details"]')).toBeNull();
+    expect(container.querySelector('.studio-connect-waiting')).toBeNull();
+    const open = container.querySelector<HTMLButtonElement>('[data-testid="connect-open-install"]');
+    expect(open?.textContent).toContain('Reconnect MCP in Details');
+    await act(async () => {
+      open?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(onOpenInstall).toHaveBeenCalledOnce();
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -33,9 +33,10 @@ const QUIET_UNAVAILABLE = new Set(['not_self_round', 'inactive_round']);
 function loadAuthMode(): ConnectAuthMode {
   try {
     const raw = localStorage.getItem(AUTH_MODE_STORAGE_KEY);
-    return raw === 'oauth' ? 'oauth' : 'key';
+    // Sign-in is the default path — paste-header is the escape hatch (Cursor bugs, CLI).
+    return raw === 'key' ? 'key' : 'oauth';
   } catch {
-    return 'key';
+    return 'oauth';
   }
 }
 
@@ -71,6 +72,12 @@ type StudioConnectCardProps = {
    * (Details mounts this for every open game; only self rounds have a payload).
    */
   hideIfUnavailable?: boolean;
+  /**
+   * Studio thread: open the Details rail for MCP install instead of expanding it
+   * inline (Claude-shaped — install lives in the side panel, not the transcript).
+   * Standalone `/status` leaves this unset and keeps the inline disclosure.
+   */
+  onOpenInstall?: () => void;
 };
 
 /**
@@ -87,6 +94,7 @@ export function StudioConnectCard({
   mode = 'setup',
   collapsible = true,
   hideIfUnavailable = false,
+  onOpenInstall,
 }: StudioConnectCardProps) {
   const { t, i18n } = useTranslation();
   const baseId = useId();
@@ -278,20 +286,20 @@ export function StudioConnectCard({
         <button
           type="button"
           role="tab"
-          aria-selected={authMode === 'key'}
-          className={`studio-connect-tab${authMode === 'key' ? ' is-active' : ''}`}
-          onClick={() => chooseAuthMode('key')}
-        >
-          {t('connect.authMode.key')}
-        </button>
-        <button
-          type="button"
-          role="tab"
           aria-selected={authMode === 'oauth'}
           className={`studio-connect-tab${authMode === 'oauth' ? ' is-active' : ''}`}
           onClick={() => chooseAuthMode('oauth')}
         >
           {t('connect.authMode.oauth')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={authMode === 'key'}
+          className={`studio-connect-tab${authMode === 'key' ? ' is-active' : ''}`}
+          onClick={() => chooseAuthMode('key')}
+        >
+          {t('connect.authMode.key')}
         </button>
       </div>
 
@@ -455,14 +463,41 @@ export function StudioConnectCard({
         isResume ? (
           <>
             {kickoffPanel}
-            <p className="studio-connect-waiting" aria-live="polite">
-              <span className="studio-connect-pulse" aria-hidden="true" />
-              {t('connect.resume.waiting')}
-            </p>
-            <details className="studio-connect-setup-details" data-testid="connect-setup-details">
-              <summary>{t('connect.resume.setupDetails')}</summary>
-              <div className="studio-connect-setup-body">{installPanel}</div>
-            </details>
+            {/* Studio foot owns the single waiting caption — a second pulse here
+                ("Czekamy…") next to "Powstaje kod" was the same fact twice. */}
+            {onOpenInstall ? (
+              <button
+                type="button"
+                className="studio-connect-open-install"
+                onClick={onOpenInstall}
+                data-testid="connect-open-install"
+              >
+                <PixelIcon name="expand" size={12} /> {t('connect.resume.openInstall')}
+              </button>
+            ) : (
+              <>
+                <p className="studio-connect-waiting" aria-live="polite">
+                  <span className="studio-connect-pulse" aria-hidden="true" />
+                  {t('connect.resume.waiting')}
+                </p>
+                <details className="studio-connect-setup-details" data-testid="connect-setup-details">
+                  <summary>{t('connect.resume.setupDetails')}</summary>
+                  <div className="studio-connect-setup-body">{installPanel}</div>
+                </details>
+              </>
+            )}
+          </>
+        ) : onOpenInstall ? (
+          <>
+            <button
+              type="button"
+              className="studio-connect-open-install is-primary"
+              onClick={onOpenInstall}
+              data-testid="connect-open-install"
+            >
+              <PixelIcon name="expand" size={12} /> {t('connect.openInstall')}
+            </button>
+            {kickoffPanel}
           </>
         ) : (
           <>

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -422,6 +422,8 @@ describe('SubmissionStatusView', () => {
       status: 'in_review',
       phase: 'ready_for_review',
       builder: 'self',
+      // Stale quiet can linger after gate-green — must not resurface as a stall chip.
+      stall: 'quiet',
       slug: 'studio-play',
       preview: { slug: 'studio-play' },
       progress: { headSha: 'v1', commits: [], checklist: [] },
@@ -455,6 +457,9 @@ describe('SubmissionStatusView', () => {
     expect(container.textContent).not.toContain('Continue with your agent');
     expect(container.textContent).not.toMatch(/could not load the connect steps/i);
     expect(container.querySelector('.status-feedback-route')).toBeNull();
+    expect(container.querySelector('.studio-status-chip')).toBeNull();
+    expect(container.textContent).not.toMatch(/quiet for a while|can't start it from here/i);
+    expect(container.querySelector('.studio-context-phase')?.textContent).toMatch(/Final check/i);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -449,6 +449,12 @@ describe('SubmissionStatusView', () => {
     // path is covered elsewhere; here we only assert the preview loaded for Studio.
     expect(container.querySelector('.studio-thread-context .status-play-cta')).toBeNull();
     expect(mockedGetSubmissionPreview.mock.results[0]?.value).toBeTruthy();
+    // Gate-green is Done — do not mount connect (endpoint is inactive_round and used
+    // to render a red "could not load connect steps" over a finished delivery).
+    expect(container.querySelector('.studio-connect')).toBeNull();
+    expect(container.textContent).not.toContain('Continue with your agent');
+    expect(container.textContent).not.toMatch(/could not load the connect steps/i);
+    expect(container.querySelector('.status-feedback-route')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -694,7 +694,8 @@ describe('SubmissionStatusView', () => {
         await flushEffects();
       });
 
-      expect(container.querySelector('.status-warning')?.textContent).toContain("can't start it from here");
+      // Connect card lead covers quiet — no second amber chip under the composer.
+      expect(container.querySelector('.studio-status-chip')).toBeNull();
       expect(container.querySelector('.studio-connect.is-resume')).not.toBeNull();
       expect(container.textContent).toContain('Continue with your agent');
       expect(container.textContent).not.toContain('Connect your coding agent');
@@ -702,7 +703,10 @@ describe('SubmissionStatusView', () => {
       const details = container.querySelector<HTMLDetailsElement>('[data-testid="connect-setup-details"]');
       expect(details).not.toBeNull();
       expect(details?.open).toBe(false);
-      expect(container.textContent).toContain('your agent will get this when you start it');
+      // One waiting caption in the foot — not "Writing code" while we wait on the agent.
+      expect(container.querySelector('.studio-context-phase')?.textContent).toMatch(/Waiting for your agent/i);
+      expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
+      expect(container.querySelector('.status-feedback-route')).toBeNull();
       expect(container.textContent?.toLowerCase()).not.toMatch(/\btoken\b/);
     } finally {
       await act(async () => {

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -247,6 +247,10 @@ type SubmissionStatusViewProps = {
    */
   onPlaytest?: () => void;
   /**
+   * Opens Studio Details for MCP install — keeps tall connect chrome out of the thread.
+   */
+  onOpenConnect?: () => void;
+  /**
    * When true, this view is nested inside Creator Studio (the Build tab). The
    * outer studio chrome already names the game — skip the page-level heading /
    * save-link lecture and point share URLs at `/studio/:token`.
@@ -275,6 +279,7 @@ export function SubmissionStatusView({
   trackingUrl,
   onRetry,
   onPlaytest,
+  onOpenConnect,
   embedded = false,
   onImproved,
   justHandedOff = false,
@@ -660,6 +665,7 @@ export function SubmissionStatusView({
                       key={`connect-${pendingRevisions.length}`}
                       token={token}
                       mode={connectCardMode(copyInputFromStatus(status)) ?? 'setup'}
+                      {...(onOpenConnect ? { onOpenInstall: onOpenConnect } : {})}
                     />
                   ) : null
                 }
@@ -675,7 +681,8 @@ export function SubmissionStatusView({
                     notes and used to look like nothing was wrong.
                     Self rounds: no-agent-yet / quiet / gate-green resurface the connect
                     card inside the transcript scroller (not this foot) so a phone still
-                    has room for the conversation. Delivery-cap is a failure sentence. */}
+                    has room for the conversation. Delivery-cap is a failure sentence.
+                    When that card is up, skip the quiet chip — the card lead already says it. */}
                 {status.failure ? (
                   <ThreadStatusChip chipKey={`failure:${status.failure.reason}`}>
                     <PixelIcon name="signal" size={13} />
@@ -686,12 +693,7 @@ export function SubmissionStatusView({
                     <PixelIcon name="signal" size={13} />
                     <span>{t('statusView.states.needs_changes.description')}</span>
                   </ThreadStatusChip>
-                ) : selfCopy === 'no_agent_yet' ? null : selfCopy === 'quiet_agent' ? (
-                  <ThreadStatusChip chipKey="quiet_self">
-                    <PixelIcon name="signal" size={13} />
-                    <span>{t('statusView.stall.quietSelf')}</span>
-                  </ThreadStatusChip>
-                ) : status.stall ? (
+                ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
                   <ThreadStatusChip chipKey={`stall:${status.stall}`}>
                     <PixelIcon name="signal" size={13} />
                     <span>{t(`statusView.stall.${status.stall}`)}</span>
@@ -714,12 +716,18 @@ export function SubmissionStatusView({
                   </button>
                 ) : null}
 
-                {/* Claude-shaped foot: phase + heartbeat only. Play lives in the header
-                    icon cluster; abandon / checklist / connect live in Details. */}
+                {/* One waiting caption. While the connect card owns the thread, do not
+                    also spin "Writing code" — the agent is not writing; we are waiting. */}
                 <ThreadContextBar
-                  phase={t(`statusView.states.${status.status}.label`)}
-                  heartbeatAt={heartbeatAt}
-                  active={!TERMINAL_STATUSES.has(status.status)}
+                  phase={
+                    isAwaitingOwnAgent(status)
+                      ? selfCopy === 'no_agent_yet'
+                        ? t('connect.waiting')
+                        : t('connect.resume.waiting')
+                      : t(`statusView.states.${status.status}.label`)
+                  }
+                  heartbeatAt={isAwaitingOwnAgent(status) ? null : heartbeatAt}
+                  active={!TERMINAL_STATUSES.has(status.status) && !isAwaitingOwnAgent(status)}
                 />
 
                 {/* Before the first agent signal there is nobody to receive a note — the
@@ -737,6 +745,7 @@ export function SubmissionStatusView({
                     stall={status.stall}
                     failureReason={status.failure?.reason}
                     phase={status.phase}
+                    suppressRouteNote={isAwaitingOwnAgent(status)}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                     onPublishedImprove={handleImproved}
                   />
@@ -1124,6 +1133,7 @@ function FeedbackPanel({
   stall,
   failureReason,
   phase,
+  suppressRouteNote = false,
   onSent,
   onPublishedImprove,
 }: {
@@ -1142,6 +1152,11 @@ function FeedbackPanel({
   failureReason?: string;
   /** Internal job phase — gate-green drafts need honest "start your agent" routing. */
   phase?: SubmissionStatus['phase'];
+  /**
+   * Hide the "saved until you start your agent" line — the connect card above already
+   * says we are waiting, so a third copy under the box is noise.
+   */
+  suppressRouteNote?: boolean;
   onSent: (text: string) => void;
   /**
    * A published-game improvement opened a new job; called with its token so the view
@@ -1195,8 +1210,9 @@ function FeedbackPanel({
   // Active self rounds already imply a listening agent — repeating that above the
   // box is chrome noise (the placeholder covers "what to write"). Waiting is the
   // case that still needs a sentence: the note will not be read until they start
-  // their agent again.
-  const routeNoteKey = composerRoute === 'waiting' ? 'statusView.feedback.routeSelfWaiting' : null;
+  // their agent again — unless the connect card already said that (`suppressRouteNote`).
+  const routeNoteKey =
+    !suppressRouteNote && composerRoute === 'waiting' ? 'statusView.feedback.routeSelfWaiting' : null;
 
   // The composer grows with what is typed, which is what replaced the resize grip: once
   // the send button moved inside the box, a drag handle in the middle of its right edge

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -679,10 +679,11 @@ export function SubmissionStatusView({
                     needs a sentence here — the thread's emptyLabel only shows when there
                     are no turns, which is exactly when a bounced build still has planning
                     notes and used to look like nothing was wrong.
-                    Self rounds: no-agent-yet / quiet / gate-green resurface the connect
-                    card inside the transcript scroller (not this foot) so a phone still
-                    has room for the conversation. Delivery-cap is a failure sentence.
-                    When that card is up, skip the quiet chip — the card lead already says it. */}
+                    Self rounds: no-agent-yet / quiet resurface the connect card inside
+                    the transcript scroller (not this foot) so a phone still has room for
+                    the conversation. Gate-green is Done — no connect, no stale quiet chip.
+                    Delivery-cap is a failure sentence. When the connect card is up, skip
+                    the quiet chip — the card lead already says it. */}
                 {status.failure ? (
                   <ThreadStatusChip chipKey={`failure:${status.failure.reason}`}>
                     <PixelIcon name="signal" size={13} />
@@ -693,7 +694,7 @@ export function SubmissionStatusView({
                     <PixelIcon name="signal" size={13} />
                     <span>{t('statusView.states.needs_changes.description')}</span>
                   </ThreadStatusChip>
-                ) : isAwaitingOwnAgent(status) ? null : status.stall ? (
+                ) : isAwaitingOwnAgent(status) || status.phase === 'ready_for_review' ? null : status.stall ? (
                   <ThreadStatusChip chipKey={`stall:${status.stall}`}>
                     <PixelIcon name="signal" size={13} />
                     <span>{t(`statusView.stall.${status.stall}`)}</span>
@@ -824,12 +825,14 @@ export function SubmissionStatusView({
 
             {/* A dead round outranks a slow one: when both are set, the failure is
                 the explanation and the stall is just its symptom. Self quiet keeps
-                its warning and resurfaces the connect card. */}
+                its warning and resurfaces the connect card. Gate-green suppresses a
+                stale quiet stall — Final check is Done, not "agent wandered off". */}
             {status.failure ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t(`statusView.failure.${failureCopyKey(status.failure.reason)}`)}
               </p>
-            ) : selfCopy === 'no_agent_yet' ? null : selfCopy === 'quiet_agent' ? (
+            ) : status.phase === 'ready_for_review' ? null : selfCopy === 'no_agent_yet' ? null : selfCopy ===
+              'quiet_agent' ? (
               <p className="status-warning">
                 <PixelIcon name="signal" size={13} /> {t('statusView.stall.quietSelf')}
               </p>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -745,7 +745,7 @@ export function SubmissionStatusView({
                     stall={status.stall}
                     failureReason={status.failure?.reason}
                     phase={status.phase}
-                    suppressRouteNote={isAwaitingOwnAgent(status)}
+                    suppressRouteNote={isAwaitingOwnAgent(status) || status.phase === 'ready_for_review'}
                     onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
                     onPublishedImprove={handleImproved}
                   />

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -920,6 +920,7 @@
     "waiting": "Waiting for your agent to check in…",
     "hide": "Hide for now",
     "show": "Show connect steps",
+    "openInstall": "Open connect steps",
     "collapsed": {
       "title": "Waiting for your coding agent",
       "hint": "Also in Details anytime."
@@ -973,6 +974,7 @@
       "kickoffTitle": "Continue prompt",
       "kickoffHint": "This prompt carries only the game slug. Your MCP connection stays in the agent config.",
       "setupDetails": "Need to reconnect MCP?",
+      "openInstall": "Reconnect MCP in Details",
       "waiting": "Waiting for your agent to check in again…"
     }
   },

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -924,6 +924,7 @@
     "waiting": "Czekamy, aż Twój agent się odezwie…",
     "hide": "Ukryj na razie",
     "show": "Pokaż kroki połączenia",
+    "openInstall": "Otwórz kroki połączenia",
     "collapsed": {
       "title": "Czekamy na Twojego agenta",
       "hint": "Zawsze też w Szczegółach."
@@ -977,6 +978,7 @@
       "kickoffTitle": "Prompt wznowienia",
       "kickoffHint": "Ten prompt niesie tylko slug gry. Połączenie MCP zostaje w konfiguracji agenta.",
       "setupDetails": "Trzeba ponownie podłączyć MCP?",
+      "openInstall": "Podłącz MCP w Szczegółach",
       "waiting": "Czekamy, aż Twój agent znów się odezwie…"
     }
   },

--- a/apps/web/src/selfBuildCopy.test.ts
+++ b/apps/web/src/selfBuildCopy.test.ts
@@ -56,6 +56,11 @@ describe('shouldShowConnectCard', () => {
     expect(shouldShowConnectCard({ builder: 'self', stall: null })).toBe(false);
     expect(shouldShowConnectCard({ builder: 'platform', stall: 'quiet' })).toBe(false);
   });
+
+  it('hides after gate-green — even with a stale quiet stall (connect would 409)', () => {
+    expect(shouldShowConnectCard({ builder: 'self', phase: 'ready_for_review' })).toBe(false);
+    expect(shouldShowConnectCard({ builder: 'self', phase: 'ready_for_review', stall: 'quiet' })).toBe(false);
+  });
 });
 
 describe('connectCardMode', () => {
@@ -63,13 +68,13 @@ describe('connectCardMode', () => {
     expect(connectCardMode({ builder: 'self', stall: 'no_agent_yet' })).toBe('setup');
   });
 
-  it('is resume after quiet or gate-green — not a full first-time install', () => {
+  it('is resume after quiet — not a full first-time install', () => {
     expect(connectCardMode({ builder: 'self', stall: 'quiet' })).toBe('resume');
-    expect(connectCardMode({ builder: 'self', phase: 'ready_for_review' })).toBe('resume');
   });
 
   it('is null when the connect card should not show', () => {
     expect(connectCardMode({ builder: 'self', stall: null })).toBeNull();
+    expect(connectCardMode({ builder: 'self', phase: 'ready_for_review' })).toBeNull();
     expect(connectCardMode({ builder: 'platform', stall: 'quiet' })).toBeNull();
   });
 });
@@ -96,9 +101,9 @@ describe('selfComposerRoute', () => {
     ).toBe('waiting');
   });
 
-  it('is waiting after a green gate closes the round', () => {
+  it('is waiting after a green gate closes the round, without a connect card', () => {
     expect(selfComposerRoute({ builder: 'self', phase: 'ready_for_review', stall: null })).toBe('waiting');
-    expect(shouldShowConnectCard({ builder: 'self', phase: 'ready_for_review' })).toBe(true);
+    expect(shouldShowConnectCard({ builder: 'self', phase: 'ready_for_review' })).toBe(false);
   });
 });
 

--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -44,24 +44,29 @@ export function selfStatusCopy(input: SelfBuildCopyInput): SelfStatusCopy | null
  *
  * Shown before the first agent signal, and again when a connected agent has gone
  * quiet — gamedev.pl cannot wake it, so the paste-ready prompt is the resume path.
- * Also shown after a green gate closes the round: Studio still looks "live", but no
- * session will check the inbox until the creator starts their agent again.
  *
- * Quiet / gate-green use {@link connectCardMode} `resume` (kickoff-first), not the
- * full first-time MCP install chrome.
+ * Not shown after a green gate (`ready_for_review`): the round closed and the
+ * connect endpoint returns `inactive_round`, so mounting the card only produced a
+ * red "could not load connect steps" while ChatGPT correctly said Done. Gate-green
+ * is Final check / waiting to publish — not a reconnect moment.
+ *
+ * Quiet uses {@link connectCardMode} `resume` (kickoff-first), not the full
+ * first-time MCP install chrome.
  */
 export function shouldShowConnectCard(input: SelfBuildCopyInput): boolean {
+  // Gate-green closes the round (connect → inactive_round). A stale `quiet` stall
+  // can still be on the status snapshot — do not resurface reconnect over "Done".
+  if (input.phase === 'ready_for_review') return false;
   const copy = selfStatusCopy(input);
-  if (copy === 'no_agent_yet' || copy === 'quiet_agent') return true;
-  return input.builder === 'self' && input.phase === 'ready_for_review';
+  return copy === 'no_agent_yet' || copy === 'quiet_agent';
 }
 
 /** Shape of the connect card when it is on screen, or null when it should not show. */
 export type ConnectCardMode = 'setup' | 'resume';
 
 /**
- * First attach gets the full install + kickoff. Quiet / gate-green already had a
- * connection — show the continue prompt first and tuck MCP re-install under details.
+ * First attach gets the full install + kickoff. Quiet already had a connection —
+ * show the continue prompt first and send MCP re-install to Details.
  */
 export function connectCardMode(input: SelfBuildCopyInput): ConnectCardMode | null {
   if (!shouldShowConnectCard(input)) return null;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5056,6 +5056,11 @@ a.user-name--profile:focus-visible {
   flex: 1;
   min-height: 0;
   height: auto;
+  /* Claude-like reading column — full-bleed thread chrome made prompts and chips
+     stretch edge-to-edge on a wide desktop. */
+  width: 100%;
+  max-width: 44rem;
+  margin-inline: auto;
 }
 
 .app:has(.studio-layout.is-game-open) .studio-thread-scroll {
@@ -5790,6 +5795,41 @@ a.user-name--profile:focus-visible {
   flex-direction: column;
   gap: 14px;
   margin-top: 12px;
+}
+
+/* Studio thread: send MCP install to Details instead of expanding it inline. */
+.studio-connect-open-install {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  align-self: flex-start;
+  min-height: 36px;
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: transparent;
+  color: var(--muted, #94a3b8);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.studio-connect-open-install:hover {
+  color: var(--text, #e2e8f0);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.studio-connect-open-install.is-primary {
+  border-color: rgba(0, 228, 172, 0.45);
+  background: rgba(0, 228, 172, 0.1);
+  color: var(--turquoise, #00e4ac);
+}
+
+.studio-connect-open-install.is-primary:hover {
+  background: rgba(0, 228, 172, 0.16);
 }
 
 /* Naming the game — the step the build waits on, so it leads the panel and is sized


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #520 after seeing the resume strip in production.

## Problems

1. **Two waiting signals** — connect card “Czekamy…” next to foot “Powstaje kod”
2. **MCP install owned the thread** — reconnect disclosure was sidebar/modal material
3. **Paste header was the default** — Sign in should lead
4. **Full-bleed thread on desktop** — no Claude-like reading width
5. **Gate-green looked broken** — ChatGPT said Done / gate-approved; Studio mounted the resume connect card, `GET /connect` returned `inactive_round`, UI showed a red “could not load connect steps”
6. **Stale quiet after Done** (Codex P2) — `ready_for_review` + leftover `stall: quiet` still showed the quiet chip above Final check

## Fix

- Default auth mode to **Sign in** (paste header is the escape hatch; tab order matches)
- Studio thread: MCP install opens **Details** (`onOpenInstall` → Details rail); kickoff stays in-thread for quiet resume
- One waiting caption when awaiting the agent; drop quiet chip + route note stacking over the connect card
- Thread column `max-width: 44rem` when a game is open
- **Do not show the connect card after `ready_for_review`** (even with a stale quiet stall)
- **Suppress stall chips after `ready_for_review`** so Final check is not undercut by “agent may still be working”

## Verification

- `npm run type-check && npm run lint`
- Unit: `selfBuildCopy`, `StudioConnectCard`, `SubmissionStatusView`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

