### PR TITLE
fix(api): staging refreshes agent heartbeat (no false quiet)

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -19,6 +19,8 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 2. Build; `report_progress`; `send_screenshot` when something draws
 3. Prefer `stage_source_file` then `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - `mode=preview` while iterating; `mode=publish` to seal (TRACE + PLAYTEST required)
+   - Each successful stage refreshes Studio’s heartbeat (so a long staging loop is not
+     mistaken for quiet / offline)
 4. Poll `get_gate_verdict` (and `get_gate_media` after a publish verdict)
 5. **After the last successful `submit_sources`, call `end`** if you will not deliver more
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1200,6 +1200,12 @@ describe('agent build channel', () => {
         expect(stagedRes.statusCode).toBe(200);
         expect(stagedRes.json()).toMatchObject({ accepted: true, path: file.path });
       }
+      // Staging must refresh the quiet clock — otherwise a long stage_source_file loop
+      // looks offline and Studio offers a platform handoff mid-upload.
+      const afterStage = await store.getSubmission(ISSUE);
+      expect(afterStage?.lastAgentSignalAt).toBeTruthy();
+      expect(afterStage?.lastAgentPresence?.key).toBe('staging_sources');
+      expect(afterStage?.state).toBe('building');
 
       const listed = await app.inject({
         method: 'GET',

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -913,6 +913,11 @@ export async function registerAgentChannelRoutes(
           path: parsed.data.path,
           content: parsed.data.content,
         });
+        // Staging is channel activity — without this, a long stage_source_file loop
+        // (Claude Chat's preferred path) looks quiet after 15m and Studio wrongly offers
+        // a platform handoff while the agent is still uploading files.
+        await markBuildingFromChannel(issueNumber, record);
+        await store?.touchLastAgentSignalAt(issueNumber, undefined, { key: 'staging_sources' });
         return reply.send({
           accepted: true,
           path: staged.path,

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -20,6 +20,7 @@ const NO_PULSE = new Set([
   'report_progress',
   'send_screenshot',
   'submit_sources',
+  // Channel PUT …/sources/stage refreshes lastAgentSignalAt (+ staging_sources presence).
   'stage_source_file',
   'clear_staged_sources',
   'ack_inbox',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -659,6 +659,7 @@
       "browsing_examples": "Browsing example games…",
       "reading_example": "Reading an example game…",
       "checking_staged": "Checking staged sources…",
+      "staging_sources": "Staging game sources…",
       "checking_inbox": "Checking creator notes…",
       "waiting_checks": "Waiting on automated checks…",
       "reviewing_captures": "Reviewing gate captures…"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -663,6 +663,7 @@
       "browsing_examples": "Przeglądanie przykładów…",
       "reading_example": "Czytanie przykładowej gry…",
       "checking_staged": "Sprawdzanie przygotowanych źródeł…",
+      "staging_sources": "Przygotowywanie źródeł gry…",
       "checking_inbox": "Sprawdzanie notatek twórcy…",
       "waiting_checks": "Czekanie na automatyczne testy…",
       "reviewing_captures": "Przeglądanie zrzutów z bramki…"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Claude (and similar clients) prefer long `stage_source_file` loops before `submit_sources`. Staging was listed as a “real write” so MCP presence pulses skipped it — but `PUT /api/agent/build/sources/stage` never refreshed `lastAgentSignalAt`.

After ~15 minutes of staging, Studio showed **quiet** / “Waiting for your agent…” and unlocked **Who builds this round?** while the agent was still uploading.

## Fix

On successful stage: `markBuildingFromChannel` + `touchLastAgentSignalAt(..., { key: 'staging_sources' })`.

## Test plan

- [x] `agent-channel` staging test asserts heartbeat + `staging_sources` presence
- [x] type-check / locales
- [ ] After deploy: stage files for >15m without `report_progress` — Studio stays live, no platform handoff offer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

