### PR TITLE
Fix screenshots and Studio links on creator profiles

### DIFF
--- a/apps/api/src/creator-profile-routes.test.ts
+++ b/apps/api/src/creator-profile-routes.test.ts
@@ -99,6 +99,38 @@ describe('creator profile routes', () => {
     expect(JSON.stringify(body)).not.toContain('Secret Google');
   });
 
+  it('includes gate screenshots in published game cards', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.claimHandle('g:creator', 'ada', '2026-07-01T00:00:00.000Z');
+    await store.createSubmission(42, 'g:creator', 'Sky Dodge');
+    await store.setSubmissionSlug(42, 'sky-dodge');
+    await store.setSubmissionPublishedAt(42, '2026-08-01T12:00:00.000Z');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-08-01T12:00:00.000Z',
+    });
+    const gamesStore = {
+      getSourceFile: async (_slug: string, _version: string, path: string) =>
+        path === 'SPEC.md' ? '---\ntitle: Sky Dodge\ngenre: arcade\n---\n' : null,
+      getDerivedArtifact: async (_slug: string, _version: string, path: string) =>
+        path === 'media/metadata.json'
+          ? Buffer.from(JSON.stringify({ captures: { opening: { file: 'opening.png' } }, video: null }))
+          : null,
+    } as unknown as GamesStore;
+    const app = await appWith(store, gamesStore);
+
+    const publicPage = await app.inject({ method: 'GET', url: '/api/creators/ada' });
+
+    expect(publicPage.statusCode).toBe(200);
+    expect(publicPage.json().games[0]).toMatchObject({
+      slug: 'sky-dodge',
+      media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null },
+    });
+  });
+
   it('reports availability and refuses reserved handles', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:a' });

--- a/apps/api/src/creator-profile-routes.ts
+++ b/apps/api/src/creator-profile-routes.ts
@@ -252,7 +252,15 @@ async function listCreatorPublishedGames(
         const version = publication.currentVersion ?? record.deliveredVersion;
         if (version) {
           const spec = await gamesStore.getSourceFile(slug, version, 'SPEC.md');
-          if (spec) entry = catalogEntryFromSpec(slug, spec, () => null);
+          if (spec) {
+            // Gate captures are derived artifacts, not game sources. Reading only
+            // SPEC.md here left every creator-profile poster empty even though the
+            // catalog and media route could already serve the same screenshot.
+            const mediaMetadata = await gamesStore.getDerivedArtifact(slug, version, 'media/metadata.json');
+            entry = catalogEntryFromSpec(slug, spec, (name) =>
+              name === 'media/metadata.json' && mediaMetadata ? mediaMetadata.toString('utf8') : null,
+            );
+          }
         }
       } catch {
         // A missing store object must not blank the whole profile.

--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -84,6 +84,36 @@ async function renderPage() {
   });
 }
 
+function creatorPageWithGame() {
+  return {
+    profile: {
+      handle: 'ada',
+      profileName: 'Ada',
+      bio: 'Builder',
+      avatarUrl: null,
+      profileCreatedAt: '2026-08-01T00:00:00.000Z',
+    },
+    games: [
+      {
+        slug: 'sky-dodge',
+        title: 'Sky Dodge',
+        genre: 'arcade',
+        controls: 'Arrow keys',
+        status: 'published',
+        media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null },
+        submittedBy: 'Ada',
+        creatorHandle: 'ada',
+        orientation: 'any',
+        touch: 'gamekit',
+        multiplayer: null,
+        saves: null,
+        world: null,
+        sensing: null,
+      },
+    ],
+  };
+}
+
 describe('CreatorProfilePage owner edit', () => {
   it('hides Edit profile for visitors', async () => {
     authUser = { uid: 'g:other', handle: 'bob' };
@@ -104,5 +134,28 @@ describe('CreatorProfilePage owner edit', () => {
     });
     expect(document.body.querySelector('.edit-profile-modal-card')).not.toBeNull();
     expect(document.body.querySelector('.edit-profile-modal-card')?.textContent).toContain('Your public profile');
+  });
+
+  it('shows screenshots and per-game Studio links to the owner', async () => {
+    authUser = { uid: 'g:ada', handle: 'ada', name: 'Ada' };
+    fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
+
+    await renderPage();
+
+    expect(container.querySelector<HTMLImageElement>('.creator-profile-game-thumb')?.getAttribute('src')).toBe(
+      '/api/games/sky-dodge/media/opening.png',
+    );
+    expect(container.querySelector<HTMLAnchorElement>('a[href="/studio/sky-dodge"]')?.textContent).toContain(
+      'Open in Studio',
+    );
+  });
+
+  it('keeps per-game Studio links private to the owner', async () => {
+    authUser = { uid: 'g:other', handle: 'bob' };
+    fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
+
+    await renderPage();
+
+    expect(container.querySelector('a[href="/studio/sky-dodge"]')).toBeNull();
   });
 });

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -5,7 +5,7 @@ import { catalogMediaUrl, isPlatformAuthor, normalizeCatalogEntry, type CatalogE
 import { fetchCreatorPage, type PublicCreatorProfile } from './creatorProfileApi.js';
 import { EditProfileModal } from './EditProfileModal.js';
 import { PixelIcon } from './PixelIcon.js';
-import { creatorPath, playPath } from './router.js';
+import { creatorPath, playPath, studioPath } from './router.js';
 import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 
 /**
@@ -142,12 +142,19 @@ export function CreatorProfilePage({
                     <div className="creator-profile-game-meta">
                       <h3 className="creator-profile-game-title">{game.title}</h3>
                       <p className="creator-profile-game-by">{t('player.byAuthor', { author })}</p>
-                      <button type="button" className="primary-btn" onClick={() => onPlay(game.slug)}>
-                        <PixelIcon name="play" size={13} /> {t('catalog.play')}
-                      </button>
-                      <a className="creator-profile-game-link" href={playPath(game.slug)}>
-                        {t('creatorProfile.openPermalink')}
-                      </a>
+                      <div className="creator-profile-game-actions">
+                        <button type="button" className="primary-btn" onClick={() => onPlay(game.slug)}>
+                          <PixelIcon name="play" size={13} /> {t('catalog.play')}
+                        </button>
+                        <a className="creator-profile-game-link" href={playPath(game.slug)}>
+                          {t('creatorProfile.openPermalink')}
+                        </a>
+                        {isOwner ? (
+                          <a className="creator-profile-game-link" href={studioPath(game.slug)}>
+                            {t('creatorProfile.openStudio')}
+                          </a>
+                        ) : null}
+                      </div>
                     </div>
                   </li>
                 );

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -877,6 +877,7 @@
     "gamesHeading": "Games ({{count}})",
     "noGames": "No published games yet.",
     "openPermalink": "Open game page",
+    "openStudio": "Open in Studio",
     "editorTitle": "Your public profile",
     "publishGateTitle": "Claim a handle to publish",
     "editorNeeded": "Building and playtesting do not need a handle — publishing does.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -881,6 +881,7 @@
     "gamesHeading": "Gry ({{count}})",
     "noGames": "Brak opublikowanych gier.",
     "openPermalink": "Otwórz stronę gry",
+    "openStudio": "Otwórz w Studio",
     "editorTitle": "Twój publiczny profil",
     "publishGateTitle": "Zajmij handle, żeby opublikować",
     "editorNeeded": "Do budowania i testów handle nie jest potrzebny — do publikacji tak.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11377,9 +11377,14 @@ a.user-name--profile:focus-visible {
   opacity: 0.75;
 }
 
+.creator-profile-game-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem 0.75rem;
+}
+
 .creator-profile-game-link {
-  display: inline-block;
-  margin-left: 0.75rem;
   font-size: 0.85rem;
 }
 


### PR DESCRIPTION
## What changed

- load gate-generated screenshot metadata for published games on creator profile pages
- show an owner-only **Open in Studio** link for each published game
- wrap the game actions responsively and add English/Polish copy
- add API and UI regression coverage for screenshots and owner visibility

## Why

Creator profile cards rebuilt catalog entries from `SPEC.md` but supplied no sibling media metadata. Gate screenshots are derived artifacts, so every profile card fell back to an empty poster even though the media route could serve the image.

Creators also had no direct path from their public profile to a game's Studio.

## Impact

Published game screenshots now appear on creator profiles. Signed-in profile owners can jump directly to each game's Studio; visitors continue to see only public play links.

The existing `/studio` visit instrumentation continues to measure creator return. No new identity or telemetry fields are introduced.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` — 3,307 tests passed
- `npm run build`
- browser verification at desktop, 390px phone, and 390×500 keyboard-height viewport
