### PR TITLE
feat(studio): allow quiet self→platform builder handoff

### DIFF
--- a/apps/api/src/builder.test.ts
+++ b/apps/api/src/builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  allowsQuietBuilderHandoff,
   DEFAULT_SELF_BUILD_CONNECT_DAYS,
   DEFAULT_SELF_BUILD_DELIVERY_CAP,
   isActiveBuildRound,
@@ -16,6 +17,24 @@ describe('builder helpers', () => {
     expect(isBuilderKind('copilot')).toBe(false);
   });
 
+  it('allows only quiet self→platform handoffs mid-round', () => {
+    expect(allowsQuietBuilderHandoff({ currentBuilder: 'self', requestedBuilder: 'platform', stall: 'quiet' })).toBe(
+      true,
+    );
+    expect(
+      allowsQuietBuilderHandoff({ currentBuilder: 'self', requestedBuilder: 'platform', stall: 'no_agent_yet' }),
+    ).toBe(false);
+    expect(allowsQuietBuilderHandoff({ currentBuilder: 'self', requestedBuilder: 'platform', stall: null })).toBe(
+      false,
+    );
+    expect(
+      allowsQuietBuilderHandoff({ currentBuilder: 'self', requestedBuilder: 'platform', stall: 'gate_not_started' }),
+    ).toBe(false);
+    expect(allowsQuietBuilderHandoff({ currentBuilder: 'platform', requestedBuilder: 'self', stall: 'quiet' })).toBe(
+      false,
+    );
+  });
+
   it('steers via inbox for in-flight rounds that already have a dispatch ref', () => {
     const withRef = { dispatch: { refs: ['task-1'] } };
     expect(shouldSteerFeedbackViaInbox({ state: 'queued', ...withRef })).toBe(true);
@@ -30,6 +49,8 @@ describe('builder helpers', () => {
         ...withRef,
       }),
     ).toBe(true);
+    // Builder handoff must resume, not mail the agent we are about to invalidate.
+    expect(shouldSteerFeedbackViaInbox({ state: 'building', ...withRef }, { builderChanging: true })).toBe(false);
     // Dispatch never landed — feedback must retry starting a session.
     expect(shouldSteerFeedbackViaInbox({ state: 'queued' })).toBe(false);
     expect(shouldSteerFeedbackViaInbox({ state: 'queued', dispatch: { refs: [] } })).toBe(false);

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -1,7 +1,9 @@
 // Which coding agent builds a round: the platform's (Copilot) or the creator's own.
 //
 // A property of the *round*, not the game. The game keeps a default (= last used) so the
-// next round can offer a sensible choice; an active round never switches mid-flight.
+// next round can offer a sensible choice. Mid-flight switches are refused except a
+// deliberate quiet self→platform handoff (agent silent; round generation bump kills the
+// self token so two agents cannot write the same round).
 
 import type { JobState, JobTransition } from './job-state.js';
 
@@ -29,7 +31,8 @@ export function selfBuildDeliveryCap(): number {
 }
 
 /**
- * Whether the current round is still live — builder must not change until it closes.
+ * Whether the current round is still live — builder must not change until it closes,
+ * except {@link allowsQuietBuilderHandoff}.
  *
  * Includes gate-red / kit_outdated `needs_changes`: those keep the round open so the
  * same session can repair (or refresh the kit) and re-deliver without a new kickoff.
@@ -54,6 +57,24 @@ export function isActiveBuildRound(record: { state?: JobState; transitions?: Job
 }
 
 /**
+ * Quiet self round → platform: the creator's escape hatch when their agent has
+ * stopped talking. Refuses the reverse and refuses while the agent is still chatty
+ * (or has never connected — that is still "waiting to start", not a handoff).
+ *
+ * Race kill: handoff goes through `resumeBuild`, which bumps `roundGeneration` before
+ * minting the platform brief, so the self MCP token dies; late self deliveries land as
+ * stale. Candidate sources (if any) seed the platform brief.
+ */
+export function allowsQuietBuilderHandoff(input: {
+  currentBuilder: BuilderKind;
+  requestedBuilder: BuilderKind;
+  stall?: string | null;
+}): boolean {
+  if (input.requestedBuilder !== 'platform' || input.currentBuilder !== 'self') return false;
+  return input.stall === 'quiet';
+}
+
+/**
  * Whether creator feedback should only go to the build-channel inbox (no new dispatch).
  *
  * An in-flight round that already has a dispatch ref has an agent that will poll the
@@ -66,12 +87,19 @@ export function isActiveBuildRound(record: { state?: JobState; transitions?: Job
  *
  * A `queued` job with **no** refs is different: dispatch never landed, so nobody will
  * read the inbox. Feedback must retry `resumeBuild` in that case.
+ *
+ * A quiet self→platform handoff must not take this path — it needs a fresh platform
+ * dispatch (and a generation bump), not mail for the silenced self agent.
  */
-export function shouldSteerFeedbackViaInbox(record: {
-  state?: JobState;
-  transitions?: JobTransition[];
-  dispatch?: { refs?: readonly string[] } | null;
-}): boolean {
+export function shouldSteerFeedbackViaInbox(
+  record: {
+    state?: JobState;
+    transitions?: JobTransition[];
+    dispatch?: { refs?: readonly string[] } | null;
+  },
+  opts?: { builderChanging?: boolean },
+): boolean {
+  if (opts?.builderChanging) return false;
   if (record.state === 'publishing') return false;
   if (!isActiveBuildRound(record)) return false;
   return (record.dispatch?.refs?.length ?? 0) > 0;

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -443,7 +443,8 @@ describe('self builder (BY-02)', () => {
       issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
     });
 
-    // Mid-round switch refused.
+    // Mid-round switch refused while the agent has never gone quiet (no_agent_yet /
+    // live building). Quiet handoff is covered in the next test.
     const mid = await app.inject({
       method: 'POST',
       url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
@@ -513,6 +514,80 @@ describe('self builder (BY-02)', () => {
       expect(record?.builder).toBe('self');
       expect(record?.dispatch?.backend).toBe('self');
     });
+  });
+
+  it('hands a quiet self round to platform, bumps generation, and seeds from the candidate', async () => {
+    const { backend, briefs } = platformStub();
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ platform: backend, gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Quiet Handoff', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    // Deliver a candidate, close the self round, reopen self, then go quiet.
+    await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF },
+    });
+    expect((await store.getSubmission(issueNumber))?.deliveredVersion).toBeTruthy();
+    await store.recordJobTransition(issueNumber, {
+      to: 'ready_for_review',
+      at: new Date().toISOString(),
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    await store.recordJobTransition(issueNumber, {
+      to: 'needs_changes',
+      at: new Date().toISOString(),
+      by: 'operator',
+      reason: 'rejected',
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
+      headers: authHeaders(),
+      payload: { feedback: 'Keep going on the draft.', builder: 'self' },
+    });
+    await vi.waitFor(async () => {
+      const live = await store.getSubmission(issueNumber);
+      expect(live?.builder).toBe('self');
+      expect(live?.state).toBe('building');
+    });
+
+    const genBefore = (await store.getSubmission(issueNumber))?.roundGeneration ?? 1;
+    const quietAt = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    await store.touchLastAgentSignalAt(issueNumber, quietAt);
+
+    const handoff = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(issueNumber, secret)}/feedback`,
+      headers: authHeaders(),
+      payload: {
+        feedback: 'Please have the platform team finish this — my agent went quiet.',
+        builder: 'platform',
+      },
+    });
+    expect(handoff.statusCode).toBe(200);
+    await vi.waitFor(() => expect(briefs.length).toBeGreaterThan(0));
+    const after = await store.getSubmission(issueNumber);
+    expect(after?.builder).toBe('platform');
+    expect(after?.dispatch?.backend).toBe('copilot');
+    expect(after?.roundGeneration).toBeGreaterThan(genBefore);
+    expect(briefs.at(-1)?.seed?.files.some((f) => f.path === 'SPEC.md')).toBe(true);
   });
 
   it('records builder provenance on delivered versions', async () => {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -29,6 +29,7 @@ import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './
 import type { AgentBackend, SeedFiles } from './agent-backend.js';
 import { resolveBuilderBackend, type AgentBackendRegistry } from './agent-backend-env.js';
 import {
+  allowsQuietBuilderHandoff,
   isActiveBuildRound,
   isBuilderKind,
   shouldSteerFeedbackViaInbox,
@@ -2942,11 +2943,29 @@ export async function registerSubmissionRoutes(
       if (record && requestedBuilder && isActiveBuildRound(record)) {
         const current = builderOf(record);
         if (requestedBuilder !== current) {
-          return reply.status(409).send({
-            error: 'builder_locked',
-            reason: 'active_round',
+          const stall = detectStall({
+            state: record.state ?? 'queued',
+            stateSince: record.stateSince ?? record.createdAt,
+            lastAgentSignalAt: record.lastAgentSignalAt,
+            agentState: record.agentState,
+            now: now(),
             builder: current,
           });
+          // Quiet / never-connected self → platform is the handoff escape hatch. Anything
+          // else mid-round stays locked (two agents must not write the same round).
+          if (
+            !allowsQuietBuilderHandoff({
+              currentBuilder: current,
+              requestedBuilder,
+              stall,
+            })
+          ) {
+            return reply.status(409).send({
+              error: 'builder_locked',
+              reason: 'active_round',
+              builder: current,
+            });
+          }
         }
       }
       // Queue *before* dispatch. resumeBuild awaits the agent-tasks API, and a slow or
@@ -2973,7 +2992,13 @@ export async function registerSubmissionRoutes(
       //
       // A queued job with no refs is the opposite: dispatch never landed, so nobody
       // will poll — fall through to resumeBuild so feedback can still start a session.
-      if (record && shouldSteerFeedbackViaInbox(record)) {
+      //
+      // Quiet self→platform handoff must resume (generation bump + platform dispatch),
+      // not drop mail for the agent we are about to invalidate.
+      const builderChanging = Boolean(
+        record && requestedBuilder && isBuilderKind(requestedBuilder) && requestedBuilder !== builderOf(record),
+      );
+      if (record && shouldSteerFeedbackViaInbox(record, { builderChanging })) {
         if (!queued) {
           return reply.status(503).send({ error: 'failed to queue feedback for the agent' });
         }
@@ -2988,11 +3013,16 @@ export async function registerSubmissionRoutes(
         feedback: inboxText,
         locale: creatorLocale,
         log: request.log,
-        ...(record?.deliveredVersion ? {} : { undelivered: true }),
+        // Handoff always opens a new round generation even when a candidate exists —
+        // that bump is what kills the quiet self agent's token.
+        ...(builderChanging ? {} : record?.deliveredVersion ? {} : { undelivered: true }),
         ...(requestedBuilder && isBuilderKind(requestedBuilder) ? { builder: requestedBuilder } : {}),
         // Name the actor so a ready_for_review → building reopen does not look like a
         // GitHub-derived observation in the job history.
-        transition: { by: 'creator', reason: 'creator_feedback' },
+        transition: {
+          by: 'creator',
+          reason: builderChanging ? 'quiet_builder_handoff' : 'creator_feedback',
+        },
       });
 
       // Accepted, and honest about what it bought. The message is kept either way — it is

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -710,7 +710,9 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.studio-connect.is-resume')).not.toBeNull();
       expect(container.textContent).toContain('Continue with your agent');
       expect(container.textContent).not.toContain('Connect your coding agent');
-      // Full first-time install stays under a closed disclosure — continue, not a reset.
+      // Quiet escape hatch: pick Gamedev.pl and send — API kills the self token.
+      expect(container.querySelector('.builder-choice')).not.toBeNull();
+      expect(container.textContent).toMatch(/Who builds this round/i); // Full first-time install stays under a closed disclosure — continue, not a reset.
       const details = container.querySelector<HTMLDetailsElement>('[data-testid="connect-setup-details"]');
       expect(details).not.toBeNull();
       expect(details?.open).toBe(false);

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -50,6 +50,9 @@ function isAwaitingOwnAgent(status: SubmissionStatus | null | undefined): boolea
  */
 function canChooseBuilder(status: SubmissionStatus | null | undefined): boolean {
   if (!status) return false;
+  // Quiet self round: offer the platform handoff (API bumps round generation so the
+  // quiet agent's token dies — two agents must not write the same round).
+  if (status.builder === 'self' && status.stall === 'quiet') return true;
   if (isAwaitingOwnAgent(status)) return false;
   // Gate-red / kit_outdated keep the round open server-side (`builder_locked` on switch).
   // Offering a selector that can only 409 is worse than hiding it until the repair lands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a BYOCA agent goes quiet (especially after it already delivered), creators were stuck until the round closed.

## Change

- **API:** mid-round `builder: platform` is allowed only when the round is self and `detectStall` is `quiet`. Handoff goes through `resumeBuild` (not the inbox steer path), which **bumps `roundGeneration`** before minting the platform brief — the self MCP token dies; late self deliveries fail as stale. Latest `deliveredVersion` seeds the platform brief when present.
- **Studio:** on quiet self rounds, **Who builds this round?** shows again so you can pick Gamedev.pl and send.
- Live / chatty self rounds still return `builder_locked` (no two writers).

## How to use (after deploy)

1. Wait until the thread shows the quiet / resume card.
2. In the composer, choose **Gamedev.pl coding agent**.
3. Send a short note — platform continues from the last delivered candidate when one exists.

## Verification

- `apps/api` builder + self-build tests (quiet handoff + still-locked when live)
- `SubmissionStatusView` quiet self shows builder choice
- `npm run type-check && npm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

