### PR TITLE
Raise serve ceiling to 534800 (Carjack City lockstep)

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 204800,
-  "platformCeilingBytes": 313000,
-  "maxProjectBytes": 517800,
+  "platformCeilingBytes": 330000,
+  "maxProjectBytes": 534800,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(517_800);
+    expect(MAX_PROJECT_BYTES).toBe(534_800);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(517_800);
+    expect(MAX_PROJECT_BYTES).toBe(534_800);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -224,7 +224,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 313_000;
+      const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -234,7 +234,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 200 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 299_939;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -97,7 +97,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (517_800, matching `maxProjectBytes`). Not a round KiB.
+ * (534_800, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,11 +106,11 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by `carjack-city`'s open-world work: measured platform bytes for its
- * (2D, non-gfx3d) module selection are 312_583, so 281_587 no longer covered a game
- * that comfortably clears the author gate — carjack assembles to 493_433 of which
- * 180_850 is author payload, 88% of the 200 KiB budget. 281_587 → 313_000, and the
- * serve cap 486_387 → 517_800.
+ * Last moved by `carjack-city`'s day/night and reactive-world work: its selected
+ * platform measures 327_252 bytes while the game remains within the 200 KiB author
+ * budget (199_723 bytes). Keep the full implementation. 313_000 → 330_000, and the
+ * serve cap 517_800 → 534_800. Snapshot publish was stranded at 517_889 with the old
+ * ceiling (run 30909878136); games-repo #477 already shipped the matching contract.
  *
  * The drift this corrects is older and larger than that change: the constant has
  * never tracked the heaviest selection. `apex-sprint` (gfx3d) already measures
@@ -122,7 +122,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
  * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
  */
-export const GAMEKIT_PLATFORM_BYTES = 313_000;
+export const GAMEKIT_PLATFORM_BYTES = 330_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Raise `GAMEKIT_PLATFORM_BYTES` 313_000 → 330_000 and `MAX_PROJECT_BYTES` 517_800 → 534_800
- Refresh the vendored `assemble-contract.json` fixture
- Update every pinned literal in `assemble.test.ts` and `games-repo-contract.test.ts` (including the synthetic `a + b` extractor fixture)

## Why

[Snapshot publish run 30909878136](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30909878136) failed baking `carjack-city` at **517_889** bytes against the old **517_800** cap. Games-repo [#477](https://github.com/gamedevpl/www.gamedev.pl-games/pull/477) already shipped `platformCeilingBytes: 330000` / `maxProjectBytes: 534800`; this is the website half of that lockstep.

Author budget is unchanged (200 KiB). Carjack's author payload stays under it (~199_723); only the serve-compat platform ceiling moves.

## Notes on sibling PRs

- [#549](https://github.com/gamedevpl/www.gamedev.pl/pull/549) aimed at the same numbers but missed `assemble.test.ts` and the `a + b` extractor pin, so Lint/Test/Build failed.
- [#550](https://github.com/gamedevpl/www.gamedev.pl/pull/550) raises to 533_800 for a different follow-on (`input.bridged`); that is below what games-repo `main` already declares, so it would leave bake still refusing the live carjack selection.

## Validation

Local green gate after install: contract + assemble unit tests (and full `npm run check` if time allows).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8588e7e2-5fe4-455d-80fb-95915fc00fde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8588e7e2-5fe4-455d-80fb-95915fc00fde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

