### PR TITLE
fix(studio): stop showing round finished while self agent still works

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -49,7 +49,9 @@ handoff unlocked.
 _publish_ gate still retires the key; `end` is optional after green.
 
 Further channel writes after `end` (or after submit’s auto-`agentEndedAt`) clear
-`agentEndedAt` (agent resumed).
+`agentEndedAt` (agent resumed). Studio status polls overlay heartbeat / ended /
+stall from the job record outside the 60s cache (and channel `onEvent` busts that
+cache), so a resume cannot keep showing “finished this round” next to live progress.
 
 ## Credentials and immediate revocation
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -915,9 +915,11 @@ export async function registerAgentChannelRoutes(
         });
         // Staging is channel activity — without this, a long stage_source_file loop
         // (Claude Chat's preferred path) looks quiet after 15m and Studio wrongly offers
-        // a platform handoff while the agent is still uploading files.
+        // a platform handoff while the agent is still uploading files. Also busts the
+        // status cache so a prior submit auto-end does not keep stall=ended on screen.
         await markBuildingFromChannel(issueNumber, record);
         await store?.touchLastAgentSignalAt(issueNumber, undefined, { key: 'staging_sources' });
+        options.onEvent?.(issueNumber);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -1382,6 +1384,7 @@ export async function registerAgentChannelRoutes(
       }
 
       await store!.markAgentEnded(issueNumber);
+      options.onEvent?.(issueNumber);
       const fresh = (await store!.getSubmission(issueNumber)) ?? record;
       return reply.send({
         accepted: true,

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2262,15 +2262,16 @@ describe('submission preview route', () => {
     expect((await app.inject({ method: 'GET', url: `/api/submissions/${token}` })).statusCode).toBe(200);
     const callsAfterFirst = getSubmission.mock.calls.length;
 
-    // Inside the window: answered from cache, so the record is not re-read.
+    // Inside the window: the heavy refresh is skipped. One cheap record read still
+    // runs to overlay live heartbeat / ended / stall (same outside-cache idea as events).
     currentTime += 59_000;
     expect((await app.inject({ method: 'GET', url: `/api/submissions/${token}` })).statusCode).toBe(200);
-    expect(getSubmission.mock.calls.length).toBe(callsAfterFirst);
+    expect(getSubmission.mock.calls.length).toBe(callsAfterFirst + 1);
 
-    // Past it: refreshed.
+    // Past it: full refresh again (abandoned check + refresh + overlay).
     currentTime += 2_000;
     expect((await app.inject({ method: 'GET', url: `/api/submissions/${token}` })).statusCode).toBe(200);
-    expect(getSubmission.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    expect(getSubmission.mock.calls.length).toBeGreaterThan(callsAfterFirst + 1);
 
     await app.close();
   });
@@ -3053,9 +3054,9 @@ describe('status route under store pressure', () => {
     release();
     const responses = await polls;
 
-    // Three abandoned-checks — one per request, outside the cache by design — and
-    // exactly one refresh behind them. A second refresh would mean no coalescing.
-    expect(getSubmission).toHaveBeenCalledTimes(4);
+    // Three abandoned-checks + one coalesced refresh + three heartbeat overlays
+    // (attachBuildEvents runs per response). A second refresh would mean no coalescing.
+    expect(getSubmission).toHaveBeenCalledTimes(7);
     for (const response of responses) expect(response.statusCode).toBe(200);
 
     await app.close();
@@ -3075,17 +3076,17 @@ describe('status route under store pressure', () => {
       app.inject({ method: 'GET', url: `/api/submissions/${token}?locale=pl` }),
     ]);
 
-    // Two keys, so two refreshes — a shared one would hand a Polish reader English.
-    // Plus the two per-request abandoned-checks.
-    expect(getSubmission).toHaveBeenCalledTimes(4);
+    // Two keys → two refreshes (a shared one would hand a Polish reader English),
+    // plus two abandoned-checks and two heartbeat overlays.
+    expect(getSubmission).toHaveBeenCalledTimes(6);
 
     await app.close();
   });
 
   it('serves the last known status when a refresh fails', async () => {
-    // Calls 1-2 are the warm request; 3 is the next request's abandoned-check, so 4 is
-    // its refresh — the one the stale-serve is there to cover.
-    const { store } = spyStore({ failOnCall: 4 });
+    // Warm: abandoned + refresh + overlay (1–3). Stale: abandoned (4), then refresh
+    // fails (5) — the stale-serve path. Overlay on the fallback is soft and may be 6.
+    const { store } = spyStore({ failOnCall: 5 });
     let currentTime = 10_000;
     const { app } = await createApp({
       githubClient: createGithubClientStub({}).githubClient,

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { assertAgentTokenActive, verifyAgentToken } from './agent-token.js';
+import { assertAgentTokenActive, mintAgentToken, verifyAgentToken } from './agent-token.js';
 import { buildApp } from './app.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
@@ -1073,6 +1073,61 @@ describe('submission routes', () => {
       by: 'creator',
       reason: 'creator_feedback',
     });
+
+    await app.close();
+  });
+
+  it('drops cached stall=ended when the self agent resumes after submit auto-end', async () => {
+    // Submit marks agentEndedAt for ChatGPT-class stop-without-end. Claude often keeps
+    // iterating: progress/stage clear ended in the store, but a 60s status cache used to
+    // keep serving stall=ended beside fresh "now" events — Studio said finished and working.
+    const { githubClient } = createGithubClientStub({ issueNumber: 78 });
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const token = mintToken(job.issueNumber, secret);
+    await store.setRoundBuilder(job.issueNumber, 'self');
+    await store.ensureRoundGeneration(job.issueNumber);
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'agent',
+      reason: 'self_signal',
+    });
+    await store.touchLastAgentSignalAt(job.issueNumber, new Date().toISOString());
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString());
+
+    const ended = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(ended.statusCode).toBe(200);
+    expect(ended.json()).toMatchObject({ builder: 'self', stall: 'ended' });
+    expect(ended.json().agentEndedAt).toBeTruthy();
+
+    const progress = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: { authorization: `Bearer ${mintAgentToken(job.issueNumber, secret, { roundGeneration: 1 })}` },
+      payload: { text: 'Fixing the roofline before the next preview.' },
+    });
+    expect(progress.statusCode).toBe(200);
+    expect((await store.getSubmission(job.issueNumber))?.agentEndedAt).toBeUndefined();
+
+    // Immediate poll must not keep the cached ended snapshot next to the new event.
+    const resumed = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(resumed.statusCode).toBe(200);
+    expect(resumed.json().stall).toBeUndefined();
+    expect(resumed.json().agentEndedAt).toBeUndefined();
+    expect(resumed.json().events?.some((event: { text: string }) => /roofline/i.test(event.text))).toBe(true);
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1531,7 +1531,8 @@ export async function registerSubmissionRoutes(
       loadBuildEvents(issueNumber),
       buildMedia(issueNumber, locale),
       buildPlayables(issueNumber, locale),
-      store ? store.getSubmission(issueNumber) : Promise.resolve(null),
+      // Soft: a store blip must not 500 a cached status poll — keep cached stall/ended.
+      store ? store.getSubmission(issueNumber).catch(() => null) : Promise.resolve(null),
     ]);
     // Drop leftover synthetic presence steps from before heartbeats stopped writing chat.
     const events = loadedEvents.filter((event) => !isMcpPresenceEventText(event.text));

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1515,27 +1515,56 @@ export async function registerSubmissionRoutes(
 
   /**
    * Attaches what the agent sent us directly — its updates, in the reader's language,
-   * and its pictures. Both sit outside the 60s status cache for the same reason: they
-   * are the only things that move in the long stretch before a pull request exists.
+   * and its pictures — plus the live heartbeat / ended fields from the job record.
+   *
+   * All of these sit outside the 60s status cache: after MCP submit auto-marks
+   * `agentEndedAt`, a Claude-class agent often keeps staging and reporting progress.
+   * Serving a cached `stall: ended` beside fresh "now" events made Studio claim the
+   * round finished while the thread was still moving.
    */
   async function attachBuildEvents(
     status: SubmissionStatusResponse,
     issueNumber: number,
     locale: string,
   ): Promise<SubmissionStatusResponse> {
-    const [loadedEvents, media, playable] = await Promise.all([
+    const [loadedEvents, media, playable, record] = await Promise.all([
       loadBuildEvents(issueNumber),
       buildMedia(issueNumber, locale),
       buildPlayables(issueNumber, locale),
+      store ? store.getSubmission(issueNumber) : Promise.resolve(null),
     ]);
     // Drop leftover synthetic presence steps from before heartbeats stopped writing chat.
     const events = loadedEvents.filter((event) => !isMcpPresenceEventText(event.text));
-    return {
+    const next: SubmissionStatusResponse = {
       ...status,
       ...(events.length > 0 ? { events: await localizeEvents(events, locale) } : {}),
       ...(media.length > 0 ? { media } : {}),
       ...(playable.length > 0 ? { playable } : {}),
     };
+    if (!record) return next;
+
+    // Overlay must clear stale keys, not only set present ones — a cached ended
+    // snapshot has to lose agentEndedAt/stall when the agent resumes.
+    if (record.lastAgentSignalAt) next.lastAgentSignalAt = record.lastAgentSignalAt;
+    else delete next.lastAgentSignalAt;
+    if (record.lastAgentPresence) next.lastAgentPresence = record.lastAgentPresence;
+    else delete next.lastAgentPresence;
+    if (record.agentEndedAt) next.agentEndedAt = record.agentEndedAt;
+    else delete next.agentEndedAt;
+
+    const stall = detectStall({
+      state: record.state ?? 'queued',
+      stateSince: record.stateSince ?? record.createdAt,
+      lastAgentSignalAt: record.lastAgentSignalAt,
+      agentState: record.agentState,
+      agentEndedAt: record.agentEndedAt,
+      now: now(),
+      builder: builderOf(record),
+    });
+    if (stall) next.stall = stall;
+    else delete next.stall;
+
+    return next;
   }
 
   // Draft previews are heavier (several GitHub Contents reads + esbuild) and used
@@ -4476,13 +4505,18 @@ export async function registerSubmissionRoutes(
   });
 
   // The agent's side of the wire. Registered here rather than in app.ts so it shares
-  // the store, the token secret, and the event cache it has to invalidate.
+  // the store, the token secret, and the caches it has to invalidate.
   await registerAgentChannelRoutes(app, {
     ...options.agentChannel,
     store,
     agentTokenSecret: submissionTokenSecret,
     now,
-    onEvent: (issueNumber) => eventsCache.delete(issueNumber),
+    onEvent: (issueNumber) => {
+      eventsCache.delete(issueNumber);
+      // Heartbeat / ended / phase move with channel writes; do not keep serving a
+      // minute-old stall next to fresh progress (submit auto-end + continue loop).
+      invalidateStatusCache(issueNumber);
+    },
   });
 
   // Remote MCP (BY-05): streamable-HTTP tools wrapping the channel above. Same secret

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -772,6 +772,9 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.studio-connect')).toBeNull();
       expect(container.querySelector('.status-warning')?.textContent).toMatch(/finished this round/i);
       expect(container.querySelector('.builder-choice')).not.toBeNull();
+      // Handoff, not mid-build — do not spin "Writing code" beside the finished chip.
+      expect(container.querySelector('.studio-thread-context.is-active')).toBeNull();
+      expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
     } finally {
       await act(async () => {
         root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -88,12 +88,16 @@ export const SENT_RECEIPT_MS = 4500;
  *
  * Gate-green (`in_review` / `ready_for_review`) used to keep spinning forever after the
  * agent finished, with "updated 20 minutes ago" under an active spinner.
+ *
+ * Self rounds with `stall: ended` / `agentEndedAt` are handoff, not mid-build — spinning
+ * "Writing code" next to "finished this round" was the same class of lie.
  */
 function isAgentWorkActive(status: SubmissionStatus | null | undefined): boolean {
   if (!status) return false;
   if (TERMINAL_STATUSES.has(status.status)) return false;
   if (isAwaitingOwnAgent(status)) return false;
   if (status.status === 'in_review' || status.phase === 'ready_for_review') return false;
+  if (status.stall === 'ended' || Boolean(status.agentEndedAt)) return false;
   return true;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On self-build (BYOCA) rounds, Studio could show **“Your agent finished this round”** while Claude was still staging/reporting progress (“Powstaje kod · aktualizacja teraz”).

Root cause: successful `submit_sources` auto-sets `agentEndedAt` (handoff unlock for ChatGPT-class stop-without-`end`). Later channel writes correctly clear that flag in the store, and progress events refresh **outside** the 60s status cache — but `stall` / `agentEndedAt` stayed cached, so the thread looked live next to a stale “finished” chip. The foot spinner also kept running on `stall: ended`.

## Fix

- Overlay live `lastAgentSignalAt` / presence / `agentEndedAt` / recomputed `stall` on every status poll (same outside-cache pattern as events).
- Channel `onEvent` now busts the status cache (as its comment already promised), including after `stage_source_file` and `end`.
- Thread foot spinner idles when the agent has ended.

## Test plan

- [x] `vitest` regression: cached `stall=ended` clears immediately after progress resume
- [x] UI: ended self round shows finished chip without active spinner
- [x] `npm run type-check` && `npm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ea959b3-3564-4816-858b-65570bba6c98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ea959b3-3564-4816-858b-65570bba6c98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

