### PR TITLE
fix(mcp): presence as heartbeat + thought flash, not Studio chat

### DIFF
--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isMcpPresenceEventText,
+  mcpPresenceKey,
   MCP_PRESENCE_MIN_GAP_MS,
   noteMcpPresencePulse,
   shouldEmitMcpPresencePulse,
@@ -13,18 +14,30 @@ describe('mcp presence pulses', () => {
     expect(shouldPulseMcpPresence('read_kit_file')).toBe(true);
     expect(shouldPulseMcpPresence('read_kit_files')).toBe(true);
     expect(shouldPulseMcpPresence('get_brief')).toBe(true);
+    expect(shouldPulseMcpPresence('list_staged_sources')).toBe(true);
     expect(shouldPulseMcpPresence('report_progress')).toBe(false);
     expect(shouldPulseMcpPresence('start')).toBe(false);
     expect(shouldPulseMcpPresence('continue_draft')).toBe(false);
     expect(shouldPulseMcpPresence('open_round')).toBe(false);
+    expect(shouldPulseMcpPresence('stage_source_file')).toBe(false);
+    expect(shouldPulseMcpPresence('clear_staged_sources')).toBe(false);
     // Inherited Object keys must not count as tools.
     expect(shouldPulseMcpPresence('toString')).toBe(false);
     expect(shouldPulseMcpPresence('constructor')).toBe(false);
   });
 
+  it('maps tools to stable thought keys for Studio i18n', () => {
+    expect(mcpPresenceKey('list_kit_files')).toBe('browsing_kit');
+    expect(mcpPresenceKey('read_kit_files')).toBe('reading_kit');
+    expect(mcpPresenceKey('get_brief')).toBe('reading_brief');
+    expect(mcpPresenceKey('list_staged_sources')).toBe('checking_staged');
+    expect(mcpPresenceKey('report_progress')).toBeNull();
+  });
+
   it('recognizes leftover synthetic chat rows so status can hide them', () => {
     expect(isMcpPresenceEventText('Browsing the Creator Kit…')).toBe(true);
     expect(isMcpPresenceEventText('Reading Creator Kit files…')).toBe(true);
+    expect(isMcpPresenceEventText('Checking staged sources…')).toBe(true);
     expect(isMcpPresenceEventText('Getting the squad moving.')).toBe(false);
   });
 

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  mcpPresenceText,
+  isMcpPresenceEventText,
   MCP_PRESENCE_MIN_GAP_MS,
   noteMcpPresencePulse,
   shouldEmitMcpPresencePulse,
@@ -20,13 +20,12 @@ describe('mcp presence pulses', () => {
     // Inherited Object keys must not count as tools.
     expect(shouldPulseMcpPresence('toString')).toBe(false);
     expect(shouldPulseMcpPresence('constructor')).toBe(false);
-    expect(mcpPresenceText('toString')).toBeNull();
   });
 
-  it('maps tools to short Studio-facing copy', () => {
-    expect(mcpPresenceText('list_kit_files')).toMatch(/Creator Kit/i);
-    expect(mcpPresenceText('get_gate_verdict')).toMatch(/checks/i);
-    expect(mcpPresenceText('start')).toBeNull();
+  it('recognizes leftover synthetic chat rows so status can hide them', () => {
+    expect(isMcpPresenceEventText('Browsing the Creator Kit…')).toBe(true);
+    expect(isMcpPresenceEventText('Reading Creator Kit files…')).toBe(true);
+    expect(isMcpPresenceEventText('Getting the squad moving.')).toBe(false);
   });
 
   it('rate-limits pulses per job', () => {

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -3,11 +3,12 @@
  *
  * ChatGPT Apps (and similar) often browse the kit for many turns with few
  * `report_progress` writes. Studio then looks idle even though the agent is busy.
- * These pulses ride successful session-authenticated tool calls — not 1:1 tool
- * logging — and are rate-limited so the build-event cap stays healthy.
+ * Pulses only refresh `lastAgentSignalAt` on the submission (heartbeat / stall) —
+ * they must NOT append durable build-event chat rows. Rate-limited so a read-heavy
+ * loop cannot hammer Firestore.
  */
 
-/** Minimum gap between synthetic presence events for one job. */
+/** Minimum gap between synthetic presence heartbeats for one job. */
 export const MCP_PRESENCE_MIN_GAP_MS = 60_000;
 
 /** Tools that already write real progress / open rounds — never synthesize for these. */
@@ -24,6 +25,11 @@ const NO_PULSE = new Set([
   'ack_inbox',
 ]);
 
+/**
+ * Tools that count as "agent is working" for the heartbeat. Values are the English
+ * strings historically written as `kind: 'step'` chat rows (filtered from status so
+ * old threads stop showing them as messages).
+ */
 const PRESENCE_COPY: Record<string, string> = {
   get_brief: 'Reading the build brief…',
   get_seed: 'Loading the seed draft…',
@@ -42,14 +48,17 @@ const PRESENCE_COPY: Record<string, string> = {
   get_gate_media: 'Reviewing gate captures…',
 };
 
+const PRESENCE_EVENT_TEXTS = new Set(Object.values(PRESENCE_COPY));
+
 export function shouldPulseMcpPresence(toolName: string): boolean {
   if (NO_PULSE.has(toolName)) return false;
   // Own-property only — `in` would also match inherited keys like `toString`.
   return Object.hasOwn(PRESENCE_COPY, toolName);
 }
 
-export function mcpPresenceText(toolName: string): string | null {
-  return Object.hasOwn(PRESENCE_COPY, toolName) ? PRESENCE_COPY[toolName]! : null;
+/** True when a durable step text is a leftover synthetic presence row (filter from chat). */
+export function isMcpPresenceEventText(text: string): boolean {
+  return PRESENCE_EVENT_TEXTS.has(text);
 }
 
 /** Cap for the in-process last-pulse map — oldest entries drop first (insertion order). */

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -3,9 +3,9 @@
  *
  * ChatGPT Apps (and similar) often browse the kit for many turns with few
  * `report_progress` writes. Studio then looks idle even though the agent is busy.
- * Pulses only refresh `lastAgentSignalAt` on the submission (heartbeat / stall) —
- * they must NOT append durable build-event chat rows. Rate-limited so a read-heavy
- * loop cannot hammer Firestore.
+ * Pulses refresh `lastAgentSignalAt` (stall / heartbeat) and a short-lived
+ * `lastAgentPresence` thought key for the thread bar — they must NOT append durable
+ * build-event chat rows. Rate-limited so a read-heavy loop cannot hammer Firestore.
  */
 
 /** Minimum gap between synthetic presence heartbeats for one job. */
@@ -26,34 +26,44 @@ const NO_PULSE = new Set([
 ]);
 
 /**
- * Tools that count as "agent is working" for the heartbeat. Values are the English
- * strings historically written as `kind: 'step'` chat rows (filtered from status so
- * old threads stop showing them as messages).
+ * Closed vocabulary for Studio thought headlines. Client translates via
+ * `statusView.presence.<key>`; English `text` matches historical chat rows so
+ * leftover durable steps can still be filtered from the transcript.
  */
-const PRESENCE_COPY: Record<string, string> = {
-  get_brief: 'Reading the build brief…',
-  get_seed: 'Loading the seed draft…',
-  get_kit: 'Fetching Creator Kit metadata…',
-  list_kit_files: 'Browsing the Creator Kit…',
-  search_kit_files: 'Searching the Creator Kit…',
-  read_kit_file: 'Reading Creator Kit files…',
-  read_kit_files: 'Reading Creator Kit files…',
-  read_kit_file_fragment: 'Reading Creator Kit files…',
-  get_sources: 'Loading existing game sources…',
-  list_examples: 'Browsing example games…',
-  get_example: 'Reading an example game…',
-  list_staged_sources: 'Checking staged sources…',
-  read_inbox: 'Checking creator notes…',
-  get_gate_verdict: 'Waiting on automated checks…',
-  get_gate_media: 'Reviewing gate captures…',
+const PRESENCE_BY_TOOL: Record<string, { key: string; text: string }> = {
+  get_brief: { key: 'reading_brief', text: 'Reading the build brief…' },
+  get_seed: { key: 'loading_seed', text: 'Loading the seed draft…' },
+  get_kit: { key: 'fetching_kit', text: 'Fetching Creator Kit metadata…' },
+  list_kit_files: { key: 'browsing_kit', text: 'Browsing the Creator Kit…' },
+  search_kit_files: { key: 'searching_kit', text: 'Searching the Creator Kit…' },
+  read_kit_file: { key: 'reading_kit', text: 'Reading Creator Kit files…' },
+  read_kit_files: { key: 'reading_kit', text: 'Reading Creator Kit files…' },
+  read_kit_file_fragment: { key: 'reading_kit', text: 'Reading Creator Kit files…' },
+  get_sources: { key: 'loading_sources', text: 'Loading existing game sources…' },
+  list_examples: { key: 'browsing_examples', text: 'Browsing example games…' },
+  get_example: { key: 'reading_example', text: 'Reading an example game…' },
+  list_staged_sources: { key: 'checking_staged', text: 'Checking staged sources…' },
+  read_inbox: { key: 'checking_inbox', text: 'Checking creator notes…' },
+  get_gate_verdict: { key: 'waiting_checks', text: 'Waiting on automated checks…' },
+  get_gate_media: { key: 'reviewing_captures', text: 'Reviewing gate captures…' },
 };
 
-const PRESENCE_EVENT_TEXTS = new Set(Object.values(PRESENCE_COPY));
+const PRESENCE_EVENT_TEXTS = new Set(Object.values(PRESENCE_BY_TOOL).map((entry) => entry.text));
 
 export function shouldPulseMcpPresence(toolName: string): boolean {
   if (NO_PULSE.has(toolName)) return false;
   // Own-property only — `in` would also match inherited keys like `toString`.
-  return Object.hasOwn(PRESENCE_COPY, toolName);
+  return Object.hasOwn(PRESENCE_BY_TOOL, toolName);
+}
+
+/** Stable presence key for Studio i18n, or null when the tool does not pulse. */
+export function mcpPresenceKey(toolName: string): string | null {
+  return Object.hasOwn(PRESENCE_BY_TOOL, toolName) ? PRESENCE_BY_TOOL[toolName]!.key : null;
+}
+
+/** Historic English presence string (filter leftover chat rows). */
+export function mcpPresenceText(toolName: string): string | null {
+  return Object.hasOwn(PRESENCE_BY_TOOL, toolName) ? PRESENCE_BY_TOOL[toolName]!.text : null;
 }
 
 /** True when a durable step text is a leftover synthetic presence row (filter from chat). */

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -406,7 +406,8 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const record = await store.getSubmission(ISSUE);
     expect(record?.lastAgentSignalAt).toBeTruthy();
-    // No new chat row — presence is heartbeat-only now.
+    expect(record?.lastAgentPresence).toMatchObject({ key: 'reading_brief' });
+    // No new chat row — presence is heartbeat + thought key, not a transcript turn.
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(before);
   });
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -390,6 +390,26 @@ describe('POST /api/mcp (BY-05)', () => {
     });
   });
 
+  it('kit browse refreshes the agent heartbeat without writing Studio chat events', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    await store.appendBuildEvent(ISSUE, { kind: 'step', text: 'Browsing the Creator Kit…' });
+    const before = (await store.listBuildEvents(ISSUE)).length;
+
+    const brief = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(brief.isError).toBe(false);
+
+    const record = await store.getSubmission(ISSUE);
+    expect(record?.lastAgentSignalAt).toBeTruthy();
+    // No new chat row — presence is heartbeat-only now.
+    expect(await store.listBuildEvents(ISSUE)).toHaveLength(before);
+  });
+
   it('start returns the session workflow in both structuredContent and the text body', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -27,12 +27,7 @@ import {
   resolveGameAgentKeyForStart,
   verifyDurableGameAgentKey,
 } from './agent-game-key-resolve.js';
-import {
-  mcpPresenceText,
-  noteMcpPresencePulse,
-  shouldEmitMcpPresencePulse,
-  shouldPulseMcpPresence,
-} from './mcp-presence.js';
+import { noteMcpPresencePulse, shouldEmitMcpPresencePulse, shouldPulseMcpPresence } from './mcp-presence.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -3337,15 +3332,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             );
           }
         } else if (store && agentTokenSecret && shouldPulseMcpPresence(name)) {
-          // Coarse Studio presence for read-heavy Apps loops that skip report_progress.
-          const presenceText = mcpPresenceText(name);
+          // Heartbeat only — never append a durable chat row. Kit-browse loops used to
+          // spam "Czytanie plików Creator Kit…" between real report_progress turns.
           const jobId = resolvePresenceJobId(sessionKeyArg, bearerToken, agentTokenSecret);
-          if (presenceText && jobId !== null) {
+          if (jobId !== null) {
             const at = now();
             if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
               noteMcpPresencePulse(presencePulseByJob, jobId, at);
               try {
-                await store.appendBuildEvent(jobId, { kind: 'step', text: presenceText });
+                await store.touchLastAgentSignalAt(jobId, new Date(at).toISOString());
               } catch (pulseError) {
                 request.log.warn({ err: pulseError, jobId, tool: name }, 'mcp presence pulse failed');
               }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -27,7 +27,12 @@ import {
   resolveGameAgentKeyForStart,
   verifyDurableGameAgentKey,
 } from './agent-game-key-resolve.js';
-import { noteMcpPresencePulse, shouldEmitMcpPresencePulse, shouldPulseMcpPresence } from './mcp-presence.js';
+import {
+  mcpPresenceKey,
+  noteMcpPresencePulse,
+  shouldEmitMcpPresencePulse,
+  shouldPulseMcpPresence,
+} from './mcp-presence.js';
 import {
   classifyAgentTokenAccess,
   InvalidAgentTokenError,
@@ -3332,15 +3337,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             );
           }
         } else if (store && agentTokenSecret && shouldPulseMcpPresence(name)) {
-          // Heartbeat only — never append a durable chat row. Kit-browse loops used to
-          // spam "Czytanie plików Creator Kit…" between real report_progress turns.
+          // Heartbeat + short-lived thought key — never a durable chat row. Kit-browse
+          // loops used to spam "Czytanie plików Creator Kit…" between real report_progress.
           const jobId = resolvePresenceJobId(sessionKeyArg, bearerToken, agentTokenSecret);
-          if (jobId !== null) {
+          const presenceKey = mcpPresenceKey(name);
+          if (jobId !== null && presenceKey) {
             const at = now();
             if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
               noteMcpPresencePulse(presencePulseByJob, jobId, at);
               try {
-                await store.touchLastAgentSignalAt(jobId, new Date(at).toISOString());
+                await store.touchLastAgentSignalAt(jobId, new Date(at).toISOString(), {
+                  key: presenceKey,
+                });
               } catch (pulseError) {
                 request.log.warn({ err: pulseError, jobId, tool: name }, 'mcp presence pulse failed');
               }

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -102,9 +102,18 @@ describe('InMemoryStore', () => {
     await store.createSubmission(61, 'g:123', 'Heartbeat');
     expect((await store.getSubmission(61))?.lastAgentSignalAt).toBeUndefined();
 
-    await store.touchLastAgentSignalAt(61, '2026-08-04T00:00:00.000Z');
+    await store.touchLastAgentSignalAt(61, '2026-08-04T00:00:00.000Z', { key: 'browsing_kit' });
     expect((await store.getSubmission(61))?.lastAgentSignalAt).toBe('2026-08-04T00:00:00.000Z');
+    expect((await store.getSubmission(61))?.lastAgentPresence).toEqual({
+      key: 'browsing_kit',
+      at: '2026-08-04T00:00:00.000Z',
+    });
     expect(await store.listBuildEvents(61)).toEqual([]);
+
+    // A real chat row clears the ambient thought.
+    await store.appendBuildEvent(61, { kind: 'step', text: 'Sketching the title screen.' });
+    expect((await store.getSubmission(61))?.lastAgentPresence).toBeUndefined();
+    expect((await store.getSubmission(61))?.lastAgentSignalAt).toBeTruthy();
   });
 
   it('ensureRoundGeneration initializes a legacy job without bumping an existing one', async () => {

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -97,6 +97,16 @@ describe('InMemoryStore', () => {
     expect(await repairStore.bumpRoundGeneration(5)).toBe(2);
   });
 
+  it('touchLastAgentSignalAt refreshes heartbeat without writing chat events', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(61, 'g:123', 'Heartbeat');
+    expect((await store.getSubmission(61))?.lastAgentSignalAt).toBeUndefined();
+
+    await store.touchLastAgentSignalAt(61, '2026-08-04T00:00:00.000Z');
+    expect((await store.getSubmission(61))?.lastAgentSignalAt).toBe('2026-08-04T00:00:00.000Z');
+    expect(await store.listBuildEvents(61)).toEqual([]);
+  });
+
   it('ensureRoundGeneration initializes a legacy job without bumping an existing one', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(6, 'g:123', 'Legacy');

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -235,6 +235,13 @@ export interface SubmissionRecord {
    */
   lastAgentSignalAt?: string;
   /**
+   * Latest MCP presence thought (closed vocabulary key + timestamp).
+   *
+   * Not a chat event — Studio flashes it as a short headline while the agent is
+   * browsing the kit. Cleared when a real build event arrives or the round closes.
+   */
+  lastAgentPresence?: { key: string; at: string };
+  /**
    * Which backend is building this job and where.
    *
    * `refs` accumulates because a revision round is a *new* task rather than a new session
@@ -1527,8 +1534,9 @@ export interface Store {
    * Refreshes {@link SubmissionRecord.lastAgentSignalAt} without writing a chat event.
    * Used by MCP presence heartbeats so kit-browse activity clears `no_agent_yet` / quiet
    * stalls without stuffing "Browsing the Creator Kit…" into the Studio thread.
+   * When `presence` is set, also stores a short-lived thought key for the Studio bar.
    */
-  touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void>;
+  touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void>;
   /** Agent progress events for a build, newest first. */
   listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]>;
   /** How many events a build has recorded — the cap that bounds a runaway agent. */
@@ -2358,6 +2366,7 @@ export class InMemoryStore implements Store {
       // Signals belong to the round that closed — keeping them makes the next self
       // round look "connected" before any agent has joined.
       delete next.lastAgentSignalAt;
+      delete next.lastAgentPresence;
     }
     this.submissions.set(issueNumber, next);
     return true;
@@ -2371,6 +2380,7 @@ export class InMemoryStore implements Store {
     delete next.seed;
     delete next.seedStatus;
     delete next.lastAgentSignalAt;
+    delete next.lastAgentPresence;
     this.submissions.set(issueNumber, next);
     return roundGeneration;
   }
@@ -2632,16 +2642,23 @@ export class InMemoryStore implements Store {
     existing.push(record);
     this.buildEvents.set(issueNumber, existing);
     const submission = this.submissions.get(issueNumber);
-    if (submission) this.submissions.set(issueNumber, { ...submission, lastAgentSignalAt: record.createdAt });
+    if (submission) {
+      const next: SubmissionRecord = { ...submission, lastAgentSignalAt: record.createdAt };
+      // A real chat row supersedes the ambient thought flash.
+      delete next.lastAgentPresence;
+      this.submissions.set(issueNumber, next);
+    }
     return { ...record };
   }
 
-  async touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void> {
+  async touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void> {
     const submission = this.submissions.get(issueNumber);
     if (!submission) return;
+    const stamped = at ?? new Date().toISOString();
     this.submissions.set(issueNumber, {
       ...submission,
-      lastAgentSignalAt: at ?? new Date().toISOString(),
+      lastAgentSignalAt: stamped,
+      ...(presence ? { lastAgentPresence: { key: presence.key, at: stamped } } : {}),
     });
   }
 
@@ -4000,6 +4017,7 @@ export class FirestoreStore implements Store {
         delete next.seed;
         delete next.seedStatus;
         delete next.lastAgentSignalAt;
+        delete next.lastAgentPresence;
         tx.set(ref, next);
       } else {
         tx.set(
@@ -4027,6 +4045,7 @@ export class FirestoreStore implements Store {
       delete next.seed;
       delete next.seedStatus;
       delete next.lastAgentSignalAt;
+      delete next.lastAgentPresence;
       tx.set(ref, next);
       return roundGeneration;
     });
@@ -4389,18 +4408,29 @@ export class FirestoreStore implements Store {
     // in-flight job without a subcollection read per job. Merged separately rather than
     // transactionally: losing a race here costs a slightly stale liveness timestamp,
     // which is not worth a transaction on the hottest write in the channel.
-    await this.db
-      .collection('submissions')
-      .doc(String(issueNumber))
-      .set({ lastAgentSignalAt: record.createdAt }, { merge: true });
+    await this.db.collection('submissions').doc(String(issueNumber)).set(
+      {
+        lastAgentSignalAt: record.createdAt,
+        // A real chat row supersedes the ambient thought flash.
+        lastAgentPresence: FieldValue.delete(),
+      },
+      { merge: true },
+    );
     return record;
   }
 
-  async touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void> {
+  async touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void> {
+    const stamped = at ?? new Date().toISOString();
     await this.db
       .collection('submissions')
       .doc(String(issueNumber))
-      .set({ lastAgentSignalAt: at ?? new Date().toISOString() }, { merge: true });
+      .set(
+        {
+          lastAgentSignalAt: stamped,
+          ...(presence ? { lastAgentPresence: { key: presence.key, at: stamped } } : {}),
+        },
+        { merge: true },
+      );
   }
 
   async listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1523,6 +1523,12 @@ export interface Store {
     issueNumber: number,
     event: Omit<BuildEvent, 'id' | 'createdAt'> & { createdAt?: string },
   ): Promise<BuildEvent>;
+  /**
+   * Refreshes {@link SubmissionRecord.lastAgentSignalAt} without writing a chat event.
+   * Used by MCP presence heartbeats so kit-browse activity clears `no_agent_yet` / quiet
+   * stalls without stuffing "Browsing the Creator Kit…" into the Studio thread.
+   */
+  touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void>;
   /** Agent progress events for a build, newest first. */
   listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]>;
   /** How many events a build has recorded — the cap that bounds a runaway agent. */
@@ -2628,6 +2634,15 @@ export class InMemoryStore implements Store {
     const submission = this.submissions.get(issueNumber);
     if (submission) this.submissions.set(issueNumber, { ...submission, lastAgentSignalAt: record.createdAt });
     return { ...record };
+  }
+
+  async touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void> {
+    const submission = this.submissions.get(issueNumber);
+    if (!submission) return;
+    this.submissions.set(issueNumber, {
+      ...submission,
+      lastAgentSignalAt: at ?? new Date().toISOString(),
+    });
   }
 
   async listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]> {
@@ -4379,6 +4394,13 @@ export class FirestoreStore implements Store {
       .doc(String(issueNumber))
       .set({ lastAgentSignalAt: record.createdAt }, { merge: true });
     return record;
+  }
+
+  async touchLastAgentSignalAt(issueNumber: number, at?: string): Promise<void> {
+    await this.db
+      .collection('submissions')
+      .doc(String(issueNumber))
+      .set({ lastAgentSignalAt: at ?? new Date().toISOString() }, { merge: true });
   }
 
   async listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]> {

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -176,6 +176,11 @@ export interface SubmissionStatusResponseBase {
    */
   lastAgentSignalAt?: string;
   /**
+   * Short-lived presence thought for the Studio thread bar (closed vocabulary key).
+   * Not a chat event — UI flashes it as a headline while the agent browses the kit.
+   */
+  lastAgentPresence?: { key: string; at: string };
+  /**
    * Pictures of the game as it is now, newest first — the build log stops being a
    * wall of text. Same reasoning as `events`: kept outside `progress` so a build
    * with no pull request yet can still show something.

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -169,6 +169,13 @@ export interface SubmissionStatusResponseBase {
    */
   events?: BuildEvent[];
   /**
+   * Last MCP/channel agent activity timestamp (heartbeat). Refreshed by real progress
+   * and by presence pulses that intentionally do **not** create chat `events`. Used by
+   * the Studio foot "updated ago" line when the transcript is quiet but the agent is
+   * still browsing the kit.
+   */
+  lastAgentSignalAt?: string;
+  /**
    * Pictures of the game as it is now, newest first — the build log stops being a
    * wall of text. Same reasoning as `events`: kept outside `progress` so a build
    * with no pull request yet can still show something.

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -49,6 +49,7 @@ import {
   type JobState,
   type JobTransition,
 } from './job-state.js';
+import { isMcpPresenceEventText } from './mcp-presence.js';
 import { logSeedStagingFailure } from './seed-metrics.js';
 import { createSelfBuildBackend } from './self-build-backend.js';
 import { mintConnectPayload, mintGameKeyKickoff } from './self-build-connect.js';
@@ -1454,11 +1455,13 @@ export async function registerSubmissionRoutes(
     issueNumber: number,
     locale: string,
   ): Promise<SubmissionStatusResponse> {
-    const [events, media, playable] = await Promise.all([
+    const [loadedEvents, media, playable] = await Promise.all([
       loadBuildEvents(issueNumber),
       buildMedia(issueNumber, locale),
       buildPlayables(issueNumber, locale),
     ]);
+    // Drop leftover synthetic presence steps from before heartbeats stopped writing chat.
+    const events = loadedEvents.filter((event) => !isMcpPresenceEventText(event.text));
     return {
       ...status,
       ...(events.length > 0 ? { events: await localizeEvents(events, locale) } : {}),
@@ -1821,6 +1824,8 @@ export async function registerSubmissionRoutes(
       builder: builderOf(record),
     });
     if (stall) status.stall = stall;
+    // Heartbeat for Studio "updated ago" — presence pulses refresh this without chat rows.
+    if (record.lastAgentSignalAt) status.lastAgentSignalAt = record.lastAgentSignalAt;
     // Echo builder fields so Studio does not invent `platform` from empty localStorage
     // when the server already knows the game's last-used choice (Codex P2 on BY-07).
     const roundBuilder = record.builder;

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1824,8 +1824,9 @@ export async function registerSubmissionRoutes(
       builder: builderOf(record),
     });
     if (stall) status.stall = stall;
-    // Heartbeat for Studio "updated ago" — presence pulses refresh this without chat rows.
+    // Heartbeat + thought flash — presence pulses refresh these without chat rows.
     if (record.lastAgentSignalAt) status.lastAgentSignalAt = record.lastAgentSignalAt;
+    if (record.lastAgentPresence) status.lastAgentPresence = record.lastAgentPresence;
     // Echo builder fields so Studio does not invent `platform` from empty localStorage
     // when the server already knows the game's last-used choice (Codex P2 on BY-07).
     const roundBuilder = record.builder;

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1261,6 +1261,39 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('flashes a presence thought in the thread bar without adding a chat turn', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const at = new Date().toISOString();
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      lastAgentSignalAt: at,
+      lastAgentPresence: { key: 'browsing_kit', at },
+      events: [],
+    });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/presence-thought/thread');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'presence-thought', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.studio-thread-context.is-thought')).not.toBeNull();
+    expect(container.querySelector('.studio-context-phase')?.textContent).toContain('Browsing the Creator Kit');
+    // Thought stays out of the transcript.
+    expect(container.querySelector('.studio-turn')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('lets the creator dismiss a stall chip above the composer', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -115,6 +115,7 @@ const TIMELINE_STEPS: SubmissionStatus['status'][] = ['queued', 'building', 'in_
 function latestAgentActivityAt(status: SubmissionStatus | null): number | null {
   if (!status) return null;
   const times = [
+    ...(status.lastAgentSignalAt ? [Date.parse(status.lastAgentSignalAt)] : []),
     ...(status.events ?? []).map((event) => Date.parse(event.createdAt)),
     ...(status.media ?? []).map((item) => (item.createdAt ? Date.parse(item.createdAt) : Number.NaN)),
     ...(status.playable ?? []).map((item) => (item.createdAt ? Date.parse(item.createdAt) : Number.NaN)),

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1612,11 +1612,17 @@ function ThreadContextBar({
   const { t } = useTranslation();
   const [, setTick] = useState(0);
 
-  // Presence ages out client-side; tick so the headline falls back without a status poll.
+  // Presence ages out client-side; one timeout at expiry so the headline falls back
+  // without a status poll — and without a lingering interval after the flash ends.
   useEffect(() => {
     if (!thought) return;
-    const id = window.setInterval(() => setTick((n) => n + 1), 5_000);
-    return () => window.clearInterval(id);
+    const remaining = thought.at + PRESENCE_THOUGHT_MS - Date.now();
+    if (remaining <= 0) {
+      setTick((n) => n + 1);
+      return;
+    }
+    const id = window.setTimeout(() => setTick((n) => n + 1), remaining);
+    return () => window.clearTimeout(id);
   }, [thought]);
 
   const thoughtFresh = thought !== null && thought !== undefined && Date.now() - thought.at <= PRESENCE_THOUGHT_MS;

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1617,7 +1617,7 @@ function ThreadContextBar({
     if (!thought) return;
     const id = window.setInterval(() => setTick((n) => n + 1), 5_000);
     return () => window.clearInterval(id);
-  }, [thought?.at, thought?.key]);
+  }, [thought]);
 
   const thoughtFresh = thought !== null && thought !== undefined && Date.now() - thought.at <= PRESENCE_THOUGHT_MS;
   const thoughtLabel =

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -124,6 +124,24 @@ function latestAgentActivityAt(status: SubmissionStatus | null): number | null {
   return times.length > 0 ? Math.max(...times) : null;
 }
 
+/** How long a presence thought stays as the thread-bar headline before falling back. */
+const PRESENCE_THOUGHT_MS = 90_000;
+
+/**
+ * Ambient MCP presence for the thread bar — a thought headline, not a chat row.
+ * Fresh for {@link PRESENCE_THOUGHT_MS}; cleared server-side when real progress arrives.
+ */
+function presenceThought(
+  status: SubmissionStatus | null,
+  nowMs: number = Date.now(),
+): { key: string; at: number } | null {
+  const presence = status?.lastAgentPresence;
+  if (!presence?.key) return null;
+  const at = Date.parse(presence.at);
+  if (!Number.isFinite(at) || nowMs - at > PRESENCE_THOUGHT_MS) return null;
+  return { key: presence.key, at };
+}
+
 /**
  * "Live · updated 3 minutes ago" — the build's pulse.
  *
@@ -727,6 +745,9 @@ export function SubmissionStatusView({
                         ? t('connect.waiting')
                         : t('connect.resume.waiting')
                       : t(`statusView.states.${status.status}.label`)
+                  }
+                  thought={
+                    isAwaitingOwnAgent(status) || TERMINAL_STATUSES.has(status.status) ? null : presenceThought(status)
                   }
                   heartbeatAt={isAwaitingOwnAgent(status) ? null : heartbeatAt}
                   active={!TERMINAL_STATUSES.has(status.status) && !isAwaitingOwnAgent(status)}
@@ -1573,12 +1594,15 @@ function ThreadStream({
  */
 function ThreadContextBar({
   phase,
+  thought,
   heartbeatAt,
   progress,
   primary,
   active = false,
 }: {
   phase: string;
+  /** Fresh MCP presence thought — replaces the coarse phase as a short headline flash. */
+  thought?: { key: string; at: number } | null;
   heartbeatAt: number | null;
   progress?: { done: number; total: number };
   primary?: { label: string; onClick: () => void };
@@ -1586,13 +1610,34 @@ function ThreadContextBar({
   active?: boolean;
 }) {
   const { t } = useTranslation();
+  const [, setTick] = useState(0);
+
+  // Presence ages out client-side; tick so the headline falls back without a status poll.
+  useEffect(() => {
+    if (!thought) return;
+    const id = window.setInterval(() => setTick((n) => n + 1), 5_000);
+    return () => window.clearInterval(id);
+  }, [thought?.at, thought?.key]);
+
+  const thoughtFresh = thought !== null && thought !== undefined && Date.now() - thought.at <= PRESENCE_THOUGHT_MS;
+  const thoughtLabel =
+    thoughtFresh && thought
+      ? t(`statusView.presence.${thought.key}`, {
+          defaultValue: '',
+        })
+      : '';
+  const headline = thoughtLabel || phase;
+  const showingThought = Boolean(thoughtLabel);
 
   return (
-    <div className={`studio-thread-context${active ? ' is-active' : ''}`}>
+    <div className={`studio-thread-context${active ? ' is-active' : ''}${showingThought ? ' is-thought' : ''}`}>
       <span className="studio-context-state">
-        <span className="studio-context-phase">
+        <span
+          className="studio-context-phase"
+          key={showingThought ? `thought:${thought!.key}:${thought!.at}` : `phase:${phase}`}
+        >
           {active ? <span className="studio-context-phase-spinner" aria-hidden="true" /> : null}
-          {phase}
+          {headline}
         </span>
         {heartbeatAt !== null ? (
           <span className="studio-context-beat">

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -631,6 +631,21 @@
       "ready_for_review": "Your game passed every check. It's waiting for the last look before going live."
     },
     "updatedAgo": "updated {{time}}",
+    "presence": {
+      "reading_brief": "Reading the build brief…",
+      "loading_seed": "Loading the seed draft…",
+      "fetching_kit": "Fetching Creator Kit metadata…",
+      "browsing_kit": "Browsing the Creator Kit…",
+      "searching_kit": "Searching the Creator Kit…",
+      "reading_kit": "Reading Creator Kit files…",
+      "loading_sources": "Loading existing game sources…",
+      "browsing_examples": "Browsing example games…",
+      "reading_example": "Reading an example game…",
+      "checking_staged": "Checking staged sources…",
+      "checking_inbox": "Checking creator notes…",
+      "waiting_checks": "Waiting on automated checks…",
+      "reviewing_captures": "Reviewing gate captures…"
+    },
     "playtestCta": "Play with a note",
     "live": "Live",
     "shareLink": "Share this game (watch only):",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -635,6 +635,21 @@
       "ready_for_review": "Twoja gra przeszła wszystkie testy. Czeka na ostatnie spojrzenie przed publikacją."
     },
     "updatedAgo": "aktualizacja {{time}}",
+    "presence": {
+      "reading_brief": "Czytanie briefu…",
+      "loading_seed": "Ładowanie szkicu startowego…",
+      "fetching_kit": "Pobieranie metadanych Creator Kit…",
+      "browsing_kit": "Przeglądanie Creator Kit…",
+      "searching_kit": "Szukanie w Creator Kit…",
+      "reading_kit": "Czytanie plików Creator Kit…",
+      "loading_sources": "Ładowanie źródeł gry…",
+      "browsing_examples": "Przeglądanie przykładów…",
+      "reading_example": "Czytanie przykładowej gry…",
+      "checking_staged": "Sprawdzanie przygotowanych źródeł…",
+      "checking_inbox": "Sprawdzanie notatek twórcy…",
+      "waiting_checks": "Czekanie na automatyczne testy…",
+      "reviewing_captures": "Przeglądanie zrzutów z bramki…"
+    },
     "playtestCta": "Graj z notatką",
     "live": "Na żywo",
     "shareLink": "Podziel się tą grą (tylko do oglądania):",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4884,6 +4884,23 @@ a.user-name--profile:focus-visible {
   background: linear-gradient(90deg, rgba(0, 228, 172, 0.06), var(--panel-card) 40%);
 }
 
+/* Ambient MCP thought — a headline flash in the bar, not a chat turn. */
+.studio-thread-context.is-thought .studio-context-phase {
+  color: var(--turquoise);
+  animation: studio-thought-flash 0.55s ease-out;
+}
+
+@keyframes studio-thought-flash {
+  from {
+    opacity: 0.35;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .studio-context-phase {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11168,31 +11168,6 @@ a.user-name--profile:focus-visible {
    that fed it went with it. `offered` / `opened` on the visit stream is what now
    answers whether the quieter door still gets used. */
 
-<<<<<<< HEAD
-=======
-/* The invitation's arrival: two gentle pulses, then stillness. Never mid-action
-   by construction — the reveal only fires on end/progress signals or the 60s
-   one-time timer, and reduced-motion users get no pulse at all. */
-.remix-open.is-revealed {
-  animation: remix-invite 1.6s ease-in-out 2;
-}
-
-@keyframes remix-invite {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.06);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .remix-open.is-revealed {
-    animation: none;
-  }
-}
-
 /* The way back when play owns the screen: a thin, always-visible pill at the
    top edge. Deliberately quiet, deliberately generous to a thumb — hidden
    chrome must never mean gone chrome. */

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -113,6 +113,11 @@ export type SubmissionStatus = {
    */
   lastAgentSignalAt?: string;
   /**
+   * Ambient presence thought (closed key + timestamp). Studio flashes it in the
+   * thread bar; it is not a transcript row.
+   */
+  lastAgentPresence?: { key: string; at: string };
+  /**
    * Pictures of the build, newest first. `branch` items are captures the agent
    * committed; `channel` items were pushed straight to the API and can appear long
    * before the first commit. Build the URL with {@link buildMediaUrl}.

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -108,6 +108,11 @@ export type SubmissionStatus = {
    */
   events?: BuildEvent[];
   /**
+   * Last agent activity (MCP heartbeat / progress). May advance without a new chat
+   * event when the agent is browsing the kit.
+   */
+  lastAgentSignalAt?: string;
+  /**
    * Pictures of the build, newest first. `branch` items are captures the agent
    * committed; `channel` items were pushed straight to the API and can appear long
    * before the first commit. Build the URL with {@link buildMediaUrl}.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

MCP kit-browse presence pulses from #514 were writing durable `kind: 'step'` build events (“Browsing the Creator Kit…” / “Czytanie plików…”), so they showed up as Studio chat turns between real `report_progress` rows.

### Change

- Presence refreshes `lastAgentSignalAt` (stall / connect honesty / foot heartbeat) **without** chat events
- Also stores a short-lived `lastAgentPresence` key; Studio flashes it as the thread-bar headline (e.g. “Browsing the Creator Kit…”) for ~90s, then falls back to “Writing code”
- Real `report_progress` / build events clear the thought
- Status filters leftover synthetic presence texts out of `events`
- EN/PL i18n for presence keys (includes `checking_staged` from #526)
- Rebased onto master after #526 / games #444

### Copilot review

- **Thought timer:** replaced lingering 5s interval with a single timeout at expiry ✅

### Test plan

- [x] Kit browse refreshes heartbeat + presence key without growing build events
- [x] Thought flashes in Studio foot; not a transcript turn
- [x] Real progress clears ambient thought
- [x] `isMcpPresenceEventText` recognizes old chat rows
- [x] Green gate after rebase; UI tests after timer fix

### Related

- Staged submit: #526 (merged)
- Kit packed docs for preview-first: games-repo #444 (merged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

