### PR TITLE
Match a music track by own property, not by truthiness

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -671,6 +671,42 @@ describe('getGameSources', () => {
     expect(sources?.gameJs).not.toContain('unused-theme');
   });
 
+  it('rejects an inherited Object.prototype name as a track', async () => {
+    // The catalog comes from JSON.parse, so `tracks.constructor` is a function rather than
+    // undefined and survives a truthiness check — and `constructor` is lowercase, so it
+    // clears the kebab-case filter too. Accepting it would embed nothing (JSON.stringify
+    // drops a function) and playMusic would fail at runtime on a build CI called clean.
+    const files = new Map<string, string | Uint8Array>([
+      ['games/raid/index.html', '<canvas id="game"></canvas>'],
+      ['games/raid/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/raid/style.css', '.game { color: teal; }'],
+      ['games/raid/SPEC.md', specMd({ title: 'Raid' })],
+      [
+        'games/raid/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle'], music: 'calm-theme', musicTracks: ['constructor'] },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/music.json', JSON.stringify({ tracks: { 'calm-theme': { loop: true } } })],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    await expect(client.getGameSources('main', 'raid')).rejects.toThrow(/music track not in catalog/);
+  });
+
   it('rejects a musicTracks list that repeats the autoplay track', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/raid/index.html', '<canvas id="game"></canvas>'],

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1332,13 +1332,19 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
           return null;
         }
         const tracks = parseMusicTracks(musicSource);
-        const selected: Record<string, unknown> = {};
+        // `Object.hasOwn`, not `tracks[name] !== undefined`: the catalog comes from
+        // JSON.parse and inherits Object.prototype, so `tracks.constructor` is a function
+        // rather than undefined and passes a truthiness check. `constructor` also clears
+        // the kebab-case filter above. Such a name would be accepted here and then embed
+        // nothing — JSON.stringify drops a function — leaving playMusic to fail at runtime;
+        // `__proto__` is worse still, since assigning it sets a prototype instead of a key
+        // and the whole tracks map serializes empty. Mirrors games-repo assemble.ts.
+        const selected: Record<string, unknown> = Object.create(null);
         for (const name of [manifest.music, ...manifest.musicTracks]) {
-          const track = tracks[name];
-          if (track === undefined) {
+          if (!Object.hasOwn(tracks, name)) {
             throw new Error(`game manifest music track not in catalog: ${name}`);
           }
-          selected[name] = track;
+          selected[name] = tracks[name];
         }
         assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = ${JSON.stringify(manifest.music)};`);
         assetChunks.push(`window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify(selected)});`);


### PR DESCRIPTION
Follow-up to #560. Codex raised this on the paired games-repo PR (gamedevpl/www.gamedev.pl-games#502) and **the same hole is here, already merged** — so this fixes it rather than leaving it to be discovered in production.

## The bug
`parseMusicTracks` returns a `JSON.parse` result, which inherits `Object.prototype`. So `tracks.constructor` is a **function**, not `undefined`, and sails through:

```ts
const track = tracks[name];
if (track === undefined) throw new Error(...)   // never fires for an inherited name
```

`constructor` is also lowercase, so it clears the `isKebabCaseName` filter above it. A game declaring `"musicTracks": ["constructor"]` was therefore accepted — and then embedded **nothing**, because `JSON.stringify` drops a function value. `playMusic('constructor')` would fail at runtime on a build every gate had called clean.

`__proto__` is worse: `selected['__proto__'] = …` sets a prototype instead of adding a key, so `Object.keys()` comes back empty and the whole tracks map serializes as `{}` — a game with no music at all, and no error anywhere.

## The fix
Membership is now `Object.hasOwn`, and the accumulator is `Object.create(null)` so a hostile name cannot reach a prototype in the first place. This mirrors the games-repo fix in `aac90d9`, which moved **all six** of its catalog checks off `in` — the four covering `audio.music` and `audio.sounds` had the identical hole and predated the feature.

## Verification
The new test **fails on master and passes with the fix** — confirmed by reverting only the source change while keeping the test:

```
× getGameSources > rejects an inherited Object.prototype name as a track
  Tests  1 failed | 50 passed (51)     ← fix reverted
  Tests  51 passed (51)                ← fix restored
```

`npm run type-check` clean, `npm run lint` clean, `npx vitest run apps/api` 2247 tests passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk4ff5V1gTbAfxcpfGVUQy)_