### PR TITLE
fix(studio): stop spinning on Final check after gate-green

### DIFF
--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -59,6 +59,10 @@ describe('pollDelayMs', () => {
     expect(pollDelayMs('queued', undefined, 'dispatched')).toBe(ACTIVE_POLL_MS);
     expect(pollDelayMs('queued')).toBeGreaterThan(ACTIVE_POLL_MS);
   });
+
+  it('polls gently once gate-green is waiting on a human', () => {
+    expect(pollDelayMs('in_review')).toBeGreaterThan(ACTIVE_POLL_MS);
+  });
 });
 
 describe('SubmissionStatusView', () => {
@@ -418,6 +422,7 @@ describe('SubmissionStatusView', () => {
     const description = container.querySelector('.status-description')?.textContent ?? '';
     expect(description).toContain('waiting for the last look');
     expect(description).not.toContain('Automated checks are making sure');
+    expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -470,6 +475,10 @@ describe('SubmissionStatusView', () => {
     expect(container.querySelector('.studio-status-chip')).toBeNull();
     expect(container.textContent).not.toMatch(/quiet for a while|can't start it from here/i);
     expect(container.querySelector('.studio-context-phase')?.textContent).toMatch(/Final check/i);
+    // Gate-green is waiting on a human — not mid-agent work. A spinner here made
+    // "Final check · updated 20 minutes ago" look eternally in progress.
+    expect(container.querySelector('.studio-thread-context.is-active')).toBeNull();
+    expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -83,6 +83,20 @@ const HALTED_STATUSES = new Set<SubmissionStatus['status']>(['needs_changes', 'a
 /** How long the compact composer's "Sent!" receipt stays up before clearing itself. */
 export const SENT_RECEIPT_MS = 4500;
 
+/**
+ * Whether the thread-foot spinner should run — agent mid-work, not "waiting on us".
+ *
+ * Gate-green (`in_review` / `ready_for_review`) used to keep spinning forever after the
+ * agent finished, with "updated 20 minutes ago" under an active spinner.
+ */
+function isAgentWorkActive(status: SubmissionStatus | null | undefined): boolean {
+  if (!status) return false;
+  if (TERMINAL_STATUSES.has(status.status)) return false;
+  if (isAwaitingOwnAgent(status)) return false;
+  if (status.status === 'in_review' || status.phase === 'ready_for_review') return false;
+  return true;
+}
+
 const STATUS_ICONS: Record<SubmissionStatus['status'], PixelIconName> = {
   queued: 'clock',
   building: 'wrench',
@@ -756,10 +770,15 @@ export function SubmissionStatusView({
                         : t(`statusView.states.${status.status}.label`)
                   }
                   thought={
-                    isAwaitingOwnAgent(status) || TERMINAL_STATUSES.has(status.status) ? null : presenceThought(status)
+                    isAwaitingOwnAgent(status) ||
+                    TERMINAL_STATUSES.has(status.status) ||
+                    status.status === 'in_review' ||
+                    status.phase === 'ready_for_review'
+                      ? null
+                      : presenceThought(status)
                   }
                   heartbeatAt={isAwaitingOwnAgent(status) ? null : heartbeatAt}
-                  active={!TERMINAL_STATUSES.has(status.status) && !isAwaitingOwnAgent(status)}
+                  active={isAgentWorkActive(status)}
                 />
 
                 {/* Before the first agent signal there is nobody to receive a note — the

--- a/apps/web/src/studioStatusPoll.ts
+++ b/apps/web/src/studioStatusPoll.ts
@@ -7,7 +7,9 @@ import type { SubmissionStatus } from './submissionApi.js';
  * (react-refresh) while tests can still assert the real intervals.
  */
 
-const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building', 'in_review']);
+// `in_review` is out on purpose: gate-green waits on a human, not the agent.
+// Tight polling + foot spinner made "Final check" look eternally in progress.
+const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building']);
 
 /** Exported so tests advance timers by the real cadence instead of a magic number. */
 export const ACTIVE_POLL_MS = 3000;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the gate passed, Studio stayed on **Ostatni sprawdzian / Final check** with an **active spinner** and “updated 20 minutes ago” — looking stuck even though the agent was done.

`in_review` / `ready_for_review` means waiting on a human, not mid-agent work. The foot bar treated every non-terminal status as `active`.

### Fix

- Spinner only while the agent is actually working (`isAgentWorkActive`)
- Drop `in_review` from the tight 3s poll set (idle poll is enough until publish)

### Test plan

- [x] `npm test -w @gamedevpl/web -- src/SubmissionStatusView.test.ts`
- [x] lint + web type-check

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61e90176-8167-4d38-a48d-ae71a2e882c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61e90176-8167-4d38-a48d-ae71a2e882c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

