### PR TITLE
fix(studio): open an improvement round's thread with the request that started it

### DIFF
--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -335,6 +335,17 @@ describe('MCP open_round (BY-24 / BY-27b)', () => {
     expect(job?.spec).not.toBe('');
     // The change request is free text, not a clarifications block.
     expect(job?.qa).toEqual([]);
+
+    // It also opens the round's thread — as the agent's relay, not the creator's words,
+    // so Studio labels and translates it the way continue_draft's relay is.
+    const messages = await store.listCreatorMessages(jobId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      text: 'Make the title screen background a solid coloured rectangle.',
+      origin: 'agent',
+    });
+    // Already delivered: the brief above is how the agent receives it.
+    expect(await store.listPendingCreatorMessages(jobId)).toEqual([]);
   });
 
   it('admits only one concurrent open_round per slug', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -138,6 +138,8 @@ export interface McpServerOptions {
     log: { error: (context: object, message: string) => void };
     builder?: BuilderKind;
     openedBy?: 'creator' | 'agent';
+    /** Opens the new job's thread with `text`, attributed to whoever wrote it. */
+    requestedBy?: 'creator' | 'agent';
     /** When set, the new job is owned by this uid (slug-transfer safe). */
     ownerUid?: string;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
@@ -1418,6 +1420,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             log: ctx.request.log,
             builder: 'self',
             openedBy: 'agent',
+            // Same relay as continue_draft: the agent wrote this summary, so the thread
+            // labels and translates it rather than passing it off as the creator's words.
+            requestedBy: 'agent',
             // Authorized creator wins over the published record's owner after a transfer.
             ownerUid: resolved.creatorUid,
           });

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1621,11 +1621,17 @@ export interface Store {
    * Queues a creator change request for the agent to collect. `origin` records who
    * typed it — omit it for the Studio composer, pass `agent` when an agent relayed the
    * request on the creator's behalf (@see CreatorMessage.origin).
+   *
+   * `delivered` writes it already collected, for a request the agent is receiving by
+   * another route — a new improvement round, whose brief already *is* this text. It
+   * still belongs in the thread (it is what the creator asked for), but queueing it
+   * would hand the agent the same instruction twice: once as its brief, once as a
+   * pending note that reads like something new to act on.
    */
   appendCreatorMessage(
     issueNumber: number,
     text: string,
-    opts?: { origin?: CreatorMessageOrigin },
+    opts?: { origin?: CreatorMessageOrigin; delivered?: boolean },
   ): Promise<CreatorMessage>;
   /** Undelivered creator messages, oldest first — the agent's inbox. */
   listPendingCreatorMessages(issueNumber: number, opts?: { limit?: number }): Promise<CreatorMessage[]>;
@@ -2929,13 +2935,14 @@ export class InMemoryStore implements Store {
   async appendCreatorMessage(
     issueNumber: number,
     text: string,
-    opts?: { origin?: CreatorMessageOrigin },
+    opts?: { origin?: CreatorMessageOrigin; delivered?: boolean },
   ): Promise<CreatorMessage> {
+    const now = new Date().toISOString();
     const record: CreatorMessage = {
       id: randomUUID(),
       text,
-      createdAt: new Date().toISOString(),
-      deliveredAt: null,
+      createdAt: now,
+      deliveredAt: opts?.delivered ? now : null,
       ...(opts?.origin === 'agent' ? { origin: 'agent' as const } : {}),
     };
     const existing = this.creatorMessages.get(issueNumber) ?? [];
@@ -4894,15 +4901,16 @@ export class FirestoreStore implements Store {
   async appendCreatorMessage(
     issueNumber: number,
     text: string,
-    opts?: { origin?: CreatorMessageOrigin },
+    opts?: { origin?: CreatorMessageOrigin; delivered?: boolean },
   ): Promise<CreatorMessage> {
     // `origin` is spread in only when it is `agent`: Firestore rejects an explicit
     // `undefined`, and a stored `'creator'` would say nothing the absent field does not.
+    const now = new Date().toISOString();
     const record: CreatorMessage = {
       id: randomUUID(),
       text,
-      createdAt: new Date().toISOString(),
-      deliveredAt: null,
+      createdAt: now,
+      deliveredAt: opts?.delivered ? now : null,
       ...(opts?.origin === 'agent' ? { origin: 'agent' as const } : {}),
     };
     await this.messagesCollection(issueNumber).doc(record.id).set(record);

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -3575,6 +3575,54 @@ describe('POST /api/submissions/:token/improve', () => {
     expect(verifyToken(body.token, secret)).not.toBe(published);
     await app.close();
   });
+
+  it('opens the new round’s thread with the request that started it', async () => {
+    // Publishing is terminal, so an improvement is a new job with an empty thread. The
+    // request used to live only in the brief the agent reads: the creator would send it,
+    // land on the new round, and find no trace of what they had just asked for — and a
+    // reload dropped the page's own local echo too.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const published = await store.allocateJobId();
+    await store.createSubmission(published, 'g:test-user', 'Echo Game');
+    await store.setSubmissionSlug(published, 'echo-game');
+    await store.setSubmissionPublishedAt(published, '2026-07-01T00:00:00.000Z');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(published, secret)}/improve`,
+      headers: authHeaders,
+      payload: {
+        feedback: 'Please add a checkpoint before the hard second level jump.',
+        context: { instrumentation: { playSeconds: 30 } },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const jobId = res.json().jobId as number;
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${res.json().token}`,
+      headers: authHeaders,
+    });
+    const revisions = status.json().progress?.revisions;
+    expect(revisions).toHaveLength(1);
+    // Their own words, so no relay label — and without the instrumentation block that
+    // was stapled on for the agent.
+    expect(revisions[0].text).toBe('Please add a checkpoint before the hard second level jump.');
+    expect(revisions[0].origin).toBeUndefined();
+
+    // Written already delivered: the brief carries the same words to the agent, so
+    // queueing it too would hand over one instruction that looks like two.
+    expect(await store.listPendingCreatorMessages(jobId)).toEqual([]);
+    await app.close();
+  });
 });
 
 /**

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -68,6 +68,7 @@ import {
   DELETED_ACCOUNT_UID,
   type BuildPreviewSummary,
   type BuildShotSummary,
+  type CreatorMessageOrigin,
   type Store,
   type SubmissionRecord,
 } from './store.js';
@@ -459,6 +460,11 @@ export interface SubmissionRoutesHandle {
     builder?: BuilderKind;
     /** Who opened this improvement — drives the queued transition and status.openedBy. */
     openedBy?: 'creator' | 'agent';
+    /**
+     * Set when a person or their agent put this request into words, to open the new
+     * job's thread with it. Omit for a machine-assembled brief — see the implementation.
+     */
+    requestedBy?: CreatorMessageOrigin;
     /** When set, the new job is owned by this uid (slug-transfer safe). */
     ownerUid?: string;
   }) => Promise<{ route: 'job'; jobId: number } | null>;
@@ -1141,6 +1147,22 @@ export async function registerSubmissionRoutes(
     /** Who opened this improvement — drives the queued transition and status.openedBy. */
     openedBy?: 'creator' | 'agent';
     /**
+     * Who put this round's request into words, when a person or their agent did. Set it
+     * and `text` opens the new job's thread, attributed accordingly — `creator` for the
+     * Studio improve composer, `agent` for a relay through MCP `open_round`.
+     *
+     * Publishing is terminal, so an improvement is a *new* job with an empty thread, and
+     * the request that started it used to live only in the brief the agent reads. The
+     * creator would send a change request, land on the new round, and find no trace of
+     * what they had just asked for — worse after a reload, which drops the page's own
+     * local echo of it too.
+     *
+     * Omitted on purpose by the suggestion paths: `buildImprovementBrief` assembles those
+     * out of player evidence, so nobody typed them. Putting one on the creator's side of
+     * the thread would be the bug #539 fixed, wearing a different hat.
+     */
+    requestedBy?: CreatorMessageOrigin;
+    /**
      * Owner of the new job. Defaults to the published source's ownerUid. Pass the
      * authorized creator after a slug transfer so quota and Studio stay aligned.
      */
@@ -1169,6 +1191,18 @@ export async function registerSubmissionRoutes(
     // stored brief and nothing else. Without this an agent-opened improvement round
     // starts with an empty spec and no idea what the creator asked for.
     await store.setSubmissionBrief(jobId, { spec: input.text, qa: [] });
+    // Open the new job's thread with the request that started it. Written already
+    // delivered: the brief below carries the same words to the agent, and a pending
+    // note would read as a second, newer instruction to act on.
+    if (input.requestedBy) {
+      try {
+        await store.appendCreatorMessage(jobId, input.text, { origin: input.requestedBy, delivered: true });
+      } catch (seedError) {
+        // Best effort. The request still reaches the agent as the brief, so a failure
+        // here costs the creator the echo, not the round.
+        input.log.error({ err: seedError, issueNumber: jobId }, 'failed to seed the improvement thread');
+      }
+    }
     await store.recordJobTransition(jobId, {
       to: 'queued',
       at: new Date(now()).toISOString(),
@@ -3201,6 +3235,10 @@ export async function registerSubmissionRoutes(
         issueNumber,
         text: contextBlock ? `${sanitizedFeedback}\n\n${contextBlock}` : sanitizedFeedback,
         title: sanitizedTitle,
+        // Their own words, typed in the improve composer — the new round's thread opens
+        // with them instead of empty. `stripPlaytestContext` keeps the instrumentation
+        // block we stapled on out of the echo.
+        requestedBy: 'creator',
         // The record was already loaded above for the ownership check.
         locale: record.locale ?? 'en',
         log: request.log,

--- a/apps/api/src/suggestion-inbox.test.ts
+++ b/apps/api/src/suggestion-inbox.test.ts
@@ -144,6 +144,10 @@ describe('POST /api/me/suggestions/:id/approve', () => {
     expect(res.json().suggestion.issueNumber).toBeUndefined();
     expect(start.mock.calls[0][0]).toMatchObject({ issueNumber: PUBLISHED_JOB_ID });
     expect(start.mock.calls[0][0].text).toContain('40 uncaught errors across 100 sessions.');
+    // No `requestedBy`, so this brief never opens the thread as a creator message. It is
+    // assembled here out of player evidence — nobody typed it, and putting it on the
+    // creator's side of the conversation would show them words they never wrote.
+    expect(start.mock.calls[0][0].requestedBy).toBeUndefined();
     await app.close();
   });
 


### PR DESCRIPTION
Follow-up to #539, which fixed the draft-feedback half of this. Same underlying question — *who wrote the words on the creator's side of the thread* — asked at the post-publish boundary.

## The bug

Publishing is terminal, so an improvement is a **new job with an empty thread**. The request that started it lived only in the brief the agent reads (`setSubmissionBrief`); nothing ever called `appendCreatorMessage`.

So a creator sends a change request from Studio, lands on the new round, and finds no trace of what they just asked for. The page's own optimistic echo (`pendingRevisions`) covers it until the first reload, which clears on token change — and the improve response deliberately hands back a *new* token, so the handoff itself drops it.

## The fix

`startImprovementRound` seeds the new job's thread, but only when a person or their agent actually put the request into words. That is the new `requestedBy`:

| Caller | `requestedBy` | Result |
|---|---|---|
| Studio improve composer (`submissions.ts`) | `creator` | Opens with the creator's own words — no label, no translation |
| MCP `open_round` (`mcp-server.ts`) | `agent` | Labelled "Summarized by your agent" and translated, exactly as #539 treats `continue_draft` |
| Approved player-evidence suggestion (`suggestion-inbox.ts`) | *omitted* | Stays out of the thread |
| Autonomous sweep (`suggestion-sweep.ts`) | *omitted* | Stays out of the thread |

The `open_round` row is worth calling out: that was the same defect as #539 in its post-publish form. The agent's relay was previously *invisible* rather than mislabelled, so it never showed up in the original report — but it's the same class, and it now gets the same labelled-and-translated treatment.

The suggestion paths pass nothing on purpose. `buildImprovementBrief` assembles those out of player evidence — nobody typed them, and putting one on the creator's side of the conversation would be the bug #539 fixed wearing a different hat. There's a test pinning that so a future caller doesn't quietly opt in.

## Why `delivered`

`appendCreatorMessage` feeds two things: the Studio thread and the agent's pending inbox (`listPendingCreatorMessages`, which rides every mutating channel reply as `pendingMessages`). For an improvement round the brief already carries the same text to the agent, so queueing it as well would hand over **one instruction that reads like two** — the agent sees a pending note and takes it for something new to act on, mid-round.

So seeded messages are written already collected. They belong in the thread (it is what the creator asked for) without also being an inbox item.

## Tests

- `submissions.test.ts` — the improve round's thread opens with the creator's words, `origin` absent, instrumentation block stripped, and nothing left pending.
- `mcp-open-round.test.ts` — `open_round` seeds one message marked `origin: 'agent'`, also nothing pending.
- `suggestion-inbox.test.ts` — an approved suggestion dispatches with no `requestedBy`.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` — all green (1172 tests across the workspaces).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjkGreoXoZWCENEWVh2nFm)_