### PR TITLE
fix(api): Copilot brief uses submit --no-wait

### DIFF
--- a/apps/api/src/copilot-backend.test.ts
+++ b/apps/api/src/copilot-backend.test.ts
@@ -55,7 +55,10 @@ describe('buildPrompt', () => {
   it('tells the agent a pull request is not a delivery', () => {
     const prompt = buildPrompt(BRIEF);
     expect(prompt).toContain('**A pull request is not a delivery.**');
-    expect(prompt).toContain('npm run submit');
+    expect(prompt).toContain('npm run submit -- <slug> --no-wait');
+    // Blocking submit on the site gate parks Copilot in read_bash while Studio stalls.
+    expect(prompt).toContain('Always deliver with `--no-wait`');
+    expect(prompt).toContain('npm run progress -- --check');
   });
 
   it('carries the per-job channel credentials', () => {

--- a/apps/api/src/copilot-backend.ts
+++ b/apps/api/src/copilot-backend.ts
@@ -161,7 +161,8 @@ export function buildPrompt(brief: BuildBrief): string {
     `export GAMEDEVPL_BUILD_TOKEN=${brief.channelToken}`,
     'npm run progress -- --step planning "Sketching the loop."       # as you go',
     'npm run preview:watch -- <slug> &                               # playable draft, early',
-    'npm run submit -- <slug>                                        # deliver, when it is good',
+    'npm run submit -- <slug> --no-wait                              # deliver, when it is good',
+    'npm run progress -- --check                                     # gate verdict + inbox',
     '```',
     '',
     'Report progress as you work — the creator is watching a live page, and silence reads as a',
@@ -181,8 +182,11 @@ export function buildPrompt(brief: BuildBrief): string {
     '— silence here is how their note sits unread until you finish the wrong thing.',
     '`--ack <id>` only after you have actually acted on a message. Stop immediately when `stop` is set.',
     '',
-    'After you upload, our own gate runs the full check against the upstream engine and either',
-    'accepts the game or comes back to you with what failed. You do not need to merge anything.',
+    '**Always deliver with `--no-wait`.** After upload the site gate can take many minutes;',
+    'blocking `submit` on that wait parks you in a silent bash session while Studio looks stuck',
+    'and creator notes go unacked. You are not done until `npm run progress -- --check` shows',
+    'GATE PASSED (or you fix a GATE FAILED, re-check locally, and submit again). Do not open a',
+    'pull request for delivery — nothing downstream reads PRs.',
   ];
 
   if (brief.locale && brief.locale !== 'en') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Platform Copilot was parking for up to **20 minutes** in `npm run submit`’s gate wait (`read_bash` loop), so Studio looked stuck and creator inbox notes (like “sprawdź grę…”) went unacked.

The brief now tells agents to:

1. `npm run submit -- <slug> --no-wait`
2. Poll `npm run progress -- --check` for GATE PASSED / FAILED
3. Ack / act on creator mail instead of blocking bash

Paired with games-repo change that also skips the wait when inbox mail is pending (real signal, not a latency guess).

### Test plan

- [x] `npm test -w @gamedevpl/api -- src/copilot-backend.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61e90176-8167-4d38-a48d-ae71a2e882c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61e90176-8167-4d38-a48d-ae71a2e882c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

