### PR TITLE
fix(studio): honest Copilot session-boot UX (no heuristics)

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -80,6 +80,15 @@ generation bump + seed from latest delivery. Do not auto-dispatch platform from 
 
 `no_agent_yet` is waiting to connect, not a handoff.
 
+### Platform session boot (no heuristics)
+
+After a platform dispatch (including self→platform handoff), the job stays
+`dispatched` until GitHub's Agent Tasks API reports `in_progress`. That is a real
+vendor signal — not a timer. Studio shows phase copy ("Starting agent" / session
+booting) and polls tightly on `phase === 'dispatched'`. Feedback also busts the
+60s status cache so the previous self stall cannot linger while Copilot is already
+queued.
+
 ## Key code
 
 | Area                         | Path                                                        |

--- a/.claude/skills/copilot-orchestration/SKILL.md
+++ b/.claude/skills/copilot-orchestration/SKILL.md
@@ -119,6 +119,10 @@ Business/Enterprise — it is wrong; a personal paid plan works. No Enterprise s
 heuristic below — use it whenever you have the task ID.
 
 **Timing observed**: a trivial one-file task went `queued` → `completed` in ≈4.5 minutes.
+A freshly created task often returns `artifacts: []` and `session_count: 0` while still
+`queued` — the session has been accepted but not started. gamedev.pl Studio maps that
+stretch to job phase `dispatched` and only advances to `building` on `in_progress`
+(see BYOCA skill "Platform session boot").
 
 ### Dumping a session's generation log
 

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -111,6 +111,14 @@ describe('transition rules', () => {
     expect(canTransition('ready_for_review', 'published')).toBe(false);
   });
 
+  it('lets a new agent session start from mid-round states without claiming it is coding yet', () => {
+    // Self→platform handoff and Copilot resume accept a task long before GitHub reports
+    // `in_progress`. Forcing `building` at dispatch lied about that boot window.
+    expect(canTransition('building', 'dispatched')).toBe(true);
+    expect(canTransition('submitted', 'dispatched')).toBe(true);
+    expect(canTransition('gating', 'dispatched')).toBe(true);
+  });
+
   // A gate-red round is not always over: `mustFixGate` tells the live session to fix the
   // cause and deliver again without a new dispatch. agent-channel records that upload
   // only when this holds, so refusing it stranded a game the agent had already repaired.

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -235,6 +235,15 @@ describe('planObservedStatusTransition', () => {
     expect(planObservedStatusTransition('building', 'building', AT)).toBeNull();
   });
 
+  it('does not erase a richer internal state that projects to the same public status', () => {
+    // `submitted`/`gating` both read as `building` to creators — a derived-status
+    // poll must not yank the delivery back to `building` on that lossy match.
+    expect(planObservedStatusTransition('submitted', 'building', AT)).toBeNull();
+    expect(planObservedStatusTransition('gating', 'building', AT)).toBeNull();
+    expect(planObservedStatusTransition('failed', 'needs_changes', AT)).toBeNull();
+    expect(planObservedStatusTransition('dispatched', 'queued', AT)).toBeNull();
+  });
+
   it('records a genuine move', () => {
     expect(planObservedStatusTransition('building', 'in_review', AT)).toEqual({
       to: 'ready_for_review',
@@ -341,11 +350,21 @@ describe('detectStall', () => {
         now: NOW,
       }),
     ).toBe('no_agent_yet');
-    // Once the agent has spoken, ordinary quiet detection applies.
+    // Once the agent has spoken, ordinary quiet detection applies — including while
+    // still `dispatched` (resume lands there until progress / in_progress).
     expect(
       detectStall({
         state: 'building',
         stateSince: ago(HOUR),
+        lastAgentSignalAt: ago(HOUR),
+        builder: 'self',
+        now: NOW,
+      }),
+    ).toBe('quiet');
+    expect(
+      detectStall({
+        state: 'dispatched',
+        stateSince: ago(60_000),
         lastAgentSignalAt: ago(HOUR),
         builder: 'self',
         now: NOW,

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -79,15 +79,41 @@ export function isTerminal(state: JobState): boolean {
 const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   queued: ['dispatched', 'building', 'canceled', 'abandoned', 'failed'],
   dispatched: ['building', 'submitted', 'failed', 'canceled', 'abandoned'],
-  building: ['submitted', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
+  // `dispatched` / `queued` let a new agent session start without pretending the session
+  // is already coding — resumeBuild hands work to Copilot long before GitHub reports
+  // `in_progress`, and a self→platform handoff often leaves the job in `building` or
+  // `submitted` from the previous round.
+  building: [
+    'submitted',
+    'ready_for_review',
+    'needs_changes',
+    'failed',
+    'canceled',
+    'abandoned',
+    'dispatched',
+    'queued',
+  ],
   // The verdict is read off the version manifest in a single poll, so a delivered job
   // reaches its outcome without ever being seen in `gating`. Listing only `gating` here
   // made `submitted` a trap: reconcileGateVerdict computes `ready_for_review` or
   // `needs_changes`, canTransition refused both, and nothing else writes `gating` — so
   // every job that arrived here stayed, showing "delivered, gate never started" for as
   // long as the creator kept the page open.
-  submitted: ['gating', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
-  gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned'],
+  //
+  // `dispatched` / `queued` / `building`: a creator handoff or revision can start a new
+  // agent session after delivery, before (or instead of) the gate finishing.
+  submitted: [
+    'gating',
+    'ready_for_review',
+    'needs_changes',
+    'failed',
+    'canceled',
+    'abandoned',
+    'dispatched',
+    'queued',
+    'building',
+  ],
+  gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued', 'building'],
   // `building` (and the queue/dispatch that precede a fresh round) let a creator or
   // their agent continue iterating after a green gate without waiting on publish —
   // Studio feedback and MCP `continue_draft` both land here. Reviewer reject still

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -100,20 +100,13 @@ const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   // every job that arrived here stayed, showing "delivered, gate never started" for as
   // long as the creator kept the page open.
   //
-  // `dispatched` / `queued` / `building`: a creator handoff or revision can start a new
-  // agent session after delivery, before (or instead of) the gate finishing.
-  submitted: [
-    'gating',
-    'ready_for_review',
-    'needs_changes',
-    'failed',
-    'canceled',
-    'abandoned',
-    'dispatched',
-    'queued',
-    'building',
-  ],
-  gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued', 'building'],
+  // `dispatched` / `queued`: a creator handoff or revision can start a new agent
+  // session after delivery, before (or instead of) the gate finishing. Do not list
+  // `building` here — `toSubmissionStatus(submitted)` is already `building`, and
+  // allowing that edge lets the lossy derived-status reconciler yank a delivery back
+  // to `building` on every sweep.
+  submitted: ['gating', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued'],
+  gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued'],
   // `building` (and the queue/dispatch that precede a fresh round) let a creator or
   // their agent continue iterating after a green gate without waiting on publish —
   // Studio feedback and MCP `continue_draft` both land here. Reviewer reject still
@@ -310,6 +303,10 @@ export function planObservedStatusTransition(
   const to = fromSubmissionStatus(observed);
   if (!current) return { to, at, by, reason: 'adopted_from_derived_status' };
   if (to === current) return null;
+  // Richer internal states project onto a coarser public status (`submitted`→`building`,
+  // `failed`→`needs_changes`, …). When the derivation only re-states that projection,
+  // keep the precise state — otherwise every poll would erase it.
+  if (toSubmissionStatus(current) === observed) return null;
   if (!canTransition(current, to)) return null;
   return { to, at, by, reason: 'derived_from_github' };
 }
@@ -501,14 +498,26 @@ export function detectStall(input: StallInput): JobStall | null {
 
   if (!sinceOk) return null;
 
-  if ((input.state === 'queued' || input.state === 'dispatched') && sinceState > thresholds.notDispatchedMs) {
+  // `not_dispatched` is only for rounds that never showed channel/session life. Once
+  // the agent has spoken, silence is `quiet` even if the job is still `dispatched`
+  // (resume lands there until `in_progress` / first progress) — otherwise self→platform
+  // handoff would stay locked forever on a quiet dispatched round.
+  if (
+    (input.state === 'queued' || input.state === 'dispatched') &&
+    !input.lastAgentSignalAt &&
+    sinceState > thresholds.notDispatchedMs
+  ) {
     return 'not_dispatched';
   }
 
-  if (input.state === 'building') {
-    // Fall back to when the build entered `building` when the agent has never spoken —
+  if (
+    input.state === 'building' ||
+    ((input.state === 'queued' || input.state === 'dispatched') && input.lastAgentSignalAt)
+  ) {
+    // Fall back to when the build entered this state when the agent has never spoken —
     // otherwise a session that dies before its first report would never register as
-    // quiet at all, which is the worst case to miss.
+    // quiet at all, which is the worst case to miss. (queued/dispatched only reach this
+    // branch when a signal exists, so the fallback is for `building` alone.)
     const lastSignal = input.lastAgentSignalAt ? Date.parse(input.lastAgentSignalAt) : NaN;
     const silenceFrom = Number.isFinite(lastSignal) ? lastSignal : Date.parse(input.stateSince);
     if (Number.isFinite(silenceFrom) && input.now - silenceFrom > thresholds.quietMs) return 'quiet';

--- a/apps/api/src/mcp-continue-draft.test.ts
+++ b/apps/api/src/mcp-continue-draft.test.ts
@@ -145,9 +145,9 @@ describe('MCP continue_draft', () => {
     });
 
     const job = await store.getSubmission(DRAFT_ISSUE);
-    expect(job?.state).toBe('building');
+    expect(job?.state).toBe('dispatched');
     expect(job?.transitions?.at(-1)).toMatchObject({
-      to: 'building',
+      to: 'dispatched',
       by: 'agent',
       reason: 'continue_draft',
     });
@@ -288,7 +288,7 @@ describe('MCP continue_draft', () => {
     expect((structured as { error: string }).error).not.toBe(DRAFT_NOT_CONTINUABLE_REASON);
   });
 
-  it('adopts a legacy draft with no state into building', async () => {
+  it('adopts a legacy draft with no state into dispatched', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(DRAFT_ISSUE, OWNER, 'Legacy Draft');
     await store.setSubmissionSlug(DRAFT_ISSUE, SLUG);
@@ -307,6 +307,6 @@ describe('MCP continue_draft', () => {
     expect(isError).toBe(false);
     expect(structured).toMatchObject({ jobId: DRAFT_ISSUE, alreadyOpen: false });
     const job = await store.getSubmission(DRAFT_ISSUE);
-    expect(job?.state).toBe('building');
+    expect(job?.state).toBe('dispatched');
   });
 });

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -565,7 +565,7 @@ describe('self builder (BY-02)', () => {
     await vi.waitFor(async () => {
       const live = await store.getSubmission(issueNumber);
       expect(live?.builder).toBe('self');
-      expect(live?.state).toBe('building');
+      expect(live?.state).toBe('dispatched');
     });
 
     const genBefore = (await store.getSubmission(issueNumber))?.roundGeneration ?? 1;
@@ -637,7 +637,7 @@ describe('self builder (BY-02)', () => {
     await vi.waitFor(async () => {
       const live = await store.getSubmission(issueNumber);
       expect(live?.builder).toBe('self');
-      expect(live?.state).toBe('building');
+      expect(live?.state).toBe('dispatched');
     });
 
     // Recent signal — quiet would refuse; MCP end unlocks handoff immediately.

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1064,14 +1064,80 @@ describe('submission routes', () => {
     expect(briefs.at(-1)?.undelivered).toBeUndefined();
     expect(briefs.at(-1)?.feedback).toContain('Make the parcels bigger');
     // Gate-green closed the round; feedback must reopen the job, not leave it stuck
-    // in ready_for_review while a session quietly starts underneath.
+    // in ready_for_review while a session quietly starts underneath. Land on
+    // `dispatched` — Copilot boots before GitHub reports `in_progress`.
     const after = await store.getSubmission(job.issueNumber);
-    expect(after?.state).toBe('building');
+    expect(after?.state).toBe('dispatched');
     expect(after?.transitions?.at(-1)).toMatchObject({
-      to: 'building',
+      to: 'dispatched',
       by: 'creator',
       reason: 'creator_feedback',
     });
+
+    await app.close();
+  });
+
+  it('self→platform handoff lands on dispatched and busts the status cache', async () => {
+    // Without the cache bust, Studio kept serving the previous self stall
+    // (`no_agent_yet` / ended) for up to a minute while Copilot was already queued.
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const token = mintToken(job.issueNumber, secret);
+    await store.setRoundBuilder(job.issueNumber, 'self');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'agent',
+      reason: 'self_signal',
+    });
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString());
+
+    const before = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(before.statusCode).toBe(200);
+    expect(before.json()).toMatchObject({ builder: 'self', stall: 'ended' });
+
+    const handoff = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${token}/feedback`,
+      headers: authHeaders,
+      payload: {
+        feedback: 'Please continue this round with the platform coding agent.',
+        builder: 'platform',
+      },
+    });
+    expect(handoff.statusCode).toBe(200);
+
+    const after = await store.getSubmission(job.issueNumber);
+    expect(after?.builder).toBe('platform');
+    expect(after?.state).toBe('dispatched');
+    expect(after?.transitions?.at(-1)).toMatchObject({
+      to: 'dispatched',
+      by: 'creator',
+      reason: 'agent_ended_handoff',
+    });
+
+    // Immediate status must not return the cached self+ended snapshot.
+    const status = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(status.statusCode).toBe(200);
+    expect(status.json()).toMatchObject({
+      builder: 'platform',
+      status: 'queued',
+      phase: 'dispatched',
+    });
+    expect(status.json().stall).toBeUndefined();
 
     await app.close();
   });
@@ -1189,10 +1255,16 @@ describe('submission routes', () => {
     // says "building" until the end of time and the creator has nothing to act on.
     const { githubClient } = createGithubClientStub({ issueNumber: 77 });
     const { backend } = createBackendStub();
-    const observe = vi.fn(async (_ref: string, opts: { hasCandidate: boolean }) => ({
-      state: 'failed' as const,
-      hasCandidate: opts.hasCandidate,
-    }));
+    // Fresh `dispatched` jobs are observed immediately (session boot). First answer
+    // advances to building; later answers (after the quiet window) name the death.
+    let observeCalls = 0;
+    const observe = vi.fn(async (_ref: string, opts: { hasCandidate: boolean }) => {
+      observeCalls += 1;
+      if (observeCalls === 1) {
+        return { state: 'in_progress' as const, hasCandidate: opts.hasCandidate };
+      }
+      return { state: 'failed' as const, hasCandidate: opts.hasCandidate };
+    });
     const clock = { t: Date.now() };
     const { app, authHeaders, store } = await createApp({
       githubClient,
@@ -1210,17 +1282,19 @@ describe('submission routes', () => {
     const [job] = await store.listSubmissionsByOwner('g:test-user');
     const token = mintToken(job.issueNumber, secret);
 
-    // Fresh dispatch: still within the quiet window, so no observation happens.
+    // Fresh dispatch: observe immediately so `in_progress` advances us to building.
     const early = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
     expect(early.statusCode).toBe(200);
-    expect(observe).not.toHaveBeenCalled();
+    expect(observe).toHaveBeenCalledWith('task-1', { hasCandidate: false });
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('building');
+    expect(early.json().phase).toBe('building');
 
     // Three minutes of silence is past the window (and past the status cache).
     clock.t += 3 * 60 * 1000;
     const status = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
 
     expect(status.statusCode).toBe(200);
-    expect(observe).toHaveBeenCalledWith('task-1', { hasCandidate: false });
+    expect(observe).toHaveBeenCalledTimes(2);
     // `failed` projects onto `needs_changes`, and `failure` names what happened —
     // without it the page reads "waiting for your input" about a session that died.
     expect(status.json().status).toBe('needs_changes');
@@ -1631,8 +1705,9 @@ describe('submission routes', () => {
 
     expect(response.statusCode).toBe(200);
     expect(briefs.at(-1)?.feedback).toContain('pick this up again');
-    // The dead round must not orphan the job: the retry moves it back to building.
-    expect((await store.getSubmission(job.issueNumber))?.state).toBe('building');
+    // The dead round must not orphan the job: the retry hands it to an agent again.
+    // `dispatched` until the session is observed `in_progress`.
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('dispatched');
     // Nothing to report when the round did start — the field exists to say otherwise.
     expect(response.json()).not.toHaveProperty('roundStarted');
 
@@ -3217,9 +3292,9 @@ describe('a session that finishes without delivering', () => {
     expect(brief?.undelivered).toBe(true);
     // The branch is the only copy of undelivered work, so the round is told where it is.
     expect(brief?.previousWorkspace).toBe('copilot/has-the-work');
-    // Building again, not failed: the creator is not shown an error about a round that
-    // is at this moment running.
-    expect((await store.getSubmission(job.issueNumber))?.state).toBe('building');
+    // Dispatched again, not failed: the creator is not shown an error about a round that
+    // is at this moment starting. `building` waits on a real `in_progress` observation.
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('dispatched');
 
     await app.close();
   });
@@ -3751,7 +3826,7 @@ describe('operator cancel and retry', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true, state: 'building', creditsSpent: 1 });
+    expect(response.json()).toEqual({ ok: true, state: 'dispatched', creditsSpent: 1 });
 
     // The branch is the only copy of undelivered work; the new round is told where it is.
     const brief = briefs.at(-1);
@@ -3759,9 +3834,9 @@ describe('operator cancel and retry', () => {
     expect(brief?.previousWorkspace).toBe('copilot/has-the-work');
 
     const record = await store.getSubmission(job.issueNumber);
-    expect(record?.state).toBe('building');
+    expect(record?.state).toBe('dispatched');
     // The history says who restarted it, not `derived_from_github`.
-    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'building', by: 'operator', reason: 'operator_retry' });
+    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'dispatched', by: 'operator', reason: 'operator_retry' });
     // The retry is an agent session like any other, so the ledger books it.
     expect(record?.costs?.filter((entry) => entry.kind === 'agent_session')).toHaveLength(2);
 
@@ -3812,9 +3887,10 @@ describe('operator cancel and retry', () => {
 
     expect(response.statusCode).toBe(200);
     const record = await store.getSubmission(job.issueNumber);
-    // Same state, new session — without the explicit transition the retry would leave
-    // no trace in the job's history at all.
-    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'building', by: 'operator', reason: 'operator_retry' });
+    // New session boots at `dispatched` — claiming `building` again would lie about
+    // Copilot startup. History still names the operator retry.
+    expect(record?.state).toBe('dispatched');
+    expect(record?.transitions?.at(-1)).toMatchObject({ to: 'dispatched', by: 'operator', reason: 'operator_retry' });
     expect(record?.dispatch?.refs).toHaveLength(2);
 
     await app.close();

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1266,7 +1266,7 @@ export async function registerSubmissionRoutes(
       return { ok: true, jobId: input.issueNumber, alreadyOpen: true };
     }
     // Only states where a new round is the honest next step. Canceled/abandoned stay dead.
-    // `undefined` is a legacy/partial record — resumeBuild adopts it into `building`.
+    // `undefined` is a legacy/partial record — resumeBuild adopts it into `dispatched`.
     const state = record.state;
     const continuable =
       state === 'ready_for_review' ||
@@ -2057,7 +2057,7 @@ export async function registerSubmissionRoutes(
             log: app.log,
             undelivered: true,
           });
-          // `resumeBuild` has already moved the job back to building. Reporting the
+          // `resumeBuild` has already moved the job back to dispatched. Reporting the
           // failure here as well would show the creator an error about a round that is
           // at this moment running again.
           return null;

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1382,11 +1382,18 @@ export async function registerSubmissionRoutes(
   // watchers of one build land together; without this each miss launched its own
   // fan-out of GitHub reads, multiplying the burst that gets the token limited.
   const statusRefreshes = new Map<string, Promise<SubmissionStatusResponse>>();
+  // Bumped on invalidate so a refresh that started on a stale snapshot cannot
+  // repopulate the cache after feedback/handoff cleared it.
+  const statusCacheEpoch = new Map<number, number>();
   /** Drop every locale variant so the next poll rebuilds from the job record. */
   function invalidateStatusCache(issueNumber: number): void {
     for (const key of [...statusCache.keys()]) {
       if (key.startsWith(`${issueNumber}:`)) statusCache.delete(key);
     }
+    for (const key of [...statusRefreshes.keys()]) {
+      if (key.startsWith(`${issueNumber}:`)) statusRefreshes.delete(key);
+    }
+    statusCacheEpoch.set(issueNumber, (statusCacheEpoch.get(issueNumber) ?? 0) + 1);
   }
   const translator = options.translator ?? createTranslatorFromEnv();
 
@@ -2736,6 +2743,7 @@ export async function registerSubmissionRoutes(
     const existing = statusRefreshes.get(cacheKey);
     if (existing) return existing;
 
+    const epochAtStart = statusCacheEpoch.get(issueNumber) ?? 0;
     const refresh = (async () => {
       // Every job answers from its own record: there is no issue to read, and the
       // GitHub round-trip it used to need is gone with the path that needed it.
@@ -2757,7 +2765,13 @@ export async function registerSubmissionRoutes(
       const status = record
         ? await localizeStatus(await nativeJobStatus(record), locale)
         : ({ status: 'queued' } as SubmissionStatusResponse);
-      statusCache.set(cacheKey, { value: status, expiresAt: now() + 60_000 });
+      // Session boot (`dispatched`) must re-observe Agent Tasks every few seconds —
+      // a 60s cache would freeze "Starting agent" while GitHub already reports
+      // `in_progress`. Skip writing when invalidate raced this refresh.
+      if ((statusCacheEpoch.get(issueNumber) ?? 0) === epochAtStart) {
+        const ttlMs = status.phase === 'dispatched' ? 2_000 : 60_000;
+        statusCache.set(cacheKey, { value: status, expiresAt: now() + ttlMs });
+      }
       if (store && record) {
         try {
           await notifyOnTransition(buildNotifyDeps(), record, status, token);
@@ -2765,8 +2779,6 @@ export async function registerSubmissionRoutes(
           app.log.error({ err: notifyError }, 'notification emit on status poll failed');
         }
       }
-      return status;
-
       return status;
     })().finally(() => {
       statusRefreshes.delete(cacheKey);

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1091,21 +1091,23 @@ export async function registerSubmissionRoutes(
       if (!input.undelivered && previous?.workspace && previous.workspace !== result.workspace) {
         await releaseWorkspace(input.issueNumber, previous.workspace, input.log);
       }
-      // Pass `record.state` even when undefined — planObservedStatusTransition adopts
-      // legacy/partial records into `building`. Guarding on truthy state skipped that
-      // and left continue_draft / feedback with a live dispatch but no durable move.
-      const transition = record
-        ? planObservedStatusTransition(
-            record.state,
-            'building',
-            new Date(now()).toISOString(),
-            input.transition?.by ?? 'creator',
-          )
-        : null;
-      if (transition) {
+      // Land on `dispatched`, not `building`. Copilot's agent-tasks API accepts the
+      // task immediately and only later reports `in_progress` (often with
+      // `session_count: 0` on create) — claiming "writing code" here made Studio look
+      // stuck or "not connected" while GitHub was still booting the session. The
+      // reconciler advances to `building` from a real observation. Same shape as
+      // `dispatchBuild` for a first round.
+      const latest = await store.getSubmission(input.issueNumber);
+      const from = latest?.state;
+      // No prior state: adopt directly (recordJobTransition does not gate on canTransition).
+      // Otherwise only advance when the walk still allows it — a self agent can deliver
+      // before this line runs, and yanking past `submitted` would reopen CP-1 hazards.
+      if (!from || canTransition(from, 'dispatched')) {
         await store.recordJobTransition(input.issueNumber, {
-          ...transition,
-          ...(input.transition ? { reason: input.transition.reason } : {}),
+          to: 'dispatched',
+          at: new Date(now()).toISOString(),
+          by: input.transition?.by ?? 'creator',
+          reason: input.transition?.reason ?? `dispatched_to_${selected.name}`,
         });
       }
       return { started: true };
@@ -1380,6 +1382,12 @@ export async function registerSubmissionRoutes(
   // watchers of one build land together; without this each miss launched its own
   // fan-out of GitHub reads, multiplying the burst that gets the token limited.
   const statusRefreshes = new Map<string, Promise<SubmissionStatusResponse>>();
+  /** Drop every locale variant so the next poll rebuilds from the job record. */
+  function invalidateStatusCache(issueNumber: number): void {
+    for (const key of [...statusCache.keys()]) {
+      if (key.startsWith(`${issueNumber}:`)) statusCache.delete(key);
+    }
+  }
   const translator = options.translator ?? createTranslatorFromEnv();
 
   // Agent progress events are read on every poll but change rarely, so they get a
@@ -1965,11 +1973,17 @@ export async function registerSubmissionRoutes(
     // queued/dispatched advances to building without waiting out the quiet window.
     const selfNeedsProjection =
       selected.name === 'self' && agentActive && Boolean(record.lastAgentSignalAt) && state !== 'building';
+    // Platform tasks sit in `queued`/`dispatched` while GitHub boots the session
+    // (`session_count: 0`, task state still `queued`). That stretch is not "quiet
+    // building" — ask every status poll so `in_progress` flips us to `building`
+    // from a real Agent Tasks signal, not a timer.
+    const awaitingSessionStart = selected.name !== 'self' && (state === 'queued' || state === 'dispatched');
     // Cost-only polls skip the quiet window: the session is already done, and waiting
     // would only delay the ledger catching up with the bill.
     if (
       !needsWorkspace &&
       !selfNeedsProjection &&
+      !awaitingSessionStart &&
       agentActive &&
       (!Number.isFinite(silence) || silence < observeQuietMs)
     ) {
@@ -1987,6 +2001,16 @@ export async function registerSubmissionRoutes(
           await store.setJobCostCredits(record.issueNumber, lastRef, observation.sessionCredits);
         } catch (error) {
           app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not reconcile agent session cost');
+        }
+      }
+      // Persist the vendor state even when the job does not move — `waiting_for_user`
+      // stalls and operator views read it, and a create response that stays `queued`
+      // must not leave `agentState` blank until the first transition.
+      if (observation.state !== record.agentState) {
+        try {
+          await store.setSubmissionAgentState(record.issueNumber, observation.state);
+        } catch (error) {
+          app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not store agent task state');
         }
       }
       // A cost-only poll on a job past the agent: write the credits and stop. State
@@ -2654,10 +2678,7 @@ export async function registerSubmissionRoutes(
       }
 
       await store.setSubmissionAbandoned(issueNumber, new Date(now()).toISOString());
-      // Drop every cached locale variant so the next poll reflects the new state.
-      for (const key of [...statusCache.keys()]) {
-        if (key.startsWith(`${issueNumber}:`)) statusCache.delete(key);
-      }
+      invalidateStatusCache(issueNumber);
 
       return reply.send({ ok: true });
     },
@@ -2984,6 +3005,9 @@ export async function registerSubmissionRoutes(
         if (!queued) {
           return reply.status(503).send({ error: 'failed to queue feedback for the agent' });
         }
+        // Inbox-only: still drop the status cache so the creator's note appears on the
+        // next poll instead of riding a stale 60s snapshot.
+        invalidateStatusCache(issueNumber);
         return reply.send({
           ok: true,
           ...(shotId ? { shotId } : {}),
@@ -3018,13 +3042,18 @@ export async function registerSubmissionRoutes(
         // that bump is what kills the self agent's token.
         ...(builderChanging ? {} : record?.deliveredVersion ? {} : { undelivered: true }),
         ...(requestedBuilder && isBuilderKind(requestedBuilder) ? { builder: requestedBuilder } : {}),
-        // Name the actor so a ready_for_review → building reopen does not look like a
+        // Name the actor so a ready_for_review → dispatched reopen does not look like a
         // GitHub-derived observation in the job history.
         transition: {
           by: 'creator',
           reason: handoffReason,
         },
       });
+
+      // Drop the cached status: without this, Studio kept serving the previous self
+      // round (`no_agent_yet` / ended) for up to a minute while Copilot was already
+      // queued on GitHub — exactly the "agent not connected" false warning.
+      invalidateStatusCache(issueNumber);
 
       // Accepted, and honest about what it bought. The message is kept either way — it is
       // on the record and in the thread, and the next round to start will read it — but a
@@ -3233,9 +3262,7 @@ export async function registerSubmissionRoutes(
       await store.clearDispatchSeedWorkspace(issueNumber);
     }
     await store.setSubmissionAbandoned(issueNumber, at);
-    for (const key of [...statusCache.keys()]) {
-      if (key.startsWith(`${issueNumber}:`)) statusCache.delete(key);
-    }
+    invalidateStatusCache(issueNumber);
 
     return reply.send({ ok: true, state: 'canceled', stopEnforced });
   });
@@ -3317,13 +3344,13 @@ export async function registerSubmissionRoutes(
       return reply.status(502).send({ error: 'dispatch_failed' });
     }
 
-    // A same-state retry (kicking a quiet build) records no transition on the resume
-    // path — building to building is not a move the table knows — so without this the
-    // retry would be invisible in the job's own history. The quiet-stall flag may keep
-    // showing until the new session first reports, which is accurate: it hasn't yet.
-    if (state === 'building') {
+    // resumeBuild lands on `dispatched` when the walk allows it. A retry that was
+    // already `dispatched` records no move (same state), so stamp an operator_retry
+    // marker — otherwise the kick is invisible in the job history. Coming from
+    // `building` / `failed` already wrote `dispatched` with this reason.
+    if (state === 'dispatched' && after?.state === 'dispatched') {
       await store.recordJobTransition(issueNumber, {
-        to: 'building',
+        to: 'dispatched',
         at: new Date(now()).toISOString(),
         by: 'operator',
         reason: 'operator_retry',
@@ -3331,7 +3358,8 @@ export async function registerSubmissionRoutes(
     }
 
     // One credit: the retry is an agent session like any other, booked by resumeBuild.
-    return reply.send({ ok: true, state: 'building', creditsSpent: 1 });
+    // Report the real phase — `dispatched` until GitHub says `in_progress`.
+    return reply.send({ ok: true, state: after?.state ?? 'dispatched', creditsSpent: 1 });
   });
 
   /**

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -5,7 +5,8 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { statusPath } from './router.js';
-import { ACTIVE_POLL_MS, SubmissionStatusView } from './SubmissionStatusView.js';
+import { SubmissionStatusView } from './SubmissionStatusView.js';
+import { ACTIVE_POLL_MS, pollDelayMs } from './studioStatusPoll.js';
 import {
   abandonSubmission,
   getChannelPlayable,
@@ -50,6 +51,15 @@ async function flushEffects() {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+describe('pollDelayMs', () => {
+  it('polls tightly while the platform agent session is still starting', () => {
+    // Public status stays `queued` for phase `dispatched`; idle polling would hide
+    // the flip to `building` when GitHub reports `in_progress`.
+    expect(pollDelayMs('queued', undefined, 'dispatched')).toBe(ACTIVE_POLL_MS);
+    expect(pollDelayMs('queued')).toBeGreaterThan(ACTIVE_POLL_MS);
+  });
+});
 
 describe('SubmissionStatusView', () => {
   afterEach(() => {

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -25,6 +25,7 @@ import { formatRelativeTime } from './relativeTime.js';
 import { connectCardMode, selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { submitImprovement } from './studioApi.js';
+import { pollDelayMs } from './studioStatusPoll.js';
 import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
 
 function copyInputFromStatus(status: SubmissionStatus | null | undefined) {
@@ -79,26 +80,8 @@ function resolveDefaultBuilder(token: string, status: SubmissionStatus | null | 
 const TERMINAL_STATUSES = new Set<SubmissionStatus['status']>(['published', 'needs_changes', 'abandoned']);
 /** Statuses that halt the linear timeline rather than sitting on a step of it. */
 const HALTED_STATUSES = new Set<SubmissionStatus['status']>(['needs_changes', 'abandoned']);
-// The agent is actively working during these — poll tightly so progress feels live.
-// Everything else (queued/publishing) changes slowly, so poll gently.
-const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building', 'in_review']);
-/** Exported so tests advance timers by the real cadence instead of a magic number. */
-export const ACTIVE_POLL_MS = 3000;
-const IDLE_POLL_MS = 10000;
 /** How long the compact composer's "Sent!" receipt stays up before clearing itself. */
 export const SENT_RECEIPT_MS = 4500;
-
-function pollDelayMs(status: SubmissionStatus['status'], stall?: SubmissionStatus['stall']): number | null {
-  // `needs_changes` is terminal for the *round*, not for the page: feedback from here
-  // starts another round, and stopping the poll meant the UI kept saying "needs changes"
-  // after a successful send until the creator refreshed. Published and abandoned are
-  // finished for good — nothing the composer can do moves them.
-  if (status === 'published' || status === 'abandoned') return null;
-  if (status === 'needs_changes') return IDLE_POLL_MS;
-  // Flip the connect card to live progress as soon as the agent signals.
-  if (stall === 'no_agent_yet') return ACTIVE_POLL_MS;
-  return ACTIVE_BUILD_STATUSES.has(status) ? ACTIVE_POLL_MS : IDLE_POLL_MS;
-}
 
 const STATUS_ICONS: Record<SubmissionStatus['status'], PixelIconName> = {
   queued: 'clock',
@@ -342,6 +325,8 @@ export function SubmissionStatusView({
   const previewInFlightRef = useRef(false);
   const loadedChannelRef = useRef<string | null>(null);
   const channelInFlightRef = useRef(false);
+  /** Immediate status re-pull after send (builder handoff / new dispatch). */
+  const requestStatusRefreshRef = useRef<() => void>(() => {});
 
   const currentTrackingUrl = useMemo(
     () => trackingUrl ?? new URL(embedded ? studioPath(token) : statusPath(token), window.location.href).toString(),
@@ -396,8 +381,8 @@ export function SubmissionStatusView({
       }
     };
 
-    const scheduleNext = (next: Pick<SubmissionStatus, 'status' | 'stall'>) => {
-      const delay = pollDelayMs(next.status, next.stall);
+    const scheduleNext = (next: Pick<SubmissionStatus, 'status' | 'stall' | 'phase'>) => {
+      const delay = pollDelayMs(next.status, next.stall, next.phase);
       if (delay === null || cancelled) return;
       timeoutId = window.setTimeout(() => {
         void poll();
@@ -432,11 +417,17 @@ export function SubmissionStatusView({
       }
     };
 
+    requestStatusRefreshRef.current = () => {
+      stopPolling();
+      void poll();
+    };
+
     void poll();
 
     return () => {
       cancelled = true;
       stopPolling();
+      requestStatusRefreshRef.current = () => {};
     };
     // i18n.language is a dependency because the API localizes the build log for us.
   }, [i18n.language, t, token]);
@@ -754,7 +745,9 @@ export function SubmissionStatusView({
                       ? selfCopy === 'no_agent_yet'
                         ? t('connect.waiting')
                         : t('connect.resume.waiting')
-                      : t(`statusView.states.${status.status}.label`)
+                      : status.phase === 'dispatched'
+                        ? t('statusView.phaseLabels.dispatched')
+                        : t(`statusView.states.${status.status}.label`)
                   }
                   thought={
                     isAwaitingOwnAgent(status) || TERMINAL_STATUSES.has(status.status) ? null : presenceThought(status)
@@ -779,7 +772,12 @@ export function SubmissionStatusView({
                     failureReason={status.failure?.reason}
                     phase={status.phase}
                     suppressRouteNote={isAwaitingOwnAgent(status) || status.phase === 'ready_for_review'}
-                    onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+                    onSent={(text) => {
+                      setPendingRevisions((current) => [...current, { text, at: Date.now() }]);
+                      // Feedback may have switched builder or landed on `dispatched` —
+                      // pull status now so we do not keep painting the previous stall.
+                      requestStatusRefreshRef.current();
+                    }}
                     onPublishedImprove={handleImproved}
                   />
                 ) : null}
@@ -967,7 +965,10 @@ export function SubmissionStatusView({
                 stall={status.stall}
                 failureReason={status.failure?.reason}
                 phase={status.phase}
-                onSent={(text) => setPendingRevisions((current) => [...current, { text, at: Date.now() }])}
+                onSent={(text) => {
+                  setPendingRevisions((current) => [...current, { text, at: Date.now() }]);
+                  requestStatusRefreshRef.current();
+                }}
                 onPublishedImprove={handleImproved}
               />
             ) : null}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -384,6 +384,12 @@ export function SubmissionStatusView({
     const scheduleNext = (next: Pick<SubmissionStatus, 'status' | 'stall' | 'phase'>) => {
       const delay = pollDelayMs(next.status, next.stall, next.phase);
       if (delay === null || cancelled) return;
+      // Clear first: an in-flight poll and an immediate post-send refresh can both
+      // complete and schedule — without this, overlapping timers stack up.
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
       timeoutId = window.setTimeout(() => {
         void poll();
       }, delay);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -643,10 +643,13 @@
       }
     },
     "phases": {
-      "dispatched": "An agent has picked up your idea and is getting started.",
+      "dispatched": "The platform agent has been assigned and is starting up. The first update can take a few minutes while the coding session boots — no need to refresh.",
       "submitted": "The agent delivered your game. We're checking it over now.",
       "gating": "Automated checks are making sure your game actually runs clean.",
       "ready_for_review": "Your game passed every check. It's waiting for the last look before going live."
+    },
+    "phaseLabels": {
+      "dispatched": "Starting agent"
     },
     "updatedAgo": "updated {{time}}",
     "presence": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -647,10 +647,13 @@
       }
     },
     "phases": {
-      "dispatched": "Agent podjął Twój pomysł i właśnie zaczyna pracę.",
+      "dispatched": "Agent platformy dostał zadanie i właśnie się uruchamia. Pierwsza aktualizacja może zająć kilka minut, zanim sesja wstanie — nie musisz odświeżać.",
       "submitted": "Agent dostarczył Twoją grę. Właśnie ją sprawdzamy.",
       "gating": "Automatyczne testy sprawdzają, czy gra działa bez zarzutu.",
       "ready_for_review": "Twoja gra przeszła wszystkie testy. Czeka na ostatnie spojrzenie przed publikacją."
+    },
+    "phaseLabels": {
+      "dispatched": "Uruchamianie agenta"
     },
     "updatedAgo": "aktualizacja {{time}}",
     "presence": {

--- a/apps/web/src/studioStatusPoll.ts
+++ b/apps/web/src/studioStatusPoll.ts
@@ -1,0 +1,33 @@
+import type { SubmissionStatus } from './submissionApi.js';
+
+/**
+ * Status-page poll cadence helpers.
+ *
+ * Kept out of {@link SubmissionStatusView} so that file only exports components
+ * (react-refresh) while tests can still assert the real intervals.
+ */
+
+const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building', 'in_review']);
+
+/** Exported so tests advance timers by the real cadence instead of a magic number. */
+export const ACTIVE_POLL_MS = 3000;
+const IDLE_POLL_MS = 10000;
+
+export function pollDelayMs(
+  status: SubmissionStatus['status'],
+  stall?: SubmissionStatus['stall'],
+  phase?: SubmissionStatus['phase'],
+): number | null {
+  // `needs_changes` is terminal for the *round*, not for the page: feedback from here
+  // starts another round, and stopping the poll meant the UI kept saying "needs changes"
+  // after a successful send until the creator refreshed. Published and abandoned are
+  // finished for good — nothing the composer can do moves them.
+  if (status === 'published' || status === 'abandoned') return null;
+  if (status === 'needs_changes') return IDLE_POLL_MS;
+  // Flip the connect card to live progress as soon as the agent signals.
+  if (stall === 'no_agent_yet') return ACTIVE_POLL_MS;
+  // Copilot session boot: job is `dispatched` (public status still `queued`) until
+  // GitHub reports `in_progress`. Poll tightly on that real phase — not a timer guess.
+  if (phase === 'dispatched') return ACTIVE_POLL_MS;
+  return ACTIVE_BUILD_STATUSES.has(status) ? ACTIVE_POLL_MS : IDLE_POLL_MS;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Studio was showing a false “agent not connected” stall after self→platform handoff while GitHub already had a Copilot task queued/starting. This lands platform rounds on the real Agent Tasks boot phase (`dispatched`) until `in_progress`, without timer heuristics.

## Changes
- **API:** `resumeBuild` / continue_draft land on `dispatched` (not `building`); observe platform tasks while `queued`/`dispatched`; persist `agentState`; bust status cache (including in-flight refreshes) on feedback/handoff; short status TTL while `phase === 'dispatched'`.
- **Quiet handoff:** `detectStall` treats silence after a channel signal as `quiet` even while still `dispatched`, so self→platform escape hatch still works.
- **State machine:** allow resume edges to `dispatched`/`queued` from mid-round states, but do **not** allow lossy `submitted`→`building` (that let the derived-status sweep undo deliveries).
- **Web:** tight poll + “Starting agent” copy on `phase === 'dispatched'`; refresh after send; clear stacked poll timers.
- **Skills:** document the no-heuristics boot contract in BYOCA / Copilot orchestration.

## Test plan
- [x] Unit: self-build handoff, continue_draft, submissions resume/cache, job-state quiet/derived-status
- [x] Rebased onto master (serve-ceiling contract fix)
- [ ] CI green on this head
- [ ] Codex / Copilot review follow-ups addressed (cache invalidation + dispatched TTL + timer clear)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61e90176-8167-4d38-a48d-ae71a2e882c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61e90176-8167-4d38-a48d-ae71a2e882c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

