### PR TITLE
fix(api): stop double-sending Studio preview (Fastify 5 thenable)

### DIFF
--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -2094,6 +2094,61 @@ describe('submission preview route', () => {
     await app.close();
   });
 
+  it('does not fall through to a second send after serving a stored draft', async () => {
+    // Fastify 5 Reply is a thenable. Awaiting `return reply.send(...)` from an async
+    // helper resolves to undefined, so the old `if (stored) return stored` fell through
+    // and tried to send again ("Reply was already sent"). Live Studio previews logged
+    // served → "no delivery yet… last known draft" → already-sent on every hit.
+    const store = new InMemoryStore();
+    const jobId = 1_000_047;
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.createSubmission(jobId, 'g:test-user', 'TV Tycoon');
+    await store.setSubmissionSlug(jobId, 'tv-tycoon');
+    await store.setSubmissionDeliveredVersion(jobId, 'v20260804T154320637Z-d53599');
+
+    const getDerivedArtifact = vi.fn(async (_s: string, _v: string, name: string) =>
+      name === 'preview.html' ? Buffer.from('<!doctype html><title>TV Tycoon</title><canvas></canvas>') : null,
+    );
+    const gamesStore = { getDerivedArtifact } as unknown as GamesStore;
+    const { githubClient } = createGithubClientStub({});
+    const logLines: string[] = [];
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      logger: {
+        level: 'warn',
+        stream: {
+          write(chunk: string) {
+            logLines.push(chunk);
+          },
+        },
+      },
+      submissionRoutes: {
+        githubToken: 'token',
+        submissionTokenSecret: secret,
+        gamesRepo: repo,
+        githubClient,
+        translator: new NoopTranslator(),
+        agentChannel: { gamesStore },
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(jobId, secret)}/preview`,
+      headers: getAuthHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ slug: 'tv-tycoon', title: 'TV Tycoon' });
+    expect(getDerivedArtifact).toHaveBeenCalled();
+    const joined = logLines.join('\n');
+    expect(joined).not.toMatch(/no delivery yet for native job/i);
+    expect(joined).not.toMatch(/already sent/i);
+
+    await app.close();
+  });
+
   it('shows the creator a build the gate refused, rather than nothing at all', async () => {
     // The regression this exists for, found on a real game: the gate went red, a red run
     // stored no artifacts, and the preview only ever read `bundle.html` — so a build that

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -3823,19 +3823,28 @@ export async function registerSubmissionRoutes(
    * broken preview and an unstarted one are different facts, and a creator told "not
    * yet" about a failure will wait for something that is not coming.
    */
+  /**
+   * Fastify 5's Reply is a thenable. Returning `reply.send(...)` from an async helper
+   * and then `await`ing that helper resolves to `undefined` (the thenable's settle
+   * value), so `if (stored) return stored` falls through and tries to send again —
+   * "Reply was already sent". Prod logs for every successful Studio preview showed
+   * exactly that (served gate-built → no delivery yet → already sent). Return a plain
+   * boolean instead, and never await a Reply.
+   */
   async function replyWithStoredDraft(
     request: FastifyRequest,
     reply: FastifyReply,
     record: SubmissionRecord,
-  ): Promise<FastifyReply | null> {
+  ): Promise<boolean> {
     const gamesStore = options.agentChannel?.gamesStore;
     const { slug } = record;
     const playableVersion = record.previewVersion ?? record.deliveredVersion;
-    if (!gamesStore || !slug || !playableVersion) return null;
+    if (!gamesStore || !slug || !playableVersion) return false;
 
     const cached = draftPreviewCache.get(record.issueNumber);
     if (cached && cached.revision === playableVersion && cached.expiresAt > now()) {
-      return reply.send(cached.value);
+      reply.send(cached.value);
+      return true;
     }
 
     // The verified bundle first, then the gate's red-run / preview-lane document. Both
@@ -3852,7 +3861,7 @@ export async function registerSubmissionRoutes(
     // that there was nothing assemblable to keep. Both are "not ready", and the channel's
     // own pushed previews cover the window. A store that *errors* throws out of here
     // instead, and is reported as the failure it is.
-    if (bundle === null) return null;
+    if (bundle === null) return false;
 
     const value: DraftPreviewValue = { slug, title: record.title || slug, html: bundle.toString('utf8') };
     rememberDraftPreview(record.issueNumber, {
@@ -3864,19 +3873,17 @@ export async function registerSubmissionRoutes(
       { issueNumber: record.issueNumber, slug, version: playableVersion, artifact },
       'served gate-built preview for a delivered version',
     );
-    return reply.send(value);
+    reply.send(value);
+    return true;
   }
 
-  async function replyWithDraft(
-    request: FastifyRequest,
-    reply: FastifyReply,
-    issueNumber: number,
-  ): Promise<FastifyReply> {
-    const serveLastKnown = (reason: string, err?: unknown): FastifyReply | null => {
+  async function replyWithDraft(request: FastifyRequest, reply: FastifyReply, issueNumber: number): Promise<void> {
+    const serveLastKnown = (reason: string, err?: unknown): boolean => {
       const lastKnown = draftPreviewCache.get(issueNumber);
-      if (!lastKnown) return null;
+      if (!lastKnown) return false;
       request.log.warn({ err, issueNumber, revision: lastKnown.revision }, reason);
-      return reply.send(lastKnown.value);
+      reply.send(lastKnown.value);
+      return true;
     };
 
     // The stored delivery is the whole path now: there is no PR to resolve and no branch
@@ -3890,36 +3897,33 @@ export async function registerSubmissionRoutes(
     const record = gamesStore ? await store?.getSubmission(issueNumber) : null;
     if (record) {
       try {
-        const stored = await replyWithStoredDraft(request, reply, record);
-        if (stored) return stored;
+        if (await replyWithStoredDraft(request, reply, record)) return;
       } catch (error) {
         // No hygiene-error branch here on purpose. This path serves the gate's own
         // bundle byte-for-byte and never assembles anything, so EmptyProjectError and
         // friends cannot arise — and catching them would only mislabel a store read
         // failure as "this game could not be previewed", which is a claim about the
         // game rather than about us.
-        const stale = serveLastKnown('stored draft read failed; serving last known draft', error);
-        if (stale) return stale;
+        if (serveLastKnown('stored draft read failed; serving last known draft', error)) return;
         // There is no second source, so this is the end of the line and it is a failure,
         // not a state. Answering 409 here would tell a creator whose game was delivered
         // an hour ago that it has not been — and they would keep waiting.
         request.log.error({ err: error, issueNumber }, 'stored draft preview failed');
-        return reply.status(502).send({ error: 'failed to load preview' });
+        reply.status(502).send({ error: 'failed to load preview' });
+        return;
       }
     }
-    {
-      const stale = serveLastKnown('no delivery yet for native job; serving last known draft');
-      if (stale) return stale;
-      // Without a store this deployment can never preview a native job — there is no PR
-      // to fall back to and nowhere for a delivery to land. 409 would say "not yet"
-      // about something that is never coming, which is the same lie as reporting a
-      // failure as a pending state, just told to an operator instead of a creator.
-      if (!gamesStore) {
-        request.log.error({ issueNumber }, 'preview requested for a native job with no games store configured');
-        return reply.status(503).send({ error: 'previews are not configured on this deployment' });
-      }
-      return reply.status(409).send({ error: 'no preview available for this submission yet' });
+    if (serveLastKnown('no delivery yet for native job; serving last known draft')) return;
+    // Without a store this deployment can never preview a native job — there is no PR
+    // to fall back to and nowhere for a delivery to land. 409 would say "not yet"
+    // about something that is never coming, which is the same lie as reporting a
+    // failure as a pending state, just told to an operator instead of a creator.
+    if (!gamesStore) {
+      request.log.error({ issueNumber }, 'preview requested for a native job with no games store configured');
+      reply.status(503).send({ error: 'previews are not configured on this deployment' });
+      return;
     }
+    reply.status(409).send({ error: 'no preview available for this submission yet' });
   }
 
   // Play the in-progress game straight from its (unmerged) PR branch. This runs the

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -3818,18 +3818,17 @@ export async function registerSubmissionRoutes(
    * already applied by the side that owns it, so the creator plays the exact document a
    * player would. It exists once the gate has run.
    *
-   * Returns null for exactly one reason: **there is nothing to serve yet** — no
+   * Returns `false` for exactly one reason: **there is nothing to serve yet** — no
    * delivery, or a delivery the gate has not bundled. Anything else throws, because a
    * broken preview and an unstarted one are different facts, and a creator told "not
    * yet" about a failure will wait for something that is not coming.
-   */
-  /**
+   *
    * Fastify 5's Reply is a thenable. Returning `reply.send(...)` from an async helper
    * and then `await`ing that helper resolves to `undefined` (the thenable's settle
    * value), so `if (stored) return stored` falls through and tries to send again —
    * "Reply was already sent". Prod logs for every successful Studio preview showed
    * exactly that (served gate-built → no delivery yet → already sent). Return a plain
-   * boolean instead, and never await a Reply.
+   * boolean instead (`true` after sending), and never await a Reply.
    */
   async function replyWithStoredDraft(
     request: FastifyRequest,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Studio preview could stay stuck on “assembling a sketch” even when `preview.html` / `bundle.html` existed. Fastify 5’s `Reply` is thenable: `await reply.send(...)` from an async helper settles to `undefined`, so callers that did `if (stored) return stored` fell through and tried a second send (“Reply was already sent”).

### Fix
- `replyWithStoredDraft` / `replyWithDraft` return a plain boolean / void and never await a `Reply`.
- Regression test captures the double-send log path.

### Review follow-up
- JSDoc above `replyWithStoredDraft` now says it returns `false`/`true`, not `null`.

## Test plan
- [x] Unit regression for stored draft reply
- [ ] CI green
- [ ] Manual: Studio Play after preview gate finishes shows the draft without a second send error in API logs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e61ce059-7121-4fa0-943a-9da216b4ce56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e61ce059-7121-4fa0-943a-9da216b4ce56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

