### PR TITLE
Raise games author budget to 232 KiB

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -26,9 +26,9 @@
     "voice",
     "editor"
   ],
-  "authorBudgetBytes": 217088,
+  "authorBudgetBytes": 237568,
   "platformCeilingBytes": 330000,
-  "maxProjectBytes": 547088,
+  "maxProjectBytes": 567568,
   "audio": {
     "musicField": "string",
     "musicTracksField": "string[]",

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(547_088);
+    expect(MAX_PROJECT_BYTES).toBe(567_568);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(547_088);
+    expect(MAX_PROJECT_BYTES).toBe(567_568);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -229,7 +229,7 @@ describe('games-repo source extractors', () => {
     // The extractor still has to resolve `BUDGET + PLATFORM` (and `a + b` / `a * b`
     // forms inside those consts), not only bare literals.
     const source = `
-      const GAME_BUDGET_BYTES = 212 * 1024;
+      const GAME_BUDGET_BYTES = 232 * 1024;
       const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
@@ -238,7 +238,7 @@ describe('games-repo source extractors', () => {
 
   it('still evaluates a + b allowance expressions when a tip uses them', () => {
     const source = `
-      const GAME_BUDGET_BYTES = 212 * 1024;
+      const GAME_BUDGET_BYTES = 232 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
       const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -80,7 +80,7 @@ export const GAME_KIT_MODULES = [
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 
 /** Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`. */
-export const GAME_BUDGET_BYTES = 212 * 1024;
+export const GAME_BUDGET_BYTES = 232 * 1024;
 
 /**
  * Raw TypeScript source-graph ceiling for the bake/play/seed bundlers
@@ -88,7 +88,7 @@ export const GAME_BUDGET_BYTES = 212 * 1024;
  * `seed-bundle.ts`). Lockstep with games-repo Check 4 `SOURCE_GRAPH_BUDGET_BYTES`.
  *
  * Distinct from {@link GAME_BUDGET_BYTES}: the assembled author payload can stay
- * under 212 KiB while comments and types push the `.ts` tree higher. Last moved
+ * under 232 KiB while comments and types push the `.ts` tree higher. Last moved
  * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish.
  */
 export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
@@ -97,18 +97,23 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (547_088, matching `maxProjectBytes`). Not a round KiB.
+ * (567_568, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
- * 212 KiB author budget; this number is serve-compat only so a game that clears that
+ * 232 KiB author budget; this number is serve-compat only so a game that clears that
  * gate is not refused here. Feature-by-feature archaeology lives in the games repo's
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * The author budget last moved for `carjack-city`'s organic incidents and believable
- * service dispatch: its author payload measures 208_829 bytes. Keep the full flagship
- * implementation. 200 → 212 KiB, and the serve cap 534_800 → 547_088.
+ * The author budget last moved for `carjack-city`'s active-run persistence on top of
+ * the organic incident simulation: the assembled project measured 563_200 bytes and
+ * stranded snapshot publish against the 547_088 serve cap (run 30928592522). Games-repo
+ * #479 already raised Check 4 to 232 KiB; keep the full flagship implementation.
+ * 212 → 232 KiB, and the serve cap 547_088 → 567_568.
+ *
+ * Before that, organic incidents and believable service dispatch: author payload
+ * 208_829 bytes. 200 → 212 KiB, serve cap 534_800 → 547_088.
  *
  * Before that, `carjack-city`'s day/night and reactive-world work moved the platform
  * ceiling: its selected platform measures 327_252 bytes while the game remained within

--- a/docs/games-repo-validation-spec.md
+++ b/docs/games-repo-validation-spec.md
@@ -21,7 +21,7 @@ This specification defines the quality gates enforced on incoming pull requests 
 
 ### 2. Game Bundle Size Cap
 
-- Hard failure if the author's own bytes exceed 217,088 (212 KiB). Games-repo Check 4
+- Hard failure if the author's own bytes exceed 237,568 (232 KiB). Games-repo Check 4
   measures those as `assembled − platformBytes` (selected GameKit modules, inlined audio,
   shell CSS) — a platform change cannot break a published game whose author spent nothing.
 - On top of that sits a single serve-compat platform ceiling for the touch pad, restart


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Snapshot publish [run 30928592522](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30928592522/job/92057220791) failed:

`carjack-city: generated project is 563200 bytes, over the 547088 cap`

Games-repo #479 already raised Check 4 to **232 KiB** / `maxProjectBytes` **567568**. The website half was still on 212 KiB, so bake refused a game that already cleared validate over there (exactly the window `docs/games-repo-validation-spec.md` warns about).

## Change

- `GAME_BUDGET_BYTES`: 212 → **232 KiB**
- `MAX_PROJECT_BYTES`: 547088 → **567568**
- Fixture `assemble-contract.json` + unit expectations + validation-spec prose locked to the same numbers

No platform-ceiling change (`GAMEKIT_PLATFORM_BYTES` stays 330000).

## After merge

Re-run the snapshot publish workflow (or wait for the next games-repo push dispatch) so the pointer can advance past the stranded bake.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90884467-98ef-40fd-a92e-ace517734339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90884467-98ef-40fd-a92e-ace517734339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

