### PR TITLE
Embed every music track a game can reach, not just the autoplay one

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -31,6 +31,7 @@
   "maxProjectBytes": 534800,
   "audio": {
     "musicField": "string",
+    "musicTracksField": "string[]",
     "musicCatalogRequiredKeys": ["version", "tracks"],
     "injectedGlobals": {
       "assets": "__GAME_AUDIO_ASSETS__",

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -72,8 +72,14 @@ describe('games-repo-contract (website half)', () => {
       gameKitModules: string[];
       authorBudgetBytes: number;
       platformCeilingBytes: number;
+      audio: { musicField: string; musicTracksField: string };
     };
     expect(fixture.version).toBe(2);
+    // The audio injection shape is half of what this fixture exists to pin: `music` is the
+    // autoplay track and `musicTracks` the extras a game switches to. Serve-time assembly
+    // must embed both, or a published game's mid-round score change silently no-ops.
+    expect(fixture.audio.musicField).toBe(MUSIC_CONTRACT.manifestFieldType);
+    expect(fixture.audio.musicTracksField).toBe(MUSIC_CONTRACT.manifestTracksFieldType);
     expect(fixture.maxProjectBytes).toBe(MAX_PROJECT_BYTES);
     expect(fixture.authorBudgetBytes).toBe(GAME_BUDGET_BYTES);
     expect(fixture.platformCeilingBytes).toBe(GAMEKIT_PLATFORM_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -129,14 +129,21 @@ export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
 
 /**
  * Music embedding contract (games-repo `tools/lib/assemble.ts`):
- * - `GAME.json` → `audio.music` is a single track-name string
+ * - `GAME.json` → `audio.music` is a single track-name string — the track that autoplays
+ * - `GAME.json` → `audio.musicTracks` is an optional array of *extra* track names a game
+ *   switches to at runtime (ambient → combat). Games may not fetch, so every named track
+ *   is embedded at build time.
  * - catalog is loaded via `readMusicCatalog()` (games-repo `tools/audio.ts`;
  *   formerly an inline `shared/audio/music.json` read in assemble.ts)
- * - inject `window.__GAME_AUDIO_MUSIC__ = "<name>"` and a one-entry tracks object
+ * - inject `window.__GAME_AUDIO_MUSIC__ = "<name>"` and a tracks object carrying the
+ *   default plus every extra
  */
 export const MUSIC_CONTRACT = {
   manifestField: 'music',
   manifestFieldType: 'string',
+  /** Optional sibling of `music`; absent on the vast majority of games. */
+  manifestTracksField: 'musicTracks',
+  manifestTracksFieldType: 'string[]',
   /** Historical path; the catalog file may still live here inside `tools/audio.ts`. */
   catalogPath: 'shared/audio/music.json',
   /** Function assemble.ts calls to load the music catalog (post-refactor lockstep). */

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -617,6 +617,92 @@ describe('getRefSha', () => {
 });
 
 describe('getGameSources', () => {
+  it('embeds every track a game can reach, not just the one that autoplays', async () => {
+    // `audio.musicTracks` is how a game changes score mid-round without a fetch, which the
+    // games-repo forbids outright. Serve-time assembly has to carry the extras too, or a
+    // published game's playMusic('combat') finds nothing and the switch silently no-ops.
+    const files = new Map<string, string | Uint8Array>([
+      ['games/raid/index.html', '<canvas id="game"></canvas>'],
+      ['games/raid/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/raid/style.css', '.game { color: teal; }'],
+      ['games/raid/SPEC.md', specMd({ title: 'Raid' })],
+      [
+        'games/raid/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle', 'coin'], music: 'calm-theme', musicTracks: ['combat-theme'] },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'const version: number = 1; window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/assets/coin.wav', new Uint8Array([3, 4])],
+      [
+        'shared/audio/music.json',
+        JSON.stringify({
+          tracks: {
+            'calm-theme': { loop: true, data: 'data:audio/mpeg;base64,AAA=' },
+            'combat-theme': { loop: true, data: 'data:audio/mpeg;base64,BBB=' },
+            'unused-theme': { loop: true, data: 'data:audio/mpeg;base64,CCC=' },
+          },
+        }),
+      ],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'raid');
+
+    // The autoplay track is still the single `music` name — extras do not change it.
+    expect(sources?.gameJs).toContain('window.__GAME_AUDIO_MUSIC__ = "calm-theme";');
+    expect(sources?.gameJs).toContain(
+      'window.__GAME_MUSIC_TRACKS__ = Object.freeze({"calm-theme":{"loop":true,"data":"data:audio/mpeg;base64,AAA="},' +
+        '"combat-theme":{"loop":true,"data":"data:audio/mpeg;base64,BBB="}});',
+    );
+    // Still not the whole catalog.
+    expect(sources?.gameJs).not.toContain('unused-theme');
+  });
+
+  it('rejects a musicTracks list that repeats the autoplay track', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/raid/index.html', '<canvas id="game"></canvas>'],
+      ['games/raid/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/raid/style.css', '.game { color: teal; }'],
+      ['games/raid/SPEC.md', specMd({ title: 'Raid' })],
+      [
+        'games/raid/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle'], music: 'calm-theme', musicTracks: ['calm-theme'] },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/music.json', JSON.stringify({ tracks: { 'calm-theme': { loop: true } } })],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    await expect(client.getGameSources('main', 'raid')).rejects.toThrow(/audio musicTracks/);
+  });
+
   it('bundles selected GameKit modules, audio assets, music catalog, and shared shell styles', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/coin-catcher/index.html', '<canvas id="game"></canvas>'],

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -111,7 +111,7 @@ export function resolveGameTypeScriptPath(resolveDir: string, specifier: string)
 
 interface GameManifest {
   engine?: { modules?: unknown };
-  audio?: { sounds?: unknown; music?: unknown };
+  audio?: { sounds?: unknown; music?: unknown; musicTracks?: unknown };
 }
 
 interface ParsedGameManifest {
@@ -122,6 +122,11 @@ interface ParsedGameManifest {
    * audio module is off. Matches games-repo `tools/lib/assemble.ts`.
    */
   music: string | null;
+  /**
+   * Extra BGM ids from GAME.json (`audio.musicTracks`), embedded alongside `music` so a
+   * game can change score mid-round without a fetch. Empty for almost every game.
+   */
+  musicTracks: string[];
 }
 
 function isKebabCaseName(value: unknown): value is string {
@@ -147,7 +152,7 @@ function parseGameManifest(source: string): ParsedGameManifest {
   }
 
   if (!modules.includes('audio')) {
-    return { modules: modules as GameKitModuleName[], sounds: [], music: null };
+    return { modules: modules as GameKitModuleName[], sounds: [], music: null, musicTracks: [] };
   }
 
   const sounds = manifest.audio?.sounds;
@@ -161,13 +166,30 @@ function parseGameManifest(source: string): ParsedGameManifest {
   }
 
   // Games-repo assemble: `audio.music` is a single track name string. Injected as
-  // `window.__GAME_AUDIO_MUSIC__ = "<name>"` with only that entry from music.json.
+  // `window.__GAME_AUDIO_MUSIC__ = "<name>"`, and it is the track that autoplays.
   const music = manifest.audio?.music;
   if (!isKebabCaseName(music)) {
     throw new Error('game manifest contains invalid audio music');
   }
 
-  return { modules: modules as GameKitModuleName[], sounds, music };
+  // `audio.musicTracks` is optional. Mirrors games-repo validate Check 3: non-empty when
+  // present, kebab-case names, no duplicates, and never a repeat of `audio.music`.
+  const rawTracks = manifest.audio?.musicTracks;
+  let musicTracks: string[] = [];
+  if (rawTracks !== undefined) {
+    if (
+      !Array.isArray(rawTracks) ||
+      rawTracks.length === 0 ||
+      new Set(rawTracks).size !== rawTracks.length ||
+      !rawTracks.every(isKebabCaseName) ||
+      rawTracks.includes(music)
+    ) {
+      throw new Error('game manifest contains invalid audio musicTracks');
+    }
+    musicTracks = rawTracks;
+  }
+
+  return { modules: modules as GameKitModuleName[], sounds, music, musicTracks };
 }
 
 /**
@@ -1302,22 +1324,24 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
         );
       }
 
-      // Music: games-repo assemble reads only `tracks` from music.json, then injects
-      // the selected name plus a one-entry map — not the whole catalog.
+      // Music: games-repo assemble reads only `tracks` from music.json, then injects the
+      // autoplay name plus a map of the tracks this game can reach — not the whole catalog.
       if (manifest.music !== null) {
         const musicSource = await readRawFile('shared/audio/music.json', ref);
         if (musicSource === null) {
           return null;
         }
         const tracks = parseMusicTracks(musicSource);
-        const track = tracks[manifest.music];
-        if (track === undefined) {
-          throw new Error(`game manifest music track not in catalog: ${manifest.music}`);
+        const selected: Record<string, unknown> = {};
+        for (const name of [manifest.music, ...manifest.musicTracks]) {
+          const track = tracks[name];
+          if (track === undefined) {
+            throw new Error(`game manifest music track not in catalog: ${name}`);
+          }
+          selected[name] = track;
         }
         assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = ${JSON.stringify(manifest.music)};`);
-        assetChunks.push(
-          `window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify({ [manifest.music]: track })});`,
-        );
+        assetChunks.push(`window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify(selected)});`);
       }
 
       const assetsJs = assetChunks.length > 0 ? `${assetChunks.join('\n')}\n` : '';


### PR DESCRIPTION
Paired half of **gamedevpl/www.gamedev.pl-games#502** (rule 6a), which adds an optional `audio.musicTracks` array to `GAME.json` so a game can change score mid-round — ambient exploration into a firefight — without a fetch, which the games repo forbids outright.

## Why this half is required
Serve-time assembly narrowed the injected catalog to `{ [manifest.music]: track }`. Without this change, a published game calling `playMusic('combat-theme')` finds nothing in `__GAME_MUSIC_TRACKS__` and the switch **silently no-ops** — the worst kind of failure, since nothing errors and the game just quietly never changes its score.

`github-client` now parses the optional list and injects the default plus every extra. `__GAME_AUDIO_MUSIC__` still names only the track that autoplays, and the whole catalog is still never shipped.

Parsing mirrors games-repo validate Check 3 — non-empty when present, kebab-case, no duplicates, never a repeat of `audio.music` — so a manifest that would fail the games-repo gate fails here too, rather than serving something subtly different from what CI blessed.

## Changes
- `fixtures/games-repo/shared/assemble-contract.json` refreshed with `audio.musicTracksField`, keeping the vendored copy in lockstep.
- `MUSIC_CONTRACT` documents the new field alongside the existing one.
- The lockstep test now pins **both** audio field shapes, not just the module list and byte ceilings — the audio injection shape is half of what that fixture exists to pin, and it was previously unasserted.
- Two new `github-client` tests: extras are embedded (and the rest of the catalog still is not), and a `musicTracks` repeating `audio.music` is rejected.

## Merge ordering
Contract version stays `2` and the key is additive, so either repo may merge first. Until this lands, a game using `musicTracks` serves with its default track and the swap is a no-op rather than an error.

## Verification
- `npm run type-check` — clean
- `npm run lint` — clean
- `npx vitest run apps/api` — 2246 tests, 147 files, all passing

`npm run contract:games-repo` skipped its live cross-repo fetch (`GAMES_REPO_TOKEN` unset in this environment); the unit tests guard the website half.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk4ff5V1gTbAfxcpfGVUQy)_