### PR TITLE
fix(mcp): make patch_source_file usable for chat agents

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -19,9 +19,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 2. Build; `report_progress`; `send_screenshot` when something draws
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
-   - **Edits:** `patch_source_file({ path, patch })` with a unified diff
-     (`---` / `+++` + `@@` hunks for one file). `@@` line numbers are optional — bare
-     `@@` is fine; the server matches by context. Do not re-emit whole `render.ts` /
+   - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
+     replace — no diff format). Or `patch_source_file({ path, patch })` with a unified
+     diff (`---` / `+++` + `@@` hunks; bare `@@` ok). Do not re-emit whole `render.ts` /
      `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
      `warnings.code=module_too_large` (on `get_sources` / `get_seed` / stage / patch)

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -19,8 +19,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 2. Build; `report_progress`; `send_screenshot` when something draws
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
-   - **Edits:** `patch_source_file({ path, patch })` with a standard unified diff
-     (`---` / `+++` + `@@` hunks for one file) — do not re-emit whole `render.ts` /
+   - **Edits:** `patch_source_file({ path, patch })` with a unified diff
+     (`---` / `+++` + `@@` hunks for one file). `@@` line numbers are optional — bare
+     `@@` is fine; the server matches by context. Do not re-emit whole `render.ts` /
      `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
      `warnings.code=module_too_large` (on `get_sources` / `get_seed` / stage / patch)

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1535,6 +1535,38 @@ describe('agent build channel', () => {
       expect(staged.size).toBe(0);
     });
 
+    it('accepts old+new exact replace without a unified diff', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/render.ts',
+          content: 'export function paint() {\n  drawSky();\n}\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          path: 'game/render.ts',
+          old: '  drawSky();\n',
+          new: '  drawSky();\n  drawHud();\n',
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({ accepted: true, replacements: 1, baseFrom: 'staged' });
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+    });
+
     it('accepts a bare @@ patch (no line numbers) matched by context', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1535,6 +1535,46 @@ describe('agent build channel', () => {
       expect(staged.size).toBe(0);
     });
 
+    it('accepts a bare @@ patch (no line numbers) matched by context', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/render.ts',
+          content: 'export function paint() {\n  drawSky();\n}\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          path: 'game/render.ts',
+          patch: [
+            '--- a/game/render.ts',
+            '+++ b/game/render.ts',
+            '@@',
+            ' export function paint() {',
+            '   drawSky();',
+            '+  drawHud();',
+            ' }',
+            '',
+          ].join('\n'),
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({ accepted: true, replacements: 1, baseFrom: 'staged' });
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+    });
+
     it('fromStaged fails closed when the delivery manifest lists unreadable paths', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -47,7 +47,7 @@ import {
 } from './kit-registry.js';
 import { seedPayload } from './seed-status.js';
 import { largeSourceFileHint } from './module-size.js';
-import { applySourcePatch, SourcePatchError } from './source-patch.js';
+import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
 import { type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
@@ -259,20 +259,51 @@ const StageSourceInputSchema = z.object({
     .optional(),
 });
 
-const StageSourcePatchInputSchema = z.object({
-  path: z.string().trim().min(1).max(120),
-  /** Unified diff for this one path (`---` / `+++` + `@@` hunks). */
-  patch: z
-    .string()
-    .transform((value) => value.trim())
-    .pipe(z.string().min(1, 'patch must not be empty').max(400_000)),
-  slug: z
-    .string()
-    .trim()
-    .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be lowercase letters, digits and dashes')
-    .max(64)
-    .optional(),
-});
+const StageSourcePatchInputSchema = z
+  .object({
+    path: z.string().trim().min(1).max(120),
+    /** Unified diff for this one path (`---` / `+++` + `@@` hunks). */
+    patch: z
+      .string()
+      .transform((value) => value.trim())
+      .pipe(z.string().min(1, 'patch must not be empty').max(400_000))
+      .optional(),
+    /** Exact unique substring to replace (pair with `new`). Prefer this over `patch` in chat. */
+    old: z.string().max(200_000).optional(),
+    /** Replacement for `old` (may be empty to delete). */
+    new: z.string().max(200_000).optional(),
+    slug: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be lowercase letters, digits and dashes')
+      .max(64)
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    const hasPatch = value.patch !== undefined;
+    const hasOld = value.old !== undefined;
+    const hasNew = value.new !== undefined;
+    if (hasPatch && (hasOld || hasNew)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'pass either patch (unified diff) or old+new (exact replace), not both',
+      });
+      return;
+    }
+    if (hasOld !== hasNew) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'old and new must be passed together for exact replace',
+      });
+      return;
+    }
+    if (!hasPatch && !hasOld) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'pass old+new (exact replace, preferred) or patch (unified diff)',
+      });
+    }
+  });
 
 const BuildPreviewInputSchema = z.object({
   html: z
@@ -1116,11 +1147,19 @@ export async function registerAgentChannelRoutes(
           });
         }
 
-        const patched = applySourcePatch({
-          content: base,
-          path: parsed.data.path,
-          patch: parsed.data.patch,
-        });
+        const patched =
+          parsed.data.old !== undefined && parsed.data.new !== undefined
+            ? applyExactReplace({
+                content: base,
+                path: parsed.data.path,
+                old: parsed.data.old,
+                new: parsed.data.new,
+              })
+            : applySourcePatch({
+                content: base,
+                path: parsed.data.path,
+                patch: parsed.data.patch!,
+              });
 
         const staged = await options.gamesStore.putStagedSourceFile({
           slug,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -316,7 +316,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (bare @@ ok — matched by context; never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
@@ -345,7 +345,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'send_screenshot as soon as the game draws anything playable.',
-  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, patch }) with a unified diff (---/+++ + @@ hunks for ONE file). Context lines must match exactly; @@ line numbers are optional (bare @@ is fine — the server matches by context). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
+  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null returns stop:false because you checked too early — continue building and call submit_sources; do not check again before a delivery. A later creator-led run may check a delivered gate again. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
@@ -2715,7 +2715,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     patch_source_file: {
-      annotations: { title: 'Patch one staged source file', ...WRITES },
+      annotations: { title: 'Edit one staged source file', ...WRITES },
       outputSchema: {
         type: 'object',
         properties: {
@@ -2747,14 +2747,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['ok', 'path', 'bytes', 'replacements', 'baseFrom', 'staged', 'stop', 'pendingMessages'],
       },
       description:
-        'Apply a unified diff to ONE existing path and write the result into the staging buffer. ' +
+        'Edit ONE existing path in the staging buffer without re-uploading the whole file. ' +
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
         'especially for large game/render.ts or game/model.ts files. ' +
-        'patch must be a unified diff for that single file. Example with line numbers: ' +
-        '"--- a/game/render.ts\\n+++ b/game/render.ts\\n@@ -10,6 +10,7 @@\\n context\\n-old\\n+new\\n context\\n". ' +
-        'Bare @@ (no line numbers) is also accepted — hunks are located by matching context lines, so you do not need get_sources just to count lines. ' +
-        'Context must match exactly (no fuzzy apply). Prefix context lines with a leading space; +/- for changes. ' +
-        'Multi-file patches are refused — call once per path. ' +
+        'PREFERRED: pass old + new (exact unique substring replace) — no @@ line numbers, no diff format. ' +
+        'ALTERNATE: pass patch as a unified diff for that single file ' +
+        '("--- a/game/render.ts\\n+++ b/game/render.ts\\n@@\\n context\\n-old\\n+new\\n context\\n"; bare @@ ok). ' +
+        'old must match exactly once; widen the snippet if it is ambiguous. Do not pass patch together with old/new. ' +
         'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -2763,25 +2762,41 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           sessionKey: SESSION_KEY_PROP,
           path: {
             type: 'string',
-            description: 'Game-relative path (e.g. game/render.ts). Must match the ---/+++ headers.',
+            description: 'Game-relative path (e.g. game/render.ts). For unified diffs, must match the ---/+++ headers.',
+          },
+          old: {
+            type: 'string',
+            description: 'Exact text to find (must appear once). Prefer old+new over patch. Pass together with new.',
+          },
+          new: {
+            type: 'string',
+            description: 'Replacement text for old (may be empty to delete). Pass together with old.',
           },
           patch: {
             type: 'string',
             description:
-              'Unified diff for this one file only (`--- a/<path>` / `+++ b/<path>` plus one or more @@ hunks). ' +
-              '@@ line numbers optional — bare `@@` is fine when context matches.',
+              'Unified diff for this one file only (alternative to old+new). Bare `@@` hunks are fine when context matches.',
           },
           slug: { type: 'string' },
         },
-        required: ['path', 'patch'],
+        required: ['path'],
       },
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const path = typeof args.path === 'string' ? args.path.trim() : '';
         if (!path) return toolErr('path is required');
-        if (typeof args.patch !== 'string' || args.patch.trim().length === 0) {
-          return toolErr('patch is required (unified diff text)');
+        const hasPatch = typeof args.patch === 'string' && args.patch.trim().length > 0;
+        const hasOld = typeof args.old === 'string';
+        const hasNew = typeof args.new === 'string';
+        if (hasPatch && (hasOld || hasNew)) {
+          return toolErr('pass either old+new (exact replace) or patch (unified diff), not both');
+        }
+        if (hasOld !== hasNew) {
+          return toolErr('old and new must be passed together');
+        }
+        if (!hasPatch && !hasOld) {
+          return toolErr('pass old+new (preferred) or patch (unified diff)');
         }
         const slug =
           typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
@@ -2792,7 +2807,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           auth.channelToken,
           {
             path,
-            patch: args.patch,
+            ...(hasPatch ? { patch: args.patch } : { old: args.old, new: args.new }),
             ...(slug ? { slug } : {}),
           },
         );

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -316,7 +316,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file({ path, patch }) with a unified diff for edits (bare @@ ok — matched by context; never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
   'Honour stop immediately — do not continue after stop:true.',
@@ -345,7 +345,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'send_screenshot as soon as the game draws anything playable.',
-  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, patch }) with a unified diff (---/+++ + @@ hunks for ONE file; context must match exactly). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
+  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, patch }) with a unified diff (---/+++ + @@ hunks for ONE file). Context lines must match exactly; @@ line numbers are optional (bare @@ is fine — the server matches by context). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   'Only call get_gate_verdict once when an already-available verdict would change what you deliver. It is not a wait loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null returns stop:false because you checked too early — continue building and call submit_sources; do not check again before a delivery. A later creator-led run may check a delivered gate again. Preview lane: preview_passed / preview_failed — fix and re-preview on the SAME key; preview_passed does NOT end the round.',
@@ -2750,9 +2750,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Apply a unified diff to ONE existing path and write the result into the staging buffer. ' +
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
         'especially for large game/render.ts or game/model.ts files. ' +
-        'patch must be a standard unified diff for that single file, e.g. ' +
+        'patch must be a unified diff for that single file. Example with line numbers: ' +
         '"--- a/game/render.ts\\n+++ b/game/render.ts\\n@@ -10,6 +10,7 @@\\n context\\n-old\\n+new\\n context\\n". ' +
-        'Context must match exactly (no fuzzy apply). Multi-file patches are refused — call once per path. ' +
+        'Bare @@ (no line numbers) is also accepted — hunks are located by matching context lines, so you do not need get_sources just to count lines. ' +
+        'Context must match exactly (no fuzzy apply). Prefix context lines with a leading space; +/- for changes. ' +
+        'Multi-file patches are refused — call once per path. ' +
         'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -2766,7 +2768,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           patch: {
             type: 'string',
             description:
-              'Unified diff for this one file only (`--- a/<path>` / `+++ b/<path>` plus one or more @@ hunks).',
+              'Unified diff for this one file only (`--- a/<path>` / `+++ b/<path>` plus one or more @@ hunks). ' +
+              '@@ line numbers optional — bare `@@` is fine when context matches.',
           },
           slug: { type: 'string' },
         },

--- a/apps/api/src/module-size.test.ts
+++ b/apps/api/src/module-size.test.ts
@@ -37,7 +37,7 @@ describe('module-size budget', () => {
     });
     expect(render).toMatch(/game\/art\.ts|game\/ui\.ts|game\/hud\.ts/);
     expect(render).toMatch(/Before adding more behavior/);
-    expect(render).toMatch(/patch_source_file/);
+    expect(render).toMatch(/patch_source_file\(\{ path, old, new \}\)/);
 
     const model = moduleTooLargeMessage({
       path: 'game/model.ts',

--- a/apps/api/src/module-size.ts
+++ b/apps/api/src/module-size.ts
@@ -58,7 +58,7 @@ export function moduleTooLargeMessage(assessment: ModuleSizeAssessment): string 
     `${assessment.path} is ${assessment.lines} lines (${assessment.bytes} bytes) — over the soft budget ` +
     `(~${MODULE_SOFT_LIMIT_LINES} lines / ~${MODULE_SOFT_LIMIT_BYTES} bytes). ` +
     `Before adding more behavior, ${splitHintFor(assessment.path)}. ` +
-    `Use patch_source_file (unified diff) for later edits; do not keep expanding this monolith.`
+    `Use patch_source_file({ path, old, new }) for later edits; do not keep expanding this monolith.`
   );
 }
 

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -259,4 +259,15 @@ describe('applyExactReplace', () => {
       }),
     ).toThrow(/more than once/);
   });
+
+  it('refuses overlapping non-unique matches', () => {
+    expect(() =>
+      applyExactReplace({
+        content: 'aaaa',
+        path: 'game.ts',
+        old: 'aaa',
+        new: 'b',
+      }),
+    ).toThrow(/more than once/);
+  });
 });

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -1,6 +1,12 @@
 import { createPatch } from 'diff';
 import { describe, expect, it } from 'vitest';
-import { applySourcePatch, normalizePatchPath, normalizeUnifiedDiff, SourcePatchError } from './source-patch.js';
+import {
+  applyExactReplace,
+  applySourcePatch,
+  normalizePatchPath,
+  normalizeUnifiedDiff,
+  SourcePatchError,
+} from './source-patch.js';
 
 describe('normalizePatchPath', () => {
   it('strips a/b prefixes, tabs, and quotes', () => {
@@ -149,5 +155,35 @@ describe('applySourcePatch', () => {
   it('refuses a stale context (no fuzzy apply)', () => {
     const patch = createPatch('game.ts', content, 'line1\nline2x\nline3\n');
     expect(() => applySourcePatch({ content: 'different\n', path: 'game.ts', patch })).toThrow(/did not apply/);
+  });
+});
+
+describe('applyExactReplace', () => {
+  const content = 'line1\nline2\nline3\n';
+
+  it('replaces a unique substring', () => {
+    const result = applyExactReplace({
+      content,
+      path: 'game.ts',
+      old: 'line2\n',
+      new: 'line2x\n',
+    });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
+    expect(result.replacements).toBe(1);
+  });
+
+  it('refuses a missing substring', () => {
+    expect(() => applyExactReplace({ content, path: 'game.ts', old: 'missing', new: 'x' })).toThrow(/not found/);
+  });
+
+  it('refuses a non-unique substring', () => {
+    expect(() =>
+      applyExactReplace({
+        content: 'aa\naa\n',
+        path: 'game.ts',
+        old: 'aa\n',
+        new: 'b\n',
+      }),
+    ).toThrow(/more than once/);
   });
 });

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -67,6 +67,21 @@ describe('applySourcePatch', () => {
     expect(result.content).toBe('line1\nline2x\nline3\n');
   });
 
+  it('applies a CRLF unified diff against LF source', () => {
+    const patch = [
+      '--- a/game/render.ts',
+      '+++ b/game/render.ts',
+      '@@ -1,3 +1,3 @@',
+      ' line1',
+      '-line2',
+      '+line2x',
+      ' line3',
+      '',
+    ].join('\r\n');
+    const result = applySourcePatch({ content, path: 'game/render.ts', patch });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
+  });
+
   it('applies a bare @@ hunk matched by context (no line numbers needed)', () => {
     const patch = [
       '--- a/game/model.ts',

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -1,6 +1,6 @@
 import { createPatch } from 'diff';
 import { describe, expect, it } from 'vitest';
-import { applySourcePatch, normalizePatchPath, SourcePatchError } from './source-patch.js';
+import { applySourcePatch, normalizePatchPath, normalizeUnifiedDiff, SourcePatchError } from './source-patch.js';
 
 describe('normalizePatchPath', () => {
   it('strips a/b prefixes, tabs, and quotes', () => {
@@ -8,6 +8,31 @@ describe('normalizePatchPath', () => {
     expect(normalizePatchPath('b/game/render.ts')).toBe('game/render.ts');
     expect(normalizePatchPath('game/render.ts\t2026-01-01 00:00:00')).toBe('game/render.ts');
     expect(normalizePatchPath('"game/render.ts"')).toBe('game/render.ts');
+  });
+});
+
+describe('normalizeUnifiedDiff', () => {
+  it('rewrites bare @@ hunks with counts derived from the body', () => {
+    const normalized = normalizeUnifiedDiff(
+      ['--- a/game/model.ts', '+++ b/game/model.ts', '@@', ' line1', '-line2', '+line2x', ' line3', ''].join('\n'),
+    );
+    expect(normalized).toContain('@@ -1,3 +1,3 @@');
+    expect(normalized).toContain('-line2');
+    expect(normalized).toContain('+line2x');
+  });
+
+  it('recounts wrong @@ line counts while keeping the start lines', () => {
+    const normalized = normalizeUnifiedDiff(
+      ['--- a/game.ts', '+++ b/game.ts', '@@ -10,1 +10,1 @@', ' line1', '-line2', '+line2x', ' line3', ''].join('\n'),
+    );
+    expect(normalized).toContain('@@ -10,3 +10,3 @@');
+  });
+
+  it('prefixes context lines that are missing the leading space', () => {
+    const normalized = normalizeUnifiedDiff(
+      ['--- a/game.ts', '+++ b/game.ts', '@@', 'line1', '-line2', '+line2x', 'line3', ''].join('\n'),
+    );
+    expect(normalized.split('\n')).toEqual(expect.arrayContaining([' line1', '-line2', '+line2x', ' line3']));
   });
 });
 
@@ -34,6 +59,76 @@ describe('applySourcePatch', () => {
     ].join('\n');
     const result = applySourcePatch({ content, path: 'game/render.ts', patch });
     expect(result.content).toBe('line1\nline2x\nline3\n');
+  });
+
+  it('applies a bare @@ hunk matched by context (no line numbers needed)', () => {
+    const patch = [
+      '--- a/game/model.ts',
+      '+++ b/game/model.ts',
+      '@@',
+      '   news: { icon: "x" },',
+      ' };',
+      ' ',
+      '+export const GENRES = [];',
+      '+',
+      ' export type Programme = { id: number };',
+      '',
+    ].join('\n');
+    const base = ['  news: { icon: "x" },', '};', '', 'export type Programme = { id: number };', ''].join('\n');
+    const result = applySourcePatch({ content: base, path: 'game/model.ts', patch });
+    expect(result.content).toContain('export const GENRES = [];');
+    expect(result.content).toContain('export type Programme');
+    expect(result.replacements).toBe(1);
+  });
+
+  it('applies when @@ line numbers are approximate but context matches', () => {
+    const patch = [
+      '--- a/game/render.ts',
+      '+++ b/game/render.ts',
+      '@@ -99,3 +99,3 @@',
+      ' line1',
+      '-line2',
+      '+line2x',
+      ' line3',
+      '',
+    ].join('\n');
+    const result = applySourcePatch({ content, path: 'game/render.ts', patch });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
+  });
+
+  it('applies when @@ line counts are wrong but the body is complete', () => {
+    const patch = [
+      '--- a/game/render.ts',
+      '+++ b/game/render.ts',
+      '@@ -1,1 +1,1 @@',
+      ' line1',
+      '-line2',
+      '+line2x',
+      ' line3',
+      '',
+    ].join('\n');
+    const result = applySourcePatch({ content, path: 'game/render.ts', patch });
+    expect(result.content).toBe('line1\nline2x\nline3\n');
+  });
+
+  it('applies two bare @@ hunks in one file', () => {
+    const base = 'alpha\nbeta\ngamma\n';
+    const patch = [
+      '--- a/game.ts',
+      '+++ b/game.ts',
+      '@@',
+      ' alpha',
+      '-beta',
+      '+BETA',
+      ' gamma',
+      '@@',
+      ' gamma',
+      '+delta',
+      '',
+    ].join('\n');
+    const result = applySourcePatch({ content: base, path: 'game.ts', patch });
+    expect(result.content).toBe('alpha\nBETA\ngamma\ndelta\n');
+    expect(result.replacements).toBe(2);
   });
 
   it('refuses an empty patch', () => {

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -117,6 +117,79 @@ describe('applySourcePatch', () => {
     expect(result.content).toBe('line1\nline2x\nline3\n');
   });
 
+  // Production refusal: "patch is not a valid unified diff" when agents invent
+  // @@ -N,M counts that do not match the body (jsdiff throws mid-parse).
+  it('applies a multi-hunk patch with invented wrong @@ counts (TV Tycoon shape)', () => {
+    const base = [
+      '// TV Tycoon — station data, economy, staff routines and the day simulation.',
+      '',
+      'export const CANVAS_W = 960;',
+      'export const CANVAS_H = 600;',
+      "export type Phase = 'planning' | 'evening' | 'morning';",
+      'export type ReportLine = { slot: number; title: string; viewers: number; contract: string; ok: boolean };',
+      'export type Round = {',
+      '  rivalNote: string;',
+      '',
+      '  progIds: number;',
+      '  contractIds: number;',
+      '};',
+      'export function createRound() {',
+      '  return {',
+      "    rivalNote: '',",
+      '',
+      '    progIds: 1,',
+      '    contractIds: 1,',
+      '  };',
+      '}',
+      '',
+    ].join('\n');
+    const patch = [
+      '--- a/game/model.ts',
+      '+++ b/game/model.ts',
+      '@@ -1,4 +1,6 @@',
+      ' // TV Tycoon — station data, economy, staff routines and the day simulation.',
+      '+',
+      "+import type { RivalSlot } from './rival.ts';",
+      ' ',
+      ' export const CANVAS_W = 960;',
+      ' export const CANVAS_H = 600;',
+      '@@ -430,7 +432,16 @@',
+      " export type Phase = 'planning' | 'evening' | 'morning';",
+      '-export type ReportLine = { slot: number; title: string; viewers: number; contract: string; ok: boolean };',
+      '+export type ReportLine = {',
+      '+  slot: number;',
+      '+  title: string;',
+      '+  viewers: number;',
+      '+  contract: string;',
+      '+  ok: boolean;',
+      '+  rivalTitle: string;',
+      '+  rivalGenre: Genre | null;',
+      '+  contested: boolean;',
+      '+};',
+      '@@ -470,6 +481,9 @@',
+      '   rivalNote: string;',
+      '+  /** What TVMAX is airing tonight, slot by slot. */',
+      '+  rivalSchedule: RivalSlot[];',
+      '+  lastReason: string;',
+      ' ',
+      '   progIds: number;',
+      '   contractIds: number;',
+      '@@ -540,6 +554,8 @@',
+      "     rivalNote: '',",
+      '+    rivalSchedule: [],',
+      "+    lastReason: '',",
+      ' ',
+      '     progIds: 1,',
+      '     contractIds: 1,',
+      '',
+    ].join('\n');
+    const result = applySourcePatch({ content: base, path: 'game/model.ts', patch });
+    expect(result.replacements).toBe(4);
+    expect(result.content).toContain("import type { RivalSlot } from './rival.ts';");
+    expect(result.content).toContain('rivalSchedule: RivalSlot[]');
+    expect(result.content).toContain('contested: boolean');
+  });
+
   it('applies two bare @@ hunks in one file', () => {
     const base = 'alpha\nbeta\ngamma\n';
     const patch = [

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -4,6 +4,11 @@
  * Chat-thin agents (Claude Chat especially) otherwise re-emit entire `render.ts` /
  * `model.ts` files on every tweak via `stage_source_file`. A unified diff keeps the
  * tool payload proportional to the edit — the format models already know well.
+ *
+ * Models often emit near-unified diffs that stock parsers reject: bare `@@` (no line
+ * numbers), approximate `@@ -N,M` counts, or context lines missing the leading space.
+ * We normalize those before apply so agents need matching context, not exact line
+ * arithmetic from a full-file re-read.
  */
 
 import { applyPatch, parsePatch } from 'diff';
@@ -43,12 +48,114 @@ export function normalizePatchPath(raw: string): string {
   return path;
 }
 
+/** Numbered hunk header, optionally with a trailing function-context label. */
+const NUMBERED_HUNK_HEADER = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s*@@(.*)$/;
+
+/**
+ * True for a line that starts a hunk: numbered `@@ -n,m +n,m @@` or bare `@@` /
+ * `@@ label` (no line numbers — common from chat models).
+ */
+function isHunkHeaderLine(line: string): boolean {
+  if (NUMBERED_HUNK_HEADER.test(line)) return true;
+  // Bare `@@` or `@@ some context` without `-N +N`.
+  return /^@@(?:\s.*)?$/.test(line) && !/^@@\s+-/.test(line);
+}
+
+function isHunkBoundary(line: string): boolean {
+  if (isHunkHeaderLine(line)) return true;
+  if (line.startsWith('diff ')) return true;
+  if (/^Index:\s/.test(line)) return true;
+  if (/^===/.test(line)) return true;
+  // Next file in a multi-file patch — not a hunk body line.
+  if (/^---\s+\S/.test(line) || /^\+\+\+\s+\S/.test(line)) return true;
+  return false;
+}
+
+/** Ensure each hunk body line has a unified-diff operation prefix. */
+function normalizeHunkBodyLine(line: string): string {
+  if (line.length === 0) return ' ';
+  const op = line[0]!;
+  if (op === '+' || op === '-' || op === ' ' || op === '\\') return line;
+  // Context line missing the leading space (LLM habit).
+  return ` ${line}`;
+}
+
+function countHunkLines(body: string[]): { oldLines: number; newLines: number } {
+  let oldLines = 0;
+  let newLines = 0;
+  for (const line of body) {
+    const op = line[0] ?? ' ';
+    if (op === '+') newLines++;
+    else if (op === '-') oldLines++;
+    else if (op === '\\') {
+      /* "\ No newline at end of file" — not counted */
+    } else {
+      oldLines++;
+      newLines++;
+    }
+  }
+  return { oldLines, newLines };
+}
+
+/**
+ * Rewrite agent-friendly near-unified diffs into something `diff` can parse:
+ * bare `@@` → numbered headers (counts from body; starts default to 1 — apply matches
+ * by context), wrong `,count` values → recounted, context lines missing a leading
+ * space → prefixed.
+ */
+export function normalizeUnifiedDiff(patchText: string): string {
+  const endsWithNewline = patchText.endsWith('\n');
+  const lines = patchText.split('\n');
+  // split keeps a trailing empty from a final newline; drop it so we don't treat it
+  // as a stray body line, then re-attach the newline at the end.
+  if (endsWithNewline && lines[lines.length - 1] === '') lines.pop();
+
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (!isHunkHeaderLine(line)) {
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    const numbered = NUMBERED_HUNK_HEADER.exec(line);
+    const oldStart = numbered ? Number(numbered[1]) : 1;
+    const newStart = numbered ? Number(numbered[3]) : 1;
+    const label = numbered ? (numbered[5] ?? '').trimEnd() : '';
+    i++;
+
+    const body: string[] = [];
+    while (i < lines.length && !isHunkBoundary(lines[i]!)) {
+      body.push(normalizeHunkBodyLine(lines[i]!));
+      i++;
+    }
+    // Trailing blank lines after the last real change are not part of the hunk.
+    while (body.length > 0 && body[body.length - 1] === ' ') body.pop();
+
+    const { oldLines, newLines } = countHunkLines(body);
+    if (oldLines === 0 && newLines === 0) {
+      throw new SourcePatchError('patch hunk is empty — each @@ hunk needs context and/or +/- lines under it');
+    }
+
+    const labelSuffix = label.length > 0 ? ` ${label.trimStart()}` : '';
+    out.push(`@@ -${oldStart},${oldLines} +${newStart},${newLines} @@${labelSuffix}`);
+    out.push(...body);
+  }
+
+  return endsWithNewline || patchText.length === 0 ? `${out.join('\n')}\n` : out.join('\n');
+}
+
 function assertPatchTargetsPath(path: string, patchText: string): number {
   let parsed;
   try {
     parsed = parsePatch(patchText);
-  } catch {
-    throw new SourcePatchError('patch is not a valid unified diff — pass ---/+++ headers and @@ hunks for one file');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new SourcePatchError(
+      `patch is not a valid unified diff — pass ---/+++ headers and @@ hunks for one file (${detail})`,
+    );
   }
   if (parsed.length === 0) {
     throw new SourcePatchError('patch is empty — pass a unified diff with at least one @@ hunk');
@@ -79,7 +186,10 @@ function assertPatchTargetsPath(path: string, patchText: string): number {
 
   const hunks = file.hunks?.length ?? 0;
   if (hunks === 0) {
-    throw new SourcePatchError('patch has no @@ hunks — nothing to apply');
+    throw new SourcePatchError(
+      'patch has no @@ hunks — nothing to apply. Use a unified diff with hunks like ' +
+        '`@@ -10,6 +10,7 @@` (line numbers optional: bare `@@` is fine if context matches)',
+    );
   }
   return hunks;
 }
@@ -90,14 +200,25 @@ function assertPatchTargetsPath(path: string, patchText: string): number {
  */
 export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatchResult {
   const path = input.path.trim();
-  const patch = input.patch.trim();
+  const rawPatch = input.patch.trim();
   if (!path) throw new SourcePatchError('path is required');
-  if (!patch) throw new SourcePatchError('patch must not be empty');
+  if (!rawPatch) throw new SourcePatchError('patch must not be empty');
+
+  let patch: string;
+  try {
+    patch = normalizeUnifiedDiff(rawPatch);
+  } catch (error) {
+    if (error instanceof SourcePatchError) throw error;
+    throw new SourcePatchError(
+      `patch could not be normalized — ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 
   const hunks = assertPatchTargetsPath(path, patch);
 
   // fuzzFactor 0: context must match exactly. Stale hunks should re-get_sources and retry,
-  // not silently land on the wrong lines of a large render.ts.
+  // not silently land on the wrong lines of a large render.ts. Line numbers may be
+  // approximate — applyPatch still locates hunks by matching context lines.
   const next = applyPatch(input.content, patch, { fuzzFactor: 0 });
   if (next === false) {
     throw new SourcePatchError(

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -28,9 +28,18 @@ export type ApplySourcePatchInput = {
   patch: string;
 };
 
+export type ApplyExactReplaceInput = {
+  content: string;
+  path: string;
+  /** Exact substring that must appear once in the file. */
+  old: string;
+  /** Replacement text (may be empty to delete). */
+  new: string;
+};
+
 export type ApplySourcePatchResult = {
   content: string;
-  /** Number of hunks applied. */
+  /** Number of hunks / replacements applied. */
   replacements: number;
 };
 
@@ -229,6 +238,45 @@ export function applySourcePatch(input: ApplySourcePatchInput): ApplySourcePatch
     throw new SourcePatchError('patch applied but made no changes');
   }
   return { content: next, replacements: hunks };
+}
+
+/**
+ * Exact unique substring replace — the chat-friendly alternative to unified diffs.
+ * `old` must appear exactly once; widen the snippet with surrounding lines if not.
+ */
+export function applyExactReplace(input: ApplyExactReplaceInput): ApplySourcePatchResult {
+  const path = input.path.trim();
+  if (!path) throw new SourcePatchError('path is required');
+  if (input.old.length === 0) {
+    throw new SourcePatchError('old must not be empty — pass the exact text to replace');
+  }
+  if (input.old === input.new) {
+    throw new SourcePatchError('old and new are identical — nothing to change');
+  }
+
+  let occurrences = 0;
+  let from = 0;
+  while (true) {
+    const at = input.content.indexOf(input.old, from);
+    if (at === -1) break;
+    occurrences++;
+    from = at + input.old.length;
+    if (occurrences > 1) break;
+  }
+
+  if (occurrences === 0) {
+    throw new SourcePatchError(
+      `old text not found in ${path} — copy the exact snippet from the current file (get_sources / staged base)`,
+    );
+  }
+  if (occurrences > 1) {
+    throw new SourcePatchError(
+      `old text matches more than once in ${path} — include more surrounding lines so it is unique`,
+    );
+  }
+
+  const content = input.content.replace(input.old, input.new);
+  return { content, replacements: 1 };
 }
 
 /** @deprecated Prefer {@link largeSourceFileHint} from `module-size.js`. Re-exported for callers. */

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -254,13 +254,15 @@ export function applyExactReplace(input: ApplyExactReplaceInput): ApplySourcePat
     throw new SourcePatchError('old and new are identical — nothing to change');
   }
 
+  // Advance by 1 so overlapping matches count (e.g. content "aaaa", old "aaa"
+  // has matches at 0 and 1). Skipping by old.length would falsely treat that as unique.
   let occurrences = 0;
   let from = 0;
   while (true) {
     const at = input.content.indexOf(input.old, from);
     if (at === -1) break;
     occurrences++;
-    from = at + input.old.length;
+    from = at + 1;
     if (occurrences > 1) break;
   }
 

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -163,7 +163,7 @@ function assertPatchTargetsPath(path: string, patchText: string): number {
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new SourcePatchError(
-      `patch is not a valid unified diff — pass ---/+++ headers and @@ hunks for one file (${detail})`,
+      `patch is not a valid unified diff (${detail}). Prefer old+new exact replace, or pass ---/+++ + @@ hunks for one file`,
     );
   }
   if (parsed.length === 0) {

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -113,8 +113,12 @@ function countHunkLines(body: string[]): { oldLines: number; newLines: number } 
  * space → prefixed.
  */
 export function normalizeUnifiedDiff(patchText: string): string {
-  const endsWithNewline = patchText.endsWith('\n');
-  const lines = patchText.split('\n');
+  // MCP / Windows clients often send CRLF. split('\n') would leave a trailing \r on
+  // every line, so applyPatch's exact context match fails against LF game sources.
+  // jsdiff itself tolerates CRLF patches; once we rewrite hunks we must too.
+  const text = patchText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const endsWithNewline = text.endsWith('\n');
+  const lines = text.split('\n');
   // split keeps a trailing empty from a final newline; drop it so we don't treat it
   // as a stray body line, then re-attach the newline at the end.
   if (endsWithNewline && lines[lines.length - 1] === '') lines.pop();
@@ -153,7 +157,7 @@ export function normalizeUnifiedDiff(patchText: string): string {
     out.push(...body);
   }
 
-  return endsWithNewline || patchText.length === 0 ? `${out.join('\n')}\n` : out.join('\n');
+  return endsWithNewline || text.length === 0 ? `${out.join('\n')}\n` : out.join('\n');
 }
 
 function assertPatchTargetsPath(path: string, patchText: string): number {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chat agents hit opaque patch failures on near-unified diffs:

- bare `@@` → `patch has no @@ hunks`
- invented `@@ -N,M` counts that don’t match the body → `patch is not a valid unified diff`

They then burn turns recalculating line arithmetic or re-fetching whole files. The oversized-module hint also steered them back to “unified diff”.

## Fix

1. **Prefer `old` + `new`** — exact unique substring replace on `patch_source_file`. No `@@`, no counts.
2. **Normalize unified `patch`** — bare `@@`, wrong `,count` values, missing context-line spaces. Regression covers the TV Tycoon multi-hunk wrong-count shape that failed in prod.
3. Workflow / tool / `module_too_large` hint steer to `old`+`new` first.

## Tests

- Unit: bare `@@`, wrong counts (incl. multi-hunk prod shape), missing space prefix, exact replace
- Channel: `old`+`new` and bare `@@` over `/sources/stage/patch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f89ad6d-6592-4d94-a50c-c7784ccff11c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f89ad6d-6592-4d94-a50c-c7784ccff11c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

