### PR TITLE
Raise GameKit platform ceiling to 380 KiB

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -27,8 +27,8 @@
     "editor"
   ],
   "authorBudgetBytes": 258048,
-  "platformCeilingBytes": 340000,
-  "maxProjectBytes": 598048,
+  "platformCeilingBytes": 380000,
+  "maxProjectBytes": 638048,
   "audio": {
     "musicField": "string",
     "musicTracksField": "string[]",

--- a/apps/api/src/assemble.test.ts
+++ b/apps/api/src/assemble.test.ts
@@ -20,7 +20,7 @@ describe('the size cap', () => {
     // Sourced from games-repo-contract.ts; CI re-checks the live games-repo
     // MAX_BUNDLE_BYTES when GAMES_REPO_TOKEN is set (issue #247). Website-first
     // budget raises update this number before games-repo main catches up.
-    expect(MAX_PROJECT_BYTES).toBe(598_048);
+    expect(MAX_PROJECT_BYTES).toBe(638_048);
   });
 
   it('accepts a game that fills the budget', () => {

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -45,7 +45,7 @@ function validContract(): Record<string, unknown> {
 
 describe('games-repo-contract (website half)', () => {
   it('keeps the serve budget at the Check 4 total (games-repo MAX_BUNDLE_BYTES)', () => {
-    expect(MAX_PROJECT_BYTES).toBe(598_048);
+    expect(MAX_PROJECT_BYTES).toBe(638_048);
     expect(GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES).toBe(MAX_PROJECT_BYTES);
     // assemble.ts must re-export the same number — a second literal would drift.
     expect(ASSEMBLE_MAX).toBe(MAX_PROJECT_BYTES);
@@ -230,7 +230,7 @@ describe('games-repo source extractors', () => {
     // forms inside those consts), not only bare literals.
     const source = `
       const GAME_BUDGET_BYTES = 252 * 1024;
-      const GAMEKIT_PLATFORM_BYTES = 340_000;
+      const GAMEKIT_PLATFORM_BYTES = 380_000;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);
@@ -240,7 +240,7 @@ describe('games-repo source extractors', () => {
     const source = `
       const GAME_BUDGET_BYTES = 252 * 1024;
       const GAMEKIT_TOUCH_BYTES = 7_501 + 5_560;
-      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 326_939;
+      const GAMEKIT_PLATFORM_BYTES = GAMEKIT_TOUCH_BYTES + 366_939;
       const MAX_BUNDLE_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;
     `;
     expect(extractMaxBundleBytes(source)).toBe(MAX_PROJECT_BYTES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -98,39 +98,32 @@ export const SOURCE_GRAPH_BUDGET_BYTES = 336 * 1024;
 /**
  * Platform half of the serve cap — games-repo `GAMEKIT_PLATFORM_BYTES` /
  * `assemble-contract.json` `platformCeilingBytes`. Together with
- * {@link GAME_BUDGET_BYTES} this must be at least games-repo `MAX_BUNDLE_BYTES`
- * (598_048 here, matching `maxProjectBytes`; the games repo is at 588_048 until its
- * own platform raise lands, and website-ahead is the safe direction). Not a round KiB.
+ * {@link GAME_BUDGET_BYTES} this must equal games-repo `MAX_BUNDLE_BYTES`
+ * (638_048, matching `maxProjectBytes`). Not a round KiB.
  *
  * One derived ceiling, not a sum of per-feature constants (games-repo #281). Check 4
  * over there bills each author for measured `assembled − platformBytes` against the
- * 232 KiB author budget; this number is serve-compat only so a game that clears that
+ * 252 KiB author budget; this number is serve-compat only so a game that clears that
  * gate is not refused here. Feature-by-feature archaeology lives in the games repo's
  * `docs/platform-byte-ledger.md`. Raise this when measurement shows a passing game
  * would exceed it — do not re-split it into named allowances on this side either.
  *
- * The author budget last moved for `carjack-city` again: a real island coastline every
- * system obeys (the street plan is clipped to it, held back behind the beach and eroded
- * back to its junctions, so nothing runs into the sea), solid car hulls for everyone on
- * foot, and the mission ladder's chain economy measure 252_340 author bytes against 864
- * bytes of headroom. Platform bytes are untouched by that change.
- * 232 → 252 KiB, and the serve cap 577_568 → 598_048.
+ * The platform ceiling last moved for the urban ground/shadow + headlight + extrusion
+ * promotion that pulled carjack-city street paint and cast shadows into GameKit:
+ * measured platform ~369_006 bytes. 340_000 → 380_000, serve cap 598_048 → 638_048.
  *
- * Before that, the platform ceiling moved for the urban top-down vehicle body + grid
- * helper promotion that pulled carjack-city hull/shape paint and sidewalk/block walks
- * into GameKit: measured platform 333_323 bytes. 330_000 → 340_000, serve cap
- * 567_568 → 577_568.
+ * Before that, the author budget moved for `carjack-city` island coastline / on-foot
+ * car collision / mission ladder: 232 → 252 KiB, serve cap 577_568 → 598_048.
  *
- * Before that, author budget for active-run persistence: 212 → 232 KiB, serve cap
- * 547_088 → 567_568 (run 30928592522 / games-repo #479).
+ * Before that, platform moved for urban top-down vehicle body + grid helpers:
+ * measured platform 333_323 bytes. 330_000 → 340_000.
  *
- * Before that, organic incidents: 200 → 212 KiB, serve cap 534_800 → 547_088.
- *
- * Before that, day/night platform: 313_000 → 330_000, serve cap 517_800 → 534_800.
+ * Before that, author budget for active-run persistence: 212 → 232 KiB
+ * (run 30928592522 / games-repo #479).
  *
  * Sized here to the heaviest 2D selection rather than to gfx3d.
  */
-export const GAMEKIT_PLATFORM_BYTES = 340_000;
+export const GAMEKIT_PLATFORM_BYTES = 380_000;
 
 /** Combined html+js+css size cap — must match games-repo `MAX_BUNDLE_BYTES`. */
 export const MAX_PROJECT_BYTES = GAME_BUDGET_BYTES + GAMEKIT_PLATFORM_BYTES;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Paired with the carjack unbloat / urban promotion in `www.gamedev.pl-games` ([PR #527](https://github.com/gamedevpl/www.gamedev.pl-games/pull/527)). That extract moves building extrusion, vehicle FX, routing, headlights, road/sidewalk paint, and cast-shadow helpers into the `urban` vertical; measured carjack platform becomes **~369 006** bytes, which exceeds today’s **340 000** `GAMEKIT_PLATFORM_BYTES` ceiling.

Rebased onto `master` after [#568](https://github.com/gamedevpl/www.gamedev.pl/pull/568) (author budget 252 KiB). This PR only raises the **platform** half.

Merge this **before** the games-repo half so bake cannot refuse a game that already clears Check 4 over there (`docs/games-repo-validation-spec.md`).

## Change

- `GAMEKIT_PLATFORM_BYTES`: 340 000 → **380 000**
- `MAX_PROJECT_BYTES`: 598 048 → **638 048**
- Author budget stays **252 KiB** (from #568)
- Fixture + unit expectations locked to the same numbers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90884467-98ef-40fd-a92e-ace517734339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90884467-98ef-40fd-a92e-ace517734339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

