### PR TITLE
Raise GameKit platform ceiling to 340 KiB

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 237568,
-  "platformCeilingBytes": 330000,
-  "maxProjectBytes": 567568,
+  "platformCeilingBytes": 340000,
+  "maxProjectBytes": 577568,
   "audio": {
     "musicField": "string",
     "musicTracksField": "string[]",

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(567_568);
+    expect(MAX_PROJECT_BYTES).toBe(577_568);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(567_568);
+    expect(MAX_PROJECT_BYTES).toBe(577_568);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -230,7 +230,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 232 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 330_000;
+      const GAMEKIT_PLATFORM_BYTES = 340_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -240,7 +240,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 232 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 326_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -97,7 +97,7 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (567_568, matching `maxProjectBytes`). Not a round KiB.
+ * (577_568, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,32 +106,21 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * The author budget last moved for `carjack-city`'s active-run persistence on top of
- * the organic incident simulation: the assembled project measured 563_200 bytes and
- * stranded snapshot publish against the 547_088 serve cap (run 30928592522). Games-repo
- * #479 already raised Check 4 to 232 KiB; keep the full flagship implementation.
- * 212 → 232 KiB, and the serve cap 547_088 → 567_568.
+ * The platform ceiling last moved for the urban top-down vehicle body + grid helper
+ * promotion that pulled carjack-city hull/shape paint and sidewalk/block walks into
+ * GameKit: measured platform 333_323 bytes. 330_000 → 340_000, serve cap
+ * 567_568 → 577_568.
  *
- * Before that, organic incidents and believable service dispatch: author payload
- * 208_829 bytes. 200 → 212 KiB, serve cap 534_800 → 547_088.
+ * Before that, author budget for active-run persistence: 212 → 232 KiB, serve cap
+ * 547_088 → 567_568 (run 30928592522 / games-repo #479).
  *
- * Before that, `carjack-city`'s day/night and reactive-world work moved the platform
- * ceiling: its selected platform measures 327_252 bytes while the game remained within
- * the then-200 KiB author budget (199_723 bytes). 313_000 → 330_000, and the serve cap
- * 517_800 → 534_800. Snapshot publish was stranded at 517_889 with the old ceiling
- * (run 30909878136); games-repo #477 shipped the matching contract.
+ * Before that, organic incidents: 200 → 212 KiB, serve cap 534_800 → 547_088.
  *
- * The drift this corrects is older and larger than that change: the constant has
- * never tracked the heaviest selection. `apex-sprint` (gfx3d) already measures
- * 434_497 platform bytes and passes only because its author payload is small. Sized
- * here to the heaviest 2D selection rather than to gfx3d, which would put the
- * backstop above 639 KB and stop it backstopping anything.
+ * Before that, day/night platform: 313_000 → 330_000, serve cap 517_800 → 534_800.
  *
- * Before it, the opt-in `editor` module (EditorKit L2): +3_700 measured,
- * 482_687 → 486_387. Before that, sensing Phase 2 (camera backdrop) raised the
- * sensing ledger line 6_500 → 9_000 (+2_500), 480_187 → 482_687.
+ * Sized here to the heaviest 2D selection rather than to gfx3d.
  */
-export const GAMEKIT_PLATFORM_BYTES = 330_000;
+export const GAMEKIT_PLATFORM_BYTES = 340_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Paired with the carjack unbloat / urban promotion in `www.gamedev.pl-games`. That extract moves top-down vehicle hull/shape paint and sidewalk/block walks into the `urban` vertical; measured carjack platform becomes **333 323** bytes, which exceeds today’s **330 000** `GAMEKIT_PLATFORM_BYTES` ceiling.

Merge this **before** the games-repo half so bake cannot refuse a game that already clears Check 4 over there (`docs/games-repo-validation-spec.md`).

## Change

- `GAMEKIT_PLATFORM_BYTES`: 330 000 → **340 000**
- `MAX_PROJECT_BYTES`: 567 568 → **577 568**
- Fixture + unit expectations locked to the same numbers

Author budget stays **232 KiB**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90884467-98ef-40fd-a92e-ace517734339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90884467-98ef-40fd-a92e-ace517734339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

