### PR TITLE
Add the urban GameKit vertical contract

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -7,6 +7,7 @@
     "world",
     "ai",
     "gameplay",
+    "urban",
     "drawing",
     "actors",
     "gfx",

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -81,7 +81,7 @@ describe('runGamesRepoContractCheck', () => {
   it('allows a short-lived website-first module rollout', async () => {
     // Website-first adds: GAME_KIT_MODULES here already includes these modules, but
     // main's assemble.ts may still list the older order. That window must stay green.
-    const aheadModules = new Set(['football']);
+    const aheadModules = new Set(['football', 'urban']);
     const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => !aheadModules.has(name));
     const olderAssemble = `
       const GAME_KIT_MODULES = [${withoutAheadExtras.map((name) => `'${name}'`).join(', ')}];

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -246,6 +246,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   // as soon as its paired games change lands; the deadline is the fail-closed backstop.
   const WEBSITE_AHEAD_EXPIRY: ReadonlyMap<string, number> = new Map([
     ['football', Date.parse('2026-08-10T00:00:00.000Z')],
+    ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const now = options.now?.() ?? Date.now();

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -48,6 +48,7 @@ describe('games-repo-contract (website half)', () => {
       'world',
       'ai',
       'gameplay',
+      'urban',
       'drawing',
       'actors',
       'gfx',
@@ -79,7 +80,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'ai', 'gameplay',
+        'input', 'collision', 'world', 'ai', 'gameplay', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -27,6 +27,8 @@ export const GAME_KIT_MODULES = [
   'world',
   'ai',
   'gameplay',
+  // Genre vertical: deterministic street topology and routing for 2D urban games.
+  'urban',
   'drawing',
   'actors',
   'gfx',

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -730,12 +730,23 @@ describe('getGameSources', () => {
   it('bundles opt-in GameKit verticals from their private TypeScript graphs', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/racer/index.html', '<canvas id="game"></canvas>'],
-      ['games/racer/game.ts', 'GameKit.mount({ verticals: [GameKit.circuitRacer, GameKit.arcadeFootball] });'],
+      [
+        'games/racer/game.ts',
+        'GameKit.mount({ verticals: [GameKit.urbanSandbox, GameKit.circuitRacer, GameKit.arcadeFootball] });',
+      ],
       ['games/racer/style.css', '.game {}'],
       ['games/racer/SPEC.md', specMd({ title: 'Racer' })],
-      ['games/racer/GAME.json', JSON.stringify({ engine: { modules: ['racing', 'football'] } })],
+      ['games/racer/GAME.json', JSON.stringify({ engine: { modules: ['urban', 'racing', 'football'] } })],
       ['shared/game-shell.css', '.shell {}'],
       ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      [
+        'shared/verticals/urban/index.ts',
+        "import { createRoadNetwork } from './streets.ts'; Object.assign(GameKit, { urbanSandbox: { createRoadNetwork } });",
+      ],
+      [
+        'shared/verticals/urban/streets.ts',
+        "export function createRoadNetwork(): string { return 'urban-vertical-loaded'; }",
+      ],
       [
         'shared/verticals/racing/index.ts',
         "import { createRace } from './simulation.ts'; Object.assign(GameKit, { circuitRacer: { createRace } });",
@@ -761,6 +772,7 @@ describe('getGameSources', () => {
 
     const sources = await client.getGameSources('main', 'racer');
 
+    expect(sources?.gameJs).toContain('urban-vertical-loaded');
     expect(sources?.gameJs).toContain('vertical-loaded');
     expect(sources?.gameJs).toContain('football-vertical-loaded');
     expect(sources?.gameJs).not.toContain('import ');

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -72,6 +72,7 @@ export interface GameSources {
 const MAX_SOURCE_GRAPH_MODULES = 64;
 const MAX_SOURCE_GRAPH_BYTES = 200 * 1024;
 const GAME_KIT_MODULE_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
+  urban: 'shared/verticals/urban/index.ts',
   racing: 'shared/verticals/racing/index.ts',
   football: 'shared/verticals/football/index.ts',
 };


### PR DESCRIPTION
## What changed

- recognize `urban` in the canonical GameKit module order
- load `shared/verticals/urban/index.ts` as a private opt-in source graph
- add a short-lived website-ahead rollout allowance so this half can merge first
- update the contract fixture and exercise urban vertical bundling in the GitHub client tests

## Why

The games repository is extracting Carjack City's deterministic street topology and routing into an opt-in `GameKit.urbanSandbox` vertical. The website assembler must recognize and bundle that graph before the games-side module can merge, otherwise games selecting `urban` would fail at serve time.

## Validation

- focused API tests: 73 passed
- focused ESLint: clean
- Prettier: clean

The broader API typecheck could not run from the isolated clone because the host's existing dependency install is missing `genaicode` and `pngjs`; none of the reported files overlap this change.