### PR TITLE
Register GameKit vehicles vertical in the module contract

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -7,6 +7,7 @@
     "world",
     "ai",
     "gameplay",
+    "vehicles",
     "urban",
     "drawing",
     "actors",

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -296,6 +296,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   // as soon as its paired games change lands; the deadline is the fail-closed backstop.
   const WEBSITE_AHEAD_EXPIRY: ReadonlyMap<string, number> = new Map([
     ['football', Date.parse('2026-08-10T00:00:00.000Z')],
+    ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -93,6 +93,7 @@ describe('games-repo-contract (website half)', () => {
       'world',
       'ai',
       'gameplay',
+      'vehicles',
       'urban',
       'drawing',
       'actors',
@@ -216,7 +217,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'ai', 'gameplay', 'urban',
+        'input', 'collision', 'world', 'ai', 'gameplay', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -44,6 +44,8 @@ export const GAME_KIT_MODULES = [
   'world',
   'ai',
   'gameplay',
+  // Top-down arcade vehicle paint/lights — pairs with gameplay.driveArcadeVehicle.
+  'vehicles',
   // Genre vertical: deterministic street topology and routing for 2D urban games.
   'urban',
   'drawing',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Paired with `www.gamedev.pl-games` [#527](https://github.com/gamedevpl/www.gamedev.pl-games/pull/527), which course-corrects carjack kit promotions: top-down vehicle paint/lights leave `urban` for a dedicated **`vehicles`** vertical (`GameKit.arcadeVehicles`).

[#571](https://github.com/gamedevpl/www.gamedev.pl/pull/571) already raised the platform ceiling; this PR only registers the new module name (website-first, grace until 2026-09-01).

Merge **before** the games-repo half.

## Change

- `GAME_KIT_MODULES`: insert **`vehicles`** after `gameplay`, before `urban`
- Fixture + contract-check grace list updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90884467-98ef-40fd-a92e-ace517734339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90884467-98ef-40fd-a92e-ace517734339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

