### PR TITLE
Fix creator profile review edge cases

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -565,6 +565,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await registerCreatorProfileRoutes(app, {
     store,
     gamesStore,
+    getRepoPublishedCatalogEntry: submissionSeams.getRepoPublishedCatalogEntry,
   });
   registerAccountDeletionRoutes(app, {
     store,

--- a/apps/api/src/creator-profile-routes.test.ts
+++ b/apps/api/src/creator-profile-routes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { GamesStore } from './games-store.js';
+import type { CatalogGameEntry, GitHubClient } from './github-client.js';
 import { InMemoryStore } from './store.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
@@ -16,11 +17,26 @@ describe('creator profile routes', () => {
     while (apps.length) await apps.pop()!.close();
   });
 
-  async function appWith(store: InMemoryStore, gamesStore?: GamesStore) {
+  async function appWith(store: InMemoryStore, gamesStore?: GamesStore, repoCatalog?: CatalogGameEntry[]) {
     const app = await buildApp({
       store,
       sessionSecret,
-      submissionRoutes: gamesStore ? { agentChannel: { gamesStore } } : undefined,
+      submissionRoutes:
+        gamesStore || repoCatalog
+          ? {
+              agentChannel: { gamesStore },
+              ...(repoCatalog
+                ? {
+                    githubToken: 'test-github-token',
+                    submissionTokenSecret: 'test-submission-secret',
+                    snapshotReader: null,
+                    githubClient: {
+                      getCatalog: async () => repoCatalog,
+                    } as unknown as GitHubClient,
+                  }
+                : {}),
+            }
+          : undefined,
     });
     apps.push(app);
     return app;
@@ -128,6 +144,50 @@ describe('creator profile routes', () => {
     expect(publicPage.json().games[0]).toMatchObject({
       slug: 'sky-dodge',
       media: { screenshots: [{ name: 'opening', file: 'opening.png' }], video: null },
+    });
+  });
+
+  it('uses repo catalog media when a migrated game also exists in the delivery store', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.claimHandle('g:creator', 'ada', '2026-07-01T00:00:00.000Z');
+    await store.createSubmission(42, 'g:creator', 'Store Title');
+    await store.setSubmissionSlug(42, 'sky-dodge');
+    await store.setSubmissionPublishedAt(42, '2026-08-01T12:00:00.000Z');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-08-01T12:00:00.000Z',
+    });
+    const gamesStore = {
+      getSourceFile: async () => '---\ntitle: Store Title\ngenre: arcade\n---\n',
+      getDerivedArtifact: async () =>
+        Buffer.from(JSON.stringify({ captures: { opening: { file: 'store-opening.png' } }, video: null })),
+    } as unknown as GamesStore;
+    const repoEntry: CatalogGameEntry = {
+      slug: 'sky-dodge',
+      title: 'Repo Title',
+      genre: 'arcade',
+      controls: '',
+      status: 'published',
+      media: { screenshots: [{ name: 'opening', file: 'repo-opening.png' }], video: null },
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: 'any',
+      submittedBy: null,
+    };
+    const app = await appWith(store, gamesStore, [repoEntry]);
+
+    const publicPage = await app.inject({ method: 'GET', url: '/api/creators/ada' });
+
+    expect(publicPage.statusCode).toBe(200);
+    expect(publicPage.json().games[0]).toMatchObject({
+      slug: 'sky-dodge',
+      title: 'Repo Title',
+      media: { screenshots: [{ name: 'opening', file: 'repo-opening.png' }], video: null },
     });
   });
 

--- a/apps/api/src/creator-profile-routes.ts
+++ b/apps/api/src/creator-profile-routes.ts
@@ -43,6 +43,8 @@ export interface CreatorProfileRoutesOptions {
   store: Store;
   /** Needed to list a creator's published games on the public profile. */
   gamesStore?: GamesStore | null;
+  /** Repo-backed catalog lookup; this source wins in the public media route too. */
+  getRepoPublishedCatalogEntry?: (slug: string) => Promise<CatalogGameEntry | null>;
   now?: () => number;
 }
 
@@ -96,7 +98,7 @@ export async function registerCreatorProfileRoutes(
   app: FastifyInstance,
   options: CreatorProfileRoutesOptions,
 ): Promise<void> {
-  const { store, gamesStore } = options;
+  const { store, gamesStore, getRepoPublishedCatalogEntry } = options;
   const now = options.now ?? Date.now;
 
   app.get('/api/me/profile', async (request, reply) => {
@@ -223,7 +225,13 @@ export async function registerCreatorProfileRoutes(
       }
     }
 
-    const games = await listCreatorPublishedGames(store, gamesStore ?? null, user.uid, profile);
+    const games = await listCreatorPublishedGames(
+      store,
+      gamesStore ?? null,
+      getRepoPublishedCatalogEntry,
+      user.uid,
+      profile,
+    );
     const body: PublicCreatorResponse = { profile, games };
     return reply.send(body);
   });
@@ -232,6 +240,7 @@ export async function registerCreatorProfileRoutes(
 async function listCreatorPublishedGames(
   store: Store,
   gamesStore: GamesStore | null,
+  getRepoPublishedCatalogEntry: ((slug: string) => Promise<CatalogGameEntry | null>) | undefined,
   ownerUid: string,
   profile: PublicCreatorProfile,
 ): Promise<CatalogGameEntry[]> {
@@ -246,8 +255,10 @@ async function listCreatorPublishedGames(
     const publication = await store.getPublication(slug);
     if (!publication || publication.state !== 'published') continue;
 
-    let entry: CatalogGameEntry | null = null;
-    if (gamesStore) {
+    // Match /api/games/:slug/media/:filename: a repo-backed catalog entry wins
+    // whenever both the migrated repo copy and store delivery exist.
+    let entry = getRepoPublishedCatalogEntry ? await getRepoPublishedCatalogEntry(slug) : null;
+    if (!entry && gamesStore) {
       try {
         const version = publication.currentVersion ?? record.deliveredVersion;
         if (version) {

--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -104,6 +104,42 @@ describe('GET /api/me/studio', () => {
     await app.close();
   });
 
+  it('includes a specifically addressed game beyond the shelf ceiling', async () => {
+    for (let game = 0; game < 51; game++) {
+      const issueNumber = 1_000 + game;
+      await store.createSubmission(issueNumber, 'g:creator', `Game ${game}`);
+      await store.setSubmissionSlug(issueNumber, `game-${game}`);
+      if (game < 50) await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      submissionRoutes: { submissionTokenSecret },
+    });
+
+    const ordinary = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio',
+      headers: authHeaders('g:creator'),
+    });
+    const ordinaryBody = ordinary.json() as { games: CreatorStudioGame[]; truncated: boolean; totalGames: number };
+    expect(ordinaryBody.games).toHaveLength(50);
+    expect(ordinaryBody.games.map((game) => game.slug)).not.toContain('game-0');
+
+    const addressed = await app.inject({
+      method: 'GET',
+      url: '/api/me/studio?game=game-0',
+      headers: authHeaders('g:creator'),
+    });
+    const addressedBody = addressed.json() as { games: CreatorStudioGame[]; truncated: boolean; totalGames: number };
+    expect(addressedBody).toMatchObject({ truncated: true, totalGames: 51 });
+    expect(addressedBody.games).toHaveLength(51);
+    expect(addressedBody.games.map((game) => game.slug)).toContain('game-0');
+
+    await app.close();
+  });
+
   it('prefers lastStatus over lastNotifiedStatus so a just-published game is not still "building"', async () => {
     // `in_review` shares a notification event with `building`, so lastNotifiedStatus
     // can lag while lastStatus is current — and publish writes lastStatus immediately.

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import { KitRegistryError, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
-import { pageOwnerGames } from './owner-games.js';
+import { collapseJobsToOwnerGames, MAX_OWNER_GAMES, pageOwnerGames } from './owner-games.js';
 import { readTarEntries, type TarEntry } from './tar.js';
 import { recentPartitions, summarizeGameHealth, type GameHealth } from './telemetry-health.js';
 import { composeWorkspaceArchive, WorkspaceCompositionError } from './workspace-archive.js';
@@ -29,6 +29,10 @@ const MAX_EVENTS_PER_REQUEST = 5_000;
 
 const QuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(MAX_DAYS).optional(),
+});
+
+const ShelfQuerySchema = z.object({
+  game: z.string().trim().min(1).max(512).optional(),
 });
 
 export interface CreatorStudioRoutesOptions {
@@ -190,8 +194,32 @@ export async function registerCreatorStudioRoutes(
       return reply.status(503).send({ error: 'submissions are not configured' });
     }
 
+    const parsed = ShelfQuerySchema.safeParse(request.query ?? {});
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
+    }
+
     const records = await store.listSubmissionsByOwner(request.user!.uid);
-    const { games: shelf, truncated, total } = pageOwnerGames(records, 'shelf');
+    const collapsed = collapseJobsToOwnerGames(records, 'shelf');
+    const total = collapsed.length;
+    const truncated = total > MAX_OWNER_GAMES;
+    const shelf = collapsed.slice(0, MAX_OWNER_GAMES);
+
+    // A profile deep link must keep working even when its game has fallen below the
+    // 50-row shelf. Resolve only against this creator's records, then append the
+    // collapsed tip for that game so legacy capability-token URLs keep working too.
+    const requested = parsed.data.game;
+    if (requested) {
+      const addressedRecord = records.find(
+        (record) => record.slug === requested || options.mintStatusToken!(record.issueNumber) === requested,
+      );
+      const addressedGame = addressedRecord
+        ? collapsed.find(({ tip }) =>
+            addressedRecord.slug ? tip.slug === addressedRecord.slug : tip.issueNumber === addressedRecord.issueNumber,
+          )
+        : undefined;
+      if (addressedGame && !shelf.includes(addressedGame)) shelf.push(addressedGame);
+    }
 
     // Which delivered versions ship an editor definition. One manifest read per
     // game with a delivery, best-effort: a read that fails only costs the Edit

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -441,6 +441,13 @@ export interface SubmissionRoutesHandle {
   /** The resolved games-repo client, or null when this deployment cannot reach one. */
   githubClient: GitHubClient | null;
   /**
+   * Finds a published entry in the repo-backed catalog only.
+   *
+   * The public media route gives this source priority over migrated store bytes, so
+   * profile cards must use the same winner or they can advertise a stale filename.
+   */
+  getRepoPublishedCatalogEntry: (slug: string) => Promise<CatalogGameEntry | null>;
+  /**
    * Starts a post-publish improvement round, choosing job dispatch or a legacy issue.
    *
    * Exported rather than reimplemented so the suggestion inbox and the creator's own
@@ -4553,5 +4560,10 @@ export async function registerSubmissionRoutes(
     dailyFeedbackQuota,
   });
 
-  return { githubClient, startImprovementRound };
+  return {
+    githubClient,
+    getRepoPublishedCatalogEntry: (slug) =>
+      githubClient ? getPublishedCatalogEntry(githubClient, slug) : Promise.resolve(null),
+    startImprovementRound,
+  };
 }

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -817,6 +817,7 @@ describe('CreatorStudioView', () => {
     const { container, root } = await renderStudio({ selectedGame: 'game-2' });
 
     expect(container.querySelector('.studio-detail-title-block h2')?.textContent).toContain('Game 2');
+    expect(fetchStudioGames).toHaveBeenCalledWith('game-2');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -244,7 +244,7 @@ export function CreatorStudioView({
     setLoading(true);
     setError(null);
 
-    Promise.all([fetchStudioGames(), fetchStudioHealth(days)])
+    Promise.all([fetchStudioGames(requestedGameRef.current), fetchStudioHealth(days)])
       .then(([shelfPage, health]) => {
         if (cancelled) return;
         const shelf = shelfPage.games;

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -259,8 +259,9 @@ export type StudioGamesResponse = {
 };
 
 /** The signed-in creator's control-panel shelf (slug + publish time when known). */
-export async function fetchStudioGames(): Promise<StudioGamesResponse> {
-  const response = await fetch(`${API_BASE}/api/me/studio`, { credentials: 'include' });
+export async function fetchStudioGames(game?: string): Promise<StudioGamesResponse> {
+  const query = game ? `?game=${encodeURIComponent(game)}` : '';
+  const response = await fetch(`${API_BASE}/api/me/studio${query}`, { credentials: 'include' });
   if (!response.ok) {
     await throwResponseError(response);
   }


### PR DESCRIPTION
## What changed

- allow an owner-only profile Studio link to address a game beyond the normal 50-game Studio shelf
- keep legacy capability-token deep links working through the same targeted lookup
- make creator-profile media metadata follow the public media route's repo-first source priority
- add regressions for an addressed 51st game and a migrated slug present in both sources

## Why

This follows up on the two Codex review findings left on #546 after it merged. Without the targeted shelf lookup, an older profile game could link to an empty Studio state. Without the shared source priority, a migrated profile card could advertise store media while the media route served the repo copy.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` — 3,309 tests passed
- `npm run build`
