### PR TITLE
fix(web): use PixelIcon for Remix panel close button

### DIFF
--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
 import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { recordRemixStep } from './visitTelemetry.js';
 import { useAuth } from './AuthContext.js';
@@ -823,7 +824,7 @@ export function RemixPanel(props: {
       <div className="remix-head">
         <span className="remix-title">{t('remix.title')}</span>
         <button type="button" className="remix-close" onClick={props.onClose} aria-label={t('remix.close')}>
-          ×
+          <PixelIcon name="close" size={12} />
         </button>
       </div>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11484,17 +11484,27 @@ a.user-name--profile:focus-visible {
 }
 
 .remix-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 28px;
   height: 28px;
-  display: grid;
-  place-items: center;
+  padding: 0;
   background: none;
   border: 1px solid var(--panel-border, #24313d);
   border-radius: 8px;
   color: var(--muted);
-  font-size: 1rem;
-  line-height: 1;
   cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.remix-close:hover,
+.remix-close:focus-visible {
+  color: var(--text);
+  border-color: var(--muted);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the raw text `×` character in `RemixPanel`'s close button with `<PixelIcon name="close" size={12} />`.
- Updated `.remix-close` CSS to `display: inline-flex` with centered alignment, removed legacy line-height/font-size properties, and added smooth hover/focus transitions.

## Verification
- `npm run type-check` — Passed
- `npm run lint` — Passed (0 warnings)
- `npm run test` — Passed (116 files, 1,045 unit tests passed)
- `npm run build` — Clean production build