### PR TITLE
fix(player): stop theater chrome flapping during mouse play

### DIFF
--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -461,6 +461,8 @@ describe('GameTheater how-to-play visit telemetry', () => {
       expect(bar.classList.contains('is-idle')).toBe(true);
       expect(container.querySelector('.theater-reveal-btn')).not.toBeNull();
 
+      // Play activity must not un-fade the bar — mouse-aim games move the pointer
+      // constantly, and a click-heavy tactics game would flap the chrome on every tap.
       await act(async () => {
         window.dispatchEvent(
           new MessageEvent('message', {
@@ -469,10 +471,25 @@ describe('GameTheater how-to-play visit telemetry', () => {
           }),
         );
       });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+      expect(container.querySelector('.theater-reveal-btn')).not.toBeNull();
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { source: 'gdpl-player', type: 'pointer' },
+            origin: 'null',
+          }),
+        );
+      });
+      expect(bar.classList.contains('is-idle')).toBe(true);
+
+      // The report path (DSA art. 16) stays reachable once the peek brings the bar
+      // back — without remounting or moving controls.
+      await act(async () => {
+        (container.querySelector('.theater-reveal-btn') as HTMLButtonElement).click();
+      });
       expect(bar.classList.contains('is-idle')).toBe(false);
-      expect(container.querySelector('.theater-reveal-btn')).toBeNull();
-      // The report path (DSA art. 16) stays directly reachable in More without
-      // remounting or moving controls when chrome returns.
       expect(container.querySelector('a.report-btn')).not.toBeNull();
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -352,10 +352,11 @@ export function GameTheater({
   // Gated on real game input: chrome never vanishes while somebody is still
   // orienting themselves. Once play begins, a quiet grace period fades it; further
   // play input does not un-fade it (see notePlayerActivity). Hover/focus and open
-  // control surfaces pin a still-visible bar in place.
+  // control surfaces pin the bar — including a race where the idle timer and a
+  // pointerenter land in the same tick.
   useEffect(() => {
     if (!playerEngaged || chromeHeld || moreOpen || howToOpen || fullscreen) {
-      if (!playerEngaged || moreOpen || howToOpen || fullscreen) setChromeIdle(false);
+      setChromeIdle(false);
       return;
     }
     const timer = window.setTimeout(() => setChromeIdle(true), PLAYER_CHROME_IDLE_MS);

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -201,7 +201,16 @@ export function GameTheater({
   const moreOpenRef = useRef(moreOpen);
   moreOpenRef.current = moreOpen;
 
+  // Play input starts the hide clock and can postpone a still-visible bar, but it
+  // must never bring a faded bar back — mouse-aim and click-heavy games would
+  // otherwise flap the chrome on every move. Peek / game-over are the return paths
+  // (ops D.11.6: pause moments + always-visible peek affordance).
   const notePlayerActivity = useCallback(() => {
+    setPlayerEngaged(true);
+    setActivityVersion((version) => version + 1);
+  }, []);
+
+  const revealChrome = useCallback(() => {
     setPlayerEngaged(true);
     setChromeIdle(false);
     setActivityVersion((version) => version + 1);
@@ -340,12 +349,13 @@ export function GameTheater({
     setHowToOpen(false);
   }, [fullscreen]);
 
-  // Media-player convention, but gated on real game input: chrome never vanishes while
-  // somebody is still orienting themselves. Once play begins, each activity gets a
-  // calm grace period. Hover/focus and open control surfaces pin the bar in place.
+  // Gated on real game input: chrome never vanishes while somebody is still
+  // orienting themselves. Once play begins, a quiet grace period fades it; further
+  // play input does not un-fade it (see notePlayerActivity). Hover/focus and open
+  // control surfaces pin a still-visible bar in place.
   useEffect(() => {
     if (!playerEngaged || chromeHeld || moreOpen || howToOpen || fullscreen) {
-      setChromeIdle(false);
+      if (!playerEngaged || moreOpen || howToOpen || fullscreen) setChromeIdle(false);
       return;
     }
     const timer = window.setTimeout(() => setChromeIdle(true), PLAYER_CHROME_IDLE_MS);
@@ -572,8 +582,8 @@ export function GameTheater({
           title={t('player.showControls')}
           // Pointerdown makes the control immediate on touch. Click keeps the same
           // route available to Enter/Space, which do not emit pointer events.
-          onPointerDown={notePlayerActivity}
-          onClick={notePlayerActivity}
+          onPointerDown={revealChrome}
+          onClick={revealChrome}
         >
           <PixelIcon name="chevronDown" size={15} />
         </button>

--- a/apps/web/src/gamePlayer.bridge.test.ts
+++ b/apps/web/src/gamePlayer.bridge.test.ts
@@ -121,7 +121,7 @@ describe('the injected bridge reports health', () => {
     bridge.stop();
   });
 
-  it('reports activity only after real game input establishes engagement', async () => {
+  it('reports activity on discrete input, never on pointer movement', async () => {
     const bridge = runBridge('<canvas id="game"></canvas>');
 
     bridge.frameWindow.dispatchEvent(new bridge.frameWindow.PointerEvent('pointermove'));
@@ -135,7 +135,8 @@ describe('the injected bridge reports health', () => {
     await new Promise((resolve) => setTimeout(resolve, 260));
     bridge.frameWindow.dispatchEvent(new bridge.frameWindow.PointerEvent('pointermove'));
     await delivered();
-    expect(bridge.received.filter((m) => m.type === 'activity')).toHaveLength(2);
+    // Movement after engagement still must not count — host chrome would flap on aim.
+    expect(bridge.received.filter((m) => m.type === 'activity')).toHaveLength(1);
     bridge.stop();
   });
 

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -9,6 +9,9 @@ describe('embedGameHtml', () => {
     // Style + script land inside <head> so rAF patches precede game scripts.
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('#game-title,#game-desc,.game-controls,.hint{display:none!important}');
+    // Desktop mouse: hide buttons-only GameKit chrome (pointer-native tactics UIs).
+    expect(out).toContain('@media not all and (any-pointer:coarse)');
+    expect(out).toContain('.gamekit-touch:not(:has(.gamekit-touch-pad))');
     expect(out).toContain('gdpl-player');
     expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</head>'));
     expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</head>'));

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -26,9 +26,9 @@ const PLAYER = 'gdpl-player';
 //      without covering the playfield — parent document listeners never see taps
 //      inside this opaque-origin frame, and focus tricks don't fire reliably on
 //      mobile either. Report-only: the game still gets the same pointer event;
-//   6. reports player activity so host chrome can follow the familiar media-player
-//      pattern: stay put until play begins, then fade after a quiet grace period and
-//      return as soon as the player moves or presses a control;
+//   6. reports discrete player activity (keydown / pointerdown) so host chrome can
+//      start its hide clock once play begins. Pointer *movement* is not activity —
+//      mouse-aim games would otherwise keep the theater bar flapping forever;
 //   7. reports health — uncaught errors and animation-frame liveness. This is the
 //      only vantage point that has them: the game runs in an opaque origin the app
 //      cannot inspect, and its CSP blocks every way it could report for itself. An
@@ -314,10 +314,8 @@ const BRIDGE = `(function(){
     else if(m.type==='resume'){setPaused(false);}
     else if(m.type==='capture'){sendSnapshot('capture');}
   });
-  var playerEngaged=false,lastActivity=0;
-  function reportActivity(force){
-    if(force)playerEngaged=true;
-    if(!playerEngaged)return;
+  var lastActivity=0;
+  function reportActivity(){
     var now=Date.now();
     if(now-lastActivity<250)return;
     lastActivity=now;
@@ -326,21 +324,15 @@ const BRIDGE = `(function(){
   addEventListener('keydown',function(e){
     // Report only — the game keeps its own Escape handling (pause menus etc).
     if(e.key==='Escape'){post({type:'key',key:'Escape'});}
-    else{reportActivity(true);}
+    else{reportActivity();}
   });
-  function playerPointerDown(){playerEngaged=true;lastActivity=Date.now();post({type:'pointer'});}
-  function playerPointerMove(){reportActivity(false);}
+  function playerPointerDown(){lastActivity=Date.now();post({type:'pointer'});}
   if(typeof PointerEvent==='function'){
     addEventListener('pointerdown',playerPointerDown,{passive:true});
-    // Movement is meaningful only after a click/tap or key has established that the
-    // pointer belongs to a player, not a cursor that happened to rest over the frame.
-    addEventListener('pointermove',playerPointerMove,{passive:true});
   }else{
     // Older/restricted WebViews may expose only the pre-Pointer Events APIs.
     addEventListener('mousedown',playerPointerDown,{passive:true});
-    addEventListener('mousemove',playerPointerMove,{passive:true});
     addEventListener('touchstart',playerPointerDown,{passive:true});
-    addEventListener('touchmove',playerPointerMove,{passive:true});
   }
   // iOS Safari: long-press on the canvas opens the callout (Copy / Translate / Look Up)
   // and the text-selection loupe ("mini zoom"). CSS covers most of it; these kill the
@@ -366,6 +358,12 @@ const BRIDGE = `(function(){
 // the Copy / Translate / Look Up callout over the playfield.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
+  // Mouse-primary desktops: a buttons-only GameKit cluster (no pad) sits on top of
+  // pointer-native UIs and steals the corner. Phones keep it via any-pointer:coarse;
+  // games that still mount a pad on desktop keep their action cluster too.
+  `@media not all and (any-pointer:coarse){` +
+  `.gamekit-touch:not(:has(.gamekit-touch-pad)){display:none!important}` +
+  `}` +
   `html,body,canvas,img,video{` +
   `-webkit-touch-callout:none;` +
   `-webkit-user-select:none;` +
@@ -573,7 +571,7 @@ export function useGamePlayer(
   onEscape?: () => void,
   /** Called on pointerdown inside the game (see the bridge's job 5). */
   onPointer?: () => void,
-  /** Called on meaningful player input and subsequent pointer movement (job 6). */
+  /** Called on discrete player input (keydown / pointerdown) so chrome can idle (job 6). */
   onActivity?: () => void,
   /** Called when the game reports a terminal round state. */
   onEnd?: () => void,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playing mouse-driven games (e.g. 2D Total War) made the theater top bar keep reappearing on every cursor move, and the GameKit hotkey circles covered the game’s own bottom UI on desktop.

### Theater chrome
- Discrete play input (click / key) still starts the idle hide clock.
- Once the bar has faded, **play activity no longer un-fades it** — only the peek control and game-over do.
- The player bridge no longer reports `pointermove` as activity.

### Desktop GameKit chrome (immediate, no republish)
- On mouse-primary desktops, hide a **buttons-only** `.gamekit-touch` cluster (no pad) inside the sandboxed frame so pointer-native tactics UIs are not covered by Fortify/Order/… circles.
- Phones (`any-pointer: coarse`) keep the overlay; games that still mount a pad on desktop keep their action cluster.

Paired kit change (future builds / standalone): `gamedevpl/www.gamedev.pl-games` branch `cursor/touch-buttons-fine-pointer-6a7b`.

## Test plan
- [x] `GameTheater` / `gamePlayer` / bridge unit tests
- [x] `npm run type-check && npm run lint && npm test && npm run build`
- [ ] After deploy: play `/play/2d-total-war` with a mouse — bar fades and stays gone while aiming; peek still restores it; bottom-left hotkey circles gone on desktop; phone still has them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2501180-13c3-47b0-b26a-ef29002c6a7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2501180-13c3-47b0-b26a-ef29002c6a7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

