### PR TITLE
Increase game and source budgets for carjack-city features

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -26,9 +26,9 @@
     "voice",
     "editor"
   ],
-  "authorBudgetBytes": 237568,
+  "authorBudgetBytes": 253952,
   "platformCeilingBytes": 330000,
-  "maxProjectBytes": 567568,
+  "maxProjectBytes": 583952,
   "audio": {
     "musicField": "string",
     "musicTracksField": "string[]",

--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -26,9 +26,9 @@
     "voice",
     "editor"
   ],
-  "authorBudgetBytes": 253952,
+  "authorBudgetBytes": 258048,
   "platformCeilingBytes": 330000,
-  "maxProjectBytes": 583952,
+  "maxProjectBytes": 588048,
   "audio": {
     "musicField": "string",
     "musicTracksField": "string[]",

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(583_952);
+    expect(MAX_PROJECT_BYTES).toBe(588_048);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(567_568);
+    expect(MAX_PROJECT_BYTES).toBe(583_952);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(567_568);
+    expect(MAX_PROJECT_BYTES).toBe(583_952);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -53,8 +53,8 @@ describe('games-repo-contract (website half)', () => {
 
   it('keeps the bake/play source-graph ceiling above the assembled author budget', () => {
     // Raw `.ts` can exceed assembled author bytes (comments/types). Carjack-city
-    // at ~247 KiB is why this is 300 KiB rather than matching GAME_BUDGET_BYTES.
-    expect(SOURCE_GRAPH_BUDGET_BYTES).toBe(300 * 1024);
+    // at ~320 KiB source is why this is 324 KiB rather than matching GAME_BUDGET_BYTES.
+    expect(SOURCE_GRAPH_BUDGET_BYTES).toBe(324 * 1024);
     expect(SOURCE_GRAPH_BUDGET_BYTES).toBeGreaterThan(GAME_BUDGET_BYTES);
   });
 
@@ -229,7 +229,7 @@ describe('games-repo source extractors', () => {
     // The extractor still has to resolve `BUDGET + PLATFORM` (and `a + b` / `a * b`
     // forms inside those consts), not only bare literals.
     const source = `
-      const GAME_BUDGET_BYTES = 232 * 1024;
+      const GAME_BUDGET_BYTES = 248 * 1024;
       const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
@@ -238,7 +238,7 @@ describe('games-repo source extractors', () => {
 
   it('still evaluates a + b allowance expressions when a tip uses them', () => {
     const source = `
-      const GAME_BUDGET_BYTES = 232 * 1024;
+      const GAME_BUDGET_BYTES = 248 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
       const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(583_952);
+    expect(MAX_PROJECT_BYTES).toBe(588_048);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -53,8 +53,8 @@ describe('games-repo-contract (website half)', () => {
 
   it('keeps the bake/play source-graph ceiling above the assembled author budget', () => {
     // Raw `.ts` can exceed assembled author bytes (comments/types). Carjack-city
-    // at ~320 KiB source is why this is 324 KiB rather than matching GAME_BUDGET_BYTES.
-    expect(SOURCE_GRAPH_BUDGET_BYTES).toBe(324 * 1024);
+    // at ~334 KiB source is why this is 336 KiB rather than matching GAME_BUDGET_BYTES.
+    expect(SOURCE_GRAPH_BUDGET_BYTES).toBe(336 * 1024);
     expect(SOURCE_GRAPH_BUDGET_BYTES).toBeGreaterThan(GAME_BUDGET_BYTES);
   });
 
@@ -229,7 +229,7 @@ describe('games-repo source extractors', () => {
     // The extractor still has to resolve `BUDGET + PLATFORM` (and `a + b` / `a * b`
     // forms inside those consts), not only bare literals.
     const source = `
-      const GAME_BUDGET_BYTES = 248 * 1024;
+      const GAME_BUDGET_BYTES = 252 * 1024;
       const GAMEKIT_PLATFORM_BYTES = 330_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
@@ -238,7 +238,7 @@ describe('games-repo source extractors', () => {
 
   it('still evaluates a + b allowance expressions when a tip uses them', () => {
     const source = `
-      const GAME_BUDGET_BYTES = 248 * 1024;
+      const GAME_BUDGET_BYTES = 252 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
       const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 316_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -80,7 +80,7 @@ export const GAME_KIT_MODULES = [
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 
 /** Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`. */
-export const GAME_BUDGET_BYTES = 248 * 1024;
+export const GAME_BUDGET_BYTES = 252 * 1024;
 
 /**
  * Raw TypeScript source-graph ceiling for the bake/play/seed bundlers
@@ -90,16 +90,16 @@ export const GAME_BUDGET_BYTES = 248 * 1024;
  * Distinct from {@link GAME_BUDGET_BYTES}: the assembled author payload can stay
  * under the author budget while comments and types push the `.ts` tree higher. Moved
  * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish;
- * 300 → 324 KiB for the same game's island coastline, on-foot car collision and
- * mission-ladder work — 327_685 raw bytes carrying 247_459 assembled ones.
+ * 300 → 336 KiB for the same game's island coastline, on-foot car collision and
+ * mission-ladder work — 334_122 raw bytes carrying 251_700 assembled ones.
  */
-export const SOURCE_GRAPH_BUDGET_BYTES = 324 * 1024;
+export const SOURCE_GRAPH_BUDGET_BYTES = 336 * 1024;
 
 /**
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (583_952, matching `maxProjectBytes`). Not a round KiB.
+ * (588_048, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -109,10 +109,11 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 324 * 1024;
  * would exceed it — do not re-split it into named allowances on this side either.
  *
  * The author budget last moved for `carjack-city` again: a real island coastline every
- * system obeys (the road network is clipped to it, so traffic cannot route out to sea),
- * solid car hulls for everyone on foot, and the mission ladder's chain economy measure
- * 247_459 author bytes against 864 bytes of headroom. Platform bytes are untouched.
- * 232 → 248 KiB, and the serve cap 567_568 → 583_952.
+ * system obeys (the street plan is clipped to it, held back behind the beach and eroded
+ * back to its junctions, so nothing runs into the sea), solid car hulls for everyone on
+ * foot, and the mission ladder's chain economy measure 251_700 author bytes against 864
+ * bytes of headroom. Platform bytes are untouched.
+ * 232 → 252 KiB, and the serve cap 567_568 → 588_048.
  *
  * Before that, `carjack-city`'s active-run persistence on top of
  * the organic incident simulation: the assembled project measured 563_200 bytes and

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -80,7 +80,7 @@ export const GAME_KIT_MODULES = [
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 
 /** Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`. */
-export const GAME_BUDGET_BYTES = 232 * 1024;
+export const GAME_BUDGET_BYTES = 248 * 1024;
 
 /**
  * Raw TypeScript source-graph ceiling for the bake/play/seed bundlers
@@ -88,16 +88,18 @@ export const GAME_BUDGET_BYTES = 232 * 1024;
  * `seed-bundle.ts`). Lockstep with games-repo Check 4 `SOURCE_GRAPH_BUDGET_BYTES`.
  *
  * Distinct from {@link GAME_BUDGET_BYTES}: the assembled author payload can stay
- * under 232 KiB while comments and types push the `.ts` tree higher. Last moved
- * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish.
+ * under the author budget while comments and types push the `.ts` tree higher. Moved
+ * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish;
+ * 300 → 324 KiB for the same game's island coastline, on-foot car collision and
+ * mission-ladder work — 327_685 raw bytes carrying 247_459 assembled ones.
  */
-export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
+export const SOURCE_GRAPH_BUDGET_BYTES = 324 * 1024;
 
 /**
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
  * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
- * (567_568, matching `maxProjectBytes`). Not a round KiB.
+ * (583_952, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
@@ -106,7 +108,13 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 300 * 1024;
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * The author budget last moved for `carjack-city`'s active-run persistence on top of
+ * The author budget last moved for `carjack-city` again: a real island coastline every
+ * system obeys (the road network is clipped to it, so traffic cannot route out to sea),
+ * solid car hulls for everyone on foot, and the mission ladder's chain economy measure
+ * 247_459 author bytes against 864 bytes of headroom. Platform bytes are untouched.
+ * 232 → 248 KiB, and the serve cap 567_568 → 583_952.
+ *
+ * Before that, `carjack-city`'s active-run persistence on top of
  * the organic incident simulation: the assembled project measured 563_200 bytes and
  * stranded snapshot publish against the 547_088 serve cap (run 30928592522). Games-repo
  * #479 already raised Check 4 to 232 KiB; keep the full flagship implementation.


### PR DESCRIPTION
## Summary
Increases the author-facing game budget and raw TypeScript source-graph ceiling to accommodate new features in carjack-city, including island coastline, solid car hulls, and mission ladder implementation.

## Key Changes
- **GAME_BUDGET_BYTES**: Increased from 232 KiB to 252 KiB (20 KiB increase)
- **SOURCE_GRAPH_BUDGET_BYTES**: Increased from 300 KiB to 336 KiB (36 KiB increase)
- **MAX_BUNDLE_BYTES**: Updated from 567,568 to 588,048 bytes (20,480 bytes increase)
- **authorBudgetBytes** in assemble-contract.json: Updated from 237,568 to 258,048 bytes
- Updated test expectations and documentation to reflect new budget values

## Implementation Details
The increases are driven by carjack-city's new features:
- Real island coastline with street plan clipping and beach erosion
- Solid car hulls for all on-foot players
- Mission ladder chain economy system

The assembled project now measures 251,700 author bytes with only 864 bytes of headroom remaining. The platform bytes remain untouched at 330,000 bytes. All budget constants maintain their lockstep relationship across the codebase (games-repo Check 4 and website-side contracts).

https://claude.ai/code/session_012h4GUeiXLNyr9PHnTa6gUX