### PR TITLE
ci: stop double-running master CI and cancel stale snapshot bakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,27 @@ name: CI
 on:
   push:
     branches: [master]
+  # Draft PRs skip the jobs below (no runner assigned). Agent branches push often;
+  # open as draft until ready for review.
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 # Least-privilege GITHUB_TOKEN: both jobs only read the repo (checkout, npm,
 # gitleaks, gate). No writes to issues/PRs/contents.
 permissions:
   contents: read
 
+# Superseded PR heads prove nothing the newer run does not. Master runs stay
+# queued — deploy waits on CI via workflow_run, so cancelling a master CI run
+# would strand a commit that already landed.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gitleaks:
     name: Secret Scanning
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +39,7 @@ jobs:
 
   build_and_test:
     name: Lint, Test & Build
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +63,7 @@ jobs:
   # GAMES_CONTRACT_REQUIRE_REMOTE=1 below to demand the live comparison instead.
   games_repo_contract:
     name: Games-repo contract
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +97,7 @@ jobs:
   # --omit=optional, a missing dist/ copy). So this starts the thing and asks it for health.
   image_build:
     name: Production image
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,17 @@
 name: Deploy to Cloud Run
 
+# Runs after CI succeeds on master — not on the push itself. Every master push used to
+# pay for lint/type-check/test/build twice (CI's build_and_test + this workflow's
+# ci-gate). Waiting on the CI workflow also means deploy inherits the image-boot and
+# games-repo contract jobs, which the old ci-gate never ran.
 on:
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [master]
+  # Manual escape hatch: redeploy the current master tip without waiting on a CI run
+  # (e.g. after a Cloud Run config fix that does not need a new commit).
+  workflow_dispatch:
 
 concurrency:
   group: cloud-run-deploy
@@ -13,22 +22,9 @@ permissions:
   id-token: write
 
 jobs:
-  ci-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run type-check
-      - run: npm run test
-      - run: npm run build
-
   deploy:
-    needs: ci-gate
+    # workflow_run fires for every CI completion, including failures — refuse those.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: 'gamedevpl'
@@ -46,9 +42,14 @@ jobs:
       GAMES_STORE_BUCKET: 'gamedevpl-games-store'
       WIF_PROVIDER: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
       WIF_SERVICE_ACCOUNT: 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com'
+      # workflow_run's github.sha is the default-branch tip at schedule time, not
+      # necessarily the commit CI validated. Prefer the triggering run's head_sha.
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Authenticate to GCP via Workload Identity Federation
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
@@ -61,7 +62,7 @@ jobs:
 
       - name: Build image via Cloud Build
         run: |
-          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          SHORT_SHA=$(echo "${DEPLOY_SHA}" | cut -c1-7)
           IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${SHORT_SHA}"
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
           gcloud builds submit . \
@@ -429,8 +430,8 @@ jobs:
       # broken assembler each return a healthy 200 and a black screen — and a site without
       # playable games is worth nothing (apps/e2e, docs/deployment.md).
       #
-      # `deploy` is a separate job from `ci-gate`, on a fresh runner with no node_modules —
-      # everything before this point is gcloud and curl — so Node is set up here.
+      # `deploy` is a fresh runner with no node_modules — everything before this point is
+      # gcloud and curl — so Node is set up here.
       - name: Set up Node for the browser gate
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -41,12 +41,14 @@ on:
         required: false
         default: false
 
-# Two publishes racing would interleave their pointer writes, and the loser could
-# leave `current.json` addressing the older snapshot. Queue them instead — the
-# snapshot prefixes are immutable, so a queued run is simply the newer truth.
+# Two publishes racing would interleave their pointer writes. Cancel the older
+# run instead of queuing: the games repo can dispatch many times in a merge
+# train, and each bake is a full catalog assemble — only the newest SHA is
+# worth publishing. Snapshot prefixes are immutable, so a cancelled mid-bake
+# leaves no half-written pointer (the pointer write is the last step).
 concurrency:
   group: games-snapshot-publish
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 # Deployment
 
 > **Status: ✅ Live in closed beta at [www.gamedev.pl](https://www.gamedev.pl)**, deployed
-> automatically by GitHub Actions (`deploy.yml`) on every push to `master`.
+> automatically by GitHub Actions (`deploy.yml`) after CI succeeds on `master`.
 >
 > The app (web + API) runs as **one Cloud Run service**: project `gamedevpl`, region
 > **`europe-west1`**, service `gamedev-app`, scale-to-zero and pinned to **one instance** until
@@ -28,9 +28,12 @@ gcloud secrets list --project gamedevpl
 
 ## Automated CD Pipeline (`.github/workflows/deploy.yml`)
 
-Deployments to Cloud Run are triggered on push to `master`:
+Deployments to Cloud Run start when the **CI** workflow completes successfully on
+`master` (`workflow_run`) — not on the push itself. That way lint / type-check / test /
+build / image-boot run once (in CI), and deploy does not re-pay for them. Manual
+`workflow_dispatch` on `deploy.yml` is the escape hatch for redeploying the current tip.
 
-1. **CI Gate (`ci-gate`):** Runs `npm run lint`, `npm run type-check`, `npm run test`, `npm run build` on Node 20.
+1. **CI (prerequisite):** `ci.yml` on `master` — secret scan, lint/type-check/test/build, games-repo contract, production image boot.
 2. **Keyless OIDC Auth:** Authenticates via GCP Workload Identity Federation (no long-lived service account keys).
 3. **Cloud Build Image Creation:** Submits image build using `infra/cloudbuild.yaml` to Artifact Registry. The WIF deployer service account must also have `roles/serviceusage.serviceUsageConsumer` and storage access for the default Cloud Build staging bucket; `infra/setup-wif.sh` grants both.
 4. **Staging / Candidate Revision:** Deploys revision to Cloud Run with `--no-traffic --tag candidate`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Actions budget concern for gamedev.pl. The **minutes that bill** are still mostly the private [`www.gamedev.pl-games`](https://github.com/gamedevpl/www.gamedev.pl-games/pull/478) validate workflow (this repo is public → standard runners are free). This PR still cuts wasted runner work on the product repo.

## Changes

1. **`deploy.yml`** — trigger on successful **CI** `workflow_run` on `master` (plus manual `workflow_dispatch`), remove the duplicate `ci-gate` job that re-ran lint/type-check/test/build on every push.
2. **`ci.yml`** — skip draft PRs; cancel superseded PR runs; keep master CI uncancelled (deploy waits on it).
3. **`publish-games.yml`** — `cancel-in-progress: true` so games-repo merge trains do not queue many full-catalog snapshot bakes.
4. **`docs/deployment.md`** — describe the new CD trigger.

## Note

Snapshot publish has been failing separately (`carjack-city` over the author byte budget) — out of scope here; cancelling superseded bakes still stops stacking failed/redundant runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a423351c-5ff5-4b00-a1bf-f9f871d012e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a423351c-5ff5-4b00-a1bf-f9f871d012e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

