### PR TITLE
Raise games author budget to 212 KiB

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -26,9 +26,9 @@
     "voice",
     "editor"
   ],
-  "authorBudgetBytes": 204800,
+  "authorBudgetBytes": 217088,
   "platformCeilingBytes": 330000,
-  "maxProjectBytes": 534800,
+  "maxProjectBytes": 547088,
   "audio": {
     "musicField": "string",
     "musicCatalogRequiredKeys": ["version", "tracks"],

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(534_800);
+    expect(MAX_PROJECT_BYTES).toBe(547_088);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(534_800);
+    expect(MAX_PROJECT_BYTES).toBe(547_088);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -223,7 +223,7 @@ describe('games-repo source extractors', () => {
     // The extractor still has to resolve `BUDGET + PLATFORM` (and `a + b` / `a * b`
     // forms inside those consts), not only bare literals.
     const source = `
-      const GAME_BUDGET_BYTES = 200 * 1024;
+      const GAME_BUDGET_BYTES = 212 * 1024;
       const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
@@ -232,7 +232,7 @@ describe('games-repo source extractors', () => {
 
   it('still evaluates a + b allowance expressions when a tip uses them', () => {
     const source = `
-      const GAME_BUDGET_BYTES = 200 * 1024;
+      const GAME_BUDGET_BYTES = 212 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
       const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -80,7 +80,7 @@ export const GAME_KIT_MODULES = [
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 
 /** Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`. */
-export const GAME_BUDGET_BYTES = 200 * 1024;
+export const GAME_BUDGET_BYTES = 212 * 1024;
 
 /**
  * Raw TypeScript source-graph ceiling for the bake/play/seed bundlers
@@ -88,7 +88,7 @@ export const GAME_BUDGET_BYTES = 200 * 1024;
  * `seed-bundle.ts`). Lockstep with games-repo Check 4 `SOURCE_GRAPH_BUDGET_BYTES`.
  *
  * Distinct from {@link GAME_BUDGET_BYTES}: the assembled author payload can stay
- * under 200 KiB while comments and types push the `.ts` tree higher. Last moved
+ * under 212 KiB while comments and types push the `.ts` tree higher. Last moved
  * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish.
  */
 export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
@@ -97,20 +97,24 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (534_800, matching `maxProjectBytes`). Not a round KiB.
+ * (547_088, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
- * 200 KiB author budget; this number is serve-compat only so a game that clears that
+ * 212 KiB author budget; this number is serve-compat only so a game that clears that
  * gate is not refused here. Feature-by-feature archaeology lives in the games repo's
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * Last moved by `carjack-city`'s day/night and reactive-world work: its selected
- * platform measures 327_252 bytes while the game remains within the 200 KiB author
- * budget (199_723 bytes). Keep the full implementation. 313_000 → 330_000, and the
- * serve cap 517_800 → 534_800. Snapshot publish was stranded at 517_889 with the old
- * ceiling (run 30909878136); games-repo #477 already shipped the matching contract.
+ * The author budget last moved for `carjack-city`'s organic incidents and believable
+ * service dispatch: its author payload measures 208_829 bytes. Keep the full flagship
+ * implementation. 200 → 212 KiB, and the serve cap 534_800 → 547_088.
+ *
+ * Before that, `carjack-city`'s day/night and reactive-world work moved the platform
+ * ceiling: its selected platform measures 327_252 bytes while the game remained within
+ * the then-200 KiB author budget (199_723 bytes). 313_000 → 330_000, and the serve cap
+ * 517_800 → 534_800. Snapshot publish was stranded at 517_889 with the old ceiling
+ * (run 30909878136); games-repo #477 shipped the matching contract.
  *
  * The drift this corrects is older and larger than that change: the constant has
  * never tracked the heaviest selection. `apex-sprint` (gfx3d) already measures

--- a/docs/games-repo-validation-spec.md
+++ b/docs/games-repo-validation-spec.md
@@ -21,7 +21,7 @@ This specification defines the quality gates enforced on incoming pull requests 
 
 ### 2. Game Bundle Size Cap
 
-- Hard failure if the author's own bytes exceed 204,800 (200 KiB). Games-repo Check 4
+- Hard failure if the author's own bytes exceed 217,088 (212 KiB). Games-repo Check 4
   measures those as `assembled − platformBytes` (selected GameKit modules, inlined audio,
   shell CSS) — a platform change cannot break a published game whose author spent nothing.
 - On top of that sits a single serve-compat platform ceiling for the touch pad, restart


### PR DESCRIPTION
## What changed

- raise the website's games author allowance from 200 KiB to 212 KiB
- raise the derived serve cap from 534,800 to 547,088 bytes while leaving the measured platform ceiling unchanged
- refresh the vendored games-repo assemble contract, contract assertions, and validation documentation

## Why

Carjack City's follow-up organic incident system measures 208,829 author bytes. The games repository explicitly requires the website half of a budget move to merge first, so a newly valid game can never pass its build gate while remaining too large for the production bake/play path.

This is a narrow 12 KiB author-budget increase with roughly 8 KiB of headroom for that implementation; it does not add another platform reserve.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` (3,382 tests passed)
- `npm run build`

## Merge order

Merge this website PR before the paired `www.gamedev.pl-games` PR.
