### PR TITLE
fix(studio): wait for gate preview on Play instead of hard error

### DIFF
--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -19,6 +19,7 @@ vi.mock('./submissionApi.js', () => ({
   getSubmissionPreview: vi.fn(async () => ({
     html: '<!doctype html><html><body><canvas id="game"></canvas></body></html>',
   })),
+  getSubmissionStatus: vi.fn(async () => ({ status: 'building' })),
   submitFeedback: vi.fn(),
 }));
 
@@ -142,7 +143,7 @@ describe('StudioPlaytestPanel theater', () => {
     await i18n.changeLanguage('en');
     vi.useFakeTimers();
 
-    const { getSubmissionPreview } = await import('./submissionApi.js');
+    const { getSubmissionPreview, getSubmissionStatus } = await import('./submissionApi.js');
     const previewHtml = '<!doctype html><html><body><canvas id="game"></canvas></body></html>';
     vi.mocked(getSubmissionPreview)
       .mockRejectedValueOnce(Object.assign(new Error('no preview available'), { status: 409 }))
@@ -151,6 +152,7 @@ describe('StudioPlaytestPanel theater', () => {
         title: 'Sky Dodge',
         html: previewHtml,
       });
+    vi.mocked(getSubmissionStatus).mockResolvedValue({ status: 'building' });
 
     const onExit = vi.fn();
     const container = document.createElement('div');
@@ -170,6 +172,7 @@ describe('StudioPlaytestPanel theater', () => {
     expect(container.textContent).toContain('Automated checks are assembling your draft');
     expect(container.textContent).not.toContain('No playable build is ready yet');
     expect(vi.mocked(getSubmissionPreview)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getSubmissionStatus)).toHaveBeenCalled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(PREVIEW_POLL_MS);
@@ -183,6 +186,42 @@ describe('StudioPlaytestPanel theater', () => {
 
     root.unmount();
     vi.useRealTimers();
+  });
+
+  it('stops waiting on 409 when the round is already needs_changes with no preview', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const { getSubmissionPreview, getSubmissionStatus } = await import('./submissionApi.js');
+    vi.mocked(getSubmissionPreview).mockRejectedValue(
+      Object.assign(new Error('no preview available'), { status: 409 }),
+    );
+    vi.mocked(getSubmissionStatus).mockResolvedValue({
+      status: 'needs_changes',
+      failure: { reason: 'gate_red' },
+    });
+
+    const onExit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const unpublished: StudioGame = { ...game, lastKnownStatus: 'building', slug: undefined, publishedAt: undefined };
+
+    await act(async () => {
+      root.render(createElement(StudioPlaytestPanel, { game: unpublished, published: false, onExit }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.studio-playtest-theater')).toBeNull();
+    expect(container.textContent).toContain('No playable build is ready yet');
+    expect(container.textContent).not.toContain('Automated checks are assembling your draft');
+    expect(vi.mocked(getSubmissionPreview)).toHaveBeenCalledTimes(1);
+
+    root.unmount();
   });
 
   it('does not exit on Escape when shelfOpen is true', async () => {

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -4,7 +4,7 @@ import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
-import { StudioPlaytestPanel } from './StudioPlaytestPanel.js';
+import { PREVIEW_POLL_MS, StudioPlaytestPanel } from './StudioPlaytestPanel.js';
 import type { StudioGame } from './studioApi.js';
 
 vi.mock('./catalog.js', () => ({
@@ -48,6 +48,7 @@ describe('StudioPlaytestPanel theater', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     document.body.className = '';
+    vi.useRealTimers();
   });
 
   it('opens a full-viewport theater with overlay controls once the build loads', async () => {
@@ -134,6 +135,50 @@ describe('StudioPlaytestPanel theater', () => {
     expect(onExit).toHaveBeenCalledTimes(2);
 
     root.unmount();
+  });
+
+  it('keeps waiting on 409 until the gate preview is ready', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    vi.useFakeTimers();
+
+    const { getSubmissionPreview } = await import('./submissionApi.js');
+    const previewHtml = '<!doctype html><html><body><canvas id="game"></canvas></body></html>';
+    vi.mocked(getSubmissionPreview)
+      .mockRejectedValueOnce(Object.assign(new Error('no preview available'), { status: 409 }))
+      .mockResolvedValueOnce({ html: previewHtml });
+
+    const onExit = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const unpublished: StudioGame = { ...game, lastKnownStatus: 'building', slug: undefined, publishedAt: undefined };
+
+    await act(async () => {
+      root.render(createElement(StudioPlaytestPanel, { game: unpublished, published: false, onExit }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.studio-playtest-theater')).toBeNull();
+    expect(container.textContent).toContain('Automated checks are assembling your draft');
+    expect(container.textContent).not.toContain('No playable build is ready yet');
+    expect(vi.mocked(getSubmissionPreview)).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PREVIEW_POLL_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(getSubmissionPreview)).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('.studio-playtest-theater')).not.toBeNull();
+    expect(container.textContent).not.toContain('Automated checks are assembling your draft');
+
+    root.unmount();
+    vi.useRealTimers();
   });
 
   it('does not exit on Escape when shelfOpen is true', async () => {

--- a/apps/web/src/StudioPlaytestPanel.test.tsx
+++ b/apps/web/src/StudioPlaytestPanel.test.tsx
@@ -146,7 +146,11 @@ describe('StudioPlaytestPanel theater', () => {
     const previewHtml = '<!doctype html><html><body><canvas id="game"></canvas></body></html>';
     vi.mocked(getSubmissionPreview)
       .mockRejectedValueOnce(Object.assign(new Error('no preview available'), { status: 409 }))
-      .mockResolvedValueOnce({ html: previewHtml });
+      .mockResolvedValueOnce({
+        slug: 'sky-dodge',
+        title: 'Sky Dodge',
+        html: previewHtml,
+      });
 
     const onExit = vi.fn();
     const container = document.createElement('div');

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -47,6 +47,9 @@ const DEV_PLAYTEST_HTML = `<!doctype html><html><head><meta charset="utf-8"><tit
 })();
 </script></body></html>`;
 
+/** How often to retry `/preview` while the gate is still assembling HTML (HTTP 409). */
+export const PREVIEW_POLL_MS = 3000;
+
 type StudioPlaytestPanelProps = {
   game: StudioGame;
   published: boolean;
@@ -112,6 +115,8 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
   const [html, setHtml] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  /** True while `/preview` returns 409 — gate is still assembling the draft HTML. */
+  const [waitingForPreview, setWaitingForPreview] = useState(false);
   const [text, setText] = useState('');
   const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent'>('idle');
   const [sendError, setSendError] = useState<string | null>(null);
@@ -135,38 +140,70 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
 
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     setHtml(null);
     setLoadError(null);
+    setWaitingForPreview(false);
     setLoading(true);
     clearSnapshot();
 
-    const load =
-      published && game.slug
-        ? fetchPublishedGame(game.slug).then((doc) => doc.html)
-        : getSubmissionPreview(game.token).then((preview) => preview.html);
+    const finishError = (message: string) => {
+      if (cancelled) return;
+      setWaitingForPreview(false);
+      setLoadError(message);
+      setLoading(false);
+    };
 
-    load
-      .then((documentHtml) => {
-        if (cancelled) return;
+    const loadOnce = async (): Promise<'done' | 'retry'> => {
+      try {
+        const documentHtml =
+          published && game.slug
+            ? (await fetchPublishedGame(game.slug)).html
+            : (await getSubmissionPreview(game.token)).html;
+        if (cancelled) return 'done';
         setHtml(documentHtml);
+        setWaitingForPreview(false);
+        setLoadError(null);
         setLoading(false);
-      })
-      .catch(() => {
-        if (cancelled) return;
+        return 'done';
+      } catch (err) {
+        if (cancelled) return 'done';
+        const status = (err as SubmissionApiError).status;
+        // 409 = sources landed, gate still assembling preview.html. Keep waiting —
+        // a one-shot error here is what made "Play" look broken right after submit.
+        if (!published && status === 409) {
+          setWaitingForPreview(true);
+          setLoadError(null);
+          setLoading(true);
+          return 'retry';
+        }
         // Local Studio seed has submissions but no games-repo HTML. Fall back to a
         // tiny canvas toy in Vite so Pause & note can still be exercised offline.
         // Vitest runs with MODE=test — keep the real empty/error surface there.
         if (import.meta.env.MODE === 'development') {
           setHtml(DEV_PLAYTEST_HTML);
+          setWaitingForPreview(false);
           setLoading(false);
-          return;
+          return 'done';
         }
-        setLoadError(t('studioPanel.playtest.loadError'));
-        setLoading(false);
-      });
+        finishError(t('studioPanel.playtest.loadError'));
+        return 'done';
+      }
+    };
+
+    const tick = async () => {
+      const outcome = await loadOnce();
+      if (outcome === 'retry' && !cancelled) {
+        timer = setTimeout(() => {
+          void tick();
+        }, PREVIEW_POLL_MS);
+      }
+    };
+    void tick();
 
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [game.token, game.slug, published, t, clearSnapshot]);
 
@@ -233,7 +270,13 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
       {!html ? (
         <div className="studio-playtest-empty">
           <p className="panel-copy studio-playtest-hint">{t('studioPanel.playtest.hint')}</p>
-          {loading ? <p className="studio-muted">{t('studioPanel.playtest.loading')}</p> : null}
+          {waitingForPreview ? (
+            <p className="studio-muted" aria-live="polite">
+              {t('studioPanel.playtest.waitingForPreview')}
+            </p>
+          ) : loading ? (
+            <p className="studio-muted">{t('studioPanel.playtest.loading')}</p>
+          ) : null}
           {loadError ? <p className="error">{loadError}</p> : null}
           {/* Theater Close only exists once HTML loads; empty/error must still offer a
               labeled way back to the build thread (Testuj replaces that surface). */}

--- a/apps/web/src/StudioPlaytestPanel.tsx
+++ b/apps/web/src/StudioPlaytestPanel.tsx
@@ -7,6 +7,7 @@ import { useEditorDraftBridge } from './editorBridge.js';
 import { PixelIcon } from './PixelIcon.js';
 import {
   getSubmissionPreview,
+  getSubmissionStatus,
   submitFeedback,
   type FeedbackContext,
   type SubmissionApiError,
@@ -49,6 +50,8 @@ const DEV_PLAYTEST_HTML = `<!doctype html><html><head><meta charset="utf-8"><tit
 
 /** How often to retry `/preview` while the gate is still assembling HTML (HTTP 409). */
 export const PREVIEW_POLL_MS = 3000;
+/** Give up waiting so a permanent 409 (gate red, no artifact) does not poll forever. */
+export const PREVIEW_WAIT_MAX_MS = 10 * 60 * 1000;
 
 type StudioPlaytestPanelProps = {
   game: StudioGame;
@@ -141,6 +144,7 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const waitStartedAt = Date.now();
     setHtml(null);
     setLoadError(null);
     setWaitingForPreview(false);
@@ -152,6 +156,23 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
       setWaitingForPreview(false);
       setLoadError(message);
       setLoading(false);
+    };
+
+    /**
+     * 409 alone is ambiguous: gate still assembling, or gate already red with no
+     * artifact. Status settles the latter — Play has unmounted the thread poller.
+     */
+    const previewStillComing = async (): Promise<boolean> => {
+      if (Date.now() - waitStartedAt >= PREVIEW_WAIT_MAX_MS) return false;
+      try {
+        const job = await getSubmissionStatus(game.token);
+        if (job.preview?.slug) return true;
+        if (job.status === 'needs_changes' || job.status === 'abandoned') return false;
+        if (job.failure) return false;
+      } catch {
+        // Status probe failed — keep waiting on the preview 409 itself.
+      }
+      return Date.now() - waitStartedAt < PREVIEW_WAIT_MAX_MS;
     };
 
     const loadOnce = async (): Promise<'done' | 'retry'> => {
@@ -171,7 +192,9 @@ export function StudioPlaytestPanel({ game, published, onExit, shelfOpen }: Stud
         const status = (err as SubmissionApiError).status;
         // 409 = sources landed, gate still assembling preview.html. Keep waiting —
         // a one-shot error here is what made "Play" look broken right after submit.
-        if (!published && status === 409) {
+        // Stop when the round is already terminal with no artifact (or we timed out).
+        if (!published && status === 409 && (await previewStillComing())) {
+          if (cancelled) return 'done';
           setWaitingForPreview(true);
           setLoadError(null);
           setLoading(true);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -351,6 +351,7 @@
     "playtest": {
       "hint": "Play the game, pause on a moment worth changing, and send a request with that viewport and live instrumentation attached.",
       "loading": "Loading the playable build…",
+      "waitingForPreview": "Automated checks are assembling your draft — this usually takes a few minutes after submit. Play will open when it’s ready.",
       "loadError": "No playable build is ready yet. Go back to the thread and try again once a preview appears.",
       "backToThread": "Back to thread",
       "theaterAria": "Playtest · {{title}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -353,6 +353,7 @@
     "playtest": {
       "hint": "Zagraj, wstrzymaj w momencie wartym zmiany i wyślij prośbę z tym widokiem oraz sygnałami z sesji.",
       "loading": "Ładujemy grywalny build…",
+      "waitingForPreview": "Automatyczne sprawdzenia składają szkic — zwykle zajmuje to kilka minut po wysłaniu. Play otworzy się, gdy będzie gotowy.",
       "loadError": "Nie ma jeszcze grywalnego buildu. Wróć do wątku i spróbuj, gdy pojawi się podgląd.",
       "backToThread": "Wróć do wątku",
       "theaterAria": "Playtest · {{title}}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a successful `submit_sources` (`ok: true`, `gateStarted: true`), opening **Play** immediately showed:

> No playable build is ready yet…

That was wrong UX. `gateStarted` only means the delivery was accepted — Cloud Build still needs to produce `preview.html`. `/preview` correctly returns **409** until then, but Play treated that as a terminal failure.

(The MCP `call_end` / `progress_stale` warnings in the same session are separate — soft protocol nudges; they do not block the gate.)

## Fix

- Poll `/preview` every 3s while unpublished drafts return HTTP 409
- Show a waiting copy instead of the hard error until HTML is ready
- On each 409, probe submission status: stop if the round is already `needs_changes` / `abandoned` / has `failure` with no preview (Codex P2) — and cap wait at 10 minutes so a stuck 409 cannot poll forever
- EN + PL strings; unit tests cover 409 → wait → theater and terminal gate-red stop

## Test plan

- [x] `StudioPlaytestPanel` unit tests (409 poll + needs_changes stop)
- [x] Green gate / CI on prior revision; follow-up commit addresses Codex review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

