### PR TITLE
feat(mcp): patch_source_file so Claude Chat need not rewrite large modules

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -21,8 +21,11 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - **Edits:** `patch_source_file({ path, patch })` with a standard unified diff
      (`---/`+++`+`@@`hunks for one file) — do not re-emit whole`render.ts`/`model.ts`files through`stage_source_file`
-   - **Modules:** keep `game/*.ts` cohesive and modest; split growing paint/HUD/art or
-     model tables so later patches stay small (chat-thin clients pay per token)
+   - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
+     `warnings.code=module_too_large` (on `get_sources` / `get_seed` / stage / patch)
+     by splitting cohesive pieces _before_ more feature work — same urgency as
+     `call_end`. Recipes: render→`art`/`ui`/`hud`/`rooms`; model→`tables`/`layout`/
+     `types`; runtime→systems
    - `fromStaged` overlays onto the latest delivery/seed — stage only changed paths
    - `mode=preview` while iterating; `mode=publish` to seal (TRACE + PLAYTEST required)
    - Each successful stage/patch refreshes Studio’s heartbeat (so a long staging loop is not

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -20,7 +20,8 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - **Edits:** `patch_source_file({ path, patch })` with a standard unified diff
-     (`---/`+++`+`@@`hunks for one file) — do not re-emit whole`render.ts`/`model.ts`files through`stage_source_file`
+     (`---` / `+++` + `@@` hunks for one file) — do not re-emit whole `render.ts` /
+     `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
      `warnings.code=module_too_large` (on `get_sources` / `get_seed` / stage / patch)
      by splitting cohesive pieces _before_ more feature work — same urgency as

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -17,10 +17,10 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 
 1. `start` → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
 2. Build; `report_progress`; `send_screenshot` when something draws
-3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (exact edit) then
+3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
-   - **Edits:** `patch_source_file({ path, oldString, newString })` — do not re-emit whole
-     `render.ts` / `model.ts` files through `stage_source_file`
+   - **Edits:** `patch_source_file({ path, patch })` with a standard unified diff
+     (`---/`+++`+`@@`hunks for one file) — do not re-emit whole`render.ts`/`model.ts`files through`stage_source_file`
    - **Modules:** keep `game/*.ts` cohesive and modest; split growing paint/HUD/art or
      model tables so later patches stay small (chat-thin clients pay per token)
    - `fromStaged` overlays onto the latest delivery/seed — stage only changed paths

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -17,9 +17,15 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 
 1. `start` → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
 2. Build; `report_progress`; `send_screenshot` when something draws
-3. Prefer `stage_source_file` then `submit_sources({ fromStaged: true, mode, kitEngineRef })`
+3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (exact edit) then
+   `submit_sources({ fromStaged: true, mode, kitEngineRef })`
+   - **Edits:** `patch_source_file({ path, oldString, newString })` — do not re-emit whole
+     `render.ts` / `model.ts` files through `stage_source_file`
+   - **Modules:** keep `game/*.ts` cohesive and modest; split growing paint/HUD/art or
+     model tables so later patches stay small (chat-thin clients pay per token)
+   - `fromStaged` overlays onto the latest delivery/seed — stage only changed paths
    - `mode=preview` while iterating; `mode=publish` to seal (TRACE + PLAYTEST required)
-   - Each successful stage refreshes Studio’s heartbeat (so a long staging loop is not
+   - Each successful stage/patch refreshes Studio’s heartbeat (so a long staging loop is not
      mistaken for quiet / offline)
    - Each stage may also publish a **live preview** of the buffer — see below
 4. **Prefer `end` after the last successful `submit_sources`** if you will not deliver
@@ -122,14 +128,14 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code                | Meaning                                                          |
-| ------------------- | ---------------------------------------------------------------- |
-| `call_end`          | Call `end` when finished iterating this round                    |
-| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet       |
+| Code                | Meaning                                                                          |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `call_end`          | Call `end` when finished iterating this round                                    |
+| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                       |
 | `gate_poll_backoff` | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true` |
-| `progress_stale`    | Call `report_progress`                                           |
-| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                               |
-| `seed_unread`       | Call `get_seed` before scaffolding from the kit                  |
+| `progress_stale`    | Call `report_progress`                                                           |
+| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                               |
+| `seed_unread`       | Call `get_seed` before scaffolding from the kit                                  |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,6 +34,7 @@
     "@gamedevpl/game-generator": "*",
     "@gamedevpl/zone-core": "*",
     "@google-cloud/firestore": "^8.7.0",
+    "diff": "^9.0.0",
     "esbuild": "0.25.12",
     "fastify": "^5.10.0",
     "fastify-rate-limit": "npm:@fastify/rate-limit@^11.1.0",

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1535,6 +1535,68 @@ describe('agent build channel', () => {
       expect(staged.size).toBe(0);
     });
 
+    it('fromStaged fails closed when the delivery manifest lists unreadable paths', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      const { gamesStore, stored, staged } = stubGamesStore();
+      app = await createApp(store, {
+        gamesStore: {
+          ...gamesStore,
+          getManifest: async () => ({ sourceFiles: ['game.ts', 'SPEC.md', 'index.html'] }),
+          getSourceFile: async (_slug: string, _version: string, path: string) =>
+            path === 'game.ts' ? 'export {};' : null,
+        } as unknown as GamesStore,
+      });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: { slug: 'comet-courier', path: 'game.ts', content: 'export const fixed = 1;' },
+      });
+      expect(staged.size).toBe(1);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          fromStaged: true,
+          kitEngineRef: 'abcdef1234567890',
+          mode: 'preview',
+        },
+      });
+      expect(response.statusCode).toBe(502);
+      expect(response.json().error).toMatch(/could not be read back/i);
+      expect(stored).toHaveLength(0);
+    });
+
+    it('refuses a whitespace-only patch before apply', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: { slug: 'comet-courier', path: 'game.ts', content: 'line1\n' },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: { path: 'game.ts', patch: '   \n\t  ' },
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toMatch(/empty|patch/i);
+    });
+
     it('refuses a unified diff that does not apply or targets the wrong path', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -910,6 +910,7 @@ describe('agent build channel', () => {
           };
         },
         getStagedSourceFiles: async () => [...staged.entries()].map(([path, content]) => ({ path, content })),
+        getStagedSourceFile: async (input: { path: string }) => staged.get(input.path) ?? null,
         clearStagedSources: async (input?: { paths?: string[] }) => {
           if (!input?.paths?.length) {
             const cleared = staged.size;
@@ -1468,6 +1469,95 @@ describe('agent build channel', () => {
       );
       // Finalize clears the buffer so the next iterate starts clean.
       expect(staged.size).toBe(0);
+    });
+
+    it('patches a delivery file into staging and fromStaged overlays the rest', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      await store.setSubmissionSlug(ISSUE, 'comet-courier');
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      const { gamesStore, stored, staged } = stubGamesStore();
+      const delivered: Record<string, string> = Object.fromEntries(
+        MINIMAL.filter((f) => f.path !== 'TRACE.json' && f.path !== 'PLAYTEST.json').map((f) => [f.path, f.content]),
+      );
+      delivered['game/render.ts'] = 'export function paint() {\n  drawSky();\n}\n';
+      app = await createApp(store, {
+        gamesStore: {
+          ...gamesStore,
+          getManifest: async () => ({ sourceFiles: Object.keys(delivered) }),
+          getSourceFile: async (_slug: string, _version: string, path: string) => delivered[path] ?? null,
+        } as unknown as GamesStore,
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          path: 'game/render.ts',
+          oldString: 'drawSky();',
+          newString: 'drawSky();\n  drawHud();',
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({
+        accepted: true,
+        path: 'game/render.ts',
+        replacements: 1,
+        baseFrom: 'delivery',
+      });
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+      expect(staged.size).toBe(1);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          fromStaged: true,
+          kitEngineRef: 'abcdef1234567890',
+          mode: 'preview',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const files = stored[0]?.files as Array<{ path: string; content: string }>;
+      expect(files.find((f) => f.path === 'game/render.ts')?.content).toContain('drawHud()');
+      expect(files.find((f) => f.path === 'game.ts')?.content).toBe(delivered['game.ts']);
+      expect(staged.size).toBe(0);
+    });
+
+    it('refuses a patch whose oldString is missing or ambiguous', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: { slug: 'comet-courier', path: 'game.ts', content: 'aa aa' },
+      });
+
+      const missing = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: { path: 'game.ts', oldString: 'zz', newString: 'yy' },
+      });
+      expect(missing.statusCode).toBe(400);
+      expect(missing.json().error).toMatch(/not found/i);
+
+      const ambiguous = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: { path: 'game.ts', oldString: 'aa', newString: 'bb' },
+      });
+      expect(ambiguous.statusCode).toBe(400);
+      expect(ambiguous.json().error).toMatch(/more than once/i);
+      expect(staged.get('game.ts')).toBe('aa aa');
     });
 
     /**

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1495,8 +1495,16 @@ describe('agent build channel', () => {
         headers: agentHeaders(),
         payload: {
           path: 'game/render.ts',
-          oldString: 'drawSky();',
-          newString: 'drawSky();\n  drawHud();',
+          patch: [
+            '--- a/game/render.ts',
+            '+++ b/game/render.ts',
+            '@@ -1,3 +1,4 @@',
+            ' export function paint() {',
+            '   drawSky();',
+            '+  drawHud();',
+            ' }',
+            '',
+          ].join('\n'),
         },
       });
       expect(patched.statusCode).toBe(200);
@@ -1527,7 +1535,7 @@ describe('agent build channel', () => {
       expect(staged.size).toBe(0);
     });
 
-    it('refuses a patch whose oldString is missing or ambiguous', async () => {
+    it('refuses a unified diff that does not apply or targets the wrong path', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);
       const { gamesStore, staged } = stubGamesStore();
@@ -1537,27 +1545,33 @@ describe('agent build channel', () => {
         method: 'PUT',
         url: '/api/agent/build/sources/stage',
         headers: agentHeaders(),
-        payload: { slug: 'comet-courier', path: 'game.ts', content: 'aa aa' },
+        payload: { slug: 'comet-courier', path: 'game.ts', content: 'line1\nline2\n' },
       });
 
-      const missing = await app.inject({
+      const stale = await app.inject({
         method: 'POST',
         url: '/api/agent/build/sources/stage/patch',
         headers: agentHeaders(),
-        payload: { path: 'game.ts', oldString: 'zz', newString: 'yy' },
+        payload: {
+          path: 'game.ts',
+          patch: ['--- a/game.ts', '+++ b/game.ts', '@@ -1,2 +1,2 @@', ' missing', '-line2', '+line2x', ''].join('\n'),
+        },
       });
-      expect(missing.statusCode).toBe(400);
-      expect(missing.json().error).toMatch(/not found/i);
+      expect(stale.statusCode).toBe(400);
+      expect(stale.json().error).toMatch(/did not apply/i);
 
-      const ambiguous = await app.inject({
+      const wrongPath = await app.inject({
         method: 'POST',
         url: '/api/agent/build/sources/stage/patch',
         headers: agentHeaders(),
-        payload: { path: 'game.ts', oldString: 'aa', newString: 'bb' },
+        payload: {
+          path: 'game.ts',
+          patch: ['--- a/other.ts', '+++ b/other.ts', '@@ -1,2 +1,2 @@', ' line1', '-line2', '+line2x', ''].join('\n'),
+        },
       });
-      expect(ambiguous.statusCode).toBe(400);
-      expect(ambiguous.json().error).toMatch(/more than once/i);
-      expect(staged.get('game.ts')).toBe('aa aa');
+      expect(wrongPath.statusCode).toBe(400);
+      expect(wrongPath.json().error).toMatch(/does not match/i);
+      expect(staged.get('game.ts')).toBe('line1\nline2\n');
     });
 
     /**

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -46,7 +46,8 @@ import {
   parseKitSidecar,
 } from './kit-registry.js';
 import { seedPayload } from './seed-status.js';
-import { applySourcePatch, largeSourceFileHint, SourcePatchError } from './source-patch.js';
+import { largeSourceFileHint } from './module-size.js';
+import { applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
@@ -1001,7 +1002,7 @@ export async function registerAgentChannelRoutes(
         options.onEvent?.(issueNumber);
         // After the buffer is durable, so the assembly it schedules reads this file too.
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
-        const hint = largeSourceFileHint(staged.path, staged.bytes);
+        const hint = largeSourceFileHint(staged.path, staged.bytes, parsed.data.content);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -1026,7 +1027,7 @@ export async function registerAgentChannelRoutes(
   );
 
   /**
-   * Exact string patch into the staging buffer.
+   * Unified-diff patch into the staging buffer.
    *
    * Base content is staged → latest delivery → seed (same overlay order as the live
    * staged preview). The patched file is then written with putStagedSourceFile, so a
@@ -1130,7 +1131,7 @@ export async function registerAgentChannelRoutes(
         options.onEvent?.(issueNumber);
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
 
-        const hint = largeSourceFileHint(staged.path, staged.bytes);
+        const hint = largeSourceFileHint(staged.path, staged.bytes, patched.content);
         return reply.send({
           accepted: true,
           path: staged.path,

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -260,9 +260,8 @@ const StageSourceInputSchema = z.object({
 
 const StageSourcePatchInputSchema = z.object({
   path: z.string().trim().min(1).max(120),
-  oldString: z.string().min(1).max(200_000),
-  newString: z.string().max(200_000),
-  replaceAll: z.boolean().optional(),
+  /** Unified diff for this one path (`---/`+++` + `@@` hunks). */
+  patch: z.string().min(1).max(400_000),
   slug: z
     .string()
     .trim()
@@ -1115,9 +1114,8 @@ export async function registerAgentChannelRoutes(
 
         const patched = applySourcePatch({
           content: base,
-          oldString: parsed.data.oldString,
-          newString: parsed.data.newString,
-          replaceAll: parsed.data.replaceAll === true,
+          path: parsed.data.path,
+          patch: parsed.data.patch,
         });
 
         const staged = await options.gamesStore.putStagedSourceFile({

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -261,8 +261,11 @@ const StageSourceInputSchema = z.object({
 
 const StageSourcePatchInputSchema = z.object({
   path: z.string().trim().min(1).max(120),
-  /** Unified diff for this one path (`---/`+++` + `@@` hunks). */
-  patch: z.string().min(1).max(400_000),
+  /** Unified diff for this one path (`---` / `+++` + `@@` hunks). */
+  patch: z
+    .string()
+    .transform((value) => value.trim())
+    .pipe(z.string().min(1, 'patch must not be empty').max(400_000)),
   slug: z
     .string()
     .trim()
@@ -1394,15 +1397,23 @@ export async function registerAgentChannelRoutes(
           }
           if (version) {
             const manifest = await options.gamesStore.getManifest(slug, version);
-            if (manifest) {
-              const loaded = await Promise.all(
-                manifest.sourceFiles.map(async (path) => ({
-                  path,
-                  content: await options.gamesStore!.getSourceFile(slug, version!, path),
-                })),
-              );
-              delivered = loaded.filter((file): file is { path: string; content: string } => file.content !== null);
+            if (!manifest) {
+              return reply.status(502).send({ error: 'the latest delivery could not be read back' });
             }
+            const loaded = await Promise.all(
+              manifest.sourceFiles.map(async (path) => ({
+                path,
+                content: await options.gamesStore!.getSourceFile(slug, version!, path),
+              })),
+            );
+            // Fail closed like fromLatestDelivery — a hole in the base would let a one-file
+            // patch assemble a tree missing paths the manifest still claims exist.
+            const missing = loaded.filter((file) => file.content === null).map((file) => file.path);
+            if (missing.length > 0) {
+              request.log.error({ slug, version, missing }, 'latest delivery missing files its manifest lists');
+              return reply.status(502).send({ error: 'the latest delivery could not be read back' });
+            }
+            delivered = loaded.map((file) => ({ path: file.path, content: file.content as string }));
           }
           const overlay = overlayGameSources({
             staged: [...staged, ...files],

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -46,6 +46,8 @@ import {
   parseKitSidecar,
 } from './kit-registry.js';
 import { seedPayload } from './seed-status.js';
+import { applySourcePatch, largeSourceFileHint, SourcePatchError } from './source-patch.js';
+import { overlayGameSources } from './staged-preview.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 import { normalizeAtIntake, type IntakeText } from './localize-intake.js';
@@ -248,6 +250,19 @@ const BuildSourcesInputSchema = z
 const StageSourceInputSchema = z.object({
   path: z.string().trim().min(1).max(120),
   content: z.string().max(1_000_000),
+  slug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be lowercase letters, digits and dashes')
+    .max(64)
+    .optional(),
+});
+
+const StageSourcePatchInputSchema = z.object({
+  path: z.string().trim().min(1).max(120),
+  oldString: z.string().min(1).max(200_000),
+  newString: z.string().max(200_000),
+  replaceAll: z.boolean().optional(),
   slug: z
     .string()
     .trim()
@@ -987,6 +1002,7 @@ export async function registerAgentChannelRoutes(
         options.onEvent?.(issueNumber);
         // After the buffer is durable, so the assembly it schedules reads this file too.
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
+        const hint = largeSourceFileHint(staged.path, staged.bytes);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -998,10 +1014,143 @@ export async function registerAgentChannelRoutes(
             maxFiles: staged.maxFiles,
             updatedAt: staged.updatedAt,
           },
+          ...(hint ? { hint } : {}),
           ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
         });
       } catch (error) {
         if (error instanceof InvalidUploadError) {
+          return reply.status(400).send({ error: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
+  /**
+   * Exact string patch into the staging buffer.
+   *
+   * Base content is staged → latest delivery → seed (same overlay order as the live
+   * staged preview). The patched file is then written with putStagedSourceFile, so a
+   * later fromStaged submit (which overlays the same way) only needs the changed paths
+   * in the buffer — chat-thin agents never re-emit a 40 KB render.ts for a one-line fix.
+   */
+  app.post(
+    '/api/agent/build/sources/stage/patch',
+    {
+      config: { rateLimit: { max: 300, timeWindow: '1 hour' } },
+      bodyLimit: 500_000,
+    },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      if (!options.gamesStore) {
+        return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+      }
+      if (stopReason(record)) {
+        return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
+      }
+
+      const parsed = StageSourcePatchInputSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      const slug = record.slug ?? parsed.data.slug;
+      if (!slug) {
+        return reply.status(400).send({
+          error: 'slug is required before patching — send the slug from get_brief / start',
+        });
+      }
+      if (record.slug && parsed.data.slug && record.slug !== parsed.data.slug) {
+        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
+      }
+      if (!record.slug && store) {
+        await store.setSubmissionSlug(issueNumber, slug);
+      }
+
+      const roundGeneration = store
+        ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+        : (record.roundGeneration ?? 1);
+
+      try {
+        const stagedContent = await options.gamesStore.getStagedSourceFile({
+          slug,
+          issueNumber,
+          roundGeneration,
+          path: parsed.data.path,
+        });
+
+        let base = stagedContent;
+        let baseFrom: 'staged' | 'delivery' | 'seed' | null = stagedContent !== null ? 'staged' : null;
+
+        if (base === null) {
+          let version = record.previewVersion ?? record.deliveredVersion;
+          if (!version) {
+            const publication = await store!.getPublication(slug);
+            if (publication?.state === 'published') version = publication.currentVersion;
+          }
+          if (version) {
+            base = await options.gamesStore.getSourceFile(slug, version, parsed.data.path);
+            if (base !== null) baseFrom = 'delivery';
+          }
+        }
+
+        if (base === null && record.seed?.files) {
+          const seedFile = record.seed.files.find((file) => file.path === parsed.data.path);
+          if (seedFile) {
+            base = seedFile.content;
+            baseFrom = 'seed';
+          }
+        }
+
+        if (base === null || baseFrom === null) {
+          return reply.status(400).send({
+            error:
+              `cannot patch ${parsed.data.path}: no base content in staging, the latest delivery, or the seed — ` +
+              'stage_source_file the full file first (or get_sources / get_seed), then patch',
+          });
+        }
+
+        const patched = applySourcePatch({
+          content: base,
+          oldString: parsed.data.oldString,
+          newString: parsed.data.newString,
+          replaceAll: parsed.data.replaceAll === true,
+        });
+
+        const staged = await options.gamesStore.putStagedSourceFile({
+          slug,
+          issueNumber,
+          roundGeneration,
+          path: parsed.data.path,
+          content: patched.content,
+        });
+        await markBuildingFromChannel(issueNumber, record);
+        await store?.touchLastAgentSignalAt(issueNumber, undefined, { key: 'staging_sources' });
+        options.onEvent?.(issueNumber);
+        options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
+
+        const hint = largeSourceFileHint(staged.path, staged.bytes);
+        return reply.send({
+          accepted: true,
+          path: staged.path,
+          bytes: staged.bytes,
+          replacements: patched.replacements,
+          baseFrom,
+          staged: {
+            files: staged.files,
+            totalBytes: staged.totalBytes,
+            maxBytes: staged.maxBytes,
+            maxFiles: staged.maxFiles,
+            updatedAt: staged.updatedAt,
+          },
+          ...(hint ? { hint } : {}),
+          ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
+        });
+      } catch (error) {
+        if (error instanceof SourcePatchError || error instanceof InvalidUploadError) {
           return reply.status(400).send({ error: error.message });
         }
         throw error;
@@ -1231,16 +1380,37 @@ export async function registerAgentChannelRoutes(
           if (staged.length === 0 && files.length === 0) {
             return reply.status(400).send({
               error:
-                'fromStaged=true but the staging buffer is empty — call stage_source_file for each path first, ' +
-                'or pass files[] inline',
+                'fromStaged=true but the staging buffer is empty — call stage_source_file / patch_source_file ' +
+                'for each changed path first, or pass files[] inline',
             });
           }
-          // Inline files win on path collision so a final fix can patch one file without
-          // re-staging the whole tree.
-          const byPath = new Map<string, string>();
-          for (const file of staged) byPath.set(file.path, file.content);
-          for (const file of files) byPath.set(file.path, file.content);
-          files = [...byPath.entries()].map(([path, content]) => ({ path, content }));
+          // Overlay matches the live staged preview: staged (plus inline) over the latest
+          // delivery over the seed. A one-file patch_source_file (or a partial stage) can
+          // therefore submit a complete tree without re-uploading unchanged paths.
+          let delivered: Array<{ path: string; content: string }> = [];
+          let version = record.previewVersion ?? record.deliveredVersion;
+          if (!version) {
+            const publication = await store!.getPublication(slug);
+            if (publication?.state === 'published') version = publication.currentVersion;
+          }
+          if (version) {
+            const manifest = await options.gamesStore.getManifest(slug, version);
+            if (manifest) {
+              const loaded = await Promise.all(
+                manifest.sourceFiles.map(async (path) => ({
+                  path,
+                  content: await options.gamesStore!.getSourceFile(slug, version!, path),
+                })),
+              );
+              delivered = loaded.filter((file): file is { path: string; content: string } => file.content !== null);
+            }
+          }
+          const overlay = overlayGameSources({
+            staged: [...staged, ...files],
+            ...(delivered.length ? { delivered } : {}),
+            ...(record.seed?.files ? { seed: record.seed.files } : {}),
+          });
+          files = Object.entries(overlay).map(([path, content]) => ({ path, content }));
         }
         mode ??= 'publish';
 

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -315,6 +315,12 @@ describe('GCS games store', () => {
     const listed = await store.listStagedSources({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
     expect(listed.files.map((f) => f.path).sort()).toEqual(draft.map((f) => f.path).sort());
     expect(objects.has('games/g/staging/7/g1/source/game.ts')).toBe(true);
+    expect(await store.getStagedSourceFile({ slug: 'g', issueNumber: 7, roundGeneration: 1, path: 'game.ts' })).toBe(
+      draft.find((f) => f.path === 'game.ts')!.content,
+    );
+    expect(
+      await store.getStagedSourceFile({ slug: 'g', issueNumber: 7, roundGeneration: 1, path: 'missing.ts' }),
+    ).toBeNull();
 
     const assembled = await store.getStagedSourceFiles({ slug: 'g', issueNumber: 7, roundGeneration: 1 });
     const { version } = await store.putCandidateSources({

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -432,6 +432,13 @@ export interface GamesStore {
   }): Promise<StagedSourcesSummary>;
   /** Reads staged contents for finalize. */
   getStagedSourceFiles(input: { slug: string; issueNumber: number; roundGeneration: number }): Promise<SourceFile[]>;
+  /** Reads one staged path (null when not in the buffer). Used by patch_source_file. */
+  getStagedSourceFile(input: {
+    slug: string;
+    issueNumber: number;
+    roundGeneration: number;
+    path: string;
+  }): Promise<string | null>;
   /** Clears the staging buffer (all paths, or a named subset). */
   clearStagedSources(input: {
     slug: string;
@@ -758,6 +765,17 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
         }),
       );
       return files;
+    },
+
+    async getStagedSourceFile(input) {
+      assertSlug(input.slug);
+      const path = assertDeliverableSourcePath(input.path);
+      const existing = await readStagingManifest(input.slug, input.issueNumber, input.roundGeneration);
+      if (!existing?.manifest.files.some((file) => file.path === path)) return null;
+      const body = await readObject(
+        `${stagingPrefix(input.slug, input.issueNumber, input.roundGeneration)}/source/${path}`,
+      );
+      return body ? body.toString('utf8') : null;
     },
 
     async clearStagedSources(input) {

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -21,6 +21,7 @@ describe('mcp presence pulses', () => {
     expect(shouldPulseMcpPresence('continue_draft')).toBe(false);
     expect(shouldPulseMcpPresence('open_round')).toBe(false);
     expect(shouldPulseMcpPresence('stage_source_file')).toBe(false);
+    expect(shouldPulseMcpPresence('patch_source_file')).toBe(false);
     expect(shouldPulseMcpPresence('clear_staged_sources')).toBe(false);
     // Inherited Object keys must not count as tools.
     expect(shouldPulseMcpPresence('toString')).toBe(false);

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -20,12 +20,12 @@ const NO_PULSE = new Set([
   'report_progress',
   'send_screenshot',
   'submit_sources',
-  // Channel PUT …/sources/stage refreshes lastAgentSignalAt (+ staging_sources presence).
+  // Channel PUT …/sources/stage (and POST …/stage/patch) refresh lastAgentSignalAt (+ staging_sources presence).
   'stage_source_file',
+  'patch_source_file',
   'clear_staged_sources',
   'ack_inbox',
 ]);
-
 /**
  * Closed vocabulary for Studio thought headlines. Client translates via
  * `statusView.presence.<key>`; English `text` matches historical chat rows so

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -320,6 +320,7 @@ describe('POST /api/mcp (BY-05)', () => {
         'report_progress',
         'send_screenshot',
         'stage_source_file',
+        'patch_source_file',
         'list_staged_sources',
         'clear_staged_sources',
         'submit_sources',
@@ -469,6 +470,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/read_kit_files|list_kit_files|read_kit_file/);
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/stage_source_file|fromStaged/);
+    expect(joined).toMatch(/patch_source_file/);
     expect(joined).toMatch(/submit_sources/);
     expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
     expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);
@@ -1087,9 +1089,7 @@ describe('POST /api/mcp (BY-05)', () => {
       stop: false,
       reason: 'no_delivery',
     });
-    expect(String((verdict.structured as { summary?: string }).summary)).toMatch(
-      /continue building.*submit_sources/i,
-    );
+    expect(String((verdict.structured as { summary?: string }).summary)).toMatch(/continue building.*submit_sources/i);
   });
 
   it('makes pending get_gate_verdict a one-shot stop and warns if the client ignores it', async () => {
@@ -1680,6 +1680,7 @@ describe('POST /api/mcp (BY-05)', () => {
       'report_progress',
       'send_screenshot',
       'stage_source_file',
+      'patch_source_file',
       'clear_staged_sources',
       'submit_sources',
       'end',

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -471,6 +471,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/send_screenshot/);
     expect(joined).toMatch(/stage_source_file|fromStaged/);
     expect(joined).toMatch(/patch_source_file/);
+    expect(joined).toMatch(/module_too_large/);
+    expect(joined).toMatch(/350 lines|12 KiB/);
     expect(joined).toMatch(/submit_sources/);
     expect(joined).toMatch(/mode:\s*"preview"|mode=preview/i);
     expect(joined).toMatch(/mode:\s*"publish"|mode=publish/i);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -309,7 +309,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, oldString, newString }) for edits (never re-emit a whole large render.ts/model.ts). Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (never re-emit a whole large render.ts/model.ts). Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
@@ -338,7 +338,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Keep modules cohesive and modest (prefer splitting a growing render.ts / model.ts into game/*.ts such as art, ui, rooms, tables) so later edits stay small.',
   'send_screenshot as soon as the game draws anything playable.',
-  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, oldString, newString }) (unique snippet; replaceAll only when intentional). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
+  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, patch }) with a unified diff (---/+++ + @@ hunks for ONE file; context must match exactly). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null returns stop:false because you checked too early — continue building and call submit_sources; do not check again before a delivery. A later creator-led run may check a delivered gate again. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
@@ -2718,38 +2718,39 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['ok', 'path', 'bytes', 'replacements', 'baseFrom', 'staged', 'stop', 'pendingMessages'],
       },
       description:
-        'Apply an exact oldString→newString edit to ONE path and write the result into the staging buffer. ' +
+        'Apply a unified diff to ONE existing path and write the result into the staging buffer. ' +
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
-        'especially for large game/render.ts or game/model.ts files. oldString must match exactly once unless replaceAll=true. ' +
+        'especially for large game/render.ts or game/model.ts files. ' +
+        'patch must be a standard unified diff for that single file, e.g. ' +
+        '"--- a/game/render.ts\\n+++ b/game/render.ts\\n@@ -10,6 +10,7 @@\\n context\\n-old\\n+new\\n context\\n". ' +
+        'Context must match exactly (no fuzzy apply). Multi-file patches are refused — call once per path. ' +
         'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
-          path: { type: 'string', description: 'Game-relative path (e.g. game/render.ts).' },
-          oldString: {
+          path: {
             type: 'string',
-            description: 'Exact text to find (include enough surrounding context to be unique).',
+            description: 'Game-relative path (e.g. game/render.ts). Must match the ---/+++ headers.',
           },
-          newString: { type: 'string', description: 'Replacement text (may be empty to delete the snippet).' },
-          replaceAll: {
-            type: 'boolean',
-            description: 'Replace every occurrence. Default false (requires a unique match).',
+          patch: {
+            type: 'string',
+            description:
+              'Unified diff for this one file only (`--- a/<path>` / `+++ b/<path>` plus one or more @@ hunks).',
           },
           slug: { type: 'string' },
         },
-        required: ['path', 'oldString', 'newString'],
+        required: ['path', 'patch'],
       },
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const path = typeof args.path === 'string' ? args.path.trim() : '';
         if (!path) return toolErr('path is required');
-        if (typeof args.oldString !== 'string' || args.oldString.length === 0) {
-          return toolErr('oldString is required');
+        if (typeof args.patch !== 'string' || args.patch.trim().length === 0) {
+          return toolErr('patch is required (unified diff text)');
         }
-        if (typeof args.newString !== 'string') return toolErr('newString is required');
         const slug =
           typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
         const res = await injectChannel(
@@ -2759,9 +2760,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           auth.channelToken,
           {
             path,
-            oldString: args.oldString,
-            newString: args.newString,
-            ...(args.replaceAll === true ? { replaceAll: true } : {}),
+            patch: args.patch,
             ...(slug ? { slug } : {}),
           },
         );

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -309,7 +309,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file once per path then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, oldString, newString }) for edits (never re-emit a whole large render.ts/model.ts). Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
@@ -336,10 +336,10 @@ const SESSION_WORKFLOW: readonly string[] = [
   // unconditional rather than gated on a round type the agent cannot see.
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them.',
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
-  'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps.',
+  'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Keep modules cohesive and modest (prefer splitting a growing render.ts / model.ts into game/*.ts such as art, ui, rooms, tables) so later edits stay small.',
   'send_screenshot as soon as the game draws anything playable.',
-  'While iterating: prefer stage_source_file({ path, content }) for each game file (list_staged_sources to check), then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
-  'Staging is already visible: once index.html, game.ts, style.css and GAME.json are staged, the platform assembles the buffer and shows the creator a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging as you work; a buffer that does not compile simply leaves the previous preview up.',
+  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, oldString, newString }) (unique snippet; replaceAll only when intentional). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
+  'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null returns stop:false because you checked too early — continue building and call submit_sources; do not check again before a delivery. A later creator-led run may check a delivered gate again. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
   'When ready to seal: record TRACE (`npm run trace -- <slug> --accept` if you have a kit checkout), stage/include PLAYTEST.json + TRACE.json, then submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) (or inline files[]).',
@@ -2589,6 +2589,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ok: { type: 'boolean' },
           path: { type: 'string' },
           bytes: { type: 'number' },
+          hint: { type: 'string' },
           staged: {
             type: 'object',
             properties: {
@@ -2611,9 +2612,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['ok', 'path', 'bytes', 'staged', 'stop', 'pendingMessages'],
       },
       description:
-        'Upload ONE game source file into this round’s staging buffer. Prefer this over a giant submit_sources files[] ' +
-        'when the tree is large (Claude Chat often truncates huge tool JSON). Call once per path, then ' +
-        'submit_sources({ fromStaged: true, mode, kitEngineRef }). Overwrites the same path if staged again. ' +
+        'Upload ONE game source file into this round’s staging buffer (full rewrite). Prefer this for new files; ' +
+        'for edits to an existing path prefer patch_source_file so you do not re-emit a whole large file. ' +
+        'Prefer over a giant submit_sources files[] when the tree is large (Claude Chat often truncates huge tool JSON). ' +
+        'Call once per path, then submit_sources({ fromStaged: true, mode, kitEngineRef }). Overwrites the same path if staged again. ' +
+        'Keep modules modest — if hint warns the file is large, split into cohesive game/*.ts modules. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -2656,6 +2659,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           rejected?: string;
           path?: string;
           bytes?: number;
+          hint?: string;
           staged?: {
             files: Array<{ path: string; bytes: number }>;
             totalBytes: number;
@@ -2673,6 +2677,123 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...(body.rejected ? { rejected: body.rejected } : {}),
           path: body.path ?? path,
           bytes: body.bytes ?? 0,
+          ...(body.hint ? { hint: body.hint } : {}),
+          staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
+          ...stopFromChannel(body),
+          pendingMessages: pendingMessagesFromChannel(body),
+        });
+      },
+    },
+
+    patch_source_file: {
+      annotations: { title: 'Patch one staged source file', ...WRITES },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean' },
+          path: { type: 'string' },
+          bytes: { type: 'number' },
+          replacements: { type: 'number' },
+          baseFrom: { type: 'string', enum: ['staged', 'delivery', 'seed'] },
+          hint: { type: 'string' },
+          staged: {
+            type: 'object',
+            properties: {
+              files: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: { path: { type: 'string' }, bytes: { type: 'number' } },
+                  required: ['path', 'bytes'],
+                },
+              },
+              totalBytes: { type: 'number' },
+              maxBytes: { type: 'number' },
+              maxFiles: { type: 'number' },
+            },
+            required: ['files', 'totalBytes', 'maxBytes', 'maxFiles'],
+          },
+          ...REPLY_CONTROL,
+        },
+        required: ['ok', 'path', 'bytes', 'replacements', 'baseFrom', 'staged', 'stop', 'pendingMessages'],
+      },
+      description:
+        'Apply an exact oldString→newString edit to ONE path and write the result into the staging buffer. ' +
+        'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
+        'especially for large game/render.ts or game/model.ts files. oldString must match exactly once unless replaceAll=true. ' +
+        'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          path: { type: 'string', description: 'Game-relative path (e.g. game/render.ts).' },
+          oldString: {
+            type: 'string',
+            description: 'Exact text to find (include enough surrounding context to be unique).',
+          },
+          newString: { type: 'string', description: 'Replacement text (may be empty to delete the snippet).' },
+          replaceAll: {
+            type: 'boolean',
+            description: 'Replace every occurrence. Default false (requires a unique match).',
+          },
+          slug: { type: 'string' },
+        },
+        required: ['path', 'oldString', 'newString'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!path) return toolErr('path is required');
+        if (typeof args.oldString !== 'string' || args.oldString.length === 0) {
+          return toolErr('oldString is required');
+        }
+        if (typeof args.newString !== 'string') return toolErr('newString is required');
+        const slug =
+          typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
+        const res = await injectChannel(
+          ctx.request,
+          'POST',
+          '/api/agent/build/sources/stage/patch',
+          auth.channelToken,
+          {
+            path,
+            oldString: args.oldString,
+            newString: args.newString,
+            ...(args.replaceAll === true ? { replaceAll: true } : {}),
+            ...(slug ? { slug } : {}),
+          },
+        );
+        const body = res.json() as {
+          error?: string;
+          accepted?: boolean;
+          rejected?: string;
+          path?: string;
+          bytes?: number;
+          replacements?: number;
+          baseFrom?: 'staged' | 'delivery' | 'seed';
+          hint?: string;
+          staged?: {
+            files: Array<{ path: string; bytes: number }>;
+            totalBytes: number;
+            maxBytes: number;
+            maxFiles: number;
+          };
+          control?: { stop?: boolean; reason?: string };
+          pending?: Array<{ id: string; text: string; createdAt: string }>;
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `patch failed (${res.statusCode})`, body);
+        }
+        return toolOk({
+          ok: body.accepted !== false,
+          ...(body.rejected ? { rejected: body.rejected } : {}),
+          path: body.path ?? path,
+          bytes: body.bytes ?? 0,
+          replacements: body.replacements ?? 0,
+          baseFrom: body.baseFrom ?? 'staged',
+          ...(body.hint ? { hint: body.hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
           ...stopFromChannel(body),
           pendingMessages: pendingMessagesFromChannel(body),
@@ -2701,8 +2822,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['files', 'totalBytes', 'maxBytes', 'maxFiles', 'updatedAt'],
       },
       description:
-        'List paths currently in the staging buffer (no contents). Use after stage_source_file to confirm the tree ' +
-        'before submit_sources({ fromStaged: true, … }). ' +
+        'List paths currently in the staging buffer (no contents). Use after stage_source_file / patch_source_file ' +
+        'to confirm changed paths before submit_sources({ fromStaged: true, … }). ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -2835,7 +2956,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         ],
       },
       description:
-        `Deliver game sources. Prefer stage_source_file per path then fromStaged=true (avoids huge tool JSON). ` +
+        `Deliver game sources. Prefer stage_source_file / patch_source_file for changed paths then fromStaged=true ` +
+        `(fromStaged overlays onto the latest delivery/seed — do not re-stage unchanged files). ` +
         `On kit_outdated: get_kit then fromLatestDelivery=true with the same mode and new kitEngineRef — do NOT re-upload the whole tree. ` +
         `mode=preview (iterate): TRACE/PLAYTEST not required; runs typecheck→smoke→build; Studio gets a draft. ` +
         `mode=publish (seal): TRACE.json + PLAYTEST.json required; full gate; only publish green ends the round. ` +
@@ -2852,8 +2974,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           fromStaged: {
             type: 'boolean',
             description:
-              'Assemble the staging buffer built with stage_source_file. Prefer this for large trees. ' +
-              'When true, files[] may be omitted (or used as path overrides). Not with fromLatestDelivery.',
+              'Assemble staging (stage_source_file / patch_source_file), overlaid on the latest delivery and seed. ' +
+              'Prefer this for large trees and for one-file patches. When true, files[] may be omitted (or used as path overrides). ' +
+              'Not with fromLatestDelivery.',
           },
           fromLatestDelivery: {
             type: 'boolean',

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -40,6 +40,7 @@ import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base6
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
 import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
+import { largeSourceFileHint, moduleSizeWarnings } from './module-size.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import {
   assertMcpSessionKeyUnexpired,
@@ -309,7 +310,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (never re-emit a whole large render.ts/model.ts). Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
@@ -334,9 +335,9 @@ const SESSION_WORKFLOW: readonly string[] = [
   // existed. Following the loop literally, it scaffolded a fresh game over a published
   // one. get_sources is cheap and answers available:false on a new game, so it is
   // unconditional rather than gated on a round type the agent cannot see.
-  'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them.',
+  'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them. If warnings.code=module_too_large, split those oversized modules into cohesive game/*.ts pieces BEFORE adding features — do not grow them further.',
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
-  'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Keep modules cohesive and modest (prefer splitting a growing render.ts / model.ts into game/*.ts such as art, ui, rooms, tables) so later edits stay small.',
+  'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'send_screenshot as soon as the game draws anything playable.',
   'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, patch }) with a unified diff (---/+++ + @@ hunks for ONE file; context must match exactly). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
@@ -853,7 +854,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff). Not errors — act on them, then continue the workflow.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior.',
       items: {
         type: 'object',
         properties: {
@@ -866,6 +867,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'call_end',
               'gate_not_started',
               'gate_poll_backoff',
+              'module_too_large',
             ],
           },
           message: { type: 'string' },
@@ -1728,6 +1730,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           },
           references: { type: 'array', items: { type: 'string' } },
           notes: { type: ['string', 'null'] },
+          ...WARNINGS_PROP,
         },
         required: ['available', 'status', 'files', 'references', 'notes'],
       },
@@ -1735,6 +1738,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Fetch the platform-generated compiling seed draft for this round when present. ' +
         'Continue the seed when available/status=available. When status=pending, wait and call again before scaffolding. ' +
         'Only scaffold from a kit template when status=unavailable. ' +
+        'Honour warnings.code=module_too_large by splitting oversized modules before growing them. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -1745,14 +1749,24 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const res = await injectChannel(ctx.request, 'GET', '/api/agent/build/seed', auth.channelToken);
-        const body = res.json();
+        const body = res.json() as {
+          error?: string;
+          available?: boolean;
+          status?: string;
+          files?: Array<{ path: string; content: string }>;
+          [key: string]: unknown;
+        };
         if (res.statusCode === 404) {
           return toolOk(body);
         }
         if (res.statusCode !== 200) {
-          return toolErr((body as { error?: string }).error ?? `seed failed (${res.statusCode})`);
+          return toolErr(body.error ?? `seed failed (${res.statusCode})`);
         }
-        return toolOk(body);
+        const sizeWarnings = Array.isArray(body.files) ? moduleSizeWarnings(body.files) : [];
+        return toolOk({
+          ...body,
+          ...(sizeWarnings.length ? { warnings: sizeWarnings } : {}),
+        });
       },
     },
 
@@ -2169,11 +2183,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'array',
             items: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } } },
           },
+          ...WARNINGS_PROP,
         },
         required: ['available', 'files'],
       },
       description:
         "Fetch the latest candidate or published sources for this job's game so a self round can continue prior work. " +
+        'When warnings.code=module_too_large, split those oversized game/*.ts modules before adding features. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -2190,14 +2206,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const res = await injectChannel(ctx.request, 'GET', '/api/agent/build/sources', auth.channelToken);
-        const body = res.json() as { error?: string; delivery?: unknown; files?: unknown[] };
+        const body = res.json() as {
+          error?: string;
+          delivery?: unknown;
+          files?: Array<{ path: string; content: string }>;
+        };
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `sources failed (${res.statusCode})`);
         }
+        const files = body.files ?? [];
+        const sizeWarnings = moduleSizeWarnings(files);
         return toolOk({
           available: Boolean(body.delivery),
           delivery: body.delivery ?? null,
-          files: body.files ?? [],
+          files,
+          ...(sizeWarnings.length ? { warnings: sizeWarnings } : {}),
         });
       },
     },
@@ -2672,12 +2695,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `stage failed (${res.statusCode})`, body);
         }
+        const hint =
+          body.hint ??
+          (typeof body.bytes === 'number' ? largeSourceFileHint(body.path ?? path, body.bytes, content) : null);
         return toolOk({
           ok: body.accepted !== false,
           ...(body.rejected ? { rejected: body.rejected } : {}),
           path: body.path ?? path,
           bytes: body.bytes ?? 0,
-          ...(body.hint ? { hint: body.hint } : {}),
+          ...(hint ? { hint, warnings: [{ code: 'module_too_large' as const, message: hint }] } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
           ...stopFromChannel(body),
           pendingMessages: pendingMessagesFromChannel(body),
@@ -2785,6 +2811,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `patch failed (${res.statusCode})`, body);
         }
+        const hint =
+          body.hint ?? (typeof body.bytes === 'number' ? largeSourceFileHint(body.path ?? path, body.bytes) : null);
         return toolOk({
           ok: body.accepted !== false,
           ...(body.rejected ? { rejected: body.rejected } : {}),
@@ -2792,7 +2820,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes: body.bytes ?? 0,
           replacements: body.replacements ?? 0,
           baseFrom: body.baseFrom ?? 'staged',
-          ...(body.hint ? { hint: body.hint } : {}),
+          ...(hint ? { hint, warnings: [{ code: 'module_too_large' as const, message: hint }] } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
           ...stopFromChannel(body),
           pendingMessages: pendingMessagesFromChannel(body),

--- a/apps/api/src/module-size.test.ts
+++ b/apps/api/src/module-size.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessModuleSize,
+  isGameTsModule,
+  largeSourceFileHint,
+  MODULE_SOFT_LIMIT_BYTES,
+  MODULE_SOFT_LIMIT_LINES,
+  moduleSizeWarnings,
+  moduleTooLargeMessage,
+} from './module-size.js';
+
+describe('module-size budget', () => {
+  it('treats game/*.ts as modules but not game.ts', () => {
+    expect(isGameTsModule('game/render.ts')).toBe(true);
+    expect(isGameTsModule('game.ts')).toBe(false);
+    expect(isGameTsModule('SPEC.md')).toBe(false);
+  });
+
+  it('flags modules past the soft line or byte ceiling', () => {
+    const byLines = assessModuleSize('game/render.ts', `${'x\n'.repeat(MODULE_SOFT_LIMIT_LINES)}`);
+    expect(byLines.oversize).toBe(true);
+    expect(byLines.lines).toBeGreaterThanOrEqual(MODULE_SOFT_LIMIT_LINES);
+
+    const under = assessModuleSize('game/render.ts', 'export const x = 1;\n');
+    expect(under.oversize).toBe(false);
+
+    const byBytes = assessModuleSize('game/model.ts', 'a'.repeat(MODULE_SOFT_LIMIT_BYTES));
+    expect(byBytes.oversize).toBe(true);
+  });
+
+  it('names a concrete split recipe for render/model', () => {
+    const render = moduleTooLargeMessage({
+      path: 'game/render.ts',
+      bytes: 20_000,
+      lines: 500,
+      oversize: true,
+    });
+    expect(render).toMatch(/game\/art\.ts|game\/ui\.ts|game\/hud\.ts/);
+    expect(render).toMatch(/Before adding more behavior/);
+    expect(render).toMatch(/patch_source_file/);
+
+    const model = moduleTooLargeMessage({
+      path: 'game/model.ts',
+      bytes: 20_000,
+      lines: 500,
+      oversize: true,
+    });
+    expect(model).toMatch(/tables|layout|types/);
+  });
+
+  it('returns capped warnings for a file list', () => {
+    const big = 'x\n'.repeat(MODULE_SOFT_LIMIT_LINES + 10);
+    const warnings = moduleSizeWarnings([
+      { path: 'game/render.ts', content: big },
+      { path: 'game/model.ts', content: big },
+      { path: 'game/runtime.ts', content: big },
+      { path: 'game/a.ts', content: big },
+      { path: 'game/b.ts', content: big },
+      { path: 'game.ts', content: big },
+      { path: 'SPEC.md', content: big },
+    ]);
+    expect(warnings).toHaveLength(4);
+    expect(warnings.every((w) => w.code === 'module_too_large')).toBe(true);
+    expect(warnings.some((w) => w.message.includes('game.ts'))).toBe(false);
+  });
+
+  it('largeSourceFileHint stays quiet under the ceiling', () => {
+    expect(largeSourceFileHint('game/render.ts', MODULE_SOFT_LIMIT_BYTES - 1, 'ok\n')).toBeNull();
+  });
+});

--- a/apps/api/src/module-size.ts
+++ b/apps/api/src/module-size.ts
@@ -1,0 +1,102 @@
+/**
+ * Soft module-size budget for chat-thin / MCP builders.
+ *
+ * A single growing `render.ts` / `model.ts` forces full-file rewrites (or large
+ * patches) on every tweak. Soft warnings nudge agents to split cohesive pieces
+ * *before* adding more behavior — never a hard gate failure (catalog games already
+ * exceed these ceilings).
+ */
+
+export const MODULE_SOFT_LIMIT_BYTES = 12 * 1024;
+export const MODULE_SOFT_LIMIT_LINES = 350;
+
+/** Local game TypeScript modules (not SPEC.md / TRACE / HTML; not the lean `game.ts` root). */
+export function isGameTsModule(path: string): boolean {
+  const normalized = path.trim().replaceAll('\\', '/');
+  if (!normalized.endsWith('.ts')) return false;
+  if (normalized === 'game.ts') return false; // composition root has its own lean rule
+  if (normalized.includes('..') || normalized.startsWith('/')) return false;
+  return true;
+}
+
+export type ModuleSizeAssessment = {
+  path: string;
+  bytes: number;
+  lines: number;
+  oversize: boolean;
+};
+
+export function assessModuleSize(path: string, content: string): ModuleSizeAssessment {
+  const bytes = Buffer.byteLength(content, 'utf8');
+  // Count like editors: a trailing newline does not invent an extra blank line for empty files.
+  const lines = content.length === 0 ? 0 : content.split(/\r?\n/).length;
+  return {
+    path,
+    bytes,
+    lines,
+    oversize: bytes >= MODULE_SOFT_LIMIT_BYTES || lines >= MODULE_SOFT_LIMIT_LINES,
+  };
+}
+
+function splitHintFor(path: string): string {
+  const base = path.replace(/^game\//, '').replace(/\.ts$/, '');
+  if (base === 'render' || base.endsWith('/render') || base.includes('paint') || base.includes('draw')) {
+    return 'split paint helpers into cohesive modules (e.g. game/art.ts, game/ui.ts, game/hud.ts, game/rooms.ts) and leave a thin paintWorld/paintForeground orchestrator';
+  }
+  if (base === 'model' || base.endsWith('/model')) {
+    return 'split tables/constants/types into cohesive modules (e.g. game/tables.ts, game/layout.ts, game/types.ts) and keep model.ts as the shared façade';
+  }
+  if (base === 'runtime' || base === 'simulation' || base.endsWith('/runtime') || base.endsWith('/simulation')) {
+    return 'split input, round flow, or systems into cohesive modules (e.g. game/input-map.ts, game/systems/*.ts) rather than growing the lifecycle file';
+  }
+  return 'split cohesive concerns into new game/*.ts modules (one concept each) rather than growing this file further';
+}
+
+/** Soft warning message for one oversized module (MCP warnings.code=module_too_large). */
+export function moduleTooLargeMessage(assessment: ModuleSizeAssessment): string {
+  return (
+    `${assessment.path} is ${assessment.lines} lines (${assessment.bytes} bytes) — over the soft budget ` +
+    `(~${MODULE_SOFT_LIMIT_LINES} lines / ~${MODULE_SOFT_LIMIT_BYTES} bytes). ` +
+    `Before adding more behavior, ${splitHintFor(assessment.path)}. ` +
+    `Use patch_source_file (unified diff) for later edits; do not keep expanding this monolith.`
+  );
+}
+
+/** Hint string for channel stage/patch receipts (non-MCP clients). */
+export function largeSourceFileHint(path: string, bytes: number, content?: string): string | null {
+  if (!isGameTsModule(path) && !path.endsWith('.ts')) {
+    // Still nudge huge non-ts? Skip — SPEC/TRACE are not the problem.
+    return null;
+  }
+  const lines = content !== undefined ? assessModuleSize(path, content).lines : Math.ceil(bytes / 40);
+  const assessment = {
+    path,
+    bytes,
+    lines,
+    oversize: bytes >= MODULE_SOFT_LIMIT_BYTES || lines >= MODULE_SOFT_LIMIT_LINES,
+  };
+  if (!assessment.oversize) return null;
+  return moduleTooLargeMessage(assessment);
+}
+
+export type ModuleSizeWarning = { code: 'module_too_large'; message: string };
+
+/**
+ * Warnings for every oversized game/*.ts module in a file list (get_sources / get_seed).
+ * Caps at a few so a carjack-sized tree does not drown the reply.
+ */
+export function moduleSizeWarnings(
+  files: ReadonlyArray<{ path: string; content: string }>,
+  options: { limit?: number } = {},
+): ModuleSizeWarning[] {
+  const limit = options.limit ?? 4;
+  const oversized = files
+    .filter((file) => isGameTsModule(file.path))
+    .map((file) => assessModuleSize(file.path, file.content))
+    .filter((entry) => entry.oversize)
+    .sort((a, b) => b.bytes - a.bytes || b.lines - a.lines);
+  return oversized.slice(0, limit).map((entry) => ({
+    code: 'module_too_large' as const,
+    message: moduleTooLargeMessage(entry),
+  }));
+}

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -1,12 +1,6 @@
 import { createPatch } from 'diff';
 import { describe, expect, it } from 'vitest';
-import {
-  applySourcePatch,
-  LARGE_SOURCE_FILE_HINT_BYTES,
-  largeSourceFileHint,
-  normalizePatchPath,
-  SourcePatchError,
-} from './source-patch.js';
+import { applySourcePatch, normalizePatchPath, SourcePatchError } from './source-patch.js';
 
 describe('normalizePatchPath', () => {
   it('strips a/b prefixes, tabs, and quotes', () => {
@@ -60,18 +54,5 @@ describe('applySourcePatch', () => {
   it('refuses a stale context (no fuzzy apply)', () => {
     const patch = createPatch('game.ts', content, 'line1\nline2x\nline3\n');
     expect(() => applySourcePatch({ content: 'different\n', path: 'game.ts', patch })).toThrow(/did not apply/);
-  });
-});
-
-describe('largeSourceFileHint', () => {
-  it('stays quiet under the soft ceiling', () => {
-    expect(largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES - 1)).toBeNull();
-  });
-
-  it('nudges toward split + unified patch past the ceiling', () => {
-    const hint = largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES);
-    expect(hint).toMatch(/game\/render\.ts/);
-    expect(hint).toMatch(/patch_source_file/);
-    expect(hint).toMatch(/unified diff/);
   });
 });

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -1,43 +1,65 @@
+import { createPatch } from 'diff';
 import { describe, expect, it } from 'vitest';
 import {
   applySourcePatch,
   LARGE_SOURCE_FILE_HINT_BYTES,
   largeSourceFileHint,
+  normalizePatchPath,
   SourcePatchError,
 } from './source-patch.js';
 
+describe('normalizePatchPath', () => {
+  it('strips a/b prefixes, tabs, and quotes', () => {
+    expect(normalizePatchPath('a/game/render.ts')).toBe('game/render.ts');
+    expect(normalizePatchPath('b/game/render.ts')).toBe('game/render.ts');
+    expect(normalizePatchPath('game/render.ts\t2026-01-01 00:00:00')).toBe('game/render.ts');
+    expect(normalizePatchPath('"game/render.ts"')).toBe('game/render.ts');
+  });
+});
+
 describe('applySourcePatch', () => {
-  it('replaces a unique snippet once', () => {
-    const result = applySourcePatch({
-      content: 'aaa\nTARGET\nbbb\n',
-      oldString: 'TARGET',
-      newString: 'REPLACED',
-    });
-    expect(result).toEqual({ content: 'aaa\nREPLACED\nbbb\n', replacements: 1 });
+  const content = 'line1\nline2\nline3\n';
+
+  it('applies a unified diff hunk', () => {
+    const patch = createPatch('game/render.ts', content, 'line1\nline2x\nline3\n');
+    const result = applySourcePatch({ content, path: 'game/render.ts', patch });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
+    expect(result.replacements).toBe(1);
   });
 
-  it('refuses an empty oldString', () => {
-    expect(() => applySourcePatch({ content: 'x', oldString: '', newString: 'y' })).toThrow(SourcePatchError);
+  it('accepts git-style a/ b/ headers', () => {
+    const patch = [
+      '--- a/game/render.ts',
+      '+++ b/game/render.ts',
+      '@@ -1,3 +1,3 @@',
+      ' line1',
+      '-line2',
+      '+line2x',
+      ' line3',
+      '',
+    ].join('\n');
+    const result = applySourcePatch({ content, path: 'game/render.ts', patch });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
   });
 
-  it('refuses a no-op identical replace', () => {
-    expect(() => applySourcePatch({ content: 'same', oldString: 'same', newString: 'same' })).toThrow(/identical/);
+  it('refuses an empty patch', () => {
+    expect(() => applySourcePatch({ content, path: 'game.ts', patch: '   ' })).toThrow(SourcePatchError);
   });
 
-  it('refuses a missing oldString', () => {
-    expect(() => applySourcePatch({ content: 'hello', oldString: 'missing', newString: 'x' })).toThrow(/not found/);
+  it('refuses a path mismatch', () => {
+    const patch = createPatch('other.ts', content, 'line1\nx\nline3\n');
+    expect(() => applySourcePatch({ content, path: 'game.ts', patch })).toThrow(/does not match/);
   });
 
-  it('refuses an ambiguous match unless replaceAll', () => {
-    expect(() => applySourcePatch({ content: 'aa aa', oldString: 'aa', newString: 'bb' })).toThrow(/more than once/);
+  it('refuses a multi-file patch', () => {
+    const one = createPatch('a.ts', 'a\n', 'b\n');
+    const two = createPatch('b.ts', 'c\n', 'd\n');
+    expect(() => applySourcePatch({ content: 'a\n', path: 'a.ts', patch: `${one}\n${two}` })).toThrow(/touches/);
+  });
 
-    const all = applySourcePatch({
-      content: 'aa aa',
-      oldString: 'aa',
-      newString: 'bb',
-      replaceAll: true,
-    });
-    expect(all).toEqual({ content: 'bb bb', replacements: 2 });
+  it('refuses a stale context (no fuzzy apply)', () => {
+    const patch = createPatch('game.ts', content, 'line1\nline2x\nline3\n');
+    expect(() => applySourcePatch({ content: 'different\n', path: 'game.ts', patch })).toThrow(/did not apply/);
   });
 });
 
@@ -46,10 +68,10 @@ describe('largeSourceFileHint', () => {
     expect(largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES - 1)).toBeNull();
   });
 
-  it('nudges toward split + patch past the ceiling', () => {
+  it('nudges toward split + unified patch past the ceiling', () => {
     const hint = largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES);
     expect(hint).toMatch(/game\/render\.ts/);
     expect(hint).toMatch(/patch_source_file/);
-    expect(hint).toMatch(/split/i);
+    expect(hint).toMatch(/unified diff/);
   });
 });

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySourcePatch,
+  LARGE_SOURCE_FILE_HINT_BYTES,
+  largeSourceFileHint,
+  SourcePatchError,
+} from './source-patch.js';
+
+describe('applySourcePatch', () => {
+  it('replaces a unique snippet once', () => {
+    const result = applySourcePatch({
+      content: 'aaa\nTARGET\nbbb\n',
+      oldString: 'TARGET',
+      newString: 'REPLACED',
+    });
+    expect(result).toEqual({ content: 'aaa\nREPLACED\nbbb\n', replacements: 1 });
+  });
+
+  it('refuses an empty oldString', () => {
+    expect(() => applySourcePatch({ content: 'x', oldString: '', newString: 'y' })).toThrow(SourcePatchError);
+  });
+
+  it('refuses a no-op identical replace', () => {
+    expect(() => applySourcePatch({ content: 'same', oldString: 'same', newString: 'same' })).toThrow(/identical/);
+  });
+
+  it('refuses a missing oldString', () => {
+    expect(() => applySourcePatch({ content: 'hello', oldString: 'missing', newString: 'x' })).toThrow(/not found/);
+  });
+
+  it('refuses an ambiguous match unless replaceAll', () => {
+    expect(() => applySourcePatch({ content: 'aa aa', oldString: 'aa', newString: 'bb' })).toThrow(/more than once/);
+
+    const all = applySourcePatch({
+      content: 'aa aa',
+      oldString: 'aa',
+      newString: 'bb',
+      replaceAll: true,
+    });
+    expect(all).toEqual({ content: 'bb bb', replacements: 2 });
+  });
+});
+
+describe('largeSourceFileHint', () => {
+  it('stays quiet under the soft ceiling', () => {
+    expect(largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES - 1)).toBeNull();
+  });
+
+  it('nudges toward split + patch past the ceiling', () => {
+    const hint = largeSourceFileHint('game/render.ts', LARGE_SOURCE_FILE_HINT_BYTES);
+    expect(hint).toMatch(/game\/render\.ts/);
+    expect(hint).toMatch(/patch_source_file/);
+    expect(hint).toMatch(/split/i);
+  });
+});

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -110,14 +110,5 @@ export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatch
   return { content: next, replacements: hunks };
 }
 
-/** Soft size hint: full-file rewrites past this burn connector tokens on chat-thin clients. */
-export const LARGE_SOURCE_FILE_HINT_BYTES = 24 * 1024;
-
-export function largeSourceFileHint(path: string, bytes: number): string | null {
-  if (bytes < LARGE_SOURCE_FILE_HINT_BYTES) return null;
-  return (
-    `${path} is ${bytes} bytes. Prefer cohesive modules under ~${LARGE_SOURCE_FILE_HINT_BYTES} bytes ` +
-    `(split render/HUD/art or model tables) and use patch_source_file with a unified diff for later ` +
-    `edits so you do not re-emit the whole file.`
-  );
-}
+/** @deprecated Prefer {@link largeSourceFileHint} from `module-size.js`. Re-exported for callers. */
+export { largeSourceFileHint, MODULE_SOFT_LIMIT_BYTES as LARGE_SOURCE_FILE_HINT_BYTES } from './module-size.js';

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -1,0 +1,83 @@
+/**
+ * Exact string patches for game source staging (MCP / agent channel).
+ *
+ * Chat-thin agents (Claude Chat especially) otherwise re-emit entire `render.ts` /
+ * `model.ts` files on every tweak via `stage_source_file`. A unique old→new replace
+ * keeps the tool payload proportional to the edit.
+ */
+
+export class SourcePatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SourcePatchError';
+  }
+}
+
+export type ApplySourcePatchInput = {
+  content: string;
+  oldString: string;
+  newString: string;
+  /** When true, replace every occurrence; otherwise `oldString` must match exactly once. */
+  replaceAll?: boolean;
+};
+
+export type ApplySourcePatchResult = {
+  content: string;
+  replacements: number;
+};
+
+/**
+ * Apply an exact string replacement. Fail closed on empty oldString, no match, or
+ * (unless replaceAll) an ambiguous multi-match.
+ */
+export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatchResult {
+  const { content, oldString, newString, replaceAll = false } = input;
+  if (oldString.length === 0) {
+    throw new SourcePatchError('oldString must not be empty');
+  }
+  if (oldString === newString) {
+    throw new SourcePatchError('oldString and newString are identical — nothing to change');
+  }
+
+  if (replaceAll) {
+    if (!content.includes(oldString)) {
+      throw new SourcePatchError('oldString not found in file — read the current sources and retry with exact text');
+    }
+    let replacements = 0;
+    let next = content;
+    let index = next.indexOf(oldString);
+    while (index !== -1) {
+      next = next.slice(0, index) + newString + next.slice(index + oldString.length);
+      replacements += 1;
+      index = next.indexOf(oldString, index + newString.length);
+    }
+    return { content: next, replacements };
+  }
+
+  const first = content.indexOf(oldString);
+  if (first === -1) {
+    throw new SourcePatchError('oldString not found in file — read the current sources and retry with exact text');
+  }
+  const second = content.indexOf(oldString, first + oldString.length);
+  if (second !== -1) {
+    throw new SourcePatchError(
+      'oldString matched more than once — pass a longer unique snippet, or set replaceAll=true',
+    );
+  }
+  return {
+    content: content.slice(0, first) + newString + content.slice(first + oldString.length),
+    replacements: 1,
+  };
+}
+
+/** Soft size hint: full-file rewrites past this burn connector tokens on chat-thin clients. */
+export const LARGE_SOURCE_FILE_HINT_BYTES = 24 * 1024;
+
+export function largeSourceFileHint(path: string, bytes: number): string | null {
+  if (bytes < LARGE_SOURCE_FILE_HINT_BYTES) return null;
+  return (
+    `${path} is ${bytes} bytes. Prefer cohesive modules under ~${LARGE_SOURCE_FILE_HINT_BYTES} bytes ` +
+    `(split render/HUD/art or model tables) and use patch_source_file for later edits so you do not ` +
+    `re-emit the whole file.`
+  );
+}

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -1,10 +1,12 @@
 /**
- * Exact string patches for game source staging (MCP / agent channel).
+ * Unified-diff patches for game source staging (MCP / agent channel).
  *
  * Chat-thin agents (Claude Chat especially) otherwise re-emit entire `render.ts` /
- * `model.ts` files on every tweak via `stage_source_file`. A unique old→new replace
- * keeps the tool payload proportional to the edit.
+ * `model.ts` files on every tweak via `stage_source_file`. A unified diff keeps the
+ * tool payload proportional to the edit — the format models already know well.
  */
+
+import { applyPatch, parsePatch } from 'diff';
 
 export class SourcePatchError extends Error {
   constructor(message: string) {
@@ -15,59 +17,97 @@ export class SourcePatchError extends Error {
 
 export type ApplySourcePatchInput = {
   content: string;
-  oldString: string;
-  newString: string;
-  /** When true, replace every occurrence; otherwise `oldString` must match exactly once. */
-  replaceAll?: boolean;
+  /** Target game-relative path (e.g. game/render.ts). Must match the patch headers. */
+  path: string;
+  /** Unified diff for this one path (`---/`+++` + `@@` hunks). */
+  patch: string;
 };
 
 export type ApplySourcePatchResult = {
   content: string;
+  /** Number of hunks applied. */
   replacements: number;
 };
 
-/**
- * Apply an exact string replacement. Fail closed on empty oldString, no match, or
- * (unless replaceAll) an ambiguous multi-match.
- */
-export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatchResult {
-  const { content, oldString, newString, replaceAll = false } = input;
-  if (oldString.length === 0) {
-    throw new SourcePatchError('oldString must not be empty');
+/** Strip common git/diff path prefixes so `a/game.ts` and `game.ts` compare equal. */
+export function normalizePatchPath(raw: string): string {
+  let path = raw.trim().replaceAll('\\', '/');
+  if (path.startsWith('"') && path.endsWith('"')) {
+    path = path.slice(1, -1);
   }
-  if (oldString === newString) {
-    throw new SourcePatchError('oldString and newString are identical — nothing to change');
-  }
+  // Timestamps after a tab (GNU diff / git): "game.ts\t2026-01-01 …"
+  const tab = path.indexOf('\t');
+  if (tab !== -1) path = path.slice(0, tab);
+  if (path.startsWith('a/') || path.startsWith('b/')) path = path.slice(2);
+  if (path.startsWith('./')) path = path.slice(2);
+  return path;
+}
 
-  if (replaceAll) {
-    if (!content.includes(oldString)) {
-      throw new SourcePatchError('oldString not found in file — read the current sources and retry with exact text');
-    }
-    let replacements = 0;
-    let next = content;
-    let index = next.indexOf(oldString);
-    while (index !== -1) {
-      next = next.slice(0, index) + newString + next.slice(index + oldString.length);
-      replacements += 1;
-      index = next.indexOf(oldString, index + newString.length);
-    }
-    return { content: next, replacements };
+function assertPatchTargetsPath(path: string, patchText: string): number {
+  let parsed;
+  try {
+    parsed = parsePatch(patchText);
+  } catch {
+    throw new SourcePatchError('patch is not a valid unified diff — pass ---/+++ headers and @@ hunks for one file');
   }
-
-  const first = content.indexOf(oldString);
-  if (first === -1) {
-    throw new SourcePatchError('oldString not found in file — read the current sources and retry with exact text');
+  if (parsed.length === 0) {
+    throw new SourcePatchError('patch is empty — pass a unified diff with at least one @@ hunk');
   }
-  const second = content.indexOf(oldString, first + oldString.length);
-  if (second !== -1) {
+  if (parsed.length > 1) {
     throw new SourcePatchError(
-      'oldString matched more than once — pass a longer unique snippet, or set replaceAll=true',
+      `patch touches ${parsed.length} files — patch_source_file accepts ONE path; call once per file`,
     );
   }
-  return {
-    content: content.slice(0, first) + newString + content.slice(first + oldString.length),
-    replacements: 1,
-  };
+  const file = parsed[0]!;
+  const names = [file.oldFileName, file.newFileName]
+    .filter((name): name is string => typeof name === 'string' && name.length > 0)
+    .map(normalizePatchPath)
+    .filter((name) => name !== '/dev/null' && name !== 'dev/null');
+
+  for (const name of names) {
+    if (name !== path) {
+      throw new SourcePatchError(
+        `patch path ${name} does not match path ${path} — keep the diff headers on the same file`,
+      );
+    }
+  }
+  if (names.length === 0) {
+    throw new SourcePatchError(
+      `patch has no file path in ---/+++ headers — use --- a/${path} / +++ b/${path} (or bare ${path})`,
+    );
+  }
+
+  const hunks = file.hunks?.length ?? 0;
+  if (hunks === 0) {
+    throw new SourcePatchError('patch has no @@ hunks — nothing to apply');
+  }
+  return hunks;
+}
+
+/**
+ * Apply a unified diff to one file. Fail closed on parse errors, multi-file patches,
+ * path mismatch, or context that does not match (no fuzzy apply).
+ */
+export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatchResult {
+  const path = input.path.trim();
+  const patch = input.patch.trim();
+  if (!path) throw new SourcePatchError('path is required');
+  if (!patch) throw new SourcePatchError('patch must not be empty');
+
+  const hunks = assertPatchTargetsPath(path, patch);
+
+  // fuzzFactor 0: context must match exactly. Stale hunks should re-get_sources and retry,
+  // not silently land on the wrong lines of a large render.ts.
+  const next = applyPatch(input.content, patch, { fuzzFactor: 0 });
+  if (next === false) {
+    throw new SourcePatchError(
+      'patch did not apply cleanly — context lines no longer match. Re-read the file (get_sources) and regenerate the unified diff',
+    );
+  }
+  if (next === input.content) {
+    throw new SourcePatchError('patch applied but made no changes');
+  }
+  return { content: next, replacements: hunks };
 }
 
 /** Soft size hint: full-file rewrites past this burn connector tokens on chat-thin clients. */
@@ -77,7 +117,7 @@ export function largeSourceFileHint(path: string, bytes: number): string | null 
   if (bytes < LARGE_SOURCE_FILE_HINT_BYTES) return null;
   return (
     `${path} is ${bytes} bytes. Prefer cohesive modules under ~${LARGE_SOURCE_FILE_HINT_BYTES} bytes ` +
-    `(split render/HUD/art or model tables) and use patch_source_file for later edits so you do not ` +
-    `re-emit the whole file.`
+    `(split render/HUD/art or model tables) and use patch_source_file with a unified diff for later ` +
+    `edits so you do not re-emit the whole file.`
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@gamedevpl/game-generator": "*",
         "@gamedevpl/zone-core": "*",
         "@google-cloud/firestore": "^8.7.0",
+        "diff": "^9.0.0",
         "esbuild": "0.25.12",
         "fastify": "^5.10.0",
         "fastify-rate-limit": "npm:@fastify/rate-limit@^11.1.0",
@@ -3410,6 +3411,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/duplexify": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Studio MCP agents (especially Claude Chat) re-emit huge `game/render.ts` / `game/model.ts` files on every tweak, and keep growing those monoliths because nothing interrupts them at a size budget.

## Fix

1. **`patch_source_file({ path, patch })`** — standard unified diff (`---/`+++` + `@@` hunks) for one existing path into the staging buffer (base = staged → delivery → seed). Exact context; no fuzzy apply.
2. **`fromStaged` overlay** — submit merges staged paths over the latest delivery/seed so one-file patches deliver a complete tree.
3. **`warnings.code=module_too_large`** — soft nudge (~350 lines / ~12 KiB per `game/*.ts`) on `get_sources`, `get_seed`, `stage_source_file`, and `patch_source_file`, with concrete split recipes (render→art/ui/hud/rooms, model→tables/layout/types). Session workflow says to honour it like `call_end`: split *before* more feature work.

Paired: games kit/skill #532, ops docs #75.

## Tests

Unified-diff apply/refusal, module-size budget, channel overlay, MCP workflow copy, lint + type-check + targeted vitest.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6763754d-6266-4963-ab2d-0202182db265?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6763754d-6266-4963-ab2d-0202182db265&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

