### PR TITLE
Make the game top bar engagement-aware

### DIFF
--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -203,15 +203,9 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
     const { slug } = singlePlayer();
     await visit(page, `/play/${slug}`, 5_000);
 
-    // The theater bar now auto-hides a few seconds into play, so the report path
-    // is reached the way a person reaches it: the peek pill is always on screen
-    // and brings the chrome back. Asserting the whole route rather than the
-    // element alone is the stronger guard — "accessible" under art. 16 is a claim
-    // about a path, and an auto-hide that swallowed the only route would pass a
-    // test that merely looked for the link.
-    const pill = page.locator('.theater-peek-btn, .theater-peek-pill');
-    await pill.waitFor({ state: 'visible', timeout: 15_000 });
-    await pill.click();
+    // The theater bar stays visible throughout play, so the report path in More
+    // never requires recovering hidden chrome first.
+    await page.locator('.game-theater-bar').waitFor({ state: 'visible' });
 
     // A mailto, not a button — the honest MVP per ReportGameButton.tsx. The four
     // headings are what makes a notice actionable under art. 16, so an empty mail

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -417,30 +417,18 @@ describe('GameTheater how-to-play visit telemetry', () => {
     setVisitSessionForTesting(null);
   });
 
-  it('hides the bar during play and restores it from the peek pill by keyboard', async () => {
+  it('keeps the theater bar visible throughout play', async () => {
     vi.useFakeTimers();
     try {
       await draw();
-      // The grace window: the bar is still there while the title registers.
       expect(container.querySelector('.game-theater-bar')).not.toBeNull();
       await act(async () => {
-        vi.advanceTimersByTime(3100);
-      });
-      // Play owns the screen; the pill is the way back.
-      expect(container.querySelector('.game-theater-bar')).toBeNull();
-      const pill = container.querySelector('.theater-peek-btn') as HTMLButtonElement | null;
-      expect(pill).not.toBeNull();
-
-      // Enter/Space on a focused button emit `click` and no pointer events at
-      // all — a pointerdown-only pill would strand a keyboard-only player with
-      // no route back to mute or exit.
-      await act(async () => {
-        pill!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        vi.advanceTimersByTime(12_000);
       });
       expect(container.querySelector('.game-theater-bar')).not.toBeNull();
-      // And the bar it brings back is the whole bar: the report path (DSA art.
-      // 16) lives in the More panel, so an auto-hide is only allowed to make it
-      // one tap deeper — never to make it unreachable.
+      expect(container.querySelector('.theater-peek-btn')).toBeNull();
+      // The report path (DSA art. 16) stays directly reachable in More without
+      // first recovering hidden chrome.
       expect(container.querySelector('a.report-btn')).not.toBeNull();
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -497,6 +497,58 @@ describe('GameTheater how-to-play visit telemetry', () => {
     }
   });
 
+  it('reveals and pins the bar at game over until the next gameplay input', async () => {
+    vi.useFakeTimers();
+    try {
+      await draw();
+      const frame = container.querySelector('iframe') as HTMLIFrameElement;
+      const bar = container.querySelector('.game-theater-bar') as HTMLElement;
+
+      await act(async () => {
+        frame.focus();
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'pointer' },
+            origin: 'null',
+          }),
+        );
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'end', outcome: 'lost' },
+            origin: 'null',
+          }),
+        );
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS * 2);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'activity' },
+            origin: 'null',
+          }),
+        );
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('records via and same-card reopen for a published play', async () => {
     await draw({ controls: 'Arrow keys to move' });
     await click(container.querySelector('.howto-btn'));

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -35,7 +35,7 @@ vi.mock('./useScreenWakeLock', () => ({
   useScreenWakeLock: () => undefined,
 }));
 
-import { GameTheater } from './GameTheater.js';
+import { GameTheater, PLAYER_CHROME_IDLE_MS } from './GameTheater.js';
 import { setVisitSessionForTesting, VisitSession, type WireVisitEvent } from './visitTelemetry.js';
 
 let container: HTMLDivElement;
@@ -417,19 +417,81 @@ describe('GameTheater how-to-play visit telemetry', () => {
     setVisitSessionForTesting(null);
   });
 
-  it('keeps the theater bar visible throughout play', async () => {
+  it('stays visible until gameplay begins, then fades after an inactivity grace period', async () => {
     vi.useFakeTimers();
     try {
       await draw();
-      expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+      const bar = container.querySelector('.game-theater-bar') as HTMLElement;
+      expect(bar.classList.contains('is-idle')).toBe(false);
       await act(async () => {
         vi.advanceTimersByTime(12_000);
       });
-      expect(container.querySelector('.game-theater-bar')).not.toBeNull();
-      expect(container.querySelector('.theater-peek-btn')).toBeNull();
+      expect(bar.classList.contains('is-idle')).toBe(false);
+
+      await act(async () => {
+        (container.querySelector('iframe') as HTMLIFrameElement).focus();
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'pointer' },
+            origin: 'null',
+          }),
+        );
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS - 1);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+      expect(bar.getAttribute('aria-hidden')).toBe('true');
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'activity' },
+            origin: 'null',
+          }),
+        );
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
       // The report path (DSA art. 16) stays directly reachable in More without
-      // first recovering hidden chrome.
+      // remounting or moving controls when chrome returns.
       expect(container.querySelector('a.report-btn')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pins the bar while one of its controls is focused', async () => {
+    vi.useFakeTimers();
+    try {
+      await draw();
+      const frame = container.querySelector('iframe') as HTMLIFrameElement;
+      const more = container.querySelector('.theater-more-btn') as HTMLButtonElement;
+      const bar = container.querySelector('.game-theater-bar') as HTMLElement;
+
+      await act(async () => {
+        frame.focus();
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'pointer' },
+            origin: 'null',
+          }),
+        );
+        more.focus();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS * 2);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
+
+      await act(async () => frame.focus());
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -446,6 +446,20 @@ describe('GameTheater how-to-play visit telemetry', () => {
       });
       expect(bar.classList.contains('is-idle')).toBe(true);
       expect(bar.getAttribute('aria-hidden')).toBe('true');
+      const reveal = container.querySelector('.theater-reveal-btn') as HTMLButtonElement | null;
+      expect(reveal).not.toBeNull();
+      expect(reveal!.getAttribute('aria-label')).toBe('Show controls');
+
+      await act(async () => {
+        reveal!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(bar.classList.contains('is-idle')).toBe(false);
+      expect(container.querySelector('.theater-reveal-btn')).toBeNull();
+      await act(async () => {
+        vi.advanceTimersByTime(PLAYER_CHROME_IDLE_MS);
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+      expect(container.querySelector('.theater-reveal-btn')).not.toBeNull();
 
       await act(async () => {
         window.dispatchEvent(
@@ -456,6 +470,7 @@ describe('GameTheater how-to-play visit telemetry', () => {
         );
       });
       expect(bar.classList.contains('is-idle')).toBe(false);
+      expect(container.querySelector('.theater-reveal-btn')).toBeNull();
       // The report path (DSA art. 16) stays directly reachable in More without
       // remounting or moving controls when chrome returns.
       expect(container.querySelector('a.report-btn')).not.toBeNull();

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -93,6 +93,10 @@ type GameTheaterProps = {
   touch?: CatalogTouch | null;
 };
 
+// Long enough that the bar never reacts like a hover tooltip, short enough to clear
+// the playfield once somebody has demonstrably started playing.
+export const PLAYER_CHROME_IDLE_MS = 3200;
+
 /**
  * True while a handheld is held the wrong way round for this game.
  *
@@ -144,6 +148,10 @@ export function GameTheater({
   const moreRef = useRef<HTMLDivElement | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
   const [howToOpen, setHowToOpen] = useState(false);
+  const [playerEngaged, setPlayerEngaged] = useState(false);
+  const [chromeIdle, setChromeIdle] = useState(false);
+  const [activityVersion, setActivityVersion] = useState(0);
+  const [chromeHeld, setChromeHeld] = useState(false);
   /**
    * The always-available doors to Remix and its painter (ops repo,
    * remix-content-editing-plan §3.1): nonces the menu bumps, threaded down to
@@ -193,6 +201,12 @@ export function GameTheater({
   const moreOpenRef = useRef(moreOpen);
   moreOpenRef.current = moreOpen;
 
+  const notePlayerActivity = useCallback(() => {
+    setPlayerEngaged(true);
+    setChromeIdle(false);
+    setActivityVersion((version) => version + 1);
+  }, []);
+
   // Closing hands focus to the game, not back to the trigger. In a player the next key
   // press is meant for the game: leaving focus on the button turns the next Space into
   // "reopen the card" instead of "fire".
@@ -212,7 +226,7 @@ export function GameTheater({
   // Escape is handled twice on purpose: the window listener below covers the app's
   // own chrome, and this covers the game iframe, which holds focus while playing
   // and swallows its own key events.
-  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore);
+  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore, notePlayerActivity);
 
   // What the game says about itself, falling back to what the catalog says about it.
   // Derived every render rather than memoized on first value, because both sources
@@ -319,6 +333,18 @@ export function GameTheater({
     setHowToOpen(false);
   }, [fullscreen]);
 
+  // Media-player convention, but gated on real game input: chrome never vanishes while
+  // somebody is still orienting themselves. Once play begins, each activity gets a
+  // calm grace period. Hover/focus and open control surfaces pin the bar in place.
+  useEffect(() => {
+    if (!playerEngaged || chromeHeld || moreOpen || howToOpen || fullscreen) {
+      setChromeIdle(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setChromeIdle(true), PLAYER_CHROME_IDLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [activityVersion, chromeHeld, fullscreen, howToOpen, moreOpen, playerEngaged]);
+
   const toggleFullscreen = useCallback(() => {
     if (document.fullscreenElement) {
       void document.exitFullscreen().catch(() => undefined);
@@ -346,6 +372,7 @@ export function GameTheater({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      notePlayerActivity();
       if (event.key === 'Escape') {
         // Innermost surface first: the card, then the menu, then leaving the game.
         if (howToOpenRef.current) {
@@ -361,7 +388,7 @@ export function GameTheater({
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [requestExit, closeHowTo]);
+  }, [requestExit, closeHowTo, notePlayerActivity]);
 
   // Close the overflow menu on an outside tap — phones have no hover to dismiss it.
   // Same-document chrome uses pointerdown here. Taps on the sandboxed game are
@@ -522,16 +549,25 @@ export function GameTheater({
 
   return (
     <section
-      className={`panel stage is-playing-full-viewport${fullscreen ? ' is-native-fullscreen' : ''}`}
+      className={`panel stage is-playing-full-viewport${fullscreen ? ' is-native-fullscreen' : ''}${chromeIdle ? ' is-player-idle' : ''}`}
       role="dialog"
       aria-modal="true"
       aria-label={displayTitle}
       ref={stageRef}
     >
-      {/* Native fullscreen is the explicit immersive mode. Otherwise the bar stays
-          visible so mute, game details, More, and Exit never move or disappear. */}
+      {/* Native fullscreen is the explicit immersive mode. Normal play keeps the bar
+          mounted in a stable location and fades it only after demonstrated activity. */}
       {!fullscreen && (
-        <div className="game-theater-bar">
+        <div
+          className={`game-theater-bar${chromeIdle ? ' is-idle' : ''}`}
+          aria-hidden={chromeIdle}
+          onPointerEnter={() => setChromeHeld(true)}
+          onPointerLeave={() => setChromeHeld(false)}
+          onFocusCapture={() => setChromeHeld(true)}
+          onBlurCapture={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setChromeHeld(false);
+          }}
+        >
           <div className="game-theater-meta">
             <span className="theater-badge" title={t('ai.generatedTooltip')}>
               <PixelIcon name={badge.icon} size={12} /> {badge.label}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -207,6 +207,13 @@ export function GameTheater({
     setActivityVersion((version) => version + 1);
   }, []);
 
+  const notePlayerEnd = useCallback(() => {
+    // A terminal screen is another orientation moment: surface exit/feedback/remix
+    // controls and keep them there until the next round begins with fresh input.
+    setPlayerEngaged(false);
+    setChromeIdle(false);
+  }, []);
+
   // Closing hands focus to the game, not back to the trigger. In a player the next key
   // press is meant for the game: leaving focus on the button turns the next Space into
   // "reopen the card" instead of "fire".
@@ -226,7 +233,7 @@ export function GameTheater({
   // Escape is handled twice on purpose: the window listener below covers the app's
   // own chrome, and this covers the game iframe, which holds focus while playing
   // and swallows its own key events.
-  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore, notePlayerActivity);
+  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore, notePlayerActivity, notePlayerEnd);
 
   // What the game says about itself, falling back to what the catalog says about it.
   // Derived every render rather than memoized on first value, because both sources

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -564,6 +564,20 @@ export function GameTheater({
     >
       {/* Native fullscreen is the explicit immersive mode. Normal play keeps the bar
           mounted in a stable location and fades it only after demonstrated activity. */}
+      {!fullscreen && chromeIdle && (
+        <button
+          type="button"
+          className="theater-reveal-btn"
+          aria-label={t('player.showControls')}
+          title={t('player.showControls')}
+          // Pointerdown makes the control immediate on touch. Click keeps the same
+          // route available to Enter/Space, which do not emit pointer events.
+          onPointerDown={notePlayerActivity}
+          onClick={notePlayerActivity}
+        >
+          <PixelIcon name="chevronDown" size={15} />
+        </button>
+      )}
       {!fullscreen && (
         <div
           className={`game-theater-bar${chromeIdle ? ' is-idle' : ''}`}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -209,84 +209,10 @@ export function GameTheater({
     requestExit();
   }, [requestExit, closeHowTo]);
 
-  /**
-   * Chrome auto-hide (ops repo realtime plan §D.11.6): during play the screen is
-   * pure game; the bar returns at the natural pauses — a finished run, top edge hover,
-   * or the always-visible top-right peek button. One rule, shared with the remix reveal:
-   * chrome appears in the gaps, never mid-action. Hidden must never mean gone — the
-   * button is one tap from mute and exit, and reveal fires on pointerdown so a
-   * phone gets it without the click delay.
-   */
-  const [chromeHidden, setChromeHidden] = useState(false);
-  const rehideTimerRef = useRef<number | null>(null);
-  const revealChrome = useCallback((rehideAfterMs?: number) => {
-    setChromeHidden(false);
-    if (rehideTimerRef.current !== null) window.clearTimeout(rehideTimerRef.current);
-    rehideTimerRef.current =
-      rehideAfterMs === undefined ? null : window.setTimeout(() => setChromeHidden(true), rehideAfterMs);
-  }, []);
-
-  const handleTopHover = useCallback(() => revealChrome(2500), [revealChrome]);
-
   // Escape is handled twice on purpose: the window listener below covers the app's
   // own chrome, and this covers the game iframe, which holds focus while playing
   // and swallows its own key events.
-  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore, handleTopHover);
-
-  // Desktop mouse proximity: moving the cursor near the top edge unveils the topbar.
-  useEffect(() => {
-    const onMouseMove = (e: MouseEvent) => {
-      if (e.clientY > 0 && e.clientY <= 48) {
-        revealChrome(2500);
-      }
-    };
-    window.addEventListener('mousemove', onMouseMove, { passive: true });
-    return () => window.removeEventListener('mousemove', onMouseMove);
-  }, [revealChrome]);
-
-  // Mobile touch swipe-down: pulling down from near the top edge unveils the topbar.
-  useEffect(() => {
-    let touchStartY = 0;
-    const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length > 0) touchStartY = e.touches[0].clientY;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      if (e.touches.length > 0) {
-        const currentY = e.touches[0].clientY;
-        if (touchStartY <= 60 && currentY - touchStartY > 20) {
-          revealChrome();
-        }
-      }
-    };
-    const stage = stageRef.current;
-    if (!stage) return;
-    stage.addEventListener('touchstart', onTouchStart, { passive: true });
-    stage.addEventListener('touchmove', onTouchMove, { passive: true });
-    return () => {
-      stage.removeEventListener('touchstart', onTouchStart);
-      stage.removeEventListener('touchmove', onTouchMove);
-    };
-  }, [revealChrome]);
-
-  useEffect(() => {
-    // Play start: a short grace so the title/author register, then the game owns
-    // the screen. A finished run hands the controls back for a while — the same
-    // beat the remix invitation uses — and then play takes over again.
-    const grace = window.setTimeout(() => setChromeHidden(true), 3000);
-    function onMessage(event: MessageEvent) {
-      if (event.origin !== 'null') return;
-      const frame = frameRef.current;
-      if (!frame || event.source !== frame.contentWindow) return;
-      const data = event.data as { source?: string; type?: string } | null;
-      if (data?.source === 'gdpl-player' && data.type === 'end') revealChrome(8000);
-    }
-    window.addEventListener('message', onMessage);
-    return () => {
-      window.clearTimeout(grace);
-      window.removeEventListener('message', onMessage);
-      if (rehideTimerRef.current !== null) window.clearTimeout(rehideTimerRef.current);
-    };
-  }, [frameRef, revealChrome]);
+  const player = useGamePlayer(frameRef, true, escapeOrExit, dismissMore);
 
   // What the game says about itself, falling back to what the catalog says about it.
   // Derived every render rather than memoized on first value, because both sources
@@ -602,26 +528,9 @@ export function GameTheater({
       aria-label={displayTitle}
       ref={stageRef}
     >
-      {/* Fullscreen hides the bar so the game owns the screen; so does play
-          itself now (chromeHidden), with the peek pill as the way back. Votes
-          stay on the bar when it's visible; secondary actions stay in More. */}
-      {!fullscreen && chromeHidden && (
-        <button
-          type="button"
-          className="theater-peek-btn"
-          aria-label={t('player.showControls')}
-          title={t('player.showControls')}
-          // Both: pointerdown for a touch that should not wait for the click,
-          // click for Enter/Space — which never emit pointer events, and this
-          // button is the only way back to mute and exit once the bar is hidden.
-          // revealChrome is idempotent, so the pair firing together is a no-op.
-          onPointerDown={() => revealChrome()}
-          onClick={() => revealChrome()}
-        >
-          <PixelIcon name="menu" size={14} />
-        </button>
-      )}
-      {!fullscreen && !chromeHidden && (
+      {/* Native fullscreen is the explicit immersive mode. Otherwise the bar stays
+          visible so mute, game details, More, and Exit never move or disappear. */}
+      {!fullscreen && (
         <div className="game-theater-bar">
           <div className="game-theater-meta">
             <span className="theater-badge" title={t('ai.generatedTooltip')}>

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -121,6 +121,24 @@ describe('the injected bridge reports health', () => {
     bridge.stop();
   });
 
+  it('reports activity only after real game input establishes engagement', async () => {
+    const bridge = runBridge('<canvas id="game"></canvas>');
+
+    bridge.frameWindow.dispatchEvent(new bridge.frameWindow.PointerEvent('pointermove'));
+    await delivered();
+    expect(bridge.received.filter((m) => m.type === 'activity')).toHaveLength(0);
+
+    bridge.frameWindow.dispatchEvent(new bridge.frameWindow.KeyboardEvent('keydown', { key: 'w' }));
+    await delivered();
+    expect(bridge.received.filter((m) => m.type === 'activity').map((m) => m.source)).toEqual(['gdpl-player']);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    bridge.frameWindow.dispatchEvent(new bridge.frameWindow.PointerEvent('pointermove'));
+    await delivered();
+    expect(bridge.received.filter((m) => m.type === 'activity')).toHaveLength(2);
+    bridge.stop();
+  });
+
   it('cancels contextmenu and selectstart so iOS cannot open the callout over the game', () => {
     const bridge = runBridge('<canvas id="game"></canvas>');
 

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -26,13 +26,16 @@ const PLAYER = 'gdpl-player';
 //      without covering the playfield — parent document listeners never see taps
 //      inside this opaque-origin frame, and focus tricks don't fire reliably on
 //      mobile either. Report-only: the game still gets the same pointer event;
-//   6. reports health — uncaught errors and animation-frame liveness. This is the
+//   6. reports player activity so host chrome can follow the familiar media-player
+//      pattern: stay put until play begins, then fade after a quiet grace period and
+//      return as soon as the player moves or presses a control;
+//   7. reports health — uncaught errors and animation-frame liveness. This is the
 //      only vantage point that has them: the game runs in an opaque origin the app
 //      cannot inspect, and its CSP blocks every way it could report for itself. An
 //      uncaught error is the single most reliable "this published game is broken"
 //      signal we can get, and `frames: 0` while on screen distinguishes a stalled
 //      game from a hard game (docs/improvement-loop-plan.md IL-1);
-//   7. reports the game's own account of its controls, for the player's How-to-play
+//   8. reports the game's own account of its controls, for the player's How-to-play
 //      card. Job 1 is exactly why this is needed: the card is host chrome because the
 //      game's `.game-controls` and `.hint` are hidden here, and an opaque origin means
 //      the host cannot read them for itself. The alternative — the catalog's `controls`
@@ -311,11 +314,34 @@ const BRIDGE = `(function(){
     else if(m.type==='resume'){setPaused(false);}
     else if(m.type==='capture'){sendSnapshot('capture');}
   });
+  var playerEngaged=false,lastActivity=0;
+  function reportActivity(force){
+    if(force)playerEngaged=true;
+    if(!playerEngaged)return;
+    var now=Date.now();
+    if(now-lastActivity<250)return;
+    lastActivity=now;
+    post({type:'activity'});
+  }
   addEventListener('keydown',function(e){
     // Report only — the game keeps its own Escape handling (pause menus etc).
     if(e.key==='Escape'){post({type:'key',key:'Escape'});}
+    else{reportActivity(true);}
   });
-  addEventListener('pointerdown',function(){post({type:'pointer'});},{passive:true});
+  function playerPointerDown(){playerEngaged=true;lastActivity=Date.now();post({type:'pointer'});}
+  function playerPointerMove(){reportActivity(false);}
+  if(typeof PointerEvent==='function'){
+    addEventListener('pointerdown',playerPointerDown,{passive:true});
+    // Movement is meaningful only after a click/tap or key has established that the
+    // pointer belongs to a player, not a cursor that happened to rest over the frame.
+    addEventListener('pointermove',playerPointerMove,{passive:true});
+  }else{
+    // Older/restricted WebViews may expose only the pre-Pointer Events APIs.
+    addEventListener('mousedown',playerPointerDown,{passive:true});
+    addEventListener('mousemove',playerPointerMove,{passive:true});
+    addEventListener('touchstart',playerPointerDown,{passive:true});
+    addEventListener('touchmove',playerPointerMove,{passive:true});
+  }
   // iOS Safari: long-press on the canvas opens the callout (Copy / Translate / Look Up)
   // and the text-selection loupe ("mini zoom"). CSS covers most of it; these kill the
   // remaining native handlers. Games have no selectable document chrome in the player.
@@ -547,6 +573,8 @@ export function useGamePlayer(
   onEscape?: () => void,
   /** Called on pointerdown inside the game (see the bridge's job 5). */
   onPointer?: () => void,
+  /** Called on meaningful player input and subsequent pointer movement (job 6). */
+  onActivity?: () => void,
 ) {
   const [meta, setMeta] = useState<GamePlayerMeta | null>(null);
   const [controls, setControls] = useState<ReportedControls | null>(null);
@@ -557,6 +585,8 @@ export function useGamePlayer(
   onEscapeRef.current = onEscape;
   const onPointerRef = useRef(onPointer);
   onPointerRef.current = onPointer;
+  const onActivityRef = useRef(onActivity);
+  onActivityRef.current = onActivity;
 
   useEffect(() => {
     if (!active) {
@@ -597,6 +627,9 @@ export function useGamePlayer(
         onEscapeRef.current?.();
       } else if (data.type === 'pointer') {
         onPointerRef.current?.();
+        onActivityRef.current?.();
+      } else if (data.type === 'activity') {
+        onActivityRef.current?.();
       }
     }
     window.addEventListener('message', onMessage);

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -575,6 +575,8 @@ export function useGamePlayer(
   onPointer?: () => void,
   /** Called on meaningful player input and subsequent pointer movement (job 6). */
   onActivity?: () => void,
+  /** Called when the game reports a terminal round state. */
+  onEnd?: () => void,
 ) {
   const [meta, setMeta] = useState<GamePlayerMeta | null>(null);
   const [controls, setControls] = useState<ReportedControls | null>(null);
@@ -587,6 +589,8 @@ export function useGamePlayer(
   onPointerRef.current = onPointer;
   const onActivityRef = useRef(onActivity);
   onActivityRef.current = onActivity;
+  const onEndRef = useRef(onEnd);
+  onEndRef.current = onEnd;
 
   useEffect(() => {
     if (!active) {
@@ -630,6 +634,8 @@ export function useGamePlayer(
         onActivityRef.current?.();
       } else if (data.type === 'activity') {
         onActivityRef.current?.();
+      } else if (data.type === 'end') {
+        onEndRef.current?.();
       }
     }
     window.addEventListener('message', onMessage);

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -316,7 +316,6 @@ const BRIDGE = `(function(){
     if(e.key==='Escape'){post({type:'key',key:'Escape'});}
   });
   addEventListener('pointerdown',function(){post({type:'pointer'});},{passive:true});
-  addEventListener('mousemove',function(e){if(e.clientY<=48){post({type:'topHover'});}},{passive:true});
   // iOS Safari: long-press on the canvas opens the callout (Copy / Translate / Look Up)
   // and the text-selection loupe ("mini zoom"). CSS covers most of it; these kill the
   // remaining native handlers. Games have no selectable document chrome in the player.
@@ -548,8 +547,6 @@ export function useGamePlayer(
   onEscape?: () => void,
   /** Called on pointerdown inside the game (see the bridge's job 5). */
   onPointer?: () => void,
-  /** Called when mouse moves into top region inside the game. */
-  onTopHover?: () => void,
 ) {
   const [meta, setMeta] = useState<GamePlayerMeta | null>(null);
   const [controls, setControls] = useState<ReportedControls | null>(null);
@@ -560,8 +557,6 @@ export function useGamePlayer(
   onEscapeRef.current = onEscape;
   const onPointerRef = useRef(onPointer);
   onPointerRef.current = onPointer;
-  const onTopHoverRef = useRef(onTopHover);
-  onTopHoverRef.current = onTopHover;
 
   useEffect(() => {
     if (!active) {
@@ -602,8 +597,6 @@ export function useGamePlayer(
         onEscapeRef.current?.();
       } else if (data.type === 'pointer') {
         onPointerRef.current?.();
-      } else if (data.type === 'topHover') {
-        onTopHoverRef.current?.();
       }
     }
     window.addEventListener('message', onMessage);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -139,6 +139,7 @@
     "share": "Share",
     "shareCopied": "Link copied",
     "moreActions": "More actions",
+    "showControls": "Show controls",
     "byAuthor": "by {{author}}",
     "byAuthorPrefix": "by ",
     "vote": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -164,8 +164,7 @@
     "howToPlayDismiss": "Press Escape, or click or tap anywhere outside, to close",
     "howToPlayTouch": "Touch",
     "howToPlayTouchPad": "On-screen pad on touch screens",
-    "howToPlayOther": "Control",
-    "showControls": "Show controls"
+    "howToPlayOther": "Control"
   },
   "catalog": {
     "title": "Games",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -164,8 +164,7 @@
     "howToPlayDismiss": "Naciśnij Escape lub kliknij obok, aby zamknąć",
     "howToPlayTouch": "Dotyk",
     "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych",
-    "howToPlayOther": "Sterowanie",
-    "showControls": "Pokaż sterowanie"
+    "howToPlayOther": "Sterowanie"
   },
   "catalog": {
     "title": "Gry",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -139,6 +139,7 @@
     "share": "Udostępnij",
     "shareCopied": "Skopiowano link",
     "moreActions": "Więcej działań",
+    "showControls": "Pokaż sterowanie",
     "byAuthor": "autor: {{author}}",
     "byAuthorPrefix": "autor: ",
     "vote": {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1655,6 +1655,43 @@ body.player-open {
   transition-delay: 0s, 0s, 700ms;
 }
 
+/* Even at full immersion, chrome is never gone: this quiet thumb-sized door replaces
+   the bar's top-right control as it fades and brings the complete bar back in one tap. */
+.theater-reveal-btn {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: max(12px, env(safe-area-inset-right));
+  z-index: 11;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  background: rgba(12, 18, 24, 0.62);
+  color: rgba(255, 255, 255, 0.8);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  opacity: 0.78;
+  transition:
+    opacity 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+
+.theater-reveal-btn:hover,
+.theater-reveal-btn:focus-visible {
+  opacity: 1;
+  background: rgba(20, 29, 38, 0.86);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: scale(1.04);
+}
+
 .game-theater-meta {
   display: flex;
   align-items: center;
@@ -1664,7 +1701,8 @@ body.player-open {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .game-theater-bar {
+  .game-theater-bar,
+  .theater-reveal-btn {
     transition: none;
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11185,48 +11185,6 @@ a.user-name--profile:focus-visible {
    that fed it went with it. `offered` / `opened` on the visit stream is what now
    answers whether the quieter door still gets used. */
 
-/* The way back when play owns the screen: a thin, always-visible pill at the
-   top edge. Deliberately quiet, deliberately generous to a thumb — hidden
-   chrome must never mean gone chrome. */
-.theater-peek-btn,
-.theater-peek-pill {
-  position: absolute;
-  top: max(12px, env(safe-area-inset-top));
-  right: max(12px, env(safe-area-inset-right));
-  z-index: 6;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 8px;
-  background: rgba(15, 23, 42, 0.7);
-  color: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  transition:
-    background 0.15s ease,
-    color 0.15s ease,
-    transform 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-.theater-peek-btn:hover,
-.theater-peek-btn:focus-visible,
-.theater-peek-pill:hover,
-.theater-peek-pill:focus-visible {
-  background: rgba(30, 41, 59, 0.9);
-  color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.4);
-  transform: scale(1.06);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-}
-
 /* —— Creator profiles —— */
 .creator-profile-page {
   max-width: 720px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1635,6 +1635,24 @@ body.player-open {
      look broken — the panel opens but nothing appears. */
   overflow: visible;
   z-index: 10;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition:
+    opacity 700ms ease,
+    transform 700ms ease,
+    visibility 0s linear 0s;
+  will-change: opacity, transform;
+}
+
+.game-theater-bar.is-idle {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  pointer-events: none;
+  /* Remove it from hit-testing immediately, but from rendering only after the fade.
+     Returning activity uses the base rule's zero delay and reveals it at once. */
+  transition-delay: 0s, 0s, 700ms;
 }
 
 .game-theater-meta {
@@ -1643,6 +1661,12 @@ body.player-open {
   gap: 12px;
   min-width: 0;
   flex: 1 1 auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-theater-bar {
+    transition: none;
+  }
 }
 
 /* Quiet AI Act disclosure — present, not a neon brand mark next to the title. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1609,10 +1609,14 @@ body.player-open {
   -webkit-tap-highlight-color: transparent;
 }
 
-/* The safe-area insets below are what keep the bar's controls and the game itself
-   clear of a notch, a rounded corner, or the home indicator now that the page opts
-   into the full screen with viewport-fit=cover. They resolve to 0 everywhere else. */
+/* The bar floats over the game instead of taking a flex row away from it. Its safe-area
+   insets keep controls clear of a notch or rounded corner; the game remains full-bleed
+   underneath, with its own side/bottom insets below. */
 .game-theater-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1620,16 +1624,17 @@ body.player-open {
   padding-top: max(12px, env(safe-area-inset-top));
   padding-left: max(24px, env(safe-area-inset-left));
   padding-right: max(24px, env(safe-area-inset-right));
-  background: rgba(18, 24, 30, 0.95);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--panel-border);
+  background: rgba(12, 18, 24, 0.72);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
   width: 100%;
   flex: none;
   /* The overflow menu hangs below the bar; clipping it would make the hamburger
      look broken — the panel opens but nothing appears. */
   overflow: visible;
-  z-index: 2;
+  z-index: 10;
 }
 
 .game-theater-meta {
@@ -1982,9 +1987,8 @@ body.player-open {
   width: 100%;
   /* Positioning context for the rotate hint / camera backdrop that overlay the game. */
   position: relative;
-  /* `height: 100%` here would resolve against the stage and ignore the header bar,
-     overflowing the game off the bottom of a short (landscape phone) viewport.
-     `flex: 1` with min-height:0 gives it exactly the space the bar leaves. */
+  /* The header is absolutely positioned, so this flex child receives the entire
+     theater instead of only the height left below the controls. */
   min-height: 0;
   display: flex;
   align-items: center;
@@ -2022,7 +2026,8 @@ body.player-open {
 
 .theater-camera-indicator {
   position: absolute;
-  top: max(12px, env(safe-area-inset-top));
+  /* Clear the floating bar while staying attached to the full-height game surface. */
+  top: calc(max(12px, env(safe-area-inset-top)) + 58px);
   left: max(12px, env(safe-area-inset-left));
   z-index: 2;
   display: inline-flex;
@@ -2119,8 +2124,8 @@ body.player-open {
 /* MOBILE GAME THEATER
    Two independent squeezes. Narrow (portrait phone): the bar can't fit three
    labelled buttons plus a description, so labels and secondary text go. Short
-   (landscape phone, ~380px tall): every pixel the bar takes is a pixel the game
-   doesn't get, so it shrinks to a thin strip. A landscape phone hits both. */
+   (landscape phone, ~380px tall): the overlay shrinks so it obscures less of the
+   game. A landscape phone hits both. */
 @media (max-width: 768px) {
   .game-theater-bar {
     padding: 8px 12px;
@@ -2174,6 +2179,10 @@ body.player-open {
     gap: 6px;
   }
 
+  .theater-camera-indicator {
+    top: calc(max(8px, env(safe-area-inset-top)) + 57px);
+  }
+
   /* Phone: sound + fullscreen leave the bar and appear as menu rows instead. */
   .theater-desktop-chrome {
     display: none !important;
@@ -2210,6 +2219,10 @@ body.player-open {
 
   .theater-title {
     font-size: 0.85rem;
+  }
+
+  .theater-camera-indicator {
+    top: calc(max(4px, env(safe-area-inset-top)) + 45px);
   }
 
   /* Shrink bar chrome only — leave the overflow menu rows at their thumb target. */

--- a/apps/web/src/styles.gameTheater.test.ts
+++ b/apps/web/src/styles.gameTheater.test.ts
@@ -31,4 +31,15 @@ describe('game theater floating bar', () => {
     expect(bar).toMatch(/background:\s*rgba\(12,\s*18,\s*24,\s*0\.72\)/);
     expect(bar).toMatch(/backdrop-filter:\s*blur\(16px\)/);
   });
+
+  it('fades slowly and becomes non-interactive once the player is idle', () => {
+    const bar = ruleBody('.game-theater-bar');
+    const idle = ruleBody('.game-theater-bar.is-idle');
+
+    expect(bar).toMatch(/opacity\s+700ms\s+ease/);
+    expect(idle).toMatch(/opacity:\s*0/);
+    expect(idle).toMatch(/visibility:\s*hidden/);
+    expect(idle).toMatch(/pointer-events:\s*none/);
+    expect(idle).toMatch(/transition-delay:\s*0s,\s*0s,\s*700ms/);
+  });
 });

--- a/apps/web/src/styles.gameTheater.test.ts
+++ b/apps/web/src/styles.gameTheater.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8').replace(
+  /\/\*[\s\S]*?\*\//g,
+  '',
+);
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`(?:^|})\\s*${escaped}\\s*\\{([^}]+)\\}`, 'm').exec(css);
+  expect(match, `no ${selector} rule in styles.css`).not.toBeNull();
+  return match![1]!;
+}
+
+describe('game theater floating bar', () => {
+  it('overlays the full-height game instead of taking a flex row', () => {
+    const bar = ruleBody('.game-theater-bar');
+
+    expect(bar).toMatch(/position:\s*absolute/);
+    expect(bar).toMatch(/top:\s*0/);
+    expect(bar).toMatch(/left:\s*0/);
+    expect(bar).toMatch(/right:\s*0/);
+    expect(ruleBody('.game-viewport-container')).toMatch(/flex:\s*1/);
+  });
+
+  it('keeps the game visible through a blurred, translucent surface', () => {
+    const bar = ruleBody('.game-theater-bar');
+
+    expect(bar).toMatch(/background:\s*rgba\(12,\s*18,\s*24,\s*0\.72\)/);
+    expect(bar).toMatch(/backdrop-filter:\s*blur\(16px\)/);
+  });
+});

--- a/apps/web/src/styles.gameTheater.test.ts
+++ b/apps/web/src/styles.gameTheater.test.ts
@@ -42,4 +42,15 @@ describe('game theater floating bar', () => {
     expect(idle).toMatch(/pointer-events:\s*none/);
     expect(idle).toMatch(/transition-delay:\s*0s,\s*0s,\s*700ms/);
   });
+
+  it('leaves a quiet thumb-sized route back to the complete bar', () => {
+    const reveal = ruleBody('.theater-reveal-btn');
+
+    expect(reveal).toMatch(/position:\s*absolute/);
+    expect(reveal).toMatch(/top:\s*max\(12px,\s*env\(safe-area-inset-top\)\)/);
+    expect(reveal).toMatch(/right:\s*max\(12px,\s*env\(safe-area-inset-right\)\)/);
+    expect(reveal).toMatch(/width:\s*44px/);
+    expect(reveal).toMatch(/height:\s*44px/);
+    expect(reveal).toMatch(/background:\s*rgba\(12,\s*18,\s*24,\s*0\.62\)/);
+  });
 });


### PR DESCRIPTION
## Summary

- float the game theater nav over the full-height playfield instead of reserving a layout row
- keep it visible while the player is orienting themselves
- after real gameplay input, fade it over 700ms following 3.2 seconds of inactivity
- leave a quiet 44×44 semi-transparent chevron in the top-right after the full bar fades
- restore the full controls immediately when that button is tapped, clicked, or keyboard-activated
- reveal the bar on renewed keyboard or pointer activity and pin it when the game reports a terminal round state
- pin it while the nav is hovered/focused or More/How to play is open
- preserve explicit native fullscreen as the fully immersive mode
- support pointer events plus mouse/touch fallbacks for restricted and older WebViews
- replace the previous mouseout-driven behavior with deterministic engagement-aware fading

## Why

The old hover/mouseout behavior hid controls too eagerly and felt unpredictable. Making the bar permanently visible fixed that interaction but left unnecessary chrome over the game. This follows the familiar media-player convention while adding a game-specific engagement gate: nothing fades until the player has actually started playing, and the compact reveal control means navigation is never completely hidden.

## User impact

The game keeps the entire viewport. Controls stay stable and discoverable at first, clear most of the playfield after engagement, and remain one obvious tap away on both desktop and mobile. The full bar also returns with renewed activity or at game over and never disappears while somebody is using it.

## Validation

- full repository gate after rebasing onto current `master`: `npm run type-check && npm run lint && npm run test && npm run build`
- focused theater/bridge/CSS/i18n suite: 48 tests passed
- browser-checked the final reveal state and restoration behavior at 1280×720 and 390×844
- verified the reveal control is 44×44, stays top-right, and restores the complete bar immediately
- previously verified the full-height stage, delayed fade, keyboard reveal, open-menu pinning, terminal-state pinning, and short-landscape overflow behavior
- `prefers-reduced-motion` disables the transition

## Instrumentation

None of the seven measurement questions changes. Existing play telemetry still answers per-game load, focused play-time, health, progress, score, and end queries; the engagement and reveal interactions stay local to presentation logic and are not persisted or joined to either telemetry stream.
