### PR TITLE
fix(mcp): hard-refuse busy get_gate_verdict polls

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -29,12 +29,15 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 ### Never busy-poll `get_gate_verdict`
 
 Agents cannot sleep between tool calls, so “poll every ~30s” turns into a tight
-loop that burns connector tool budgets. When `status` is `pending`:
+loop that burns connector tool budgets. Soft warnings were ignored (Claude-class
+connectors kept polling), so back-to-back polls are **hard-refused**
+(`isError`, `code=gate_poll_backoff`, plus channel HTTP 429). When `status` is
+`pending`:
 
 - Honour `retryAfterSeconds` (~30) as **wall-clock** wait before the next poll, **or**
 - Call **`end`** and stop — Studio already shows gate progress
-- Back-to-back polls emit soft `warnings.code=gate_poll_backoff` (and keep
-  re-emitting `call_end` after submit until `end`)
+- A second poll inside ~25s returns `isError` with `code=gate_poll_backoff` (and
+  soft `call_end` still re-emits on successful tools after submit until `end`)
 
 ### `kit_outdated` — do not re-upload the tree
 
@@ -92,14 +95,19 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code                | Meaning                                                                    |
-| ------------------- | -------------------------------------------------------------------------- |
-| `call_end`          | Call `end` when finished iterating this round                              |
-| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                 |
-| `gate_poll_backoff` | Stop tight-looping `get_gate_verdict` — wait ~30s wall-clock or call `end` |
-| `progress_stale`    | Call `report_progress`                                                     |
-| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                         |
-| `seed_unread`       | Call `get_seed` before scaffolding from the kit                            |
+| Code               | Meaning                                                    |
+| ------------------ | ---------------------------------------------------------- |
+| `call_end`         | Call `end` when finished iterating this round              |
+| `gate_not_started` | Delivery ok but Cloud Build did not start — no preview yet |
+| `progress_stale`   | Call `report_progress`                                     |
+| `inbox_pending`    | `read_inbox` → apply → `ack_inbox`                         |
+| `seed_unread`      | Call `get_seed` before scaffolding from the kit            |
+
+### Hard refuse (isError)
+
+| Code                | Meaning                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `gate_poll_backoff` | Tight `get_gate_verdict` loop — wait `retryAfterSeconds` wall-clock, or call `end` (Studio shows the gate) |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1668,4 +1668,33 @@ describe('the delivery reminder on every channel call', () => {
 
     await app.close();
   });
+
+  it('hard-refuses back-to-back pending gate polls via presence backoff (429)', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionSlug(ISSUE, 'test-game');
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    const channelApp = await createApp(store);
+
+    const first = await channelApp.inject({
+      method: 'GET',
+      url: '/api/agent/build/gate',
+      headers: agentHeaders(),
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json()).toMatchObject({ status: 'pending', retryAfterSeconds: 30 });
+    expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
+
+    const second = await channelApp.inject({
+      method: 'GET',
+      url: '/api/agent/build/gate',
+      headers: agentHeaders(),
+    });
+    expect(second.statusCode).toBe(429);
+    expect(second.json()).toMatchObject({ code: 'gate_poll_backoff' });
+    expect(typeof second.json().retryAfterSeconds).toBe('number');
+    expect(second.headers['retry-after']).toBeTruthy();
+
+    await channelApp.close();
+  });
 });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -45,6 +45,11 @@ import {
   parseKitRegistry,
   parseKitSidecar,
 } from './kit-registry.js';
+import {
+  GATE_POLL_PRESENCE_KEY,
+  GATE_POLL_RETRY_AFTER_SECONDS,
+  gatePollBackoffFromPresence,
+} from './mcp-session-nudges.js';
 import { seedPayload } from './seed-status.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
@@ -1959,23 +1964,54 @@ export async function registerAgentChannelRoutes(
    */
   app.get(
     '/api/agent/build/gate',
+    // Soft per-IP cap; per-job busy-poll refuse below is the real throttle.
     { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
     async (request, reply) => {
       const resolved = await resolveBuild(request, reply, { allowTerminalReceipt: true });
       if (!resolved) return reply;
-      const { record, access } = resolved;
+      const { record, access, issueNumber } = resolved;
 
       const query = request.query as { version?: string };
       const requestedVersion = typeof query.version === 'string' && query.version.trim() ? query.version.trim() : null;
       const version = requestedVersion ?? record.previewVersion ?? record.deliveredVersion ?? null;
 
+      const refusePendingBusyPoll = () => {
+        // Only pending reads are throttled — a landed verdict may be re-read immediately
+        // (terminal receipt on multiple transports, etc.). Soft MCP warnings were ignored
+        // by Claude connectors, so this is a hard 429.
+        const retryAfterSeconds = gatePollBackoffFromPresence(record.lastAgentPresence, Date.now());
+        if (retryAfterSeconds === null) return null;
+        reply.header('Retry-After', String(retryAfterSeconds));
+        return reply.status(429).send({
+          error: `get_gate_verdict busy-poll refused — wait ${retryAfterSeconds}s wall-clock before the next poll, or call end now (Studio shows the gate)`,
+          code: 'gate_poll_backoff',
+          retryAfterSeconds,
+        });
+      };
+
+      const stampPendingGatePoll = async () => {
+        try {
+          await store?.touchLastAgentSignalAt(
+            issueNumber,
+            undefined,
+            { key: GATE_POLL_PRESENCE_KEY },
+            { preserveEnded: true },
+          );
+        } catch (error) {
+          request.log.warn({ err: error, issueNumber }, 'gate poll presence stamp failed');
+        }
+      };
+
       if (!version || !record.slug) {
+        const refused = refusePendingBusyPoll();
+        if (refused) return refused;
+        await stampPendingGatePoll();
         return reply.send({
           status: 'pending',
           deliveryId: null,
           summary:
             'nothing has been delivered yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
-          retryAfterSeconds: 30,
+          retryAfterSeconds: GATE_POLL_RETRY_AFTER_SECONDS,
           access,
         });
       }
@@ -1992,12 +2028,15 @@ export async function registerAgentChannelRoutes(
         previewVersion: version,
       });
       if (!gate) {
+        const refused = refusePendingBusyPoll();
+        if (refused) return refused;
+        await stampPendingGatePoll();
         return reply.send({
           status: 'pending',
           deliveryId: version,
           summary:
             'gate has not reported yet — do not busy-poll; wait ~30s wall-clock before the next get_gate_verdict, or call end if done (Studio shows the gate)',
-          retryAfterSeconds: 30,
+          retryAfterSeconds: GATE_POLL_RETRY_AFTER_SECONDS,
           access,
         });
       }
@@ -2011,6 +2050,7 @@ export async function registerAgentChannelRoutes(
             : gate.status === 'preview_failed'
               ? 'preview_failed'
               : 'red';
+      // Landed verdict — do not stamp waiting_checks / do not throttle re-reads.
       return reply.send({
         status,
         deliveryId: version,

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1063,7 +1063,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
   });
 
-  it('pending get_gate_verdict carries retryAfterSeconds and soft-warns on busy-poll', async () => {
+  it('pending get_gate_verdict carries retryAfterSeconds and hard-refuses busy-poll', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
     // No gate verdict on the version yet — channel returns pending.
@@ -1097,13 +1097,17 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(String((first.structured as { summary?: string }).summary)).toMatch(/do not busy-poll/i);
     const firstWarnings = (first.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(firstWarnings.some((w) => w.code === 'call_end')).toBe(true);
+    // Soft warning path is gone — Claude ignored it.
     expect(firstWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(false);
+    expect((await store.getSubmission(ISSUE))?.lastAgentPresence?.key).toBe('waiting_checks');
 
     const second = await callTool(app, 'get_gate_verdict', { sessionKey }, { 'mcp-session-id': sessionId });
-    expect(second.isError).toBe(false);
-    const secondWarnings = (second.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
-    expect(secondWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(true);
-    expect(secondWarnings.some((w) => w.code === 'call_end')).toBe(true);
+    expect(second.isError).toBe(true);
+    expect(second.structured).toMatchObject({
+      code: 'gate_poll_backoff',
+    });
+    expect(typeof (second.structured as { retryAfterSeconds?: number }).retryAfterSeconds).toBe('number');
+    expect(String((second.structured as { error?: string }).error)).toMatch(/busy-poll refused/i);
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -57,6 +57,7 @@ import {
 } from './mcp-debug-log.js';
 import { mcpMissingCredentialHint, sendMcpOAuthChallenge, shouldIssueMcpOAuthChallenge } from './mcp-oauth-metadata.js';
 import {
+  GATE_POLL_RETRY_AFTER_SECONDS,
   INBOX_PIGGYBACK_TOOLS,
   createMcpNudgeTracker,
   pendingCountFromPayload,
@@ -301,7 +302,7 @@ const BEHAVIOURAL_CONTRACT = [
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
-  'Do not busy-poll get_gate_verdict — when status is pending, wait retryAfterSeconds (~30s wall-clock) before the next poll, or call end if done. Honour warnings.code=gate_poll_backoff.',
+  'Do not busy-poll get_gate_verdict — when status is pending, wait retryAfterSeconds (~30s wall-clock) before the next poll, or call end if done. Back-to-back polls are hard-refused (isError, code=gate_poll_backoff).',
   'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
@@ -327,7 +328,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
-  'Only poll get_gate_verdict when you still need the verdict to decide whether to fix before ending. Never busy-poll: when status=pending, honour retryAfterSeconds (~30) as wall-clock wait, or call end and stop. Back-to-back get_gate_verdict calls waste your tool budget (warnings.code=gate_poll_backoff). Only poll when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
+  'Only poll get_gate_verdict when you still need the verdict to decide whether to fix before ending. Never busy-poll: when status=pending, honour retryAfterSeconds (~30) as wall-clock wait, or call end and stop. Back-to-back get_gate_verdict calls are hard-refused (isError, code=gate_poll_backoff) and waste your tool budget. Only poll when gateStarted was true on submit. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
   'For publish, if you are still iterating on the verdict: poll get_gate_verdict at most once per ~30s wall-clock until green, red, or kit_outdated — never in a tight loop. If you are done delivering, call end instead of polling.',
   'Once a publish verdict lands, get_gate_media returns the screenshots and gameplay video the gate recorded — check the frames for visual defects the report cannot describe, and show them to the creator. Essential when you cannot run the game yourself.',
@@ -742,6 +743,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     if (toolName === 'submit_sources' && data.ok === true) {
       nudgeTracker.noteSubmitSuccess(jobId, nowMs);
     }
+    if (toolName === 'get_gate_verdict') {
+      nudgeTracker.noteGatePoll(jobId, nowMs, data.status === 'pending');
+    }
     const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs);
     const prior = Array.isArray(data.warnings)
       ? (data.warnings as NudgeWarning[]).filter(
@@ -807,25 +811,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     openWorldHint: false,
   } as const;
 
-  /** Soft nudges — advisory, never isError. */
+  /** Soft nudges — advisory, never isError. (Busy gate polls are hard-refused separately.) */
   const WARNINGS_PROP = {
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff). Not errors — act on them, then continue the workflow.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started). Not errors — act on them, then continue the workflow. Busy get_gate_verdict loops are hard-refused (isError, code=gate_poll_backoff), not soft-nudged.',
       items: {
         type: 'object',
         properties: {
           code: {
             type: 'string',
-            enum: [
-              'progress_stale',
-              'inbox_pending',
-              'seed_unread',
-              'call_end',
-              'gate_not_started',
-              'gate_poll_backoff',
-            ],
+            enum: ['progress_stale', 'inbox_pending', 'seed_unread', 'call_end', 'gate_not_started'],
           },
           message: { type: 'string' },
         },
@@ -3064,7 +3061,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         '(does not end the round). Publish lane: green / red / kit_outdated — only green ends the round. ' +
         'Verdicts typically land in 2–5 minutes. Do NOT busy-poll: when status=pending, wait retryAfterSeconds (~30) ' +
         'of wall-clock time before the next call, or call end if you will not deliver more (Studio shows the gate). ' +
-        'Back-to-back polls trigger warnings.code=gate_poll_backoff and burn tool limits. ' +
+        'Back-to-back polls are hard-refused (isError, code=gate_poll_backoff) and burn tool limits. ' +
         'kit_outdated is terminal — stop polling, re-run get_kit, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) ' +
         '(same mode as the refused delivery; omit mode only to reuse that lane; do not re-upload the whole tree; do not wait for green/red). ' +
         'Terminal receipt: still readable after the round closes ' +
@@ -3084,13 +3081,46 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const auth = await resolveAuth(ctx, args, { allowTerminalReceipt: true });
         if (!('channelToken' in auth)) return auth;
 
+        // Soft warnings were ignored by Claude-class connectors — refuse before the
+        // channel call so a tight loop cannot burn presence / Firestore / tool budget.
+        const backoff = nudgeTracker.gatePollBackoff(auth.claims.jobId, now());
+        if (backoff) {
+          return toolErr(
+            `get_gate_verdict busy-poll refused — wait ${backoff.retryAfterSeconds}s wall-clock before the next poll, or call end now (Studio shows the gate)`,
+            {
+              code: 'gate_poll_backoff',
+              retryAfterSeconds: backoff.retryAfterSeconds,
+            },
+          );
+        }
+
         const deliveryId =
           typeof args.deliveryId === 'string' && args.deliveryId.trim() ? args.deliveryId.trim() : null;
         const path = deliveryId
           ? `/api/agent/build/gate?version=${encodeURIComponent(deliveryId)}`
           : '/api/agent/build/gate';
         const res = await injectChannel(ctx.request, 'GET', path, auth.channelToken);
-        const body = res.json() as Record<string, unknown> & { error?: string; status?: string };
+        const body = res.json() as Record<string, unknown> & {
+          error?: string;
+          status?: string;
+          code?: string;
+          retryAfterSeconds?: number;
+        };
+        if (res.statusCode === 429 || body.code === 'gate_poll_backoff') {
+          const retryAfterSeconds =
+            typeof body.retryAfterSeconds === 'number' && Number.isFinite(body.retryAfterSeconds)
+              ? body.retryAfterSeconds
+              : GATE_POLL_RETRY_AFTER_SECONDS;
+          return toolErr(
+            typeof body.error === 'string' && body.error.trim()
+              ? body.error
+              : `get_gate_verdict busy-poll refused — wait ${retryAfterSeconds}s wall-clock, or call end now (Studio shows the gate)`,
+            {
+              code: 'gate_poll_backoff',
+              retryAfterSeconds,
+            },
+          );
+        }
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `gate verdict failed (${res.statusCode})`);
         }

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   GATE_POLL_MIN_INTERVAL_MS,
+  GATE_POLL_PRESENCE_KEY,
   PROGRESS_STALE_CALLS,
   PROGRESS_STALE_MS,
   createMcpNudgeTracker,
+  gatePollBackoffFromPresence,
+  gatePollRetryAfterSeconds,
   pendingCountFromPayload,
 } from './mcp-session-nudges.js';
 
@@ -83,14 +86,30 @@ describe('mcp-session-nudges', () => {
     ).not.toContain('call_end');
   });
 
-  it('soft-warns gate_poll_backoff on tight get_gate_verdict loops', () => {
+  it('hard-refuses pending gate polls closer than the min interval (no soft warning)', () => {
     const nudges = createMcpNudgeTracker();
     const t0 = 1_000_000;
-    expect(nudges.warningsFor(1, 'get_gate_verdict', t0).map((w) => w.code)).not.toContain('gate_poll_backoff');
-    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000).map((w) => w.code)).toContain('gate_poll_backoff');
+    expect(nudges.gatePollBackoff(1, t0)).toBeNull();
+    nudges.noteGatePoll(1, t0, true);
+    expect(nudges.gatePollBackoff(1, t0 + 1_000)).toEqual({
+      retryAfterSeconds: Math.ceil((GATE_POLL_MIN_INTERVAL_MS - 1_000) / 1000),
+    });
+    expect(nudges.gatePollBackoff(1, t0 + GATE_POLL_MIN_INTERVAL_MS)).toBeNull();
+    // Landed verdict — immediate re-read is allowed (terminal receipt, etc.).
+    nudges.noteGatePoll(1, t0 + GATE_POLL_MIN_INTERVAL_MS + 1, false);
+    expect(nudges.gatePollBackoff(1, t0 + GATE_POLL_MIN_INTERVAL_MS + 2)).toBeNull();
+    // Soft warnings must not carry gate_poll_backoff — busy polls are isError.
+    expect(nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000).map((w) => w.code)).not.toContain('gate_poll_backoff');
+  });
+
+  it('gatePollRetryAfterSeconds / presence helper share the interval', () => {
+    const t0 = 1_000_000;
+    expect(gatePollRetryAfterSeconds(null, t0)).toBeNull();
+    expect(gatePollRetryAfterSeconds(t0, t0 + 1_000)).toBe(Math.ceil((GATE_POLL_MIN_INTERVAL_MS - 1_000) / 1000));
     expect(
-      nudges.warningsFor(1, 'get_gate_verdict', t0 + 1_000 + GATE_POLL_MIN_INTERVAL_MS).map((w) => w.code),
-    ).not.toContain('gate_poll_backoff');
+      gatePollBackoffFromPresence({ key: GATE_POLL_PRESENCE_KEY, at: new Date(t0).toISOString() }, t0 + 1_000),
+    ).toBe(Math.ceil((GATE_POLL_MIN_INTERVAL_MS - 1_000) / 1000));
+    expect(gatePollBackoffFromPresence({ key: 'browsing_kit', at: new Date(t0).toISOString() }, t0 + 1_000)).toBeNull();
   });
 
   it('does not progress-nudge submit_sources (call_end owns that reply)', () => {

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -5,10 +5,13 @@
  * `report_progress`, so the Studio UI looks frozen; creator notes only ride writes.
  * These warnings are advisory (never `isError`) and are merged into successful tool
  * results by the MCP dispatcher.
+ *
+ * Gate-poll busy-loops are different: Claude-class connectors ignored soft
+ * `gate_poll_backoff` warnings and burned tool budgets. Those are hard-refused
+ * (`isError`) via `gatePollBackoff` / the channel 429 — not soft-nudged.
  */
 
-export type NudgeCode =
-  'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started' | 'gate_poll_backoff';
+export type NudgeCode = 'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started';
 
 export interface NudgeWarning {
   code: NudgeCode;
@@ -32,12 +35,17 @@ export interface JobNudgeState {
   awaitingEnd: boolean;
   /** Wall-clock ms of the last successful get_gate_verdict in this tracker. */
   lastGatePollAt: number | null;
+  /** True when that last successful poll returned status=pending (only those are throttled). */
+  lastGatePollPending: boolean;
 }
 
-/** Minimum wall-clock gap between get_gate_verdict polls before soft `gate_poll_backoff`. */
+/** Minimum wall-clock gap between get_gate_verdict polls before hard refuse. */
 export const GATE_POLL_MIN_INTERVAL_MS = 25_000;
 /** Hint returned on pending gate reads — agents must wait this many seconds, not busy-poll. */
 export const GATE_POLL_RETRY_AFTER_SECONDS = 30;
+
+/** Presence key stamped on successful gate reads (Studio + durable backoff). */
+export const GATE_POLL_PRESENCE_KEY = 'waiting_checks';
 
 /** No progress for this long (wall clock) → `progress_stale`. */
 export const PROGRESS_STALE_MS = 90_000;
@@ -86,6 +94,32 @@ export const SEED_NUDGE_TOOLS = new Set([
   'read_kit_file_fragment',
 ]);
 
+/**
+ * Seconds to wait before the next poll, or null when the poll is allowed.
+ * Pure — does not mutate tracker state.
+ */
+export function gatePollRetryAfterSeconds(lastPollAtMs: number | null, nowMs: number): number | null {
+  if (lastPollAtMs === null) return null;
+  const elapsed = nowMs - lastPollAtMs;
+  if (elapsed >= GATE_POLL_MIN_INTERVAL_MS) return null;
+  return Math.max(1, Math.ceil((GATE_POLL_MIN_INTERVAL_MS - elapsed) / 1000));
+}
+
+/**
+ * Durable backoff from Studio presence: a recent `waiting_checks` stamp means a
+ * successful gate poll already ran (this instance or another). Used by the channel
+ * so Cloud Run instance hops cannot reset the in-process tracker.
+ */
+export function gatePollBackoffFromPresence(
+  presence: { key: string; at: string } | undefined,
+  nowMs: number,
+): number | null {
+  if (!presence || presence.key !== GATE_POLL_PRESENCE_KEY) return null;
+  const atMs = Date.parse(presence.at);
+  if (!Number.isFinite(atMs)) return null;
+  return gatePollRetryAfterSeconds(atMs, nowMs);
+}
+
 export interface McpNudgeTracker {
   ensure(jobId: number, nowMs: number): JobNudgeState;
   noteProgress(jobId: number, nowMs: number): void;
@@ -99,6 +133,16 @@ export interface McpNudgeTracker {
   /** `nowMs` is only used if the job has never been ensured — callers should pass the injected clock. */
   notePendingCount(jobId: number, count: number, nowMs: number): void;
   noteToolSuccess(jobId: number, toolName: string, nowMs: number): void;
+  /**
+   * Record a successful get_gate_verdict. Only `pending: true` polls count toward
+   * the busy-poll interval — landed verdicts may be re-read immediately.
+   */
+  noteGatePoll(jobId: number, nowMs: number, pending: boolean): void;
+  /**
+   * In-process busy-poll check after a pending poll. Returns `{ retryAfterSeconds }`
+   * when too soon; null when allowed (including after a landed verdict). Does not mutate.
+   */
+  gatePollBackoff(jobId: number, nowMs: number): { retryAfterSeconds: number } | null;
   warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[];
   /** Test helper. */
   peek(jobId: number): JobNudgeState | undefined;
@@ -124,6 +168,7 @@ export function createMcpNudgeTracker(
         seedStatus: null,
         awaitingEnd: false,
         lastGatePollAt: null,
+        lastGatePollPending: false,
       };
       states.set(jobId, state);
     }
@@ -164,6 +209,20 @@ export function createMcpNudgeTracker(
   function notePendingCount(jobId: number, count: number, nowMs: number): void {
     const state = ensure(jobId, nowMs);
     state.pendingCount = Math.max(0, count);
+  }
+
+  function noteGatePoll(jobId: number, nowMs: number, pending: boolean): void {
+    const state = ensure(jobId, nowMs);
+    state.lastGatePollAt = nowMs;
+    state.lastGatePollPending = pending;
+  }
+
+  function gatePollBackoff(jobId: number, nowMs: number): { retryAfterSeconds: number } | null {
+    const state = ensure(jobId, nowMs);
+    if (!state.lastGatePollPending) return null;
+    const retryAfterSeconds = gatePollRetryAfterSeconds(state.lastGatePollAt, nowMs);
+    if (retryAfterSeconds === null) return null;
+    return { retryAfterSeconds };
   }
 
   function noteToolSuccess(jobId: number, toolName: string, nowMs: number): void {
@@ -234,19 +293,6 @@ export function createMcpNudgeTracker(
       });
     }
 
-    // Agents cannot sleep between tool calls, so "poll every ~30s" becomes a tight loop
-    // that burns connector tool budgets. Soft-warn when polls are closer than the gap.
-    if (toolName === 'get_gate_verdict') {
-      if (state.lastGatePollAt !== null && nowMs - state.lastGatePollAt < GATE_POLL_MIN_INTERVAL_MS) {
-        const waitSec = Math.max(1, Math.ceil((GATE_POLL_MIN_INTERVAL_MS - (nowMs - state.lastGatePollAt)) / 1000));
-        warnings.push({
-          code: 'gate_poll_backoff',
-          message: `Do not busy-poll get_gate_verdict — wait ~${waitSec}s wall-clock before the next poll (retryAfterSeconds=${GATE_POLL_RETRY_AFTER_SECONDS}). If you will not deliver more, call end instead; Studio shows the gate.`,
-        });
-      }
-      state.lastGatePollAt = nowMs;
-    }
-
     return warnings;
   }
 
@@ -260,6 +306,8 @@ export function createMcpNudgeTracker(
     noteEnded,
     notePendingCount,
     noteToolSuccess,
+    noteGatePoll,
+    gatePollBackoff,
     warningsFor,
     peek: (jobId) => states.get(jobId),
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Soft `warnings.code=gate_poll_backoff` from #563 did not stop Claude-class connectors from tight-looping `get_gate_verdict` while status stayed `pending`.

### Changes
- **Hard refuse** back-to-back *pending* polls: MCP returns `isError` with `code=gate_poll_backoff` + `retryAfterSeconds`.
- **Channel HTTP 429** on the same condition, keyed off a durable `waiting_checks` presence stamp so Cloud Run instance hops cannot reset an in-memory tracker.
- Landed verdicts (`green` / `red` / etc.) stay immediately re-readable (terminal receipt on multiple transports).
- Soft-warning path for `gate_poll_backoff` removed; skill + behavioural contract updated.

### Test plan
- [x] `mcp-session-nudges` / `mcp-server` / `agent-channel` unit tests
- [x] Full green gate (`type-check` / `lint` / `test` / `build`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cda5a12-0903-4f47-8016-dd54b4d1ce84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cda5a12-0903-4f47-8016-dd54b4d1ce84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

