### PR TITLE
fix(bake): resolve `vehicles` to its vertical, and check entry paths in lockstep

### DIFF
--- a/apps/api/scripts/check-games-repo-contract.ts
+++ b/apps/api/scripts/check-games-repo-contract.ts
@@ -6,6 +6,8 @@
  * `tools/lib/assemble.ts`, `tools/validate.ts` and `shared/delivery-contract.json`
  * still match `games-repo-contract.ts` on this side:
  *   - GAME_KIT_MODULES order
+ *   - GAME_KIT_VERTICALS entry paths (a module promoted to a vertical keeps its name,
+ *     so the order check alone cannot see the source move)
  *   - MAX_BUNDLE_BYTES === MAX_PROJECT_BYTES
  *   - music injection contract (tracks + __GAME_AUDIO_MUSIC__ + readMusicCatalog)
  *   - delivery contract (fixed files and their order, extra-module pattern, caps)

--- a/apps/api/src/games-repo-contract-check.test.ts
+++ b/apps/api/src/games-repo-contract-check.test.ts
@@ -9,11 +9,21 @@ import {
   DELIVERY_MAX_UPLOAD_BYTES,
   DELIVERY_RESERVED_SEGMENTS,
   GAME_KIT_MODULES,
+  GAME_KIT_VERTICAL_ENTRIES,
   MAX_PROJECT_BYTES,
 } from './games-repo-contract.js';
 
+const VERTICALS_SOURCE = `
+  const GAME_KIT_VERTICALS = Object.freeze({
+${Object.entries(GAME_KIT_VERTICAL_ENTRIES)
+  .map(([name, entry]) => `    ${name}: '${entry}',`)
+  .join('\n')}
+  });
+`;
+
 const ASSEMBLE_SOURCE = `
   const GAME_KIT_MODULES = [${GAME_KIT_MODULES.map((name) => `'${name}'`).join(', ')}];
+  ${VERTICALS_SOURCE}
   const catalog = readMusicCatalog();
   const track = catalog.tracks[name];
   out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
@@ -115,6 +125,7 @@ describe('runGamesRepoContractCheck', () => {
     const withoutAheadExtras = GAME_KIT_MODULES.filter((name) => !aheadModules.has(name));
     const olderAssemble = `
       const GAME_KIT_MODULES = [${withoutAheadExtras.map((name) => `'${name}'`).join(', ')}];
+      ${VERTICALS_SOURCE}
       const catalog = readMusicCatalog();
       const track = catalog.tracks[name];
       out += 'window.__GAME_AUDIO_MUSIC__ = ' + JSON.stringify(name);
@@ -161,6 +172,46 @@ describe('runGamesRepoContractCheck', () => {
     expect(outcome.kind).toBe('drift');
     expect(outcome.kind === 'drift' && outcome.reason).toContain('Undeclared or expired website-ahead modules');
     expect(outcome.kind === 'drift' && outcome.reason).toContain('collision');
+  });
+
+  it('reports drift when a module moved to a vertical this side still reads from shared/modules', async () => {
+    // The regression that broke the nightly bake: games-repo #527 promoted `vehicles` to
+    // a vertical. Both sides still listed the name, so the module check stayed green while
+    // the bake looked for shared/modules/vehicles.ts and reported the game as missing.
+    const assembleWithNewVertical = ASSEMBLE_SOURCE.replace(
+      "urban: 'shared/verticals/urban/index.ts',",
+      "urban: 'shared/verticals/urban/index.ts',\n    gfx3d: 'shared/verticals/gfx3d/index.ts',",
+    );
+    const { fetchImpl } = createFetch({
+      ...agreeingPages(),
+      'tools/lib/assemble.ts': [ok(assembleWithNewVertical)],
+    });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('drift');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('GAME_KIT_VERTICALS mismatch');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('shared/modules/gfx3d.ts');
+  });
+
+  it('reports drift when a shared vertical resolves to a different entry path', async () => {
+    const movedEntry = ASSEMBLE_SOURCE.replace(
+      "urban: 'shared/verticals/urban/index.ts',",
+      "urban: 'shared/verticals/urban/entry.ts',",
+    );
+    const { fetchImpl } = createFetch({ ...agreeingPages(), 'tools/lib/assemble.ts': [ok(movedEntry)] });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('drift');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('shared/verticals/urban/entry.ts');
+  });
+
+  it('notes rather than fails when the games tip has no verticals literal to compare', async () => {
+    const noVerticals = ASSEMBLE_SOURCE.replace(VERTICALS_SOURCE, '');
+    const { fetchImpl } = createFetch({ ...agreeingPages(), 'tools/lib/assemble.ts': [ok(noVerticals)] });
+
+    const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
+    expect(outcome.kind).toBe('ok');
+    expect(outcome.kind === 'ok' && outcome.notes?.[0]).toContain('GAME_KIT_VERTICALS not compared');
   });
 
   it('skips without a token so forks and fresh clones stay green', async () => {

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -38,11 +38,14 @@ import {
   DELIVERY_RESERVED_SEGMENTS,
   extractDeliveryContract,
   extractGameKitModules,
+  extractGameKitVerticals,
   extractMaxBundleBytes,
   extractMusicContractSignals,
   GAME_KIT_MODULES,
+  GAME_KIT_VERTICAL_ENTRIES,
   MAX_PROJECT_BYTES,
   type DeliveryContract,
+  type GameKitModuleName,
 } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
@@ -324,6 +327,50 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     log(`  ✓ GAME_KIT_MODULES (${remoteModules.length} modules)`);
   }
 
+  // Names agreeing is not the same as resolving to the same file. A module promoted to a
+  // vertical keeps its name in GAME_KIT_MODULES, so the check above stays green while this
+  // side still reads `shared/modules/<name>.ts` and finds nothing — which surfaces as
+  // "game sources not found on ref" in the nightly bake, one game short of a snapshot.
+  //
+  // An assemble source with no verticals literal at all is a shape this side does not
+  // recognize rather than evidence of drift — same tolerance the delivery half gets — so
+  // it becomes a note on an otherwise green run instead of a failure.
+  let remoteVerticals: Record<string, string>;
+  let verticalNote: string | null = null;
+  try {
+    remoteVerticals = extractGameKitVerticals(assembleSource);
+  } catch (error: unknown) {
+    remoteVerticals = {};
+    verticalNote = `GAME_KIT_VERTICALS not compared: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  const verticalDrift: string[] = [];
+  for (const [name, remotePath] of Object.entries(remoteVerticals)) {
+    // Only modules this side recognizes matter: a vertical for a games-repo-only module
+    // is the website-behind case the module check already rules on.
+    if (!(GAME_KIT_MODULES as readonly string[]).includes(name)) continue;
+    const localPath = GAME_KIT_VERTICAL_ENTRIES[name as GameKitModuleName];
+    if (localPath === undefined) {
+      verticalDrift.push(`${name}: games-repo=${remotePath} website=(resolved as shared/modules/${name}.ts)`);
+    } else if (localPath !== remotePath) {
+      verticalDrift.push(`${name}: games-repo=${remotePath} website=${localPath}`);
+    }
+  }
+  if (verticalDrift.length > 0) {
+    return {
+      kind: 'drift',
+      reason:
+        `GAME_KIT_VERTICALS mismatch.\n${verticalDrift.map((entry) => `  ${entry}`).join('\n')}\n` +
+        `  Every games-repo vertical must resolve to the same entry path in ` +
+        `GAME_KIT_VERTICAL_ENTRIES in apps/api/src/games-repo-contract.ts, or the bake cannot ` +
+        `find the module's source and every game selecting it fails to publish.`,
+    };
+  }
+  if (verticalNote) {
+    log(`  – GAME_KIT_VERTICALS (not compared)`);
+  } else {
+    log(`  ✓ GAME_KIT_VERTICALS (${Object.keys(remoteVerticals).length} verticals)`);
+  }
+
   const remoteBudget = extractMaxBundleBytes(validateSource);
   if (remoteBudget > MAX_PROJECT_BYTES) {
     const assignLine =
@@ -366,6 +413,9 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
   log('  ✓ music contract (__GAME_AUDIO_MUSIC__ + tracks + readMusicCatalog)');
 
   const notes: string[] = [];
+  if (verticalNote) {
+    notes.push(verticalNote);
+  }
   if (deliverySource === null) {
     notes.push(
       `${DELIVERY_CONTRACT_PATH} is absent from ${repo}@${ref} (404) — the delivery half was NOT ` +

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -8,10 +8,12 @@ import {
   DELIVERY_RESERVED_SEGMENTS,
   extractDeliveryContract,
   extractGameKitModules,
+  extractGameKitVerticals,
   extractMaxBundleBytes,
   extractMusicContractSignals,
   GAME_BUDGET_BYTES,
   GAME_KIT_MODULES,
+  GAME_KIT_VERTICAL_ENTRIES,
   GAMEKIT_PLATFORM_BYTES,
   MAX_PROJECT_BYTES,
   MUSIC_CONTRACT,
@@ -223,6 +225,34 @@ describe('games-repo source extractors', () => {
       ] as const;
     `;
     expect(extractGameKitModules(source)).toEqual([...GAME_KIT_MODULES]);
+  });
+
+  it('reads GAME_KIT_VERTICALS from an assemble.ts-shaped source', () => {
+    const source = `
+      const GAME_KIT_VERTICALS = Object.freeze({
+        vehicles: 'shared/verticals/vehicles/index.ts',
+        urban: 'shared/verticals/urban/index.ts',
+        racing: 'shared/verticals/racing/index.ts',
+        football: 'shared/verticals/football/index.ts',
+      });
+    `;
+    expect(extractGameKitVerticals(source)).toEqual(GAME_KIT_VERTICAL_ENTRIES);
+  });
+
+  it('rejects an assemble source with no verticals to compare', () => {
+    expect(() => extractGameKitVerticals('const GAME_KIT_MODULES = [];')).toThrow(/no GAME_KIT_VERTICALS object/);
+    expect(() => extractGameKitVerticals('const GAME_KIT_VERTICALS = Object.freeze({});')).toThrow(
+      /GAME_KIT_VERTICALS object is empty/,
+    );
+  });
+
+  it('resolves every vertical to a games-repo path, never to shared/modules', () => {
+    // The regression behind the failed nightly bake: `vehicles` was a name both sides
+    // knew, but only the games repo knew it had moved out of shared/modules.
+    for (const [name, entry] of Object.entries(GAME_KIT_VERTICAL_ENTRIES)) {
+      expect(GAME_KIT_MODULES).toContain(name);
+      expect(entry).toBe(`shared/verticals/${name}/index.ts`);
+    }
   });
 
   it('evaluates MAX_BUNDLE_BYTES from the single platform ceiling', () => {

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -151,6 +151,38 @@ export const MUSIC_CONTRACT = {
   windowTracksName: '__GAME_MUSIC_TRACKS__',
 } as const;
 
+/**
+ * Modules whose source is not `shared/modules/<name>.ts` but a genre vertical with a
+ * private multi-file graph behind an index — games-repo assemble `GAME_KIT_VERTICALS`.
+ *
+ * Kept here rather than next to the bundler because it is a cross-repo value, and the
+ * lockstep check compares it: a module can be listed in {@link GAME_KIT_MODULES} on both
+ * sides — names agreeing, check green — while this side still looks for it under
+ * `shared/modules/`. That is not a 502 on one route, it is a bake failure, and a bake
+ * that fails on one game leaves the pointer on the previous snapshot and publishes
+ * nothing. `vehicles` became a vertical in games-repo #527 and this map did not follow;
+ * the nightly bake had to be the thing that noticed.
+ */
+export const GAME_KIT_VERTICAL_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
+  vehicles: 'shared/verticals/vehicles/index.ts',
+  urban: 'shared/verticals/urban/index.ts',
+  racing: 'shared/verticals/racing/index.ts',
+  football: 'shared/verticals/football/index.ts',
+};
+
+/** Pull the `GAME_KIT_VERTICALS = { ... }` object literal out of games-repo assemble source. */
+export function extractGameKitVerticals(assembleSource: string): Record<string, string> {
+  const match = assembleSource.match(/GAME_KIT_VERTICALS\s*=\s*(?:Object\.freeze\()?\{([\s\S]*?)\}/);
+  if (!match) {
+    throw new Error('games-repo assemble source has no GAME_KIT_VERTICALS object');
+  }
+  const entries = [...match[1].matchAll(/['"]?([a-z0-9-]+)['"]?\s*:\s*['"]([^'"]+)['"]/g)];
+  if (entries.length === 0) {
+    throw new Error('games-repo GAME_KIT_VERTICALS object is empty');
+  }
+  return Object.fromEntries(entries.map((entry) => [entry[1], entry[2]]));
+}
+
 /** Pull the `GAME_KIT_MODULES = [ ... ]` array literal out of games-repo assemble source. */
 export function extractGameKitModules(assembleSource: string): string[] {
   const match = assembleSource.match(/GAME_KIT_MODULES\s*=\s*\[([\s\S]*?)\]/);

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { build, transform } from 'esbuild';
 import { classifyTouchSource, type CatalogGameTouch } from './catalog-touch.js';
-import { GAME_KIT_MODULES, SOURCE_GRAPH_BUDGET_BYTES, type GameKitModuleName } from './games-repo-contract.js';
+import {
+  GAME_KIT_MODULES,
+  GAME_KIT_VERTICAL_ENTRIES,
+  SOURCE_GRAPH_BUDGET_BYTES,
+  type GameKitModuleName,
+} from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
 export type { CatalogGameTouch } from './catalog-touch.js';
@@ -72,11 +77,12 @@ export interface GameSources {
 const MAX_SOURCE_GRAPH_MODULES = 64;
 /** Alias of {@link SOURCE_GRAPH_BUDGET_BYTES} — keep the local name at the call sites. */
 const MAX_SOURCE_GRAPH_BYTES = SOURCE_GRAPH_BUDGET_BYTES;
-const GAME_KIT_MODULE_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
-  urban: 'shared/verticals/urban/index.ts',
-  racing: 'shared/verticals/racing/index.ts',
-  football: 'shared/verticals/football/index.ts',
-};
+/**
+ * Where a module's entry source lives when it is not `shared/modules/<name>.ts`.
+ * The map itself is contract, so it lives with the rest of the games-repo contract
+ * and CI compares it against the games repo's own `GAME_KIT_VERTICALS`.
+ */
+const GAME_KIT_MODULE_ENTRIES = GAME_KIT_VERTICAL_ENTRIES;
 
 /**
  * Maps a relative import specifier onto a `.ts` source path.


### PR DESCRIPTION
The nightly snapshot publish has been failing on one game:

```
✗ carjack-city: game sources not found on ref
snapshot 20260805T060647Z-c356 not published: 97 games baked, 889 media, 1 failed — pointer left unchanged
```

([run 30980232020](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/30980232020/job/92222893180#step:7:162))

## What actually broke

carjack-city's sources were on the ref the whole time — the message is misleading.

games-repo #527 promoted `vehicles` out of `shared/modules/vehicles.ts` into a genre vertical at `shared/verticals/vehicles/index.ts`, and registered it in that repo's `GAME_KIT_VERTICALS`. This side keeps its own copy of that map — `GAME_KIT_MODULE_ENTRIES` in `github-client.ts`, which listed only `urban`, `racing`, `football` — and the copy did not follow. So the bake looked for a flat module that no longer exists, `getGameSources` returned `null`, and the only report that survives that far up the stack is "not found".

carjack-city is the one game in the catalog that selects `vehicles`.

One failed game is not one missing game: a partial bake deliberately leaves `current.json` on the previous snapshot, so the whole publish fails and every merged game waits behind it.

## Why the contract check stayed green

The name half was already in lockstep — `vehicles` is in `GAME_KIT_MODULES` on both sides, because the name never changed, only where the source lives. Names agreeing is not the same as resolving to the same file.

## Changes

- **`games-repo-contract.ts`** — the vertical map moves here as `GAME_KIT_VERTICAL_ENTRIES` (it is a cross-repo value, not a bundler detail) and gains the missing `vehicles` entry, plus an `extractGameKitVerticals` parser for the games-repo literal.
- **`github-client.ts`** — resolves against the shared map instead of a private copy.
- **`games-repo-contract-check.ts`** — now compares entry *paths*, not just names. A vertical this side would resolve under `shared/modules/`, or one that resolves to a different entry path, is drift and fails in CI instead of in the nightly. An assemble source with no verticals literal at all is a shape we do not recognize rather than evidence of drift, so it becomes a note on an otherwise green run — the same tolerance the delivery half gets.

## Verification

Drove the real `getGameSources` against a local games-repo checkout rather than only the tests: carjack-city **fails** to assemble without the map entry and **assembles** (587 KiB) with it, so both the reproduction and the fix are confirmed against the actual bake path.

Full API suite green — 2342 tests across 151 files, plus `type-check` and `lint`. New tests cover the promoted-vertical drift, a moved entry path, and the tolerated missing-literal case.

## Note for the reviewer

`WEBSITE_AHEAD_EXPIRY` in the check still carries a `vehicles` entry dated `2026-09-01`. games-repo has shipped `vehicles` now, so that exception is dead weight and could be dropped — left alone here since it is not load-bearing for this failure.

After merge, re-running the publish workflow should advance the pointer to a full 98-game snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXgyVgCkJpEJiGj6jPgxJt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXgyVgCkJpEJiGj6jPgxJt)_