### PR TITLE
Show share link for published games in Studio

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -504,9 +504,18 @@ describe('CreatorStudioView', () => {
     });
     expect(setDraftShared).toHaveBeenCalledWith('token-draft', true);
 
-    // Published games already live at /play/<slug> — no draft-share head control.
+    // Published games have no draft switch — the link is already public — but the head
+    // control stays so the permalink is still one click away.
     await rerender({ selectedGame: 'live-game' });
-    expect(container.querySelector('[data-testid="studio-head-share"]')).toBeNull();
+    const liveShare = container.querySelector<HTMLButtonElement>('[data-testid="studio-head-share"]');
+    expect(liveShare).not.toBeNull();
+    await act(async () => {
+      liveShare!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.studio-head-share-popover .studio-share-toggle')).toBeNull();
+    expect(container.querySelector('.studio-head-share-popover .inline-link')?.textContent).toContain(
+      '/play/live-game',
+    );
 
     root.unmount();
   });
@@ -837,6 +846,34 @@ describe('CreatorStudioView', () => {
       'true',
     );
     expect(container.querySelector('.studio-share-toggle')).not.toBeNull();
+
+    root.unmount();
+  });
+
+  it('keeps a share link in Overview once the game is live in the catalog', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-live',
+          title: 'Live Game',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'published',
+          slug: 'live-game',
+          publishedAt: '2026-07-31T09:00:00.000Z',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: 'live-game', selectedTab: 'details' });
+
+    // Nothing left to toggle — the game is public — but the permalink must still be here,
+    // otherwise a published game has no share affordance anywhere in Studio.
+    expect(container.querySelector('.studio-share-toggle')).toBeNull();
+    expect(container.querySelector('.studio-share.is-live .inline-link')?.textContent).toContain('/play/live-game');
+    expect(container.querySelector('.studio-share .status-share-copy')).not.toBeNull();
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -501,9 +501,12 @@ export function CreatorStudioView({
   }
   openTabRef.current = openTab;
 
-  const canShareDraft = Boolean(
-    activeGame && activeGame.slug && activeGame.lastKnownStatus !== 'abandoned' && !isStudioGameShelfLive(activeGame),
-  );
+  // Share is about the permalink, not about the draft switch: a game already live in
+  // the catalog has nothing to toggle, but it still needs a way to hand the link out.
+  // Hiding the control there left published games with no share affordance anywhere.
+  const canShare = Boolean(activeGame && activeGame.slug && activeGame.lastKnownStatus !== 'abandoned');
+  const shareIsLive = Boolean(activeGame && isStudioGameShelfLive(activeGame));
+  const shareTitle = t(shareIsLive ? 'studioPanel.share.liveTitle' : 'studioPanel.share.title');
 
   useEffect(() => {
     setShareMenuOpen(false);
@@ -729,29 +732,26 @@ export function CreatorStudioView({
                         <PixelIcon name="play" size={14} />{' '}
                         <span className="studio-head-action-label">{t('studioPanel.tabs.playtest')}</span>
                       </button>
-                      {canShareDraft && activeGame ? (
+                      {canShare && activeGame ? (
                         <div className="studio-head-share">
                           <button
                             type="button"
                             className={`studio-head-action is-icon-only${shareMenuOpen ? ' is-active' : ''}`}
                             aria-pressed={shareMenuOpen}
                             aria-expanded={shareMenuOpen}
-                            aria-label={t('studioPanel.share.title')}
+                            aria-label={shareTitle}
                             data-testid="studio-head-share"
                             onClick={() => setShareMenuOpen((open) => !open)}
                           >
                             <PixelIcon name="share" size={14} />{' '}
-                            <span className="studio-head-action-label">{t('studioPanel.share.title')}</span>
+                            <span className="studio-head-action-label">{shareTitle}</span>
                           </button>
                           {shareMenuOpen ? (
-                            <div
-                              className="studio-head-share-popover"
-                              role="dialog"
-                              aria-label={t('studioPanel.share.title')}
-                            >
+                            <div className="studio-head-share-popover" role="dialog" aria-label={shareTitle}>
                               <DraftShareControl
                                 game={activeGame}
                                 compact
+                                live={shareIsLive}
                                 onSharedChange={(shared) => {
                                   setGames((prev) =>
                                     prev.map((game) =>
@@ -1183,9 +1183,12 @@ function DetailsPanel({
               </div>
             </section>
 
-            {!catalogLive && game.slug && game.lastKnownStatus !== 'abandoned' ? (
-              <section className="studio-rail-section" aria-label={t('studioPanel.share.title')}>
-                <DraftShareControl game={game} onSharedChange={onDraftSharedChange} />
+            {game.slug && game.lastKnownStatus !== 'abandoned' ? (
+              <section
+                className="studio-rail-section"
+                aria-label={t(catalogLive ? 'studioPanel.share.liveTitle' : 'studioPanel.share.title')}
+              >
+                <DraftShareControl game={game} live={catalogLive} onSharedChange={onDraftSharedChange} />
               </section>
             ) : null}
           </>
@@ -1272,15 +1275,22 @@ function DetailsPanel({
  * way — the link is the only way in, which is what makes one switch enough. The link
  * shown is the game's ordinary permalink, the same one it will keep once it is live,
  * so there is nothing to re-share when that happens.
+ *
+ * Once the game *is* live in the catalog there is no switch left to show — the link is
+ * public by definition — but the creator still wants to hand it out, so `live` drops the
+ * toggle and keeps the permalink and its copy button.
  */
 function DraftShareControl({
   game,
   compact = false,
+  live = false,
   onSharedChange,
 }: {
   game: StudioGame;
   /** Drop the card chrome when nested in the header popover. */
   compact?: boolean;
+  /** Game is live in the catalog: permalink only, no draft switch. */
+  live?: boolean;
   onSharedChange?: (shared: boolean) => void;
 }) {
   const { t } = useTranslation();
@@ -1340,23 +1350,27 @@ function DraftShareControl({
   }
 
   return (
-    <div className={`studio-share${compact ? ' is-compact' : ''}`}>
+    <div className={`studio-share${compact ? ' is-compact' : ''}${live ? ' is-live' : ''}`}>
       <div className="studio-share-head">
-        <h3 className="studio-share-title">{t('studioPanel.share.title')}</h3>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={shared}
-          className={`studio-share-toggle${shared ? ' is-on' : ''}`}
-          onClick={() => void toggle()}
-          disabled={busy}
-        >
-          <span className="studio-share-toggle-track" aria-hidden="true" />
-          {shared ? t('studioPanel.share.on') : t('studioPanel.share.off')}
-        </button>
+        <h3 className="studio-share-title">{t(live ? 'studioPanel.share.liveTitle' : 'studioPanel.share.title')}</h3>
+        {live ? null : (
+          <button
+            type="button"
+            role="switch"
+            aria-checked={shared}
+            className={`studio-share-toggle${shared ? ' is-on' : ''}`}
+            onClick={() => void toggle()}
+            disabled={busy}
+          >
+            <span className="studio-share-toggle-track" aria-hidden="true" />
+            {shared ? t('studioPanel.share.on') : t('studioPanel.share.off')}
+          </button>
+        )}
       </div>
-      <p className="studio-share-hint">{t(shared ? 'studioPanel.share.hintOn' : 'studioPanel.share.hintOff')}</p>
-      {shared ? (
+      <p className="studio-share-hint">
+        {t(live ? 'studioPanel.share.liveHint' : shared ? 'studioPanel.share.hintOn' : 'studioPanel.share.hintOff')}
+      </p>
+      {live || shared ? (
         <p className="status-note status-share">
           <a className="inline-link" href={url}>
             {url}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -342,6 +342,8 @@
     },
     "share": {
       "title": "Share the draft",
+      "liveTitle": "Share the game",
+      "liveHint": "This game is live in the arcade. Anyone with this link plays the latest published version.",
       "on": "On",
       "off": "Off",
       "hintOff": "Only you can play this game right now. Turn this on to give anyone with the link a go — it stays out of the arcade either way.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -344,6 +344,8 @@
     },
     "share": {
       "title": "Udostępnij wersję roboczą",
+      "liveTitle": "Udostępnij grę",
+      "liveHint": "Ta gra jest już w arcade. Każdy z tym linkiem zagra w najnowszą opublikowaną wersję.",
       "on": "Wł.",
       "off": "Wył.",
       "hintOff": "Na razie tylko Ty możesz zagrać w tę grę. Włącz, aby każdy z linkiem mógł spróbować — i tak nie trafi do arcade.",


### PR DESCRIPTION
## Summary
Updated the share control in Creator Studio to remain visible for games that are live in the catalog, while removing the draft toggle since published games have no draft state to toggle.

## Key Changes
- **Share control visibility**: Changed from hiding the share button entirely for live games to keeping it visible but in a simplified "live" mode
  - Removed the `canShareDraft` check that hid the control for published games
  - Introduced `canShare` (shows control if game has slug and isn't abandoned) and `shareIsLive` (indicates if game is published)
  - Share button now appears for both draft and published games

- **DraftShareControl component**: Added `live` prop to conditionally render UI based on game state
  - When `live=true`: hides the draft toggle switch, shows only the permalink and copy button
  - When `live=false`: shows the existing draft toggle and conditional hint text
  - Updated title and hint text to reflect whether sharing a draft or published game

- **UI/UX improvements**:
  - Added `.is-live` CSS class to style the live share state differently
  - Updated aria-labels and section labels to use appropriate titles for draft vs. live games
  - Permalink remains visible and copyable in both states

- **Localization**: Added new translation keys for live game sharing
  - `studioPanel.share.liveTitle`: "Share the game"
  - `studioPanel.share.liveHint`: Explains that the game is live and anyone with the link plays the latest published version
  - Added Polish translations for both new keys

- **Tests**: Updated test expectations to verify share control remains visible for published games and that the toggle is hidden in live mode

## Implementation Details
The change addresses a UX gap where published games had no share affordance in the Studio interface. The permalink is the same before and after publication, so creators still need a way to share it even after going live. The solution keeps the share control but removes the draft toggle since there's nothing to toggle for published games.

https://claude.ai/code/session_01MRpsXtLNv4CbWNV52dVNC8