### PR TITLE
Add MCP Apps views (SEP-1865) Phase 0 spike

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@
 # ADMIN_UIDS=
 # DAILY_GENERATION_QUOTA=20
 
+# --- Remote MCP --------------------------------------------------------------------
+# MCP_UI=true turns on MCP Apps views (SEP-1865) on /api/mcp: a ui:// resource registry
+# and _meta.ui on the tools that have a view. Off by default, and even when on it only
+# ever reaches a client that declared the io.modelcontextprotocol/ui extension — every
+# other client sees the same tools/list and initialize result as before.
+# MCP_UI=false
+
 # --- Hosting -----------------------------------------------------------------------
 # PORT=3001
 # HOST=127.0.0.1

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1877,3 +1877,141 @@ describe('POST /api/mcp (BY-05)', () => {
     });
   });
 });
+
+describe('MCP Apps views (SEP-1865, Phase 0)', () => {
+  let app: FastifyInstance | null = null;
+  const previousFlag = process.env.MCP_UI;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+    if (previousFlag === undefined) delete process.env.MCP_UI;
+    else process.env.MCP_UI = previousFlag;
+  });
+
+  const UI_EXTENSION = 'io.modelcontextprotocol/ui';
+  const UI_MIME = 'text/html;profile=mcp-app';
+
+  async function initializeWith(instance: FastifyInstance, declaresUi: boolean) {
+    const res = await mcpCall(instance, 'initialize', {
+      protocolVersion: '2025-11-25',
+      capabilities: declaresUi ? { extensions: { [UI_EXTENSION]: { mimeTypes: [UI_MIME] } } } : {},
+      clientInfo: { name: declaresUi ? 'view-capable-host' : 'plain-agent', version: '0' },
+    });
+    expect(res.statusCode).toBe(200);
+    return {
+      sessionId: String(res.headers['mcp-session-id']),
+      capabilities: res.json().result.capabilities as Record<string, unknown>,
+    };
+  }
+
+  async function listTools(instance: FastifyInstance, sessionId: string) {
+    const listed = await mcpCall(instance, 'tools/list', {}, { 'mcp-session-id': sessionId });
+    expect(listed.statusCode).toBe(200);
+    return listed.json().result.tools as Array<{ name: string; _meta?: { ui?: { resourceUri?: string } } }>;
+  }
+
+  it('leaves every non-declaring client on the pre-views contract, flag on or not', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const { sessionId, capabilities } = await initializeWith(app, false);
+    // A client that never negotiated views is told nothing about them.
+    expect(capabilities).toEqual({ tools: { listChanged: false } });
+    expect(capabilities.extensions).toBeUndefined();
+    expect(capabilities.resources).toBeUndefined();
+
+    const tools = await listTools(app, sessionId);
+    expect(tools.length).toBeGreaterThan(10);
+    expect(tools.every((tool) => tool._meta === undefined)).toBe(true);
+  });
+
+  it('echoes the extension and attaches the card once a client declares it', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const { sessionId, capabilities } = await initializeWith(app, true);
+    expect(capabilities.extensions).toEqual({ [UI_EXTENSION]: { mimeTypes: [UI_MIME] } });
+    expect(capabilities.resources).toBeDefined();
+
+    const tools = await listTools(app, sessionId);
+    const verdict = tools.find((tool) => tool.name === 'get_gate_verdict');
+    expect(verdict?._meta?.ui?.resourceUri).toBe('ui://gamedevpl/round-status');
+    // Only the opted-in tool carries a view.
+    expect(tools.filter((tool) => tool._meta !== undefined).map((tool) => tool.name)).toEqual(['get_gate_verdict']);
+  });
+
+  it('serves the card over resources/list and resources/read', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const { sessionId } = await initializeWith(app, true);
+    const headers = { 'mcp-session-id': sessionId };
+
+    const listed = await mcpCall(app, 'resources/list', {}, headers);
+    expect(listed.statusCode).toBe(200);
+    const resources = listed.json().result.resources as Array<{ uri: string; mimeType: string }>;
+    expect(resources).toEqual([expect.objectContaining({ uri: 'ui://gamedevpl/round-status', mimeType: UI_MIME })]);
+
+    const read = await mcpCall(app, 'resources/read', { uri: 'ui://gamedevpl/round-status' }, headers);
+    expect(read.statusCode).toBe(200);
+    const contents = read.json().result.contents as Array<{ uri: string; mimeType: string; text: string }>;
+    expect(contents[0]?.mimeType).toBe(UI_MIME);
+    expect(contents[0]?.text).toContain('ui/initialize');
+
+    const missing = await mcpCall(app, 'resources/read', { uri: 'ui://gamedevpl/nope' }, headers);
+    expect(missing.json().error?.code).toBe(-32602);
+  });
+
+  it('offers nothing at all while the flag is off, even to a declaring client', async () => {
+    delete process.env.MCP_UI;
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const { sessionId, capabilities } = await initializeWith(app, true);
+    expect(capabilities).toEqual({ tools: { listChanged: false } });
+
+    const tools = await listTools(app, sessionId);
+    expect(tools.every((tool) => tool._meta === undefined)).toBe(true);
+
+    const listed = await mcpCall(app, 'resources/list', {}, { 'mcp-session-id': sessionId });
+    expect(listed.json().error?.code).toBe(-32601);
+  });
+
+  it('keeps the negotiated capability across start, which re-registers the correlator', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const { sessionId } = await initializeWith(app, true);
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+
+    // start re-sets the transport session mid-round; a plain overwrite there used to
+    // drop uiCapable and the card would vanish for the rest of the round.
+    const tools = await listTools(app, sessionId);
+    expect(tools.find((tool) => tool.name === 'get_gate_verdict')?._meta?.ui?.resourceUri).toBe(
+      'ui://gamedevpl/round-status',
+    );
+  });
+
+  it('treats a correlator adopted from another instance as not view-capable', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    // Cloud Run is multi-instance: this correlator was negotiated somewhere else, so
+    // this instance cannot know what it renders. Degrade to text, never assume UI.
+    const foreign = 'fedcba9876543210fedcba9876543210fedc';
+    const tools = await listTools(app, foreign);
+    expect(tools.every((tool) => tool._meta === undefined)).toBe(true);
+  });
+});

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1926,6 +1926,25 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     const tools = await listTools(app, sessionId);
     expect(tools.length).toBeGreaterThan(10);
     expect(tools.every((tool) => tool._meta === undefined)).toBe(true);
+
+    // The resource methods are on the same gate as `_meta.ui`: a client that never
+    // negotiated views gets the answer it got before views existed, so probing cannot
+    // reveal a surface it did not ask for.
+    for (const method of ['resources/list', 'resources/templates/list']) {
+      const probed = await mcpCall(app, method, {}, { 'mcp-session-id': sessionId });
+      expect(probed.json().error?.code).toBe(-32601);
+    }
+    const read = await mcpCall(
+      app,
+      'resources/read',
+      { uri: 'ui://gamedevpl/round-status' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(read.json().error?.code).toBe(-32601);
+
+    // Same for a caller with no session at all.
+    const anonymous = await mcpCall(app, 'resources/read', { uri: 'ui://gamedevpl/round-status' });
+    expect(anonymous.json().error?.code).toBe(-32601);
   });
 
   it('echoes the extension and attaches the card once a client declares it', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -57,6 +57,14 @@ import {
 } from './mcp-debug-log.js';
 import { mcpMissingCredentialHint, sendMcpOAuthChallenge, shouldIssueMcpOAuthChallenge } from './mcp-oauth-metadata.js';
 import {
+  MCP_UI_TOOL_RESOURCES,
+  clientDeclaresUi,
+  mcpUiEnabled,
+  mcpUiServerCapability,
+  readUiResource,
+  uiResourceDescriptors,
+} from './mcp-ui.js';
+import {
   INBOX_PIGGYBACK_TOOLS,
   createMcpNudgeTracker,
   pendingCountFromPayload,
@@ -118,6 +126,11 @@ export interface McpServerOptions {
    * cannot exist for them. Copy only; this gates no access.
    */
   privateBeta?: boolean;
+  /**
+   * MCP Apps (SEP-1865) views — off unless `MCP_UI` says otherwise. Phase 0 spike:
+   * clients that do not declare the extension see today's contract unchanged either way.
+   */
+  uiEnabled?: boolean;
   gamesStore?: GamesStore;
   objectStore?: GcsObjectStore;
   /**
@@ -418,9 +431,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   const dailyFeedbackQuota = options.dailyFeedbackQuota ?? 20;
   const privateBeta = options.privateBeta ?? (process.env.PRIVATE_BETA ?? '').toLowerCase() === 'true';
   const missingCredentialHint = mcpMissingCredentialHint(privateBeta);
+  const uiEnabled = options.uiEnabled ?? mcpUiEnabled();
 
-  /** Transport sessions only — never consulted for authorization. */
-  const transportSessions = new Map<string, { createdAt: number }>();
+  /**
+   * Transport sessions only — never consulted for authorization. `uiCapable` records
+   * whether this client declared the MCP Apps extension at initialize, so `_meta.ui` is
+   * only ever emitted to a client that asked for it. A correlator adopted from another
+   * instance has no recorded answer and is treated as not capable: the failure mode is a
+   * client that supports views not getting one, never a client being handed UI metadata
+   * it never negotiated.
+   */
+  const transportSessions = new Map<string, { createdAt: number; uiCapable?: boolean }>();
   /**
    * Correlators explicitly terminated via DELETE on this instance. Prevents the
    * multi-instance adopt path from resurrecting a session the client just closed.
@@ -449,6 +470,25 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     for (let i = 0; i < overflow; i += 1) {
       transportSessions.delete(oldest[i]![0]);
     }
+  }
+
+  /**
+   * Record/refresh a transport correlator. Keeps any negotiated `uiCapable` answer —
+   * `start` and `open_round` re-set the session mid-round, and a plain overwrite there
+   * would silently drop a client's view capability partway through a round.
+   */
+  function noteTransportSession(sessionId: string, uiCapable?: boolean): void {
+    const existing = transportSessions.get(sessionId);
+    transportSessions.set(sessionId, {
+      createdAt: now(),
+      uiCapable: uiCapable ?? existing?.uiCapable ?? false,
+    });
+  }
+
+  /** Emit view metadata only for a flag-enabled server and a client that negotiated it. */
+  function sessionWantsUi(sessionId: string | null): boolean {
+    if (!uiEnabled || !sessionId) return false;
+    return transportSessions.get(sessionId)?.uiCapable === true;
   }
 
   function pruneInvalidStartBuckets(currentTime: number): void {
@@ -928,7 +968,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           // never saw initialize (Cloud Run multi-instance). Reminting here used to
           // embed a new id in the sessionKey while the client kept sending the old one.
           const sessionId = ctx.sessionId && looksLikeMcpSessionId(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
-          transportSessions.set(sessionId, { createdAt: now() });
+          noteTransportSession(sessionId);
 
           const jobId = active.issueNumber;
           const roundGeneration = active.roundGeneration ?? 1;
@@ -1086,7 +1126,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         pruneTransportSessions(now());
         pruneInvalidStartBuckets(now());
         const sessionId = ctx.sessionId && looksLikeMcpSessionId(ctx.sessionId) ? ctx.sessionId : newMcpSessionId();
-        transportSessions.set(sessionId, { createdAt: now() });
+        noteTransportSession(sessionId);
 
         const sessionKey = mintMcpSessionKey(agentTokenSecret, {
           sessionId,
@@ -3325,8 +3365,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       const requested = typeof params.protocolVersion === 'string' ? params.protocolVersion : PROTOCOL_VERSION;
       const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : PROTOCOL_VERSION;
 
+      // MCP Apps: remember what this client can render, and answer in kind. A client
+      // that does not declare the extension gets exactly the capabilities it got before
+      // views existed — no `resources`, no `extensions`.
+      const uiCapable = uiEnabled && clientDeclaresUi(params);
+
       const sessionId = newMcpSessionId();
-      transportSessions.set(sessionId, { createdAt: now() });
+      noteTransportSession(sessionId, uiCapable);
       reply.header('Mcp-Session-Id', sessionId);
       reply.header('MCP-Session-Id', sessionId);
 
@@ -3335,6 +3380,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           protocolVersion,
           capabilities: {
             tools: { listChanged: false },
+            ...(uiCapable
+              ? {
+                  resources: { subscribe: false, listChanged: false },
+                  extensions: mcpUiServerCapability(),
+                }
+              : {}),
           },
           serverInfo: {
             name: 'gamedevpl',
@@ -3388,7 +3439,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         );
         return reply.status(404).send({ error: 'unknown MCP session' });
       }
-      transportSessions.set(sessionHeader, { createdAt: now() });
+      noteTransportSession(sessionHeader);
       request.log.info(
         {
           event: 'mcp_session_adopted',
@@ -3415,17 +3466,46 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     }
 
     if (message.method === 'tools/list') {
+      // `_meta.ui` is added only for a client that negotiated the extension, so this
+      // list stays byte-identical for every client that shipped before views existed.
+      const withUi = sessionWantsUi(sessionHeader);
       return reply.send(
         jsonRpcResult(message.id, {
-          tools: Object.entries(tools).map(([name, tool]) => ({
-            name,
-            description: tool.description,
-            inputSchema: tool.inputSchema,
-            outputSchema: tool.outputSchema,
-            ...(tool.annotations ? { annotations: tool.annotations } : {}),
-          })),
+          tools: Object.entries(tools).map(([name, tool]) => {
+            const uiResourceUri = withUi ? MCP_UI_TOOL_RESOURCES[name] : undefined;
+            return {
+              name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              outputSchema: tool.outputSchema,
+              ...(tool.annotations ? { annotations: tool.annotations } : {}),
+              ...(uiResourceUri ? { _meta: { ui: { resourceUri: uiResourceUri, visibility: ['model', 'app'] } } } : {}),
+            };
+          }),
         }),
       );
+    }
+
+    // MCP Apps resources. Answered whenever the flag is on — a client that never
+    // negotiated the extension is not told they exist (see initialize) and has no
+    // reason to ask, but answering an explicit probe keeps the spike debuggable.
+    if (uiEnabled && message.method === 'resources/list') {
+      return reply.send(jsonRpcResult(message.id, { resources: uiResourceDescriptors() }));
+    }
+
+    // Every view is a fixed `ui://` document; nothing here is parameterised by URI.
+    if (uiEnabled && message.method === 'resources/templates/list') {
+      return reply.send(jsonRpcResult(message.id, { resourceTemplates: [] }));
+    }
+
+    if (uiEnabled && message.method === 'resources/read') {
+      const params = (message.params ?? {}) as { uri?: unknown };
+      const uri = typeof params.uri === 'string' ? params.uri : '';
+      const resource = readUiResource(uri);
+      if (!resource) {
+        return reply.send(jsonRpcError(message.id, -32602, `unknown resource: ${uri || '(missing uri)'}`));
+      }
+      return reply.send(jsonRpcResult(message.id, { contents: [resource] }));
     }
 
     if (message.method === 'tools/call') {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3486,19 +3486,26 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       );
     }
 
-    // MCP Apps resources. Answered whenever the flag is on — a client that never
-    // negotiated the extension is not told they exist (see initialize) and has no
-    // reason to ask, but answering an explicit probe keeps the spike debuggable.
-    if (uiEnabled && message.method === 'resources/list') {
+    // MCP Apps resources, on exactly the same gate as `_meta.ui`: the flag AND a client
+    // that negotiated the extension. A client that did not gets `method not found`, the
+    // same answer it got before views existed — no probe reveals a surface it did not
+    // ask for. Caveat worth carrying into Phase 1: capability lives on the transport
+    // correlator, so a client whose session is adopted by another instance mid-round
+    // reads as not capable and would be refused here. Single-instance today
+    // (`--max-instances 1`), and a spike runs against one process, but a durable view
+    // surface cannot key off the correlator alone.
+    const wantsUiResources = sessionWantsUi(sessionHeader);
+
+    if (wantsUiResources && message.method === 'resources/list') {
       return reply.send(jsonRpcResult(message.id, { resources: uiResourceDescriptors() }));
     }
 
     // Every view is a fixed `ui://` document; nothing here is parameterised by URI.
-    if (uiEnabled && message.method === 'resources/templates/list') {
+    if (wantsUiResources && message.method === 'resources/templates/list') {
       return reply.send(jsonRpcResult(message.id, { resourceTemplates: [] }));
     }
 
-    if (uiEnabled && message.method === 'resources/read') {
+    if (wantsUiResources && message.method === 'resources/read') {
       const params = (message.params ?? {}) as { uri?: unknown };
       const uri = typeof params.uri === 'string' ? params.uri : '';
       const resource = readUiResource(uri);

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MCP_UI_EXTENSION,
+  MCP_UI_MIME_TYPE,
+  MCP_UI_TOOL_RESOURCES,
+  ROUND_STATUS_RESOURCE_URI,
+  clientDeclaresUi,
+  mcpUiEnabled,
+  mcpUiServerCapability,
+  readUiResource,
+  uiResourceDescriptors,
+} from './mcp-ui.js';
+
+function withUiExtension(value: unknown) {
+  return { capabilities: { extensions: { [MCP_UI_EXTENSION]: value } } };
+}
+
+describe('mcpUiEnabled', () => {
+  it('stays off unless the flag is explicitly set, so production keeps the pre-views contract', () => {
+    expect(mcpUiEnabled({})).toBe(false);
+    expect(mcpUiEnabled({ MCP_UI: '' })).toBe(false);
+    expect(mcpUiEnabled({ MCP_UI: 'false' })).toBe(false);
+    expect(mcpUiEnabled({ MCP_UI: 'no' })).toBe(false);
+    expect(mcpUiEnabled({ MCP_UI: 'true' })).toBe(true);
+    expect(mcpUiEnabled({ MCP_UI: 'TRUE' })).toBe(true);
+    expect(mcpUiEnabled({ MCP_UI: '1' })).toBe(true);
+  });
+});
+
+describe('clientDeclaresUi', () => {
+  it('accepts a client that declares the extension with our mime type', () => {
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: [MCP_UI_MIME_TYPE] }))).toBe(true);
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['text/html;profile=mcp-app', 'text/other'] }))).toBe(true);
+  });
+
+  it('takes a declaration without mimeTypes at its word', () => {
+    expect(clientDeclaresUi(withUiExtension({}))).toBe(true);
+  });
+
+  it('refuses a client that can only render content types we do not serve', () => {
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['application/vnd.remote-dom'] }))).toBe(false);
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: 'text/html;profile=mcp-app' }))).toBe(false);
+  });
+
+  it('treats every shape that does not declare the extension as not capable', () => {
+    expect(clientDeclaresUi(undefined)).toBe(false);
+    expect(clientDeclaresUi({})).toBe(false);
+    expect(clientDeclaresUi({ capabilities: {} })).toBe(false);
+    expect(clientDeclaresUi({ capabilities: { extensions: {} } })).toBe(false);
+    expect(clientDeclaresUi({ capabilities: { extensions: { 'io.example/other': {} } } })).toBe(false);
+    expect(clientDeclaresUi({ capabilities: { extensions: { [MCP_UI_EXTENSION]: true } } })).toBe(false);
+    expect(clientDeclaresUi('nonsense')).toBe(false);
+  });
+});
+
+describe('ui resources', () => {
+  it('advertises the round-status card under the ui:// scheme with the SEP-1865 mime type', () => {
+    const descriptors = uiResourceDescriptors();
+    expect(descriptors).toHaveLength(1);
+    expect(descriptors[0]).toMatchObject({
+      uri: ROUND_STATUS_RESOURCE_URI,
+      mimeType: MCP_UI_MIME_TYPE,
+    });
+    expect(ROUND_STATUS_RESOURCE_URI.startsWith('ui://')).toBe(true);
+    // Descriptors carry no bodies — `resources/read` serves those.
+    expect(descriptors[0]).not.toHaveProperty('text');
+    expect(mcpUiServerCapability()).toEqual({ [MCP_UI_EXTENSION]: { mimeTypes: [MCP_UI_MIME_TYPE] } });
+  });
+
+  it('reads the card by uri and nothing else', () => {
+    const resource = readUiResource(ROUND_STATUS_RESOURCE_URI);
+    expect(resource?.mimeType).toBe(MCP_UI_MIME_TYPE);
+    expect(resource?.text).toContain('<!doctype html>');
+    expect(readUiResource('ui://gamedevpl/does-not-exist')).toBeNull();
+    expect(readUiResource('https://www.gamedev.pl/')).toBeNull();
+    expect(readUiResource('')).toBeNull();
+  });
+
+  it('is self-contained, because the host CSP is deny-all and we declare no domains', () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).not.toMatch(/<script[^>]+src=/i);
+    expect(html).not.toMatch(/<link[^>]+href=/i);
+    expect(html).not.toMatch(/https?:\/\//);
+    expect(html).not.toMatch(/\bfetch\(|XMLHttpRequest|WebSocket|import\s*\(/);
+  });
+
+  it('speaks the view side of the lifecycle: handshake, tool results, teardown', () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('ui/initialize');
+    expect(html).toContain('ui/notifications/initialized');
+    expect(html).toContain('ui/notifications/tool-result');
+    expect(html).toContain('ui/notifications/size-changed');
+    expect(html).toContain('ui/resource-teardown');
+    // Only the embedding host may drive this view.
+    expect(html).toContain('event.source !== host');
+    // Strict mode is on, so the teardown handler must be a named function, not
+    // arguments.callee — which throws there.
+    expect(html).not.toContain('arguments.callee');
+  });
+
+  it('attaches views to read tools only — a card on a write tool would render mid-delivery', () => {
+    expect(MCP_UI_TOOL_RESOURCES).toEqual({ get_gate_verdict: ROUND_STATUS_RESOURCE_URI });
+  });
+});

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -37,6 +37,27 @@ describe('clientDeclaresUi', () => {
     expect(clientDeclaresUi(withUiExtension({}))).toBe(true);
   });
 
+  it('accepts any legal spelling of the media type, not just our exact string', () => {
+    // Media-type parameters allow surrounding whitespace, quoted values, and differ in
+    // case only inside the value — all of these mean the same thing as our constant.
+    for (const mimeType of [
+      'text/html; profile=mcp-app',
+      'text/html ;profile=mcp-app',
+      'text/html;profile="mcp-app"',
+      'text/html; profile="MCP-App"',
+      'TEXT/HTML;PROFILE=mcp-app',
+      '  text/html;profile=mcp-app  ',
+    ]) {
+      expect(clientDeclaresUi(withUiExtension({ mimeTypes: [mimeType] }))).toBe(true);
+    }
+  });
+
+  it('still refuses html without the mcp-app profile, and the profile on another type', () => {
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['text/html'] }))).toBe(false);
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['text/plain;profile=mcp-app'] }))).toBe(false);
+    expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['text/html;profile=something-else'] }))).toBe(false);
+  });
+
   it('refuses a client that can only render content types we do not serve', () => {
     expect(clientDeclaresUi(withUiExtension({ mimeTypes: ['application/vnd.remote-dom'] }))).toBe(false);
     expect(clientDeclaresUi(withUiExtension({ mimeTypes: 'text/html;profile=mcp-app' }))).toBe(false);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -1,0 +1,416 @@
+/**
+ * MCP Apps (SEP-1865, extension `io.modelcontextprotocol/ui`) — Phase 0.
+ *
+ * Phase 0 is a spike, not a feature: capability negotiation, a `ui://` resource
+ * registry, and one **static** card that renders whatever tool result the host hands
+ * it. There is no polling and no app-only tool yet — those are Phase 1, once the host
+ * questions this phase exists to answer come back green.
+ *
+ * Two rules hold this together, and both are load-bearing:
+ *
+ * 1. **Existing clients must see today's contract byte for byte.** Claude Code, Cursor
+ *    and headless agents never declare the extension, so they never get `_meta.ui`, a
+ *    `resources` capability, or anything else new. `MCP_UI` gates the whole surface on
+ *    top of that.
+ * 2. **A view is trusted first-party UI holding a live tool-call bridge.** Game code is
+ *    untrusted and must never be served as a `ui://` resource — it would run in the
+ *    frame that owns that bridge. Playable-preview views nest the game one iframe
+ *    deeper instead (Phase 2); nothing here does that yet.
+ *
+ * CSP metadata is deliberately omitted from the resource descriptors: the host default
+ * is deny-all, which is exactly right for a card that fetches nothing. Declaring
+ * `connectDomains` / `frameDomains` is a Phase 2 concern.
+ */
+
+/** Extension id hosts advertise in `initialize` and we echo back when we support it. */
+export const MCP_UI_EXTENSION = 'io.modelcontextprotocol/ui';
+
+/** The only view content type SEP-1865 defines for its initial release. */
+export const MCP_UI_MIME_TYPE = 'text/html;profile=mcp-app';
+
+/** Phase 0's single view. */
+export const ROUND_STATUS_RESOURCE_URI = 'ui://gamedevpl/round-status';
+
+/**
+ * Tools that carry `_meta.ui` when the client is UI-capable. Read tools only in
+ * Phase 0 — a card attached to a write tool would render mid-delivery, which is a
+ * Phase 1 conversation once the dashboard actually has live state to show.
+ */
+export const MCP_UI_TOOL_RESOURCES: Readonly<Record<string, string>> = Object.freeze({
+  get_gate_verdict: ROUND_STATUS_RESOURCE_URI,
+});
+
+/** Off unless explicitly enabled — production stays on today's contract until the spike lands. */
+export function mcpUiEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MCP_UI ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}
+
+/**
+ * Did the client declare the UI extension in `initialize`? A client that declares it
+ * but lists mime types we cannot serve counts as not capable; a client that omits
+ * `mimeTypes` entirely is taken at its word (the field is optional in practice).
+ */
+export function clientDeclaresUi(params: unknown): boolean {
+  if (!params || typeof params !== 'object') return false;
+  const capabilities = (params as { capabilities?: unknown }).capabilities;
+  if (!capabilities || typeof capabilities !== 'object') return false;
+  const extensions = (capabilities as { extensions?: unknown }).extensions;
+  if (!extensions || typeof extensions !== 'object') return false;
+  const ui = (extensions as Record<string, unknown>)[MCP_UI_EXTENSION];
+  if (!ui || typeof ui !== 'object') return false;
+  const mimeTypes = (ui as { mimeTypes?: unknown }).mimeTypes;
+  if (mimeTypes === undefined) return true;
+  if (!Array.isArray(mimeTypes)) return false;
+  return mimeTypes.some((value) => typeof value === 'string' && value.trim().toLowerCase() === MCP_UI_MIME_TYPE);
+}
+
+/** What we echo in `initialize.capabilities.extensions` for a UI-capable client. */
+export function mcpUiServerCapability(): Record<string, unknown> {
+  return { [MCP_UI_EXTENSION]: { mimeTypes: [MCP_UI_MIME_TYPE] } };
+}
+
+interface UiResource {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+  text: string;
+}
+
+/**
+ * The round-status card. Self-contained by necessity — the host CSP is `default-src
+ * 'none'` with inline script/style allowed, so no external anything, and screenshots
+ * would have to arrive as data URIs rather than URLs.
+ *
+ * Written without template literals or `${}` so it survives being a TS template string
+ * unescaped. Colours come from the host's theme variables with gamedev.pl's identity as
+ * the fallback, so the card looks native in both a light and a dark client.
+ */
+const ROUND_STATUS_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>gamedev.pl — round status</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --gd-accent: #00e4ac;
+        --gd-bg: var(--color-background-secondary, var(--color-background-primary, #1d2123));
+        --gd-fg: var(--color-text-primary, #f2f4f5);
+        --gd-muted: var(--color-text-secondary, #9aa3a7);
+        --gd-border: var(--color-border-primary, rgba(255, 255, 255, 0.12));
+        --gd-radius: var(--border-radius-md, 10px);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        padding: 12px;
+        font-family: var(--font-sans, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif);
+        background: transparent;
+        color: var(--gd-fg);
+      }
+      .card {
+        background: var(--gd-bg);
+        border: 1px solid var(--gd-border);
+        border-radius: var(--gd-radius);
+        padding: 14px 16px;
+        max-width: 640px;
+      }
+      .head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 10px;
+      }
+      .brand { font-weight: 600; letter-spacing: -0.01em; }
+      .brand .dot { color: var(--gd-accent); }
+      .pill {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 3px 9px;
+        border-radius: 999px;
+        border: 1px solid currentColor;
+        white-space: nowrap;
+      }
+      .pill-waiting, .pill-pending { color: var(--gd-muted); }
+      .pill-green, .pill-preview_passed { color: var(--gd-accent); }
+      .pill-red, .pill-preview_failed { color: #ff6b6b; }
+      .pill-kit_outdated { color: #ffb454; }
+      .summary { margin: 0; font-size: 14px; line-height: 1.5; }
+      .meta {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 4px 14px;
+        margin: 12px 0 0;
+        font-size: 12.5px;
+      }
+      .meta dt { color: var(--gd-muted); }
+      .meta dd { margin: 0; word-break: break-word; }
+      .report {
+        margin: 12px 0 0;
+        padding: 10px;
+        border-radius: 8px;
+        border: 1px solid var(--gd-border);
+        background: rgba(127, 127, 127, 0.08);
+        font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+        font-size: 12px;
+        line-height: 1.45;
+        white-space: pre-wrap;
+        max-height: 220px;
+        overflow: auto;
+      }
+      .foot { margin: 12px 0 0; font-size: 11.5px; color: var(--gd-muted); }
+      [hidden] { display: none !important; }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="head">
+        <span class="brand">gamedev<span class="dot">.pl</span></span>
+        <span id="pill" class="pill pill-waiting">waiting</span>
+      </div>
+      <p id="summary" class="summary">Waiting for the gate verdict…</p>
+      <dl id="meta" class="meta"></dl>
+      <pre id="report" class="report" hidden></pre>
+      <p id="foot" class="foot"></p>
+    </main>
+    <script>
+      (function () {
+        'use strict';
+
+        var host = window.parent;
+        var nextId = 1;
+        var initializeId = null;
+        var initialized = false;
+
+        var pill = document.getElementById('pill');
+        var summary = document.getElementById('summary');
+        var metaList = document.getElementById('meta');
+        var report = document.getElementById('report');
+        var foot = document.getElementById('foot');
+
+        function post(payload) {
+          if (!host || host === window) return null;
+          host.postMessage(payload, '*');
+          return payload.id === undefined ? null : payload.id;
+        }
+
+        function request(method, params) {
+          var id = nextId++;
+          post({ jsonrpc: '2.0', id: id, method: method, params: params || {} });
+          return id;
+        }
+
+        function notify(method, params) {
+          post({ jsonrpc: '2.0', method: method, params: params || {} });
+        }
+
+        function log(level, text) {
+          notify('notifications/message', { level: level, logger: 'gamedevpl-round-status', data: text });
+        }
+
+        function reportSize() {
+          notify('ui/notifications/size-changed', {
+            height: document.documentElement.scrollHeight,
+            width: document.documentElement.scrollWidth
+          });
+        }
+
+        function applyThemeVariables(variables) {
+          if (!variables || typeof variables !== 'object') return;
+          var names = Object.keys(variables);
+          for (var i = 0; i < names.length; i++) {
+            var name = names[i];
+            if (name.indexOf('--') !== 0) continue;
+            var value = variables[name];
+            if (typeof value === 'string') document.documentElement.style.setProperty(name, value);
+          }
+        }
+
+        var hostLocale = undefined;
+        var hostTimeZone = undefined;
+
+        function applyHostContext(context) {
+          if (!context || typeof context !== 'object') return;
+          if (typeof context.theme === 'string') {
+            document.documentElement.setAttribute('data-theme', context.theme);
+          }
+          if (typeof context.locale === 'string') hostLocale = context.locale;
+          if (typeof context.timeZone === 'string') hostTimeZone = context.timeZone;
+          applyThemeVariables(context.themeVariables || context.theme_variables || context.cssVariables);
+        }
+
+        /** Gate timestamps are ISO; show them in the reader's locale and zone. */
+        function formatTime(value) {
+          if (typeof value !== 'string' || !value) return value;
+          var parsed = new Date(value);
+          if (isNaN(parsed.getTime())) return value;
+          try {
+            return parsed.toLocaleString(hostLocale || undefined, {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+              timeZone: hostTimeZone || undefined
+            });
+          } catch (error) {
+            return parsed.toISOString();
+          }
+        }
+
+        function addRow(term, value) {
+          if (value === undefined || value === null || value === '') return;
+          var dt = document.createElement('dt');
+          dt.textContent = term;
+          var dd = document.createElement('dd');
+          dd.textContent = String(value);
+          metaList.appendChild(dt);
+          metaList.appendChild(dd);
+        }
+
+        /**
+         * Hosts differ in how they wrap a tool result, and pinning that down is half the
+         * point of this spike — so dig for the payload rather than assuming one shape.
+         */
+        function extractVerdict(params) {
+          if (!params || typeof params !== 'object') return null;
+          var candidates = [
+            params.structuredContent,
+            params.result && params.result.structuredContent,
+            params.toolResult && params.toolResult.structuredContent,
+            params.result,
+            params
+          ];
+          for (var i = 0; i < candidates.length; i++) {
+            var candidate = candidates[i];
+            if (candidate && typeof candidate === 'object' && typeof candidate.status === 'string') return candidate;
+          }
+          var content =
+            (params.content) ||
+            (params.result && params.result.content) ||
+            (params.toolResult && params.toolResult.content);
+          if (Array.isArray(content)) {
+            for (var j = 0; j < content.length; j++) {
+              var part = content[j];
+              if (!part || part.type !== 'text' || typeof part.text !== 'string') continue;
+              try {
+                var parsed = JSON.parse(part.text);
+                if (parsed && typeof parsed === 'object' && typeof parsed.status === 'string') return parsed;
+              } catch (error) {
+                /* not our JSON body — keep looking */
+              }
+            }
+          }
+          return null;
+        }
+
+        var COPY = {
+          pending: 'The gate is still running. Verdicts usually land in two to five minutes.',
+          green: 'Publish gate green — the round is complete.',
+          red: 'Publish gate red. The report below says what failed.',
+          preview_passed: 'Preview gate passed — the build runs. Publish still needs a green publish gate.',
+          preview_failed: 'Preview gate failed. The report below says what broke.',
+          kit_outdated: 'The Creator Kit rotated mid-round. Re-run get_kit, then resubmit with fromLatestDelivery.'
+        };
+
+        function render(verdict) {
+          var status = typeof verdict.status === 'string' ? verdict.status : 'pending';
+          pill.textContent = status.replace(/_/g, ' ');
+          pill.className = 'pill pill-' + status;
+          summary.textContent =
+            (typeof verdict.summary === 'string' && verdict.summary) || COPY[status] || 'Gate status: ' + status;
+
+          metaList.textContent = '';
+          addRow('Lane', verdict.lane);
+          addRow('Delivery', verdict.deliveryId);
+          addRow('Version', verdict.version);
+          addRow('Ran at', formatTime(verdict.ranAt));
+          if (status === 'pending' && typeof verdict.retryAfterSeconds === 'number') {
+            addRow('Recheck in', verdict.retryAfterSeconds + 's');
+          }
+
+          if (typeof verdict.report === 'string' && verdict.report.trim()) {
+            report.textContent = verdict.report;
+            report.hidden = false;
+          } else {
+            report.hidden = true;
+          }
+
+          foot.textContent =
+            status === 'pending'
+              ? 'This card is a static snapshot — ask your agent to poll again for a fresh verdict.'
+              : '';
+          reportSize();
+        }
+
+        function onHostMessage(event) {
+          if (host && host !== window && event.source !== host) return;
+          var message = event.data;
+          if (!message || typeof message !== 'object' || message.jsonrpc !== '2.0') return;
+
+          if (initializeId !== null && message.id === initializeId && !initialized) {
+            initialized = true;
+            if (message.result) applyHostContext(message.result.hostContext);
+            notify('ui/notifications/initialized', {});
+            log('debug', 'round-status view initialized');
+            reportSize();
+            return;
+          }
+
+          if (message.method === 'ui/notifications/tool-result') {
+            var verdict = extractVerdict(message.params);
+            if (verdict) render(verdict);
+            else log('warning', 'tool-result arrived in an unrecognised shape');
+            return;
+          }
+
+          if (message.method === 'ping') {
+            post({ jsonrpc: '2.0', id: message.id, result: {} });
+            return;
+          }
+
+          if (message.method === 'ui/resource-teardown') {
+            window.removeEventListener('message', onHostMessage);
+            window.removeEventListener('resize', reportSize);
+          }
+        }
+
+        window.addEventListener('message', onHostMessage);
+
+        initializeId = request('ui/initialize', {
+          protocolVersion: '2026-01-26',
+          capabilities: {},
+          clientInfo: { name: 'gamedevpl-round-status', version: '0.1.0' }
+        });
+
+        window.addEventListener('resize', reportSize);
+      })();
+    </script>
+  </body>
+</html>
+`;
+
+const UI_RESOURCES: readonly UiResource[] = Object.freeze([
+  {
+    uri: ROUND_STATUS_RESOURCE_URI,
+    name: 'Round status card',
+    description: "Renders a gamedev.pl build round's gate verdict inside the conversation.",
+    mimeType: MCP_UI_MIME_TYPE,
+    text: ROUND_STATUS_HTML,
+  },
+]);
+
+/** Descriptors for `resources/list` — no bodies. */
+export function uiResourceDescriptors(): Array<Omit<UiResource, 'text'>> {
+  return UI_RESOURCES.map(({ text: _text, ...descriptor }) => descriptor);
+}
+
+/** One `resources/read` content entry, or null when the URI is not ours. */
+export function readUiResource(uri: string): { uri: string; mimeType: string; text: string } | null {
+  const found = UI_RESOURCES.find((resource) => resource.uri === uri);
+  if (!found) return null;
+  return { uri: found.uri, mimeType: found.mimeType, text: found.text };
+}

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -47,6 +47,34 @@ export function mcpUiEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * Canonicalise a media type so `text/html; profile="MCP-App"` and
+ * `text/html;profile=mcp-app` compare equal. Media-type parameters allow surrounding
+ * whitespace and quoted values, and case only matters inside the value — comparing the
+ * raw strings would silently deny views to a client that spelled it legally.
+ */
+function canonicalMediaType(value: string): string | null {
+  const segments = value.split(';');
+  const base = (segments.shift() ?? '').trim().toLowerCase();
+  if (!base) return null;
+  const parameters = segments
+    .map((segment) => {
+      const separator = segment.indexOf('=');
+      if (separator === -1) return null;
+      const name = segment.slice(0, separator).trim().toLowerCase();
+      let parameterValue = segment.slice(separator + 1).trim();
+      if (parameterValue.length >= 2 && parameterValue.startsWith('"') && parameterValue.endsWith('"')) {
+        parameterValue = parameterValue.slice(1, -1);
+      }
+      return name ? `${name}=${parameterValue.toLowerCase()}` : null;
+    })
+    .filter((parameter): parameter is string => parameter !== null)
+    .sort();
+  return [base, ...parameters].join(';');
+}
+
+const CANONICAL_UI_MIME_TYPE = canonicalMediaType(MCP_UI_MIME_TYPE);
+
+/**
  * Did the client declare the UI extension in `initialize`? A client that declares it
  * but lists mime types we cannot serve counts as not capable; a client that omits
  * `mimeTypes` entirely is taken at its word (the field is optional in practice).
@@ -62,7 +90,7 @@ export function clientDeclaresUi(params: unknown): boolean {
   const mimeTypes = (ui as { mimeTypes?: unknown }).mimeTypes;
   if (mimeTypes === undefined) return true;
   if (!Array.isArray(mimeTypes)) return false;
-  return mimeTypes.some((value) => typeof value === 'string' && value.trim().toLowerCase() === MCP_UI_MIME_TYPE);
+  return mimeTypes.some((value) => typeof value === 'string' && canonicalMediaType(value) === CANONICAL_UI_MIME_TYPE);
 }
 
 /** What we echo in `initialize.capabilities.extensions` for a UI-capable client. */

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2772,7 +2772,11 @@ export async function registerSubmissionRoutes(
   // varies by language is resolved per-request in `attachBuildEvents`, from text the
   // agent already sent. `cacheKey` still carries the locale so existing entries and
   // `invalidateStatusCache`'s prefix scan keep working.
-  async function refreshStatus(issueNumber: number, cacheKey: string, token: string): Promise<SubmissionStatusResponse> {
+  async function refreshStatus(
+    issueNumber: number,
+    cacheKey: string,
+    token: string,
+  ): Promise<SubmissionStatusResponse> {
     const existing = statusRefreshes.get(cacheKey);
     if (existing) return existing;
 
@@ -4531,6 +4535,8 @@ export async function registerSubmissionRoutes(
     agentTokenSecret: submissionTokenSecret,
     now,
     privateBeta: options.privateBeta,
+    // MCP Apps views (SEP-1865) read MCP_UI directly — off in production until the
+    // Phase 0 host spike lands. No behaviour changes for clients without the extension.
     gamesStore: options.agentChannel?.gamesStore,
     objectStore: options.agentChannel?.objectStore,
     startImprovementRound,


### PR DESCRIPTION
Implements Phase 0 of MCP Apps views support (SEP-1865), enabling MCP clients to render UI cards for tool results. This is a controlled spike that maintains backward compatibility—clients that don't declare the extension see the exact same contract as before.

## Summary

Adds a new `mcp-ui.ts` module that implements the MCP Apps extension (`io.modelcontextprotocol/ui`), allowing the server to serve HTML views to capable clients. The implementation includes:

- A self-contained round-status card that displays gate verdicts from `get_gate_verdict` tool results
- Capability negotiation during `initialize` to detect and respond to UI-capable clients
- A `ui://` resource registry with `resources/list` and `resources/read` support
- Tool metadata (`_meta.ui`) attachment for tools that have associated views

## Key Changes

- **mcp-ui.ts** (new): Core module containing:
  - `MCP_UI_EXTENSION` and `MCP_UI_MIME_TYPE` constants for SEP-1865
  - `clientDeclaresUi()` to detect UI-capable clients from initialize params
  - `mcpUiEnabled()` flag check (off by default, requires `MCP_UI=true`)
  - `ROUND_STATUS_HTML`: self-contained HTML card with embedded JavaScript for lifecycle management
  - Resource descriptor and read functions for the ui:// registry

- **mcp-server.ts**: Integration with MCP server:
  - Track `uiCapable` per transport session to remember client capabilities across `start` and `open_round` calls
  - Emit `resources` capability and `extensions` in initialize response only for UI-capable clients
  - Add `_meta.ui` to tool descriptors only when client negotiated the extension
  - Implement `resources/list` and `resources/read` handlers (gated by flag and capability)
  - Preserve UI capability when re-setting transport sessions mid-round

- **mcp-ui.test.ts** (new): Comprehensive unit tests for:
  - Flag parsing and client capability detection
  - Resource descriptor and content serving
  - Self-contained HTML validation (no external resources)
  - View lifecycle protocol compliance

- **mcp-server.test.ts**: Integration tests covering:
  - Non-declaring clients remain on pre-views contract
  - UI-capable clients receive extension and resource metadata
  - Resource serving via `resources/list` and `resources/read`
  - Flag-off behavior (no views offered even to declaring clients)
  - Capability persistence across `start` (which re-registers the session)
  - Foreign correlators (multi-instance) treated as not view-capable

- **.env.example**: Documentation of `MCP_UI` flag

## Notable Implementation Details

- **Backward compatibility**: Clients that don't declare the extension receive zero view-related metadata, maintaining byte-for-byte compatibility with the pre-views contract
- **Security**: The round-status card is self-contained with no external resources, relying on host CSP (`default-src 'none'`) and inline script/style allowance
- **Multi-instance safety**: Correlators adopted from other Cloud Run instances are treated as not view-capable, preventing assumptions about what they can render
- **Session lifecycle**: The `noteTransportSession()` helper preserves `uiCapable` across mid-round session re-registration in `start` and `open_round`
- **Phase 0 scope**: Static card only (no polling), read tools only (no mid-delivery rendering), no app-only tools yet

https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B