### PR TITLE
Guard game iframe against WebMCP tool exposure

### DIFF
--- a/apps/web/src/GameFrame.sandbox.test.ts
+++ b/apps/web/src/GameFrame.sandbox.test.ts
@@ -22,6 +22,10 @@ describe('Sandbox Invariant Security Guard', () => {
     expect(iframe).not.toBeNull();
     expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts allow-pointer-lock');
     expect(iframe?.getAttribute('allow')).toBe('accelerometer; gyroscope; magnetometer');
+    // WebMCP guard: `allow="tools"` would expose browser-agent tool registration
+    // to untrusted game code. The exact match above already forbids it; this names
+    // the invariant so it survives future edits to the sensor list.
+    expect(iframe?.getAttribute('allow') ?? '').not.toContain('tools');
 
     act(() => {
       root.unmount();

--- a/apps/web/src/GameFrame.tsx
+++ b/apps/web/src/GameFrame.tsx
@@ -33,6 +33,11 @@ type GameFrameProps = GameFrameSource & {
  * Microphone loudness for shout games is owned by the theater shell
  * (`useVoiceMeterBridge`). Opaque-origin documents cannot call `getUserMedia`
  * without `allow-same-origin`, which we never grant.
+ *
+ * The `allow` list must never grow `tools`: WebMCP-capable browsers expose agent
+ * tool registration to a cross-origin iframe granted `allow="tools"`, and game
+ * code is untrusted — it must never present tools to a visitor's browser agent.
+ * Asserted in GameFrame.sandbox.test.ts; invariant in docs/security-model.md.
  */
 export function GameFrame(props: GameFrameProps) {
   const localRef = useRef<HTMLIFrameElement>(null);

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -106,10 +106,16 @@ credentials operated by gamedev.pl. Historical details are available in Git hist
 ## Non-negotiable invariants
 
 - Games render only in `sandbox="allow-scripts allow-pointer-lock"` without `allow-same-origin`.
-- The game iframe never gains an `allow=` permission delegation. Device capabilities
-  (party input, device tilt — `apps/web/src/sensing.ts`) are read by the shell on its own
-  origin and relayed as clamped, structured postMessage data; raw sensor readings and
-  camera pixels never cross into a game and never leave the browser.
+- The game iframe's `allow=` delegation is pinned to exactly
+  `accelerometer; gyroscope; magnetometer` (opt-in GameKit tilt) and never grows —
+  asserted by `apps/web/src/GameFrame.sandbox.test.ts`. In particular it never includes
+  `tools`: WebMCP-capable browsers expose agent tool registration to a cross-origin
+  iframe only when it is granted `allow="tools"`, and granting that would let untrusted
+  game code present tools to a visitor's in-browser agent under our name. If the shell
+  ever registers WebMCP tools itself, only the shell does — game-derived capability
+  keeps crossing the postMessage bridge as data. Camera pixels and microphone loudness
+  stay shell-owned, and party input / shell-read sensors reach games only as clamped,
+  structured postMessage data.
 - Games are served from a separate cookieless origin in production.
 - Public specs and issue text are data, never agent instructions.
 - Agent-authored changes require review and validation; they are never auto-merged.


### PR DESCRIPTION
## Summary
This PR strengthens the security model by explicitly preventing game iframes from gaining `allow="tools"` permission, which would expose browser agent tool registration to untrusted game code.

## Key Changes
- **Security Model Documentation**: Updated `docs/security-model.md` to clarify that the game iframe's `allow=` delegation is pinned to exactly `accelerometer; gyroscope; magnetometer` and explicitly forbids `tools`. Added explanation of the WebMCP threat: granting `allow="tools"` would let untrusted game code present tools to a visitor's in-browser agent under the shell's name.

- **Code Comments**: Enhanced `GameFrame.tsx` with a detailed comment explaining why `tools` must never be added to the `allow` list, with cross-reference to the test assertion and security model documentation.

- **Test Assertion**: Added explicit test in `GameFrame.sandbox.test.ts` that verifies the `allow` attribute does not contain `tools`. This named invariant ensures the security constraint survives future edits to the sensor permission list.

## Implementation Details
The changes are defensive in nature—the exact match assertion on `allow="accelerometer; gyroscope; magnetometer"` already prevents `tools` from being added, but the new test makes the invariant explicit and documents the specific threat model. This follows the principle of making security constraints visible and testable rather than relying on implicit assumptions.

https://claude.ai/code/session_01W4QVtQPu8yR1AzcA2pwvhr