### PR TITLE
Increase platform byte ceiling to 313KB to support carjack-city

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -26,8 +26,8 @@
     "editor"
   ],
   "authorBudgetBytes": 204800,
-  "platformCeilingBytes": 281587,
-  "maxProjectBytes": 486387,
+  "platformCeilingBytes": 313000,
+  "maxProjectBytes": 517800,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(486_387);
+    expect(MAX_PROJECT_BYTES).toBe(517_800);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -13,7 +13,7 @@ import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(486_387);
+    expect(MAX_PROJECT_BYTES).toBe(517_800);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -93,7 +93,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 281_587;
+      const GAMEKIT_PLATFORM_BYTES = 313_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -103,7 +103,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 268_526;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 299_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -67,7 +67,7 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (486_387, matching `maxProjectBytes`). Not a round KiB.
+ * (517_800, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -76,11 +76,23 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by the opt-in `editor` module (EditorKit L2): +3_700 measured,
- * 482_687 → 486_387. Before it, sensing Phase 2 (camera backdrop) raised the sensing
- * ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
+ * Last moved by `carjack-city`'s open-world work: measured platform bytes for its
+ * (2D, non-gfx3d) module selection are 312_583, so 281_587 no longer covered a game
+ * that comfortably clears the author gate — carjack assembles to 493_433 of which
+ * 180_850 is author payload, 88% of the 200 KiB budget. 281_587 → 313_000, and the
+ * serve cap 486_387 → 517_800.
+ *
+ * The drift this corrects is older and larger than that change: the constant has
+ * never tracked the heaviest selection. `apex-sprint` (gfx3d) already measures
+ * 434_497 platform bytes and passes only because its author payload is small. Sized
+ * here to the heaviest 2D selection rather than to gfx3d, which would put the
+ * backstop above 639 KB and stop it backstopping anything.
+ *
+ * Before it, the opt-in `editor` module (EditorKit L2): +3_700 measured,
+ * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
+ * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
  */
-export const GAMEKIT_PLATFORM_BYTES = 281_587;
+export const GAMEKIT_PLATFORM_BYTES = 313_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
Raises `GAMEKIT_PLATFORM_BYTES` from 281,587 to 313,000, moving the serve cap from 486,387 to 517,800.

> [!IMPORTANT]
> **Merge this before `gamedevpl/www.gamedev.pl-games#448`.** That branch asserts the same numbers; if the games side lands first, play/draft 502s. This change is safe to merge on its own — raising a ceiling cannot reject a game that passed before.

## Why

`carjack-city`'s open-world work assembles to 493,433 bytes, of which **180,850 is author payload — 88% of the 200 KiB author budget**. It comfortably clears the gate that actually governs game design, but the *total* sat over the serve cap.

The cap was stale rather than tight. Measured platform bytes for carjack's (2D, non-`gfx3d`) module selection are **312,583** against a declared 281,587, and that drift predates this work: **`apex-sprint` already measures 434,497** platform bytes and passes only because its author payload is small. This constant has never tracked the heaviest selection.

Sized to the heaviest 2D selection rather than to `gfx3d`, which would put the backstop above 639 KB and stop it backstopping anything. That matches how the number has always been moved, and what its own doc comment prescribes: raise it when measurement shows a passing game would exceed it, and keep it one derived ceiling rather than a sum of per-feature allowances.

## Changes

- `GAMEKIT_PLATFORM_BYTES` 281,587 → 313,000; `MAX_PROJECT_BYTES` 486,387 → 517,800
- Vendored `assemble-contract.json` fixture moved in lockstep
- Two contract fixtures carried the old total. The summed-parts case is now `7_501 + 5_560 + 299_939`, which still exercises the extractor's `a + b` resolution and still sums to 313,000

Verified: `apps/api/src/games-repo-contract.test.ts` and `assemble.test.ts`, 17 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xy1dTmEwUNkULkbmKwFUjv