### PR TITLE
Raise game serve ceiling for full Carjack City

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 204800,
-  "platformCeilingBytes": 313000,
-  "maxProjectBytes": 517800,
+  "platformCeilingBytes": 330000,
+  "maxProjectBytes": 534800,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(517_800);
+    expect(MAX_PROJECT_BYTES).toBe(534_800);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -224,7 +224,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 313_000;
+      const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -97,7 +97,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (517_800, matching `maxProjectBytes`). Not a round KiB.
+ * (534_800, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,11 +106,10 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by `carjack-city`'s open-world work: measured platform bytes for its
- * (2D, non-gfx3d) module selection are 312_583, so 281_587 no longer covered a game
- * that comfortably clears the author gate — carjack assembles to 493_433 of which
- * 180_850 is author payload, 88% of the 200 KiB budget. 281_587 → 313_000, and the
- * serve cap 486_387 → 517_800.
+ * Last moved by `carjack-city`'s day/night and reactive-world work: its selected
+ * platform measures 327_252 bytes while the game remains within the 200 KiB author
+ * budget (199_723 bytes). Keep the full implementation. 313_000 → 330_000, and the
+ * serve cap 517_800 → 534_800.
  *
  * The drift this corrects is older and larger than that change: the constant has
  * never tracked the heaviest selection. `apex-sprint` (gfx3d) already measures
@@ -122,7 +121,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
  * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
  */
-export const GAMEKIT_PLATFORM_BYTES = 313_000;
+export const GAMEKIT_PLATFORM_BYTES = 330_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
## What changed

- raise the platform/serve ceiling from 313,000 to 330,000 bytes
- raise the combined assembled project cap from 517,800 to 534,800 bytes
- refresh the vendored games-repo contract fixture and contract tests

## Why

The full Carjack City day/night and reactive-world implementation assembles to 526,975 bytes. Its author payload is still within the unchanged 200 KiB author budget (199,723 bytes); the selected platform payload now measures 327,252 bytes.

This widens only the serve-compat ceiling so visual and simulation detail does not need to be removed to compensate for platform growth.

## Coordination

Merge this website PR before [games-repo PR #477](https://github.com/gamedevpl/www.gamedev.pl-games/pull/477), per the lockstep contract's rollout order.