### PR TITLE
fix(infra): IAM CEL extract() for staging objectAdmin condition

### DIFF
--- a/infra/gate-hardening.md
+++ b/infra/gate-hardening.md
@@ -74,9 +74,11 @@ able to destroy candidate/published versions. MCP `stage_source_file` / clear, h
 rewrite `games/<slug>/staging/<issue>/g<gen>/manifest.json` and delete staged sources.
 
 `setup-gcp.sh` therefore also grants the runtime `roles/storage.objectAdmin` **with an
-IAM condition** limited to object names under `games/*/staging/`. Outside that prefix the
-runtime still cannot overwrite or delete. Re-run `./infra/setup-gcp.sh` after merging so
-production gets the binding (merge alone does not apply IAM).
+IAM condition** limited to object names under `games/<slug>/staging/…`. The condition uses
+`resource.name.extract('…/games/{slug}/staging/') != ''` — IAM CEL on `resource.name`
+only supports `startsWith` / `endsWith` / `extract` (not `contains`). Outside that
+prefix the runtime still cannot overwrite or delete. Re-run `./infra/setup-gcp.sh` after
+merging so production gets the binding (merge alone does not apply IAM).
 
 Staging manifest writes use GCS `ifGenerationMatch` with retry so concurrent
 `stage_source_file` calls cannot drop each other's entries.

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -258,11 +258,13 @@ done
 
 # Staging buffers need overwrite + delete (manifest upsert, clear). Bound to the staging
 # prefix only — versions/ and everything else stay create+read for the runtime.
-# CEL: object resource names are projects/_/buckets/BUCKET/objects/OBJECT_PATH.
+# IAM CEL on resource.name only allows startsWith/endsWith/extract (no contains/matches),
+# so we match games/<slug>/staging/… via extract; empty extract ⇒ path is outside staging.
+# Object names are projects/_/buckets/BUCKET/objects/OBJECT_PATH.
 gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${RUN_SA}" \
   --role="roles/storage.objectAdmin" \
-  --condition="expression=resource.name.startsWith('projects/_/buckets/${STORE_BUCKET}/objects/games/') && resource.name.contains('/staging/'),title=games-store-staging-mutate,description=Overwrite/delete only under games/*/staging/ for MCP file-by-file staging" \
+  --condition="expression=resource.type == 'storage.googleapis.com/Object' && resource.name.extract('projects/_/buckets/${STORE_BUCKET}/objects/games/{slug}/staging/') != '',title=games-store-staging-mutate,description=Overwrite/delete only under games/*/staging/ for MCP file-by-file staging" \
   --project="$PROJECT_ID" \
   >/dev/null
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./infra/setup-gcp.sh` failed when granting runtime `objectAdmin` on the staging prefix:

```
undeclared reference to 'contains'
resource.name.contains('/staging/')
```

GCP IAM CEL on `resource.name` only supports `startsWith` / `endsWith` / `extract` — not `contains`.

### Change

Match `games/<slug>/staging/…` with:

```
resource.type == 'storage.googleapis.com/Object' &&
resource.name.extract('projects/_/buckets/<bucket>/objects/games/{slug}/staging/') != ''
```

Docs in `gate-hardening.md` updated to match.

### Owner

Re-run `./infra/setup-gcp.sh` after merge (or cherry-pick this commit and re-run now). Earlier steps from the failed run (viewer/creator bindings, etc.) are fine to re-apply.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

