### PR TITLE
Raise bake/play TypeScript source-graph ceiling to 300 KiB

### DIFF
--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -15,6 +15,7 @@ import {
   GAMEKIT_PLATFORM_BYTES,
   MAX_PROJECT_BYTES,
   MUSIC_CONTRACT,
+  SOURCE_GRAPH_BUDGET_BYTES,
 } from './games-repo-contract.js';
 import { MAX_PROJECT_BYTES as ASSEMBLE_MAX } from './assemble.js';
 import { ALLOWED_SOURCE_FILES, MAX_UPLOAD_BYTES, MAX_UPLOAD_FILES } from './games-store.js';
@@ -48,6 +49,13 @@ describe('games-repo-contract (website half)', () => {
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
+  });
+
+  it('keeps the bake/play source-graph ceiling above the assembled author budget', () => {
+    // Raw `.ts` can exceed assembled author bytes (comments/types). Carjack-city
+    // at ~247 KiB is why this is 300 KiB rather than matching GAME_BUDGET_BYTES.
+    expect(SOURCE_GRAPH_BUDGET_BYTES).toBe(300 * 1024);
+    expect(SOURCE_GRAPH_BUDGET_BYTES).toBeGreaterThan(GAME_BUDGET_BYTES);
   });
 
   it('keeps the fixtures/games-repo assemble-contract snapshot in lockstep', async () => {

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -83,6 +83,17 @@ export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 export const GAME_BUDGET_BYTES = 200 * 1024;
 
 /**
+ * Raw TypeScript source-graph ceiling for the bake/play/seed bundlers
+ * (`MAX_SOURCE_GRAPH_BYTES` in `github-client.ts`, `MAX_GAME_SOURCE_BYTES` in
+ * `seed-bundle.ts`). Lockstep with games-repo Check 4 `SOURCE_GRAPH_BUDGET_BYTES`.
+ *
+ * Distinct from {@link GAME_BUDGET_BYTES}: the assembled author payload can stay
+ * under 200 KiB while comments and types push the `.ts` tree higher. Last moved
+ * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish.
+ */
+export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
+
+/**
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
 import { classifyTouchSource, type CatalogGameTouch } from './catalog-touch.js';
-import { GAME_KIT_MODULES, type GameKitModuleName } from './games-repo-contract.js';
+import { GAME_KIT_MODULES, SOURCE_GRAPH_BUDGET_BYTES, type GameKitModuleName } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
 export type { CatalogGameTouch } from './catalog-touch.js';
@@ -70,7 +70,8 @@ export interface GameSources {
 // GAME_KIT_MODULES lives in games-repo-contract.ts — CI re-checks the live
 // games repo copy when GAMES_REPO_TOKEN is set (issue #247).
 const MAX_SOURCE_GRAPH_MODULES = 64;
-const MAX_SOURCE_GRAPH_BYTES = 200 * 1024;
+/** Alias of {@link SOURCE_GRAPH_BUDGET_BYTES} — keep the local name at the call sites. */
+const MAX_SOURCE_GRAPH_BYTES = SOURCE_GRAPH_BUDGET_BYTES;
 const GAME_KIT_MODULE_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
   urban: 'shared/verticals/urban/index.ts',
   racing: 'shared/verticals/racing/index.ts',

--- a/apps/api/src/seed-bundle.ts
+++ b/apps/api/src/seed-bundle.ts
@@ -18,10 +18,11 @@
 import { build, type Message } from 'esbuild';
 import type { SeedFile } from './game-seed.js';
 import { resolveGameTypeScriptPath } from './github-client.js';
+import { SOURCE_GRAPH_BUDGET_BYTES } from './games-repo-contract.js';
 
 /** Same ceilings as the play-path bundler, so agreement between the two is by value. */
 const MAX_GAME_MODULES = 64;
-const MAX_GAME_SOURCE_BYTES = 200 * 1024;
+const MAX_GAME_SOURCE_BYTES = SOURCE_GRAPH_BUDGET_BYTES;
 
 export type SeedBundleResult = { ok: true } | { ok: false; errors: string[] };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[Publish games snapshot #30907598574](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30907598574) (and every run since ~00:31 UTC 2026-08-04) fails baking `carjack-city`:

```
game TypeScript exceeds 204800 bytes [plugin github-typescript-modules]
```

The live snapshot pointer never advances. Carjack’s `.ts` tree is ~247 KiB; the bake/play bundler’s `MAX_SOURCE_GRAPH_BYTES` was 200 KiB. The assembled author budget (still 200 KiB) was never the problem — comments/types count in the source graph and assemble away.

## Fix

- Export `SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024` from `games-repo-contract.ts`
- Point `github-client.ts` and `seed-bundle.ts` at it (was a duplicated `200 * 1024`)
- Assembled `GAME_BUDGET_BYTES` / assemble-contract stay at 200 KiB

Paired games-repo PR (Check 4 mirror of the same ceiling): https://github.com/gamedevpl/www.gamedev.pl-games/pull/483

**Merge this first** — snapshot publish reads this repo’s master; raising the ceiling here is what unblocks the catalog.

## Verify

- `npm run type-check && npm run lint && npm test && npm run build` — green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08c25815-be73-44e2-b1b3-f42fd1f2f178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c25815-be73-44e2-b1b3-f42fd1f2f178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

