### PR TITLE
fix(mcp): truthful gateStarted + auto handoff unlock on submit

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -36,9 +36,14 @@ creator **self→platform** handoff immediately). Still call **`end`**:
 - Without `end`, your session may look finished while still connected; quiet
   (~15 minutes) remains a fallback only
 
-`gateStarted` is **true only when Cloud Build returned a build id** — not merely
-when the upload was accepted. If `ok` but `gateStarted: false`, honour
-`warnings.code=gate_not_started` (no preview is assembling).
+`gateStarted` is **true when Cloud Build accepted the create** (HTTP 2xx), even
+if the build id could not be parsed. If `ok` but `gateStarted: false`, honour
+`warnings.code=gate_not_started` (no preview is assembling — safe to retry).
+Do **not** retry solely because `buildId` is missing when `gateStarted` is true.
+
+Gate-poll presence (`get_gate_verdict` / `get_gate_media`) refreshes the
+heartbeat without clearing `agentEndedAt`, so submit→poll→stop still leaves
+handoff unlocked.
 
 `end` does **not** publish, close the job, or bump generation by itself. A green
 _publish_ gate still retires the key; `end` is optional after green.

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -26,18 +26,25 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 
 ### `end` is required after submit (not optional etiquette)
 
-ChatGPT-class agents usually **submit and stop**. That is not enough:
+ChatGPT-class agents usually **submit and stop**. Soft `call_end` alone was not
+enough, so a successful MCP `submit_sources` also sets `agentEndedAt` (unlocks
+creator **self→platform** handoff immediately). Still call **`end`**:
 
 - Successful `submit_sources` returns soft `warnings: [{ code: "call_end", … }]`
-- `end` sets `agentEndedAt` → stall `ended` → Studio unlocks **self→platform** handoff
-  immediately (creator chooses; API bumps `roundGeneration` so the self token dies)
-- Without `end`, creators wait on the **quiet** fallback (~15 minutes silence in
-  `building`) — do not treat that timeout as the primary design
+  (and re-emits `call_end` on later tools until you call `end`)
+- `end` sets `stop: true` / `reason: agent_ended` for your MCP session
+- Without `end`, your session may look finished while still connected; quiet
+  (~15 minutes) remains a fallback only
+
+`gateStarted` is **true only when Cloud Build returned a build id** — not merely
+when the upload was accepted. If `ok` but `gateStarted: false`, honour
+`warnings.code=gate_not_started` (no preview is assembling).
 
 `end` does **not** publish, close the job, or bump generation by itself. A green
 _publish_ gate still retires the key; `end` is optional after green.
 
-Further channel writes after `end` clear `agentEndedAt` (agent resumed).
+Further channel writes after `end` (or after submit’s auto-`agentEndedAt`) clear
+`agentEndedAt` (agent resumed).
 
 ## Credentials and immediate revocation
 
@@ -56,21 +63,22 @@ Further channel writes after `end` clear `agentEndedAt` (agent resumed).
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code             | Meaning                                         |
-| ---------------- | ----------------------------------------------- |
-| `call_end`       | Call `end` when finished iterating this round   |
-| `progress_stale` | Call `report_progress`                          |
-| `inbox_pending`  | `read_inbox` → apply → `ack_inbox`              |
-| `seed_unread`    | Call `get_seed` before scaffolding from the kit |
+| Code               | Meaning                                                    |
+| ------------------ | ---------------------------------------------------------- |
+| `call_end`         | Call `end` when finished iterating this round              |
+| `gate_not_started` | Delivery ok but Cloud Build did not start — no preview yet |
+| `progress_stale`   | Call `report_progress`                                     |
+| `inbox_pending`    | `read_inbox` → apply → `ack_inbox`                         |
+| `seed_unread`      | Call `get_seed` before scaffolding from the kit            |
 
 ## Builder handoff (Studio)
 
 Mid-round switch is refused while the self agent is live (`builder_locked`), except:
 
-| Signal                         | Who                | Effect                                   |
-| ------------------------------ | ------------------ | ---------------------------------------- |
-| `agentEndedAt` / stall `ended` | Agent called `end` | Primary unlock for self→platform handoff |
-| stall `quiet`                  | ~15m silence       | Fallback if `end` was never called       |
+| Signal                         | Who                                     | Effect                                   |
+| ------------------------------ | --------------------------------------- | ---------------------------------------- |
+| `agentEndedAt` / stall `ended` | MCP submit (auto) or agent called `end` | Primary unlock for self→platform handoff |
+| stall `quiet`                  | ~15m silence                            | Fallback if neither happened             |
 
 `allowsSelfToPlatformHandoff` checks `agentEndedAt` directly so a later
 `gate_not_started` stall (ops visibility after a wedged gate) does not revoke handoff.

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -147,8 +147,9 @@ Two concrete instances of that (observed 2026-07-23):
   session. Soft `warnings.code=call_end` re-emits until `end`. Quiet is only the
   fallback. `gateStarted` means Cloud Build returned a build id — not mere upload
   acceptance. Reviewing a PR that "fixes" handoff by shortening quiet, redefines
-  `gateStarted` as `accepted`, or drops submit→`agentEndedAt` / `call_end`, is
-  missing the contract — see `.claude/skills/byoca-mcp/SKILL.md`.
+  `gateStarted` as mere upload `accepted` (ignoring Cloud Build create), or drops
+  submit→`agentEndedAt` / `call_end` / gate-poll `preserveEnded`, is missing the
+  contract — see `.claude/skills/byoca-mcp/SKILL.md`.
 - **A fix that narrows a predicate can reintroduce the same defect through a smaller
   door — and its regression test will not notice.** Observed (BY-25, 2026-08-02): a
   correct fix replaced "does the creator have ANY non-abandoned job with this slug"

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -142,10 +142,12 @@ Two concrete instances of that (observed 2026-07-23):
   overstated.
 - **Do not assume a 15-minute quiet stall is how self→platform handoff is supposed to
   work.** Observed (BYOCA handoff follow-up, 2026-08-04): ChatGPT-class agents usually
-  `submit_sources` and stop. The primary signal is MCP `end` (submit returns
-  `warnings.code=call_end`); stall `ended` unlocks creator handoff immediately. Quiet is
-  only the fallback when `end` was never called. Reviewing a PR that "fixes" handoff by
-  shortening the quiet window, or that adds submit without an `end` / `call_end` path, is
+  `submit_sources` and stop. A successful MCP submit now also sets `agentEndedAt`
+  (handoff unlock) even if `end` is skipped; `end` still sets `stop:true` for the
+  session. Soft `warnings.code=call_end` re-emits until `end`. Quiet is only the
+  fallback. `gateStarted` means Cloud Build returned a build id — not mere upload
+  acceptance. Reviewing a PR that "fixes" handoff by shortening quiet, redefines
+  `gateStarted` as `accepted`, or drops submit→`agentEndedAt` / `call_end`, is
   missing the contract — see `.claude/skills/byoca-mcp/SKILL.md`.
 - **A fix that narrows a predicate can reintroduce the same defect through a smaller
   door — and its regression test will not notice.** Observed (BY-25, 2026-08-02): a

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1141,7 +1141,7 @@ describe('agent build channel', () => {
       expect(response.json().buildId).toBeUndefined();
     });
 
-    it('reports gateStarted only when the trigger returns a build id', async () => {
+    it('reports gateStarted when Cloud Build accepted the create', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);
       const { gamesStore } = stubGamesStore();
@@ -1172,6 +1172,39 @@ describe('agent build channel', () => {
         gateStarted: true,
         buildId: 'projects/x/builds/abc',
       });
+
+      await app.close();
+      app = await buildApp({
+        store,
+        sessionSecret,
+        submissionRoutes: {
+          githubClient: stubGitHub(),
+          githubToken: 'gh-token',
+          submissionTokenSecret: secret,
+          translator: new NoopTranslator(),
+          agentChannel: {
+            gamesStore,
+            // 2xx without a parseable build id — still started, do not advise retry.
+            onSourcesDelivered: async () => ({ accepted: true }),
+          },
+        },
+      });
+
+      const acceptedNoId = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          files: MINIMAL.map((f) =>
+            f.path === 'SPEC.md' ? { ...f, content: '---\ntitle: Comet Courier\n---\nv2\n' } : f,
+          ),
+          mode: 'preview',
+        },
+      });
+      expect(acceptedNoId.statusCode).toBe(200);
+      expect(acceptedNoId.json()).toMatchObject({ accepted: true, gateStarted: true });
+      expect(acceptedNoId.json().buildId).toBeUndefined();
     });
 
     it('preview mode accepts TRACE-less drafts and does not seal deliveredVersion', async () => {

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1128,7 +1128,7 @@ describe('agent build channel', () => {
         },
       });
 
-      await app.inject({
+      const response = await app.inject({
         method: 'POST',
         url: '/api/agent/build/sources',
         headers: agentHeaders(),
@@ -1136,6 +1136,42 @@ describe('agent build channel', () => {
       });
 
       expect(delivered).toEqual([{ slug: 'comet-courier', version: 'v1' }]);
+      // Hook returned void — delivery accepted, but no Cloud Build id.
+      expect(response.json()).toMatchObject({ accepted: true, gateStarted: false });
+      expect(response.json().buildId).toBeUndefined();
+    });
+
+    it('reports gateStarted only when the trigger returns a build id', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore } = stubGamesStore();
+      app = await buildApp({
+        store,
+        sessionSecret,
+        submissionRoutes: {
+          githubClient: stubGitHub(),
+          githubToken: 'gh-token',
+          submissionTokenSecret: secret,
+          translator: new NoopTranslator(),
+          agentChannel: {
+            gamesStore,
+            onSourcesDelivered: async () => ({ buildId: 'projects/x/builds/abc' }),
+          },
+        },
+      });
+
+      const withGate = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: { slug: 'comet-courier', files: MINIMAL, mode: 'preview' },
+      });
+      expect(withGate.statusCode).toBe(200);
+      expect(withGate.json()).toMatchObject({
+        accepted: true,
+        gateStarted: true,
+        buildId: 'projects/x/builds/abc',
+      });
     });
 
     it('preview mode accepts TRACE-less drafts and does not seal deliveredVersion', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1204,13 +1204,14 @@ export async function registerAgentChannelRoutes(
         // known: the trigger takes a slug and a version and has no idea whose ledger to
         // write to. Best-effort like every other write in this handler — the delivery has
         // already been accepted, and refusing it now would make the agent upload again.
-        if (store && gate?.buildId) {
+        const buildId = gate && typeof gate === 'object' && typeof gate.buildId === 'string' ? gate.buildId : undefined;
+        if (store && buildId) {
           await store
             .recordJobCost(issueNumber, {
               kind: 'gate_run',
               at: new Date().toISOString(),
               by: 'cloud-build',
-              ref: gate.buildId,
+              ref: buildId,
             })
             .catch(() => {});
         }
@@ -1224,6 +1225,11 @@ export async function registerAgentChannelRoutes(
           accepted: true,
           mode,
           delivery: { slug, version },
+          // True only when Cloud Build (or a test trigger) returned a build id —
+          // not merely "we accepted the upload". Agents must not treat acceptance as
+          // "preview is assembling" when the gate never started.
+          gateStarted: Boolean(buildId),
+          ...(buildId ? { buildId } : {}),
           ...(await channelState(issueNumber, fresh)),
         });
       } catch (error) {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -314,7 +314,7 @@ export interface AgentChannelOptions {
      * Omitted means the acceptance (publish) gate.
      */
     mode?: 'health' | 'preview';
-  }) => Promise<{ buildId?: string } | void> | void;
+  }) => Promise<{ buildId?: string; accepted?: boolean } | void> | void;
 }
 
 type RejectionReason =
@@ -1205,6 +1205,7 @@ export async function registerAgentChannelRoutes(
         // write to. Best-effort like every other write in this handler — the delivery has
         // already been accepted, and refusing it now would make the agent upload again.
         const buildId = gate && typeof gate === 'object' && typeof gate.buildId === 'string' ? gate.buildId : undefined;
+        const gateAccepted = Boolean(buildId || (gate && typeof gate === 'object' && gate.accepted === true));
         if (store && buildId) {
           await store
             .recordJobCost(issueNumber, {
@@ -1225,10 +1226,10 @@ export async function registerAgentChannelRoutes(
           accepted: true,
           mode,
           delivery: { slug, version },
-          // True only when Cloud Build (or a test trigger) returned a build id —
-          // not merely "we accepted the upload". Agents must not treat acceptance as
-          // "preview is assembling" when the gate never started.
-          gateStarted: Boolean(buildId),
+          // True when Cloud Build accepted the create (build id and/or accepted:true).
+          // False only when the trigger was missing or failed — not when the id was
+          // unparseable from an otherwise successful create.
+          gateStarted: gateAccepted,
           ...(buildId ? { buildId } : {}),
           ...(await channelState(issueNumber, fresh)),
         });

--- a/apps/api/src/gate-trigger.test.ts
+++ b/apps/api/src/gate-trigger.test.ts
@@ -70,16 +70,19 @@ describe('createCloudBuildGateTrigger', () => {
     const { impl } = stubFetch();
     const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
 
-    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({ buildId: 'build-abc' });
+    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({
+      accepted: true,
+      buildId: 'build-abc',
+    });
   });
 
   it('keeps the gate running when the response is not the shape we expected', async () => {
     // The build is already queued by the time this is parsed. An unrecognised body costs
-    // us the id, and must not cost us the verification.
+    // us the id, and must not cost us the verification — or tell the agent to resubmit.
     const { impl } = stubFetch({ json: async () => ({ nothing: 'useful' }) });
     const trigger = createCloudBuildGateTrigger({ ...OPTIONS, fetchImpl: impl });
 
-    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({});
+    await expect(trigger!({ slug: 'comet-courier', version: 'v1' })).resolves.toEqual({ accepted: true });
   });
 
   it('uses the read-only games token, never a credential that can start agent work', async () => {

--- a/apps/api/src/gate-trigger.ts
+++ b/apps/api/src/gate-trigger.ts
@@ -175,6 +175,12 @@ function buildSpec(
  */
 export interface GateTriggerResult {
   buildId?: string;
+  /**
+   * True when Cloud Build accepted the create (HTTP 2xx). May be true without
+   * `buildId` when the operation body could not be parsed — the build is still
+   * queued in that case; do not treat it as "gate did not start".
+   */
+  accepted?: boolean;
 }
 
 export function createCloudBuildGateTrigger(
@@ -224,7 +230,8 @@ export function createCloudBuildGateTrigger(
         .then((body: unknown) => (body as { metadata?: { build?: { id?: string } } })?.metadata?.build?.id)
         .catch(() => undefined);
       log?.info({ slug: input.slug, version: input.version, buildId }, 'gate started');
-      return buildId ? { buildId } : {};
+      // Always mark accepted on 2xx — missing id is a bookkeeping gap, not a failed start.
+      return { accepted: true, ...(buildId ? { buildId } : {}) };
     } catch (error) {
       // Loud, because the consequence is silent: the candidate is stored, the agent
       // thinks it is done, and nothing will ever verify it unless someone notices this.

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -4,6 +4,7 @@ import {
   mcpPresenceKey,
   MCP_PRESENCE_MIN_GAP_MS,
   noteMcpPresencePulse,
+  presencePreservesEnded,
   shouldEmitMcpPresencePulse,
   shouldPulseMcpPresence,
 } from './mcp-presence.js';
@@ -32,6 +33,13 @@ describe('mcp presence pulses', () => {
     expect(mcpPresenceKey('get_brief')).toBe('reading_brief');
     expect(mcpPresenceKey('list_staged_sources')).toBe('checking_staged');
     expect(mcpPresenceKey('report_progress')).toBeNull();
+  });
+
+  it('preserves agentEndedAt for gate-poll presence only', () => {
+    expect(presencePreservesEnded('get_gate_verdict')).toBe(true);
+    expect(presencePreservesEnded('get_gate_media')).toBe(true);
+    expect(presencePreservesEnded('list_kit_files')).toBe(false);
+    expect(presencePreservesEnded('get_brief')).toBe(false);
   });
 
   it('recognizes leftover synthetic chat rows so status can hide them', () => {

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -49,6 +49,17 @@ const PRESENCE_BY_TOOL: Record<string, { key: string; text: string }> = {
   get_gate_media: { key: 'reviewing_captures', text: 'Reviewing gate captures…' },
 };
 
+/**
+ * Gate-poll presence must refresh the heartbeat without clearing `agentEndedAt`.
+ * Submit auto-ends for handoff; agents are told to poll next — clearing ended on
+ * those pulses would relock self→platform until quiet timeout.
+ */
+export const PRESENCE_PRESERVE_ENDED = new Set(['get_gate_verdict', 'get_gate_media']);
+
+export function presencePreservesEnded(toolName: string): boolean {
+  return PRESENCE_PRESERVE_ENDED.has(toolName);
+}
+
 const PRESENCE_EVENT_TEXTS = new Set(Object.values(PRESENCE_BY_TOOL).map((entry) => entry.text));
 
 export function shouldPulseMcpPresence(toolName: string): boolean {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -85,7 +85,9 @@ async function createApp(
   store: InMemoryStore,
   gamesStore?: GamesStore,
   objectStore?: GcsObjectStore,
-  channelExtras?: { onSourcesDelivered?: (input: unknown) => Promise<{ buildId?: string } | void> | void },
+  channelExtras?: {
+    onSourcesDelivered?: (input: unknown) => Promise<{ buildId?: string; accepted?: boolean } | void> | void;
+  },
 ) {
   return await buildApp({
     store,
@@ -995,6 +997,67 @@ describe('POST /api/mcp (BY-05)', () => {
     const warnings = (submitted.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(warnings.some((w) => w.code === 'gate_not_started')).toBe(false);
     expect(warnings.some((w) => w.code === 'call_end')).toBe(true);
+  });
+
+  it('submit_sources treats accepted-without-buildId as gateStarted (no retry warning)', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore, undefined, {
+      onSourcesDelivered: async () => ({ accepted: true }),
+    });
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const submitted = await callTool(
+      app,
+      'submit_sources',
+      {
+        sessionKey,
+        kitEngineRef: ENGINE,
+        files: MINIMAL_FILES.map((f) => ({ ...f, encoding: 'utf8' })),
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(submitted.isError).toBe(false);
+    expect(submitted.structured).toMatchObject({ ok: true, gateStarted: true });
+    expect((submitted.structured as { buildId?: string }).buildId).toBeUndefined();
+    const warnings = (submitted.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
+    expect(warnings.some((w) => w.code === 'gate_not_started')).toBe(false);
+  });
+
+  it('keeps agentEndedAt after get_gate_verdict presence pulse', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore({ green: false, report: 'still building' });
+    app = await createApp(store, gamesStore, undefined, {
+      onSourcesDelivered: async () => ({ accepted: true, buildId: 'build-1' }),
+    });
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const submitted = await callTool(
+      app,
+      'submit_sources',
+      {
+        sessionKey,
+        kitEngineRef: ENGINE,
+        files: MINIMAL_FILES.map((f) => ({ ...f, encoding: 'utf8' })),
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(submitted.isError).toBe(false);
+    const endedAt = (await store.getSubmission(ISSUE))?.agentEndedAt;
+    expect(endedAt).toBeTruthy();
+
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    const verdict = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(verdict.isError).toBe(false);
+    // Gate-poll presence must not clear the submit auto-end handoff unlock.
+    expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBe(endedAt);
+    expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -81,7 +81,12 @@ function stubGamesStore(gate?: { green: boolean; ranAt?: string; report?: string
   return { gamesStore, stored };
 }
 
-async function createApp(store: InMemoryStore, gamesStore?: GamesStore, objectStore?: GcsObjectStore) {
+async function createApp(
+  store: InMemoryStore,
+  gamesStore?: GamesStore,
+  objectStore?: GcsObjectStore,
+  channelExtras?: { onSourcesDelivered?: (input: unknown) => Promise<{ buildId?: string } | void> | void },
+) {
   return await buildApp({
     store,
     sessionSecret: 'dev-session-secret-change-me',
@@ -90,7 +95,11 @@ async function createApp(store: InMemoryStore, gamesStore?: GamesStore, objectSt
       githubToken: 'gh-token',
       submissionTokenSecret: secret,
       translator: new NoopTranslator(),
-      agentChannel: { ...(gamesStore ? { gamesStore } : {}), ...(objectStore ? { objectStore } : {}) },
+      agentChannel: {
+        ...(gamesStore ? { gamesStore } : {}),
+        ...(objectStore ? { objectStore } : {}),
+        ...channelExtras,
+      },
     },
   });
 }
@@ -935,9 +944,14 @@ describe('POST /api/mcp (BY-05)', () => {
       deliveryId: 'v1',
       stop: false,
       pendingMessages: expect.any(Array),
+      // Tests do not wire Cloud Build — delivery accepted, gate not started.
+      gateStarted: false,
     });
     const submitWarnings = (submitted.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(submitWarnings.some((w) => w.code === 'call_end')).toBe(true);
+    expect(submitWarnings.some((w) => w.code === 'gate_not_started')).toBe(true);
+    // Successful MCP submit unlocks handoff even before explicit end.
+    expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
 
     const ended = await callTool(app, 'end', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(ended.isError).toBe(false);
@@ -949,6 +963,38 @@ describe('POST /api/mcp (BY-05)', () => {
     const verdict = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(verdict.isError).toBe(false);
     expect(verdict.structured).toMatchObject({ status: 'red', deliveryId: 'v1' });
+  });
+
+  it('submit_sources reports gateStarted when Cloud Build returns a build id', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore, undefined, {
+      onSourcesDelivered: async () => ({ buildId: 'build-xyz' }),
+    });
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const submitted = await callTool(
+      app,
+      'submit_sources',
+      {
+        sessionKey,
+        kitEngineRef: ENGINE,
+        files: MINIMAL_FILES.map((f) => ({ ...f, encoding: 'utf8' })),
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(submitted.isError).toBe(false);
+    expect(submitted.structured).toMatchObject({
+      ok: true,
+      gateStarted: true,
+      buildId: 'build-xyz',
+    });
+    const warnings = (submitted.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
+    expect(warnings.some((w) => w.code === 'gate_not_started')).toBe(false);
+    expect(warnings.some((w) => w.code === 'call_end')).toBe(true);
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2937,9 +2937,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
       description:
         'Signal that you are finished iterating this round (commit / done). Call after your last submit_sources ' +
-        'when you will not deliver more — required whenever submit returns warnings.code=call_end. ' +
-        'Does not publish by itself; unlocks creator handoff to the platform without waiting for silence. ' +
-        'After a green publish verdict the key already retires — end is optional then. ' +
+        'when you will not deliver more — required whenever submit returns warnings.code=call_end (sets stop:true). ' +
+        'Successful submit already unlocks creator handoff (agentEndedAt); end closes your MCP session cleanly. ' +
+        'Does not publish by itself. After a green publish verdict the key already retires — end is optional then. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -293,8 +293,9 @@ const BEHAVIOURAL_CONTRACT = [
   'Send a screenshot as soon as the game draws anything playable.',
   'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file once per path then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
-  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end). Do not stop after submit alone.',
+  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
+  'gateStarted true means Cloud Build started; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -319,8 +320,8 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
-  'After every successful submit_sources: if you will not deliver more this round, call end immediately (warnings.code=call_end). submit alone is not enough — ChatGPT-class agents often stop after submit; end tells Studio you are done so the creator can hand off without waiting.',
-  'Poll get_gate_verdict until preview_passed or preview_failed; fix and re-preview on the SAME key. preview_passed does NOT end the round.',
+  'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
+  'Poll get_gate_verdict until preview_passed or preview_failed; fix and re-preview on the SAME key. preview_passed does NOT end the round. Only poll when gateStarted was true on submit.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated (publish lane).',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
@@ -725,6 +726,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     }
 
     nudgeTracker.noteToolSuccess(jobId, toolName, nowMs);
+    if (toolName === 'submit_sources' && data.ok === true) {
+      nudgeTracker.noteSubmitSuccess(jobId, nowMs);
+    }
     const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs);
     const prior = Array.isArray(data.warnings)
       ? (data.warnings as NudgeWarning[]).filter(
@@ -795,11 +799,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread). Not errors — act on them, then continue the workflow.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started). Not errors — act on them, then continue the workflow.',
       items: {
         type: 'object',
         properties: {
-          code: { type: 'string', enum: ['progress_stale', 'inbox_pending', 'seed_unread', 'call_end'] },
+          code: {
+            type: 'string',
+            enum: ['progress_stale', 'inbox_pending', 'seed_unread', 'call_end', 'gate_not_started'],
+          },
           message: { type: 'string' },
         },
         required: ['code', 'message'],
@@ -2721,7 +2728,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               version: { type: 'string' },
             },
           },
-          gateStarted: { type: 'boolean' },
+          gateStarted: {
+            type: 'boolean',
+            description:
+              'True only when Cloud Build accepted the gate run (a build id exists). ' +
+              'False means the delivery was stored but the gate did not start — do not assume a preview is assembling.',
+          },
+          buildId: {
+            type: 'string',
+            description: 'Cloud Build id when gateStarted is true.',
+          },
           deliveriesRemaining: { type: ['number', 'null'] },
           ...REPLY_CONTROL,
         },
@@ -2742,6 +2758,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
         `files[{path, content, encoding utf8|base64}] optional when fromStaged=true (inline paths override staged); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
         'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
+        'gateStarted is true only when the gate Cloud Build actually started — not merely when the upload was accepted. ' +
+        'A successful delivery unlocks creator handoff (agentEndedAt); still call end when you will not deliver more (warnings.code=call_end). ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -2850,6 +2868,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           delivery?: { slug: string; version: string };
           deliveryCap?: number;
           deliveriesUsed?: number;
+          gateStarted?: boolean;
+          buildId?: string;
           control?: { stop?: boolean; reason?: string };
           pending?: Array<{ id: string; text: string; createdAt: string }>;
         };
@@ -2862,28 +2882,43 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           (await store!.getSubmission(auth.issueNumber))?.roundDeliveryCount ?? auth.record.roundDeliveryCount ?? 0;
 
         const accepted = body.accepted !== false;
+        const gateStarted = body.gateStarted === true;
+        // ChatGPT-class agents usually submit and stop without calling end. Soft
+        // call_end was ignored; mark ended here so Studio unlocks self→platform
+        // handoff immediately. Further channel writes clear agentEndedAt again.
+        if (accepted && store) {
+          await store.markAgentEnded(auth.issueNumber).catch(() => {});
+        }
+        const warnings: Array<{ code: string; message: string }> = [];
+        if (accepted) {
+          warnings.push({
+            code: 'call_end',
+            message:
+              'Call end when you will not deliver more this round (sets stop:true). ' +
+              'Creator handoff is already unlocked from this submit; without end your session may look finished while still connected. ' +
+              'If you will keep iterating (poll get_gate_verdict / fix / resubmit), call end only after your last delivery.',
+          });
+          if (!gateStarted) {
+            warnings.push({
+              code: 'gate_not_started',
+              message:
+                'Delivery accepted but the gate did not start (no Cloud Build id). ' +
+                'Do not assume a Studio preview is assembling — retry submit_sources or tell the creator.',
+            });
+          }
+        }
         return toolOk({
           ok: accepted,
           mode: body.mode === 'preview' ? 'preview' : 'publish',
           ...(body.rejected ? { rejected: body.rejected } : {}),
           deliveryId: body.delivery?.version ?? null,
           delivery: body.delivery ?? null,
-          gateStarted: body.accepted === true,
+          gateStarted,
+          ...(typeof body.buildId === 'string' && body.buildId ? { buildId: body.buildId } : {}),
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
           ...stopFromChannel(body),
           pendingMessages: pendingMessagesFromChannel(body),
-          ...(accepted
-            ? {
-                warnings: [
-                  {
-                    code: 'call_end',
-                    message:
-                      'Call end when you will not deliver more this round. submit_sources alone is not enough — ' +
-                      'without end, Studio cannot tell you finished and the creator may wait on a quiet timeout.',
-                  },
-                ],
-              }
-            : {}),
+          ...(warnings.length > 0 ? { warnings } : {}),
         });
       },
     },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -22,6 +22,7 @@ import { creatorOwnsSlug, findActiveRoundForSlug, findDraftJobForSlug } from './
 import {
   mcpPresenceKey,
   noteMcpPresencePulse,
+  presencePreservesEnded,
   shouldEmitMcpPresencePulse,
   shouldPulseMcpPresence,
 } from './mcp-presence.js';
@@ -295,7 +296,7 @@ const BEHAVIOURAL_CONTRACT = [
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
-  'gateStarted true means Cloud Build started; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
+  'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -2731,12 +2732,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           gateStarted: {
             type: 'boolean',
             description:
-              'True only when Cloud Build accepted the gate run (a build id exists). ' +
+              'True when Cloud Build accepted the gate create (HTTP 2xx), with or without a parseable build id. ' +
               'False means the delivery was stored but the gate did not start — do not assume a preview is assembling.',
           },
           buildId: {
             type: 'string',
-            description: 'Cloud Build id when gateStarted is true.',
+            description:
+              'Cloud Build id when the create response included one (may be absent even when gateStarted is true).',
           },
           deliveriesRemaining: { type: ['number', 'null'] },
           ...REPLY_CONTROL,
@@ -2758,7 +2760,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
         `files[{path, content, encoding utf8|base64}] optional when fromStaged=true (inline paths override staged); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
         'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
-        'gateStarted is true only when the gate Cloud Build actually started — not merely when the upload was accepted. ' +
+        'gateStarted is true when Cloud Build accepted the gate create — not merely when the upload was accepted. ' +
         'A successful delivery unlocks creator handoff (agentEndedAt); still call end when you will not deliver more (warnings.code=call_end). ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -3430,9 +3432,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
               noteMcpPresencePulse(presencePulseByJob, jobId, at);
               try {
-                await store.touchLastAgentSignalAt(jobId, new Date(at).toISOString(), {
-                  key: presenceKey,
-                });
+                await store.touchLastAgentSignalAt(
+                  jobId,
+                  new Date(at).toISOString(),
+                  { key: presenceKey },
+                  { preserveEnded: presencePreservesEnded(name) },
+                );
               } catch (pulseError) {
                 request.log.warn({ err: pulseError, jobId, tool: name }, 'mcp presence pulse failed');
               }

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -67,4 +67,24 @@ describe('mcp-session-nudges', () => {
     nudges.noteToolSuccess(1, 'get_seed', t0);
     expect(nudges.warningsFor(1, 'read_kit_files', t0 + 1).map((w) => w.code)).not.toContain('seed_unread');
   });
+
+  it('re-emits call_end after submit until end', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.noteSubmitSuccess(1, t0);
+    expect(nudges.warningsFor(1, 'submit_sources', t0).map((w) => w.code)).not.toContain('call_end');
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0).map((w) => w.code)).toContain('call_end');
+    nudges.noteToolSuccess(1, 'end', t0 + 1);
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 2).map((w) => w.code)).not.toContain('call_end');
+  });
+
+  it('does not progress-nudge submit_sources (call_end owns that reply)', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.ensure(1, t0);
+    for (let i = 0; i < PROGRESS_STALE_CALLS + 2; i += 1) {
+      nudges.noteToolSuccess(1, 'read_kit_file', t0 + i);
+    }
+    expect(nudges.warningsFor(1, 'submit_sources', t0 + 50_000).map((w) => w.code)).not.toContain('progress_stale');
+  });
 });

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -7,7 +7,7 @@
  * results by the MCP dispatcher.
  */
 
-export type NudgeCode = 'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end';
+export type NudgeCode = 'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started';
 
 export interface NudgeWarning {
   code: NudgeCode;
@@ -24,6 +24,11 @@ export interface JobNudgeState {
   seedFetched: boolean;
   /** Last known seedStatus from brief/seed payloads. */
   seedStatus: 'pending' | 'available' | 'unavailable' | null;
+  /**
+   * True after a successful submit_sources until `end` — subsequent tools re-emit
+   * `call_end` so ChatGPT-class agents that keep chatting without ending still see it.
+   */
+  awaitingEnd: boolean;
 }
 
 /** No progress for this long (wall clock) → `progress_stale`. */
@@ -41,6 +46,9 @@ export const PROGRESS_NUDGE_EXEMPT = new Set([
   'read_inbox',
   'ack_inbox',
   'end',
+  // Submit already carries call_end / gate_not_started — progress_stale on the same
+  // reply drowned the handoff instruction for ChatGPT-class agents.
+  'submit_sources',
 ]);
 
 /**
@@ -76,6 +84,10 @@ export interface McpNudgeTracker {
   noteInboxCheck(jobId: number, nowMs: number): void;
   noteSeedFetch(jobId: number, nowMs: number): void;
   noteSeedStatus(jobId: number, status: 'pending' | 'available' | 'unavailable' | null, nowMs: number): void;
+  /** Successful submit_sources — creator handoff may already be unlocked; still need `end`. */
+  noteSubmitSuccess(jobId: number, nowMs: number): void;
+  /** Successful MCP `end` — clear the post-submit call_end loop. */
+  noteEnded(jobId: number, nowMs: number): void;
   /** `nowMs` is only used if the job has never been ensured — callers should pass the injected clock. */
   notePendingCount(jobId: number, count: number, nowMs: number): void;
   noteToolSuccess(jobId: number, toolName: string, nowMs: number): void;
@@ -102,6 +114,7 @@ export function createMcpNudgeTracker(
         lastInboxCheckAt: null,
         seedFetched: false,
         seedStatus: null,
+        awaitingEnd: false,
       };
       states.set(jobId, state);
     }
@@ -129,6 +142,16 @@ export function createMcpNudgeTracker(
     state.seedStatus = status;
   }
 
+  function noteSubmitSuccess(jobId: number, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
+    state.awaitingEnd = true;
+  }
+
+  function noteEnded(jobId: number, nowMs: number): void {
+    const state = ensure(jobId, nowMs);
+    state.awaitingEnd = false;
+  }
+
   function notePendingCount(jobId: number, count: number, nowMs: number): void {
     const state = ensure(jobId, nowMs);
     state.pendingCount = Math.max(0, count);
@@ -145,6 +168,9 @@ export function createMcpNudgeTracker(
     }
     if (toolName === 'get_seed') {
       noteSeedFetch(jobId, nowMs);
+    }
+    if (toolName === 'end') {
+      noteEnded(jobId, nowMs);
     }
     if (!PROGRESS_NUDGE_EXEMPT.has(toolName)) {
       state.callsSinceProgress += 1;
@@ -187,6 +213,16 @@ export function createMcpNudgeTracker(
       });
     }
 
+    // Re-emit after submit until end — ChatGPT often stops on the submit reply itself,
+    // but when it keeps chatting this keeps call_end in every subsequent tool result.
+    if (state.awaitingEnd && toolName !== 'end' && toolName !== 'submit_sources') {
+      warnings.push({
+        code: 'call_end',
+        message:
+          'Still waiting for end — call end now if you will not deliver more this round (Studio handoff may already be unlocked from submit).',
+      });
+    }
+
     return warnings;
   }
 
@@ -196,6 +232,8 @@ export function createMcpNudgeTracker(
     noteInboxCheck,
     noteSeedFetch,
     noteSeedStatus,
+    noteSubmitSuccess,
+    noteEnded,
     notePendingCount,
     noteToolSuccess,
     warningsFor,

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -116,6 +116,24 @@ describe('InMemoryStore', () => {
     expect((await store.getSubmission(61))?.lastAgentSignalAt).toBeTruthy();
   });
 
+  it('touchLastAgentSignalAt can preserve agentEndedAt for gate-poll presence', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(62, 'g:123', 'Ended');
+    await store.markAgentEnded(62, '2026-08-04T01:00:00.000Z');
+
+    await store.touchLastAgentSignalAt(
+      62,
+      '2026-08-04T01:01:00.000Z',
+      { key: 'waiting_checks' },
+      { preserveEnded: true },
+    );
+    expect((await store.getSubmission(62))?.agentEndedAt).toBe('2026-08-04T01:00:00.000Z');
+    expect((await store.getSubmission(62))?.lastAgentSignalAt).toBe('2026-08-04T01:01:00.000Z');
+
+    await store.touchLastAgentSignalAt(62, '2026-08-04T01:02:00.000Z', { key: 'browsing_kit' });
+    expect((await store.getSubmission(62))?.agentEndedAt).toBeUndefined();
+  });
+
   it('ensureRoundGeneration initializes a legacy job without bumping an existing one', async () => {
     const store = new InMemoryStore();
     await store.createSubmission(6, 'g:123', 'Legacy');

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1581,8 +1581,15 @@ export interface Store {
    * Used by MCP presence heartbeats so kit-browse activity clears `no_agent_yet` / quiet
    * stalls without stuffing "Browsing the Creator Kit…" into the Studio thread.
    * When `presence` is set, also stores a short-lived thought key for the Studio bar.
+   * Clears `agentEndedAt` unless `options.preserveEnded` — gate-poll presence must not
+   * relock self→platform handoff after submit auto-end.
    */
-  touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void>;
+  touchLastAgentSignalAt(
+    issueNumber: number,
+    at?: string,
+    presence?: { key: string },
+    options?: { preserveEnded?: boolean },
+  ): Promise<void>;
   /**
    * Marks that the agent finished iterating this round (MCP `end`). Idempotent.
    * Does not bump generation or stop the channel — creator handoff does that.
@@ -2818,7 +2825,12 @@ export class InMemoryStore implements Store {
     return { ...record };
   }
 
-  async touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void> {
+  async touchLastAgentSignalAt(
+    issueNumber: number,
+    at?: string,
+    presence?: { key: string },
+    options?: { preserveEnded?: boolean },
+  ): Promise<void> {
     const submission = this.submissions.get(issueNumber);
     if (!submission) return;
     const stamped = at ?? new Date().toISOString();
@@ -2827,7 +2839,9 @@ export class InMemoryStore implements Store {
       lastAgentSignalAt: stamped,
       ...(presence ? { lastAgentPresence: { key: presence.key, at: stamped } } : {}),
     };
-    delete next.agentEndedAt;
+    if (!options?.preserveEnded) {
+      delete next.agentEndedAt;
+    }
     this.submissions.set(issueNumber, next);
   }
 
@@ -4774,7 +4788,12 @@ export class FirestoreStore implements Store {
     return record;
   }
 
-  async touchLastAgentSignalAt(issueNumber: number, at?: string, presence?: { key: string }): Promise<void> {
+  async touchLastAgentSignalAt(
+    issueNumber: number,
+    at?: string,
+    presence?: { key: string },
+    options?: { preserveEnded?: boolean },
+  ): Promise<void> {
     const stamped = at ?? new Date().toISOString();
     await this.db
       .collection('submissions')
@@ -4782,7 +4801,7 @@ export class FirestoreStore implements Store {
       .set(
         {
           lastAgentSignalAt: stamped,
-          agentEndedAt: FieldValue.delete(),
+          ...(options?.preserveEnded ? {} : { agentEndedAt: FieldValue.delete() }),
           ...(presence ? { lastAgentPresence: { key: presence.key, at: stamped } } : {}),
         },
         { merge: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. **`gateStarted` lied.** MCP mapped it to delivery `accepted`, so agents treated a successful `submit_sources` as “preview is assembling” even when Cloud Build never started.
2. **`end` was ignored.** ChatGPT-class agents submit and stop; soft `call_end` did not unlock Studio handoff until quiet (~15m).

## Fix

- Channel/MCP: `gateStarted` when Cloud Build **accepted the create** (HTTP 2xx), with optional `buildId`; `gate_not_started` only when the trigger truly failed (no duplicate-run retry advice on unparseable id)
- Successful MCP submit `markAgentEnded` (handoff unlock); `call_end` still required for `stop:true` and re-emits until `end`
- **Codex P1:** gate-poll presence (`get_gate_verdict` / `get_gate_media`) uses `preserveEnded` so polling does not clear `agentEndedAt`
- **Codex P2:** trigger returns `{ accepted: true }` on 2xx even without a parseable build id
- Merged master (Games-repo contract / bundle ceiling)

## Test plan

- [x] Focused MCP/channel/gate/store/presence tests
- [x] Full green gate: type-check, lint, test, build

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c529d6d-4443-43db-ab77-fe443b7168fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c529d6d-4443-43db-ab77-fe443b7168fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

