### PR TITLE
fix(mcp): fromLatestDelivery for kit_outdated without re-upload

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -29,8 +29,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 When the gate returns `kit_outdated` (or soft copy says the kit rotated):
 
 1. `get_kit` for a fresh `engineRef` only — do not dump the kit into context
-2. `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef })` — server copies the
-   last candidate; optional `files[]` only for paths you actually changed
+2. `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef })` — same `mode` as the
+   refused delivery (preview stays preview; omit mode only to reuse that lane). Server
+   copies the last candidate; optional `files[]` only for paths you actually changed
 3. Do **not** `get_sources` + `stage_source_file` every path again (burns connector tokens)
 
 ### `end` is required after submit (not optional etiquette)

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -24,6 +24,15 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 4. Poll `get_gate_verdict` (and `get_gate_media` after a publish verdict)
 5. **After the last successful `submit_sources`, call `end`** if you will not deliver more
 
+### `kit_outdated` — do not re-upload the tree
+
+When the gate returns `kit_outdated` (or soft copy says the kit rotated):
+
+1. `get_kit` for a fresh `engineRef` only — do not dump the kit into context
+2. `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef })` — server copies the
+   last candidate; optional `files[]` only for paths you actually changed
+3. Do **not** `get_sources` + `stage_source_file` every path again (burns connector tokens)
+
 ### `end` is required after submit (not optional etiquette)
 
 ChatGPT-class agents usually **submit and stop**. Soft `call_end` alone was not

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -194,6 +194,14 @@ const BuildSourcesInputSchema = z
      */
     fromStaged: z.boolean().optional(),
     /**
+     * Re-deliver the job's latest candidate (previewVersion, then deliveredVersion)
+     * from the games store without the agent re-uploading every path. Built for
+     * `kit_outdated`: get_kit → submit_sources({ fromLatestDelivery:true, kitEngineRef })
+     * with optional files[] overlays for paths that actually changed. Mutually exclusive
+     * with fromStaged.
+     */
+    fromLatestDelivery: z.boolean().optional(),
+    /**
      * Creator Kit engineRef the sources were built against. Required for self-build
      * deliveries (BY-06); the gate compares it to `kits/current.json`'s N/N−1 window.
      */
@@ -211,11 +219,19 @@ const BuildSourcesInputSchema = z
     mode: z.enum(['preview', 'publish']).default('publish'),
   })
   .superRefine((value, ctx) => {
-    const inline = value.files?.length ?? 0;
-    if (!value.fromStaged && inline === 0) {
+    if (value.fromStaged && value.fromLatestDelivery) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'files is required (or set fromStaged=true after staging files one-by-one)',
+        message: 'fromStaged and fromLatestDelivery cannot both be true — pick one',
+        path: ['fromLatestDelivery'],
+      });
+    }
+    const inline = value.files?.length ?? 0;
+    if (!value.fromStaged && !value.fromLatestDelivery && inline === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'files is required (or set fromStaged=true after staging, or fromLatestDelivery=true to reuse the last candidate)',
         path: ['files'],
       });
     }
@@ -619,8 +635,10 @@ export async function registerAgentChannelRoutes(
               mustFixGate:
                 gate.status === 'kit_outdated'
                   ? `The gate refused your delivery (${gate.version}) because the Creator Kit is ` +
-                    'outdated (`kit_outdated`). Refresh the kit (re-run get_kit), rebuild against ' +
-                    'it, and deliver again with the new kitEngineRef.'
+                    'outdated (`kit_outdated`). Re-run get_kit for a fresh engineRef, then ' +
+                    'submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT ' +
+                    're-stage or re-upload the whole tree through the model (burns tokens). Only ' +
+                    'pass files[] for paths you actually changed for the new kit.'
                   : gate.status === 'preview_failed'
                     ? `The preview check refused your delivery (${gate.version}). Fix typecheck/smoke/build, ` +
                       'then submit_sources again with mode=preview. TRACE.json is not required until mode=publish.'
@@ -1120,7 +1138,35 @@ export async function registerAgentChannelRoutes(
           : (record.roundGeneration ?? 1);
 
         let files = parsed.data.files ?? [];
-        if (parsed.data.fromStaged) {
+        if (parsed.data.fromLatestDelivery) {
+          const version = record.previewVersion ?? record.deliveredVersion;
+          if (!version) {
+            return reply.status(400).send({
+              error: 'fromLatestDelivery=true but this job has no candidate yet — deliver files[] or fromStaged first',
+            });
+          }
+          const manifest = await options.gamesStore.getManifest(slug, version);
+          if (!manifest) {
+            return reply.status(502).send({ error: 'the latest delivery could not be read back' });
+          }
+          const loaded = await Promise.all(
+            manifest.sourceFiles.map(async (path) => ({
+              path,
+              content: await options.gamesStore!.getSourceFile(slug, version, path),
+            })),
+          );
+          const missing = loaded.filter((file) => file.content === null).map((file) => file.path);
+          if (missing.length > 0) {
+            request.log.error({ slug, version, missing }, 'latest delivery missing files its manifest lists');
+            return reply.status(502).send({ error: 'the latest delivery could not be read back' });
+          }
+          // Inline files win on path collision so kit_outdated / small fixes overlay without
+          // re-uploading the whole tree through the model.
+          const byPath = new Map<string, string>();
+          for (const file of loaded) byPath.set(file.path, file.content as string);
+          for (const file of files) byPath.set(file.path, file.content);
+          files = [...byPath.entries()].map(([path, content]) => ({ path, content }));
+        } else if (parsed.data.fromStaged) {
           const staged = await options.gamesStore.getStagedSourceFiles({
             slug,
             issueNumber,

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -196,9 +196,10 @@ const BuildSourcesInputSchema = z
     /**
      * Re-deliver the job's latest candidate (previewVersion, then deliveredVersion)
      * from the games store without the agent re-uploading every path. Built for
-     * `kit_outdated`: get_kit → submit_sources({ fromLatestDelivery:true, kitEngineRef })
+     * `kit_outdated`: get_kit → submit_sources({ fromLatestDelivery:true, mode, kitEngineRef })
      * with optional files[] overlays for paths that actually changed. Mutually exclusive
-     * with fromStaged.
+     * with fromStaged. When mode is omitted with fromLatestDelivery, the previous
+     * candidate's deliveryMode is reused (preview stays preview).
      */
     fromLatestDelivery: z.boolean().optional(),
     /**
@@ -214,9 +215,10 @@ const BuildSourcesInputSchema = z
       .optional(),
     /**
      * Preview: typecheck→smoke→build, TRACE/PLAYTEST optional, Studio-playable only.
-     * Publish (default): full gate; TRACE/PLAYTEST required. Keeps `npm run submit` safe.
+     * Publish: full gate; TRACE/PLAYTEST required. Default when omitted is publish,
+     * except with fromLatestDelivery — then the previous candidate's lane is reused.
      */
-    mode: z.enum(['preview', 'publish']).default('publish'),
+    mode: z.enum(['preview', 'publish']).optional(),
   })
   .superRefine((value, ctx) => {
     if (value.fromStaged && value.fromLatestDelivery) {
@@ -1132,7 +1134,11 @@ export async function registerAgentChannelRoutes(
         // and `canTransition('queued','submitted')` is false, so the protective
         // transition was skipped and the job stayed `building` (CP-1 double-close).
         const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
-        const mode: DeliveryMode = parsed.data.mode === 'preview' ? 'preview' : 'publish';
+        // Explicit mode wins. Omitting mode defaults to publish — except
+        // fromLatestDelivery, which reuses the previous candidate's lane so a
+        // kit_outdated preview recovery does not suddenly demand TRACE/PLAYTEST.
+        let mode: DeliveryMode | undefined =
+          parsed.data.mode === 'preview' || parsed.data.mode === 'publish' ? parsed.data.mode : undefined;
         const roundGeneration = store
           ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
           : (record.roundGeneration ?? 1);
@@ -1148,6 +1154,9 @@ export async function registerAgentChannelRoutes(
           const manifest = await options.gamesStore.getManifest(slug, version);
           if (!manifest) {
             return reply.status(502).send({ error: 'the latest delivery could not be read back' });
+          }
+          if (!mode) {
+            mode = manifest.deliveryMode === 'preview' ? 'preview' : 'publish';
           }
           const loaded = await Promise.all(
             manifest.sourceFiles.map(async (path) => ({
@@ -1186,6 +1195,7 @@ export async function registerAgentChannelRoutes(
           for (const file of files) byPath.set(file.path, file.content);
           files = [...byPath.entries()].map(([path, content]) => ({ path, content }));
         }
+        mode ??= 'publish';
 
         const { version } = await options.gamesStore.putCandidateSources({
           slug,

--- a/apps/api/src/kit-window.test.ts
+++ b/apps/api/src/kit-window.test.ts
@@ -41,6 +41,8 @@ describe('kit window (kits/current.json)', () => {
     expect(report).toContain('cccccccccccccccccccccccccccccccccccccccc');
     expect(report).toContain(REGISTRY.current);
     expect(report).toContain(REGISTRY.previous!);
-    expect(report).toMatch(/get_kit|Refresh the Creator Kit/i);
+    expect(report).toMatch(/get_kit/i);
+    expect(report).toMatch(/fromLatestDelivery/);
+    expect(report).toMatch(/do not re-stage|do not re-upload/i);
   });
 });

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -64,7 +64,9 @@ export function kitOutdatedReport(kitEngineRef: string, registry: KitRegistry): 
       : `current=${registry.current}, previous=${registry.previous}`;
   return (
     `kit_outdated: delivery was built against kitEngineRef=${kitEngineRef}, which is ` +
-    `outside the supported window (${window}). Refresh the Creator Kit (re-run get_kit / ` +
-    `fetch the current kit) and rebuild against it before delivering again.`
+    `outside the supported window (${window}). Re-run get_kit for a fresh engineRef, then ` +
+    `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do not re-stage or ` +
+    `re-upload the whole tree through the model. Only pass files[] for paths you actually ` +
+    `changed for the new kit.`
   );
 }

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -65,8 +65,9 @@ export function kitOutdatedReport(kitEngineRef: string, registry: KitRegistry): 
   return (
     `kit_outdated: delivery was built against kitEngineRef=${kitEngineRef}, which is ` +
     `outside the supported window (${window}). Re-run get_kit for a fresh engineRef, then ` +
-    `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do not re-stage or ` +
-    `re-upload the whole tree through the model. Only pass files[] for paths you actually ` +
-    `changed for the new kit.`
+    `submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — pass the same mode ` +
+    `as this delivery (preview stays preview); omit mode only to reuse that lane. Do not ` +
+    `re-stage or re-upload the whole tree through the model. Only pass files[] for paths ` +
+    `you actually changed for the new kit.`
   );
 }

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -364,6 +364,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(gateVerdict?.description).toMatch(/~30s/);
     expect(gateVerdict?.description).toMatch(/kit_outdated/);
     expect(gateVerdict?.description).toMatch(/re-run get_kit/);
+    expect(gateVerdict?.description).toMatch(/fromLatestDelivery/);
     expect(gateVerdict?.description).toMatch(/terminal receipt/i);
   });
 
@@ -474,7 +475,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/terminal receipt/i);
     // Both failure branches are covered.
     expect(joined).toMatch(/red \/ preview_failed:.*resubmit on the SAME key/i);
-    expect(joined).toMatch(/kit_outdated: re-run get_kit/i);
+    expect(joined).toMatch(/kit_outdated:.*fromLatestDelivery/i);
+    expect(joined).toMatch(/do NOT get_sources \+ re-stage/i);
 
     // Inbox policy: no scheduled polling; drain non-empty pendingMessages from write replies.
     expect(result.structuredContent.inboxPolicy).toMatch(/do not schedule background or recurring inbox checks/i);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2756,9 +2756,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
       description:
         `Deliver game sources. Prefer stage_source_file per path then fromStaged=true (avoids huge tool JSON). ` +
-        `On kit_outdated: get_kit then fromLatestDelivery=true with the new kitEngineRef — do NOT re-upload the whole tree. ` +
+        `On kit_outdated: get_kit then fromLatestDelivery=true with the same mode and new kitEngineRef — do NOT re-upload the whole tree. ` +
         `mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
-        `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
+        `mode=publish (seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
+        `Omitting mode defaults to publish, except with fromLatestDelivery (reuses the previous candidate's lane). ` +
         `files[{path, content, encoding utf8|base64}] optional when fromStaged/fromLatestDelivery (inline paths override); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
         'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
         'gateStarted is true when Cloud Build accepted the gate create — not merely when the upload was accepted. ' +
@@ -2778,8 +2779,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'boolean',
             description:
               'Re-deliver the job’s latest candidate from the store (no re-upload). Use after kit_outdated: ' +
-              'get_kit → submit_sources({ fromLatestDelivery:true, kitEngineRef }). Optional files[] overlay only ' +
-              'the paths you changed. Not with fromStaged.',
+              'get_kit → submit_sources({ fromLatestDelivery:true, mode, kitEngineRef }). Pass the same mode ' +
+              'as the refused delivery (preview stays preview); if mode is omitted the previous lane is inferred. ' +
+              'Optional files[] overlay only the paths you changed. Not with fromStaged.',
           },
           files: {
             type: 'array',
@@ -2802,7 +2804,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'string',
             enum: ['preview', 'publish'],
             description:
-              'preview = iterate without TRACE (Studio draft). publish = sealed candidate (TRACE required; default).',
+              'preview = iterate without TRACE (Studio draft). publish = sealed candidate (TRACE required). ' +
+              'Default publish when omitted, except fromLatestDelivery reuses the previous candidate lane.',
           },
           slug: { type: 'string' },
           note: { type: 'string' },
@@ -2846,7 +2849,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr('kitEngineRef is required — send the engineRef from get_kit / kit.json');
         }
 
-        const mode = args.mode === 'preview' ? 'preview' : 'publish';
+        // Pass mode through only when the agent set it. Omitting lets the channel infer
+        // the previous candidate's lane for fromLatestDelivery (preview kit_outdated
+        // recovery must not suddenly demand TRACE).
+        const mode = args.mode === 'preview' || args.mode === 'publish' ? args.mode : undefined;
 
         const decodedFiles: Array<{ path: string; content: string }> = [];
         for (const file of inlineFiles) {
@@ -2873,7 +2879,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...(fromStaged ? { fromStaged: true } : {}),
           ...(fromLatestDelivery ? { fromLatestDelivery: true } : {}),
           kitEngineRef,
-          mode,
+          ...(mode ? { mode } : {}),
         });
         const body = res.json() as {
           error?: string;
@@ -3018,8 +3024,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Poll the gate verdict for a delivery (default: latest). Preview lane: preview_passed / preview_failed ' +
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
         'Verdicts typically land in 2–5 minutes; poll every ~30s. kit_outdated is terminal — stop polling, ' +
-        're-run get_kit, then submit_sources({ fromLatestDelivery: true, kitEngineRef }) ' +
-        '(do not re-upload the whole tree; do not wait for green/red). ' +
+        're-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
+        '(same mode as the refused delivery; omit mode only to reuse that lane; do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
         "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
         'so the verdict stays readable if the round closes between polls. ' +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -327,7 +327,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Poll get_gate_verdict about every 30s until it is green, red, or kit_outdated (publish lane).',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
-  'kit_outdated: re-run get_kit, rebuild against the new kit, and resubmit.',
+  'kit_outdated: re-run get_kit for a fresh engineRef, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT get_sources + re-stage the whole tree (burns tokens). Only pass files[] for paths you actually changed.',
   // Green closes the round before the next tool call; writes and non-receipt reads then
   // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
   // happen on earlier write replies — do not instruct post-green tools (Codex P1).
@@ -2756,9 +2756,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
       description:
         `Deliver game sources. Prefer stage_source_file per path then fromStaged=true (avoids huge tool JSON). ` +
+        `On kit_outdated: get_kit then fromLatestDelivery=true with the new kitEngineRef — do NOT re-upload the whole tree. ` +
         `mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
         `mode=publish (default, seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
-        `files[{path, content, encoding utf8|base64}] optional when fromStaged=true (inline paths override staged); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
+        `files[{path, content, encoding utf8|base64}] optional when fromStaged/fromLatestDelivery (inline paths override); ≤${MAX_SUBMIT_FILES}; kitEngineRef required. ` +
         'Subject to delivery cap and filename allowlist. Reply includes stop and pendingMessages. ' +
         'gateStarted is true when Cloud Build accepted the gate create — not merely when the upload was accepted. ' +
         'A successful delivery unlocks creator handoff (agentEndedAt); still call end when you will not deliver more (warnings.code=call_end). ' +
@@ -2771,7 +2772,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'boolean',
             description:
               'Assemble the staging buffer built with stage_source_file. Prefer this for large trees. ' +
-              'When true, files[] may be omitted (or used as path overrides).',
+              'When true, files[] may be omitted (or used as path overrides). Not with fromLatestDelivery.',
+          },
+          fromLatestDelivery: {
+            type: 'boolean',
+            description:
+              'Re-deliver the job’s latest candidate from the store (no re-upload). Use after kit_outdated: ' +
+              'get_kit → submit_sources({ fromLatestDelivery:true, kitEngineRef }). Optional files[] overlay only ' +
+              'the paths you changed. Not with fromStaged.',
           },
           files: {
             type: 'array',
@@ -2806,6 +2814,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (!('channelToken' in auth)) return auth;
 
         const fromStaged = args.fromStaged === true;
+        const fromLatestDelivery = args.fromLatestDelivery === true;
+        if (fromStaged && fromLatestDelivery) {
+          return toolErr('fromStaged and fromLatestDelivery cannot both be true — pick one');
+        }
         const filesParse = z
           .array(
             z.object({
@@ -2821,10 +2833,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr(filesParse.error.issues[0]?.message ?? 'invalid files');
         }
         const inlineFiles = filesParse.data ?? [];
-        if (!fromStaged && inlineFiles.length === 0) {
+        if (!fromStaged && !fromLatestDelivery && inlineFiles.length === 0) {
           return toolErr(
-            'submit_sources needs files[] or fromStaged=true after stage_source_file. ' +
-              'For large trees: stage_source_file each path, then submit_sources({ fromStaged: true, mode, kitEngineRef }).',
+            'submit_sources needs files[], fromStaged=true after stage_source_file, or fromLatestDelivery=true. ' +
+              'On kit_outdated: get_kit then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }). ' +
+              'For large first trees: stage_source_file each path, then fromStaged=true.',
           );
         }
 
@@ -2858,6 +2871,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           slug,
           ...(decodedFiles.length ? { files: decodedFiles } : {}),
           ...(fromStaged ? { fromStaged: true } : {}),
+          ...(fromLatestDelivery ? { fromLatestDelivery: true } : {}),
           kitEngineRef,
           mode,
         });
@@ -3004,7 +3018,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Poll the gate verdict for a delivery (default: latest). Preview lane: preview_passed / preview_failed ' +
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
         'Verdicts typically land in 2–5 minutes; poll every ~30s. kit_outdated is terminal — stop polling, ' +
-        're-run get_kit, rebuild against the new kit, and deliver again (do not wait for green/red). ' +
+        're-run get_kit, then submit_sources({ fromLatestDelivery: true, kitEngineRef }) ' +
+        '(do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
         "when your capability's generation owns that delivery (generation may be exactly one behind current), " +
         'so the verdict stays readable if the round closes between polls. ' +

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -313,6 +313,57 @@ describe('self builder (BY-02)', () => {
     expect(stored[0]?.backend).toBe('self');
   });
 
+  it('re-delivers from the latest candidate without re-uploading the tree', async () => {
+    const { gamesStore, stored } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Reuse Delivery', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: KIT_REF, mode: 'preview' },
+    });
+    expect(first.json()).toMatchObject({ accepted: true });
+    expect(stored).toHaveLength(1);
+
+    const nextKit = 'fedcba0987654321';
+    const reused = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: {
+        slug,
+        fromLatestDelivery: true,
+        kitEngineRef: nextKit,
+        mode: 'preview',
+        files: [{ path: 'SPEC.md', content: '# Patched only\n' }],
+      },
+    });
+    expect(reused.statusCode).toBe(200);
+    expect(reused.json()).toMatchObject({ accepted: true });
+    expect(stored).toHaveLength(2);
+    expect(stored[1]?.kitEngineRef).toBe(nextKit);
+    const secondFiles = stored[1]?.files as Array<{ path: string; content: string }>;
+    expect(secondFiles.find((f) => f.path === 'SPEC.md')?.content).toBe('# Patched only\n');
+    expect(secondFiles.find((f) => f.path === 'game.ts')?.content).toBe(
+      MINIMAL_FILES.find((f) => f.path === 'game.ts')!.content,
+    );
+  });
+
   it('rejects a self-build delivery that omits kitEngineRef', async () => {
     const { gamesStore } = stubGamesStore();
     const created = await createApp({ gamesStore });

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -68,9 +68,18 @@ function stubGamesStore(options?: {
     issueNumber: number;
     backend?: string;
     kitEngineRef?: string;
+    mode?: 'preview' | 'publish';
     files: unknown[];
   }> = [];
-  const versions = new Map<string, { files: typeof MINIMAL_FILES; backend?: string; kitEngineRef?: string }>();
+  const versions = new Map<
+    string,
+    {
+      files: typeof MINIMAL_FILES;
+      backend?: string;
+      kitEngineRef?: string;
+      deliveryMode?: 'preview' | 'publish';
+    }
+  >();
   const derived = new Map<string, Buffer>();
   const gamesStore = {
     putCandidateSources: async (input: {
@@ -79,6 +88,7 @@ function stubGamesStore(options?: {
       files: typeof MINIMAL_FILES;
       backend?: string;
       kitEngineRef?: string;
+      mode?: 'preview' | 'publish';
     }) => {
       stored.push(input);
       const version = `v${stored.length}`;
@@ -86,6 +96,7 @@ function stubGamesStore(options?: {
         files: input.files,
         backend: input.backend,
         kitEngineRef: input.kitEngineRef,
+        deliveryMode: input.mode === 'preview' ? 'preview' : 'publish',
       });
       return {
         version,
@@ -96,6 +107,7 @@ function stubGamesStore(options?: {
           issueNumber: input.issueNumber,
           backend: input.backend,
           kitEngineRef: input.kitEngineRef,
+          deliveryMode: input.mode === 'preview' ? 'preview' : 'publish',
           sourceFiles: input.files.map((f) => f.path),
         },
       };
@@ -110,6 +122,7 @@ function stubGamesStore(options?: {
         issueNumber: 0,
         backend: hit.backend,
         kitEngineRef: hit.kitEngineRef,
+        deliveryMode: hit.deliveryMode,
         sourceFiles: hit.files.map((f) => f.path),
         ...(options?.gateGreen !== undefined
           ? { gate: { green: options.gateGreen, ranAt: new Date().toISOString() } }
@@ -325,6 +338,7 @@ describe('self builder (BY-02)', () => {
       headers: authHeaders(),
       payload: { title: 'Reuse Delivery', concept: CONCEPT, builder: 'self' },
     });
+    expect(submit.statusCode).toBe(200);
     const slug = submit.json().slug as string;
     let issueNumber = 0;
     await vi.waitFor(async () => {
@@ -354,14 +368,62 @@ describe('self builder (BY-02)', () => {
       },
     });
     expect(reused.statusCode).toBe(200);
-    expect(reused.json()).toMatchObject({ accepted: true });
+    expect(reused.json()).toMatchObject({ accepted: true, mode: 'preview' });
     expect(stored).toHaveLength(2);
     expect(stored[1]?.kitEngineRef).toBe(nextKit);
+    expect(stored[1]?.mode).toBe('preview');
     const secondFiles = stored[1]?.files as Array<{ path: string; content: string }>;
     expect(secondFiles.find((f) => f.path === 'SPEC.md')?.content).toBe('# Patched only\n');
     expect(secondFiles.find((f) => f.path === 'game.ts')?.content).toBe(
       MINIMAL_FILES.find((f) => f.path === 'game.ts')!.content,
     );
+  });
+
+  it('fromLatestDelivery without mode reuses the previous candidate lane', async () => {
+    const { gamesStore, stored } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Infer Preview Lane', concept: CONCEPT, builder: 'self' },
+    });
+    expect(submit.statusCode).toBe(200);
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+
+    // Preview candidates may omit TRACE/PLAYTEST — kit_outdated recovery must not
+    // silently flip to publish and 400 on those seals.
+    const previewOnly = MINIMAL_FILES.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json');
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: previewOnly, kitEngineRef: KIT_REF, mode: 'preview' },
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json()).toMatchObject({ accepted: true, mode: 'preview' });
+
+    const reused = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: {
+        slug,
+        fromLatestDelivery: true,
+        kitEngineRef: 'fedcba0987654321',
+        // mode omitted on purpose — must stay preview
+      },
+    });
+    expect(reused.statusCode).toBe(200);
+    expect(reused.json()).toMatchObject({ accepted: true, mode: 'preview' });
+    expect(stored[1]?.mode).toBe('preview');
   });
 
   it('rejects a self-build delivery that omits kitEngineRef', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BYOCA agents hit `kit_outdated` after a Creator Kit rotate and then re-`stage_source_file`'d the whole tree (~tens of thousands of tokens). This adds `submit_sources({ fromLatestDelivery: true, … })` so the API copies the last stored candidate server-side (optional `files[]` overlays only).

### Review follow-ups
- **Preserve preview lane:** when `fromLatestDelivery` is set and `mode` is omitted, reuse the previous candidate’s `deliveryMode` instead of defaulting to `publish` (which 400s TRACE-less preview trees).
- Tool/workflow copy names `mode` explicitly; MCP no longer forces `mode: "publish"` when the agent omits it on this path.
- Copilot nit: assert `submit.statusCode` in the self-build regression test.
- Rebased onto master after #566 landed the 232 KiB serve-budget lockstep (that was the earlier Games-repo contract CI failure).

## Test plan
- [x] `apps/api` vitest: self-build / mcp-server / kit-window
- [ ] CI green after rebase
- [ ] Manual: preview → kit_outdated → `fromLatestDelivery` without mode stays preview
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e61ce059-7121-4fa0-943a-9da216b4ce56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e61ce059-7121-4fa0-943a-9da216b4ce56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

