### PR TITLE
feat(mcp): stage source files one-by-one before submit

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -701,6 +701,7 @@ describe('agent build channel', () => {
         kitEngineRef?: string;
         mode?: string;
       }> = [];
+      const staged = new Map<string, string>();
       const gamesStore = {
         putCandidateSources: async (input: {
           slug: string;
@@ -714,6 +715,48 @@ describe('agent build channel', () => {
           validateSourceUpload(input.files as Array<{ path: string; content: string }>, input.mode ?? 'publish');
           return { version: 'v1', manifest: {} as never };
         },
+        putStagedSourceFile: async (input: { path: string; content: string }) => {
+          staged.set(input.path, input.content);
+          const files = [...staged.entries()].map(([path, content]) => ({
+            path,
+            bytes: Buffer.byteLength(content, 'utf8'),
+          }));
+          return {
+            path: input.path,
+            bytes: Buffer.byteLength(input.content, 'utf8'),
+            files,
+            totalBytes: files.reduce((sum, file) => sum + file.bytes, 0),
+            maxBytes: 2 * 1024 * 1024,
+            maxFiles: 200,
+            updatedAt: '2026-08-03T23:00:00.000Z',
+          };
+        },
+        listStagedSources: async () => {
+          const files = [...staged.entries()].map(([path, content]) => ({
+            path,
+            bytes: Buffer.byteLength(content, 'utf8'),
+          }));
+          return {
+            files,
+            totalBytes: files.reduce((sum, file) => sum + file.bytes, 0),
+            maxBytes: 2 * 1024 * 1024,
+            maxFiles: 200,
+            updatedAt: files.length ? '2026-08-03T23:00:00.000Z' : null,
+          };
+        },
+        getStagedSourceFiles: async () => [...staged.entries()].map(([path, content]) => ({ path, content })),
+        clearStagedSources: async (input?: { paths?: string[] }) => {
+          if (!input?.paths?.length) {
+            const cleared = staged.size;
+            staged.clear();
+            return { cleared };
+          }
+          let cleared = 0;
+          for (const path of input.paths) {
+            if (staged.delete(path)) cleared += 1;
+          }
+          return { cleared };
+        },
         getManifest: async () => null,
         getSourceFile: async () => null,
         putGateResult: async () => {},
@@ -722,7 +765,7 @@ describe('agent build channel', () => {
         getDerivedArtifact: async () => null,
         getKitRegistry: async () => null,
       } as unknown as GamesStore;
-      return { gamesStore, stored };
+      return { gamesStore, stored, staged };
     }
 
     it('stores a delivered game as a candidate version', async () => {
@@ -1138,6 +1181,57 @@ describe('agent build channel', () => {
       expect(record?.previewVersion).toBe('v1');
       expect(record?.deliveredVersion).toBeUndefined();
       expect(record?.state).not.toBe('submitted');
+    });
+
+    it('stages files one-by-one and finalizes with fromStaged', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, stored, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      const draft = MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+      for (const file of draft) {
+        const stagedRes = await app.inject({
+          method: 'PUT',
+          url: '/api/agent/build/sources/stage',
+          headers: agentHeaders(),
+          payload: { slug: 'comet-courier', path: file.path, content: file.content },
+        });
+        expect(stagedRes.statusCode).toBe(200);
+        expect(stagedRes.json()).toMatchObject({ accepted: true, path: file.path });
+      }
+
+      const listed = await app.inject({
+        method: 'GET',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+      });
+      expect(
+        listed
+          .json()
+          .files.map((f: { path: string }) => f.path)
+          .sort(),
+      ).toEqual(draft.map((f) => f.path).sort());
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          fromStaged: true,
+          kitEngineRef: 'abcdef1234567890',
+          mode: 'preview',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ accepted: true, mode: 'preview' });
+      expect(stored[0]?.mode).toBe('preview');
+      expect((stored[0]?.files as Array<{ path: string }>).map((f) => f.path).sort()).toEqual(
+        draft.map((f) => f.path).sort(),
+      );
+      // Finalize clears the buffer so the next iterate starts clean.
+      expect(staged.size).toBe(0);
     });
   });
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -19,7 +19,13 @@ import {
 } from './agent-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
-import { InvalidUploadError, MAX_UPLOAD_FILES, type DeliveryMode, type GamesStore } from './games-store.js';
+import {
+  InvalidUploadError,
+  MAX_UPLOAD_BYTES,
+  MAX_UPLOAD_FILES,
+  type DeliveryMode,
+  type GamesStore,
+} from './games-store.js';
 import { parseGameMedia, parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import {
@@ -164,38 +170,66 @@ const DEFAULT_MAX_SUBMITS_PER_WINDOW = 20;
  * exactly the order of operations that produces zip-slip bugs. A flat list of
  * (path, content) is checked before a single byte is stored.
  */
-const BuildSourcesInputSchema = z.object({
+const BuildSourcesInputSchema = z
+  .object({
+    slug: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be lowercase letters, digits and dashes')
+      .max(64),
+    files: z
+      .array(
+        z.object({
+          path: z.string().trim().min(1).max(120),
+          content: z.string().max(1_000_000),
+        }),
+      )
+      // Keep in lockstep with games-store MAX_UPLOAD_FILES (MCP advertise the same).
+      .max(MAX_UPLOAD_FILES, 'too many files')
+      .optional(),
+    /**
+     * Assemble the job's staged buffer (built via PUT …/sources/stage) instead of
+     * requiring the full tree in this request — for MCP clients that cannot emit a
+     * huge files[] payload cleanly.
+     */
+    fromStaged: z.boolean().optional(),
+    /**
+     * Creator Kit engineRef the sources were built against. Required for self-build
+     * deliveries (BY-06); the gate compares it to `kits/current.json`'s N/N−1 window.
+     */
+    kitEngineRef: z
+      .string()
+      .trim()
+      .min(7, 'kitEngineRef must be a kit engine commit')
+      .max(64)
+      .regex(/^[0-9a-f]+$/i, 'kitEngineRef must be a hex commit sha')
+      .optional(),
+    /**
+     * Preview: typecheck→smoke→build, TRACE/PLAYTEST optional, Studio-playable only.
+     * Publish (default): full gate; TRACE/PLAYTEST required. Keeps `npm run submit` safe.
+     */
+    mode: z.enum(['preview', 'publish']).default('publish'),
+  })
+  .superRefine((value, ctx) => {
+    const inline = value.files?.length ?? 0;
+    if (!value.fromStaged && inline === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'files is required (or set fromStaged=true after staging files one-by-one)',
+        path: ['files'],
+      });
+    }
+  });
+
+const StageSourceInputSchema = z.object({
+  path: z.string().trim().min(1).max(120),
+  content: z.string().max(1_000_000),
   slug: z
     .string()
     .trim()
     .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be lowercase letters, digits and dashes')
-    .max(64),
-  files: z
-    .array(
-      z.object({
-        path: z.string().trim().min(1).max(120),
-        content: z.string().max(1_000_000),
-      }),
-    )
-    .min(1, 'files is required')
-    // Keep in lockstep with games-store MAX_UPLOAD_FILES (MCP advertise the same).
-    .max(MAX_UPLOAD_FILES, 'too many files'),
-  /**
-   * Creator Kit engineRef the sources were built against. Required for self-build
-   * deliveries (BY-06); the gate compares it to `kits/current.json`'s N/N−1 window.
-   */
-  kitEngineRef: z
-    .string()
-    .trim()
-    .min(7, 'kitEngineRef must be a kit engine commit')
     .max(64)
-    .regex(/^[0-9a-f]+$/i, 'kitEngineRef must be a hex commit sha')
     .optional(),
-  /**
-   * Preview: typecheck→smoke→build, TRACE/PLAYTEST optional, Studio-playable only.
-   * Publish (default): full gate; TRACE/PLAYTEST required. Keeps `npm run submit` safe.
-   */
-  mode: z.enum(['preview', 'publish']).default('publish'),
 });
 
 const BuildPreviewInputSchema = z.object({
@@ -824,6 +858,160 @@ export async function registerAgentChannelRoutes(
   );
 
   /**
+   * File-by-file staging before a delivery.
+   *
+   * MCP clients (Claude Chat especially) often fail mid-serialization when emitting a
+   * huge `files[]` in one tool call. Staging lets them PUT one path at a time into a
+   * job-scoped buffer, then finalize with `fromStaged=true` — the gate still sees one
+   * assembled upload; only the wire shape changes.
+   */
+  app.put(
+    '/api/agent/build/sources/stage',
+    {
+      config: { rateLimit: { max: 300, timeWindow: '1 hour' } },
+      bodyLimit: 1_500_000,
+    },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      if (!options.gamesStore) {
+        return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+      }
+      if (stopReason(record)) {
+        return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
+      }
+
+      const parsed = StageSourceInputSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      const slug = record.slug ?? parsed.data.slug;
+      if (!slug) {
+        return reply.status(400).send({
+          error: 'slug is required before staging — send the slug from get_brief / start',
+        });
+      }
+      if (record.slug && parsed.data.slug && record.slug !== parsed.data.slug) {
+        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
+      }
+      if (!record.slug && store) {
+        await store.setSubmissionSlug(issueNumber, slug);
+      }
+
+      const roundGeneration = store
+        ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+        : (record.roundGeneration ?? 1);
+
+      try {
+        const staged = await options.gamesStore.putStagedSourceFile({
+          slug,
+          issueNumber,
+          roundGeneration,
+          path: parsed.data.path,
+          content: parsed.data.content,
+        });
+        return reply.send({
+          accepted: true,
+          path: staged.path,
+          bytes: staged.bytes,
+          staged: {
+            files: staged.files,
+            totalBytes: staged.totalBytes,
+            maxBytes: staged.maxBytes,
+            maxFiles: staged.maxFiles,
+            updatedAt: staged.updatedAt,
+          },
+          ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
+        });
+      } catch (error) {
+        if (error instanceof InvalidUploadError) {
+          return reply.status(400).send({ error: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
+  app.get(
+    '/api/agent/build/sources/stage',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      if (!options.gamesStore) {
+        return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+      }
+      if (!record.slug) {
+        return reply.send({
+          files: [],
+          totalBytes: 0,
+          maxBytes: MAX_UPLOAD_BYTES,
+          maxFiles: MAX_UPLOAD_FILES,
+          updatedAt: null,
+        });
+      }
+
+      const roundGeneration = store
+        ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+        : (record.roundGeneration ?? 1);
+      const staged = await options.gamesStore.listStagedSources({
+        slug: record.slug,
+        issueNumber,
+        roundGeneration,
+      });
+      return reply.send(staged);
+    },
+  );
+
+  // POST rather than DELETE: MCP inject + many clients are unreliable with DELETE bodies,
+  // and selective clear needs a paths[] payload.
+  app.post(
+    '/api/agent/build/sources/stage/clear',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      if (!options.gamesStore) {
+        return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+      }
+      if (!record.slug) {
+        return reply.send({ accepted: true, cleared: 0 });
+      }
+
+      const body = (request.body ?? {}) as { paths?: unknown };
+      const paths = Array.isArray(body.paths)
+        ? body.paths.filter((path): path is string => typeof path === 'string' && path.trim().length > 0)
+        : undefined;
+
+      const roundGeneration = store
+        ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+        : (record.roundGeneration ?? 1);
+
+      try {
+        const { cleared } = await options.gamesStore.clearStagedSources({
+          slug: record.slug,
+          issueNumber,
+          roundGeneration,
+          ...(paths?.length ? { paths } : {}),
+        });
+        return reply.send({ accepted: true, cleared });
+      } catch (error) {
+        if (error instanceof InvalidUploadError) {
+          return reply.status(400).send({ error: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
+  /**
    * Deliver the game.
    *
    * This is what replaces "open a pull request and wait for a human to merge it". The
@@ -920,16 +1108,47 @@ export async function registerAgentChannelRoutes(
         // transition was skipped and the job stayed `building` (CP-1 double-close).
         const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
         const mode: DeliveryMode = parsed.data.mode === 'preview' ? 'preview' : 'publish';
+        const roundGeneration = store
+          ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+          : (record.roundGeneration ?? 1);
+
+        let files = parsed.data.files ?? [];
+        if (parsed.data.fromStaged) {
+          const staged = await options.gamesStore.getStagedSourceFiles({
+            slug,
+            issueNumber,
+            roundGeneration,
+          });
+          if (staged.length === 0 && files.length === 0) {
+            return reply.status(400).send({
+              error:
+                'fromStaged=true but the staging buffer is empty — call stage_source_file for each path first, ' +
+                'or pass files[] inline',
+            });
+          }
+          // Inline files win on path collision so a final fix can patch one file without
+          // re-staging the whole tree.
+          const byPath = new Map<string, string>();
+          for (const file of staged) byPath.set(file.path, file.content);
+          for (const file of files) byPath.set(file.path, file.content);
+          files = [...byPath.entries()].map(([path, content]) => ({ path, content }));
+        }
+
         const { version } = await options.gamesStore.putCandidateSources({
           slug,
           issueNumber,
-          files: parsed.data.files,
+          files,
           // Provenance: which backend built this version. Backend name on the dispatch
           // ('copilot' / 'self') is the durable record; builder is the round selector.
           backend: record.dispatch?.backend ?? record.builder,
           mode,
           ...(parsed.data.kitEngineRef ? { kitEngineRef: parsed.data.kitEngineRef } : {}),
         });
+        // Staging is spent once the candidate is written — clear so the next iterate
+        // starts clean and a half-edited buffer cannot leak into a later round.
+        if (parsed.data.fromStaged) {
+          await options.gamesStore.clearStagedSources({ slug, issueNumber, roundGeneration }).catch(() => {});
+        }
         // Preview updates Studio's playable pointer without marking a sealed delivery —
         // control.delivered / publication reconciliation still wait for mode=publish.
         // Publish sets both (setSubmissionDeliveredVersion also refreshes previewVersion).
@@ -947,7 +1166,7 @@ export async function registerAgentChannelRoutes(
         // SPEC title for the catalog, so the two surfaces disagreed. Adopting it here
         // keeps them aligned for every delivery from now on.
         if (store) {
-          const spec = parsed.data.files.find((file) => file.path === 'SPEC.md')?.content;
+          const spec = files.find((file) => file.path === 'SPEC.md')?.content;
           const deliveredTitle = spec ? parseSpecTitle(spec) : null;
           if (deliveredTitle) {
             const sanitized = sanitizeCreatorText(deliveredTitle, { singleLine: true }).slice(0, 80);

--- a/apps/api/src/canonical-base64.test.ts
+++ b/apps/api/src/canonical-base64.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { decodeCanonicalBase64, decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
+
+describe('decodeCanonicalBase64', () => {
+  it('decodes valid padded base64', () => {
+    expect(decodeCanonicalBase64Utf8('YWJj')).toBe('abc');
+    expect(decodeCanonicalBase64('YWI=').toString('utf8')).toBe('ab');
+  });
+
+  it('allows whitespace inside the payload', () => {
+    expect(decodeCanonicalBase64Utf8('YW Jj\n')).toBe('abc');
+  });
+
+  it('rejects the silent corruption Node would otherwise accept', () => {
+    // Buffer.from('YWJj!!!', 'base64') === 'abc' — that must not pass here.
+    expect(() => decodeCanonicalBase64('YWJj!!!')).toThrow(InvalidBase64Error);
+    expect(() => decodeCanonicalBase64('YWI')).toThrow(InvalidBase64Error);
+    expect(() => decodeCanonicalBase64('')).toThrow(InvalidBase64Error);
+    expect(() => decodeCanonicalBase64('@@@@')).toThrow(InvalidBase64Error);
+  });
+});

--- a/apps/api/src/canonical-base64.ts
+++ b/apps/api/src/canonical-base64.ts
@@ -1,0 +1,36 @@
+/**
+ * Strict base64 decode — Node's `Buffer.from(s, 'base64')` ignores invalid characters,
+ * so a truncated or corrupted payload like `YWJj!!!` silently becomes `abc`. Callers that
+ * accept agent-supplied base64 must reject that class of damage before storing bytes.
+ */
+
+export class InvalidBase64Error extends Error {
+  constructor(message = 'invalid base64') {
+    super(message);
+    this.name = 'InvalidBase64Error';
+  }
+}
+
+/**
+ * Decode standard base64 (whitespace allowed). Rejects non-canonical alphabet, bad
+ * padding, and inputs Node would otherwise silently strip.
+ */
+export function decodeCanonicalBase64(raw: string): Buffer {
+  const compact = raw.replace(/\s+/g, '');
+  if (compact.length === 0) {
+    throw new InvalidBase64Error('empty base64');
+  }
+  if (compact.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(compact)) {
+    throw new InvalidBase64Error('invalid base64');
+  }
+  const bytes = Buffer.from(compact, 'base64');
+  // Round-trip catches characters Node ignored and padding Node "fixed".
+  if (bytes.toString('base64') !== compact) {
+    throw new InvalidBase64Error('invalid base64');
+  }
+  return bytes;
+}
+
+export function decodeCanonicalBase64Utf8(raw: string): string {
+  return decodeCanonicalBase64(raw).toString('utf8');
+}

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -197,23 +197,38 @@ describe('defaultVersionId', () => {
 
 function stubGcs() {
   const objects = new Map<string, Buffer>();
+  const generations = new Map<string, number>();
   const impl = (async (url: string | URL, init: RequestInit = {}) => {
     const href = String(url);
     if (init.method === 'POST') {
-      const name = decodeURIComponent(new URL(href).searchParams.get('name') ?? '');
+      const parsed = new URL(href);
+      const name = decodeURIComponent(parsed.searchParams.get('name') ?? '');
+      const ifMatch = parsed.searchParams.get('ifGenerationMatch');
+      const current = generations.get(name) ?? 0;
+      if (ifMatch !== null && Number(ifMatch) !== current) {
+        return new Response('Precondition Failed', { status: 412 });
+      }
       objects.set(name, Buffer.from(init.body as Uint8Array));
-      return new Response('{}', { status: 200 });
+      const next = current + 1;
+      generations.set(name, next);
+      return new Response(JSON.stringify({ generation: String(next) }), { status: 200 });
     }
     if (init.method === 'DELETE') {
       const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
       objects.delete(name);
+      generations.delete(name);
       return new Response(null, { status: 200 });
     }
     const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
     const body = objects.get(name);
-    return body ? new Response(new Uint8Array(body), { status: 200 }) : new Response('', { status: 404 });
+    if (!body) return new Response('', { status: 404 });
+    const generation = String(generations.get(name) ?? 1);
+    return new Response(new Uint8Array(body), {
+      status: 200,
+      headers: { 'x-goog-generation': generation },
+    });
   }) as unknown as typeof fetch;
-  return { impl, objects };
+  return { impl, objects, generations };
 }
 
 describe('GCS games store', () => {
@@ -312,6 +327,73 @@ describe('GCS games store', () => {
 
     await store.clearStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
     expect((await store.listStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 })).files).toEqual([]);
+  });
+
+  it('retries staging manifest writes when a concurrent update wins the generation race', async () => {
+    const objects = new Map<string, Buffer>();
+    const generations = new Map<string, number>();
+    let manifestWrites = 0;
+    const impl = (async (url: string | URL, init: RequestInit = {}) => {
+      const href = String(url);
+      if (init.method === 'POST') {
+        const parsed = new URL(href);
+        const name = decodeURIComponent(parsed.searchParams.get('name') ?? '');
+        if (name.endsWith('/manifest.json')) {
+          manifestWrites += 1;
+          // First attempt pretends another writer landed first.
+          if (manifestWrites === 1) {
+            return new Response('Precondition Failed', { status: 412 });
+          }
+        }
+        const ifMatch = parsed.searchParams.get('ifGenerationMatch');
+        const current = generations.get(name) ?? 0;
+        if (ifMatch !== null && Number(ifMatch) !== current) {
+          return new Response('Precondition Failed', { status: 412 });
+        }
+        objects.set(name, Buffer.from(init.body as Uint8Array));
+        const next = current + 1;
+        generations.set(name, next);
+        return new Response('{}', { status: 200 });
+      }
+      if (init.method === 'DELETE') {
+        const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
+        objects.delete(name);
+        generations.delete(name);
+        return new Response(null, { status: 200 });
+      }
+      const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
+      // After the first 412, the concurrent writer's manifest appears for the retry read.
+      if (name.endsWith('/manifest.json') && manifestWrites >= 1 && !objects.has(name)) {
+        const concurrent = {
+          slug: 'g',
+          issueNumber: 7,
+          roundGeneration: 1,
+          updatedAt: '2026-07-30T10:00:00.000Z',
+          files: [{ path: 'SPEC.md', bytes: 3 }],
+          totalBytes: 3,
+        };
+        objects.set(name, Buffer.from(JSON.stringify(concurrent)));
+        generations.set(name, 1);
+      }
+      const body = objects.get(name);
+      if (!body) return new Response('', { status: 404 });
+      return new Response(new Uint8Array(body), {
+        status: 200,
+        headers: { 'x-goog-generation': String(generations.get(name) ?? 1) },
+      });
+    }) as unknown as typeof fetch;
+
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+    const result = await store.putStagedSourceFile({
+      slug: 'g',
+      issueNumber: 7,
+      roundGeneration: 1,
+      path: 'game.ts',
+      content: 'export {};',
+    });
+
+    expect(manifestWrites).toBeGreaterThanOrEqual(2);
+    expect(result.files.map((f) => f.path).sort()).toEqual(['SPEC.md', 'game.ts']);
   });
 
   it('records kit_outdated on a preview-lane check without touching gate', async () => {

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -204,6 +204,11 @@ function stubGcs() {
       objects.set(name, Buffer.from(init.body as Uint8Array));
       return new Response('{}', { status: 200 });
     }
+    if (init.method === 'DELETE') {
+      const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
+      objects.delete(name);
+      return new Response(null, { status: 200 });
+    }
     const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
     const body = objects.get(name);
     return body ? new Response(new Uint8Array(body), { status: 200 }) : new Response('', { status: 404 });
@@ -275,6 +280,38 @@ describe('GCS games store', () => {
     await store.putGateResult('g', version, { green: false, report: '3 checks failed' });
 
     expect((await store.getManifest('g', version))?.gate).toMatchObject({ green: false, report: '3 checks failed' });
+  });
+
+  it('stages files one-by-one and assembles them for finalize', async () => {
+    const { impl, objects } = stubGcs();
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+    const draft = MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+
+    for (const file of draft) {
+      await store.putStagedSourceFile({
+        slug: 'g',
+        issueNumber: 7,
+        roundGeneration: 1,
+        path: file.path,
+        content: file.content,
+      });
+    }
+
+    const listed = await store.listStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
+    expect(listed.files.map((f) => f.path).sort()).toEqual(draft.map((f) => f.path).sort());
+    expect(objects.has('games/g/staging/7/g1/source/game.ts')).toBe(true);
+
+    const assembled = await store.getStagedSourceFiles({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
+    const { version } = await store.putCandidateSources({
+      slug: 'g',
+      issueNumber: 7,
+      files: assembled,
+      mode: 'preview',
+    });
+    expect(version).toBeTruthy();
+
+    await store.clearStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
+    expect((await store.listStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 })).files).toEqual([]);
   });
 
   it('records kit_outdated on a preview-lane check without touching gate', async () => {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -175,6 +175,41 @@ export function forbiddenDeliveryPathReason(path: string): string | null {
 }
 
 /**
+ * Validates one delivery path (shape + allowlist). Used by full uploads and by
+ * file-by-file staging — required-set checks (SPEC.md, TRACE, …) stay on finalize.
+ */
+export function assertDeliverableSourcePath(rawPath: string): string {
+  const path = rawPath.trim();
+  // Traversal is checked before anything else and rejected by shape, not by
+  // normalization: `..` never appears in a legitimate game file, so there is no reason
+  // to be clever about resolving it.
+  if (path.includes('..') || path.startsWith('/') || path.includes('\\') || path.includes('\0')) {
+    throw new InvalidUploadError(`illegal path: ${rawPath}`);
+  }
+
+  const forbidden = forbiddenDeliveryPathReason(path);
+  if (forbidden) throw new InvalidUploadError(forbidden);
+
+  if (RESERVED_SEGMENTS.has(path.split('/')[0])) {
+    throw new InvalidUploadError(
+      `path not deliverable: ${path}. \`${path.split('/')[0]}\` belongs to the harness — ` +
+        'GameKit, the tooling and other games are read-only context.',
+    );
+  }
+
+  const allowed =
+    (ALLOWED_SOURCE_FILES as readonly string[]).includes(path) ||
+    (EXTRA_SOURCE_PATTERN.test(path) && !path.includes('//'));
+  if (!allowed) {
+    throw new InvalidUploadError(
+      `path not deliverable: ${path}. Deliver only your own game's files ` +
+        `(${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules under the game).`,
+    );
+  }
+  return path;
+}
+
+/**
  * Validates an upload against the delivery contract.
  *
  * Returns the files to store; throws {@link InvalidUploadError} with a message meant for
@@ -195,35 +230,8 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
   let total = 0;
 
   for (const file of files) {
-    const path = file.path.trim();
-
-    // Traversal is checked before anything else and rejected by shape, not by
-    // normalization: `..` never appears in a legitimate game file, so there is no reason
-    // to be clever about resolving it.
-    if (path.includes('..') || path.startsWith('/') || path.includes('\\') || path.includes('\0')) {
-      throw new InvalidUploadError(`illegal path: ${file.path}`);
-    }
+    const path = assertDeliverableSourcePath(file.path);
     if (seen.has(path)) throw new InvalidUploadError(`duplicate path: ${path}`);
-
-    const forbidden = forbiddenDeliveryPathReason(path);
-    if (forbidden) throw new InvalidUploadError(forbidden);
-
-    if (RESERVED_SEGMENTS.has(path.split('/')[0])) {
-      throw new InvalidUploadError(
-        `path not deliverable: ${path}. \`${path.split('/')[0]}\` belongs to the harness — ` +
-          'GameKit, the tooling and other games are read-only context.',
-      );
-    }
-
-    const allowed =
-      (ALLOWED_SOURCE_FILES as readonly string[]).includes(path) ||
-      (EXTRA_SOURCE_PATTERN.test(path) && !path.includes('//'));
-    if (!allowed) {
-      throw new InvalidUploadError(
-        `path not deliverable: ${path}. Deliver only your own game's files ` +
-          `(${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules under the game).`,
-      );
-    }
 
     total += Buffer.byteLength(file.content, 'utf8');
     if (total > MAX_UPLOAD_BYTES) throw new InvalidUploadError(`upload too large: over ${MAX_UPLOAD_BYTES} bytes`);
@@ -387,6 +395,27 @@ export interface PublicationRecord {
   healthCheck?: PublicationHealthCheck;
 }
 
+/** One path in a job's pre-delivery staging buffer (file-by-file MCP uploads). */
+export type StagedSourceEntry = { path: string; bytes: number };
+
+/** Summary of a job's staging buffer — paths only, no contents. */
+export type StagedSourcesSummary = {
+  files: StagedSourceEntry[];
+  totalBytes: number;
+  maxBytes: number;
+  maxFiles: number;
+  updatedAt: string | null;
+};
+
+type StagingManifest = {
+  slug: string;
+  issueNumber: number;
+  roundGeneration: number;
+  updatedAt: string;
+  files: StagedSourceEntry[];
+  totalBytes: number;
+};
+
 export interface GamesStore {
   /** Writes a candidate version's sources. Returns the version id assigned. */
   putCandidateSources(input: {
@@ -403,6 +432,32 @@ export interface GamesStore {
     /** Preview skips TRACE/PLAYTEST; default publish. */
     mode?: DeliveryMode;
   }): Promise<{ version: string; manifest: VersionManifest }>;
+  /**
+   * Upserts one file into the job's staging buffer (does not run the gate).
+   * Scoped by roundGeneration so a retired key cannot clobber a newer round's buffer.
+   */
+  putStagedSourceFile(input: {
+    slug: string;
+    issueNumber: number;
+    roundGeneration: number;
+    path: string;
+    content: string;
+  }): Promise<StagedSourcesSummary & { path: string; bytes: number }>;
+  /** Lists staged paths + byte totals (no contents). */
+  listStagedSources(input: {
+    slug: string;
+    issueNumber: number;
+    roundGeneration: number;
+  }): Promise<StagedSourcesSummary>;
+  /** Reads staged contents for finalize. */
+  getStagedSourceFiles(input: { slug: string; issueNumber: number; roundGeneration: number }): Promise<SourceFile[]>;
+  /** Clears the staging buffer (all paths, or a named subset). */
+  clearStagedSources(input: {
+    slug: string;
+    issueNumber: number;
+    roundGeneration: number;
+    paths?: string[];
+  }): Promise<{ cleared: number }>;
   getManifest(slug: string, version: string): Promise<VersionManifest | null>;
   getSourceFile(slug: string, version: string, path: string): Promise<string | null>;
   /**
@@ -528,7 +583,51 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
     if (!response.ok) throw new Error(`games store write of ${name} failed: ${response.status}`);
   }
 
+  async function deleteObject(name: string): Promise<void> {
+    const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(name)}`;
+    const response = await fetchImpl(url, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${await getAccessToken()}` },
+    });
+    // 404 is fine — clear is idempotent.
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`games store delete of ${name} failed: ${response.status}`);
+    }
+  }
+
   const versionPrefix = (slug: string, version: string) => `games/${slug}/versions/${version}`;
+  const stagingPrefix = (slug: string, issueNumber: number, roundGeneration: number) =>
+    `games/${slug}/staging/${issueNumber}/g${roundGeneration}`;
+
+  async function readStagingManifest(
+    slug: string,
+    issueNumber: number,
+    roundGeneration: number,
+  ): Promise<StagingManifest | null> {
+    const body = await readObject(`${stagingPrefix(slug, issueNumber, roundGeneration)}/manifest.json`);
+    return body ? (JSON.parse(body.toString('utf8')) as StagingManifest) : null;
+  }
+
+  function emptyStagingSummary(): StagedSourcesSummary {
+    return {
+      files: [],
+      totalBytes: 0,
+      maxBytes: MAX_UPLOAD_BYTES,
+      maxFiles: MAX_UPLOAD_FILES,
+      updatedAt: null,
+    };
+  }
+
+  function summaryFromManifest(manifest: StagingManifest | null): StagedSourcesSummary {
+    if (!manifest) return emptyStagingSummary();
+    return {
+      files: [...manifest.files].sort((a, b) => a.path.localeCompare(b.path)),
+      totalBytes: manifest.totalBytes,
+      maxBytes: MAX_UPLOAD_BYTES,
+      maxFiles: MAX_UPLOAD_FILES,
+      updatedAt: manifest.updatedAt,
+    };
+  }
 
   return {
     async putCandidateSources(input) {
@@ -564,6 +663,102 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
 
       return { version, manifest };
+    },
+
+    async putStagedSourceFile(input) {
+      assertSlug(input.slug);
+      const path = assertDeliverableSourcePath(input.path);
+      const bytes = Buffer.byteLength(input.content, 'utf8');
+      if (bytes > 1_000_000) {
+        throw new InvalidUploadError(`file too large: ${path} is ${bytes} bytes (max 1000000 per file)`);
+      }
+
+      const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
+      const existing = (await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration)) ?? {
+        slug: input.slug,
+        issueNumber: input.issueNumber,
+        roundGeneration: input.roundGeneration,
+        updatedAt: new Date(now()).toISOString(),
+        files: [],
+        totalBytes: 0,
+      };
+
+      const previous = existing.files.find((file) => file.path === path);
+      const nextFiles = previous
+        ? existing.files.map((file) => (file.path === path ? { path, bytes } : file))
+        : [...existing.files, { path, bytes }];
+      if (nextFiles.length > MAX_UPLOAD_FILES) {
+        throw new InvalidUploadError(`too many staged files: ${nextFiles.length} > ${MAX_UPLOAD_FILES}`);
+      }
+      const totalBytes = existing.totalBytes - (previous?.bytes ?? 0) + bytes;
+      if (totalBytes > MAX_UPLOAD_BYTES) {
+        throw new InvalidUploadError(`staged upload too large: over ${MAX_UPLOAD_BYTES} bytes`);
+      }
+
+      await writeObject(`${prefix}/source/${path}`, Buffer.from(input.content, 'utf8'), 'text/plain; charset=utf-8');
+      const manifest: StagingManifest = {
+        slug: input.slug,
+        issueNumber: input.issueNumber,
+        roundGeneration: input.roundGeneration,
+        updatedAt: new Date(now()).toISOString(),
+        files: nextFiles,
+        totalBytes,
+      };
+      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
+      return { path, bytes, ...summaryFromManifest(manifest) };
+    },
+
+    async listStagedSources(input) {
+      assertSlug(input.slug);
+      return summaryFromManifest(await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration));
+    },
+
+    async getStagedSourceFiles(input) {
+      assertSlug(input.slug);
+      const manifest = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      if (!manifest || manifest.files.length === 0) return [];
+      const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
+      const files = await Promise.all(
+        manifest.files.map(async (entry) => {
+          const body = await readObject(`${prefix}/source/${entry.path}`);
+          if (!body) {
+            throw new InvalidUploadError(
+              `staged file missing: ${entry.path} — stage it again, then submit_sources with fromStaged=true`,
+            );
+          }
+          return { path: entry.path, content: body.toString('utf8') };
+        }),
+      );
+      return files;
+    },
+
+    async clearStagedSources(input) {
+      assertSlug(input.slug);
+      const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
+      const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      if (!existing || existing.files.length === 0) return { cleared: 0 };
+
+      const removePaths = input.paths?.length
+        ? new Set(input.paths.map((path) => assertDeliverableSourcePath(path)))
+        : null;
+      const toClear = removePaths ? existing.files.filter((file) => removePaths.has(file.path)) : existing.files;
+
+      await Promise.all(toClear.map((file) => deleteObject(`${prefix}/source/${file.path}`)));
+
+      if (!removePaths || toClear.length === existing.files.length) {
+        await deleteObject(`${prefix}/manifest.json`);
+        return { cleared: toClear.length };
+      }
+
+      const remaining = existing.files.filter((file) => !removePaths.has(file.path));
+      const manifest: StagingManifest = {
+        ...existing,
+        updatedAt: new Date(now()).toISOString(),
+        files: remaining,
+        totalBytes: remaining.reduce((sum, file) => sum + file.bytes, 0),
+      };
+      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
+      return { cleared: toClear.length };
     },
 
     async getManifest(slug, version) {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -141,6 +141,17 @@ export class InvalidUploadError extends Error {
   }
 }
 
+/** Staging manifest lost a race — caller should re-read and retry. */
+export class StagingGenerationMismatchError extends Error {
+  constructor(message = 'staging manifest generation mismatch') {
+    super(message);
+    this.name = 'StagingGenerationMismatchError';
+  }
+}
+
+/** How many times a staging manifest write may retry after a concurrent update. */
+export const MAX_STAGING_MANIFEST_RETRIES = 8;
+
 /** Hint derived from {@link ALLOWED_SOURCE_FILES} so refusal text cannot drift from the contract. */
 const ALLOWED_SOURCES_HINT = `${ALLOWED_SOURCE_FILES.join(', ')}, or your own .ts modules`;
 
@@ -558,17 +569,35 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
     });
 
   async function readObject(name: string): Promise<Buffer | null> {
+    const got = await readObjectWithGeneration(name);
+    return got?.body ?? null;
+  }
+
+  async function readObjectWithGeneration(name: string): Promise<{ body: Buffer; generation: number } | null> {
     const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(name)}?alt=media`;
     const response = await fetchImpl(url, { headers: { authorization: `Bearer ${await getAccessToken()}` } });
     if (response.status === 404) return null;
     if (!response.ok) throw new Error(`games store read of ${name} failed: ${response.status}`);
-    return Buffer.from(await response.arrayBuffer());
+    const generationHeader = response.headers.get('x-goog-generation');
+    const generation = generationHeader !== null ? Number(generationHeader) : 0;
+    return {
+      body: Buffer.from(await response.arrayBuffer()),
+      generation: Number.isFinite(generation) ? generation : 0,
+    };
   }
 
-  async function writeObject(name: string, body: Buffer, contentType: string): Promise<void> {
-    const url =
+  async function writeObject(
+    name: string,
+    body: Buffer,
+    contentType: string,
+    opts?: { ifGenerationMatch?: number },
+  ): Promise<void> {
+    let url =
       `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(bucket)}/o` +
       `?uploadType=media&name=${encodeURIComponent(name)}`;
+    if (opts?.ifGenerationMatch !== undefined) {
+      url += `&ifGenerationMatch=${opts.ifGenerationMatch}`;
+    }
     const response = await fetchImpl(url, {
       method: 'POST',
       headers: {
@@ -580,6 +609,9 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       },
       body: new Uint8Array(body),
     });
+    if (response.status === 412) {
+      throw new StagingGenerationMismatchError(`games store write of ${name} lost a race (412)`);
+    }
     if (!response.ok) throw new Error(`games store write of ${name} failed: ${response.status}`);
   }
 
@@ -603,9 +635,13 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
     slug: string,
     issueNumber: number,
     roundGeneration: number,
-  ): Promise<StagingManifest | null> {
-    const body = await readObject(`${stagingPrefix(slug, issueNumber, roundGeneration)}/manifest.json`);
-    return body ? (JSON.parse(body.toString('utf8')) as StagingManifest) : null;
+  ): Promise<{ manifest: StagingManifest; generation: number } | null> {
+    const got = await readObjectWithGeneration(`${stagingPrefix(slug, issueNumber, roundGeneration)}/manifest.json`);
+    if (!got) return null;
+    return {
+      manifest: JSON.parse(got.body.toString('utf8')) as StagingManifest,
+      generation: got.generation,
+    };
   }
 
   function emptyStagingSummary(): StagedSourcesSummary {
@@ -674,48 +710,70 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       }
 
       const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
-      const existing = (await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration)) ?? {
-        slug: input.slug,
-        issueNumber: input.issueNumber,
-        roundGeneration: input.roundGeneration,
-        updatedAt: new Date(now()).toISOString(),
-        files: [],
-        totalBytes: 0,
-      };
-
-      const previous = existing.files.find((file) => file.path === path);
-      const nextFiles = previous
-        ? existing.files.map((file) => (file.path === path ? { path, bytes } : file))
-        : [...existing.files, { path, bytes }];
-      if (nextFiles.length > MAX_UPLOAD_FILES) {
-        throw new InvalidUploadError(`too many staged files: ${nextFiles.length} > ${MAX_UPLOAD_FILES}`);
-      }
-      const totalBytes = existing.totalBytes - (previous?.bytes ?? 0) + bytes;
-      if (totalBytes > MAX_UPLOAD_BYTES) {
-        throw new InvalidUploadError(`staged upload too large: over ${MAX_UPLOAD_BYTES} bytes`);
-      }
-
+      // Source bytes first — orphaned sources without a manifest entry are harmless;
+      // a lost race on the manifest is retried below.
       await writeObject(`${prefix}/source/${path}`, Buffer.from(input.content, 'utf8'), 'text/plain; charset=utf-8');
-      const manifest: StagingManifest = {
-        slug: input.slug,
-        issueNumber: input.issueNumber,
-        roundGeneration: input.roundGeneration,
-        updatedAt: new Date(now()).toISOString(),
-        files: nextFiles,
-        totalBytes,
-      };
-      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
-      return { path, bytes, ...summaryFromManifest(manifest) };
+
+      for (let attempt = 0; attempt < MAX_STAGING_MANIFEST_RETRIES; attempt++) {
+        const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+        const base = existing?.manifest ?? {
+          slug: input.slug,
+          issueNumber: input.issueNumber,
+          roundGeneration: input.roundGeneration,
+          updatedAt: new Date(now()).toISOString(),
+          files: [],
+          totalBytes: 0,
+        };
+        const generation = existing?.generation ?? 0;
+
+        const previous = base.files.find((file) => file.path === path);
+        const nextFiles = previous
+          ? base.files.map((file) => (file.path === path ? { path, bytes } : file))
+          : [...base.files, { path, bytes }];
+        if (nextFiles.length > MAX_UPLOAD_FILES) {
+          throw new InvalidUploadError(`too many staged files: ${nextFiles.length} > ${MAX_UPLOAD_FILES}`);
+        }
+        const totalBytes = base.totalBytes - (previous?.bytes ?? 0) + bytes;
+        if (totalBytes > MAX_UPLOAD_BYTES) {
+          throw new InvalidUploadError(`staged upload too large: over ${MAX_UPLOAD_BYTES} bytes`);
+        }
+
+        const manifest: StagingManifest = {
+          slug: input.slug,
+          issueNumber: input.issueNumber,
+          roundGeneration: input.roundGeneration,
+          updatedAt: new Date(now()).toISOString(),
+          files: nextFiles,
+          totalBytes,
+        };
+        try {
+          await writeObject(
+            `${prefix}/manifest.json`,
+            Buffer.from(JSON.stringify(manifest, null, 2)),
+            'application/json',
+            { ifGenerationMatch: generation },
+          );
+          return { path, bytes, ...summaryFromManifest(manifest) };
+        } catch (error) {
+          if (error instanceof StagingGenerationMismatchError) continue;
+          throw error;
+        }
+      }
+      throw new InvalidUploadError(
+        'could not update staging manifest — too many concurrent stage_source_file calls; retry',
+      );
     },
 
     async listStagedSources(input) {
       assertSlug(input.slug);
-      return summaryFromManifest(await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration));
+      const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      return summaryFromManifest(existing?.manifest ?? null);
     },
 
     async getStagedSourceFiles(input) {
       assertSlug(input.slug);
-      const manifest = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      const manifest = existing?.manifest;
       if (!manifest || manifest.files.length === 0) return [];
       const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
       const files = await Promise.all(
@@ -735,30 +793,46 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
     async clearStagedSources(input) {
       assertSlug(input.slug);
       const prefix = stagingPrefix(input.slug, input.issueNumber, input.roundGeneration);
-      const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
-      if (!existing || existing.files.length === 0) return { cleared: 0 };
 
-      const removePaths = input.paths?.length
-        ? new Set(input.paths.map((path) => assertDeliverableSourcePath(path)))
-        : null;
-      const toClear = removePaths ? existing.files.filter((file) => removePaths.has(file.path)) : existing.files;
+      for (let attempt = 0; attempt < MAX_STAGING_MANIFEST_RETRIES; attempt++) {
+        const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+        if (!existing || existing.manifest.files.length === 0) return { cleared: 0 };
 
-      await Promise.all(toClear.map((file) => deleteObject(`${prefix}/source/${file.path}`)));
+        const removePaths = input.paths?.length
+          ? new Set(input.paths.map((path) => assertDeliverableSourcePath(path)))
+          : null;
+        const toClear = removePaths
+          ? existing.manifest.files.filter((file) => removePaths.has(file.path))
+          : existing.manifest.files;
 
-      if (!removePaths || toClear.length === existing.files.length) {
-        await deleteObject(`${prefix}/manifest.json`);
-        return { cleared: toClear.length };
+        await Promise.all(toClear.map((file) => deleteObject(`${prefix}/source/${file.path}`)));
+
+        if (!removePaths || toClear.length === existing.manifest.files.length) {
+          await deleteObject(`${prefix}/manifest.json`);
+          return { cleared: toClear.length };
+        }
+
+        const remaining = existing.manifest.files.filter((file) => !removePaths.has(file.path));
+        const manifest: StagingManifest = {
+          ...existing.manifest,
+          updatedAt: new Date(now()).toISOString(),
+          files: remaining,
+          totalBytes: remaining.reduce((sum, file) => sum + file.bytes, 0),
+        };
+        try {
+          await writeObject(
+            `${prefix}/manifest.json`,
+            Buffer.from(JSON.stringify(manifest, null, 2)),
+            'application/json',
+            { ifGenerationMatch: existing.generation },
+          );
+          return { cleared: toClear.length };
+        } catch (error) {
+          if (error instanceof StagingGenerationMismatchError) continue;
+          throw error;
+        }
       }
-
-      const remaining = existing.files.filter((file) => !removePaths.has(file.path));
-      const manifest: StagingManifest = {
-        ...existing,
-        updatedAt: new Date(now()).toISOString(),
-        files: remaining,
-        totalBytes: remaining.reduce((sum, file) => sum + file.bytes, 0),
-      };
-      await writeObject(`${prefix}/manifest.json`, Buffer.from(JSON.stringify(manifest, null, 2)), 'application/json');
-      return { cleared: toClear.length };
+      throw new InvalidUploadError('could not clear staging manifest — too many concurrent updates; retry');
     },
 
     async getManifest(slug, version) {

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -19,6 +19,8 @@ const NO_PULSE = new Set([
   'report_progress',
   'send_screenshot',
   'submit_sources',
+  'stage_source_file',
+  'clear_staged_sources',
   'ack_inbox',
 ]);
 
@@ -34,6 +36,7 @@ const PRESENCE_COPY: Record<string, string> = {
   get_sources: 'Loading existing game sources…',
   list_examples: 'Browsing example games…',
   get_example: 'Reading an example game…',
+  list_staged_sources: 'Checking staged sources…',
   read_inbox: 'Checking creator notes…',
   get_gate_verdict: 'Waiting on automated checks…',
   get_gate_media: 'Reviewing gate captures…',

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -310,6 +310,9 @@ describe('POST /api/mcp (BY-05)', () => {
         'get_example',
         'report_progress',
         'send_screenshot',
+        'stage_source_file',
+        'list_staged_sources',
+        'clear_staged_sources',
         'submit_sources',
         'get_gate_verdict',
         'read_inbox',
@@ -425,6 +428,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/get_kit/);
     expect(joined).toMatch(/read_kit_files|list_kit_files|read_kit_file/);
     expect(joined).toMatch(/send_screenshot/);
+    expect(joined).toMatch(/stage_source_file|fromStaged/);
     expect(joined).toMatch(/submit_sources/);
     expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
     expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);
@@ -1423,6 +1427,7 @@ describe('POST /api/mcp (BY-05)', () => {
       'get_sources',
       'list_examples',
       'get_example',
+      'list_staged_sources',
       'read_inbox',
     ];
     for (const name of readers) {
@@ -1434,12 +1439,15 @@ describe('POST /api/mcp (BY-05)', () => {
       'continue_draft',
       'report_progress',
       'send_screenshot',
+      'stage_source_file',
+      'clear_staged_sources',
       'submit_sources',
       'ack_inbox',
     ];
     for (const name of writers) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, name).toBe(false);
     }
+    expect(tools.find((tool) => tool.name === 'list_staged_sources')?.annotations?.readOnlyHint).toBe(true);
   });
 
   it('declares an outputSchema for every tool', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -925,6 +925,31 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(verdict.structured).toMatchObject({ status: 'red', deliveryId: 'v1' });
   });
 
+  it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    // Node's Buffer.from would decode this as "abc" — we must refuse.
+    const bad = await callTool(
+      app,
+      'stage_source_file',
+      {
+        sessionKey,
+        path: 'game.ts',
+        encoding: 'base64',
+        content: 'YWJj!!!',
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(bad.isError).toBe(true);
+    expect(JSON.stringify(bad.structured)).toMatch(/invalid base64/i);
+  });
+
   describe('terminal receipt (generation one behind) on all three transports', () => {
     async function closeRoundGreen(store: InMemoryStore, gamesStore: GamesStore) {
       await store.setSubmissionDeliveredVersion(ISSUE, 'v1');

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -294,7 +294,7 @@ function stopFromChannel(body: { control?: { stop?: boolean; reason?: string } }
 const BEHAVIOURAL_CONTRACT = [
   'Report progress before and after long steps (and whenever a reply carries warnings with code progress_stale).',
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, submit_sources with mode=preview (no TRACE required). Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file once per path then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'Honour stop immediately — do not continue after stop:true.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
@@ -320,9 +320,9 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
-  'While iterating: submit_sources({ mode: "preview", kitEngineRef, files }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build.',
+  'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Poll get_gate_verdict until preview_passed or preview_failed; fix and re-preview on the SAME key. preview_passed does NOT end the round.',
-  'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), include PLAYTEST.json, then submit_sources({ mode: "publish", … }).',
+  'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated (publish lane).',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
@@ -449,7 +449,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
   async function injectChannel(
     request: FastifyRequest,
-    method: 'GET' | 'POST',
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
     path: string,
     channelToken: string,
     body?: Record<string, unknown> | unknown[],
@@ -2509,6 +2509,215 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
     },
 
+    stage_source_file: {
+      annotations: { title: 'Stage one source file', ...WRITES },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' },
+          path: { type: 'string' },
+          bytes: { type: 'number' },
+          staged: {
+            type: 'object',
+            properties: {
+              files: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: { path: { type: 'string' }, bytes: { type: 'number' } },
+                  required: ['path', 'bytes'],
+                },
+              },
+              totalBytes: { type: 'number' },
+              maxBytes: { type: 'number' },
+              maxFiles: { type: 'number' },
+            },
+            required: ['files', 'totalBytes', 'maxBytes', 'maxFiles'],
+          },
+          ...REPLY_CONTROL,
+        },
+        required: ['ok', 'path', 'bytes', 'staged', 'stop', 'pendingMessages'],
+      },
+      description:
+        'Upload ONE game source file into this round’s staging buffer. Prefer this over a giant submit_sources files[] ' +
+        'when the tree is large (Claude Chat often truncates huge tool JSON). Call once per path, then ' +
+        'submit_sources({ fromStaged: true, mode, kitEngineRef }). Overwrites the same path if staged again. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          path: { type: 'string', description: 'Game-relative path (e.g. game.ts, SPEC.md).' },
+          content: { type: 'string', description: 'File contents (utf8 text, or base64 when encoding=base64).' },
+          encoding: { type: 'string', enum: ['utf8', 'base64'] },
+          slug: { type: 'string' },
+        },
+        required: ['path', 'content'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!path) return toolErr('path is required');
+        if (typeof args.content !== 'string') return toolErr('content is required');
+        let content = args.content;
+        if (args.encoding === 'base64') {
+          try {
+            content = Buffer.from(args.content, 'base64').toString('utf8');
+          } catch {
+            return toolErr(`file ${path}: invalid base64 content`);
+          }
+        }
+        const slug =
+          typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
+        const res = await injectChannel(ctx.request, 'PUT', '/api/agent/build/sources/stage', auth.channelToken, {
+          path,
+          content,
+          ...(slug ? { slug } : {}),
+        });
+        const body = res.json() as {
+          error?: string;
+          accepted?: boolean;
+          rejected?: string;
+          path?: string;
+          bytes?: number;
+          staged?: {
+            files: Array<{ path: string; bytes: number }>;
+            totalBytes: number;
+            maxBytes: number;
+            maxFiles: number;
+          };
+          control?: { stop?: boolean; reason?: string };
+          pending?: Array<{ id: string; text: string; createdAt: string }>;
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `stage failed (${res.statusCode})`, body);
+        }
+        return toolOk({
+          ok: body.accepted !== false,
+          ...(body.rejected ? { rejected: body.rejected } : {}),
+          path: body.path ?? path,
+          bytes: body.bytes ?? 0,
+          staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
+          ...stopFromChannel(body),
+          pendingMessages: pendingMessagesFromChannel(body),
+        });
+      },
+    },
+
+    list_staged_sources: {
+      annotations: { title: 'List staged source files', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { path: { type: 'string' }, bytes: { type: 'number' } },
+              required: ['path', 'bytes'],
+            },
+          },
+          totalBytes: { type: 'number' },
+          maxBytes: { type: 'number' },
+          maxFiles: { type: 'number' },
+          updatedAt: { type: ['string', 'null'] },
+        },
+        required: ['files', 'totalBytes', 'maxBytes', 'maxFiles', 'updatedAt'],
+      },
+      description:
+        'List paths currently in the staging buffer (no contents). Use after stage_source_file to confirm the tree ' +
+        'before submit_sources({ fromStaged: true, … }). ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: { sessionKey: SESSION_KEY_PROP },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const res = await injectChannel(ctx.request, 'GET', '/api/agent/build/sources/stage', auth.channelToken);
+        const body = res.json() as {
+          error?: string;
+          files?: Array<{ path: string; bytes: number }>;
+          totalBytes?: number;
+          maxBytes?: number;
+          maxFiles?: number;
+          updatedAt?: string | null;
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `list staged failed (${res.statusCode})`, body);
+        }
+        return toolOk({
+          files: body.files ?? [],
+          totalBytes: body.totalBytes ?? 0,
+          maxBytes: body.maxBytes ?? 0,
+          maxFiles: body.maxFiles ?? 0,
+          updatedAt: body.updatedAt ?? null,
+        });
+      },
+    },
+
+    clear_staged_sources: {
+      annotations: { title: 'Clear staged source files', ...WRITES },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' },
+          cleared: { type: 'number' },
+          ...REPLY_CONTROL,
+        },
+        required: ['ok', 'cleared', 'stop', 'pendingMessages'],
+      },
+      description:
+        'Clear the staging buffer (all paths, or only paths[]). Use before re-staging a clean tree. ' +
+        'Successful submit_sources({ fromStaged: true }) also clears automatically. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          paths: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional subset to clear; omit to clear everything.',
+          },
+        },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const paths = Array.isArray(args.paths)
+          ? args.paths.filter((path): path is string => typeof path === 'string' && path.trim().length > 0)
+          : undefined;
+        const res = await injectChannel(
+          ctx.request,
+          'POST',
+          '/api/agent/build/sources/stage/clear',
+          auth.channelToken,
+          paths?.length ? { paths } : {},
+        );
+        const body = res.json() as {
+          error?: string;
+          accepted?: boolean;
+          cleared?: number;
+          control?: { stop?: boolean; reason?: string };
+          pending?: Array<{ id: string; text: string; createdAt: string }>;
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `clear staged failed (${res.statusCode})`, body);
+        }
+        return toolOk({
+          ok: body.accepted !== false,
+          cleared: body.cleared ?? 0,
+          ...stopFromChannel(body),
+          pendingMessages: pendingMessagesFromChannel(body),
+        });
+      },
+    },
+
     submit_sources: {
       annotations: { title: 'Deliver sources to the gate', ...CONSUMES },
       outputSchema: {
@@ -2541,15 +2750,22 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         ],
       },
       description:
-        `Deliver game sources. mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
+        `Deliver game sources. Prefer stage_source_file per path then fromStaged=true (avoids huge tool JSON). ` +
+        `mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
         `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
-        `files[{path, content, encoding utf8|base64}] ≤${MAX_SUBMIT_FILES}; kitEngineRef required (from get_kit / kit.json). ` +
+        `files[{path, content, encoding utf8|base64}] optional when fromStaged=true (inline paths override staged); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
         'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          fromStaged: {
+            type: 'boolean',
+            description:
+              'Assemble the staging buffer built with stage_source_file. Prefer this for large trees. ' +
+              'When true, files[] may be omitted (or used as path overrides).',
+          },
           files: {
             type: 'array',
             maxItems: MAX_SUBMIT_FILES,
@@ -2576,12 +2792,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           slug: { type: 'string' },
           note: { type: 'string' },
         },
-        required: ['files', 'kitEngineRef'],
+        required: ['kitEngineRef'],
       },
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
 
+        const fromStaged = args.fromStaged === true;
         const filesParse = z
           .array(
             z.object({
@@ -2590,14 +2807,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               encoding: z.enum(['utf8', 'base64']).optional(),
             }),
           )
-          .min(1)
           .max(MAX_SUBMIT_FILES)
+          .optional()
           .safeParse(args.files);
         if (!filesParse.success) {
           return toolErr(filesParse.error.issues[0]?.message ?? 'invalid files');
         }
-        if (filesParse.data.length > MAX_SUBMIT_FILES) {
-          return toolErr(`too many files (max ${MAX_SUBMIT_FILES})`);
+        const inlineFiles = filesParse.data ?? [];
+        if (!fromStaged && inlineFiles.length === 0) {
+          return toolErr(
+            'submit_sources needs files[] or fromStaged=true after stage_source_file. ' +
+              'For large trees: stage_source_file each path, then submit_sources({ fromStaged: true, mode, kitEngineRef }).',
+          );
         }
 
         const kitEngineRef = typeof args.kitEngineRef === 'string' ? args.kitEngineRef.trim() : '';
@@ -2608,7 +2829,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const mode = args.mode === 'preview' ? 'preview' : 'publish';
 
         const decodedFiles: Array<{ path: string; content: string }> = [];
-        for (const file of filesParse.data) {
+        for (const file of inlineFiles) {
           if (file.encoding === 'base64') {
             try {
               decodedFiles.push({ path: file.path, content: Buffer.from(file.content, 'base64').toString('utf8') });
@@ -2625,7 +2846,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
         const res = await injectChannel(ctx.request, 'POST', '/api/agent/build/sources', auth.channelToken, {
           slug,
-          files: decodedFiles,
+          ...(decodedFiles.length ? { files: decodedFiles } : {}),
+          ...(fromStaged ? { fromStaged: true } : {}),
           kitEngineRef,
           mode,
         });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -43,6 +43,7 @@ import {
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
+import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
 import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
@@ -2563,9 +2564,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         let content = args.content;
         if (args.encoding === 'base64') {
           try {
-            content = Buffer.from(args.content, 'base64').toString('utf8');
-          } catch {
-            return toolErr(`file ${path}: invalid base64 content`);
+            content = decodeCanonicalBase64Utf8(args.content);
+          } catch (error) {
+            if (error instanceof InvalidBase64Error) {
+              return toolErr(`file ${path}: invalid base64 content`);
+            }
+            throw error;
           }
         }
         const slug =
@@ -2832,9 +2836,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         for (const file of inlineFiles) {
           if (file.encoding === 'base64') {
             try {
-              decodedFiles.push({ path: file.path, content: Buffer.from(file.content, 'base64').toString('utf8') });
-            } catch {
-              return toolErr(`file ${file.path}: invalid base64 content`);
+              decodedFiles.push({ path: file.path, content: decodeCanonicalBase64Utf8(file.content) });
+            } catch (error) {
+              if (error instanceof InvalidBase64Error) {
+                return toolErr(`file ${file.path}: invalid base64 content`);
+              }
+              throw error;
             }
           } else {
             decodedFiles.push({ path: file.path, content: file.content });

--- a/infra/gate-hardening.md
+++ b/infra/gate-hardening.md
@@ -16,16 +16,16 @@ is ours; candidate files are **data** materialized into our pinned harness only.
 
 ## Inventory — what a run can reach
 
-| Surface                    | Before hardening                                                                                     | Intended after owner applies `setup-gcp.sh` + this config                                                                              |
-| -------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Service account**        | Unspecified → project Cloud Build / Compute default (often broad: Editor-class or runtime SA powers) | `gate-runner@PROJECT.iam.gserviceaccount.com` only                                                                                     |
+| Surface                    | Before hardening                                                                                     | Intended after owner applies `setup-gcp.sh` + this config                                                                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Service account**        | Unspecified → project Cloud Build / Compute default (often broad: Editor-class or runtime SA powers) | `gate-runner@PROJECT.iam.gserviceaccount.com` only                                                                                                                                  |
 | **SA roles (intended)**    | n/a / ambient                                                                                        | Games-store `roles/storage.objectAdmin` **on that bucket only** (includes delete — see below); `secretmanager.secretAccessor` **on `github-token` only**; `roles/logging.logWriter` |
-| **Secrets in step env**    | `GAMES_REPO_TOKEN` (`github-token`, contents:read)                                                   | Same sole secret; runner unsets it and scrubs the harness `git` remote **before** `check:game`                                         |
-| **Metadata server**        | GCE metadata credentials for the build SA                                                            | Same mechanism; blast radius limited by the gate SA’s IAM                                                                              |
-| **Network egress**         | Default Cloud Build pool: unrestricted egress                                                        | Still unrestricted until owner adds a private pool / VPC egress policy (below)                                                         |
-| **Writable paths**         | `/workspace`, `/tmp`, container root FS                                                              | Unchanged (ephemeral VM); no durable write except via games-store API                                                                  |
-| **Source of build CONFIG** | This YAML + inline `gate-trigger` spec                                                               | Unchanged — slug/version are CLI data only                                                                                             |
-| **Timeout / machine**      | `3600s`, `E2_HIGHCPU_8`, default disk                                                                | `1800s`, `E2_HIGHCPU_8`, `diskSizeGb: 50`                                                                                              |
+| **Secrets in step env**    | `GAMES_REPO_TOKEN` (`github-token`, contents:read)                                                   | Same sole secret; runner unsets it and scrubs the harness `git` remote **before** `check:game`                                                                                      |
+| **Metadata server**        | GCE metadata credentials for the build SA                                                            | Same mechanism; blast radius limited by the gate SA’s IAM                                                                                                                           |
+| **Network egress**         | Default Cloud Build pool: unrestricted egress                                                        | Still unrestricted until owner adds a private pool / VPC egress policy (below)                                                                                                      |
+| **Writable paths**         | `/workspace`, `/tmp`, container root FS                                                              | Unchanged (ephemeral VM); no durable write except via games-store API                                                                                                               |
+| **Source of build CONFIG** | This YAML + inline `gate-trigger` spec                                                               | Unchanged — slug/version are CLI data only                                                                                                                                          |
+| **Timeout / machine**      | `3600s`, `E2_HIGHCPU_8`, default disk                                                                | `1800s`, `E2_HIGHCPU_8`, `diskSizeGb: 50`                                                                                                                                           |
 
 ### Egress the run actually needs
 
@@ -49,7 +49,6 @@ ability to start further builds should be granted to `gate-runner`.
   role that enables those writes is `objectAdmin`, which also permits **delete/overwrite
   of every object in the bucket** — see “Store IAM: why objectAdmin” below.
 
-
 ## Store IAM: why `objectAdmin` (delete on every stored game)
 
 The brief asks for “store write only.” The gate SA is granted
@@ -67,6 +66,20 @@ equally powerful custom role with `storage.objects.delete`).
 Accepted residual risk until a compensating control lands: a compromised gate run can
 delete or overwrite any store object the SA can name, not merely “create namespaced
 immutable objects.”
+
+### Cloud Run runtime: staging-prefix mutate (MCP file staging)
+
+The API runtime keeps bucket-wide `objectCreator` + `objectViewer` only — it must not be
+able to destroy candidate/published versions. MCP `stage_source_file` / clear, however,
+rewrite `games/<slug>/staging/<issue>/g<gen>/manifest.json` and delete staged sources.
+
+`setup-gcp.sh` therefore also grants the runtime `roles/storage.objectAdmin` **with an
+IAM condition** limited to object names under `games/*/staging/`. Outside that prefix the
+runtime still cannot overwrite or delete. Re-run `./infra/setup-gcp.sh` after merging so
+production gets the binding (merge alone does not apply IAM).
+
+Staging manifest writes use GCS `ifGenerationMatch` with retry so concurrent
+`stage_source_file` calls cannot drop each other's entries.
 
 ### Compensating controls (owner console — required follow-up)
 
@@ -98,7 +111,10 @@ Add these to the post-merge owner list (not done by merging this PR):
 These require project credentials. Re-run or perform after merging:
 
 1. **Apply SA + IAM** — `./infra/setup-gcp.sh` (or the gate-runner block alone). Until this
-   exists, builds that set `serviceAccount: gate-runner@…` will fail to start.
+   exists, builds that set `serviceAccount: gate-runner@…` will fail to start. The same
+   script also grants the Cloud Run runtime conditional `objectAdmin` on
+   `games/*/staging/**` (MCP file staging overwrite/clear) — re-run after that change
+   lands or staging will 403 on the second file.
 2. **Confirm default Cloud Build SA is not still Editor** — historically
    `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` received broad project roles. Gate
    builds must not rely on it; audit and remove excess roles if present

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -236,9 +236,12 @@ fi
 # Unlike the snapshot bucket, Cloud Run must *write* here: a delivery arrives over the
 # build channel, which is served by the API, so the runtime is what stores a candidate
 # version. It gets objectCreator + objectViewer rather than objectAdmin — create and read
-# but never delete — so a compromised runtime cannot destroy stored games, and the
-# immutable version ids mean it has no existing path worth overwriting anyway. The
-# deployer keeps objectAdmin for the bake; the gate writes through its own SA (below).
+# but never delete on published/candidate versions — so a compromised runtime cannot
+# destroy stored games, and the immutable version ids mean it has no existing path worth
+# overwriting anyway. MCP file-by-file staging (games/*/staging/**) is the exception:
+# it rewrites a per-job manifest and clears buffers, so a *conditional* objectAdmin on
+# that prefix alone is granted below. The deployer keeps full objectAdmin for the bake;
+# the gate writes through its own SA (further below).
 gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${DEPLOYER_SA}" \
   --role="roles/storage.objectAdmin" \
@@ -253,12 +256,22 @@ for role in roles/storage.objectViewer roles/storage.objectCreator; do
     >/dev/null
 done
 
+# Staging buffers need overwrite + delete (manifest upsert, clear). Bound to the staging
+# prefix only — versions/ and everything else stay create+read for the runtime.
+# CEL: object resource names are projects/_/buckets/BUCKET/objects/OBJECT_PATH.
+gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
+  --member="serviceAccount:${RUN_SA}" \
+  --role="roles/storage.objectAdmin" \
+  --condition="expression=resource.name.startsWith('projects/_/buckets/${STORE_BUCKET}/objects/games/') && resource.name.contains('/staging/'),title=games-store-staging-mutate,description=Overwrite/delete only under games/*/staging/ for MCP file-by-file staging" \
+  --project="$PROJECT_ID" \
+  >/dev/null
+
 # Live objects are never aged out — these are the originals, not a rebuildable
 # projection. Object versioning + soft-delete are the BY-11 compensating controls
 # for gate-runner's objectAdmin (overwrite/delete recovery); the lifecycle rule
 # only deletes *noncurrent* versions so versioning does not grow unbounded.
 # See infra/gate-hardening.md "Store IAM: why objectAdmin".
-echo "    IAM applied (deployer: admin, Cloud Run: read+create)."
+echo "    IAM applied (deployer: admin, Cloud Run: read+create, staging prefix: mutate)."
 echo "    Ensuring object versioning, 30d soft-delete, and noncurrent-version prune…"
 gcloud storage buckets update "gs://${STORE_BUCKET}" \
   --versioning \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Claude (and similar) often truncates a giant `submit_sources` `files[]` JSON payload. This adds a staging buffer so agents upload one path at a time, then finalize.

### Change

- MCP: `stage_source_file`, `list_staged_sources`, `clear_staged_sources`
- `submit_sources({ fromStaged: true, mode, kitEngineRef })` assembles the buffer
- Channel: `PUT/GET …/sources/stage`, `POST …/sources/stage/clear`
- GCS under `games/<slug>/staging/<issue>/g<roundGeneration>/`
- Workflow copy prefers stage-then-submit for large trees

### Codex review follow-ups

- **P1 IAM:** runtime gets conditional `objectAdmin` only on `games/*/staging/**` (still create+read elsewhere). **Re-run `./infra/setup-gcp.sh` after merge** — IAM is not applied by deploy alone.
- **P2 races:** staging manifest writes use `ifGenerationMatch` + retry so concurrent `stage_source_file` calls merge instead of clobbering.
- **P2 base64:** `decodeCanonicalBase64` rejects payloads Node would silently corrupt (`YWJj!!!` → refuse, not `abc`).

### Test plan

- [x] Stage several files, list, submit fromStaged preview
- [x] Clear staging; auto-clear after successful fromStaged submit
- [x] Manifest generation race retries and merges
- [x] Malformed base64 refused on stage_source_file
- [x] Root green gate

### Related

- Preview deliveries: #523
- Presence heartbeat: #527
- Kit docs companion: games-repo #444

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

