### PR TITLE
Add workspace checkout feature for creators to work in their own IDE

### DIFF
--- a/apps/api/fixtures/games-repo/shared/delivery-contract.json
+++ b/apps/api/fixtures/games-repo/shared/delivery-contract.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "_comment": "Cross-repo DELIVERY contract — which files a game may deliver to www.gamedev.pl. Games-repo half: tools/submit.mjs reads this file (no second literal). Website half: www.gamedev.pl apps/api/src/games-repo-contract.ts (DELIVERY_CONTRACT) feeds games-store.ts ALLOWED_SOURCE_FILES, and CI contract:games-repo compares the two. This list has drifted three times (TRACE, then PLAYTEST, then AGENT); each drift turned a finished game into a multi-delivery retry loop, because the site refused a path validate had just made mandatory. ADDING A FILE: merge the WEBSITE side first — a site that accepts a path no game sends yet is harmless, a game that sends a path the site refuses 400s at upload.",
+  "fixedFiles": [
+    "SPEC.md",
+    "GAME.json",
+    "CAPTURE.json",
+    "ACCEPTANCE.json",
+    "TRACE.json",
+    "PLAYTEST.json",
+    "AGENT.json",
+    "EDITOR.json",
+    "index.html",
+    "game.ts",
+    "style.css",
+    "sim.ts"
+  ],
+  "extraModulePattern": "^[a-z0-9][a-z0-9/-]{0,60}\\.ts$",
+  "reservedSegments": ["shared", "tools", "games", "node_modules", "dist", "references", "templates"],
+  "maxFiles": 200,
+  "maxUploadBytes": 2097152,
+  "_notDelivered": "media/ is produced by the site's capture harness from the sources delivered here, so it is refused rather than uploaded. TRACE.json is the one entry above that is not source in the ordinary sense: the gate replays CAPTURE.json against the upstream engine and diffs against it, which is what proves the game behaves the same on our engine as it did on yours."
+}

--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -3,16 +3,19 @@
  *
  * The check itself lives in `../src/games-repo-contract-check.ts`; this file is the
  * environment, the logging, and the exit code. It asserts the games repo's
- * `tools/lib/assemble.ts` and `tools/validate.ts` still match
- * `games-repo-contract.ts` on this side:
+ * `tools/lib/assemble.ts`, `tools/validate.ts` and `shared/delivery-contract.json`
+ * still match `games-repo-contract.ts` on this side:
  *   - GAME_KIT_MODULES order
  *   - MAX_BUNDLE_BYTES === MAX_PROJECT_BYTES
  *   - music injection contract (tracks + __GAME_AUDIO_MUSIC__ + readMusicCatalog)
+ *   - delivery contract (fixed files and their order, extra-module pattern, caps)
  *
  * Requires GAMES_REPO_TOKEN (contents:read on the games repo). Drift fails. A games
  * repo that cannot be read — no token, exhausted quota, GitHub down — warns and
  * passes, because it is not evidence of drift; set GAMES_CONTRACT_REQUIRE_REMOTE=1
- * to demand the live comparison instead.
+ * to demand the live comparison instead. A half that was tolerated rather than
+ * compared (a games tip with no delivery contract yet) is warned about on an
+ * otherwise green run.
  *
  * Usage: npm run contract:games-repo -w @gamedevpl/api
  */
@@ -46,6 +49,9 @@ async function main(): Promise<void> {
 
   switch (outcome.kind) {
     case 'ok':
+      for (const note of outcome.notes ?? []) {
+        annotate('games-repo contract half not compared', note);
+      }
       console.log('games-repo contract: ok');
       return;
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -521,6 +521,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     store,
     gamesStore,
     mintStatusToken: submissionTokenSecret ? (issueNumber) => mintToken(issueNumber, submissionTokenSecret) : undefined,
+    objectStore,
   });
 
   // The Creator Studio content editor (EditorKit): drafts in Firestore, publish

--- a/apps/api/src/creator-studio-workspace.test.ts
+++ b/apps/api/src/creator-studio-workspace.test.ts
@@ -226,6 +226,44 @@ describe('GET /api/me/studio/games/:slug/workspace', () => {
     expect(entries.some((item) => item.path === `games/${SLUG}/SPEC.md`)).toBe(true);
   });
 
+  it('ignores a canceled round when choosing what to check out', async () => {
+    // A round the operator canceled keeps whatever it delivered and is newer than the job
+    // that published the live game. Serving it would hand back rejected work, and a
+    // delivery built on it would overwrite what is live.
+    const store3 = new InMemoryStore();
+    await store3.upsertUser({ uid: 'g:creator' });
+    await store3.createSubmission(ISSUE, 'g:creator', 'Comet Courier');
+    await store3.setSubmissionSlug(ISSUE, SLUG);
+    await store3.setSubmissionDeliveredVersion(ISSUE, VERSION);
+    await store3.setPublication({
+      slug: SLUG,
+      state: 'published',
+      currentVersion: VERSION,
+      publishedAt: '2026-08-01T00:00:00.000Z',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await store3.createSubmission(ISSUE + 1, 'g:creator', 'Comet Courier');
+    await store3.setSubmissionSlug(ISSUE + 1, SLUG);
+    await store3.setSubmissionDeliveredVersion(ISSUE + 1, 'v-rejected');
+    await store3.recordJobTransition(ISSUE + 1, {
+      to: 'canceled',
+      at: '2026-08-02T00:00:00.000Z',
+      by: 'operator',
+      reason: 'operator_cancel',
+    });
+
+    const app = await createApp(store3, objectsWithScaffold());
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    // The stub can only read VERSION back, so 200 proves the canceled round's
+    // `v-rejected` was not chosen.
+    expect(res.statusCode).toBe(200);
+  });
+
   it('503s rather than improvising when no scaffold is published for the current engine', async () => {
     const objects = objectsWithScaffold();
     objects.delete(`workspaces/${ENGINE}.tgz`);

--- a/apps/api/src/creator-studio-workspace.test.ts
+++ b/apps/api/src/creator-studio-workspace.test.ts
@@ -1,0 +1,235 @@
+import { gunzipSync, gzipSync } from 'node:zlib';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import type { GcsObjectStore } from './gcs-sign.js';
+import { InMemoryStore } from './store.js';
+import { readTarEntries, writeTarGz, type TarEntry } from './tar.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+const ENGINE = 'deadbeef0123456789abcdef0123456789abcdef';
+const SHA = 'a'.repeat(64);
+const ISSUE = 42;
+const SLUG = 'comet-courier';
+const VERSION = 'v-1';
+
+function authHeaders(uid: string) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+const SOURCES: Record<string, string> = {
+  'SPEC.md': '---\nslug: comet-courier\n---\n',
+  'game.ts': "import './game/model.js';\n",
+  'game/model.ts': 'export const speed = 3;\n',
+};
+
+/** Only the two reads the workspace route makes; the rest of the store is not exercised. */
+function stubGamesStore(sources = SOURCES): GamesStore {
+  return {
+    getManifest: async (slug: string, version: string) =>
+      slug === SLUG && version === VERSION ? ({ sourceFiles: Object.keys(sources) } as VersionManifest) : null,
+    getSourceFile: async (_slug: string, _version: string, path: string) => sources[path] ?? null,
+  } as unknown as GamesStore;
+}
+
+function scaffoldTarball(): Buffer {
+  return gzipSync(
+    // Wrapped in a directory on purpose: the packer may or may not wrap, and the
+    // composer is supposed to tolerate both.
+    Buffer.from(
+      gunzipSync(
+        writeTarGz([
+          { path: 'workspace/README.md', content: '# your working copy\n' },
+          { path: 'workspace/setup.mjs', content: 'fetch the kit\n' },
+          { path: 'workspace/.gitignore', content: 'node_modules\n' },
+        ]),
+      ),
+    ),
+  );
+}
+
+function objectsWithScaffold(): Map<string, Buffer> {
+  return new Map<string, Buffer>([
+    [
+      'kits/current.json',
+      Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-01T00:00:00.000Z' })),
+    ],
+    ['kits/' + ENGINE + '.json', Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-01T00:00:00.000Z' }))],
+    ['kits/' + ENGINE + '.tgz', Buffer.from('fake-kit')],
+    ['workspaces/' + ENGINE + '.tgz', scaffoldTarball()],
+  ]);
+}
+
+function mockObjectStore(objects: Map<string, Buffer>): GcsObjectStore {
+  return {
+    readObject: async (name) => objects.get(name) ?? null,
+    objectExists: async (name) => objects.has(name),
+    signReadUrl: async (name) => `https://signed.example/${name}?sig=1`,
+  };
+}
+
+async function createApp(store: InMemoryStore, objects: Map<string, Buffer>, gamesStore = stubGamesStore()) {
+  return await buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      submissionTokenSecret: 'test-submission-secret',
+      agentChannel: { objectStore: mockObjectStore(objects), gamesStore },
+    },
+  });
+}
+
+async function entriesOf(archive: Buffer): Promise<TarEntry[]> {
+  const buffer = gunzipSync(archive);
+  async function* once(): AsyncGenerator<Uint8Array> {
+    yield buffer;
+  }
+  const entries: TarEntry[] = [];
+  for await (const item of readTarEntries(once())) entries.push(item);
+  return entries;
+}
+
+describe('GET /api/me/studio/games/:slug/workspace', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.createSubmission(ISSUE, 'g:creator', 'Comet Courier');
+    await store.setSubmissionSlug(ISSUE, SLUG);
+    await store.setSubmissionDeliveredVersion(ISSUE, VERSION);
+  });
+
+  it('hands back a working copy: scaffold at the root, sources under games/<slug>/', async () => {
+    const app = await createApp(store, objectsWithScaffold());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('application/gzip');
+    expect(res.headers['content-disposition']).toBe(`attachment; filename="${SLUG}-workspace.tgz"`);
+
+    const entries = await entriesOf(res.rawPayload);
+    expect(entries.map((entry) => entry.path).sort()).toEqual([
+      '.gitignore',
+      'README.md',
+      'gamedev.lock',
+      `games/${SLUG}/SPEC.md`,
+      `games/${SLUG}/game.ts`,
+      `games/${SLUG}/game/model.ts`,
+      'setup.mjs',
+    ]);
+  });
+
+  it('pins the checkout to the current engine and tells setup where to fetch the kit', async () => {
+    const app = await createApp(store, objectsWithScaffold());
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    const entries = await entriesOf(res.rawPayload);
+    const lock = JSON.parse(Buffer.from(entries.find((e) => e.path === 'gamedev.lock')!.bytes).toString('utf8'));
+    expect(lock).toMatchObject({
+      slug: SLUG,
+      engineRef: ENGINE,
+      kitUrl: `https://signed.example/kits/${ENGINE}.tgz?sig=1`,
+      kitSha256: SHA,
+    });
+  });
+
+  it('never ships the engine — the kit is fetched at setup, not handed over', async () => {
+    const app = await createApp(store, objectsWithScaffold());
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    const paths = (await entriesOf(res.rawPayload)).map((entry) => entry.path);
+    expect(paths.some((path) => path.startsWith('shared/'))).toBe(false);
+  });
+
+  it('requires a session', async () => {
+    const app = await createApp(store, objectsWithScaffold());
+    const res = await app.inject({ method: 'GET', url: `/api/me/studio/games/${SLUG}/workspace` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('404s another creator’s game rather than confirming it exists', async () => {
+    await store.upsertUser({ uid: 'g:stranger' });
+    const app = await createApp(store, objectsWithScaffold());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:stranger'),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('says so plainly when the first build has not delivered anything yet', async () => {
+    const empty = new InMemoryStore();
+    await empty.upsertUser({ uid: 'g:creator' });
+    await empty.createSubmission(ISSUE, 'g:creator', 'Comet Courier');
+    await empty.setSubmissionSlug(ISSUE, SLUG);
+    const app = await createApp(empty, objectsWithScaffold());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe('nothing_delivered');
+  });
+
+  it('503s rather than improvising when no scaffold is published for the current engine', async () => {
+    const objects = objectsWithScaffold();
+    objects.delete(`workspaces/${ENGINE}.tgz`);
+    const app = await createApp(store, objects);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error).toBe('workspace_scaffold_missing');
+  });
+
+  it('refuses to assemble an archive from a scaffold that carries engine content', async () => {
+    const objects = objectsWithScaffold();
+    objects.set(
+      `workspaces/${ENGINE}.tgz`,
+      gzipSync(
+        Buffer.from(
+          gunzipSync(
+            writeTarGz([
+              { path: 'README.md', content: 'x' },
+              { path: 'shared/modules/gfx.ts', content: 'export {}' },
+            ]),
+          ),
+        ),
+      ),
+    );
+    const app = await createApp(store, objects);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+});

--- a/apps/api/src/creator-studio-workspace.test.ts
+++ b/apps/api/src/creator-studio-workspace.test.ts
@@ -192,6 +192,40 @@ describe('GET /api/me/studio/games/:slug/workspace', () => {
     expect(res.json().error).toBe('nothing_delivered');
   });
 
+  it('checks out the live publication when the newest round has delivered nothing yet', async () => {
+    // The shape of every post-publish improvement: a fresh empty job on a slug whose
+    // older job still points at what it delivered before publication. Handing back that
+    // older delivery would have the creator edit a superseded base and deliver over
+    // newer published work.
+    const store2 = new InMemoryStore();
+    await store2.upsertUser({ uid: 'g:creator' });
+    await store2.createSubmission(ISSUE, 'g:creator', 'Comet Courier');
+    await store2.setSubmissionSlug(ISSUE, SLUG);
+    await store2.setSubmissionDeliveredVersion(ISSUE, 'v-old');
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await store2.createSubmission(ISSUE + 1, 'g:creator', 'Comet Courier');
+    await store2.setSubmissionSlug(ISSUE + 1, SLUG);
+    await store2.setPublication({
+      slug: SLUG,
+      state: 'published',
+      currentVersion: VERSION,
+      publishedAt: '2026-08-01T00:00:00.000Z',
+    });
+
+    const app = await createApp(store2, objectsWithScaffold());
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    // The stub only knows VERSION, so a 200 is itself the assertion: resolving to the
+    // older job's `v-old` would have failed the manifest read with a 502.
+    expect(res.statusCode).toBe(200);
+    const entries = await entriesOf(res.rawPayload);
+    expect(entries.some((item) => item.path === `games/${SLUG}/SPEC.md`)).toBe(true);
+  });
+
   it('503s rather than improvising when no scaffold is published for the current engine', async () => {
     const objects = objectsWithScaffold();
     objects.delete(`workspaces/${ENGINE}.tgz`);

--- a/apps/api/src/creator-studio-workspace.test.ts
+++ b/apps/api/src/creator-studio-workspace.test.ts
@@ -207,6 +207,20 @@ describe('GET /api/me/studio/games/:slug/workspace', () => {
     expect(res.json().error).toBe('workspace_scaffold_missing');
   });
 
+  it('answers 502, not 500, when the published scaffold cannot be decompressed', async () => {
+    const objects = objectsWithScaffold();
+    objects.set(`workspaces/${ENGINE}.tgz`, Buffer.from('not gzip at all'));
+    const app = await createApp(store, objects);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace`,
+      headers: authHeaders('g:creator'),
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+
   it('refuses to assemble an archive from a scaffold that carries engine content', async () => {
     const objects = objectsWithScaffold();
     objects.set(

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -396,12 +396,29 @@ export async function registerCreatorStudioRoutes(
         });
       }
 
+      // Bounded at the gunzip, not only after it: `readTarEntries`' cap is on what it
+      // retains, so an over-large or corrupt scaffold would already have been inflated
+      // in full by the time that applied. The scaffold is our own artifact rather than
+      // creator input, so this guards a mispublish rather than an attacker — but the
+      // cost of being wrong about that is the API's memory, and the bound is one option.
       const scaffold: TarEntry[] = [];
-      async function* once(): AsyncGenerator<Uint8Array> {
-        yield gunzipSync(scaffoldBody!);
-      }
-      for await (const item of readTarEntries(once(), { maxTotalBytes: MAX_SCAFFOLD_BYTES })) {
-        scaffold.push(item);
+      try {
+        const unpacked = gunzipSync(scaffoldBody, { maxOutputLength: MAX_SCAFFOLD_BYTES });
+        async function* once(): AsyncGenerator<Uint8Array> {
+          yield unpacked;
+        }
+        for await (const item of readTarEntries(once(), { maxTotalBytes: MAX_SCAFFOLD_BYTES })) {
+          scaffold.push(item);
+        }
+      } catch (error) {
+        // Unreadable is the same class of problem as invalid, and gets the same answer:
+        // a controlled 502 naming an operator problem, rather than a 500 that reads to
+        // the creator as "the site is broken" and to us as an unhandled exception.
+        throw new WorkspaceCompositionError(
+          `workspace scaffold for engine ${engineRef} could not be read: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       }
 
       const archive = composeWorkspaceArchive({

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -1,7 +1,12 @@
+import { gunzipSync } from 'node:zlib';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
+import { KitRegistryError, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
 import { pageOwnerGames } from './owner-games.js';
+import { readTarEntries, type TarEntry } from './tar.js';
 import { recentPartitions, summarizeGameHealth, type GameHealth } from './telemetry-health.js';
+import { composeWorkspaceArchive, WorkspaceCompositionError } from './workspace-archive.js';
 import type { GamesStore } from './games-store.js';
 import type { Store, TelemetryEvent } from './store.js';
 
@@ -32,8 +37,13 @@ export interface CreatorStudioRoutesOptions {
   gamesStore?: GamesStore;
   /** Mints status tokens so the studio can deep-link into the build page. */
   mintStatusToken?: (issueNumber: number) => string;
+  /** Reads the workspace scaffold and signs the kit URL the scaffold fetches. */
+  objectStore?: GcsObjectStore;
   now?: () => number;
 }
+
+/** Ceiling on the scaffold we will unpack — it is a handful of text files, not a kit. */
+const MAX_SCAFFOLD_BYTES = 1024 * 1024;
 
 export interface CreatorStudioGame {
   token: string;
@@ -300,5 +310,135 @@ export async function registerCreatorStudioRoutes(
 
     const body: CreatorScorecardsResponse = { scorecards, truncated, totalGames: total };
     return reply.send(body);
+  });
+
+  /**
+   * A working copy of the creator's own game, for creators who would rather use their
+   * own IDE than the Studio's agent flow.
+   *
+   * This is a checkout, not a handover: the archive is sources plus the scaffold that
+   * fetches the toolchain and explains how to deliver back, and the game keeps its home
+   * here. Nothing about the round trip changes — the creator's agent still opens a round
+   * and calls `submit_sources`, the site's gate still rebuilds against its own pinned
+   * engine, and a human still publishes. See `workspace-archive.ts` for what is in the
+   * archive and why GameKit is not.
+   *
+   * Ownership is the same `ownerUid` + `slug` attribution the rest of this file uses, so
+   * a slug the caller did not commission 404s rather than 403s — a creator has no reason
+   * to learn which other slugs exist.
+   */
+  app.get<{ Params: { slug: string } }>('/api/me/studio/games/:slug/workspace', async (request, reply) => {
+    if (!requireUser(request, reply)) return;
+    if (!options.gamesStore || !options.objectStore) {
+      return reply.status(503).send({ error: 'workspace checkout is not configured on this deployment' });
+    }
+
+    const slug = request.params.slug;
+    if (!/^[a-z0-9][a-z0-9-]{0,60}$/.test(slug)) {
+      return reply.status(400).send({ error: 'invalid slug' });
+    }
+
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const owned = records.filter((record) => record.slug === slug && !record.abandonedAt);
+    if (owned.length === 0) {
+      return reply.status(404).send({ error: 'no such game' });
+    }
+
+    // Same preference order as the agent's own `get_sources`: the newest thing the
+    // creator has, which for an improvement round is the live publication rather than
+    // this job's (still empty) delivery.
+    let version = owned.map((record) => record.previewVersion ?? record.deliveredVersion).find(Boolean) ?? null;
+    if (!version) {
+      const publication = await store.getPublication(slug);
+      if (publication?.state === 'published') version = publication.currentVersion;
+    }
+    if (!version) {
+      return reply.status(409).send({
+        error: 'nothing_delivered',
+        message: 'this game has no delivered version yet — let the first build finish, then check it out',
+      });
+    }
+
+    const manifest = await options.gamesStore.getManifest(slug, version);
+    if (!manifest) {
+      request.log.error({ slug, version }, 'workspace checkout: manifest missing for a version a job points at');
+      return reply.status(502).send({ error: 'the delivered version could not be read back' });
+    }
+
+    const sources = await Promise.all(
+      manifest.sourceFiles.map(async (path) => ({
+        path,
+        content: await options.gamesStore!.getSourceFile(slug, version, path),
+      })),
+    );
+    const missing = sources.filter((file) => file.content === null).map((file) => file.path);
+    if (missing.length > 0) {
+      request.log.error({ slug, version, missing }, 'workspace checkout: version is missing files its manifest lists');
+      return reply.status(502).send({ error: 'the delivered version could not be read back' });
+    }
+
+    try {
+      const registryBody = await options.objectStore.readObject('kits/current.json');
+      if (!registryBody) {
+        return reply.status(503).send({
+          error: 'kit_registry_missing',
+          message: 'the Creator Kit registry is not published yet',
+        });
+      }
+      const engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
+
+      const sidecarBody = await options.objectStore.readObject(`kits/${engineRef}.json`);
+      const scaffoldBody = await options.objectStore.readObject(`workspaces/${engineRef}.tgz`);
+      if (!sidecarBody || !scaffoldBody) {
+        return reply.status(503).send({
+          error: 'workspace_scaffold_missing',
+          message: `no workspace scaffold published for engine ${engineRef}`,
+        });
+      }
+
+      const scaffold: TarEntry[] = [];
+      async function* once(): AsyncGenerator<Uint8Array> {
+        yield gunzipSync(scaffoldBody!);
+      }
+      for await (const item of readTarEntries(once(), { maxTotalBytes: MAX_SCAFFOLD_BYTES })) {
+        scaffold.push(item);
+      }
+
+      const archive = composeWorkspaceArchive({
+        slug,
+        lock: {
+          slug,
+          engineRef,
+          // Short-lived by design. `setup.mjs` is meant to be re-run — that is also the
+          // re-baseline path when the pin falls outside the kit's N/N−1 window — so a URL
+          // that expires costs a fresh checkout link, not a broken workspace.
+          kitUrl: await options.objectStore.signReadUrl(`kits/${engineRef}.tgz`, DEFAULT_SIGNED_URL_TTL_SECONDS),
+          kitSha256: parseKitSidecar(sidecarBody.toString('utf8')).sha256,
+          issuedAt: new Date(now()).toISOString(),
+        },
+        scaffold,
+        sources: sources as Array<{ path: string; content: string }>,
+      });
+
+      return (
+        reply
+          .header('content-type', 'application/gzip')
+          .header('content-disposition', `attachment; filename="${slug}-workspace.tgz"`)
+          // The signed kit URL inside makes every archive short-lived and per-creator.
+          .header('cache-control', 'private, no-store')
+          .send(archive)
+      );
+    } catch (error) {
+      if (error instanceof KitRegistryError) {
+        return reply.status(503).send({ error: error.code, message: error.message });
+      }
+      if (error instanceof WorkspaceCompositionError) {
+        // A scaffold that fails its own invariants is an operator problem, not the
+        // creator's: refuse rather than hand over an archive we cannot vouch for.
+        request.log.error({ slug, err: error }, 'workspace checkout: refused to compose an archive');
+        return reply.status(502).send({ error: 'the workspace could not be assembled' });
+      }
+      throw error;
+    }
   });
 }

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -327,140 +327,160 @@ export async function registerCreatorStudioRoutes(
    * a slug the caller did not commission 404s rather than 403s — a creator has no reason
    * to learn which other slugs exist.
    */
-  app.get<{ Params: { slug: string } }>('/api/me/studio/games/:slug/workspace', async (request, reply) => {
-    if (!requireUser(request, reply)) return;
-    if (!options.gamesStore || !options.objectStore) {
-      return reply.status(503).send({ error: 'workspace checkout is not configured on this deployment' });
-    }
-
-    const slug = request.params.slug;
-    if (!/^[a-z0-9][a-z0-9-]{0,60}$/.test(slug)) {
-      return reply.status(400).send({ error: 'invalid slug' });
-    }
-
-    const records = await store.listSubmissionsByOwner(request.user!.uid);
-    const owned = records.filter((record) => record.slug === slug && !record.abandonedAt);
-    if (owned.length === 0) {
-      return reply.status(404).send({ error: 'no such game' });
-    }
-
-    // Same preference order as the agent's own `get_sources`, and it has to be read off
-    // the *newest* round rather than the first owned record that happens to carry a
-    // version. An improvement round starts empty on a slug whose older job still points
-    // at the version it delivered before publication; scanning all records would hand
-    // back that older delivery, and a creator who edited it and delivered would overwrite
-    // newer published work with something derived from a superseded base. When the newest
-    // round has nothing of its own, the live publication is what they last played.
-    const tip = [...owned].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
-    let version = tip.previewVersion ?? tip.deliveredVersion ?? null;
-    if (!version) {
-      const publication = await store.getPublication(slug);
-      if (publication?.state === 'published') version = publication.currentVersion;
-    }
-    if (!version) {
-      return reply.status(409).send({
-        error: 'nothing_delivered',
-        message: 'this game has no delivered version yet — let the first build finish, then check it out',
-      });
-    }
-
-    const manifest = await options.gamesStore.getManifest(slug, version);
-    if (!manifest) {
-      request.log.error({ slug, version }, 'workspace checkout: manifest missing for a version a job points at');
-      return reply.status(502).send({ error: 'the delivered version could not be read back' });
-    }
-
-    const sources = await Promise.all(
-      manifest.sourceFiles.map(async (path) => ({
-        path,
-        content: await options.gamesStore!.getSourceFile(slug, version, path),
-      })),
-    );
-    const missing = sources.filter((file) => file.content === null).map((file) => file.path);
-    if (missing.length > 0) {
-      request.log.error({ slug, version, missing }, 'workspace checkout: version is missing files its manifest lists');
-      return reply.status(502).send({ error: 'the delivered version could not be read back' });
-    }
-
-    try {
-      const registryBody = await options.objectStore.readObject('kits/current.json');
-      if (!registryBody) {
-        return reply.status(503).send({
-          error: 'kit_registry_missing',
-          message: 'the Creator Kit registry is not published yet',
-        });
-      }
-      const engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
-
-      const sidecarBody = await options.objectStore.readObject(`kits/${engineRef}.json`);
-      const scaffoldBody = await options.objectStore.readObject(`workspaces/${engineRef}.tgz`);
-      if (!sidecarBody || !scaffoldBody) {
-        return reply.status(503).send({
-          error: 'workspace_scaffold_missing',
-          message: `no workspace scaffold published for engine ${engineRef}`,
-        });
+  app.get<{ Params: { slug: string } }>(
+    '/api/me/studio/games/:slug/workspace',
+    // The most expensive read a signed-in creator can ask for: up to 200 source-object
+    // reads, the registry and scaffold on top, and a gzip held in memory. The rate-limit
+    // plugin is registered with `global: false`, so a route that says nothing has no
+    // ceiling at all. Generous against real use — nobody checks out a game 30 times an
+    // hour — and bounded against a loop.
+    { config: { rateLimit: { max: 30, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!requireUser(request, reply)) return;
+      if (!options.gamesStore || !options.objectStore) {
+        return reply.status(503).send({ error: 'workspace checkout is not configured on this deployment' });
       }
 
-      // Bounded at the gunzip, not only after it: `readTarEntries`' cap is on what it
-      // retains, so an over-large or corrupt scaffold would already have been inflated
-      // in full by the time that applied. The scaffold is our own artifact rather than
-      // creator input, so this guards a mispublish rather than an attacker — but the
-      // cost of being wrong about that is the API's memory, and the bound is one option.
-      const scaffold: TarEntry[] = [];
-      try {
-        const unpacked = gunzipSync(scaffoldBody, { maxOutputLength: MAX_SCAFFOLD_BYTES });
-        async function* once(): AsyncGenerator<Uint8Array> {
-          yield unpacked;
-        }
-        for await (const item of readTarEntries(once(), { maxTotalBytes: MAX_SCAFFOLD_BYTES })) {
-          scaffold.push(item);
-        }
-      } catch (error) {
-        // Unreadable is the same class of problem as invalid, and gets the same answer:
-        // a controlled 502 naming an operator problem, rather than a 500 that reads to
-        // the creator as "the site is broken" and to us as an unhandled exception.
-        throw new WorkspaceCompositionError(
-          `workspace scaffold for engine ${engineRef} could not be read: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
+      const slug = request.params.slug;
+      if (!/^[a-z0-9][a-z0-9-]{0,60}$/.test(slug)) {
+        return reply.status(400).send({ error: 'invalid slug' });
       }
 
-      const archive = composeWorkspaceArchive({
-        slug,
-        lock: {
-          slug,
-          engineRef,
-          // Short-lived by design. `setup.mjs` is meant to be re-run — that is also the
-          // re-baseline path when the pin falls outside the kit's N/N−1 window — so a URL
-          // that expires costs a fresh checkout link, not a broken workspace.
-          kitUrl: await options.objectStore.signReadUrl(`kits/${engineRef}.tgz`, DEFAULT_SIGNED_URL_TTL_SECONDS),
-          kitSha256: parseKitSidecar(sidecarBody.toString('utf8')).sha256,
-          issuedAt: new Date(now()).toISOString(),
-        },
-        scaffold,
-        sources: sources as Array<{ path: string; content: string }>,
-      });
-
-      return (
-        reply
-          .header('content-type', 'application/gzip')
-          .header('content-disposition', `attachment; filename="${slug}-workspace.tgz"`)
-          // The signed kit URL inside makes every archive short-lived and per-creator.
-          .header('cache-control', 'private, no-store')
-          .send(archive)
+      const records = await store.listSubmissionsByOwner(request.user!.uid);
+      // Canceled rounds are excluded as well as abandoned ones, matching the shelf the
+      // creator is looking at when they click this. A round the operator canceled can still
+      // carry a preview or delivery, and it is newer than the job that published the live
+      // game — so keeping it would hand back work that was rejected, and a delivery built on
+      // it would overwrite what is live. That is the same hazard as picking a stale record,
+      // reached from the other direction.
+      const owned = records.filter(
+        (record) => record.slug === slug && !record.abandonedAt && record.state !== 'canceled',
       );
-    } catch (error) {
-      if (error instanceof KitRegistryError) {
-        return reply.status(503).send({ error: error.code, message: error.message });
+      if (owned.length === 0) {
+        return reply.status(404).send({ error: 'no such game' });
       }
-      if (error instanceof WorkspaceCompositionError) {
-        // A scaffold that fails its own invariants is an operator problem, not the
-        // creator's: refuse rather than hand over an archive we cannot vouch for.
-        request.log.error({ slug, err: error }, 'workspace checkout: refused to compose an archive');
-        return reply.status(502).send({ error: 'the workspace could not be assembled' });
+
+      // Same preference order as the agent's own `get_sources`, and it has to be read off
+      // the *newest* round rather than the first owned record that happens to carry a
+      // version. An improvement round starts empty on a slug whose older job still points
+      // at the version it delivered before publication; scanning all records would hand
+      // back that older delivery, and a creator who edited it and delivered would overwrite
+      // newer published work with something derived from a superseded base. When the newest
+      // round has nothing of its own, the live publication is what they last played.
+      const tip = [...owned].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+      let version = tip.previewVersion ?? tip.deliveredVersion ?? null;
+      if (!version) {
+        const publication = await store.getPublication(slug);
+        if (publication?.state === 'published') version = publication.currentVersion;
       }
-      throw error;
-    }
-  });
+      if (!version) {
+        return reply.status(409).send({
+          error: 'nothing_delivered',
+          message: 'this game has no delivered version yet — let the first build finish, then check it out',
+        });
+      }
+
+      const manifest = await options.gamesStore.getManifest(slug, version);
+      if (!manifest) {
+        request.log.error({ slug, version }, 'workspace checkout: manifest missing for a version a job points at');
+        return reply.status(502).send({ error: 'the delivered version could not be read back' });
+      }
+
+      const sources = await Promise.all(
+        manifest.sourceFiles.map(async (path) => ({
+          path,
+          content: await options.gamesStore!.getSourceFile(slug, version, path),
+        })),
+      );
+      const missing = sources.filter((file) => file.content === null).map((file) => file.path);
+      if (missing.length > 0) {
+        request.log.error(
+          { slug, version, missing },
+          'workspace checkout: version is missing files its manifest lists',
+        );
+        return reply.status(502).send({ error: 'the delivered version could not be read back' });
+      }
+
+      try {
+        const registryBody = await options.objectStore.readObject('kits/current.json');
+        if (!registryBody) {
+          return reply.status(503).send({
+            error: 'kit_registry_missing',
+            message: 'the Creator Kit registry is not published yet',
+          });
+        }
+        const engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
+
+        const sidecarBody = await options.objectStore.readObject(`kits/${engineRef}.json`);
+        const scaffoldBody = await options.objectStore.readObject(`workspaces/${engineRef}.tgz`);
+        if (!sidecarBody || !scaffoldBody) {
+          return reply.status(503).send({
+            error: 'workspace_scaffold_missing',
+            message: `no workspace scaffold published for engine ${engineRef}`,
+          });
+        }
+
+        // Bounded at the gunzip, not only after it: `readTarEntries`' cap is on what it
+        // retains, so an over-large or corrupt scaffold would already have been inflated
+        // in full by the time that applied. The scaffold is our own artifact rather than
+        // creator input, so this guards a mispublish rather than an attacker — but the
+        // cost of being wrong about that is the API's memory, and the bound is one option.
+        const scaffold: TarEntry[] = [];
+        try {
+          const unpacked = gunzipSync(scaffoldBody, { maxOutputLength: MAX_SCAFFOLD_BYTES });
+          async function* once(): AsyncGenerator<Uint8Array> {
+            yield unpacked;
+          }
+          for await (const item of readTarEntries(once(), { maxTotalBytes: MAX_SCAFFOLD_BYTES })) {
+            scaffold.push(item);
+          }
+        } catch (error) {
+          // Unreadable is the same class of problem as invalid, and gets the same answer:
+          // a controlled 502 naming an operator problem, rather than a 500 that reads to
+          // the creator as "the site is broken" and to us as an unhandled exception.
+          throw new WorkspaceCompositionError(
+            `workspace scaffold for engine ${engineRef} could not be read: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+
+        const archive = composeWorkspaceArchive({
+          slug,
+          lock: {
+            slug,
+            engineRef,
+            // Short-lived by design. `setup.mjs` is meant to be re-run — that is also the
+            // re-baseline path when the pin falls outside the kit's N/N−1 window — so a URL
+            // that expires costs a fresh checkout link, not a broken workspace.
+            kitUrl: await options.objectStore.signReadUrl(`kits/${engineRef}.tgz`, DEFAULT_SIGNED_URL_TTL_SECONDS),
+            kitSha256: parseKitSidecar(sidecarBody.toString('utf8')).sha256,
+            issuedAt: new Date(now()).toISOString(),
+          },
+          scaffold,
+          sources: sources as Array<{ path: string; content: string }>,
+        });
+
+        return (
+          reply
+            .header('content-type', 'application/gzip')
+            .header('content-disposition', `attachment; filename="${slug}-workspace.tgz"`)
+            // The signed kit URL inside makes every archive short-lived and per-creator.
+            .header('cache-control', 'private, no-store')
+            .send(archive)
+        );
+      } catch (error) {
+        if (error instanceof KitRegistryError) {
+          return reply.status(503).send({ error: error.code, message: error.message });
+        }
+        if (error instanceof WorkspaceCompositionError) {
+          // A scaffold that fails its own invariants is an operator problem, not the
+          // creator's: refuse rather than hand over an archive we cannot vouch for.
+          request.log.error({ slug, err: error }, 'workspace checkout: refused to compose an archive');
+          return reply.status(502).send({ error: 'the workspace could not be assembled' });
+        }
+        throw error;
+      }
+    },
+  );
 }

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -344,10 +344,15 @@ export async function registerCreatorStudioRoutes(
       return reply.status(404).send({ error: 'no such game' });
     }
 
-    // Same preference order as the agent's own `get_sources`: the newest thing the
-    // creator has, which for an improvement round is the live publication rather than
-    // this job's (still empty) delivery.
-    let version = owned.map((record) => record.previewVersion ?? record.deliveredVersion).find(Boolean) ?? null;
+    // Same preference order as the agent's own `get_sources`, and it has to be read off
+    // the *newest* round rather than the first owned record that happens to carry a
+    // version. An improvement round starts empty on a slug whose older job still points
+    // at the version it delivered before publication; scanning all records would hand
+    // back that older delivery, and a creator who edited it and delivered would overwrite
+    // newer published work with something derived from a superseded base. When the newest
+    // round has nothing of its own, the live publication is what they last played.
+    const tip = [...owned].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+    let version = tip.previewVersion ?? tip.deliveredVersion ?? null;
     if (!version) {
       const publication = await store.getPublication(slug);
       if (publication?.state === 'published') version = publication.currentVersion;

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -314,13 +314,23 @@ describe('runGamesRepoContractCheck — delivery contract', () => {
     expect(reason).toContain('extraModulePattern');
   });
 
-  it('reports drift when either cap moves, in either direction', async () => {
+  it('reports drift when a games-repo cap exceeds what this side accepts', async () => {
+    // The failing direction: deliveries sized for the games-repo cap 400 at upload.
     expect(driftReason((await check(deliverySource({ maxFiles: DELIVERY_MAX_FILES + 50 }))).outcome)).toContain(
       'maxFiles',
     );
     expect(
-      driftReason((await check(deliverySource({ maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES / 2 }))).outcome),
+      driftReason((await check(deliverySource({ maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES * 2 }))).outcome),
     ).toContain('maxUploadBytes');
+  });
+
+  it('passes with a note when this side accepts more than the games repo advertises', async () => {
+    // A website-first cap raise. Inert for deliveries, and failing it would make the
+    // documented safe merge order the one that reddens master — same asymmetry as the
+    // fixed-file list.
+    const { outcome } = await check(deliverySource({ maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES / 2 }));
+    expect(outcome.kind).toBe('ok');
+    expect((outcome as { notes?: string[] }).notes?.join('\n')).toContain('maxUploadBytes');
   });
 
   it('reports drift when the reserved segments diverge, but not when they are merely reordered', async () => {

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runGamesRepoContractCheck } from './games-repo-contract-check.js';
-import { GAME_KIT_MODULES, MAX_PROJECT_BYTES } from './games-repo-contract.js';
+import {
+  DELIVERY_CONTRACT_PATH,
+  DELIVERY_CONTRACT_VERSION,
+  DELIVERY_EXTRA_MODULE_PATTERN,
+  DELIVERY_FIXED_FILES,
+  DELIVERY_MAX_FILES,
+  DELIVERY_MAX_UPLOAD_BYTES,
+  DELIVERY_RESERVED_SEGMENTS,
+  GAME_KIT_MODULES,
+  MAX_PROJECT_BYTES,
+} from './games-repo-contract.js';
 
 const ASSEMBLE_SOURCE = `
   const GAME_KIT_MODULES = [${GAME_KIT_MODULES.map((name) => `'${name}'`).join(', ')}];
@@ -10,6 +20,29 @@ const ASSEMBLE_SOURCE = `
 `;
 
 const VALIDATE_SOURCE = `const MAX_BUNDLE_BYTES = ${MAX_PROJECT_BYTES};`;
+
+/** The games-repo delivery contract as it stands when the two halves agree. */
+function deliverySource(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    version: DELIVERY_CONTRACT_VERSION,
+    _comment: 'prose the parser ignores',
+    fixedFiles: [...DELIVERY_FIXED_FILES],
+    extraModulePattern: DELIVERY_EXTRA_MODULE_PATTERN.source,
+    reservedSegments: [...DELIVERY_RESERVED_SEGMENTS],
+    maxFiles: DELIVERY_MAX_FILES,
+    maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES,
+    ...overrides,
+  });
+}
+
+/** The three files the check reads, all in agreement. */
+function agreeingPages(delivery: string | Response[] = deliverySource()): Record<string, Response[]> {
+  return {
+    'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+    'tools/validate.ts': [ok(VALIDATE_SOURCE)],
+    [DELIVERY_CONTRACT_PATH]: typeof delivery === 'string' ? [ok(delivery)] : delivery,
+  };
+}
 
 function ok(body: string, headers: Record<string, string> = {}): Response {
   return new Response(body, { status: 200, headers });
@@ -39,17 +72,14 @@ const BASE = { repo: 'gamedevpl/www.gamedev.pl-games', ref: 'main', token: 't', 
 
 describe('runGamesRepoContractCheck', () => {
   it('passes when both halves agree', async () => {
-    const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
-      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
-    });
+    const { fetchImpl } = createFetch(agreeingPages());
 
     await expect(runGamesRepoContractCheck({ ...BASE, fetchImpl })).resolves.toEqual({ kind: 'ok' });
   });
 
   it('reports drift when the games-repo budget moved ahead of the website', async () => {
     const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [ok(`const MAX_BUNDLE_BYTES = ${MAX_PROJECT_BYTES + 679};`)],
     });
 
@@ -60,7 +90,7 @@ describe('runGamesRepoContractCheck', () => {
 
   it('passes when the website budget is ahead of games-repo main (website-first)', async () => {
     const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [ok(`const MAX_BUNDLE_BYTES = ${MAX_PROJECT_BYTES - 8_000};`)],
     });
 
@@ -69,8 +99,8 @@ describe('runGamesRepoContractCheck', () => {
 
   it('reports drift when the module order diverges', async () => {
     const { fetchImpl } = createFetch({
+      ...agreeingPages(),
       'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE.replace("'input'", "'sensing', 'input'"))],
-      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
     });
 
     const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
@@ -89,10 +119,7 @@ describe('runGamesRepoContractCheck', () => {
       const track = catalog.tracks[name];
       out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
     `;
-    const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(olderAssemble)],
-      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
-    });
+    const { fetchImpl } = createFetch({ ...agreeingPages(), 'tools/lib/assemble.ts': [ok(olderAssemble)] });
 
     await expect(
       runGamesRepoContractCheck({ ...BASE, fetchImpl, now: () => Date.parse('2026-08-04T00:00:00.000Z') }),
@@ -107,10 +134,7 @@ describe('runGamesRepoContractCheck', () => {
       const track = catalog.tracks[name];
       out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
     `;
-    const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(olderAssemble)],
-      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
-    });
+    const { fetchImpl } = createFetch({ ...agreeingPages(), 'tools/lib/assemble.ts': [ok(olderAssemble)] });
 
     const outcome = await runGamesRepoContractCheck({
       ...BASE,
@@ -131,10 +155,7 @@ describe('runGamesRepoContractCheck', () => {
       const track = catalog.tracks[name];
       out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
     `;
-    const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(assembleWithout)],
-      'tools/validate.ts': [ok(VALIDATE_SOURCE)],
-    });
+    const { fetchImpl } = createFetch({ ...agreeingPages(), 'tools/lib/assemble.ts': [ok(assembleWithout)] });
 
     const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
     expect(outcome.kind).toBe('drift');
@@ -155,7 +176,7 @@ describe('runGamesRepoContractCheck', () => {
 
   it('retries a rate-limited read and succeeds on the retry', async () => {
     const { fetchImpl, calls } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [
         failure(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000' }, 'API rate limit exceeded'),
         ok(VALIDATE_SOURCE),
@@ -169,7 +190,7 @@ describe('runGamesRepoContractCheck', () => {
   it('waits the Retry-After a secondary limit asks for', async () => {
     const sleep = vi.fn(async () => {});
     const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [failure(403, { 'retry-after': '7' }, 'secondary rate limit'), ok(VALIDATE_SOURCE)],
     });
 
@@ -180,7 +201,7 @@ describe('runGamesRepoContractCheck', () => {
   it('does not fail the build when the quota is exhausted — that is not drift', async () => {
     const reset = Math.floor(Date.UTC(2026, 6, 28, 1, 0, 0) / 1000);
     const { fetchImpl } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [
         failure(
           403,
@@ -200,7 +221,7 @@ describe('runGamesRepoContractCheck', () => {
 
   it('does not retry a bare 403 — that is a permission problem, not a limit', async () => {
     const { fetchImpl, calls } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [failure(403, {}, 'Resource not accessible by personal access token')],
     });
 
@@ -212,7 +233,7 @@ describe('runGamesRepoContractCheck', () => {
 
   it('gives up after bounded retries on a 5xx', async () => {
     const { fetchImpl, calls } = createFetch({
-      'tools/lib/assemble.ts': [ok(ASSEMBLE_SOURCE)],
+      ...agreeingPages(),
       'tools/validate.ts': [
         failure(502, {}, 'Bad gateway'),
         failure(502, {}, 'Bad gateway'),
@@ -233,5 +254,113 @@ describe('runGamesRepoContractCheck', () => {
     const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
     expect(outcome.kind).toBe('unreachable');
     expect(outcome.kind === 'unreachable' && outcome.reason).toContain('ENOTFOUND');
+  });
+});
+
+describe('runGamesRepoContractCheck — delivery contract', () => {
+  async function check(delivery: string | Response[]) {
+    const { fetchImpl, calls } = createFetch(agreeingPages(delivery));
+    return { outcome: await runGamesRepoContractCheck({ ...BASE, fetchImpl }), calls };
+  }
+
+  function driftReason(outcome: Awaited<ReturnType<typeof runGamesRepoContractCheck>>): string {
+    expect(outcome.kind).toBe('drift');
+    return outcome.kind === 'drift' ? outcome.reason : '';
+  }
+
+  it('reads the contract from the games repo when both halves agree', async () => {
+    const { outcome, calls } = await check(deliverySource());
+    expect(outcome).toEqual({ kind: 'ok' });
+    expect(calls.some((url) => url.includes(DELIVERY_CONTRACT_PATH))).toBe(true);
+  });
+
+  it('reports drift, by name, for a file the games repo sends and this side refuses', async () => {
+    const { outcome } = await check(deliverySource({ fixedFiles: [...DELIVERY_FIXED_FILES, 'BALANCE.json'] }));
+    const reason = driftReason(outcome);
+    expect(reason).toContain('delivery contract mismatch');
+    expect(reason).toContain('games repo sends and this side refuses: BALANCE.json');
+  });
+
+  it('passes with a note when this side accepts a file the games repo does not list yet', async () => {
+    // The documented rollout order is website-first, so this state is the safe one. If it
+    // failed, the safe order would be the one that reddens master and the unsafe order the
+    // comfortable one — see describeDeliveryDrift.
+    const withoutEditor = DELIVERY_FIXED_FILES.filter((path) => path !== 'EDITOR.json');
+    const { outcome } = await check(deliverySource({ fixedFiles: withoutEditor }));
+    expect(outcome.kind).toBe('ok');
+    expect((outcome as { notes?: string[] }).notes?.join('\n')).toContain('EDITOR.json');
+  });
+
+  it('reports a reorder distinctly from an add', async () => {
+    const swapped = [...DELIVERY_FIXED_FILES];
+    [swapped[0], swapped[1]] = [swapped[1], swapped[0]];
+    const reason = driftReason((await check(deliverySource({ fixedFiles: swapped }))).outcome);
+    expect(reason).toContain('fixedFiles order differs');
+    expect(reason).not.toContain('sends and this side refuses');
+  });
+
+  it('does not read a website-ahead entry as a phantom reorder', async () => {
+    // Dropping a middle entry shifts every later one; comparing full lists would call that
+    // a reorder on top of the (tolerated) missing entry.
+    const withoutTrace = DELIVERY_FIXED_FILES.filter((path) => path !== 'TRACE.json');
+    const { outcome } = await check(deliverySource({ fixedFiles: withoutTrace }));
+    expect(outcome.kind).toBe('ok');
+  });
+
+  it('reports drift when the extra-module pattern diverges', async () => {
+    const reason = driftReason(
+      (await check(deliverySource({ extraModulePattern: '^[a-z0-9][a-z0-9/-]{0,90}\\.ts$' }))).outcome,
+    );
+    expect(reason).toContain('extraModulePattern');
+  });
+
+  it('reports drift when either cap moves, in either direction', async () => {
+    expect(driftReason((await check(deliverySource({ maxFiles: DELIVERY_MAX_FILES + 50 }))).outcome)).toContain(
+      'maxFiles',
+    );
+    expect(
+      driftReason((await check(deliverySource({ maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES / 2 }))).outcome),
+    ).toContain('maxUploadBytes');
+  });
+
+  it('reports drift when the reserved segments diverge, but not when they are merely reordered', async () => {
+    const reason = driftReason((await check(deliverySource({ reservedSegments: ['shared', 'tools'] }))).outcome);
+    expect(reason).toContain('reservedSegments');
+
+    const shuffled = [...DELIVERY_RESERVED_SEGMENTS].reverse();
+    expect((await check(deliverySource({ reservedSegments: shuffled }))).outcome).toEqual({ kind: 'ok' });
+  });
+
+  it('reports drift on a shape-version bump — the parser has to be taught first', async () => {
+    expect(driftReason((await check(deliverySource({ version: DELIVERY_CONTRACT_VERSION + 1 }))).outcome)).toContain(
+      'version:',
+    );
+  });
+
+  it('reports drift rather than crashing on a malformed contract file', async () => {
+    expect(driftReason((await check('{ not json')).outcome)).toContain('not valid JSON');
+    expect(driftReason((await check(deliverySource({ maxFiles: 'lots' }))).outcome)).toContain('positive integer');
+  });
+
+  it('tolerates a games tip that predates the contract file — 404 is not drift', async () => {
+    const { outcome } = await check([failure(404, {}, 'Not Found')]);
+    expect(outcome.kind).toBe('ok');
+    expect(outcome.kind === 'ok' && outcome.notes?.join('\n')).toContain(DELIVERY_CONTRACT_PATH);
+    expect(outcome.kind === 'ok' && outcome.notes?.join('\n')).toContain('NOT');
+  });
+
+  it('does not retry a 404 on the contract file', async () => {
+    const { calls } = await check([failure(404, {}, 'Not Found')]);
+    expect(calls.filter((url) => url.includes(DELIVERY_CONTRACT_PATH))).toHaveLength(1);
+  });
+
+  it('still treats an unreadable contract file as unreachable, not as absent', async () => {
+    const { outcome } = await check([
+      failure(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000' }, 'API rate limit exceeded'),
+      failure(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000' }, 'API rate limit exceeded'),
+      failure(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-limit': '5000' }, 'API rate limit exceeded'),
+    ]);
+    expect(outcome.kind).toBe('unreachable');
+    expect(outcome.kind === 'unreachable' && outcome.reason).toContain(DELIVERY_CONTRACT_PATH);
   });
 });

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -460,11 +460,26 @@ function describeDeliveryDrift(remote: DeliveryContract): { drift: string | null
     problems.push(`reservedSegments: games-repo=${remoteSegments.join(', ')} website=${localSegments.join(', ')}`);
   }
 
-  if (remote.maxFiles !== DELIVERY_MAX_FILES) {
-    problems.push(`maxFiles: games-repo=${remote.maxFiles} website=${DELIVERY_MAX_FILES}`);
-  }
-  if (remote.maxUploadBytes !== DELIVERY_MAX_UPLOAD_BYTES) {
-    problems.push(`maxUploadBytes: games-repo=${remote.maxUploadBytes} website=${DELIVERY_MAX_UPLOAD_BYTES}`);
+  // Caps get the same directional treatment as the file list, for the same reason: a
+  // games repo that advertises a *higher* cap than this side accepts sends deliveries
+  // that 400, while this side accepting more than the games repo advertises is inert and
+  // is what a website-first raise looks like in the middle. Comparing for equality would
+  // make the safe order red and the unsafe order comfortable.
+  for (const cap of [
+    { name: 'maxFiles', remote: remote.maxFiles, local: DELIVERY_MAX_FILES },
+    { name: 'maxUploadBytes', remote: remote.maxUploadBytes, local: DELIVERY_MAX_UPLOAD_BYTES },
+  ]) {
+    if (cap.remote > cap.local) {
+      problems.push(
+        `${cap.name}: games-repo=${cap.remote} exceeds website=${cap.local} — deliveries sized for the ` +
+          `games-repo cap are refused at upload. Raise this side first.`,
+      );
+    } else if (cap.remote < cap.local) {
+      notes.push(
+        `delivery contract: this side allows ${cap.name}=${cap.local} against the games repo's ${cap.remote}. ` +
+          `Harmless and expected mid-rollout (this side widens first); land the paired games-repo change.`,
+      );
+    }
   }
 
   if (problems.length === 0) {

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -2,9 +2,10 @@
  * The cross-repo lockstep check itself (issue #247), separated from the CI script
  * so its failure modes are unit-testable.
  *
- * Reads `tools/lib/assemble.ts` and `tools/validate.ts` from the games repo and
- * asserts they still match `games-repo-contract.ts` on this side. Two outcomes are
- * emphatically not the same thing, and the difference is why this lives here:
+ * Reads `tools/lib/assemble.ts`, `tools/validate.ts` and `shared/delivery-contract.json`
+ * from the games repo and asserts they still match `games-repo-contract.ts` on this side.
+ * Two outcomes are emphatically not the same thing, and the difference is why this lives
+ * here:
  *
  *   - **drift** — the two halves disagree. That is the bug this check exists to
  *     catch, and it fails CI.
@@ -19,14 +20,29 @@
  * is that it says so loudly — as a CI annotation, with GitHub's own rate-limit
  * headers — and that `GAMES_CONTRACT_REQUIRE_REMOTE=1` turns it back into a failure
  * for anyone who wants the strict posture.
+ *
+ * A games tip that has no `shared/delivery-contract.json` yet is a third thing again: a
+ * successfully observed absence, not a failed read, and the expected state while this side
+ * merges first. It is tolerated, annotated on the ok outcome, and — unlike an unreachable
+ * remote — not turned into a failure by `GAMES_CONTRACT_REQUIRE_REMOTE`, which exists to
+ * demand that the fetch happened, and it did.
  */
 
 import {
+  DELIVERY_CONTRACT_PATH,
+  DELIVERY_CONTRACT_VERSION,
+  DELIVERY_EXTRA_MODULE_PATTERN,
+  DELIVERY_FIXED_FILES,
+  DELIVERY_MAX_FILES,
+  DELIVERY_MAX_UPLOAD_BYTES,
+  DELIVERY_RESERVED_SEGMENTS,
+  extractDeliveryContract,
   extractGameKitModules,
   extractMaxBundleBytes,
   extractMusicContractSignals,
   GAME_KIT_MODULES,
   MAX_PROJECT_BYTES,
+  type DeliveryContract,
 } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
@@ -35,8 +51,11 @@ export type ContractCheckOutcome =
   | { kind: 'skipped'; reason: string }
   /** The games repo could not be read. Says nothing about drift. */
   | { kind: 'unreachable'; reason: string }
-  /** Both halves agree. */
-  | { kind: 'ok' }
+  /**
+   * Every half that could be compared agrees. `notes` carries the halves that were
+   * tolerated rather than compared, so a green run still says so out loud.
+   */
+  | { kind: 'ok'; notes?: string[] }
   /** The halves disagree — the failure this check is for. */
   | { kind: 'drift'; reason: string };
 
@@ -61,7 +80,15 @@ const MAX_RETRY_DELAY_MS = 10_000;
 /** Enough of GitHub's error body to name the cause without pasting a page of JSON. */
 const MAX_BODY_CHARS = 300;
 
-class UnreachableGamesRepoError extends Error {}
+class UnreachableGamesRepoError extends Error {
+  /** HTTP status of the last response, absent when the fault was below HTTP. */
+  readonly status: number | undefined;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+  }
+}
 
 /** True when `remote` is an exact prefix of `local` (same order; local may be longer). */
 export function isModulePrefix(remote: string[], local: string[]): boolean {
@@ -156,6 +183,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   async function readGamesRepoFile(path: string): Promise<string> {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
     let lastFailure = 'no attempt was made';
+    let lastStatus: number | undefined;
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
       let response: Response;
@@ -171,6 +199,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
       } catch (error: unknown) {
         // A network fault is transient by definition — retry it like a 5xx.
         lastFailure = error instanceof Error ? error.message : String(error);
+        lastStatus = undefined;
         if (attempt + 1 < MAX_ATTEMPTS) {
           await sleep(RETRY_BASE_DELAY_MS * 2 ** attempt);
           continue;
@@ -187,6 +216,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
       }
 
       lastFailure = await describeFailure(response);
+      lastStatus = response.status;
       if (!isTransientResponse(response) || attempt + 1 >= MAX_ATTEMPTS) {
         break;
       }
@@ -203,15 +233,35 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
       await sleep(delayMs);
     }
 
-    throw new UnreachableGamesRepoError(`cannot read ${repo}@${ref}:${path} (${lastFailure})`);
+    throw new UnreachableGamesRepoError(`cannot read ${repo}@${ref}:${path} (${lastFailure})`, lastStatus);
+  }
+
+  /**
+   * Same read, but a 404 answers `null`. Only for halves this side is allowed to be ahead
+   * on: a games tip that predates the file is the expected state during a website-first
+   * rollout, and treating it as unreachable would make the ordering rule unusable. A wrong
+   * repo or ref cannot slip through as "absent": it 404s the two required files as well,
+   * and those reject the whole run as unreachable whatever this one answered.
+   */
+  async function readOptionalGamesRepoFile(path: string): Promise<string | null> {
+    try {
+      return await readGamesRepoFile(path);
+    } catch (error: unknown) {
+      if (error instanceof UnreachableGamesRepoError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   let assembleSource: string;
   let validateSource: string;
+  let deliverySource: string | null;
   try {
-    [assembleSource, validateSource] = await Promise.all([
+    [assembleSource, validateSource, deliverySource] = await Promise.all([
       readGamesRepoFile('tools/lib/assemble.ts'),
       readGamesRepoFile('tools/validate.ts'),
+      readOptionalGamesRepoFile(DELIVERY_CONTRACT_PATH),
     ]);
   } catch (error: unknown) {
     if (error instanceof UnreachableGamesRepoError) {
@@ -314,5 +364,116 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   }
   log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + readMusicCatalog)');
 
-  return { kind: 'ok' };
+  const notes: string[] = [];
+  if (deliverySource === null) {
+    notes.push(
+      `${DELIVERY_CONTRACT_PATH} is absent from ${repo}@${ref} (404) — the delivery half was NOT ` +
+        `compared. Expected only while this side is ahead of the games tip; if the file has landed ` +
+        `there, GAMES_PUBLISHED_REF is probably pointing at an older ref.`,
+    );
+    log(`  · ${DELIVERY_CONTRACT_PATH}: absent on the games tip — delivery half not compared`);
+  } else {
+    let remoteDelivery: DeliveryContract;
+    try {
+      remoteDelivery = extractDeliveryContract(deliverySource);
+    } catch (error: unknown) {
+      return { kind: 'drift', reason: error instanceof Error ? error.message : String(error) };
+    }
+    const delivery = describeDeliveryDrift(remoteDelivery);
+    if (delivery.drift) {
+      return { kind: 'drift', reason: delivery.drift };
+    }
+    notes.push(...delivery.notes);
+    log(`  ✓ delivery contract (${remoteDelivery.fixedFiles.length} fixed files, ${remoteDelivery.maxFiles} max)`);
+  }
+
+  return notes.length > 0 ? { kind: 'ok', notes } : { kind: 'ok' };
+}
+
+/**
+ * Compare the games repo's delivery contract against this side's constants.
+ *
+ * Asymmetric, and deliberately so — it enforces the ordering rule rather than mere
+ * equality. A path the games repo sends and this side refuses is the bug the whole check
+ * exists for: every delivery carrying it 400s at upload. The reverse — this side accepting
+ * a path no game sends yet — is the *intended* middle state of a website-first rollout, so
+ * failing on it would make the documented safe order the one that turns master red, and the
+ * unsafe order the comfortable one. It is reported as a note instead, loudly enough that a
+ * permanently half-landed change is still visible.
+ *
+ * Same asymmetry the GameKit module half already uses for website-ahead extras, arrived at
+ * for the same reason.
+ */
+function describeDeliveryDrift(remote: DeliveryContract): { drift: string | null; notes: string[] } {
+  const localFixed = [...DELIVERY_FIXED_FILES] as string[];
+  const problems: string[] = [];
+  const notes: string[] = [];
+
+  if (remote.version !== DELIVERY_CONTRACT_VERSION) {
+    problems.push(
+      `version: games-repo=${remote.version} website=${DELIVERY_CONTRACT_VERSION} — the contract ` +
+        `shape changed; update extractDeliveryContract before the values.`,
+    );
+  }
+
+  // The two directions are different bugs with different fixes, so they are never
+  // collapsed into one "lists differ" line.
+  const addedByGames = remote.fixedFiles.filter((path) => !localFixed.includes(path));
+  const websiteOnly = localFixed.filter((path) => !remote.fixedFiles.includes(path));
+  if (addedByGames.length > 0) {
+    problems.push(
+      `fixedFiles the games repo sends and this side refuses: ${addedByGames.join(', ')} — every ` +
+        `delivery carrying one 400s at upload. Add them to DELIVERY_FIXED_FILES now.`,
+    );
+  }
+  if (websiteOnly.length > 0) {
+    notes.push(
+      `delivery contract: this side accepts ${websiteOnly.join(', ')}, which the games repo does not ` +
+        `list yet. Harmless to deliveries and expected mid-rollout (this side widens first), but if the ` +
+        `paired games-repo change is not on its way, drop the entries here.`,
+    );
+  }
+
+  // Order is contractual — both sides render this list into agent-facing text — but only
+  // over what both sides have. Comparing full lists would re-fail the website-ahead case
+  // above as a phantom reorder.
+  const sharedRemote = remote.fixedFiles.filter((path) => localFixed.includes(path));
+  const sharedLocal = localFixed.filter((path) => remote.fixedFiles.includes(path));
+  if (addedByGames.length === 0 && sharedRemote.join(',') !== sharedLocal.join(',')) {
+    problems.push(
+      `fixedFiles order differs — games-repo: ${sharedRemote.join(', ')}; website: ${sharedLocal.join(', ')}. ` +
+        `Order is contractual: both sides render this list into agent-facing text.`,
+    );
+  }
+
+  if (remote.extraModulePattern !== DELIVERY_EXTRA_MODULE_PATTERN.source) {
+    problems.push(
+      `extraModulePattern: games-repo=${remote.extraModulePattern} ` +
+        `website=${DELIVERY_EXTRA_MODULE_PATTERN.source}`,
+    );
+  }
+
+  // Order carries no meaning for reserved segments — both sides use them as a set.
+  const localSegments = [...DELIVERY_RESERVED_SEGMENTS].sort();
+  const remoteSegments = [...remote.reservedSegments].sort();
+  if (localSegments.join(',') !== remoteSegments.join(',')) {
+    problems.push(`reservedSegments: games-repo=${remoteSegments.join(', ')} website=${localSegments.join(', ')}`);
+  }
+
+  if (remote.maxFiles !== DELIVERY_MAX_FILES) {
+    problems.push(`maxFiles: games-repo=${remote.maxFiles} website=${DELIVERY_MAX_FILES}`);
+  }
+  if (remote.maxUploadBytes !== DELIVERY_MAX_UPLOAD_BYTES) {
+    problems.push(`maxUploadBytes: games-repo=${remote.maxUploadBytes} website=${DELIVERY_MAX_UPLOAD_BYTES}`);
+  }
+
+  if (problems.length === 0) {
+    return { drift: null, notes };
+  }
+  return {
+    drift:
+      `delivery contract mismatch (${DELIVERY_CONTRACT_PATH} vs apps/api/src/games-repo-contract.ts):\n` +
+      problems.map((problem) => `  - ${problem}`).join('\n'),
+    notes,
+  };
 }

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DELIVERY_CONTRACT_VERSION,
+  DELIVERY_EXTRA_MODULE_PATTERN,
+  DELIVERY_FIXED_FILES,
+  DELIVERY_MAX_FILES,
+  DELIVERY_MAX_UPLOAD_BYTES,
+  DELIVERY_RESERVED_SEGMENTS,
+  extractDeliveryContract,
   extractGameKitModules,
   extractMaxBundleBytes,
   extractMusicContractSignals,
@@ -10,6 +17,30 @@ import {
   MUSIC_CONTRACT,
 } from './games-repo-contract.js';
 import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
+import { ALLOWED_SOURCE_FILES, MAX_UPLOAD_BYTES, MAX_UPLOAD_FILES } from './games-store.js';
+
+/** The real games-repo file, snapshotted under fixtures/ (see local-games-repo.ts). */
+async function readDeliveryContractFixture(): Promise<string> {
+  const { readFile } = await import('node:fs/promises');
+  const { fileURLToPath } = await import('node:url');
+  const path = await import('node:path');
+  return readFile(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/games-repo/shared/delivery-contract.json'),
+    'utf8',
+  );
+}
+
+/** A well-formed contract to mutate one field of, so each rejection test names one cause. */
+function validContract(): Record<string, unknown> {
+  return {
+    version: DELIVERY_CONTRACT_VERSION,
+    fixedFiles: [...DELIVERY_FIXED_FILES],
+    extraModulePattern: DELIVERY_EXTRA_MODULE_PATTERN.source,
+    reservedSegments: [...DELIVERY_RESERVED_SEGMENTS],
+    maxFiles: DELIVERY_MAX_FILES,
+    maxUploadBytes: DELIVERY_MAX_UPLOAD_BYTES,
+  };
+}
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
@@ -72,6 +103,97 @@ describe('games-repo-contract (website half)', () => {
   it('documents the music field as a string over the tracks catalog key', () => {
     expect(MUSIC_CONTRACT.manifestFieldType).toBe('string');
     expect(MUSIC_CONTRACT.catalogTracksKey).toBe('tracks');
+  });
+});
+
+describe('delivery contract (website half)', () => {
+  it('is the single source games-store enforces, not a second literal', () => {
+    expect(ALLOWED_SOURCE_FILES).toBe(DELIVERY_FIXED_FILES);
+    expect(MAX_UPLOAD_FILES).toBe(DELIVERY_MAX_FILES);
+    expect(MAX_UPLOAD_BYTES).toBe(DELIVERY_MAX_UPLOAD_BYTES);
+  });
+
+  it('keeps the fixed deliverables in the contract order', () => {
+    expect([...DELIVERY_FIXED_FILES]).toEqual([
+      'SPEC.md',
+      'GAME.json',
+      'CAPTURE.json',
+      'ACCEPTANCE.json',
+      'TRACE.json',
+      'PLAYTEST.json',
+      'AGENT.json',
+      'EDITOR.json',
+      'index.html',
+      'game.ts',
+      'style.css',
+      'sim.ts',
+    ]);
+  });
+
+  it('keeps the extra-module pattern comparable to the games-repo JSON byte-for-byte', () => {
+    // A regex *literal* would render `/` as `\/` in `.source` and read as permanent drift.
+    expect(DELIVERY_EXTRA_MODULE_PATTERN.source).toBe('^[a-z0-9][a-z0-9/-]{0,60}\\.ts$');
+    expect(DELIVERY_EXTRA_MODULE_PATTERN.test('game/editor-content.ts')).toBe(true);
+    expect(DELIVERY_EXTRA_MODULE_PATTERN.test('Game.ts')).toBe(false);
+  });
+});
+
+describe('extractDeliveryContract', () => {
+  it('accepts the real games-repo contract file and agrees with the local constants', async () => {
+    const contract = extractDeliveryContract(await readDeliveryContractFixture());
+    expect(contract.version).toBe(DELIVERY_CONTRACT_VERSION);
+    expect(contract.fixedFiles).toEqual([...DELIVERY_FIXED_FILES]);
+    expect(contract.extraModulePattern).toBe(DELIVERY_EXTRA_MODULE_PATTERN.source);
+    expect([...contract.reservedSegments].sort()).toEqual([...DELIVERY_RESERVED_SEGMENTS].sort());
+    expect(contract.maxFiles).toBe(DELIVERY_MAX_FILES);
+    expect(contract.maxUploadBytes).toBe(DELIVERY_MAX_UPLOAD_BYTES);
+  });
+
+  it('ignores the underscore-prefixed prose the contract carries for humans', () => {
+    const withProse = JSON.stringify({ ...validContract(), _comment: 'why', _notDelivered: 'media/' });
+    expect(extractDeliveryContract(withProse).fixedFiles).toEqual([...DELIVERY_FIXED_FILES]);
+  });
+
+  it('rejects input that is not JSON', () => {
+    expect(() => extractDeliveryContract('{ nope')).toThrow(/not valid JSON/);
+  });
+
+  it('rejects a JSON array or scalar where an object belongs', () => {
+    expect(() => extractDeliveryContract('[]')).toThrow(/must be a JSON object/);
+    expect(() => extractDeliveryContract('7')).toThrow(/must be a JSON object/);
+  });
+
+  it('rejects a missing or empty fixedFiles list', () => {
+    const { fixedFiles: _omitted, ...withoutFixedFiles } = validContract();
+    expect(() => extractDeliveryContract(JSON.stringify(withoutFixedFiles))).toThrow(/`fixedFiles` must be an array/);
+    expect(() => extractDeliveryContract(JSON.stringify({ ...validContract(), fixedFiles: [] }))).toThrow(
+      /`fixedFiles` is empty/,
+    );
+  });
+
+  it('names the offending index when a fixed file is not a string', () => {
+    const broken = { ...validContract(), fixedFiles: ['SPEC.md', 42] };
+    expect(() => extractDeliveryContract(JSON.stringify(broken))).toThrow(/`fixedFiles\[1\]`/);
+  });
+
+  it('rejects an extraModulePattern that is not a compilable regular expression', () => {
+    expect(() => extractDeliveryContract(JSON.stringify({ ...validContract(), extraModulePattern: '[' }))).toThrow(
+      /not a valid regular expression/,
+    );
+    expect(() => extractDeliveryContract(JSON.stringify({ ...validContract(), extraModulePattern: '' }))).toThrow(
+      /must be a non-empty string/,
+    );
+  });
+
+  it('rejects caps that are not positive integers', () => {
+    for (const bad of [0, -1, 1.5, '200', null]) {
+      expect(() => extractDeliveryContract(JSON.stringify({ ...validContract(), maxFiles: bad }))).toThrow(
+        /`maxFiles` must be a positive integer/,
+      );
+      expect(() => extractDeliveryContract(JSON.stringify({ ...validContract(), maxUploadBytes: bad }))).toThrow(
+        /`maxUploadBytes` must be a positive integer/,
+      );
+    }
   });
 });
 

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -18,6 +18,23 @@
  * allows this side to list modules the published games tip has not shipped yet
  * (website-ahead extras), and fails only when games-repo introduces a name or
  * reorders shared modules this side does not recognize.
+ *
+ * ---
+ *
+ * The second half of this file is the **delivery** contract — which files a game may
+ * upload — cut from the same games-repo file `tools/submit.mjs` reads
+ * ({@link DELIVERY_CONTRACT_PATH}). It used to be a hand-kept literal on each side and
+ * drifted three times (TRACE, then PLAYTEST, then AGENT); each drift turned a finished
+ * game into a multi-delivery retry loop, because the site refused a path the games repo
+ * had just made mandatory.
+ *
+ * **Adding a deliverable file? Merge this side first — the same order as raising a byte
+ * budget, for the same underlying reason:** the side that *accepts* has to widen before
+ * the side that *sends*. A site that allows a path no game delivers yet is inert; a game
+ * that delivers a path the site refuses gets a 400 at upload, and the agent that could
+ * have fixed it is gone twenty minutes later. Removing a file is the mirror image —
+ * games-repo stops sending it first, this side drops the entry last — so the rule in both
+ * directions is that the allowlist here is never the narrower of the two.
  */
 
 /** Canonical GameKit module order — must match games-repo `GAME_KIT_MODULES`. */
@@ -162,6 +179,182 @@ export function extractMusicContractSignals(assembleSource: string): {
       new RegExp(`\\b${MUSIC_CONTRACT.catalogReader}\\s*\\(`).test(assembleSource) ||
       new RegExp(catalogPathPattern).test(assembleSource),
   };
+}
+
+/* ── Delivery contract (games-repo `shared/delivery-contract.json`) ─────────────── */
+
+/** Where the machine-readable delivery contract lives in the games repo. */
+export const DELIVERY_CONTRACT_PATH = 'shared/delivery-contract.json';
+
+/** Shape version this side understands. A bump means the shape changed, not the values. */
+export const DELIVERY_CONTRACT_VERSION = 1;
+
+/**
+ * Fixed files a game may deliver — games-repo `delivery-contract.json` `fixedFiles`, in
+ * that order. Order is part of the contract: both sides render it into agent-facing
+ * refusal and instruction text, so a reshuffle is a visible change even when the set is
+ * identical, and the CI check reports it separately from an add or a remove.
+ *
+ * Game-shape only: SPEC / GAME / CAPTURE / ACCEPTANCE / TRACE / PLAYTEST / AGENT / EDITOR,
+ * the playable trio, and `sim.ts`. Media bytes are produced by our gate and never
+ * uploaded, so `media/` is refused rather than listed here.
+ */
+export const DELIVERY_FIXED_FILES = [
+  'SPEC.md',
+  'GAME.json',
+  'CAPTURE.json',
+  'ACCEPTANCE.json',
+  // The committed behavioural golden. It is not source in the ordinary sense, but the
+  // gate replays CAPTURE.json against our engine and diffs the result against this file,
+  // so a delivery without it is one the gate cannot check — it fails at the trace stage
+  // with `no committed trace`, having proved nothing about the game.
+  'TRACE.json',
+  // The per-game playtest contract the harness requires of every game (validate Check
+  // 26, `tools/lib/playtest-contract.ts`). Same shape of dependency as TRACE.json: a
+  // harness-side requirement that only the agent can satisfy, so leaving it off this
+  // list does not keep anything out — it makes every delivery unpassable. It did: the
+  // check landed in the games repo while this list stayed as it was, and from then on
+  // each delivered game reached validate and stopped there, with no gate artifacts and
+  // therefore no draft preview for the creator watching.
+  'PLAYTEST.json',
+  // Validate Check 28 (`tools/lib/agent-contract.ts`) requires AGENT.json so
+  // `npm run agent-play` knows whether to replay CAPTURE or load a closed-loop module.
+  // Same drift class as TRACE/PLAYTEST above: the check landed in the games repo while
+  // this list stayed put, so agents that wrote a correct AGENT.json were told the path
+  // was not deliverable, dropped it, and then failed the remote gate at Check 28 —
+  // burning a session on allowlist archaeology instead of the game.
+  //
+  // Accepted, but not hard-required at upload yet: in-flight builder workspaces still ship
+  // the pre-companion submit tool that omits AGENT.json, and the two repos cannot deploy
+  // atomically. Requiring it at upload would 400 those deliveries before the gate could
+  // even run. Let Check 28 report the missing contract until old workspaces drain; then
+  // promote to a required upload (same path TRACE/PLAYTEST already took) in
+  // `validateSourceUpload`.
+  'AGENT.json',
+  // The editor declaration (EditorKit L0, games-repo Check 31). Optional — only
+  // born-editable games ship one — but same drift class as TRACE/PLAYTEST/AGENT
+  // above: the games repo already sends it, and refusing it here would 400 every
+  // born-editable delivery at upload. The generated `game/editor-content.ts` needs no
+  // entry, it matches {@link DELIVERY_EXTRA_MODULE_PATTERN}.
+  'EDITOR.json',
+  'index.html',
+  'game.ts',
+  'style.css',
+  'sim.ts',
+] as const;
+
+/**
+ * Additional source files a game may carry beyond the fixed set — its own modules only.
+ * Kept narrow on purpose: relative imports inside the game directory are the one thing
+ * games legitimately add, and everything else is a smell. Covers modules under `game/`
+ * and other in-game modules (`entities/player.ts`, …).
+ *
+ * Built from the contract's string form rather than written as a regex literal: `.source`
+ * on a literal escapes the `/` inside the character class (`[a-z0-9\/-]`), which would not
+ * match the games-repo JSON byte-for-byte and would read as drift on every CI run.
+ */
+export const DELIVERY_EXTRA_MODULE_PATTERN = new RegExp('^[a-z0-9][a-z0-9/-]{0,60}\\.ts$');
+
+/**
+ * First path segments a game may not use. Set semantics, not a sequence — order carries no
+ * meaning here and the CI check compares them as sets.
+ */
+export const DELIVERY_RESERVED_SEGMENTS = [
+  'shared',
+  'tools',
+  'games',
+  'node_modules',
+  'dist',
+  'references',
+  'templates',
+] as const;
+
+/** Cap on files per delivery. */
+export const DELIVERY_MAX_FILES = 200;
+
+/** Total bytes one delivery may carry. */
+export const DELIVERY_MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+
+/** The games-repo delivery contract as read off the wire. */
+export interface DeliveryContract {
+  version: number;
+  fixedFiles: string[];
+  extraModulePattern: string;
+  reservedSegments: string[];
+  maxFiles: number;
+  maxUploadBytes: number;
+}
+
+/**
+ * Parse games-repo `shared/delivery-contract.json`. Unlike the assemble/validate
+ * extractors this reads a file written to be read, so it validates the shape strictly and
+ * names the offending field: a contract that parses into partial garbage would compare
+ * "clean" against this side and hide exactly the drift the check exists to catch.
+ */
+export function extractDeliveryContract(json: string): DeliveryContract {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error: unknown) {
+    throw new Error(
+      `games-repo delivery contract is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('games-repo delivery contract must be a JSON object');
+  }
+  const raw = parsed as Record<string, unknown>;
+
+  return {
+    version: readPositiveInteger(raw, 'version'),
+    fixedFiles: readStringArray(raw, 'fixedFiles', { allowEmpty: false }),
+    extraModulePattern: readPattern(raw, 'extraModulePattern'),
+    reservedSegments: readStringArray(raw, 'reservedSegments', { allowEmpty: true }),
+    maxFiles: readPositiveInteger(raw, 'maxFiles'),
+    maxUploadBytes: readPositiveInteger(raw, 'maxUploadBytes'),
+  };
+}
+
+function readStringArray(raw: Record<string, unknown>, key: string, options: { allowEmpty: boolean }): string[] {
+  const value = raw[key];
+  if (!Array.isArray(value)) {
+    throw new Error(`games-repo delivery contract field \`${key}\` must be an array of strings`);
+  }
+  if (!options.allowEmpty && value.length === 0) {
+    throw new Error(`games-repo delivery contract field \`${key}\` is empty`);
+  }
+  return value.map((entry, index) => {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      throw new Error(`games-repo delivery contract \`${key}[${index}]\` is not a non-empty string`);
+    }
+    return entry;
+  });
+}
+
+function readPositiveInteger(raw: Record<string, unknown>, key: string): number {
+  const value = raw[key];
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`games-repo delivery contract field \`${key}\` must be a positive integer`);
+  }
+  return value;
+}
+
+function readPattern(raw: Record<string, unknown>, key: string): string {
+  const value = raw[key];
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`games-repo delivery contract field \`${key}\` must be a non-empty string`);
+  }
+  try {
+    new RegExp(value);
+  } catch (error: unknown) {
+    throw new Error(
+      `games-repo delivery contract field \`${key}\` is not a valid regular expression: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  return value;
 }
 
 function evaluateByteExpression(expression: string, source: string): number {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -19,6 +19,13 @@
 
 import { randomBytes } from 'node:crypto';
 import { GoogleAuth } from 'google-auth-library';
+import {
+  DELIVERY_EXTRA_MODULE_PATTERN,
+  DELIVERY_FIXED_FILES,
+  DELIVERY_MAX_FILES,
+  DELIVERY_MAX_UPLOAD_BYTES,
+  DELIVERY_RESERVED_SEGMENTS,
+} from './games-repo-contract.js';
 import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from './kit-window.js';
 
 /**
@@ -30,65 +37,28 @@ import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from './kit-w
  * reaches `shared/`, `tools/`, or another game's directory, so a prompt-injected or
  * simply confused agent cannot widen its own scope.
  *
- * Game-shape only: SPEC / GAME / CAPTURE / PLAYTEST / TRACE, the playable trio, and the
- * game's own `.ts` modules (including under `game/`). Media bytes are produced by our
- * gate, never uploaded — `media/` paths are refused below.
+ * The list itself lives in `games-repo-contract.ts`, beside the other halves of the
+ * cross-repo lockstep, because it is shared with the games repo's own submit tool — and
+ * because keeping two literals in step by hand is what drifted three times. Change it
+ * there (and read the ordering rule in that file's header before you do); enforcement
+ * stays here. Media bytes are produced by our gate, never uploaded — `media/` paths are
+ * refused below rather than listed.
  */
-export const ALLOWED_SOURCE_FILES = [
-  'SPEC.md',
-  'GAME.json',
-  'CAPTURE.json',
-  'ACCEPTANCE.json',
-  // The committed behavioural golden. It is not source in the ordinary sense, but the
-  // gate replays CAPTURE.json against our engine and diffs the result against this file,
-  // so a delivery without it is one the gate cannot check — it fails at the trace stage
-  // with `no committed trace`, having proved nothing about the game.
-  'TRACE.json',
-  // The per-game playtest contract the harness requires of every game (validate Check
-  // 26, `tools/lib/playtest-contract.ts`). Same shape of dependency as TRACE.json: a
-  // harness-side requirement that only the agent can satisfy, so leaving it off this
-  // list does not keep anything out — it makes every delivery unpassable. It did: the
-  // check landed in the games repo while this list stayed as it was, and from then on
-  // each delivered game reached validate and stopped there, with no gate artifacts and
-  // therefore no draft preview for the creator watching.
-  'PLAYTEST.json',
-  // Validate Check 28 (`tools/lib/agent-contract.ts`) requires AGENT.json so
-  // `npm run agent-play` knows whether to replay CAPTURE or load a closed-loop module.
-  // Same drift class as TRACE/PLAYTEST above: the check landed in the games repo while
-  // this list stayed put, so agents that wrote a correct AGENT.json were told the path
-  // was not deliverable, dropped it, and then failed the remote gate at Check 28 —
-  // burning a session on allowlist archaeology instead of the game.
-  //
-  // Accepted here, but not hard-required yet: in-flight builder workspaces still ship the
-  // pre-companion submit tool that omits AGENT.json, and the two repos cannot deploy
-  // atomically. Requiring it at upload would 400 those deliveries before the gate could
-  // even run. Let Check 28 report the missing contract until old workspaces drain; then
-  // promote to a required upload (same path TRACE/PLAYTEST already took).
-  'AGENT.json',
-  // The editor declaration (EditorKit L0, games-repo Check 31). Optional — only
-  // born-editable games ship one — but same drift class as TRACE/PLAYTEST/AGENT
-  // above: the games repo's `FIXED_FILES` already lists it, and refusing it here
-  // would 400 every born-editable delivery at upload. The generated
-  // `game/editor-content.ts` needs no entry, it matches EXTRA_SOURCE_PATTERN.
-  'EDITOR.json',
-  'index.html',
-  'game.ts',
-  'style.css',
-  'sim.ts',
-] as const;
+export const ALLOWED_SOURCE_FILES = DELIVERY_FIXED_FILES;
 
-/**
- * Additional source files a game may carry beyond the fixed set — its own modules only.
- * Kept narrow on purpose: relative imports inside the game directory are the one thing
- * games legitimately add, and everything else is a smell. Covers modules under `game/`
- * and other in-game modules (`entities/player.ts`, …).
- */
-const EXTRA_SOURCE_PATTERN = /^[a-z0-9][a-z0-9/-]{0,60}\.ts$/;
+/** A game's own `.ts` modules, the one thing it may add beyond the fixed set. */
+const EXTRA_SOURCE_PATTERN = DELIVERY_EXTRA_MODULE_PATTERN;
 
 /**
  * Config-shaped or executable-config paths an externally-authored delivery must never
  * carry. Named separately from the allowlist so the rejection reason can point at the
  * offending path as a config/exec smell rather than a vague "not deliverable".
+ *
+ * Deliberately *not* part of the shared delivery contract: these are platform-side
+ * anti-RCE controls with no games-repo counterpart. The games repo's submit tool has
+ * nothing to gain from knowing them — it never sends such a path — while a game that does
+ * is either confused or hostile, and either way this side must refuse it whatever the
+ * shared contract says. Tightening them is a website-only change and needs no lockstep.
  */
 const FORBIDDEN_DELIVERY_BASENAME =
   /^(tsconfig(\..*)?\.json|package(-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|composer\.json|\.npmrc|\.eslintrc(\..*)?|vite\.config\..+|webpack\.config\..+|rollup\.config\..+|jest\.config\..+|vitest\.config\..+)$/i;
@@ -108,7 +78,7 @@ const FORBIDDEN_DELIVERY_EXTENSION = /\.(js|mjs|cjs|jsx|tsx|sh|bash|zsh|ps1|bat|
  * reviewing a diff can see it holding. Costing an agent one clear error message is a
  * better trade than a directory listing nobody can interpret at a glance.
  */
-const RESERVED_SEGMENTS = new Set(['shared', 'tools', 'games', 'node_modules', 'dist', 'references', 'templates']);
+const RESERVED_SEGMENTS = new Set<string>(DELIVERY_RESERVED_SEGMENTS);
 
 /** Mirrors the games repo's own slug rule, so a name valid here is valid there. */
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
@@ -118,10 +88,10 @@ const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
  * in the catalog is a few hundred KB of TypeScript) and far below anything that would
  * make a rogue upload interesting as a storage attack.
  */
-export const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+export const MAX_UPLOAD_BYTES = DELIVERY_MAX_UPLOAD_BYTES;
 /** Cap on files per delivery. Aligned with the MCP `submit_sources` schema; the
  * byte budget (`MAX_UPLOAD_BYTES`) and filename allowlist still bound abuse. */
-export const MAX_UPLOAD_FILES = 200;
+export const MAX_UPLOAD_FILES = DELIVERY_MAX_FILES;
 
 export interface SourceFile {
   path: string;

--- a/apps/api/src/tar.test.ts
+++ b/apps/api/src/tar.test.ts
@@ -213,6 +213,15 @@ describe('writeTarGz', () => {
     expect(writeTarGz(files).equals(writeTarGz(files))).toBe(true);
   });
 
+  it('pins the gzip header timestamp, not just the tar payload', () => {
+    // Comparing two archives written back to back cannot see a seconds-resolution
+    // timestamp, so determinism is asserted against the header field itself. Node
+    // leaves gzip MTIME at zero because it never calls deflateSetHeader — true, but
+    // true by omission, which is worth a test rather than a comment.
+    const archive = writeTarGz([{ path: 'x.txt', content: 'same\n' }]);
+    expect(archive.readUInt32LE(4)).toBe(0);
+  });
+
   it('refuses paths that would extract outside the archive root', () => {
     expect(() => writeTarGz([{ path: '/etc/passwd', content: '' }])).toThrow(/refusing/);
     expect(() => writeTarGz([{ path: 'a/../../b', content: '' }])).toThrow(/refusing/);

--- a/apps/api/src/tar.test.ts
+++ b/apps/api/src/tar.test.ts
@@ -1,5 +1,10 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
 import { describe, expect, it } from 'vitest';
-import { readTarEntries, type TarEntry } from './tar.js';
+import { readTarEntries, writeTarGz, type TarEntry } from './tar.js';
 
 const BLOCK = 512;
 
@@ -166,5 +171,66 @@ describe('readTarEntries', () => {
     const buffer = archive({ name: 'repo-abc123/games/pong/media/gameplay.mp4', body: 'z'.repeat(4096) });
 
     await expect(collect(stream(buffer), { maxTotalBytes: 1024 })).rejects.toThrow(/exceeds 1024 retained bytes/);
+  });
+});
+
+describe('writeTarGz', () => {
+  it('round-trips through the reader in this file', async () => {
+    const archive = writeTarGz([
+      { path: 'README.md', content: '# workspace\n' },
+      { path: 'games/comet-courier/game.ts', content: 'export const x = 1;\n' },
+      { path: 'setup.mjs', content: 'process.exit(0);\n', executable: true },
+    ]);
+
+    const entries = await collect(stream(gunzipSync(archive)));
+    expect(entries.map((entry) => entry.path)).toEqual(['README.md', 'games/comet-courier/game.ts', 'setup.mjs']);
+    expect(Buffer.from(entries[1].bytes).toString('utf8')).toBe('export const x = 1;\n');
+  });
+
+  it('extracts with the system tar, which is what the creator actually runs', () => {
+    const archive = writeTarGz([
+      { path: 'a/b/deep.txt', content: 'nested\n' },
+      { path: 'top.txt', content: 'top\n' },
+    ]);
+    const dir = mkdtempSync(join(tmpdir(), 'tar-write-'));
+    try {
+      writeFileSync(join(dir, 'out.tgz'), archive);
+      // Real tar is the only check that catches a bad checksum: this file's own
+      // reader never validates one, so a writer bug would round-trip happily here
+      // and fail on the creator's machine.
+      const result = spawnSync('tar', ['-xzf', 'out.tgz'], { cwd: dir, encoding: 'utf8' });
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(dir, 'a', 'b', 'deep.txt'), 'utf8')).toBe('nested\n');
+      expect(readFileSync(join(dir, 'top.txt'), 'utf8')).toBe('top\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a pure function of its input, so the same workspace is the same bytes', () => {
+    const files = [{ path: 'x.txt', content: 'same\n' }];
+    expect(writeTarGz(files).equals(writeTarGz(files))).toBe(true);
+  });
+
+  it('refuses paths that would extract outside the archive root', () => {
+    expect(() => writeTarGz([{ path: '/etc/passwd', content: '' }])).toThrow(/refusing/);
+    expect(() => writeTarGz([{ path: 'a/../../b', content: '' }])).toThrow(/refusing/);
+  });
+
+  it('refuses a duplicate path rather than letting last-one-wins decide', () => {
+    expect(() =>
+      writeTarGz([
+        { path: 'dup.txt', content: 'first' },
+        { path: 'dup.txt', content: 'second' },
+      ]),
+    ).toThrow(/duplicate/);
+  });
+
+  it('splits a long path across name and prefix instead of truncating it', async () => {
+    const path = `games/a-game/${'nested/'.repeat(14)}module.ts`;
+    expect(path.length).toBeGreaterThan(100);
+    const entries = await collect(stream(gunzipSync(writeTarGz([{ path, content: 'x' }]))));
+    expect(entries[0].path).toBe(path);
   });
 });

--- a/apps/api/src/tar.ts
+++ b/apps/api/src/tar.ts
@@ -1,5 +1,5 @@
 /**
- * Just enough tar to read a GitHub source archive.
+ * Just enough tar to read a GitHub source archive, and to write a small one.
  *
  * `GET /repos/<repo>/tarball/<ref>` answers the whole games repo in one request,
  * which is the difference between a bake that costs ~1,000 GitHub reads and one
@@ -15,7 +15,15 @@
  *
  * Not handled, because a source archive never contains them: sparse files, device
  * nodes, hard links. They are skipped rather than guessed at.
+ *
+ * The writer ({@link writeTarGz}) is here for the same reason the reader is: the
+ * one archive we emit — a creator's workspace, a few dozen small text files — needs
+ * plain ustar and nothing else, and a dependency that can express symlinks, sparse
+ * files and long-name extensions is a larger surface than the format we actually
+ * want to produce.
  */
+
+import { gzipSync } from 'node:zlib';
 
 const BLOCK_SIZE = 512;
 
@@ -221,4 +229,110 @@ export async function* readTarEntries(
       yield { path, bytes: Uint8Array.from(body) };
     }
   }
+}
+
+/** One file to write. Directory entries are implied by paths and never emitted. */
+export interface TarInput {
+  path: string;
+  /** Text is encoded UTF-8; bytes are written as given. */
+  content: string | Uint8Array;
+  /** Defaults to 0o644, or 0o755 when {@link TarInput.executable} is set. */
+  executable?: boolean;
+}
+
+/** Octal, NUL-terminated, left-padded — the ustar convention for numeric fields. */
+function writeOctal(header: Buffer, value: number, offset: number, length: number): void {
+  const text = value.toString(8).padStart(length - 1, '0');
+  header.write(`${text}\0`, offset, length, 'ascii');
+}
+
+/**
+ * Split a path across ustar's `name` (100) and `prefix` (155) fields.
+ *
+ * Long-name extensions (pax `x`, GNU `L`) are deliberately not emitted: they are a
+ * second encoding of the same fact, and every consumer of what we write is either
+ * `tar -xz` or this file's own reader. A path that will not fit is a bug in the
+ * caller, so it throws rather than silently truncating a file into the wrong place.
+ */
+function splitUstarPath(path: string): { name: string; prefix: string } {
+  if (Buffer.byteLength(path, 'utf8') <= NAME_LENGTH) {
+    return { name: path, prefix: '' };
+  }
+  const cut = path.lastIndexOf('/', PREFIX_LENGTH);
+  const prefix = cut === -1 ? '' : path.slice(0, cut);
+  const name = cut === -1 ? path : path.slice(cut + 1);
+  if (
+    prefix === '' ||
+    Buffer.byteLength(name, 'utf8') > NAME_LENGTH ||
+    Buffer.byteLength(prefix, 'utf8') > PREFIX_LENGTH
+  ) {
+    throw new Error(`tar: path too long for ustar (${path})`);
+  }
+  return { name, prefix };
+}
+
+function buildHeader(path: string, size: number, mode: number, mtime: number): Buffer {
+  const header = Buffer.alloc(BLOCK_SIZE);
+  const { name, prefix } = splitUstarPath(path);
+
+  header.write(name, NAME_OFFSET, NAME_LENGTH, 'utf8');
+  writeOctal(header, mode, 100, 8);
+  writeOctal(header, 0, 108, 8); // uid
+  writeOctal(header, 0, 116, 8); // gid
+  writeOctal(header, size, SIZE_OFFSET, SIZE_LENGTH);
+  writeOctal(header, mtime, 136, 12);
+  header.write(TYPE_FILE, TYPE_OFFSET, 1, 'ascii');
+  header.write('ustar\0', MAGIC_OFFSET, 6, 'ascii');
+  header.write('00', 263, 2, 'ascii');
+  header.write(prefix, PREFIX_OFFSET, PREFIX_LENGTH, 'utf8');
+
+  // The checksum is computed with its own field read as spaces, then written back
+  // over it — the one field that cannot be filled in a single pass.
+  header.write(' '.repeat(8), 148, 8, 'ascii');
+  let sum = 0;
+  for (const byte of header) {
+    sum += byte;
+  }
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'ascii');
+
+  return header;
+}
+
+/**
+ * A gzipped ustar archive of small files, held in memory.
+ *
+ * In memory because the caller is an HTTP response of a few dozen text files, and a
+ * stream would buy nothing but a Content-Length we would then have to give up. Byte
+ * output is a pure function of the inputs: `mtime` defaults to 0 rather than "now",
+ * so the same workspace requested twice is the same archive and can be compared,
+ * cached, or ETagged without a timestamp making every response unique.
+ */
+export function writeTarGz(files: TarInput[], options: { mtime?: number } = {}): Buffer {
+  const mtime = options.mtime ?? 0;
+  const seen = new Set<string>();
+  const blocks: Buffer[] = [];
+
+  for (const file of files) {
+    const path = file.path.replace(/^\.\//, '');
+    if (path === '' || path.startsWith('/') || path.split('/').includes('..')) {
+      throw new Error(`tar: refusing to write path "${file.path}"`);
+    }
+    // A duplicate would extract as last-one-wins, so the archive would disagree with
+    // the list the caller thinks it handed over.
+    if (seen.has(path)) {
+      throw new Error(`tar: duplicate path "${path}"`);
+    }
+    seen.add(path);
+
+    const body = typeof file.content === 'string' ? Buffer.from(file.content, 'utf8') : Buffer.from(file.content);
+    blocks.push(buildHeader(path, body.length, file.executable ? 0o755 : 0o644, mtime), body);
+    const padding = (BLOCK_SIZE - (body.length % BLOCK_SIZE)) % BLOCK_SIZE;
+    if (padding > 0) {
+      blocks.push(Buffer.alloc(padding));
+    }
+  }
+
+  // Two zero blocks terminate the archive; anything less and `tar` warns.
+  blocks.push(Buffer.alloc(BLOCK_SIZE * 2));
+  return gzipSync(Buffer.concat(blocks), { level: 9 });
 }

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -71,6 +71,10 @@ const StudioStepSchema = z.enum([
   'agent_signaled',
   'gate_verdict',
   'round_opened',
+  // A creator took a working copy to their own IDE (docs/own-ide-checkout.md). Its
+  // value is as the denominator for a question nothing else can answer: of the
+  // creators who leave to work locally, how many come back and deliver.
+  'workspace_checkout',
 ]);
 /** Platform vs creator's own agent. Optional on create_step; required on studio_step. */
 const BuilderDimensionSchema = z.enum(['platform', 'self']);

--- a/apps/api/src/workspace-archive.test.ts
+++ b/apps/api/src/workspace-archive.test.ts
@@ -145,4 +145,22 @@ describe('stripCommonRoot', () => {
     const entries = [entry('README.md'), entry('docs/guide.md')];
     expect(stripCommonRoot(entries).map((item) => item.path)).toEqual(['README.md', 'docs/guide.md']);
   });
+
+  it('never mistakes a reserved root for a wrapper', () => {
+    // Publishing the kit to the workspace object by mistake makes every entry share
+    // `shared/`. Stripping it would rewrite shared/modules/gfx.ts to modules/gfx.ts and
+    // walk the engine past the no-engine check into a creator's archive.
+    const entries = [entry('shared/modules/gfx.ts'), entry('shared/game-kit.d.ts')];
+    expect(stripCommonRoot(entries).map((item) => item.path)).toEqual([
+      'shared/modules/gfx.ts',
+      'shared/game-kit.d.ts',
+    ]);
+  });
+
+  it('refuses a kit mispublished as the scaffold, wrapper or not', () => {
+    const kitish = [entry('shared/modules/gfx.ts', 'export {}'), entry('shared/game-kit.d.ts', 'declare const x: 1;')];
+    expect(() =>
+      composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold: kitish, sources: SOURCES }),
+    ).toThrow(WorkspaceCompositionError);
+  });
 });

--- a/apps/api/src/workspace-archive.test.ts
+++ b/apps/api/src/workspace-archive.test.ts
@@ -1,0 +1,148 @@
+import { gunzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import { readTarEntries, type TarEntry } from './tar.js';
+import { composeWorkspaceArchive, stripCommonRoot, WorkspaceCompositionError } from './workspace-archive.js';
+
+function entry(path: string, body = ''): TarEntry {
+  return { path, bytes: Buffer.from(body, 'utf8') };
+}
+
+const LOCK = {
+  slug: 'comet-courier',
+  engineRef: 'a1b2c3d4e5f6',
+  kitUrl: 'https://signed.example/kits/a1b2c3d4e5f6.tgz?sig=1',
+  kitSha256: 'f'.repeat(64),
+  issuedAt: '2026-08-04T10:00:00.000Z',
+};
+
+const SCAFFOLD = [
+  entry('README.md', '# your working copy\n'),
+  entry('setup.mjs', 'fetch kit\n'),
+  entry('.gitignore', 'node_modules\n'),
+];
+
+const SOURCES = [
+  { path: 'SPEC.md', content: '---\nslug: comet-courier\n---\n' },
+  { path: 'game.ts', content: "import './game/model.js';\n" },
+  { path: 'game/model.ts', content: 'export const speed = 3;\n' },
+];
+
+async function extract(archive: Buffer): Promise<TarEntry[]> {
+  const entries: TarEntry[] = [];
+  const buffer = gunzipSync(archive);
+  async function* once(): AsyncGenerator<Uint8Array> {
+    yield buffer;
+  }
+  for await (const item of readTarEntries(once())) {
+    entries.push(item);
+  }
+  return entries;
+}
+
+function textOf(entries: TarEntry[], path: string): string {
+  const found = entries.find((item) => item.path === path);
+  if (!found) throw new Error(`no ${path} in archive: ${entries.map((item) => item.path).join(', ')}`);
+  return Buffer.from(found.bytes).toString('utf8');
+}
+
+describe('composeWorkspaceArchive', () => {
+  it('lays the scaffold at the root and the sources under games/<slug>/', async () => {
+    const entries = await extract(
+      composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold: SCAFFOLD, sources: SOURCES }),
+    );
+
+    expect(entries.map((item) => item.path).sort()).toEqual([
+      '.gitignore',
+      'README.md',
+      'gamedev.lock',
+      'games/comet-courier/SPEC.md',
+      'games/comet-courier/game.ts',
+      'games/comet-courier/game/model.ts',
+      'setup.mjs',
+    ]);
+    expect(textOf(entries, 'games/comet-courier/game/model.ts')).toBe('export const speed = 3;\n');
+  });
+
+  it('writes the lock the setup script reads', async () => {
+    const entries = await extract(
+      composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold: SCAFFOLD, sources: SOURCES }),
+    );
+    expect(JSON.parse(textOf(entries, 'gamedev.lock'))).toEqual(LOCK);
+  });
+
+  it('is deterministic, so the same checkout is the same bytes', () => {
+    const input = { slug: 'comet-courier', lock: LOCK, scaffold: SCAFFOLD, sources: SOURCES };
+    expect(composeWorkspaceArchive(input).equals(composeWorkspaceArchive(input))).toBe(true);
+  });
+
+  it('does not depend on the order the store listed sources in', () => {
+    const forward = composeWorkspaceArchive({
+      slug: 'comet-courier',
+      lock: LOCK,
+      scaffold: SCAFFOLD,
+      sources: SOURCES,
+    });
+    const reversed = composeWorkspaceArchive({
+      slug: 'comet-courier',
+      lock: LOCK,
+      scaffold: SCAFFOLD,
+      sources: [...SOURCES].reverse(),
+    });
+    expect(forward.equals(reversed)).toBe(true);
+  });
+
+  it('refuses a scaffold carrying GameKit, because the kit is fetched and never shipped', () => {
+    expect(() =>
+      composeWorkspaceArchive({
+        slug: 'comet-courier',
+        lock: LOCK,
+        scaffold: [...SCAFFOLD, entry('shared/modules/gfx.ts', 'export {}')],
+        sources: SOURCES,
+      }),
+    ).toThrow(WorkspaceCompositionError);
+  });
+
+  it('refuses a scaffold that writes into games/ or ships its own lock', () => {
+    for (const bad of ['games/other/game.ts', 'gamedev.lock']) {
+      expect(() =>
+        composeWorkspaceArchive({
+          slug: 'comet-courier',
+          lock: LOCK,
+          scaffold: [...SCAFFOLD, entry(bad, 'x')],
+          sources: SOURCES,
+        }),
+      ).toThrow(WorkspaceCompositionError);
+    }
+  });
+
+  it('refuses a source path that would escape the game directory', () => {
+    expect(() =>
+      composeWorkspaceArchive({
+        slug: 'comet-courier',
+        lock: LOCK,
+        scaffold: SCAFFOLD,
+        sources: [{ path: '../../etc/passwd', content: 'x' }],
+      }),
+    ).toThrow(/refusing source path/);
+  });
+
+  it('refuses a game with nothing delivered rather than handing back an empty repo', () => {
+    expect(() =>
+      composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold: SCAFFOLD, sources: [] }),
+    ).toThrow(/no delivered sources/);
+  });
+});
+
+describe('stripCommonRoot', () => {
+  it('drops a single wrapping directory', () => {
+    expect(stripCommonRoot([entry('wrap/README.md'), entry('wrap/setup.mjs')]).map((item) => item.path)).toEqual([
+      'README.md',
+      'setup.mjs',
+    ]);
+  });
+
+  it('leaves entries alone when they do not all share one root', () => {
+    const entries = [entry('README.md'), entry('docs/guide.md')];
+    expect(stripCommonRoot(entries).map((item) => item.path)).toEqual(['README.md', 'docs/guide.md']);
+  });
+});

--- a/apps/api/src/workspace-archive.test.ts
+++ b/apps/api/src/workspace-archive.test.ts
@@ -126,6 +126,29 @@ describe('composeWorkspaceArchive', () => {
     ).toThrow(/refusing source path/);
   });
 
+  it('refuses a scaffold that lists the same path twice', () => {
+    // Must be a composition error, not the tar writer's plain Error: the route only maps
+    // the former to a controlled 502, so the latter would surface as a 500.
+    expect(() =>
+      composeWorkspaceArchive({
+        slug: 'comet-courier',
+        lock: LOCK,
+        scaffold: [...SCAFFOLD, entry('README.md', 'second copy\n')],
+        sources: SOURCES,
+      }),
+    ).toThrow(WorkspaceCompositionError);
+  });
+
+  it('refuses a scaffold missing the files that make it a working copy', () => {
+    // An empty or truncated tar decompresses fine and yields nothing, which would
+    // otherwise be a 200 carrying sources with no way to fetch the kit or deliver back.
+    for (const scaffold of [[], SCAFFOLD.filter((item) => item.path !== 'setup.mjs')]) {
+      expect(() => composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold, sources: SOURCES })).toThrow(
+        /missing/,
+      );
+    }
+  });
+
   it('refuses a game with nothing delivered rather than handing back an empty repo', () => {
     expect(() =>
       composeWorkspaceArchive({ slug: 'comet-courier', lock: LOCK, scaffold: SCAFFOLD, sources: [] }),

--- a/apps/api/src/workspace-archive.ts
+++ b/apps/api/src/workspace-archive.ts
@@ -1,0 +1,151 @@
+/**
+ * Composes the archive a creator gets when they choose to work on their game in
+ * their own IDE.
+ *
+ * The product framing matters to what this file does and does not build. This is a
+ * **working copy**, not a copy they can take away: gamedev.pl stays the game's home,
+ * its system of record, and the only place it publishes from. So the archive carries
+ * exactly two things — the creator's own sources, and the scaffold that knows how to
+ * fetch the toolchain and deliver back — and deliberately carries neither GameKit nor
+ * anything built.
+ *
+ * Three parts, from three different owners:
+ *
+ *   - **the scaffold** (`workspaces/<engineRef>.tgz`, packed by the games repo) —
+ *     README, `setup.mjs`, `.gitignore`. Games-repo owns it because it is the half
+ *     that describes the kit's own commands.
+ *   - **the sources** (`games/<slug>/…`, from the immutable version store) — the same
+ *     bytes the gate last read, so what the creator opens is what the site last built.
+ *   - **`gamedev.lock`** (written here) — which engine this checkout is pinned to and
+ *     where to fetch that kit, because only the site knows both.
+ *
+ * **GameKit is never in the archive.** It is not published to any registry, and the
+ * scaffold fetches it at setup time against a short-lived signed URL and gitignores
+ * it. That is a licensing boundary (the kit is token-authed, not distributed) and it
+ * is also what keeps a checkout from being a self-contained fork: sources without the
+ * engine do not run. {@link assertNoEngineContent} enforces it here as well as at pack
+ * time, because this is the side that actually hands bytes to a creator.
+ */
+
+import { writeTarGz, type TarEntry, type TarInput } from './tar.js';
+
+/** What the site adds to every workspace so `setup.mjs` knows what to fetch. */
+export interface WorkspaceLock {
+  slug: string;
+  engineRef: string;
+  kitUrl: string;
+  kitSha256: string;
+  issuedAt: string;
+}
+
+export interface ComposeWorkspaceInput {
+  slug: string;
+  lock: WorkspaceLock;
+  /** Entries of the games-repo scaffold tarball, already decompressed. */
+  scaffold: TarEntry[];
+  /** The game's delivered sources, paths relative to the game directory. */
+  sources: Array<{ path: string; content: string }>;
+}
+
+export class WorkspaceCompositionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkspaceCompositionError';
+  }
+}
+
+/**
+ * Paths that would mean the scaffold is shipping the engine or a game.
+ *
+ * `shared/` is GameKit itself; `games/` is this side's namespace and a scaffold
+ * writing into it could shadow the creator's own files. Checked against the archive
+ * we are about to emit rather than trusting the packer, because a bad scaffold
+ * published once would otherwise be handed to every creator until someone noticed.
+ */
+function assertNoEngineContent(path: string): void {
+  const first = path.split('/')[0];
+  if (first === 'shared' || first === 'node_modules') {
+    throw new WorkspaceCompositionError(
+      `workspace scaffold must not carry engine content (${path}) — the kit is fetched at setup, never shipped`,
+    );
+  }
+  if (first === 'games') {
+    throw new WorkspaceCompositionError(`workspace scaffold must not write into games/ (${path})`);
+  }
+}
+
+/**
+ * Drop a single wrapping directory if the tarball has one.
+ *
+ * `npm pack`-style archives wrap everything in one directory and `git archive` adds a
+ * `<repo>-<sha>/` prefix, so whether the scaffold arrives wrapped depends on how it was
+ * packed — a detail this side should tolerate rather than encode. Only an unambiguous
+ * wrapper is stripped: every entry must share it, and there must be more than one path
+ * segment to strip from.
+ */
+export function stripCommonRoot(entries: TarEntry[]): TarEntry[] {
+  if (entries.length === 0) return entries;
+  const first = entries[0].path.split('/')[0];
+  const wrapped = entries.every((entry) => {
+    const segments = entry.path.split('/');
+    return segments.length > 1 && segments[0] === first;
+  });
+  if (!wrapped) return entries;
+  return entries.map((entry) => ({ ...entry, bytes: entry.bytes, path: entry.path.slice(first.length + 1) }));
+}
+
+/** Normalizes and refuses anything that would extract outside the archive root. */
+function safePath(path: string, what: string): string {
+  const normalized = path.replace(/^\.\//, '').trim();
+  if (normalized === '' || normalized.startsWith('/') || normalized.split('/').includes('..')) {
+    throw new WorkspaceCompositionError(`refusing ${what} path "${path}"`);
+  }
+  return normalized;
+}
+
+/**
+ * The ready-to-`git init` archive, as gzipped tar bytes.
+ *
+ * Deterministic: the same sources, scaffold and lock produce the same bytes, which is
+ * what lets the response be compared or cached. `issuedAt` lives in the lock rather
+ * than in file mtimes, so the archive changes only when its contents actually do.
+ */
+export function composeWorkspaceArchive(input: ComposeWorkspaceInput): Buffer {
+  const { slug, lock } = input;
+  const files: TarInput[] = [];
+  const claimed = new Set<string>();
+
+  for (const entry of stripCommonRoot(input.scaffold)) {
+    const path = safePath(entry.path, 'scaffold');
+    assertNoEngineContent(path);
+    if (path === 'gamedev.lock') {
+      // The site owns this file; a scaffold shipping its own would be overwritten
+      // silently, which is the kind of thing that is only ever noticed in the field.
+      throw new WorkspaceCompositionError('workspace scaffold must not ship gamedev.lock — the site writes it');
+    }
+    claimed.add(path);
+    files.push({ path, content: entry.bytes, executable: path.endsWith('.mjs') || path.endsWith('.sh') });
+  }
+
+  if (input.sources.length === 0) {
+    throw new WorkspaceCompositionError(`${slug} has no delivered sources to check out`);
+  }
+
+  for (const source of input.sources) {
+    const relative = safePath(source.path, 'source');
+    const path = `games/${slug}/${relative}`;
+    if (claimed.has(path)) {
+      throw new WorkspaceCompositionError(`duplicate path in workspace: ${path}`);
+    }
+    claimed.add(path);
+    files.push({ path, content: source.content });
+  }
+
+  files.push({ path: 'gamedev.lock', content: `${JSON.stringify(lock, null, 2)}\n` });
+
+  // Sorted so the archive is a function of its contents and not of the order the
+  // store happened to list them in.
+  files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  return writeTarGz(files);
+}

--- a/apps/api/src/workspace-archive.ts
+++ b/apps/api/src/workspace-archive.ts
@@ -62,6 +62,13 @@ export class WorkspaceCompositionError extends Error {
  * we are about to emit rather than trusting the packer, because a bad scaffold
  * published once would otherwise be handed to every creator until someone noticed.
  */
+/**
+ * First path segments the scaffold may never use — the engine, the creator's own
+ * namespace, and installed output. Shared with {@link stripCommonRoot}, which must not
+ * mistake any of them for a packaging wrapper.
+ */
+const RESERVED_ROOTS = new Set(['shared', 'node_modules', 'games']);
+
 function assertNoEngineContent(path: string): void {
   const first = path.split('/')[0];
   if (first === 'shared' || first === 'node_modules') {
@@ -82,10 +89,19 @@ function assertNoEngineContent(path: string): void {
  * packed — a detail this side should tolerate rather than encode. Only an unambiguous
  * wrapper is stripped: every entry must share it, and there must be more than one path
  * segment to strip from.
+ *
+ * **A reserved root is never treated as a wrapper.** If the Creator Kit were ever
+ * published to the workspace object by mistake, every entry would share the root
+ * `shared/` — and stripping it would rewrite `shared/modules/gfx.ts` to
+ * `modules/gfx.ts`, walking the engine straight past {@link assertNoEngineContent} and
+ * into a creator's archive. Leaving the root on is what lets that check see it. The
+ * cost of the guard is refusing to unwrap a scaffold someone deliberately wrapped in a
+ * directory called `shared`, which is not a thing anyone should do.
  */
 export function stripCommonRoot(entries: TarEntry[]): TarEntry[] {
   if (entries.length === 0) return entries;
   const first = entries[0].path.split('/')[0];
+  if (RESERVED_ROOTS.has(first)) return entries;
   const wrapped = entries.every((entry) => {
     const segments = entry.path.split('/');
     return segments.length > 1 && segments[0] === first;

--- a/apps/api/src/workspace-archive.ts
+++ b/apps/api/src/workspace-archive.ts
@@ -69,6 +69,16 @@ export class WorkspaceCompositionError extends Error {
  */
 const RESERVED_ROOTS = new Set(['shared', 'node_modules', 'games']);
 
+/**
+ * Scaffold members without which the archive is not a working copy.
+ *
+ * `setup.mjs` is how the kit arrives and the README is how the creator gets back; an
+ * archive missing either is sources in a folder. Named here rather than trusted from the
+ * packer because this is the side that hands bytes to a creator. Kept to the two that are
+ * load-bearing, so adding an optional scaffold file does not need a change on both sides.
+ */
+const REQUIRED_SCAFFOLD_FILES = ['setup.mjs', 'README.md'];
+
 function assertNoEngineContent(path: string): void {
   const first = path.split('/')[0];
   if (first === 'shared' || first === 'node_modules') {
@@ -139,8 +149,23 @@ export function composeWorkspaceArchive(input: ComposeWorkspaceInput): Buffer {
       // silently, which is the kind of thing that is only ever noticed in the field.
       throw new WorkspaceCompositionError('workspace scaffold must not ship gamedev.lock — the site writes it');
     }
+    // Caught here rather than left to the tar writer: the writer throws a plain Error,
+    // which the route does not recognize as a composition failure and would return as a
+    // 500 — the wrong answer for a scaffold we published badly.
+    if (claimed.has(path)) {
+      throw new WorkspaceCompositionError(`workspace scaffold lists ${path} twice`);
+    }
     claimed.add(path);
     files.push({ path, content: entry.bytes, executable: path.endsWith('.mjs') || path.endsWith('.sh') });
+  }
+
+  // An empty or truncated tar decompresses cleanly and simply yields nothing, so without
+  // this the creator gets a 200 and an archive with their sources but no `setup.mjs` and
+  // no README — no way to fetch the kit, and no instructions for delivering back. Silent
+  // uselessness is worse than a refusal an operator can see.
+  const missingScaffold = REQUIRED_SCAFFOLD_FILES.filter((required) => !claimed.has(required));
+  if (missingScaffold.length > 0) {
+    throw new WorkspaceCompositionError(`workspace scaffold is missing ${missingScaffold.join(', ')}`);
   }
 
   if (input.sources.length === 0) {

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -559,6 +559,64 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('offers a working copy beside the agent keys, and only for a game there is one of', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-live',
+          title: 'TV Tycoon',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'published',
+          slug: 'tv-tycoon',
+          publishedAt: '2026-07-31T09:00:00.000Z',
+        },
+        // No slug yet: the first build has not produced a game to check out.
+        {
+          token: 'token-fresh',
+          title: 'Space Miner',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+        },
+        {
+          token: 'token-gone',
+          title: 'Dead End',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'abandoned',
+          slug: 'dead-end',
+        },
+      ]),
+    );
+
+    const { container, root, rerender } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
+
+    // The working copy lives in the credentials pane with the other bring-your-own-agent
+    // controls, so every assertion here has to open that pane first — the rail lands on
+    // overview.
+    const openKeys = async () => {
+      const keys = container.querySelector('[data-testid="studio-rail-icon-keys"]');
+      await act(async () => {
+        keys!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    };
+
+    await openKeys();
+    expect(container.querySelector('[data-testid="workspace-checkout"]')).not.toBeNull();
+    expect(container.textContent).toContain('Work on this game in your own IDE');
+
+    await rerender({ selectedGame: 'token-fresh', selectedTab: 'details' });
+    await openKeys();
+    expect(container.querySelector('[data-testid="workspace-checkout"]')).toBeNull();
+
+    await rerender({ selectedGame: 'dead-end', selectedTab: 'details' });
+    await openKeys();
+    expect(container.querySelector('[data-testid="workspace-checkout"]')).toBeNull();
+
+    root.unmount();
+  });
+
   it('makes the details panel behave like a sheet on a narrow screen', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -30,6 +30,7 @@ import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
 import { StudioDetailsBuildProgress } from './StudioDetailsBuildProgress.js';
 import { StudioDetailsMedia } from './StudioDetailsMedia.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
+import { StudioWorkspaceCheckoutPanel } from './StudioWorkspaceCheckoutPanel.js';
 import { SubmissionStatusView } from './SubmissionStatusView.js';
 import {
   approveSuggestion,
@@ -1162,6 +1163,13 @@ function DetailsPanel({
               {showLegacyKey ? <StudioAgentKeyPanel token={game.token} /> : null}
               <StudioCreatorAgentKeyPanel />
               <StudioOAuthClientsPanel />
+              {/* Working copy belongs in the credentials pane rather than the create
+                  flow: it is the same bring-your-own-agent corner, and a creator who
+                  wants their own IDE is already here fetching a key. It needs a slug —
+                  a game without one has nothing to check out yet. */}
+              {game.slug && game.lastKnownStatus !== 'abandoned' ? (
+                <StudioWorkspaceCheckoutPanel slug={game.slug} />
+              ) : null}
             </div>
           ) : null}
 

--- a/apps/web/src/StudioWorkspaceCheckoutPanel.test.tsx
+++ b/apps/web/src/StudioWorkspaceCheckoutPanel.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioWorkspaceCheckoutPanel } from './StudioWorkspaceCheckoutPanel.js';
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function archiveResponse() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({
+      'content-type': 'application/gzip',
+      'content-disposition': 'attachment; filename="sky-dodge-workspace.tgz"',
+    }),
+    blob: async () => new Blob(['tgz-bytes'], { type: 'application/gzip' }),
+  };
+}
+
+function errorResponse(status: number, body: Record<string, unknown>) {
+  return { ok: false, status, headers: new Headers(), json: async () => body };
+}
+
+describe('StudioWorkspaceCheckoutPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  /** Anchors the panel builds to hand the archive over; jsdom cannot follow the click. */
+  let clicked: Array<{ download: string; href: string }>;
+  const realAnchorClick = HTMLAnchorElement.prototype.click;
+
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    // jsdom implements neither, and the panel's whole success path is the object URL.
+    createObjectURL = vi.fn(() => 'blob:workspace');
+    revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+
+    clicked = [];
+    HTMLAnchorElement.prototype.click = function record(this: HTMLAnchorElement) {
+      clicked.push({ download: this.download, href: this.href });
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    HTMLAnchorElement.prototype.click = realAnchorClick;
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function render(slug = 'sky-dodge') {
+    await act(async () => {
+      root.render(createElement(StudioWorkspaceCheckoutPanel, { slug }));
+      await flush();
+    });
+  }
+
+  function startButton(): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>('[data-testid="workspace-checkout-start"]');
+    if (!button) throw new Error('checkout button is not rendered');
+    return button;
+  }
+
+  async function click() {
+    await act(async () => {
+      startButton().click();
+      await flush();
+    });
+    await act(async () => {
+      await flush();
+    });
+  }
+
+  it('checks the working copy out and hands the archive to the browser', async () => {
+    const fetchMock = vi.fn(async () => archiveResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render();
+    await click();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/me/studio/games/sky-dodge/workspace',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(clicked).toEqual([{ download: 'sky-dodge-workspace.tgz', href: 'blob:workspace' }]);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="workspace-checkout-done"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="workspace-checkout-error"]')).toBeNull();
+    // The anchor is a transport, not part of the panel — it must not survive the click.
+    expect(document.querySelector('a[download]')).toBeNull();
+  });
+
+  it('says the game is a checkout that comes back, not a copy to keep', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => archiveResponse()),
+    );
+    await render();
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Work on this game in your own IDE');
+    expect(text).toContain('working copy');
+    expect(text).toMatch(/delivers the changes back/i);
+    expect(text).toMatch(/gate and review/i);
+    // The feature is explicitly not a way to walk off with the game.
+    expect(text).not.toMatch(/export|eject|take your game|download your game/i);
+  });
+
+  it.each([
+    [401, { error: 'unauthorized' }, /signed out/i],
+    [404, { error: 'no such game' }, /couldn't find this game/i],
+    [503, { error: 'workspace_scaffold_missing', message: 'no workspace scaffold published' }, /temporarily/i],
+    [502, { error: 'the delivered version could not be read back' }, /couldn't put your working copy together/i],
+  ])('renders a plain-language message for %i', async (status, body, expected) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(status, body)),
+    );
+    await render();
+    await click();
+
+    const error = container.querySelector('[data-testid="workspace-checkout-error"]');
+    expect(error?.textContent ?? '').toMatch(expected);
+    expect(container.querySelector('[data-testid="workspace-checkout-done"]')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('leaks no server wording on failures other than the 409', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        errorResponse(503, { error: 'kit_registry_missing', message: 'the Creator Kit registry is not published yet' }),
+      ),
+    );
+    await render();
+    await click();
+
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('kit_registry_missing');
+    expect(text).not.toContain('the Creator Kit registry is not published yet');
+  });
+
+  it('surfaces the 409 message, which names the state the creator can act on', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        errorResponse(409, {
+          error: 'nothing_delivered',
+          message: 'this game has no delivered version yet — let the first build finish, then check it out',
+        }),
+      ),
+    );
+    await render();
+    await click();
+
+    expect(container.querySelector('[data-testid="workspace-checkout-error"]')?.textContent).toBe(
+      'this game has no delivered version yet — let the first build finish, then check it out',
+    );
+  });
+
+  it('falls back to translated copy when a 409 arrives without a message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(409, { error: 'nothing_delivered' })),
+    );
+    await render();
+    await click();
+
+    expect(container.querySelector('[data-testid="workspace-checkout-error"]')?.textContent).toMatch(
+      /no delivered version yet/i,
+    );
+  });
+
+  it('disables the button while a checkout is running so it cannot be fired twice', async () => {
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return archiveResponse();
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render();
+    await act(async () => {
+      startButton().click();
+      await flush();
+    });
+
+    expect(startButton().disabled).toBe(true);
+    expect(startButton().textContent).toMatch(/Preparing/i);
+
+    await act(async () => {
+      startButton().click();
+      await flush();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release?.();
+      await flush();
+      await flush();
+    });
+    expect(startButton().disabled).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/StudioWorkspaceCheckoutPanel.tsx
+++ b/apps/web/src/StudioWorkspaceCheckoutPanel.tsx
@@ -1,0 +1,127 @@
+import { useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { PixelIcon } from './PixelIcon.js';
+import { fetchGameWorkspace, type StudioApiError } from './studioApi.js';
+import { recordStudioStep } from './visitTelemetry.js';
+
+type StudioWorkspaceCheckoutPanelProps = {
+  slug: string;
+};
+
+/**
+ * Hands the archive to the browser without navigating away from the studio.
+ *
+ * The object URL is released on a later task than the click: releasing it in the same
+ * task can cancel the download the click just started.
+ */
+function saveArchive(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/**
+ * One sentence per failure, in the creator's language.
+ *
+ * The server's own wording is used for exactly one case: 409 says the first build has
+ * not finished yet, which is an ordinary state with an action attached, and the route
+ * words it better than a status code can. Every other body carries a machine code or an
+ * internal detail, so it never reaches the screen.
+ */
+function checkoutErrorText(error: StudioApiError, t: TFunction): string {
+  switch (error.status) {
+    case 401:
+      return t('workspaceCheckout.errors.signedOut');
+    case 404:
+      return t('workspaceCheckout.errors.notFound');
+    case 409:
+      return error.message === 'nothing_delivered' && error.detail
+        ? error.detail
+        : t('workspaceCheckout.errors.notDelivered');
+    case 503:
+      return t('workspaceCheckout.errors.unavailable');
+    default:
+      return t('workspaceCheckout.errors.failed');
+  }
+}
+
+/**
+ * Checkout of a working copy, for creators who would rather use their own IDE and their
+ * own repo than the Studio's agent flow (CO-05).
+ *
+ * A panel of its own rather than a button in the overview actions, and placed with the
+ * agent-key panels at the foot of Details: this is the "bring your own agent" corner of
+ * the studio, it needs a line of explanation the action row has no space for, and a
+ * creator who wants their own IDE is already down here fetching a key. It is deliberately
+ * nowhere near the create flow — that path never has to mention it.
+ *
+ * A checkout is not a handover. The game's home, and the only way to publish it, is still
+ * here, which is why the copy talks about delivering back rather than about what the
+ * creator now holds.
+ */
+export function StudioWorkspaceCheckoutPanel({ slug }: StudioWorkspaceCheckoutPanelProps) {
+  const { t } = useTranslation();
+  const baseId = useId();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [delivered, setDelivered] = useState(false);
+
+  async function handleCheckout() {
+    setPending(true);
+    setError(null);
+    setDelivered(false);
+    try {
+      const archive = await fetchGameWorkspace(slug);
+      saveArchive(archive.blob, archive.filename);
+      // Recorded on success only, and always as `self`: a creator taking a working copy
+      // is choosing to build it themselves, whoever built the last round.
+      recordStudioStep('workspace_checkout', 'self');
+      setDelivered(true);
+    } catch (err) {
+      setError(checkoutErrorText(err as StudioApiError, t));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="studio-agent-key" aria-labelledby={`${baseId}-title`} data-testid="workspace-checkout">
+      <h3 id={`${baseId}-title`} className="studio-agent-key-title">
+        {t('workspaceCheckout.title')}
+      </h3>
+      <p className="studio-share-hint">{t('workspaceCheckout.hint')}</p>
+
+      <div className="studio-connect-actions">
+        <button
+          type="button"
+          className="studio-connect-skip"
+          disabled={pending}
+          onClick={() => void handleCheckout()}
+          data-testid="workspace-checkout-start"
+        >
+          <PixelIcon name="folder" size={12} />{' '}
+          {pending ? t('workspaceCheckout.pending') : t('workspaceCheckout.action')}
+        </button>
+      </div>
+
+      {/* A download leaves no trace in the page, and on a desktop it can land in a
+          folder the creator never looks at — so say it happened. */}
+      {delivered && !error ? (
+        <p className="studio-connect-state" aria-live="polite" data-testid="workspace-checkout-done">
+          {t('workspaceCheckout.done')}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="error" data-testid="workspace-checkout-error">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1046,6 +1046,20 @@
     "expiry": "This game's key expires {{when}}.",
     "rotatedKickoff": "Your key was rotated — copy this fresh kickoff for your agent:"
   },
+  "workspaceCheckout": {
+    "title": "Work on this game in your own IDE",
+    "hint": "Get a working copy — this game's sources, a setup script and a README, ready for your own editor and your own Git repo. The game stays here: when you're done, your agent delivers the changes back and they go through the usual round, gate and review before anything is published.",
+    "action": "Get working copy",
+    "pending": "Preparing your working copy…",
+    "done": "Your working copy is on its way to your downloads.",
+    "errors": {
+      "signedOut": "You're signed out. Sign in again to get a working copy.",
+      "notFound": "We couldn't find this game on your shelf.",
+      "notDelivered": "This game has no delivered version yet — let the first build finish, then check it out.",
+      "unavailable": "Working copies are temporarily unavailable. Try again a little later.",
+      "failed": "We couldn't put your working copy together. Try again in a moment."
+    }
+  },
   "oauthClients": {
     "title": "Connected coding agents",
     "hint": "Agents you approved to sign in as you. Revoking disconnects them — they will need your approval again.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1050,6 +1050,20 @@
     "expiry": "Klucz tej gry wygasa {{when}}.",
     "rotatedKickoff": "Klucz został obrócony — skopiuj ten nowy kickoff dla agenta:"
   },
+  "workspaceCheckout": {
+    "title": "Pracuj nad tą grą we własnym IDE",
+    "hint": "Pobierz kopię roboczą — źródła tej gry, skrypt konfiguracyjny i README, gotowe dla Twojego edytora i Twojego repozytorium Git. Gra zostaje tutaj: gdy skończysz, Twój agent oddaje zmiany, a te przechodzą zwykłą rundę, bramkę i recenzję, zanim cokolwiek zostanie opublikowane.",
+    "action": "Pobierz kopię roboczą",
+    "pending": "Przygotowujemy kopię roboczą…",
+    "done": "Kopia robocza trafia do Twoich pobranych plików.",
+    "errors": {
+      "signedOut": "Nie jesteś zalogowany. Zaloguj się ponownie, aby pobrać kopię roboczą.",
+      "notFound": "Nie znaleźliśmy tej gry na Twojej półce.",
+      "notDelivered": "Ta gra nie ma jeszcze dostarczonej wersji — poczekaj, aż skończy się pierwszy build, i wtedy pobierz kopię roboczą.",
+      "unavailable": "Kopie robocze są chwilowo niedostępne. Spróbuj nieco później.",
+      "failed": "Nie udało się złożyć kopii roboczej. Spróbuj za chwilę."
+    }
+  },
   "oauthClients": {
     "title": "Podłączone agenty kodujące",
     "hint": "Agenty, którym zatwierdziłeś logowanie na Twoje konto. Odłączenie wymaga ponownej zgody.",

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -216,6 +216,12 @@ export type StudioApiError = Error & {
   revision?: number;
   /** How long the publish cooldown has left (429). */
   retryAfterMs?: number;
+  /**
+   * The server's human-readable `message`, where a route sends one alongside `error`.
+   * Only surfaced where the wording is meant for the creator (see the workspace
+   * checkout's 409) — `error` itself is a machine code and never reaches the UI.
+   */
+  detail?: string;
 };
 
 async function readJson(response: Response): Promise<unknown> {
@@ -225,6 +231,7 @@ async function readJson(response: Response): Promise<unknown> {
 async function throwResponseError(response: Response): Promise<never> {
   const body = (await readJson(response)) as {
     error?: string;
+    message?: unknown;
     category?: string;
     problems?: unknown;
     revision?: unknown;
@@ -233,6 +240,7 @@ async function throwResponseError(response: Response): Promise<never> {
   const error = new Error(body?.error ?? `Request failed (${response.status})`) as StudioApiError;
   error.status = response.status;
   error.category = body?.category;
+  if (typeof body?.message === 'string' && body.message.trim().length > 0) error.detail = body.message;
   // Structured detail the editor routes send alongside `error`. Dropping it made
   // the panel's per-problem feedback dead code and cost the cooldown its number.
   if (Array.isArray(body?.problems) && body.problems.every((problem) => typeof problem === 'string')) {
@@ -288,6 +296,37 @@ export async function fetchStudioScorecards(): Promise<StudioScorecard[]> {
   }
   const body = (await response.json()) as { scorecards?: StudioScorecard[] };
   return body.scorecards ?? [];
+}
+
+/** The archive bytes plus the name the server asked us to save them under. */
+export type GameWorkspaceArchive = { blob: Blob; filename: string };
+
+/** `attachment; filename="x.tgz"` → `x.tgz`. A name carrying a path separator is refused. */
+function filenameFromDisposition(header: string | null): string | null {
+  const match = header ? /filename="?([^";]+)"?/i.exec(header) : null;
+  const name = match?.[1]?.trim();
+  return name && !name.includes('/') && !name.includes('\\') ? name : null;
+}
+
+/**
+ * A working copy of one of the creator's own games, for creators who would rather work
+ * in their own IDE than through the Studio's agent flow.
+ *
+ * Read through `fetch` rather than by pointing a link at the route: it answers failures
+ * as JSON (401 / 404 / 409 / 502 / 503), and a plain navigation would drop the creator
+ * on a page of raw JSON instead of a sentence they can act on.
+ */
+export async function fetchGameWorkspace(slug: string): Promise<GameWorkspaceArchive> {
+  const response = await fetch(`${API_BASE}/api/me/studio/games/${encodeURIComponent(slug)}/workspace`, {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+  return {
+    blob: await response.blob(),
+    filename: filenameFromDisposition(response.headers.get('content-disposition')) ?? `${slug}-workspace.tgz`,
+  };
 }
 
 /**

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -136,7 +136,10 @@ export type StudioStep =
   | 'connect_restored'
   | 'agent_signaled'
   | 'gate_verdict'
-  | 'round_opened';
+  | 'round_opened'
+  // A working copy left for the creator's own IDE (docs/own-ide-checkout.md) — the
+  // denominator for "of those who go local, how many deliver back".
+  | 'workspace_checkout';
 
 /**
  * Closed detail for studio steps that need one. `install` / `kickoff` are connect-card

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ survives only in this repo's early history.
 | [`deployment.md`](./deployment.md)                                 | Minimal delivery shape for the app, games origin, and submission API                                   |
 | [`container-orchestration.md`](./container-orchestration.md)       | **Archived** design for the removed self-hosted generation direction                                   |
 | [`remix-to-pr.md`](./remix-to-pr.md)                               | Spec for the player-remix → pull-request feature                                                       |
+| [`own-ide-checkout.md`](./own-ide-checkout.md)                     | 🚧 A working copy for creators who prefer their own IDE — checkout, deliver back, one delivery contract |
 | [`notifications-plan.md`](./notifications-plan.md)                 | Notify creators/players of transitions: detection sweep, per-user storage, in-app → email → push       |
 | [`creator-qa-plan.md`](./creator-qa-plan.md)                       | Clarifying-questions pass before spec freeze — raises the hit rate of the one-shot agent run           |
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions              |

--- a/docs/own-ide-checkout.md
+++ b/docs/own-ide-checkout.md
@@ -1,0 +1,81 @@
+# Working on a game in your own IDE
+
+> **Status: 🚧 Built, not yet released.** The server half and the games-repo scaffold are
+> in place; see [`games-repo.md`](./games-repo.md) for how a game is normally built and
+> [`security-model.md`](./security-model.md) for the boundaries this respects.
+
+Most creators describe a game and let an agent build it. Some would rather open the code in
+their own editor, with their own tools, their own Git history. This is that path.
+
+It is a **checkout, not a handover.** The game's home stays here: gamedev.pl remains its
+system of record, and the only place it publishes from. What a creator gets is a working
+copy and a documented way back.
+
+## The round trip
+
+```mermaid
+flowchart LR
+    S["Studio — work on this game<br/>in your own IDE"] --> A["workspace archive<br/>(sources + scaffold + lock)"]
+    A --> K["setup.mjs fetches the<br/>pinned Creator Kit"]
+    K --> D["develop locally<br/>check:static / check:game"]
+    D --> R["open a round,<br/>connect your agent"]
+    R --> U["submit_sources"]
+    U --> G["the gate rebuilds against<br/>our pinned engine"]
+    G --> H["human review → publish"]
+```
+
+Nothing about the second half changes: delivery, gating and publication are the same path
+every other build takes, which is what keeps one set of invariants rather than two.
+
+## What is in the archive
+
+`GET /api/me/studio/games/:slug/workspace` (session-authenticated, owner only) composes
+three things from three owners:
+
+| Part                | Owner      | Why there                                                           |
+| ------------------- | ---------- | ------------------------------------------------------------------- |
+| `games/<slug>/…`    | the store  | The same bytes the gate last read, so the copy matches what shipped |
+| scaffold + `README` | games repo | It describes the kit's own commands, so it lives with the kit       |
+| `gamedev.lock`      | this app   | Only the site knows the current engine and where to fetch that kit  |
+
+**GameKit is not in the archive.** The engine is not published to any registry; `setup.mjs`
+fetches the pinned kit against a short-lived signed URL, verifies its digest, and the
+scaffold gitignores it. That is a licensing boundary, and it is also why a working copy is
+not a fork: sources without the engine do not run.
+
+Nothing built is accepted back, either — the site assembles the bundle, because that is
+where serve-time policy lives (CSP, AI-Act provenance marking, the credential scan, the byte
+budget). See `apps/api/src/workspace-archive.ts`.
+
+## Engine pinning and coming back after a while
+
+The lock pins the checkout to one `engineRef`. The kit registry supports a window of the
+current engine and the one before it, so a workspace left alone across a couple of engine
+releases will get a `kit_outdated` verdict when it delivers.
+
+That is a recoverable chore, not a dead end: re-run `setup.mjs` to fetch the current kit,
+re-run `npm run check:game`, **read** the trace diff, accept it deliberately, and deliver.
+`TRACE.json` and media freshness are functions of the assembled bundle, so they genuinely do
+change when the engine does — an accepted diff should be a decision, not a reflex.
+
+Start every returning session by pulling current sources and diffing. Platform-side lanes
+(content edits in the Studio, improvement rounds) can move a game while a checkout sits on
+someone's disk, and the checkout is not the source of truth.
+
+## One delivery allowlist, not two
+
+Which files a game may deliver used to be a literal here and a second literal in the games
+repo's `tools/submit.mjs`. It drifted three times — `TRACE.json`, then `PLAYTEST.json`, then
+`AGENT.json` — and each drift meant a correct game was refused at upload for sending a file
+validation had just started requiring.
+
+Both sides now read the games repo's `shared/delivery-contract.json`, and
+`npm run contract:games-repo` fails on drift. The comparison is asymmetric on purpose:
+
+- The games repo sends a path this side refuses → **drift, CI fails.** That is the failure
+  creators feel.
+- This side accepts a path the games repo does not list yet → **a note, CI passes.** That is
+  the intended middle of a rollout, because the accepting side must always widen first.
+
+Removals run the same rule in reverse: the games repo stops sending a file first, and this
+side drops the entry last. The allowlist here is never the narrower of the two.


### PR DESCRIPTION
## Summary

This PR implements a workspace checkout feature that allows creators to download their game sources along with a scaffold to work in their own IDE, while maintaining gamedev.pl as the system of record for publication. The feature includes server-side archive composition, client-side download handling, and cross-repo contract validation for deliverable files.

## Key Changes

### Server-side Implementation
- **Workspace archive composition** (`workspace-archive.ts`): New module that composes a gzipped tarball containing:
  - Game scaffold (README, setup.mjs, .gitignore) from the games repo
  - Creator's delivered sources from the version store
  - `gamedev.lock` file pinning the engine and kit URL
  - Validates that no engine content (GameKit) is included in the archive
  
- **Creator Studio route** (`creator-studio.ts`): Added `GET /api/me/studio/games/:slug/workspace` endpoint that:
  - Authenticates the request and verifies ownership
  - Fetches the game's delivered version and sources
  - Reads the workspace scaffold from object storage
  - Composes and returns the workspace archive with proper headers
  - Handles various error cases (not found, not delivered, unavailable)

- **Tar writer** (`tar.ts`): Extended tar module with `writeTarGz()` function to create gzipped tarballs with deterministic output, supporting both text and binary content

### Delivery Contract Management
- **Contract definition** (`games-repo-contract.ts`): Extracted delivery contract constants (`DELIVERY_FIXED_FILES`, `DELIVERY_MAX_FILES`, `DELIVERY_MAX_UPLOAD_BYTES`, etc.) from games-repo's `shared/delivery-contract.json`
- **Contract validation** (`games-repo-contract-check.ts`): Extended cross-repo lockstep check to validate the delivery contract alongside existing module and budget checks
- **Games store alignment** (`games-store.ts`): Updated to reference delivery contract constants as the single source of truth for allowed files

### Client-side Implementation
- **Workspace checkout panel** (`StudioWorkspaceCheckoutPanel.tsx`): New React component that:
  - Provides UI for downloading workspace archives
  - Handles fetch with proper error messaging
  - Uses object URLs to trigger browser downloads without navigation
  - Displays localized error messages for various failure scenarios
  
- **Studio API** (`studioApi.ts`): Added `fetchGameWorkspace()` function and extended error type to include server message details
- **Studio view integration** (`CreatorStudioView.tsx`): Integrated workspace checkout panel in the game details view

### Testing & Documentation
- Comprehensive test suites for archive composition, tar operations, and API endpoints
- Integration tests verifying round-trip archive creation and extraction
- Documentation (`own-ide-checkout.md`) explaining the feature, round-trip flow, and archive contents
- Telemetry tracking for workspace checkout usage

## Notable Implementation Details

- **Deterministic archives**: Workspace archives are byte-for-byte identical for the same inputs, enabling caching and verification
- **No engine shipping**: Deliberately excludes GameKit from archives; scaffold fetches it at setup time via signed URL
- **Ownership verification**: Uses existing `ownerUid` + `slug` attribution model; non-owned slugs return 404 not 403
- **Contract-first approach**: Delivery contract lives in games-repo and is the single source of truth; website enforces it rather than maintaining a duplicate
- **Graceful degradation**: Feature returns 503 if not configured on deployment; works alongside existing agent-based workflow

https://claude.ai/code/session_018ny5RYa1cFtxT4kefc5iua