### PR TITLE
fix(mcp): make gate verdict checks one-shot

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -32,13 +32,16 @@ Agents cannot sleep between tool calls, so “poll every ~30s” turns into a ti
 loop that burns connector tool budgets. `get_gate_verdict` is therefore a one-shot
 check, not a wait loop. When `status` is `pending`:
 
-- The response returns `stop: true`, `reason: gate_pending`: stop the agent run
-  immediately and let Studio show the eventual result
-- `retryAfterSeconds` (~30) is informational for a later creator-led run, not
-  permission to wait and call again in the current run
-- Back-to-back calls mean the client ignored `stop:true`; they emit soft
-  `warnings.code=gate_poll_backoff` (and keep re-emitting `call_end` after submit
-  until `end`)
+- With a real `deliveryId`, the response returns `stop: true`,
+  `reason: gate_pending`: stop the agent run immediately and let Studio show the
+  eventual result
+- With `deliveryId: null`, nothing has been delivered: the response returns
+  `stop: false`, `reason: no_delivery`; continue building and call
+  `submit_sources` instead of checking again
+- `retryAfterSeconds` (~30) is informational for a later creator-led run checking a
+  delivered gate, not permission to wait and call again in the current run
+- Back-to-back calls emit soft `warnings.code=gate_poll_backoff` (and keep
+  re-emitting `call_end` after submit until `end`)
 
 ### `kit_outdated` — do not re-upload the tree
 
@@ -100,7 +103,7 @@ Merged by `applySessionNudges` / submit handler. Act, then continue:
 | ------------------- | ---------------------------------------------------------------- |
 | `call_end`          | Call `end` when finished iterating this round                    |
 | `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet       |
-| `gate_poll_backoff` | Client ignored pending's `stop:true` — stop this run immediately |
+| `gate_poll_backoff` | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true` |
 | `progress_stale`    | Call `report_progress`                                           |
 | `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                               |
 | `seed_unread`       | Call `get_seed` before scaffolding from the kit                  |

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -23,18 +23,22 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
      mistaken for quiet / offline)
 4. **Prefer `end` after the last successful `submit_sources`** if you will not deliver
    more — Studio shows the gate; do not sit in a `get_gate_verdict` loop
-5. Only poll `get_gate_verdict` when you still need the verdict to decide whether to
-   fix before ending (and `get_gate_media` after a publish verdict)
+5. Only call `get_gate_verdict` once when an already-available verdict would change
+   what you deliver (and `get_gate_media` after a publish verdict)
 
 ### Never busy-poll `get_gate_verdict`
 
 Agents cannot sleep between tool calls, so “poll every ~30s” turns into a tight
-loop that burns connector tool budgets. When `status` is `pending`:
+loop that burns connector tool budgets. `get_gate_verdict` is therefore a one-shot
+check, not a wait loop. When `status` is `pending`:
 
-- Honour `retryAfterSeconds` (~30) as **wall-clock** wait before the next poll, **or**
-- Call **`end`** and stop — Studio already shows gate progress
-- Back-to-back polls emit soft `warnings.code=gate_poll_backoff` (and keep
-  re-emitting `call_end` after submit until `end`)
+- The response returns `stop: true`, `reason: gate_pending`: stop the agent run
+  immediately and let Studio show the eventual result
+- `retryAfterSeconds` (~30) is informational for a later creator-led run, not
+  permission to wait and call again in the current run
+- Back-to-back calls mean the client ignored `stop:true`; they emit soft
+  `warnings.code=gate_poll_backoff` (and keep re-emitting `call_end` after submit
+  until `end`)
 
 ### `kit_outdated` — do not re-upload the tree
 
@@ -92,14 +96,14 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code                | Meaning                                                                    |
-| ------------------- | -------------------------------------------------------------------------- |
-| `call_end`          | Call `end` when finished iterating this round                              |
-| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                 |
-| `gate_poll_backoff` | Stop tight-looping `get_gate_verdict` — wait ~30s wall-clock or call `end` |
-| `progress_stale`    | Call `report_progress`                                                     |
-| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                         |
-| `seed_unread`       | Call `get_seed` before scaffolding from the kit                            |
+| Code                | Meaning                                                          |
+| ------------------- | ---------------------------------------------------------------- |
+| `call_end`          | Call `end` when finished iterating this round                    |
+| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet       |
+| `gate_poll_backoff` | Client ignored pending's `stop:true` — stop this run immediately |
+| `progress_stale`    | Call `report_progress`                                           |
+| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                               |
+| `seed_unread`       | Call `get_seed` before scaffolding from the kit                  |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1974,7 +1974,7 @@ export async function registerAgentChannelRoutes(
           status: 'pending',
           deliveryId: null,
           summary:
-            'nothing has been delivered yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
+            'nothing has been delivered yet — do not loop on get_gate_verdict; stop this run and let Studio show the gate',
           retryAfterSeconds: 30,
           access,
         });
@@ -1996,7 +1996,7 @@ export async function registerAgentChannelRoutes(
           status: 'pending',
           deliveryId: version,
           summary:
-            'gate has not reported yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
+            'gate has not reported yet — do not loop on get_gate_verdict; stop this run and let Studio show the eventual result',
           retryAfterSeconds: 30,
           access,
         });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1974,7 +1974,7 @@ export async function registerAgentChannelRoutes(
           status: 'pending',
           deliveryId: null,
           summary:
-            'nothing has been delivered yet — do not loop on get_gate_verdict; stop this run and let Studio show the gate',
+            'nothing has been delivered yet — continue building and call submit_sources first; do not call get_gate_verdict again before a delivery',
           retryAfterSeconds: 30,
           access,
         });

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -329,7 +329,11 @@ describe('POST /api/mcp (BY-05)', () => {
         'ack_inbox',
       ]),
     );
-    const tools = listed.json().result.tools as Array<{ name: string; description: string }>;
+    const tools = listed.json().result.tools as Array<{
+      name: string;
+      description: string;
+      annotations?: { title?: string };
+    }>;
     const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
     // start advertises the returned workflow / inbox policy / refusal guidance.
@@ -358,9 +362,11 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(tools.find((t) => t.name === 'read_kit_file_fragment')?.description).toMatch(/lines|bytes/i);
 
     const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
+    expect(gateVerdict?.annotations?.title).toBe('Check the gate once');
+    expect(gateVerdict?.annotations?.title).not.toMatch(/poll/i);
     expect(gateVerdict?.description).toMatch(/2–5 minutes/);
-    expect(gateVerdict?.description).toMatch(/~30/);
-    expect(gateVerdict?.description).toMatch(/busy-poll|Do NOT busy-poll/i);
+    expect(gateVerdict?.description).toMatch(/one-shot/i);
+    expect(gateVerdict?.description).toMatch(/pending.*stop:true/i);
     expect(gateVerdict?.description).toMatch(/gate_poll_backoff/);
     expect(gateVerdict?.description).toMatch(/kit_outdated/);
     expect(gateVerdict?.description).toMatch(/re-run get_kit/);
@@ -467,7 +473,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
     expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);
     expect(joined).toMatch(/get_gate_verdict/);
-    expect(joined).toMatch(/Never busy-poll|at most once per ~30s wall-clock/i);
+    expect(joined).toMatch(/call get_gate_verdict once|one-shot/i);
+    expect(joined).toMatch(/pending.*stop:true/i);
     expect(joined).toMatch(/Prefer end over sitting in a get_gate_verdict loop/i);
     // The stop condition is explicit: green means done — END immediately; no post-green
     // tools (key retires; get_gate_verdict may still answer via terminal receipt).
@@ -967,7 +974,7 @@ describe('POST /api/mcp (BY-05)', () => {
     await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
     const verdict = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(verdict.isError).toBe(false);
-    expect(verdict.structured).toMatchObject({ status: 'red', deliveryId: 'v1' });
+    expect(verdict.structured).toMatchObject({ status: 'red', deliveryId: 'v1', stop: false });
   });
 
   it('submit_sources reports gateStarted when Cloud Build returns a build id', async () => {
@@ -1063,7 +1070,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
   });
 
-  it('pending get_gate_verdict carries retryAfterSeconds and soft-warns on busy-poll', async () => {
+  it('makes pending get_gate_verdict a one-shot stop and warns if the client ignores it', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
     // No gate verdict on the version yet — channel returns pending.
@@ -1093,14 +1100,17 @@ describe('POST /api/mcp (BY-05)', () => {
       status: 'pending',
       deliveryId: 'v1',
       retryAfterSeconds: 30,
+      stop: true,
+      reason: 'gate_pending',
     });
-    expect(String((first.structured as { summary?: string }).summary)).toMatch(/do not busy-poll/i);
+    expect(String((first.structured as { summary?: string }).summary)).toMatch(/STOP this agent run/i);
     const firstWarnings = (first.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(firstWarnings.some((w) => w.code === 'call_end')).toBe(true);
     expect(firstWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(false);
 
     const second = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(second.isError).toBe(false);
+    expect(second.structured).toMatchObject({ stop: true, reason: 'gate_pending' });
     const secondWarnings = (second.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(secondWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(true);
     expect(secondWarnings.some((w) => w.code === 'call_end')).toBe(true);
@@ -1196,7 +1206,12 @@ describe('POST /api/mcp (BY-05)', () => {
         { 'mcp-session-id': sessionId, authorization: `Bearer ${bearer}` },
       );
       expect(verdict.isError).toBe(false);
-      expect(verdict.structured).toMatchObject({ status: 'green', access: 'terminal_receipt' });
+      expect(verdict.structured).toMatchObject({
+        status: 'green',
+        access: 'terminal_receipt',
+        stop: true,
+        reason: 'gate_green',
+      });
 
       const write = await callTool(
         app,
@@ -1512,6 +1527,9 @@ describe('POST /api/mcp (BY-05)', () => {
     // The rest of the loop must survive the rewrite.
     expect(instructions).toMatch(/sessionKey/);
     expect(instructions).toMatch(/get_gate_verdict/);
+    expect(instructions).toMatch(/one-shot check/i);
+    expect(instructions).toMatch(/pending returns stop:true/i);
+    expect(instructions).not.toMatch(/poll get_gate_verdict until green/i);
     expect(instructions).toMatch(/honour stop/i);
   });
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1070,6 +1070,28 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
   });
 
+  it('keeps a no-delivery gate check active so the agent can continue building', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const verdict = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(verdict.isError).toBe(false);
+    expect(verdict.structured).toMatchObject({
+      status: 'pending',
+      deliveryId: null,
+      stop: false,
+      reason: 'no_delivery',
+    });
+    expect(String((verdict.structured as { summary?: string }).summary)).toMatch(
+      /continue building.*submit_sources/i,
+    );
+  });
+
   it('makes pending get_gate_verdict a one-shot stop and warns if the client ignores it', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
@@ -1528,7 +1550,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(instructions).toMatch(/sessionKey/);
     expect(instructions).toMatch(/get_gate_verdict/);
     expect(instructions).toMatch(/one-shot check/i);
-    expect(instructions).toMatch(/pending returns stop:true/i);
+    expect(instructions).toMatch(/pending delivery returns stop:true/i);
+    expect(instructions).toMatch(/deliveryId:null means continue building/i);
     expect(instructions).not.toMatch(/poll get_gate_verdict until green/i);
     expect(instructions).toMatch(/honour stop/i);
   });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -314,7 +314,7 @@ const BEHAVIOURAL_CONTRACT = [
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
-  'Treat get_gate_verdict as a one-shot check, never a polling loop. When status is pending it returns stop:true: stop immediately and let Studio show the eventual result. A later creator-led run may check again. Honour warnings.code=gate_poll_backoff if you ignore that stop.',
+  'Treat get_gate_verdict as a one-shot check, never a polling loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null means you checked before delivering: stop is false, so continue building and call submit_sources instead of checking again. A later creator-led run may check a delivered gate again. Honour warnings.code=gate_poll_backoff on repeated checks.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -340,9 +340,9 @@ const SESSION_WORKFLOW: readonly string[] = [
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
-  'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. When status=pending, honour stop:true immediately and let Studio show the eventual result; do not call any more tools in this run. A later creator-led run may check again. Only check when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
+  'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null returns stop:false because you checked too early — continue building and call submit_sources; do not check again before a delivery. A later creator-led run may check a delivered gate again. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
-  'For publish, prefer end after delivery and let Studio show the gate. If you need an already-available verdict before deciding whether to fix, call get_gate_verdict once; pending returns stop:true and ends this run.',
+  'For publish, prefer end after delivery and let Studio show the gate. If you need an already-available verdict before deciding whether to fix, call get_gate_verdict once; a pending delivery returns stop:true and ends this run.',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
   'kit_outdated: re-run get_kit for a fresh engineRef, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT get_sources + re-stage the whole tree (burns tokens). Only pass files[] for paths you actually changed.',
@@ -2992,7 +2992,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'Call end when you will not deliver more this round (sets stop:true). ' +
               'Creator handoff is already unlocked from this submit; without end your session may look finished while still connected. ' +
               'Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. ' +
-              'If you need an already-available verdict to keep iterating, call get_gate_verdict once; pending returns stop:true and ends this run.',
+              'If you need an already-available verdict to keep iterating, call get_gate_verdict once; a pending delivery returns stop:true and ends this run.',
           });
           if (!gateStarted) {
             warnings.push({
@@ -3106,9 +3106,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'One-shot check of the gate verdict for a delivery (default: latest); this is not a polling or waiting tool. ' +
         'Preview lane: preview_passed / preview_failed ' +
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
-        'Verdicts typically land in 2–5 minutes. When status=pending the result has stop:true: STOP this run immediately, ' +
-        'do not call get_gate_verdict or any other tool again, and let Studio show the eventual result. ' +
-        'retryAfterSeconds is only for a later creator-led run. Ignoring stop triggers warnings.code=gate_poll_backoff and burns tool limits. ' +
+        'Verdicts typically land in 2–5 minutes. When status=pending and deliveryId is set, the result has stop:true: ' +
+        'STOP this run immediately and let Studio show the eventual result. A pending result with deliveryId:null means ' +
+        'you checked before delivering: stop is false, so continue building and call submit_sources instead of checking again. ' +
+        'retryAfterSeconds is only for a later creator-led run checking a delivered gate. Repeated checks trigger warnings.code=gate_poll_backoff. ' +
         'kit_outdated is terminal — stop polling, re-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
         '(same mode as the refused delivery; omit mode only to reuse that lane; do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
@@ -3138,13 +3139,22 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `gate verdict failed (${res.statusCode})`);
         }
-        if (body.status === 'pending') {
+        if (body.status === 'pending' && typeof body.deliveryId === 'string') {
           return toolOk({
             ...body,
             summary:
               'gate is still running — STOP this agent run now; do not call get_gate_verdict or any other tool again. Studio will show the eventual result.',
             stop: true,
             reason: 'gate_pending',
+          });
+        }
+        if (body.status === 'pending') {
+          return toolOk({
+            ...body,
+            summary:
+              'nothing has been delivered yet — continue building and call submit_sources; do not call get_gate_verdict again before a delivery',
+            stop: false,
+            reason: 'no_delivery',
           });
         }
         if (body.status === 'green') {
@@ -3421,7 +3431,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             'prompt goes in the key argument instead. start returns a sessionKey — pass it on every later tool call — ' +
             'and your workflow (the ordered start→done loop): follow it; honour stop; screenshot early; kit-check ' +
             'before submit; normally call end after delivery and let Studio show the gate. get_gate_verdict is a ' +
-            'one-shot check, never a loop: pending returns stop:true and ends this run. Do not poll the inbox on a schedule; ' +
+            'one-shot check, never a loop: a pending delivery returns stop:true, while deliveryId:null means continue building. Do not poll the inbox on a schedule; ' +
             'a green verdict ends the round and the key retires.',
         }),
       );

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -314,7 +314,7 @@ const BEHAVIOURAL_CONTRACT = [
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
-  'Do not busy-poll get_gate_verdict — when status is pending, wait retryAfterSeconds (~30s wall-clock) before the next poll, or call end if done. Honour warnings.code=gate_poll_backoff.',
+  'Treat get_gate_verdict as a one-shot check, never a polling loop. When status is pending it returns stop:true: stop immediately and let Studio show the eventual result. A later creator-led run may check again. Honour warnings.code=gate_poll_backoff if you ignore that stop.',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -340,9 +340,9 @@ const SESSION_WORKFLOW: readonly string[] = [
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
-  'Only poll get_gate_verdict when you still need the verdict to decide whether to fix before ending. Never busy-poll: when status=pending, honour retryAfterSeconds (~30) as wall-clock wait, or call end and stop. Back-to-back get_gate_verdict calls waste your tool budget (warnings.code=gate_poll_backoff). Only poll when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
+  'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. When status=pending, honour stop:true immediately and let Studio show the eventual result; do not call any more tools in this run. A later creator-led run may check again. Only check when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
-  'For publish, if you are still iterating on the verdict: poll get_gate_verdict at most once per ~30s wall-clock until green, red, or kit_outdated — never in a tight loop. If you are done delivering, call end instead of polling.',
+  'For publish, prefer end after delivery and let Studio show the gate. If you need an already-available verdict before deciding whether to fix, call get_gate_verdict once; pending returns stop:true and ends this run.',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
   'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
   'kit_outdated: re-run get_kit for a fresh engineRef, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT get_sources + re-stage the whole tree (burns tokens). Only pass files[] for paths you actually changed.',
@@ -2992,7 +2992,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'Call end when you will not deliver more this round (sets stop:true). ' +
               'Creator handoff is already unlocked from this submit; without end your session may look finished while still connected. ' +
               'Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. ' +
-              'If you will keep iterating (poll get_gate_verdict at most once per ~30s wall-clock / fix / resubmit), call end only after your last delivery.',
+              'If you need an already-available verdict to keep iterating, call get_gate_verdict once; pending returns stop:true and ends this run.',
           });
           if (!gateStarted) {
             warnings.push({
@@ -3073,7 +3073,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     get_gate_verdict: {
-      annotations: { title: 'Poll the gate verdict', ...READS },
+      annotations: { title: 'Check the gate once', ...READS },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3094,17 +3094,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           retryAfterSeconds: {
             type: 'number',
             description:
-              'When status is pending: wait this many wall-clock seconds before the next poll (do not busy-poll).',
+              'Informational delay before a later creator-led run checks again. stop:true takes priority in this run.',
           },
+          stop: { type: 'boolean', description: 'When true, stop this agent run immediately.' },
+          reason: { type: 'string' },
+          ...WARNINGS_PROP,
         },
-        required: ['status', 'deliveryId', 'summary', 'access'],
+        required: ['status', 'deliveryId', 'summary', 'access', 'stop'],
       },
       description:
-        'Poll the gate verdict for a delivery (default: latest). Preview lane: preview_passed / preview_failed ' +
+        'One-shot check of the gate verdict for a delivery (default: latest); this is not a polling or waiting tool. ' +
+        'Preview lane: preview_passed / preview_failed ' +
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
-        'Verdicts typically land in 2–5 minutes. Do NOT busy-poll: when status=pending, wait retryAfterSeconds (~30) ' +
-        'of wall-clock time before the next call, or call end if you will not deliver more (Studio shows the gate). ' +
-        'Back-to-back polls trigger warnings.code=gate_poll_backoff and burn tool limits. ' +
+        'Verdicts typically land in 2–5 minutes. When status=pending the result has stop:true: STOP this run immediately, ' +
+        'do not call get_gate_verdict or any other tool again, and let Studio show the eventual result. ' +
+        'retryAfterSeconds is only for a later creator-led run. Ignoring stop triggers warnings.code=gate_poll_backoff and burns tool limits. ' +
         'kit_outdated is terminal — stop polling, re-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
         '(same mode as the refused delivery; omit mode only to reuse that lane; do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
@@ -3134,7 +3138,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `gate verdict failed (${res.statusCode})`);
         }
-        return toolOk(body);
+        if (body.status === 'pending') {
+          return toolOk({
+            ...body,
+            summary:
+              'gate is still running — STOP this agent run now; do not call get_gate_verdict or any other tool again. Studio will show the eventual result.',
+            stop: true,
+            reason: 'gate_pending',
+          });
+        }
+        if (body.status === 'green') {
+          return toolOk({ ...body, stop: true, reason: 'gate_green' });
+        }
+        return toolOk({ ...body, stop: false });
       },
     },
 
@@ -3404,7 +3420,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             "the game slug — nothing else is needed. A per-game or legacy key from the creator's Studio kickoff " +
             'prompt goes in the key argument instead. start returns a sessionKey — pass it on every later tool call — ' +
             'and your workflow (the ordered start→done loop): follow it; honour stop; screenshot early; kit-check ' +
-            'before submit; poll get_gate_verdict until green, then finish. Do not poll the inbox on a schedule; ' +
+            'before submit; normally call end after delivery and let Studio show the gate. get_gate_verdict is a ' +
+            'one-shot check, never a loop: pending returns stop:true and ends this run. Do not poll the inbox on a schedule; ' +
             'a green verdict ends the round and the key retires.',
         }),
       );

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -76,7 +76,7 @@ describe('mcp-session-nudges', () => {
     expect(nudges.warningsFor(1, 'submit_sources', t0).map((w) => w.code)).not.toContain('call_end');
     const onGate = nudges.warningsFor(1, 'get_gate_verdict', t0);
     expect(onGate.map((w) => w.code)).toContain('call_end');
-    expect(onGate.find((w) => w.code === 'call_end')?.message).toMatch(/do not busy-poll/i);
+    expect(onGate.find((w) => w.code === 'call_end')?.message).toMatch(/one-shot check.*stop:true/i);
     nudges.noteToolSuccess(1, 'end', t0 + 1);
     expect(
       nudges.warningsFor(1, 'get_gate_verdict', t0 + GATE_POLL_MIN_INTERVAL_MS + 2).map((w) => w.code),

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -87,7 +87,12 @@ describe('mcp-session-nudges', () => {
     const nudges = createMcpNudgeTracker();
     const t0 = 1_000_000;
     expect(nudges.warningsFor(1, 'get_gate_verdict', t0).map((w) => w.code)).not.toContain('gate_poll_backoff');
-    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000).map((w) => w.code)).toContain('gate_poll_backoff');
+    const repeated = nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000);
+    expect(repeated.map((w) => w.code)).toContain('gate_poll_backoff');
+    const message = repeated.find((w) => w.code === 'gate_poll_backoff')?.message ?? '';
+    expect(message).toMatch(/deliveryId is null.*submit_sources/i);
+    expect(message).toContain('retryAfterSeconds=30');
+    expect(message).not.toMatch(/~\d+s/);
     expect(
       nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000 + GATE_POLL_MIN_INTERVAL_MS).map((w) => w.code),
     ).not.toContain('gate_poll_backoff');

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -34,7 +34,7 @@ export interface JobNudgeState {
   lastGatePollAt: number | null;
 }
 
-/** Minimum wall-clock gap used to detect a client that ignored pending's `stop:true`. */
+/** Minimum wall-clock gap used to detect repeated gate checks inside one agent run. */
 export const GATE_POLL_MIN_INTERVAL_MS = 25_000;
 /** Informational delay before a later creator-led run checks a pending gate again. */
 export const GATE_POLL_RETRY_AFTER_SECONDS = 30;
@@ -234,14 +234,13 @@ export function createMcpNudgeTracker(
       });
     }
 
-    // Defense in depth for clients that ignore pending's stop:true. The stop is carried
-    // directly by every pending response; this warning makes an ignored stop unmistakable.
+    // Defense in depth for clients that repeat the one-shot check. A delivered pending
+    // response carries stop:true; a no-delivery response tells the agent to keep building.
     if (toolName === 'get_gate_verdict') {
       if (state.lastGatePollAt !== null && nowMs - state.lastGatePollAt < GATE_POLL_MIN_INTERVAL_MS) {
-        const waitSec = Math.max(1, Math.ceil((GATE_POLL_MIN_INTERVAL_MS - (nowMs - state.lastGatePollAt)) / 1000));
         warnings.push({
           code: 'gate_poll_backoff',
-          message: `You ignored stop:true from a pending gate. STOP this run now; do not call get_gate_verdict or any other tool again. Studio will show the result. A later creator-led run may check again after ~${waitSec}s (retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS}).`,
+          message: `Do not repeat get_gate_verdict in one run. If a delivery is pending, honour stop:true; if deliveryId is null, continue building and call submit_sources instead. A later creator-led run may check a delivered gate after retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS} has elapsed.`,
         });
       }
       state.lastGatePollAt = nowMs;

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -34,9 +34,9 @@ export interface JobNudgeState {
   lastGatePollAt: number | null;
 }
 
-/** Minimum wall-clock gap between get_gate_verdict polls before soft `gate_poll_backoff`. */
+/** Minimum wall-clock gap used to detect a client that ignored pending's `stop:true`. */
 export const GATE_POLL_MIN_INTERVAL_MS = 25_000;
-/** Hint returned on pending gate reads — agents must wait this many seconds, not busy-poll. */
+/** Informational delay before a later creator-led run checks a pending gate again. */
 export const GATE_POLL_RETRY_AFTER_SECONDS = 30;
 
 /** No progress for this long (wall clock) → `progress_stale`. */
@@ -229,19 +229,19 @@ export function createMcpNudgeTracker(
         code: 'call_end',
         message:
           toolName === 'get_gate_verdict'
-            ? 'Still waiting for end — do not busy-poll get_gate_verdict. Call end now if you will not deliver more this round; Studio shows the gate. Only re-poll after ~30s wall-clock if you still need the verdict to fix.'
+            ? 'Still waiting for end — get_gate_verdict is a one-shot check, not a loop. Honour stop:true on pending and let Studio show the gate.'
             : 'Still waiting for end — call end now if you will not deliver more this round (Studio handoff may already be unlocked from submit).',
       });
     }
 
-    // Agents cannot sleep between tool calls, so "poll every ~30s" becomes a tight loop
-    // that burns connector tool budgets. Soft-warn when polls are closer than the gap.
+    // Defense in depth for clients that ignore pending's stop:true. The stop is carried
+    // directly by every pending response; this warning makes an ignored stop unmistakable.
     if (toolName === 'get_gate_verdict') {
       if (state.lastGatePollAt !== null && nowMs - state.lastGatePollAt < GATE_POLL_MIN_INTERVAL_MS) {
         const waitSec = Math.max(1, Math.ceil((GATE_POLL_MIN_INTERVAL_MS - (nowMs - state.lastGatePollAt)) / 1000));
         warnings.push({
           code: 'gate_poll_backoff',
-          message: `Do not busy-poll get_gate_verdict — wait ~${waitSec}s wall-clock before the next poll (retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS}). If you will not deliver more, call end instead; Studio shows the gate.`,
+          message: `You ignored stop:true from a pending gate. STOP this run now; do not call get_gate_verdict or any other tool again. Studio will show the result. A later creator-led run may check again after ~${waitSec}s (retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS}).`,
         });
       }
       state.lastGatePollAt = nowMs;

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -93,7 +93,8 @@ describe('ui resources', () => {
     expect(resource?.mimeType).toBe(MCP_UI_MIME_TYPE);
     expect(resource?.text).toContain('<!doctype html>');
     expect(resource?.text).toContain('The agent has stopped');
-    expect(resource?.text).toContain("addRow('Next step', 'Watch Studio')");
+    expect(resource?.text).toContain("verdict.deliveryId ? 'Watch Studio' : 'Continue building'");
+    expect(resource?.text).toContain('Nothing has been delivered yet. Continue building');
     expect(resource?.text).not.toContain('ask your agent to poll again');
     expect(resource?.text).not.toContain("addRow('Recheck in'");
     expect(readUiResource('ui://gamedevpl/does-not-exist')).toBeNull();

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -92,6 +92,10 @@ describe('ui resources', () => {
     const resource = readUiResource(ROUND_STATUS_RESOURCE_URI);
     expect(resource?.mimeType).toBe(MCP_UI_MIME_TYPE);
     expect(resource?.text).toContain('<!doctype html>');
+    expect(resource?.text).toContain('The agent has stopped');
+    expect(resource?.text).toContain("addRow('Next step', 'Watch Studio')");
+    expect(resource?.text).not.toContain('ask your agent to poll again');
+    expect(resource?.text).not.toContain("addRow('Recheck in'");
     expect(readUiResource('ui://gamedevpl/does-not-exist')).toBeNull();
     expect(readUiResource('https://www.gamedev.pl/')).toBeNull();
     expect(readUiResource('')).toBeNull();

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -336,7 +336,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         }
 
         var COPY = {
-          pending: 'The gate is still running. Verdicts usually land in two to five minutes.',
+          pending: 'The gate is still running. This agent run has stopped; Studio will show the eventual result.',
           green: 'Publish gate green — the round is complete.',
           red: 'Publish gate red. The report below says what failed.',
           preview_passed: 'Preview gate passed — the build runs. Publish still needs a green publish gate.',
@@ -356,8 +356,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
           addRow('Delivery', verdict.deliveryId);
           addRow('Version', verdict.version);
           addRow('Ran at', formatTime(verdict.ranAt));
-          if (status === 'pending' && typeof verdict.retryAfterSeconds === 'number') {
-            addRow('Recheck in', verdict.retryAfterSeconds + 's');
+          if (status === 'pending') {
+            addRow('Next step', 'Watch Studio');
           }
 
           if (typeof verdict.report === 'string' && verdict.report.trim()) {
@@ -369,7 +369,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
           foot.textContent =
             status === 'pending'
-              ? 'This card is a static snapshot — ask your agent to poll again for a fresh verdict.'
+              ? 'This card is a static snapshot. The agent has stopped; Studio will show the eventual result.'
               : '';
           reportSize();
         }

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -336,7 +336,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         }
 
         var COPY = {
-          pending: 'The gate is still running. This agent run has stopped; Studio will show the eventual result.',
+          pending: 'Gate status is pending.',
           green: 'Publish gate green — the round is complete.',
           red: 'Publish gate red. The report below says what failed.',
           preview_passed: 'Preview gate passed — the build runs. Publish still needs a green publish gate.',
@@ -357,7 +357,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           addRow('Version', verdict.version);
           addRow('Ran at', formatTime(verdict.ranAt));
           if (status === 'pending') {
-            addRow('Next step', 'Watch Studio');
+            addRow('Next step', verdict.deliveryId ? 'Watch Studio' : 'Continue building');
           }
 
           if (typeof verdict.report === 'string' && verdict.report.trim()) {
@@ -369,7 +369,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
           foot.textContent =
             status === 'pending'
-              ? 'This card is a static snapshot. The agent has stopped; Studio will show the eventual result.'
+              ? verdict.deliveryId
+                ? 'This card is a static snapshot. The agent has stopped; Studio will show the eventual result.'
+                : 'Nothing has been delivered yet. Continue building and submit before checking again.'
               : '';
           reportSize();
         }


### PR DESCRIPTION
## What changed

- rename the visible MCP action from **Poll the gate verdict** to **Check the gate once**
- remove the contradictory bootstrap instruction that told agents to poll until green
- return `stop: true` with `reason: gate_pending` when an actual delivered gate is still pending
- keep a premature no-delivery check active with `stop: false`, `reason: no_delivery`, and direct the agent back to building/submitting
- return an explicit stop on a green publish verdict
- keep `gate_poll_backoff` as defense in depth, with one unambiguous retry rule
- update the MCP Apps status card so it distinguishes “watch Studio” from “continue building”
- update the BYOCA playbook and regression coverage

## Why

A connector agent repeatedly called `get_gate_verdict` in a tight loop while the response was pending. The server already returned advisory backoff prose, but the MCP initialization instructions still said “poll … until green” and the UI action itself was titled “Poll the gate verdict.” The client followed those stronger invitations and ignored the soft warning.

A pending delivered gate is now a one-shot boundary: the agent stops and Studio owns displaying the eventual result. If nothing has been delivered, checking the gate does not stop the round; the agent continues building and submits first.

## Impact

This prevents repeated tool calls and transcript spam while preserving the active build path for premature checks. Red, preview-failed, and kit-outdated verdicts remain actionable, and creator handoff remains unlocked after submit.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test` — all workspaces passed
- `npm run build`
- focused MCP regression suite passed

The branch was created from remote `master` and reconciles MCP Apps changes that landed after the original local worktree was created.