### PR TITLE
fix(mcp): stop agents busy-polling get_gate_verdict

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -21,8 +21,20 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    - `mode=preview` while iterating; `mode=publish` to seal (TRACE + PLAYTEST required)
    - Each successful stage refreshes Studio’s heartbeat (so a long staging loop is not
      mistaken for quiet / offline)
-4. Poll `get_gate_verdict` (and `get_gate_media` after a publish verdict)
-5. **After the last successful `submit_sources`, call `end`** if you will not deliver more
+4. **Prefer `end` after the last successful `submit_sources`** if you will not deliver
+   more — Studio shows the gate; do not sit in a `get_gate_verdict` loop
+5. Only poll `get_gate_verdict` when you still need the verdict to decide whether to
+   fix before ending (and `get_gate_media` after a publish verdict)
+
+### Never busy-poll `get_gate_verdict`
+
+Agents cannot sleep between tool calls, so “poll every ~30s” turns into a tight
+loop that burns connector tool budgets. When `status` is `pending`:
+
+- Honour `retryAfterSeconds` (~30) as **wall-clock** wait before the next poll, **or**
+- Call **`end`** and stop — Studio already shows gate progress
+- Back-to-back polls emit soft `warnings.code=gate_poll_backoff` (and keep
+  re-emitting `call_end` after submit until `end`)
 
 ### `kit_outdated` — do not re-upload the tree
 
@@ -80,13 +92,14 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code               | Meaning                                                    |
-| ------------------ | ---------------------------------------------------------- |
-| `call_end`         | Call `end` when finished iterating this round              |
-| `gate_not_started` | Delivery ok but Cloud Build did not start — no preview yet |
-| `progress_stale`   | Call `report_progress`                                     |
-| `inbox_pending`    | `read_inbox` → apply → `ack_inbox`                         |
-| `seed_unread`      | Call `get_seed` before scaffolding from the kit            |
+| Code                | Meaning                                                                    |
+| ------------------- | -------------------------------------------------------------------------- |
+| `call_end`          | Call `end` when finished iterating this round                              |
+| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                 |
+| `gate_poll_backoff` | Stop tight-looping `get_gate_verdict` — wait ~30s wall-clock or call `end` |
+| `progress_stale`    | Call `report_progress`                                                     |
+| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                         |
+| `seed_unread`       | Call `get_seed` before scaffolding from the kit                            |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1944,7 +1944,9 @@ export async function registerAgentChannelRoutes(
         return reply.send({
           status: 'pending',
           deliveryId: null,
-          summary: 'nothing has been delivered yet',
+          summary:
+            'nothing has been delivered yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
+          retryAfterSeconds: 30,
           access,
         });
       }
@@ -1964,7 +1966,9 @@ export async function registerAgentChannelRoutes(
         return reply.send({
           status: 'pending',
           deliveryId: version,
-          summary: 'gate has not reported yet',
+          summary:
+            'gate has not reported yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
+          retryAfterSeconds: 30,
           access,
         });
       }

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -361,7 +361,9 @@ describe('POST /api/mcp (BY-05)', () => {
 
     const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
     expect(gateVerdict?.description).toMatch(/2–5 minutes/);
-    expect(gateVerdict?.description).toMatch(/~30s/);
+    expect(gateVerdict?.description).toMatch(/~30/);
+    expect(gateVerdict?.description).toMatch(/busy-poll|Do NOT busy-poll/i);
+    expect(gateVerdict?.description).toMatch(/gate_poll_backoff/);
     expect(gateVerdict?.description).toMatch(/kit_outdated/);
     expect(gateVerdict?.description).toMatch(/re-run get_kit/);
     expect(gateVerdict?.description).toMatch(/fromLatestDelivery/);
@@ -467,6 +469,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
     expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);
     expect(joined).toMatch(/get_gate_verdict/);
+    expect(joined).toMatch(/Never busy-poll|at most once per ~30s wall-clock/i);
+    expect(joined).toMatch(/Prefer end over sitting in a get_gate_verdict loop/i);
     // The stop condition is explicit: green means done — END immediately; no post-green
     // tools (key retires; get_gate_verdict may still answer via terminal receipt).
     expect(joined).toMatch(/green \(publish only\): the round is complete/i);
@@ -1060,6 +1064,49 @@ describe('POST /api/mcp (BY-05)', () => {
     // Gate-poll presence must not clear the submit auto-end handoff unlock.
     expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBe(endedAt);
     expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
+  });
+
+  it('pending get_gate_verdict carries retryAfterSeconds and soft-warns on busy-poll', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    // No gate verdict on the version yet — channel returns pending.
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore, undefined, {
+      onSourcesDelivered: async () => ({ accepted: true, buildId: 'build-pending' }),
+    });
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    await callTool(
+      app,
+      'submit_sources',
+      {
+        sessionKey,
+        kitEngineRef: ENGINE,
+        files: MINIMAL_FILES.map((f) => ({ ...f, encoding: 'utf8' })),
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+
+    const first = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(first.isError).toBe(false);
+    expect(first.structured).toMatchObject({
+      status: 'pending',
+      deliveryId: 'v1',
+      retryAfterSeconds: 30,
+    });
+    expect(String((first.structured as { summary?: string }).summary)).toMatch(/do not busy-poll/i);
+    const firstWarnings = (first.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
+    expect(firstWarnings.some((w) => w.code === 'call_end')).toBe(true);
+    expect(firstWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(false);
+
+    const second = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(second.isError).toBe(false);
+    const secondWarnings = (second.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
+    expect(secondWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(true);
+    expect(secondWarnings.some((w) => w.code === 'call_end')).toBe(true);
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -294,9 +294,10 @@ const BEHAVIOURAL_CONTRACT = [
   'Send a screenshot as soon as the game draws anything playable.',
   'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file once per path then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
-  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Do not stop after submit alone without end.',
+  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
+  'Do not busy-poll get_gate_verdict — when status is pending, wait retryAfterSeconds (~30s wall-clock) before the next poll, or call end if done. Honour warnings.code=gate_poll_backoff.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -321,10 +322,10 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
-  'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
-  'Poll get_gate_verdict until preview_passed or preview_failed; fix and re-preview on the SAME key. preview_passed does NOT end the round. Only poll when gateStarted was true on submit.',
+  'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
+  'Only poll get_gate_verdict when you still need the verdict to decide whether to fix before ending. Never busy-poll: when status=pending, honour retryAfterSeconds (~30) as wall-clock wait, or call end and stop. Back-to-back get_gate_verdict calls waste your tool budget (warnings.code=gate_poll_backoff). Only poll when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
-  'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated (publish lane).',
+  'For publish, if you are still iterating on the verdict: poll get_gate_verdict at most once per ~30s wall-clock until green, red, or kit_outdated — never in a tight loop. If you are done delivering, call end instead of polling.',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
   'kit_outdated: re-run get_kit for a fresh engineRef, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT get_sources + re-stage the whole tree (burns tokens). Only pass files[] for paths you actually changed.',
@@ -709,7 +710,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       nudgeTracker.notePendingCount(jobId, pending, nowMs);
     }
 
-    const seedStatusRaw = data.seedStatus ?? data.status;
+    // Only brief/seed payloads carry seed lifecycle status. Gate and other tools also
+    // use a `status` field (e.g. pending/green) — never treat those as seedStatus.
+    const seedStatusRaw =
+      typeof data.seedStatus === 'string'
+        ? data.seedStatus
+        : toolName === 'get_seed' && typeof data.status === 'string'
+          ? data.status
+          : undefined;
     if (seedStatusRaw === 'pending' || seedStatusRaw === 'available' || seedStatusRaw === 'unavailable') {
       nudgeTracker.noteSeedStatus(jobId, seedStatusRaw, nowMs);
     } else if (data.seedAvailable === true) {
@@ -800,13 +808,20 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started). Not errors — act on them, then continue the workflow.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff). Not errors — act on them, then continue the workflow.',
       items: {
         type: 'object',
         properties: {
           code: {
             type: 'string',
-            enum: ['progress_stale', 'inbox_pending', 'seed_unread', 'call_end', 'gate_not_started'],
+            enum: [
+              'progress_stale',
+              'inbox_pending',
+              'seed_unread',
+              'call_end',
+              'gate_not_started',
+              'gate_poll_backoff',
+            ],
           },
           message: { type: 'string' },
         },
@@ -2918,7 +2933,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             message:
               'Call end when you will not deliver more this round (sets stop:true). ' +
               'Creator handoff is already unlocked from this submit; without end your session may look finished while still connected. ' +
-              'If you will keep iterating (poll get_gate_verdict / fix / resubmit), call end only after your last delivery.',
+              'Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. ' +
+              'If you will keep iterating (poll get_gate_verdict at most once per ~30s wall-clock / fix / resubmit), call end only after your last delivery.',
           });
           if (!gateStarted) {
             warnings.push({
@@ -3017,14 +3033,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           report: { type: 'string' },
           gateStatus: { type: 'string' },
           previewPassed: { type: 'boolean' },
+          retryAfterSeconds: {
+            type: 'number',
+            description:
+              'When status is pending: wait this many wall-clock seconds before the next poll (do not busy-poll).',
+          },
         },
         required: ['status', 'deliveryId', 'summary', 'access'],
       },
       description:
         'Poll the gate verdict for a delivery (default: latest). Preview lane: preview_passed / preview_failed ' +
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
-        'Verdicts typically land in 2–5 minutes; poll every ~30s. kit_outdated is terminal — stop polling, ' +
-        're-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
+        'Verdicts typically land in 2–5 minutes. Do NOT busy-poll: when status=pending, wait retryAfterSeconds (~30) ' +
+        'of wall-clock time before the next call, or call end if you will not deliver more (Studio shows the gate). ' +
+        'Back-to-back polls trigger warnings.code=gate_poll_backoff and burn tool limits. ' +
+        'kit_outdated is terminal — stop polling, re-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
         '(same mode as the refused delivery; omit mode only to reuse that lane; do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
         "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
@@ -3049,7 +3072,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ? `/api/agent/build/gate?version=${encodeURIComponent(deliveryId)}`
           : '/api/agent/build/gate';
         const res = await injectChannel(ctx.request, 'GET', path, auth.channelToken);
-        const body = res.json() as Record<string, unknown> & { error?: string };
+        const body = res.json() as Record<string, unknown> & { error?: string; status?: string };
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `gate verdict failed (${res.statusCode})`);
         }

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  GATE_POLL_MIN_INTERVAL_MS,
   PROGRESS_STALE_CALLS,
   PROGRESS_STALE_MS,
   createMcpNudgeTracker,
@@ -73,9 +74,23 @@ describe('mcp-session-nudges', () => {
     const t0 = 1_000_000;
     nudges.noteSubmitSuccess(1, t0);
     expect(nudges.warningsFor(1, 'submit_sources', t0).map((w) => w.code)).not.toContain('call_end');
-    expect(nudges.warningsFor(1, 'get_gate_verdict', t0).map((w) => w.code)).toContain('call_end');
+    const onGate = nudges.warningsFor(1, 'get_gate_verdict', t0);
+    expect(onGate.map((w) => w.code)).toContain('call_end');
+    expect(onGate.find((w) => w.code === 'call_end')?.message).toMatch(/do not busy-poll/i);
     nudges.noteToolSuccess(1, 'end', t0 + 1);
-    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 2).map((w) => w.code)).not.toContain('call_end');
+    expect(
+      nudges.warningsFor(1, 'get_gate_verdict', t0 + GATE_POLL_MIN_INTERVAL_MS + 2).map((w) => w.code),
+    ).not.toContain('call_end');
+  });
+
+  it('soft-warns gate_poll_backoff on tight get_gate_verdict loops', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0).map((w) => w.code)).not.toContain('gate_poll_backoff');
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000).map((w) => w.code)).toContain('gate_poll_backoff');
+    expect(
+      nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000 + GATE_POLL_MIN_INTERVAL_MS).map((w) => w.code),
+    ).not.toContain('gate_poll_backoff');
   });
 
   it('does not progress-nudge submit_sources (call_end owns that reply)', () => {

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -7,7 +7,8 @@
  * results by the MCP dispatcher.
  */
 
-export type NudgeCode = 'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started';
+export type NudgeCode =
+  'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started' | 'gate_poll_backoff';
 
 export interface NudgeWarning {
   code: NudgeCode;
@@ -29,7 +30,14 @@ export interface JobNudgeState {
    * `call_end` so ChatGPT-class agents that keep chatting without ending still see it.
    */
   awaitingEnd: boolean;
+  /** Wall-clock ms of the last successful get_gate_verdict in this tracker. */
+  lastGatePollAt: number | null;
 }
+
+/** Minimum wall-clock gap between get_gate_verdict polls before soft `gate_poll_backoff`. */
+export const GATE_POLL_MIN_INTERVAL_MS = 25_000;
+/** Hint returned on pending gate reads — agents must wait this many seconds, not busy-poll. */
+export const GATE_POLL_RETRY_AFTER_SECONDS = 30;
 
 /** No progress for this long (wall clock) → `progress_stale`. */
 export const PROGRESS_STALE_MS = 90_000;
@@ -115,6 +123,7 @@ export function createMcpNudgeTracker(
         seedFetched: false,
         seedStatus: null,
         awaitingEnd: false,
+        lastGatePollAt: null,
       };
       states.set(jobId, state);
     }
@@ -219,8 +228,23 @@ export function createMcpNudgeTracker(
       warnings.push({
         code: 'call_end',
         message:
-          'Still waiting for end — call end now if you will not deliver more this round (Studio handoff may already be unlocked from submit).',
+          toolName === 'get_gate_verdict'
+            ? 'Still waiting for end — do not busy-poll get_gate_verdict. Call end now if you will not deliver more this round; Studio shows the gate. Only re-poll after ~30s wall-clock if you still need the verdict to fix.'
+            : 'Still waiting for end — call end now if you will not deliver more this round (Studio handoff may already be unlocked from submit).',
       });
+    }
+
+    // Agents cannot sleep between tool calls, so "poll every ~30s" becomes a tight loop
+    // that burns connector tool budgets. Soft-warn when polls are closer than the gap.
+    if (toolName === 'get_gate_verdict') {
+      if (state.lastGatePollAt !== null && nowMs - state.lastGatePollAt < GATE_POLL_MIN_INTERVAL_MS) {
+        const waitSec = Math.max(1, Math.ceil((GATE_POLL_MIN_INTERVAL_MS - (nowMs - state.lastGatePollAt)) / 1000));
+        warnings.push({
+          code: 'gate_poll_backoff',
+          message: `Do not busy-poll get_gate_verdict — wait ~${waitSec}s wall-clock before the next poll (retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS}). If you will not deliver more, call end instead; Studio shows the gate.`,
+        });
+      }
+      state.lastGatePollAt = nowMs;
     }
 
     return warnings;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Claude-class connectors were tight-looping `get_gate_verdict` while status stayed `pending`, ignoring `call_end` and burning tool budgets.

### Changes
- Prefer `end` after submit over sitting in a gate poll loop (Studio shows the gate).
- Pending gate reads return `retryAfterSeconds: 30` and a “do not busy-poll” summary.
- Soft `warnings.code=gate_poll_backoff` when polls arrive closer than ~25s.
- Stronger `call_end` wording on gate polls; skill/workflow copy updated.

### Rebase
- Rebased onto current `master` (includes #565 `fromLatestDelivery`). Conflict in `get_gate_verdict` description resolved by keeping both the busy-poll guidance and the kit_outdated → `fromLatestDelivery` recovery copy.

## Test plan
- [x] `mcp-server` / `mcp-session-nudges` unit tests
- [ ] CI green after rebase
- [ ] Codex review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e61ce059-7121-4fa0-943a-9da216b4ce56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e61ce059-7121-4fa0-943a-9da216b4ce56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

