### PR TITLE
fix(web): Cursor-style Studio Details panes and clearer shelf rail

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -595,6 +595,99 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('shows title initials on shelf rows instead of anonymous status bulbs', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: '2D Total War',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: '2d-total-war',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: '2d-total-war' });
+
+    const mark = container.querySelector('.studio-shelf-mark');
+    expect(mark?.textContent).toBe('2T');
+    expect(container.querySelector('.studio-shelf-dot')).toBeNull();
+
+    root.unmount();
+  });
+
+  it('opens Details on the Overview icon pane, and switches panes one at a time', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
+
+    // Cursor-shaped strip: icons pick one pane. Overview is the landing surface — Share
+    // lives there; Connect / Build / Keys are not dumped into the same scroll.
+    const overview = container.querySelector('[data-testid="studio-rail-icon-overview"]');
+    const connect = container.querySelector('[data-testid="studio-rail-icon-connect"]');
+    const build = container.querySelector('[data-testid="studio-rail-icon-build"]');
+    const keys = container.querySelector('[data-testid="studio-rail-icon-keys"]');
+    expect(overview?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-testid="studio-rail-pane-overview"]')).not.toBeNull();
+    expect(container.querySelector('.studio-share-toggle')).not.toBeNull();
+    expect(container.querySelector('[data-testid="studio-details-progress"]')).toBeNull();
+
+    await act(async () => {
+      connect!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(connect?.getAttribute('aria-pressed')).toBe('true');
+    expect(overview?.getAttribute('aria-pressed')).toBe('false');
+    expect(container.querySelector('[data-testid="studio-rail-pane-connect"]')).not.toBeNull();
+    expect(container.querySelector('.studio-share-toggle')).toBeNull();
+
+    await act(async () => {
+      build!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(build?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-testid="studio-rail-pane-build"]')).not.toBeNull();
+
+    await act(async () => {
+      keys!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(keys?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-testid="studio-rail-pane-keys"]')).not.toBeNull();
+    expect(container.textContent).toMatch(/Creator key|legacy per-game key/i);
+
+    // Header Details always re-opens on Overview — not whatever pane was left selected.
+    const details = Array.from(container.querySelectorAll('.studio-head-action')).find((button) =>
+      button.textContent?.includes('Details'),
+    );
+    await act(async () => {
+      details!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      details!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('[data-testid="studio-rail-icon-overview"]')?.getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+    expect(container.querySelector('.studio-share-toggle')).not.toBeNull();
+
+    root.unmount();
+  });
+
   it('does not carry one game’s details state onto another', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
@@ -773,6 +866,13 @@ describe('CreatorStudioView — what players think', () => {
     if (detailsAction) {
       await act(async () => {
         detailsAction.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+    // Stats / suggestions / autonomy live on the Stats icon pane, not Overview.
+    const statsIcon = container.querySelector('[data-testid="studio-rail-icon-stats"]');
+    if (statsIcon) {
+      await act(async () => {
+        statsIcon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       });
     }
     return { container, root };

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -1107,7 +1107,13 @@ function DetailsPanel({
 
           {activePane === 'connect' ? (
             showConnect ? (
-              <StudioConnectCard token={game.token} collapsible={false} hideIfUnavailable density="panel" />
+              <StudioConnectCard
+                token={game.token}
+                collapsible={false}
+                hideIfUnavailable
+                unavailableLabel={t('studioPanel.rail.connectEmpty')}
+                density="panel"
+              />
             ) : (
               <p className="studio-rail-empty">{t('studioPanel.rail.connectEmpty')}</p>
             )

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -998,90 +998,115 @@ function DetailsPanel({
     }
   }
 
+  const showConnect = game.lastKnownStatus !== 'abandoned' && game.lastKnownStatus !== 'published';
+  const showProgress = showConnect;
+  const showLegacyKey = Boolean(game.slug && game.lastKnownStatus !== 'abandoned');
+
   return (
     <div className="studio-overview">
-      <ul className="funnel-stats studio-facts">
-        <li>
-          <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.createdAt), i18n.language)}</span>
-          <span className="funnel-stat-label">{t('studioPanel.overview.created')}</span>
-        </li>
-        {publishedAt ? (
+      <section className="studio-rail-section" aria-label={t('studioPanel.overview.status')}>
+        <ul className="funnel-stats studio-facts">
           <li>
-            <span className="funnel-stat-value">{formatRelativeTime(Date.parse(publishedAt), i18n.language)}</span>
-            <span className="funnel-stat-label">{t('studioPanel.overview.published')}</span>
+            <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.createdAt), i18n.language)}</span>
+            <span className="funnel-stat-label">{t('studioPanel.overview.created')}</span>
           </li>
-        ) : null}
-        {health ? (
-          <li>
-            <span className="funnel-stat-value">
-              {health.sessions}
-              <span className="studio-fact-suffix">
-                · {formatSeconds(health.totalPlaySeconds)} {t('studioPanel.overview.play')}
+          {publishedAt ? (
+            <li>
+              <span className="funnel-stat-value">{formatRelativeTime(Date.parse(publishedAt), i18n.language)}</span>
+              <span className="funnel-stat-label">{t('studioPanel.overview.published')}</span>
+            </li>
+          ) : null}
+          {health ? (
+            <li>
+              <span className="funnel-stat-value">
+                {health.sessions}
+                <span className="studio-fact-suffix">
+                  · {formatSeconds(health.totalPlaySeconds)} {t('studioPanel.overview.play')}
+                </span>
               </span>
-            </span>
-            <span className="funnel-stat-label">{t('studioPanel.overview.sessions')}</span>
-          </li>
-        ) : null}
-      </ul>
+              <span className="funnel-stat-label">{t('studioPanel.overview.sessions')}</span>
+            </li>
+          ) : null}
+        </ul>
 
-      <div className="studio-actions">
-        {/* Nothing here to reopen the build with: the thread is on the screen already,
-            beside this panel. Playing a published game is the one action that is not
-            simply "look left". */}
-        {catalogLive && game.slug ? (
-          <button type="button" className="primary-btn" onClick={onPlay}>
-            <PixelIcon name="play" size={12} /> {t('myGames.play')}
+        <div className="studio-actions">
+          {/* Nothing here to reopen the build with: the thread is on the screen already,
+              beside this panel. Playing a published game is the one action that is not
+              simply "look left". */}
+          {catalogLive && game.slug ? (
+            <button type="button" className="primary-btn" onClick={onPlay}>
+              <PixelIcon name="play" size={12} /> {t('myGames.play')}
+            </button>
+          ) : null}
+          <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
+            <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
           </button>
-        ) : null}
-        <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
-          <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
-        </button>
-        {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
-          <button
-            type="button"
-            className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
-            onClick={() => void handleAbandon()}
-            disabled={abandoning}
-          >
-            {abandonArmed ? t('studioPanel.overview.abandonConfirm') : t('studioPanel.overview.abandon')}
-          </button>
-        ) : null}
-      </div>
+          {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
+            <button
+              type="button"
+              className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
+              onClick={() => void handleAbandon()}
+              disabled={abandoning}
+            >
+              {abandonArmed ? t('studioPanel.overview.abandonConfirm') : t('studioPanel.overview.abandon')}
+            </button>
+          ) : null}
+        </div>
+      </section>
 
       {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
           public play link — offering a second "share the draft" switch would lie. */}
-      {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? <DraftShareControl game={game} /> : null}
-
-      {/* Checklist fraction left the thread foot — Details is where Claude-style chrome
-          keeps build meta without crowding the composer. */}
-      {game.lastKnownStatus !== 'abandoned' && game.lastKnownStatus !== 'published' ? (
-        <StudioDetailsBuildProgress token={game.token} />
+      {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? (
+        <section className="studio-rail-section" aria-label={t('studioPanel.share.title')}>
+          <DraftShareControl game={game} />
+        </section>
       ) : null}
 
-      {/* Self-build connect steps live here too so the thread can dismiss them without
-          losing the path back — hideIfUnavailable keeps platform rounds silent. */}
-      {game.lastKnownStatus !== 'abandoned' && game.lastKnownStatus !== 'published' ? (
-        <StudioConnectCard token={game.token} collapsible={false} hideIfUnavailable />
+      {/* Checklist fraction left the thread foot — Details keeps build meta without
+          crowding the composer. Heading lives inside the component so an empty
+          checklist does not leave a stranded section title. */}
+      {showProgress ? <StudioDetailsBuildProgress token={game.token} /> : null}
+
+      {/* Self-build connect — panel density so install is scannable; hideIfUnavailable
+          keeps platform rounds silent (returns null — no orphan heading). */}
+      {showConnect ? (
+        <StudioConnectCard
+          token={game.token}
+          collapsible={false}
+          hideIfUnavailable
+          density="panel"
+          panelHeading={t('studioPanel.rail.connect')}
+        />
       ) : null}
 
-      {game.slug && game.lastKnownStatus !== 'abandoned' ? <StudioAgentKeyPanel token={game.token} /> : null}
-
-      <StudioCreatorAgentKeyPanel />
-      <StudioOAuthClientsPanel />
+      {/* Keys and OAuth grants are rare ops — collapsed so they do not own the rail. */}
+      <details className="studio-rail-credentials" data-testid="studio-rail-credentials">
+        <summary>
+          <span className="studio-rail-section-title">{t('studioPanel.rail.credentials')}</span>
+          <span className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</span>
+        </summary>
+        <div className="studio-rail-credentials-body">
+          {showLegacyKey ? <StudioAgentKeyPanel token={game.token} /> : null}
+          <StudioCreatorAgentKeyPanel />
+          <StudioOAuthClientsPanel />
+        </div>
+      </details>
 
       {/* Only once there is play to report on. Before a game is live every one of these
           numbers is zero, and a wall of zeroes reads as a verdict rather than as
           "nobody has played it yet, because nobody can". */}
       {catalogLive ? (
-        <StatsSection
-          game={game}
-          health={health}
-          days={days}
-          healthDays={healthDays}
-          truncated={truncated}
-          scorecard={scorecard}
-          onDaysChange={onDaysChange}
-        />
+        <section className="studio-rail-section">
+          <StatsSection
+            game={game}
+            health={health}
+            days={days}
+            healthDays={healthDays}
+            truncated={truncated}
+            scorecard={scorecard}
+            onDaysChange={onDaysChange}
+          />
+        </section>
       ) : null}
     </div>
   );

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -5,7 +5,7 @@ import { AuthModal } from './AuthModal.js';
 import { ClaimHandleModal } from './ClaimHandleModal.js';
 import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 import type { GameHealth } from './healthApi.js';
-import { PixelIcon } from './PixelIcon.js';
+import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { playPath, studioPath, type StudioTab } from './router.js';
 import { abandonSubmission } from './submissionApi.js';
@@ -17,6 +17,7 @@ import {
   isStudioGamePublished,
   isStudioGameShelfLive,
   sortStudioGames,
+  studioGameInitials,
   STUDIO_LIVE_STATUSES,
   STUDIO_SHELF_TOOLS_AT,
   type StudioShelfFilter,
@@ -394,6 +395,8 @@ export function CreatorStudioView({
    * picker already does all three; this arrived without any of them.
    */
   const detailsOpen = tab === 'details';
+  /** Which Details icon-pane is open — Cursor-style strip, one job at a time. */
+  const [detailsPane, setDetailsPane] = useState<DetailsPaneId>('overview');
   const [detailsIsSheet, setDetailsIsSheet] = useState(false);
   useEffect(() => {
     if (!detailsOpen) {
@@ -707,7 +710,14 @@ export function CreatorStudioView({
                         className={`studio-head-action is-icon-only${tab === 'details' ? ' is-active' : ''}`}
                         aria-pressed={tab === 'details'}
                         aria-label={t('studioPanel.tabs.details')}
-                        onClick={() => openTab(tab === 'details' ? 'thread' : 'details')}
+                        onClick={() => {
+                          if (tab === 'details') {
+                            openTab('thread');
+                            return;
+                          }
+                          setDetailsPane('overview');
+                          openTab('details');
+                        }}
                       >
                         <PixelIcon name="expand" size={12} />{' '}
                         <span className="studio-head-action-label">{t('studioPanel.tabs.details')}</span>
@@ -738,7 +748,10 @@ export function CreatorStudioView({
                         justHandedOff={handoffToken != null}
                         onImproved={(newToken) => setHandoffToken(newToken)}
                         onPlaytest={() => openTab('playtest')}
-                        onOpenConnect={() => openTab('details')}
+                        onOpenConnect={() => {
+                          setDetailsPane('connect');
+                          openTab('details');
+                        }}
                         onRetry={
                           onRetryConcept
                             ? (concept) => {
@@ -776,17 +789,6 @@ export function CreatorStudioView({
                         aria-label={t('studioPanel.tabs.details')}
                         {...(detailsIsSheet ? { role: 'dialog', 'aria-modal': true } : {})}
                       >
-                        <div className="studio-rail-head">
-                          <h3>{t('studioPanel.tabs.details')}</h3>
-                          <button
-                            type="button"
-                            className="modal-close-btn"
-                            onClick={() => openTab('thread')}
-                            aria-label={t('studioPanel.close')}
-                          >
-                            <PixelIcon name="close" size={14} />
-                          </button>
-                        </div>
                         <DetailsPanel
                           // Keyed on the game, so switching to another one gives a fresh
                           // panel rather than reusing this one's state. Without it every
@@ -802,6 +804,9 @@ export function CreatorStudioView({
                           healthDays={healthDays}
                           truncated={truncated}
                           scorecard={selectedScorecard}
+                          pane={detailsPane}
+                          onPaneChange={setDetailsPane}
+                          onClose={() => openTab('thread')}
                           onDaysChange={setDays}
                           onOpenPlaytest={() => openTab('playtest')}
                           onPlay={() => activeGame.slug && onPlay(activeGame.slug)}
@@ -925,15 +930,14 @@ function StudioShelfList({
               aria-current={active ? 'true' : undefined}
               title={game.title}
             >
-              {/* A dot, not a label. Every row used to carry its status in words and its
-                  age beside it, which made a list of five games a wall of small text with
-                  the titles — the only thing being chosen between — third in the reading
-                  order. The state that matters at a glance is "is this one moving", and a
-                  dot says that without spending a line on it. */}
+              {/* Collapsed rail shows letters, not anonymous bulbs — first letters of the
+                  first two title words. Status still rides on the mark's colour. */}
               <span
-                className={`studio-shelf-dot${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
+                className={`studio-shelf-mark${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
                 aria-hidden="true"
-              />
+              >
+                {studioGameInitials(game.title)}
+              </span>
               <span className="studio-shelf-title">{game.title}</span>
               <span className="studio-sr-only">
                 {status ? t(`statusView.states.${status}.label`) : t('myGames.checking')} ·{' '}
@@ -947,10 +951,19 @@ function StudioShelfList({
   );
 }
 
+/** Cursor-style Details strip — one pane at a time, chosen by icon. */
+type DetailsPaneId = 'overview' | 'connect' | 'build' | 'keys' | 'stats';
+
+type DetailsPaneDef = {
+  id: DetailsPaneId;
+  icon: PixelIconName;
+  labelKey: string;
+};
+
 /**
  * The things beside the thread: when the game was made, how it is doing, who can play
  * it, and how to stop it. Everything here is *about* the game; the thread is where it
- * is talked to.
+ * is talked to. Layout mirrors Cursor’s secondary icon rail — icons pick one pane.
  */
 function DetailsPanel({
   game,
@@ -959,6 +972,9 @@ function DetailsPanel({
   healthDays,
   truncated,
   scorecard,
+  pane,
+  onPaneChange,
+  onClose,
   onDaysChange,
   onOpenPlaytest,
   onPlay,
@@ -970,6 +986,9 @@ function DetailsPanel({
   healthDays: string[];
   truncated: boolean;
   scorecard: StudioScorecard | null;
+  pane: DetailsPaneId;
+  onPaneChange: (pane: DetailsPaneId) => void;
+  onClose: () => void;
   onDaysChange: (days: number) => void;
   onOpenPlaytest: () => void;
   onPlay: () => void;
@@ -1002,112 +1021,145 @@ function DetailsPanel({
   const showProgress = showConnect;
   const showLegacyKey = Boolean(game.slug && game.lastKnownStatus !== 'abandoned');
 
+  const panes: DetailsPaneDef[] = [
+    { id: 'overview', icon: 'eye', labelKey: 'studioPanel.rail.overview' },
+    ...(showConnect ? [{ id: 'connect' as const, icon: 'signal' as const, labelKey: 'studioPanel.rail.connect' }] : []),
+    ...(showProgress ? [{ id: 'build' as const, icon: 'wrench' as const, labelKey: 'studioPanel.rail.build' }] : []),
+    { id: 'keys', icon: 'lock', labelKey: 'studioPanel.rail.credentials' },
+    ...(catalogLive ? [{ id: 'stats' as const, icon: 'star' as const, labelKey: 'studioPanel.rail.stats' }] : []),
+  ];
+
+  // If the open pane disappeared (e.g. published while on Connect), fall back.
+  const activePane = panes.some((entry) => entry.id === pane) ? pane : 'overview';
+  const activeLabel = t(panes.find((entry) => entry.id === activePane)?.labelKey ?? 'studioPanel.tabs.details');
+
   return (
-    <div className="studio-overview">
-      <section className="studio-rail-section" aria-label={t('studioPanel.overview.status')}>
-        <ul className="funnel-stats studio-facts">
-          <li>
-            <span className="funnel-stat-value">{formatRelativeTime(Date.parse(game.createdAt), i18n.language)}</span>
-            <span className="funnel-stat-label">{t('studioPanel.overview.created')}</span>
-          </li>
-          {publishedAt ? (
-            <li>
-              <span className="funnel-stat-value">{formatRelativeTime(Date.parse(publishedAt), i18n.language)}</span>
-              <span className="funnel-stat-label">{t('studioPanel.overview.published')}</span>
-            </li>
-          ) : null}
-          {health ? (
-            <li>
-              <span className="funnel-stat-value">
-                {health.sessions}
-                <span className="studio-fact-suffix">
-                  · {formatSeconds(health.totalPlaySeconds)} {t('studioPanel.overview.play')}
-                </span>
-              </span>
-              <span className="funnel-stat-label">{t('studioPanel.overview.sessions')}</span>
-            </li>
-          ) : null}
-        </ul>
+    <div className="studio-rail-shell" data-testid="studio-rail-shell">
+      <div className="studio-rail-head">
+        <h3>{activeLabel}</h3>
+        <button type="button" className="modal-close-btn" onClick={onClose} aria-label={t('studioPanel.close')}>
+          <PixelIcon name="close" size={14} />
+        </button>
+      </div>
 
-        <div className="studio-actions">
-          {/* Nothing here to reopen the build with: the thread is on the screen already,
-              beside this panel. Playing a published game is the one action that is not
-              simply "look left". */}
-          {catalogLive && game.slug ? (
-            <button type="button" className="primary-btn" onClick={onPlay}>
-              <PixelIcon name="play" size={12} /> {t('myGames.play')}
-            </button>
+      <div className="studio-rail-body">
+        <div className="studio-rail-pane studio-overview" data-testid={`studio-rail-pane-${activePane}`}>
+          {activePane === 'overview' ? (
+            <>
+              <section className="studio-rail-section" aria-label={t('studioPanel.overview.status')}>
+                <ul className="funnel-stats studio-facts">
+                  <li>
+                    <span className="funnel-stat-value">
+                      {formatRelativeTime(Date.parse(game.createdAt), i18n.language)}
+                    </span>
+                    <span className="funnel-stat-label">{t('studioPanel.overview.created')}</span>
+                  </li>
+                  {publishedAt ? (
+                    <li>
+                      <span className="funnel-stat-value">
+                        {formatRelativeTime(Date.parse(publishedAt), i18n.language)}
+                      </span>
+                      <span className="funnel-stat-label">{t('studioPanel.overview.published')}</span>
+                    </li>
+                  ) : null}
+                  {health ? (
+                    <li>
+                      <span className="funnel-stat-value">
+                        {health.sessions}
+                        <span className="studio-fact-suffix">
+                          · {formatSeconds(health.totalPlaySeconds)} {t('studioPanel.overview.play')}
+                        </span>
+                      </span>
+                      <span className="funnel-stat-label">{t('studioPanel.overview.sessions')}</span>
+                    </li>
+                  ) : null}
+                </ul>
+
+                <div className="studio-actions">
+                  {catalogLive && game.slug ? (
+                    <button type="button" className="primary-btn" onClick={onPlay}>
+                      <PixelIcon name="play" size={12} /> {t('myGames.play')}
+                    </button>
+                  ) : null}
+                  <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
+                    <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
+                  </button>
+                  {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
+                    <button
+                      type="button"
+                      className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
+                      onClick={() => void handleAbandon()}
+                      disabled={abandoning}
+                    >
+                      {abandonArmed ? t('studioPanel.overview.abandonConfirm') : t('studioPanel.overview.abandon')}
+                    </button>
+                  ) : null}
+                </div>
+              </section>
+
+              {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? (
+                <section className="studio-rail-section" aria-label={t('studioPanel.share.title')}>
+                  <DraftShareControl game={game} />
+                </section>
+              ) : null}
+            </>
           ) : null}
-          <button type="button" className="secondary-btn" onClick={onOpenPlaytest}>
-            <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
-          </button>
-          {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
+
+          {activePane === 'connect' ? (
+            showConnect ? (
+              <StudioConnectCard token={game.token} collapsible={false} hideIfUnavailable density="panel" />
+            ) : (
+              <p className="studio-rail-empty">{t('studioPanel.rail.connectEmpty')}</p>
+            )
+          ) : null}
+
+          {activePane === 'build' ? (
+            showProgress ? (
+              <StudioDetailsBuildProgress token={game.token} emptyLabel={t('studioPanel.rail.buildEmpty')} />
+            ) : (
+              <p className="studio-rail-empty">{t('studioPanel.rail.buildEmpty')}</p>
+            )
+          ) : null}
+
+          {activePane === 'keys' ? (
+            <div className="studio-rail-credentials-body">
+              <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
+              {showLegacyKey ? <StudioAgentKeyPanel token={game.token} /> : null}
+              <StudioCreatorAgentKeyPanel />
+              <StudioOAuthClientsPanel />
+            </div>
+          ) : null}
+
+          {activePane === 'stats' && catalogLive ? (
+            <StatsSection
+              game={game}
+              health={health}
+              days={days}
+              healthDays={healthDays}
+              truncated={truncated}
+              scorecard={scorecard}
+              onDaysChange={onDaysChange}
+            />
+          ) : null}
+        </div>
+
+        <nav className="studio-rail-icons" aria-label={t('studioPanel.tabs.details')}>
+          {panes.map((entry) => (
             <button
+              key={entry.id}
               type="button"
-              className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
-              onClick={() => void handleAbandon()}
-              disabled={abandoning}
+              className={`studio-rail-icon${activePane === entry.id ? ' is-active' : ''}`}
+              aria-pressed={activePane === entry.id}
+              aria-label={t(entry.labelKey)}
+              title={t(entry.labelKey)}
+              data-testid={`studio-rail-icon-${entry.id}`}
+              onClick={() => onPaneChange(entry.id)}
             >
-              {abandonArmed ? t('studioPanel.overview.abandonConfirm') : t('studioPanel.overview.abandon')}
+              <PixelIcon name={entry.icon} size={14} />
             </button>
-          ) : null}
-        </div>
-      </section>
-
-      {/* Draft share is for pre-catalog games. A revise tip on a live slug already has a
-          public play link — offering a second "share the draft" switch would lie. */}
-      {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? (
-        <section className="studio-rail-section" aria-label={t('studioPanel.share.title')}>
-          <DraftShareControl game={game} />
-        </section>
-      ) : null}
-
-      {/* Checklist fraction left the thread foot — Details keeps build meta without
-          crowding the composer. Heading lives inside the component so an empty
-          checklist does not leave a stranded section title. */}
-      {showProgress ? <StudioDetailsBuildProgress token={game.token} /> : null}
-
-      {/* Self-build connect — panel density so install is scannable; hideIfUnavailable
-          keeps platform rounds silent (returns null — no orphan heading). */}
-      {showConnect ? (
-        <StudioConnectCard
-          token={game.token}
-          collapsible={false}
-          hideIfUnavailable
-          density="panel"
-          panelHeading={t('studioPanel.rail.connect')}
-        />
-      ) : null}
-
-      {/* Keys and OAuth grants are rare ops — collapsed so they do not own the rail. */}
-      <details className="studio-rail-credentials" data-testid="studio-rail-credentials">
-        <summary>
-          <span className="studio-rail-section-title">{t('studioPanel.rail.credentials')}</span>
-          <span className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</span>
-        </summary>
-        <div className="studio-rail-credentials-body">
-          {showLegacyKey ? <StudioAgentKeyPanel token={game.token} /> : null}
-          <StudioCreatorAgentKeyPanel />
-          <StudioOAuthClientsPanel />
-        </div>
-      </details>
-
-      {/* Only once there is play to report on. Before a game is live every one of these
-          numbers is zero, and a wall of zeroes reads as a verdict rather than as
-          "nobody has played it yet, because nobody can". */}
-      {catalogLive ? (
-        <section className="studio-rail-section">
-          <StatsSection
-            game={game}
-            health={health}
-            days={days}
-            healthDays={healthDays}
-            truncated={truncated}
-            scorecard={scorecard}
-            onDaysChange={onDaysChange}
-          />
-        </section>
-      ) : null}
+          ))}
+        </nav>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -543,6 +543,46 @@ describe('StudioConnectCard', () => {
     await act(async () => root.unmount());
   });
 
+  it('shows unavailableLabel in the Details pane when the round is not self', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: 'connect_unavailable', reason: 'not_self_round', builder: 'platform' }),
+      })),
+    );
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(StudioConnectCard, {
+          token: 'plat-tok',
+          hideIfUnavailable: true,
+          unavailableLabel: 'This round does not need a coding-agent connect step.',
+          collapsible: false,
+          density: 'panel',
+        }),
+      );
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('.studio-connect')).toBeNull();
+    expect(container.querySelector('.studio-rail-empty')?.textContent).toContain(
+      'does not need a coding-agent connect step',
+    );
+
+    await act(async () => root.unmount());
+  });
+
   it('surfaces missing_slug instead of hiding when hideIfUnavailable', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/StudioConnectCard.test.tsx
+++ b/apps/web/src/StudioConnectCard.test.tsx
@@ -605,6 +605,43 @@ describe('StudioConnectCard', () => {
     await act(async () => root.unmount());
   });
 
+  it('panel density shows install with kickoff collapsed and no waiting wall', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(StudioConnectCard, {
+          token: 'status-tok',
+          density: 'panel',
+          collapsible: false,
+          panelHeading: 'Connect your agent',
+        }),
+      );
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-density="panel"]')).not.toBeNull();
+    expect(container.querySelector('.studio-rail-section-title')?.textContent).toContain('Connect your agent');
+    expect(container.querySelector('.studio-connect-lead')).toBeNull();
+    expect(container.querySelector('.studio-connect-waiting')).toBeNull();
+    expect(container.querySelector('.studio-connect-step-num')).toBeNull();
+    const kickoffDetails = container.querySelector<HTMLDetailsElement>('[data-testid="connect-kickoff-details"]');
+    expect(kickoffDetails).not.toBeNull();
+    expect(kickoffDetails?.open).toBe(false);
+    expect(kickoffDetails?.textContent).toContain('Build prompt');
+    expect(container.querySelector('[data-testid="connect-install-cursor"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it('Studio resume sends MCP install to Details instead of expanding inline', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -78,6 +78,13 @@ type StudioConnectCardProps = {
    * Standalone `/status` leaves this unset and keeps the inline disclosure.
    */
   onOpenInstall?: () => void;
+  /**
+   * `panel`: denser Details-rail layout — no lead/waiting wall, kickoff tucked under
+   * a disclosure so install stays scannable. `thread` (default) keeps the full card.
+   */
+  density?: 'thread' | 'panel';
+  /** Section heading when `density="panel"` — omitted when the card returns null. */
+  panelHeading?: string;
 };
 
 /**
@@ -95,7 +102,10 @@ export function StudioConnectCard({
   collapsible = true,
   hideIfUnavailable = false,
   onOpenInstall,
+  density = 'thread',
+  panelHeading,
 }: StudioConnectCardProps) {
+  const isPanel = density === 'panel';
   const { t, i18n } = useTranslation();
   const baseId = useId();
   const authHeaderRef = useRef<string | null>(null);
@@ -306,7 +316,7 @@ export function StudioConnectCard({
       {authMode === 'key' ? (
         <div className="studio-connect-step">
           <div className="studio-connect-step-head">
-            {!isResume ? (
+            {!isResume && !isPanel ? (
               <span className="studio-connect-step-num" aria-hidden="true">
                 1
               </span>
@@ -375,7 +385,7 @@ export function StudioConnectCard({
       ) : (
         <div className="studio-connect-step">
           <div className="studio-connect-step-head">
-            {!isResume ? (
+            {!isResume && !isPanel ? (
               <span className="studio-connect-step-num" aria-hidden="true">
                 1
               </span>
@@ -401,7 +411,7 @@ export function StudioConnectCard({
   const kickoffPanel: ReactNode = payload ? (
     <div className="studio-connect-step">
       <div className="studio-connect-step-head">
-        {!isResume ? (
+        {!isResume && !isPanel ? (
           <span className="studio-connect-step-num" aria-hidden="true">
             2
           </span>
@@ -429,38 +439,63 @@ export function StudioConnectCard({
     </div>
   ) : null;
 
-  return (
+  const kickoffDisclosure =
+    payload && !loading ? (
+      <details className="studio-connect-setup-details" data-testid="connect-kickoff-details">
+        <summary>{t('studioPanel.rail.kickoffDetails')}</summary>
+        <div className="studio-connect-setup-body">{kickoffPanel}</div>
+      </details>
+    ) : null;
+
+  const card = (
     <section
-      className={`studio-connect${error ? ' is-error' : ''}${isResume ? ' is-resume' : ''}`}
-      aria-labelledby={`${baseId}-title`}
+      className={`studio-connect${error ? ' is-error' : ''}${isResume ? ' is-resume' : ''}${isPanel ? ' is-panel' : ''}`}
+      aria-labelledby={isPanel && panelHeading ? `${baseId}-panel` : isPanel ? undefined : `${baseId}-title`}
+      aria-label={isPanel && !panelHeading ? (isResume ? t('connect.resume.title') : t('connect.title')) : undefined}
       data-connect-mode={mode}
+      data-density={density}
       data-testid="connect-expanded"
     >
-      <div className="studio-connect-title-row">
-        <h3 id={`${baseId}-title`} className="studio-connect-title">
-          {isResume ? t('connect.resume.title') : t('connect.title')}
-        </h3>
-        {collapsible && !error ? (
-          <button
-            type="button"
-            className="studio-connect-hide"
-            onClick={hideCard}
-            data-testid="connect-hide"
-            title={t('connect.hide')}
-          >
-            <PixelIcon name="close" size={11} /> {t('connect.hide')}
-          </button>
-        ) : null}
-      </div>
+      {isPanel && panelHeading ? (
+        <h4 id={`${baseId}-panel`} className="studio-rail-section-title">
+          {panelHeading}
+        </h4>
+      ) : null}
+      {!isPanel ? (
+        <div className="studio-connect-title-row">
+          <h3 id={`${baseId}-title`} className="studio-connect-title">
+            {isResume ? t('connect.resume.title') : t('connect.title')}
+          </h3>
+          {collapsible && !error ? (
+            <button
+              type="button"
+              className="studio-connect-hide"
+              onClick={hideCard}
+              data-testid="connect-hide"
+              title={t('connect.hide')}
+            >
+              <PixelIcon name="close" size={11} /> {t('connect.hide')}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       {/* Lead is setup guidance — drop it once we only have an error, so a phone foot/thread
-          is not mostly paragraph + red line. */}
-      {!error ? <p className="studio-connect-lead">{isResume ? t('connect.resume.lead') : t('connect.lead')}</p> : null}
+          is not mostly paragraph + red line. Panel density skips it: the rail section heading
+          already names the job. */}
+      {!error && !isPanel ? (
+        <p className="studio-connect-lead">{isResume ? t('connect.resume.lead') : t('connect.lead')}</p>
+      ) : null}
 
       {loading ? <p className="studio-connect-state">{t('connect.loading')}</p> : null}
       {error ? <p className="error">{error}</p> : null}
 
       {payload && !loading ? (
-        isResume ? (
+        isPanel ? (
+          <>
+            {installPanel}
+            {kickoffDisclosure}
+          </>
+        ) : isResume ? (
           <>
             {kickoffPanel}
             {/* Studio foot owns the single waiting caption — a second pulse here
@@ -527,4 +562,9 @@ export function StudioConnectCard({
       ) : null}
     </section>
   );
+
+  if (isPanel) {
+    return <div className="studio-rail-section">{card}</div>;
+  }
+  return card;
 }

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -70,8 +70,12 @@ type StudioConnectCardProps = {
   /**
    * When true, a non-self / inactive round yields nothing instead of an error
    * (Details mounts this for every open game; only self rounds have a payload).
+   * Pair with `unavailableLabel` in the Details pane so the Connect icon does not
+   * open a blank rail for platform rounds.
    */
   hideIfUnavailable?: boolean;
+  /** Shown instead of null when `hideIfUnavailable` quiets a non-self round. */
+  unavailableLabel?: string;
   /**
    * Studio thread: open the Details rail for MCP install instead of expanding it
    * inline (Claude-shaped — install lives in the side panel, not the transcript).
@@ -101,6 +105,7 @@ export function StudioConnectCard({
   mode = 'setup',
   collapsible = true,
   hideIfUnavailable = false,
+  unavailableLabel,
   onOpenInstall,
   density = 'thread',
   panelHeading,
@@ -164,8 +169,11 @@ export function StudioConnectCard({
     };
   }, [token, t, hideIfUnavailable]);
 
-  if (agentConnected || unavailable) {
+  if (agentConnected) {
     return null;
+  }
+  if (unavailable) {
+    return unavailableLabel ? <p className="studio-rail-empty">{unavailableLabel}</p> : null;
   }
 
   const hideCard = () => {

--- a/apps/web/src/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.tsx
@@ -11,10 +11,18 @@ const DETAILS_POLL_MS = 10_000;
  * thread foot. Kept out of the composer strip so the conversation stays Claude-quiet;
  * open Details when you want the count.
  */
-export function StudioDetailsBuildProgress({ token }: { token: string }) {
+export function StudioDetailsBuildProgress({
+  token,
+  emptyLabel,
+}: {
+  token: string;
+  /** When set, an empty checklist renders this instead of nothing. */
+  emptyLabel?: string;
+}) {
   const { t, i18n } = useTranslation();
   const [progress, setProgress] = useState<BuildProgress | null>(null);
   const [events, setEvents] = useState<BuildEvent[]>([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -27,6 +35,8 @@ export function StudioDetailsBuildProgress({ token }: { token: string }) {
         setEvents(status.events ?? []);
       } catch {
         // Secondary chrome — a failed poll must not toast over the thread.
+      } finally {
+        if (!cancelled) setLoaded(true);
       }
     };
 
@@ -43,56 +53,57 @@ export function StudioDetailsBuildProgress({ token }: { token: string }) {
   const doneCount = reported?.done ?? checklist.filter((item) => item.checked).length;
   const totalCount = reported?.total ?? checklist.length;
 
-  if (totalCount === 0) return null;
+  if (totalCount === 0) {
+    if (!loaded) return <p className="studio-rail-empty">{t('statusView.loading')}</p>;
+    if (emptyLabel) return <p className="studio-rail-empty">{emptyLabel}</p>;
+    return null;
+  }
 
   const donePercent = (doneCount / totalCount) * 100;
   const currentStep = checklist.find((item) => !item.checked);
   const note = events[0]?.text ?? progress?.note;
 
   return (
-    <section className="studio-rail-section" data-testid="studio-details-progress">
+    <div className="studio-details-progress" data-testid="studio-details-progress">
       <div className="build-progress-heading-row">
-        <h4 className="studio-rail-section-title">{t('studioPanel.rail.build')}</h4>
         <span className="build-progress-count">
           {t('statusView.progress.checklistCount', { done: doneCount, total: totalCount })}
         </span>
       </div>
-      <div className="studio-details-progress">
-        <div
-          className="build-progress-bar"
-          role="progressbar"
-          aria-valuenow={doneCount}
-          aria-valuemin={0}
-          aria-valuemax={totalCount}
-        >
-          <div className="build-progress-bar-fill" style={{ width: `${donePercent}%` }} />
-        </div>
-        {note ? (
-          <p className="studio-details-progress-note">
-            <span className="build-progress-note-label">
-              {events[0]?.step ? t(`statusView.progress.steps.${events[0].step}`) : t('statusView.progress.agentSays')}
-            </span>
-            <span className="build-progress-note-text">{note}</span>
-          </p>
-        ) : currentStep ? (
-          <p className="build-progress-current">
-            <span className="build-progress-current-spinner" aria-hidden="true" />
-            {t('statusView.progress.currentStep', { step: currentStep.text })}
-          </p>
-        ) : null}
-        {checklist.length > 0 ? (
-          <ul className="studio-details-checklist">
-            {checklist.map((item, index) => (
-              <li key={index} className={item.checked ? 'checklist-done' : 'checklist-pending'}>
-                <span aria-hidden="true">
-                  <PixelIcon name={item.checked ? 'check' : 'checkbox'} size={12} />
-                </span>{' '}
-                {item.text}
-              </li>
-            ))}
-          </ul>
-        ) : null}
+      <div
+        className="build-progress-bar"
+        role="progressbar"
+        aria-valuenow={doneCount}
+        aria-valuemin={0}
+        aria-valuemax={totalCount}
+      >
+        <div className="build-progress-bar-fill" style={{ width: `${donePercent}%` }} />
       </div>
-    </section>
+      {note ? (
+        <p className="studio-details-progress-note">
+          <span className="build-progress-note-label">
+            {events[0]?.step ? t(`statusView.progress.steps.${events[0].step}`) : t('statusView.progress.agentSays')}
+          </span>
+          <span className="build-progress-note-text">{note}</span>
+        </p>
+      ) : currentStep ? (
+        <p className="build-progress-current">
+          <span className="build-progress-current-spinner" aria-hidden="true" />
+          {t('statusView.progress.currentStep', { step: currentStep.text })}
+        </p>
+      ) : null}
+      {checklist.length > 0 ? (
+        <ul className="studio-details-checklist">
+          {checklist.map((item, index) => (
+            <li key={index} className={item.checked ? 'checklist-done' : 'checklist-pending'}>
+              <span aria-hidden="true">
+                <PixelIcon name={item.checked ? 'check' : 'checkbox'} size={12} />
+              </span>{' '}
+              {item.text}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.tsx
@@ -50,47 +50,49 @@ export function StudioDetailsBuildProgress({ token }: { token: string }) {
   const note = events[0]?.text ?? progress?.note;
 
   return (
-    <div className="studio-details-progress" data-testid="studio-details-progress">
+    <section className="studio-rail-section" data-testid="studio-details-progress">
       <div className="build-progress-heading-row">
-        <h3 className="build-progress-heading">{t('statusView.progress.checklistTitle')}</h3>
+        <h4 className="studio-rail-section-title">{t('studioPanel.rail.build')}</h4>
         <span className="build-progress-count">
           {t('statusView.progress.checklistCount', { done: doneCount, total: totalCount })}
         </span>
       </div>
-      <div
-        className="build-progress-bar"
-        role="progressbar"
-        aria-valuenow={doneCount}
-        aria-valuemin={0}
-        aria-valuemax={totalCount}
-      >
-        <div className="build-progress-bar-fill" style={{ width: `${donePercent}%` }} />
+      <div className="studio-details-progress">
+        <div
+          className="build-progress-bar"
+          role="progressbar"
+          aria-valuenow={doneCount}
+          aria-valuemin={0}
+          aria-valuemax={totalCount}
+        >
+          <div className="build-progress-bar-fill" style={{ width: `${donePercent}%` }} />
+        </div>
+        {note ? (
+          <p className="studio-details-progress-note">
+            <span className="build-progress-note-label">
+              {events[0]?.step ? t(`statusView.progress.steps.${events[0].step}`) : t('statusView.progress.agentSays')}
+            </span>
+            <span className="build-progress-note-text">{note}</span>
+          </p>
+        ) : currentStep ? (
+          <p className="build-progress-current">
+            <span className="build-progress-current-spinner" aria-hidden="true" />
+            {t('statusView.progress.currentStep', { step: currentStep.text })}
+          </p>
+        ) : null}
+        {checklist.length > 0 ? (
+          <ul className="studio-details-checklist">
+            {checklist.map((item, index) => (
+              <li key={index} className={item.checked ? 'checklist-done' : 'checklist-pending'}>
+                <span aria-hidden="true">
+                  <PixelIcon name={item.checked ? 'check' : 'checkbox'} size={12} />
+                </span>{' '}
+                {item.text}
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </div>
-      {note ? (
-        <p className="studio-details-progress-note">
-          <span className="build-progress-note-label">
-            {events[0]?.step ? t(`statusView.progress.steps.${events[0].step}`) : t('statusView.progress.agentSays')}
-          </span>
-          <span className="build-progress-note-text">{note}</span>
-        </p>
-      ) : currentStep ? (
-        <p className="build-progress-current">
-          <span className="build-progress-current-spinner" aria-hidden="true" />
-          {t('statusView.progress.currentStep', { step: currentStep.text })}
-        </p>
-      ) : null}
-      {checklist.length > 0 ? (
-        <ul className="studio-details-checklist">
-          {checklist.map((item, index) => (
-            <li key={index} className={item.checked ? 'checklist-done' : 'checklist-pending'}>
-              <span aria-hidden="true">
-                <PixelIcon name={item.checked ? 'check' : 'checkbox'} size={12} />
-              </span>{' '}
-              {item.text}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -327,6 +327,13 @@
       "abandon": "Abandon this build",
       "abandonConfirm": "Yes, abandon — discard this round"
     },
+    "rail": {
+      "connect": "Connect your agent",
+      "build": "Build progress",
+      "credentials": "Keys & connected agents",
+      "credentialsHint": "Creator key, legacy per-game key, and agents you’ve approved.",
+      "kickoffDetails": "Build prompt"
+    },
     "share": {
       "title": "Share the draft",
       "on": "On",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -332,7 +332,11 @@
       "build": "Build progress",
       "credentials": "Keys & connected agents",
       "credentialsHint": "Creator key, legacy per-game key, and agents you’ve approved.",
-      "kickoffDetails": "Build prompt"
+      "kickoffDetails": "Build prompt",
+      "overview": "Overview",
+      "stats": "Stats",
+      "connectEmpty": "This round does not need a coding-agent connect step.",
+      "buildEmpty": "No checklist yet — it appears once the agent posts tasks."
     },
     "share": {
       "title": "Share the draft",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -329,6 +329,13 @@
       "abandon": "Porzuć ten build",
       "abandonConfirm": "Tak, porzuć — odrzuć tę rundę"
     },
+    "rail": {
+      "connect": "Podłącz agenta",
+      "build": "Postęp buildu",
+      "credentials": "Klucze i podłączone agenty",
+      "credentialsHint": "Klucz twórcy, legacy klucz per-gra i agenty, które zatwierdziłeś.",
+      "kickoffDetails": "Prompt budowy"
+    },
     "share": {
       "title": "Udostępnij wersję roboczą",
       "on": "Wł.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -334,7 +334,11 @@
       "build": "Postęp buildu",
       "credentials": "Klucze i podłączone agenty",
       "credentialsHint": "Klucz twórcy, legacy klucz per-gra i agenty, które zatwierdziłeś.",
-      "kickoffDetails": "Prompt budowy"
+      "kickoffDetails": "Prompt budowy",
+      "overview": "Przegląd",
+      "stats": "Statystyki",
+      "connectEmpty": "Ta runda nie potrzebuje kroku połączenia z agentem.",
+      "buildEmpty": "Nie ma jeszcze checklisty — pojawi się, gdy agent doda zadania."
     },
     "share": {
       "title": "Udostępnij wersję roboczą",

--- a/apps/web/src/studioShelf.test.ts
+++ b/apps/web/src/studioShelf.test.ts
@@ -5,6 +5,7 @@ import {
   filterStudioGames,
   isStudioGameShelfLive,
   sortStudioGames,
+  studioGameInitials,
   STUDIO_SHELF_TOOLS_AT,
 } from './studioShelf.js';
 
@@ -147,5 +148,13 @@ describe('studioShelf', () => {
     expect(filterStudioGames(games, { query: 'dodge' }).map((item) => item.token)).toEqual(['a-tip']);
     expect(filterStudioGames(games, { query: 'arena' }).map((item) => item.token)).toEqual(['b']);
     expect(filterStudioGames(games, { query: 'zzz' })).toEqual([]);
+  });
+
+  it('builds two-letter shelf marks from the first two title words', () => {
+    expect(studioGameInitials('2D Total War')).toBe('2T');
+    expect(studioGameInitials('Sky Dodge')).toBe('SD');
+    expect(studioGameInitials('Asteroids')).toBe('AS');
+    expect(studioGameInitials('  ')).toBe('?');
+    expect(studioGameInitials('Łódź Arcade')).toBe('ŁA');
   });
 });

--- a/apps/web/src/studioShelf.ts
+++ b/apps/web/src/studioShelf.ts
@@ -105,3 +105,21 @@ export function filterStudioGames(
     (game) => matchesStudioShelfFilter(game, filter) && matchesStudioShelfQuery(game, query),
   );
 }
+
+/**
+ * Two-letter mark for the collapsed shelf — first letter of the first two words.
+ * One-word titles take the first two letters. Skips empty tokens; prefers letters/digits.
+ */
+export function studioGameInitials(title: string): string {
+  const words = title
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter(Boolean);
+  if (words.length === 0) return '?';
+  if (words.length === 1) {
+    const word = words[0]!;
+    return word.slice(0, Math.min(2, word.length)).toLocaleUpperCase();
+  }
+  return `${words[0]![0]!}${words[1]![0]!}`.toLocaleUpperCase();
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5056,10 +5056,9 @@ a.user-name--profile:focus-visible {
   flex: 1;
   min-height: 0;
   height: auto;
-  /* Claude-like reading column — full-bleed thread chrome made prompts and chips
-     stretch edge-to-edge on a wide desktop. */
+  /* Chat-app reading column (~Claude / Cursor composer width). */
   width: 100%;
-  max-width: 44rem;
+  max-width: 768px;
   margin-inline: auto;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8709,7 +8709,111 @@ a.user-name--profile:focus-visible {
 .studio-overview {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 0;
+}
+
+/* One job per band — stops the Details rail reading as a single wall of chrome. */
+.studio-rail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.studio-rail-section:first-child {
+  padding-top: 4px;
+}
+
+.studio-rail-section:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.studio-rail-section-title {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.55px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.studio-rail-credentials {
+  margin: 0;
+  padding: 12px 0 0;
+}
+
+.studio-rail-credentials > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 2px 0 10px;
+}
+
+.studio-rail-credentials > summary::-webkit-details-marker {
+  display: none;
+}
+
+.studio-rail-credentials > summary::after {
+  content: '+';
+  position: absolute;
+  right: 0;
+  top: 2px;
+  color: var(--muted);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.studio-rail-credentials {
+  position: relative;
+}
+
+.studio-rail-credentials[open] > summary::after {
+  content: '−';
+}
+
+.studio-rail-credentials-hint {
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  line-height: 1.35;
+  padding-right: 1.5rem;
+}
+
+.studio-rail-credentials-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 4px 0 8px;
+}
+
+/* Panel density: install chrome without the thread's title/lead/waiting stack. */
+.studio-connect.is-panel {
+  gap: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.studio-connect.is-panel .studio-connect-step-title {
+  font-size: 0.88rem;
+}
+
+.studio-connect.is-panel .studio-connect-same {
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.studio-connect.is-panel .studio-connect-snippet {
+  font-size: 0.75rem;
+  max-height: 9rem;
+  overflow: auto;
 }
 
 .studio-facts {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4494,16 +4494,26 @@ a.user-name--profile:focus-visible {
 
 @media (min-width: 1100px) {
   .studio-workspace.is-details-open {
-    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 400px);
   }
 }
 
 .studio-rail {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
   border-radius: 12px;
   border: 1px solid var(--panel-border);
   background: var(--panel-card);
-  padding: 14px 16px 18px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.studio-rail-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
 }
 
 .studio-rail-head {
@@ -4511,7 +4521,9 @@ a.user-name--profile:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  margin-bottom: 6px;
+  flex: none;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--panel-border);
 }
 
 .studio-rail-head h3 {
@@ -4521,6 +4533,65 @@ a.user-name--profile:focus-visible {
   letter-spacing: 0.6px;
   text-transform: uppercase;
   color: var(--muted);
+}
+
+.studio-rail-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.studio-rail-pane {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 10px 14px 16px;
+}
+
+/* Cursor-like secondary strip — one icon, one pane. */
+.studio-rail-icons {
+  display: flex;
+  flex-direction: column;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+  border-left: 1px solid var(--panel-border);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.studio-rail-icon {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.studio-rail-icon:hover {
+  color: var(--text);
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.studio-rail-icon.is-active {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.35);
+  background: rgba(0, 228, 172, 0.1);
+}
+
+.studio-rail-empty {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
 }
 
 /* The sheet's backdrop: something to tap beside it, and a dimmed page behind so the
@@ -4537,12 +4608,26 @@ a.user-name--profile:focus-visible {
     inset: auto 0 0 0;
     z-index: 1100;
     max-height: min(80vh, 40rem);
-    overflow-y: auto;
+    overflow: hidden;
     border-radius: 16px 16px 0 0;
     border-bottom: 0;
     background: var(--panel);
     box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
     animation: fadeIn 0.2s ease;
+  }
+
+  /* Phone sheet: icons as a horizontal strip under the title, not a side column. */
+  .studio-workspace.is-details-open .studio-rail-body {
+    flex-direction: column;
+  }
+
+  .studio-workspace.is-details-open .studio-rail-icons {
+    flex-direction: row;
+    justify-content: center;
+    order: -1;
+    border-left: 0;
+    border-bottom: 1px solid var(--panel-border);
+    padding: 8px 10px;
   }
 }
 
@@ -4619,22 +4704,36 @@ a.user-name--profile:focus-visible {
   box-shadow: 0 0 16px var(--turquoise-glow);
 }
 
-/* A shelf row is a title. The state that matters at a glance rides on a dot. */
-.studio-shelf-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--panel-border);
+/* Shelf mark: two title letters. Colour carries live/published; letters carry identity. */
+.studio-shelf-mark {
   flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  border: 1px solid var(--panel-border);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
-.studio-shelf-dot.is-live {
-  background: var(--accent-blue);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+.studio-shelf-mark.is-live {
+  color: #7dd3fc;
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.12);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.1);
 }
 
-.studio-shelf-dot.is-published {
-  background: var(--turquoise);
+.studio-shelf-mark.is-published {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.4);
+  background: rgba(0, 228, 172, 0.1);
 }
 
 /* ── THE THREAD ──────────────────────────────────────────────────────────────────
@@ -5221,10 +5320,10 @@ a.user-name--profile:focus-visible {
     padding: 6px 10px;
   }
 
-  /* Icon-only in the title row — Playtest's word plus Details (and Claim) was enough to
-     shove the trailing control past the right edge on a 390px phone with a long title.
-     Clipped rather than display: none so the button keeps its accessible name. */
-  .app:has(.studio-layout.is-game-open) .studio-head-action .studio-head-action-label {
+  /* Icon-only peers in the title row — Details / Edit / Claim were enough to shove the
+     trailing control past the right edge on a 390px phone with a long title. Play keeps
+     its word: clipping it made the primary CTA a tiny icon twin of Details. */
+  .app:has(.studio-layout.is-game-open) .studio-head-action:not(.is-primary) .studio-head-action-label {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -8507,16 +8606,43 @@ a.user-name--profile:focus-visible {
   z-index: 1100;
 }
 
-/* 5+ games on a desktop: collapse to a left-edge rail of dots after selection.
-   Not a "switch game" combo — the shelf stays the shelf, just skinny. */
+/* 5+ games on a desktop: collapse to a left-edge rail of title marks after selection.
+   Width matches the header mascot column, so the rail and the logo share one vertical
+   band instead of a skinny strip floating left of the face. */
 @media (min-width: 801px) {
+  /* Variable on `.app` (ancestor of both header and shelf) — children inherit it. */
+  .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) {
+    --studio-shelf-collapsed-width: 80px;
+  }
+
   .studio-layout.is-compact-shelf:not(.is-shelf-open) {
-    grid-template-columns: 56px 1fr;
+    grid-template-columns: var(--studio-shelf-collapsed-width, 80px) 1fr;
+  }
+
+  /* Full-bleed studio content starts at x=0 while the header kept 28px — the mascot
+     sat indented past the rail. Pull the header in; the wordmark still runs into the
+     main column, and the face sits over the same band as the game marks. */
+  .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) .app-header {
+    padding-left: 0;
+  }
+
+  .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) .logo-brand {
+    gap: 2px;
+    padding-left: 6px;
+  }
+
+  .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) .nav-up {
+    width: 32px;
+    height: 32px;
+  }
+
+  .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) .app-header .logo .mascot {
+    margin-right: 10px;
   }
 
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf {
     align-items: center;
-    padding: 12px 8px;
+    padding: 12px 10px;
     gap: 10px;
   }
 
@@ -8554,7 +8680,20 @@ a.user-name--profile:focus-visible {
 
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item {
     justify-content: center;
-    padding: 10px 8px;
+    padding: 8px;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-mark {
+    width: 36px;
+    height: 36px;
+    border-radius: 11px;
+    font-size: 0.72rem;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item.is-active,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item.is-active:hover {
+    /* No left inset bar in the icon rail — the active mark is enough. */
+    box-shadow: 0 0 14px rgba(0, 228, 172, 0.12);
   }
 
   .studio-layout.is-compact-shelf.is-shelf-open .studio-shelf-edge-toggle {
@@ -8711,17 +8850,17 @@ a.user-name--profile:focus-visible {
   gap: 0;
 }
 
-/* One job per band — stops the Details rail reading as a single wall of chrome. */
+/* One job per band inside a single icon-pane. */
 .studio-rail-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 14px 0;
+  padding: 12px 0;
   border-bottom: 1px solid var(--panel-border);
 }
 
 .studio-rail-section:first-child {
-  padding-top: 4px;
+  padding-top: 2px;
 }
 
 .studio-rail-section:last-child {
@@ -8738,58 +8877,20 @@ a.user-name--profile:focus-visible {
   color: var(--muted);
 }
 
-.studio-rail-credentials {
-  margin: 0;
-  padding: 12px 0 0;
-}
-
-.studio-rail-credentials > summary {
-  list-style: none;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 2px 0 10px;
-}
-
-.studio-rail-credentials > summary::-webkit-details-marker {
-  display: none;
-}
-
-.studio-rail-credentials > summary::after {
-  content: '+';
-  position: absolute;
-  right: 0;
-  top: 2px;
-  color: var(--muted);
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1;
-}
-
-.studio-rail-credentials {
-  position: relative;
-}
-
-.studio-rail-credentials[open] > summary::after {
-  content: '−';
-}
-
 .studio-rail-credentials-hint {
+  margin: 0 0 8px;
   font-size: 0.78rem;
   color: var(--muted);
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
   line-height: 1.35;
-  padding-right: 1.5rem;
 }
 
 .studio-rail-credentials-body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 4px 0 8px;
 }
 
 /* Panel density: install chrome without the thread's title/lead/waiting stack. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8796,6 +8796,7 @@ a.user-name--profile:focus-visible {
 /* Panel density: install chrome without the thread's title/lead/waiting stack. */
 .studio-connect.is-panel {
   gap: 12px;
+  margin: 0;
   padding: 0;
   border: 0;
   background: transparent;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Studio chrome was reading as one long wall (connect + keys + OAuth + share), and the collapsed game shelf was a column of anonymous bulbs that didn’t line up with the header mascot.

## Change

### Details rail (Cursor-shaped)
- Secondary **icon strip** — Overview / Connect / Build / Keys / Stats — one pane at a time
- Thread “Install MCP” opens the **Connect** pane; header Details lands on **Overview**
- Connect `density="panel"`: install first; kickoff under disclosure; no lead/waiting wall
- Platform / inactive rounds: Connect pane shows the empty caption instead of a blank rail (Codex P2)
- Thread column `max-width: 768px`

### Collapsed game shelf
- **Title initials** (first letters of the first two words) instead of status bulbs — e.g. `2D Total War` → `2T`
- Rail widened to **80px** and header left padding pulled in when collapsed so the mascot and the rail share one vertical band

### Play
- On narrow screens, peer actions stay icon-only, but **Play keeps its label** so it doesn’t disappear into the icon cluster

## Verification

- `npm run type-check && npm run lint`
- Unit: `studioShelf` initials, `CreatorStudioView` (icon panes + shelf marks + stats pane), `StudioConnectCard` unavailable empty label, connect/progress suites

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

