### PR TITLE
fix(infra): --condition=None on unconditional games-store IAM

### DIFF
--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -245,6 +245,7 @@ fi
 gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${DEPLOYER_SA}" \
   --role="roles/storage.objectAdmin" \
+  --condition=None \
   --project="$PROJECT_ID" \
   >/dev/null
 
@@ -252,6 +253,7 @@ for role in roles/storage.objectViewer roles/storage.objectCreator; do
   gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
     --member="serviceAccount:${RUN_SA}" \
     --role="$role" \
+    --condition=None \
     --project="$PROJECT_ID" \
     >/dev/null
 done
@@ -349,6 +351,7 @@ grant_gate_with_retry() {
 grant_gate_with_retry gcloud storage buckets add-iam-policy-binding "gs://${STORE_BUCKET}" \
   --member="serviceAccount:${GATE_SA_EMAIL}" \
   --role="roles/storage.objectAdmin" \
+  --condition=None \
   --project="$PROJECT_ID"
 
 grant_gate_with_retry gcloud projects add-iam-policy-binding "$PROJECT_ID" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the staging conditional `objectAdmin` binding lands, `gcloud storage buckets add-iam-policy-binding` for gate-runner (and re-runs of deployer/runtime grants) prompts:

```
[1] EXPRESSION=…games-store-staging-mutate…
[2] None
[3] Specify a new condition
```

### Change

Pass `--condition=None` on the unconditional store-bucket bindings (deployer admin, runtime viewer/creator, gate-runner admin) so the script stays non-interactive.

### Right now

If you're stuck on that prompt: choose **2 (None)** — gate-runner needs full-bucket admin, not the staging condition. Then pull this fix before the next re-run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f848e546-4d56-4944-b20b-8b6460ebdeea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f848e546-4d56-4944-b20b-8b6460ebdeea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

