### PR TITLE
raise the serve cap to 534_800, catching up with games-repo main

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 204800,
-  "platformCeilingBytes": 329000,
-  "maxProjectBytes": 533800,
+  "platformCeilingBytes": 330000,
+  "maxProjectBytes": 534800,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 204800,
-  "platformCeilingBytes": 313000,
-  "maxProjectBytes": 517800,
+  "platformCeilingBytes": 329000,
+  "maxProjectBytes": 533800,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(533_800);
+    expect(MAX_PROJECT_BYTES).toBe(534_800);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(517_800);
+    expect(MAX_PROJECT_BYTES).toBe(533_800);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(533_800);
+    expect(MAX_PROJECT_BYTES).toBe(534_800);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -224,7 +224,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 329_000;
+      const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -234,7 +234,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 315_939;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(517_800);
+    expect(MAX_PROJECT_BYTES).toBe(533_800);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -224,7 +224,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 313_000;
+      const GAMEKIT_PLATFORM_BYTES = 329_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -234,7 +234,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 299_939;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 315_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -97,7 +97,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (533_800, matching `maxProjectBytes`). Not a round KiB.
+ * (534_800, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,15 +106,14 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by the canvas-bridge provenance work (games-repo #480), which adds
- * `input.bridged()` so a game that reads the bridge's action key *and* hit-tests
- * `consumeClick` can tell a synthesized press from a real one. Small in itself, but
- * `carjack-city` was 29 bytes under the cap, so it is what tipped the measurement:
- * that selection now measures 328_475 platform bytes and assembles to 518_994.
- * 313_000 → 329_000, and the serve cap 517_800 → 533_800.
+ * Last moved by `carjack-city`'s world-services expansion (games-repo #477), which raised
+ * the games-repo half to 330_000 — leaving this side behind the ceiling games are already
+ * built against, which `games-repo-contract-check` reports as drift. 313_000 → 330_000,
+ * and the serve cap 517_800 → 534_800.
  *
- * Raised website-first, per `games-repo-contract-check`: the games repo may not build
- * against a ceiling this side would refuse at serve time.
+ * Catching up rather than leading, which is the one direction the check tolerates: it
+ * fails only when the games repo builds above what this side would serve. The games repo
+ * is at 330_000 today; this now matches it exactly.
  *
  * Before it, `carjack-city`'s open-world work: measured platform bytes for its
  * (2D, non-gfx3d) module selection are 312_583, so 281_587 no longer covered a game
@@ -132,7 +131,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
  * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
  */
-export const GAMEKIT_PLATFORM_BYTES = 329_000;
+export const GAMEKIT_PLATFORM_BYTES = 330_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -97,7 +97,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (517_800, matching `maxProjectBytes`). Not a round KiB.
+ * (533_800, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,7 +106,17 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by `carjack-city`'s open-world work: measured platform bytes for its
+ * Last moved by the canvas-bridge provenance work (games-repo #480), which adds
+ * `input.bridged()` so a game that reads the bridge's action key *and* hit-tests
+ * `consumeClick` can tell a synthesized press from a real one. Small in itself, but
+ * `carjack-city` was 29 bytes under the cap, so it is what tipped the measurement:
+ * that selection now measures 328_475 platform bytes and assembles to 518_994.
+ * 313_000 → 329_000, and the serve cap 517_800 → 533_800.
+ *
+ * Raised website-first, per `games-repo-contract-check`: the games repo may not build
+ * against a ceiling this side would refuse at serve time.
+ *
+ * Before it, `carjack-city`'s open-world work: measured platform bytes for its
  * (2D, non-gfx3d) module selection are 312_583, so 281_587 no longer covered a game
  * that comfortably clears the author gate — carjack assembles to 493_433 of which
  * 180_850 is author payload, 88% of the 200 KiB budget. 281_587 → 313_000, and the
@@ -122,7 +132,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
  * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
  */
-export const GAMEKIT_PLATFORM_BYTES = 313_000;
+export const GAMEKIT_PLATFORM_BYTES = 329_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
Brings this side up to the ceiling the games repo already builds against. **Rewritten** from the 533_800 version — see below, the reason for the change moved while it was open.

## What changed under it

`contract:games-repo` reads the **live** games-repo main, and it failed:

```
MAX_BUNDLE_BYTES mismatch: games-repo=534800 website MAX_PROJECT_BYTES=533800
Website is behind the build ceiling — raise GAMEKIT_PLATFORM_BYTES / MAX_PROJECT_BYTES (website-first).
```

While this PR was open, games-repo main raised its own half to 330_000 for `carjack-city`'s world-services expansion ([games-repo #477](https://github.com/gamedevpl/www.gamedev.pl-games/pull/477)). So the drift is main's, and 329_000 was aiming at a number that had already moved.

**This is therefore no longer a website-first raise for [games-repo #480](https://github.com/gamedevpl/www.gamedev.pl-games/pull/480).** That PR needs no ceiling change at all any more: on the new base `carjack-city` assembles to **528_198** against 534_800, with **6_602 bytes** to spare. #480 now carries only its own trim, not a ceiling move.

## The number

313_000 → **330_000**, cap **534_800**, matching main exactly. Catching up rather than leading, which is the direction the check tolerates — it fails only when the games repo builds above what this side would serve.

## What moves with it

- `GAMEKIT_PLATFORM_BYTES` and its doc comment, rewritten to record that this followed #477 rather than #480.
- `fixtures/games-repo/shared/assemble-contract.json`, kept in lockstep.
- The pinned literals in `assemble.test.ts` and `games-repo-contract.test.ts`.
- **Both** synthetic extractor sources — including the `a + b` allowance one, whose parts are re-summed (`13_061 + 316_939`) rather than the assertion being loosened, so it still tests that the extractor evaluates expressions instead of testing a number I just changed.

## Verification

`apps/api`: **147 suites, 2233 tests, all passing** (needs `npm run build:packages` first — without it 47 suites fail to resolve `@gamedevpl/game-generator`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd2LMxMfsvR1XnaXjHfZRz