### PR TITLE
Add public game page at /:handle/:slug with repo-style layout

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,6 +18,7 @@ import { parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
 import { registerAuthPlugin, type GoogleAuthVerifier } from './auth.js';
 import { registerCreatorProfileRoutes } from './creator-profile-routes.js';
 import { registerGamePageRoutes, type GamePageRoutesOptions } from './game-page-routes.js';
+import { registerGameBoardRoutes, type GameBoardRoutesOptions } from './game-board-routes.js';
 import { registerAccountDeletionRoutes, type AccountDeletionRoutesOptions } from './account-deletion-routes.js';
 import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
@@ -119,6 +120,8 @@ export interface BuildAppOptions {
   contactRoutes?: ContactRoutesOptions;
   /** Seams for the public game page (cache TTL / clock under test). */
   gamePageRoutes?: Partial<Omit<GamePageRoutesOptions, 'store'>>;
+  /** Seams for the game page's task board. */
+  gameBoardRoutes?: Partial<Omit<GameBoardRoutesOptions, 'store'>>;
   /** Seams for delayed account erasure; defaults to OIDC-or-deny-all from env. */
   accountDeletionRoutes?: Partial<
     Omit<AccountDeletionRoutesOptions, 'store' | 'adminUids' | 'internalAuthVerifier'>
@@ -582,6 +585,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     publishedRef: process.env.GAMES_PUBLISHED_REF ?? 'main',
     ...options.gamePageRoutes,
   });
+
+  // The game page's task board. Reads only — assignment stays on the suggestion
+  // inbox route, which owns the quota and the attribution.
+  await registerGameBoardRoutes(app, { store, ...options.gameBoardRoutes });
   registerAccountDeletionRoutes(app, {
     store,
     adminUids,
@@ -673,9 +680,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // stay authed (they are under /api/creators/:handle/availability and need a session).
     if (/^\/api\/creators\/[^/]+\/?(\?|$)/.test(request.url)) return;
     // The public game page (game-page-routes.ts) — a landing page has to load for a
-    // visitor with no session. Only `/page` passes: the playable document, media,
-    // votes and every other `/api/games/:slug/*` route stay walled during beta.
-    if (/^\/api\/games\/[^/]+\/page(\?|$)/.test(request.url)) return;
+    // visitor with no session. Only `/page` and its board pass: the playable
+    // document, media, votes and every other `/api/games/:slug/*` route stay walled
+    // during beta. The board's own owner-only column is gated in its handler, which
+    // reads `request.user` — present or absent, the wall does not decide it.
+    if (/^\/api\/games\/[^/]+\/(page|board)(\?|$)/.test(request.url)) return;
     // Internal endpoints (the Cloud Scheduler notification sweep) authenticate via
     // an OIDC token in the handler, not a session — the wall would 401 them first.
     if (request.url.startsWith('/api/internal/')) return;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,6 +20,7 @@ import { registerCreatorProfileRoutes } from './creator-profile-routes.js';
 import { registerGamePageRoutes, type GamePageRoutesOptions } from './game-page-routes.js';
 import { registerGameBoardRoutes, type GameBoardRoutesOptions } from './game-board-routes.js';
 import { registerGameReviewRoutes, type GameReviewRoutesOptions } from './game-review-routes.js';
+import { registerGameSourcesRoutes, type GameSourcesRoutesOptions } from './game-sources-routes.js';
 import { registerAccountDeletionRoutes, type AccountDeletionRoutesOptions } from './account-deletion-routes.js';
 import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
@@ -125,6 +126,8 @@ export interface BuildAppOptions {
   gameBoardRoutes?: Partial<Omit<GameBoardRoutesOptions, 'store'>>;
   /** Seams for the side-by-side review surface. */
   gameReviewRoutes?: Partial<Omit<GameReviewRoutesOptions, 'store'>>;
+  /** Seams for the public read-only sources view. */
+  gameSourcesRoutes?: Partial<Omit<GameSourcesRoutesOptions, 'store'>>;
   /** Seams for delayed account erasure; defaults to OIDC-or-deny-all from env. */
   accountDeletionRoutes?: Partial<
     Omit<AccountDeletionRoutesOptions, 'store' | 'adminUids' | 'internalAuthVerifier'>
@@ -597,6 +600,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // and operator only, and it never publishes — that stays the operator action the
   // job-admin route implements, for the reasons documented there.
   await registerGameReviewRoutes(app, { store, gamesStore, adminUids, ...options.gameReviewRoutes });
+
+  // Public read-only sources for store-published creator games. Owner decision: code
+  // is worth reading, and the creator checkout already hands over the same bytes.
+  await registerGameSourcesRoutes(app, { store, gamesStore, ...options.gameSourcesRoutes });
   registerAccountDeletionRoutes(app, {
     store,
     adminUids,
@@ -692,7 +699,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // document, media, votes and every other `/api/games/:slug/*` route stay walled
     // during beta. The board's own owner-only column is gated in its handler, which
     // reads `request.user` — present or absent, the wall does not decide it.
-    if (/^\/api\/games\/[^/]+\/(page|board)(\?|$)/.test(request.url)) return;
+    // `sources` joins them: reading a published creator game's code needs no session,
+    // by the same decision that made the tab public at all.
+    if (/^\/api\/games\/[^/]+\/(page|board|sources)(\/file)?(\?|$)/.test(request.url)) return;
     // Internal endpoints (the Cloud Scheduler notification sweep) authenticate via
     // an OIDC token in the handler, not a session — the wall would 401 them first.
     if (request.url.startsWith('/api/internal/')) return;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -21,6 +21,8 @@ import { registerGamePageRoutes, type GamePageRoutesOptions } from './game-page-
 import { registerGameBoardRoutes, type GameBoardRoutesOptions } from './game-board-routes.js';
 import { registerGameReviewRoutes, type GameReviewRoutesOptions } from './game-review-routes.js';
 import { registerGameSourcesRoutes, type GameSourcesRoutesOptions } from './game-sources-routes.js';
+import { registerGameFollowRoutes, type GameFollowRoutesOptions } from './game-follow-routes.js';
+import { createFollowerFanout } from './game-follow-notify.js';
 import { registerAccountDeletionRoutes, type AccountDeletionRoutesOptions } from './account-deletion-routes.js';
 import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
@@ -128,6 +130,8 @@ export interface BuildAppOptions {
   gameReviewRoutes?: Partial<Omit<GameReviewRoutesOptions, 'store'>>;
   /** Seams for the public read-only sources view. */
   gameSourcesRoutes?: Partial<Omit<GameSourcesRoutesOptions, 'store'>>;
+  /** Seams for per-game following. */
+  gameFollowRoutes?: Partial<Omit<GameFollowRoutesOptions, 'store'>>;
   /** Seams for delayed account erasure; defaults to OIDC-or-deny-all from env. */
   accountDeletionRoutes?: Partial<
     Omit<AccountDeletionRoutesOptions, 'store' | 'adminUids' | 'internalAuthVerifier'>
@@ -513,6 +517,15 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // end up pointed at different buckets. Publishing re-reads the gate verdict off the
     // manifest rather than trusting the job's derived state.
     gamesStore,
+    // Tell followers a game they follow moved. Reuses the submission routes' own
+    // notification deps, so email and the unsubscribe token behave identically here.
+    notifyFollowers: async (event) => {
+      await createFollowerFanout({
+        store,
+        emitDeps: submissionSeams.buildNotifyDeps(),
+        log: { error: (context, message) => app.log.error(context, message) },
+      })(event);
+    },
   });
 
   // Creator control panel (docs/improvement-loop-plan.md IL-2 creator surface). Own
@@ -604,6 +617,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // Public read-only sources for store-published creator games. Owner decision: code
   // is worth reading, and the creator checkout already hands over the same bytes.
   await registerGameSourcesRoutes(app, { store, gamesStore, ...options.gameSourcesRoutes });
+
+  // Following a game: a subscription rather than a bookmark. The count is public,
+  // the follower list is not, and the only message it sends is "new version".
+  await registerGameFollowRoutes(app, { store, ...options.gameFollowRoutes });
   registerAccountDeletionRoutes(app, {
     store,
     adminUids,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import { registerAdminRoutes } from './admin.js';
 import { parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
 import { registerAuthPlugin, type GoogleAuthVerifier } from './auth.js';
 import { registerCreatorProfileRoutes } from './creator-profile-routes.js';
+import { registerGamePageRoutes, type GamePageRoutesOptions } from './game-page-routes.js';
 import { registerAccountDeletionRoutes, type AccountDeletionRoutesOptions } from './account-deletion-routes.js';
 import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
@@ -116,6 +117,8 @@ export interface BuildAppOptions {
   suggestionInboxRoutes?: Partial<Omit<SuggestionInboxRoutesOptions, 'store'>>;
   /** Seams for the public contact form (mailer fake in tests). */
   contactRoutes?: ContactRoutesOptions;
+  /** Seams for the public game page (cache TTL / clock under test). */
+  gamePageRoutes?: Partial<Omit<GamePageRoutesOptions, 'store'>>;
   /** Seams for delayed account erasure; defaults to OIDC-or-deny-all from env. */
   accountDeletionRoutes?: Partial<
     Omit<AccountDeletionRoutesOptions, 'store' | 'adminUids' | 'internalAuthVerifier'>
@@ -567,6 +570,18 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     gamesStore,
     getRepoPublishedCatalogEntry: submissionSeams.getRepoPublishedCatalogEntry,
   });
+
+  // The public game page at `/:handle/:slug` — one aggregate read per game. Same
+  // open posture as the creator profile above (exempted from the beta wall below):
+  // the page is a landing page; playing is what stays gated during closed beta.
+  await registerGamePageRoutes(app, {
+    store,
+    gamesStore,
+    getRepoPublishedCatalogEntry: submissionSeams.getRepoPublishedCatalogEntry,
+    githubClient: submissionSeams.githubClient ?? undefined,
+    publishedRef: process.env.GAMES_PUBLISHED_REF ?? 'main',
+    ...options.gamePageRoutes,
+  });
   registerAccountDeletionRoutes(app, {
     store,
     adminUids,
@@ -657,6 +672,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // Public creator profiles — same posture as contact/legal. Availability checks
     // stay authed (they are under /api/creators/:handle/availability and need a session).
     if (/^\/api\/creators\/[^/]+\/?(\?|$)/.test(request.url)) return;
+    // The public game page (game-page-routes.ts) — a landing page has to load for a
+    // visitor with no session. Only `/page` passes: the playable document, media,
+    // votes and every other `/api/games/:slug/*` route stay walled during beta.
+    if (/^\/api\/games\/[^/]+\/page(\?|$)/.test(request.url)) return;
     // Internal endpoints (the Cloud Scheduler notification sweep) authenticate via
     // an OIDC token in the handler, not a session — the wall would 401 them first.
     if (request.url.startsWith('/api/internal/')) return;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -19,6 +19,7 @@ import { registerAuthPlugin, type GoogleAuthVerifier } from './auth.js';
 import { registerCreatorProfileRoutes } from './creator-profile-routes.js';
 import { registerGamePageRoutes, type GamePageRoutesOptions } from './game-page-routes.js';
 import { registerGameBoardRoutes, type GameBoardRoutesOptions } from './game-board-routes.js';
+import { registerGameReviewRoutes, type GameReviewRoutesOptions } from './game-review-routes.js';
 import { registerAccountDeletionRoutes, type AccountDeletionRoutesOptions } from './account-deletion-routes.js';
 import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
@@ -122,6 +123,8 @@ export interface BuildAppOptions {
   gamePageRoutes?: Partial<Omit<GamePageRoutesOptions, 'store'>>;
   /** Seams for the game page's task board. */
   gameBoardRoutes?: Partial<Omit<GameBoardRoutesOptions, 'store'>>;
+  /** Seams for the side-by-side review surface. */
+  gameReviewRoutes?: Partial<Omit<GameReviewRoutesOptions, 'store'>>;
   /** Seams for delayed account erasure; defaults to OIDC-or-deny-all from env. */
   accountDeletionRoutes?: Partial<
     Omit<AccountDeletionRoutesOptions, 'store' | 'adminUids' | 'internalAuthVerifier'>
@@ -589,6 +592,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // The game page's task board. Reads only — assignment stays on the suggestion
   // inbox route, which owns the quota and the attribution.
   await registerGameBoardRoutes(app, { store, ...options.gameBoardRoutes });
+
+  // The review surface: a delivered candidate, playable beside what is live. Owner
+  // and operator only, and it never publishes — that stays the operator action the
+  // job-admin route implements, for the reasons documented there.
+  await registerGameReviewRoutes(app, { store, gamesStore, adminUids, ...options.gameReviewRoutes });
   registerAccountDeletionRoutes(app, {
     store,
     adminUids,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -717,8 +717,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // during beta. The board's own owner-only column is gated in its handler, which
     // reads `request.user` — present or absent, the wall does not decide it.
     // `sources` joins them: reading a published creator game's code needs no session,
-    // by the same decision that made the tab public at all.
-    if (/^\/api\/games\/[^/]+\/(page|board|sources)(\/file)?(\?|$)/.test(request.url)) return;
+    // by the same decision that made the tab public at all. `follow` too, for its
+    // *count* — the page shows it beside the play numbers, and a landing page that
+    // renders through the wall with one number silently missing is a worse answer
+    // than either fully public or fully walled. Following still needs a session:
+    // the PUT checks `request.user` in its own handler.
+    if (/^\/api\/games\/[^/]+\/(page|board|sources|follow)(\/file)?(\?|$)/.test(request.url)) return;
     // Internal endpoints (the Cloud Scheduler notification sweep) authenticate via
     // an OIDC token in the handler, not a session — the wall would 401 them first.
     if (request.url.startsWith('/api/internal/')) return;

--- a/apps/api/src/creator-profile.ts
+++ b/apps/api/src/creator-profile.ts
@@ -19,6 +19,18 @@ export const HANDLE_RENAME_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
  * Path segments, brand, and vocabulary a creator must not claim as a handle.
  * Kept lowercase; matching is case-insensitive after normalisation.
  */
+/**
+ * The handle platform-authored games live under, so every published game has an
+ * address in the `/:handle/:slug` namespace.
+ *
+ * Most of the catalog predates creator profiles and has no owner to name; without a
+ * fallback those games would have no game page at all, which would leave the whole
+ * surface reachable only for games made after profiles shipped. It is a *namespace*,
+ * not a profile: nobody signs in as it, and it stays in {@link RESERVED_HANDLES} below
+ * so no creator can ever claim it.
+ */
+export const PLATFORM_HANDLE = 'gamedevpl';
+
 export const RESERVED_HANDLES: ReadonlySet<string> = new Set([
   'admin',
   'administrator',

--- a/apps/api/src/email-templates.ts
+++ b/apps/api/src/email-templates.ts
@@ -178,6 +178,19 @@ export function submissionPushContent(
   return { title: copy.subject, body: `“${title}” ${copy.lead}` };
 }
 
+/**
+ * Push copy for "a game you follow has a new version".
+ *
+ * Its own function rather than a row in `notificationCopy`, which is keyed by
+ * submission type: this notification is about somebody else's game, addressed to a
+ * player rather than a creator, and folding it in would widen that table's meaning.
+ */
+export function followedGamePushContent(locale: Locale, title: string): { title: string; body: string } {
+  return locale === 'pl'
+    ? { title: 'Nowa wersja gry, którą obserwujesz', body: `„${title}” ma nową wersję.` }
+    : { title: 'A game you follow was updated', body: `“${title}” has a new version.` };
+}
+
 export function submissionNotificationMessage(
   to: string,
   locale: Locale,

--- a/apps/api/src/erase-player-signals.ts
+++ b/apps/api/src/erase-player-signals.ts
@@ -88,6 +88,8 @@ export interface ErasePlayerSignalsResult {
   uid: string;
   /** Games where a vote was found (and cleared, unless this was a dry run). */
   votesCleared: string[];
+  /** Games this account followed (and unfollowed, unless this was a dry run). */
+  followsCleared: string[];
   /** Feedback rows found (and deleted, unless this was a dry run). */
   feedbackDeleted: number;
   /** Games whose saved progress was found (and deleted, unless this was a dry run). */
@@ -156,13 +158,23 @@ export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Pr
 
   const slugs = await store.listGameSlugs();
   const votesCleared: string[] = [];
+  const followsCleared: string[] = [];
   for (const slug of slugs) {
     const vote = await store.getVote(slug, uid);
-    if (vote === null) continue;
-    votesCleared.push(slug);
-    // `clearVote` is transactional and fixes the parent game's tallies; deleting the
-    // vote document directly would strand the counts.
-    if (!dryRun) await store.clearVote(slug, uid);
+    if (vote !== null) {
+      votesCleared.push(slug);
+      // `clearVote` is transactional and fixes the parent game's tallies; deleting the
+      // vote document directly would strand the counts.
+      if (!dryRun) await store.clearVote(slug, uid);
+    }
+
+    // Follows are keyed by uid as the document id, exactly like votes, so they are
+    // findable only by walking the games — and they are personal data for the same
+    // reason a vote is: they say which games this person cares about.
+    if (await store.isFollowingGame(slug, uid)) {
+      followsCleared.push(slug);
+      if (!dryRun) await store.clearGameFollow(slug, uid);
+    }
   }
 
   // Listed before deleting even on a real run, so the report names the games rather
@@ -203,6 +215,7 @@ export async function erasePlayerSignals(options: ErasePlayerSignalsOptions): Pr
   return {
     uid,
     votesCleared,
+    followsCleared,
     feedbackDeleted,
     savesDeleted,
     editorDraftsDeleted,

--- a/apps/api/src/game-board-routes.test.ts
+++ b/apps/api/src/game-board-routes.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { InMemoryStore, type SuggestionRecord } from './store.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+function authCookie(uid: string): string {
+  return `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}`;
+}
+
+function suggestion(overrides: Partial<SuggestionRecord> = {}): SuggestionRecord {
+  return {
+    id: 'sug-neon-courier-defect-1',
+    slug: 'neon-courier',
+    ownerUid: 'g:creator',
+    class: 'defect',
+    priority: 8,
+    evidence: [{ finding: 'Crashes for 12% of sessions', metrics: { errorRate: 0.12 } }],
+    status: 'proposed',
+    computedFrom: '2026-08-04T00:00:00.000Z',
+    createdAt: '2026-08-04T01:00:00.000Z',
+    updatedAt: '2026-08-04T01:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * A published game plus three later rounds, one per live column: an improvement the
+ * agent opened and is building, a delivered round waiting on review, and a shipped one.
+ */
+async function seedBoard(store: InMemoryStore): Promise<void> {
+  await store.upsertUser({ uid: 'g:creator' });
+  await store.claimHandle('g:creator', 'nightshift', '2026-07-01T00:00:00.000Z');
+
+  await store.createSubmission(1_000_001, 'g:creator', 'Neon Courier');
+  await store.setSubmissionSlug(1_000_001, 'neon-courier');
+  await store.setSubmissionPublishedAt(1_000_001, '2026-08-01T12:00:00.000Z');
+  await store.recordJobTransition(1_000_001, { to: 'published', by: 'admin' });
+  await store.setPublication({
+    slug: 'neon-courier',
+    state: 'published',
+    currentVersion: 'v3',
+    publishedAt: '2026-08-01T12:00:00.000Z',
+  });
+
+  await store.createSubmission(1_000_002, 'g:creator', 'Improve Neon Courier');
+  await store.setSubmissionSlug(1_000_002, 'neon-courier');
+  await store.recordJobTransition(1_000_002, { to: 'queued', by: 'agent', reason: 'agent_open_round' });
+  await store.recordJobTransition(1_000_002, { to: 'dispatched', by: 'agent' });
+  await store.recordJobTransition(1_000_002, { to: 'building', by: 'agent' });
+
+  await store.createSubmission(1_000_003, 'g:creator', 'Touch controls on phones');
+  await store.setSubmissionSlug(1_000_003, 'neon-courier');
+  await store.recordJobTransition(1_000_003, { to: 'queued', by: 'creator', reason: 'improvement_requested' });
+  await store.recordJobTransition(1_000_003, { to: 'dispatched', by: 'platform' });
+  await store.recordJobTransition(1_000_003, { to: 'building', by: 'agent' });
+  await store.recordJobTransition(1_000_003, { to: 'submitted', by: 'agent', reason: 'sources_delivered' });
+  await store.recordJobTransition(1_000_003, { to: 'ready_for_review', by: 'platform', reason: 'gate_green' });
+
+  // Abandoned work is not work; it must not sit in a column forever.
+  await store.createSubmission(1_000_004, 'g:creator', 'Abandoned idea');
+  await store.setSubmissionSlug(1_000_004, 'neon-courier');
+  await store.recordJobTransition(1_000_004, { to: 'building', by: 'agent' });
+  await store.setSubmissionAbandoned(1_000_004, '2026-08-02T00:00:00.000Z');
+}
+
+describe('game board routes', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  async function appWith(store: InMemoryStore, betaAllowedUids?: string) {
+    const app = await buildApp({ store, sessionSecret, betaAllowedUids });
+    apps.push(app);
+    return app;
+  }
+
+  it('projects the job state machine onto the public columns', async () => {
+    const store = new InMemoryStore();
+    await seedBoard(store);
+    const app = await appWith(store);
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/board' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.building).toEqual([
+      { title: 'Improve Neon Courier', state: 'building', since: expect.any(String), agentOpened: true },
+    ]);
+    expect(body.review).toEqual([
+      { title: 'Touch controls on phones', state: 'ready_for_review', since: expect.any(String) },
+    ]);
+    expect(body.released).toEqual([{ title: 'Neon Courier', state: 'published', since: '2026-08-01T12:00:00.000Z' }]);
+    // Abandoned rounds are gone from every column.
+    expect(JSON.stringify(body)).not.toContain('Abandoned idea');
+    // A visitor never learns job ids.
+    expect(body.building[0].jobId).toBeUndefined();
+    expect(body.released[0].jobId).toBeUndefined();
+  });
+
+  it('withholds the open column from everyone but the owner', async () => {
+    const store = new InMemoryStore();
+    await seedBoard(store);
+    await store.putSuggestion(suggestion());
+    await store.upsertUser({ uid: 'g:stranger' });
+    const app = await appWith(store);
+
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/neon-courier/board' });
+    expect(anonymous.json()).toMatchObject({ open: [], openVisibility: 'private', viewerIsOwner: false });
+    // The finding is scorecard-derived; it must not reach a visitor at all.
+    expect(anonymous.body).not.toContain('Crashes for 12%');
+
+    const stranger = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/board',
+      headers: { cookie: authCookie('g:stranger') },
+    });
+    expect(stranger.json()).toMatchObject({ open: [], openVisibility: 'private', viewerIsOwner: false });
+
+    const owner = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/board',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    const body = owner.json();
+    expect(body).toMatchObject({ openVisibility: 'owner', viewerIsOwner: true });
+    expect(body.open).toEqual([
+      {
+        id: 'sug-neon-courier-defect-1',
+        taskClass: 'defect',
+        priority: 8,
+        findings: ['Crashes for 12% of sessions'],
+        createdAt: '2026-08-04T01:00:00.000Z',
+      },
+    ]);
+    // The owner does get job ids — they address the work in the Studio.
+    expect(body.building[0].jobId).toBe(1_000_002);
+  });
+
+  it('shows the owner only open tasks for this game, and only proposed ones', async () => {
+    const store = new InMemoryStore();
+    await seedBoard(store);
+    await store.putSuggestion(suggestion());
+    await store.putSuggestion(suggestion({ id: 'sug-other-game', slug: 'other-game' }));
+    await store.putSuggestion(suggestion({ id: 'sug-dispatched', status: 'dispatched' }));
+    const app = await appWith(store);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/board',
+      headers: { cookie: authCookie('g:creator') },
+    });
+
+    expect(response.json().open.map((task: { id: string }) => task.id)).toEqual(['sug-neon-courier-defect-1']);
+  });
+
+  it('404s an unpublished game and 400s a bad slug', async () => {
+    const store = new InMemoryStore();
+    const app = await appWith(store);
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/never-was/board' })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/api/games/Not%20A%20Slug/board' })).statusCode).toBe(400);
+  });
+
+  it('404s after a takedown, even though the job that shipped it stays published', async () => {
+    const store = new InMemoryStore();
+    await seedBoard(store);
+    // The job keeps `publishedAt` — publication state is what withdraws a game, and
+    // the board must not outlive the page that stops serving it.
+    await store.takedownPublication('neon-courier', 'reported', '2026-08-05T00:00:00.000Z');
+
+    const app = await appWith(store);
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/board' });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('stays reachable through the private-beta wall', async () => {
+    const store = new InMemoryStore();
+    await seedBoard(store);
+    const app = await appWith(store, 'g:creator');
+
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/neon-courier/board' });
+    expect(anonymous.statusCode).toBe(200);
+
+    // The owner column still works through the wall for the owner's own session.
+    await store.putSuggestion(suggestion());
+    const owner = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/board',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(owner.json().open).toHaveLength(1);
+  });
+});

--- a/apps/api/src/game-board-routes.ts
+++ b/apps/api/src/game-board-routes.ts
@@ -1,0 +1,193 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { isTerminal, type JobState } from './job-state.js';
+import { OPEN_SUGGESTION_STATUSES, type Store, type SubmissionRecord, type SuggestionRecord } from './store.js';
+
+/**
+ * The public task board — `GET /api/games/:slug/board`.
+ *
+ * Four columns, matching the "repo page" layout (ops `docs/game-page-plan.md`):
+ * open tasks → being built → built and waiting to be played → released. Nothing here
+ * is a new work model: the middle two columns are a projection of the job state
+ * machine (`job-state.ts`) onto a game's slug, the last is the jobs that shipped, and
+ * the first is the IL-3 suggestion inbox for this game.
+ *
+ * **The open column is owner-only, and that is a privacy decision.** Suggestions are
+ * derived from a game's scorecard — per-game play, error and vote aggregates that are
+ * creator- and operator-facing everywhere else in the product. Publishing them here
+ * would make "which games are going badly" a public listing, which is a call for the
+ * owner to make deliberately rather than one a board layout makes by accident. A
+ * signed-out visitor is told the column exists and is private, never shown a hole.
+ *
+ * Assignment stays where it already lives: `POST /api/me/suggestions/:id/approve`
+ * (suggestion-inbox.ts) is what turns an open task into a build, charges the
+ * improvement quota, and records who decided. This route reads; it never dispatches.
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const SlugParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(64),
+});
+
+/** How many rows a column may carry. A board is a working surface, not an archive. */
+const COLUMN_LIMIT = 20;
+
+/** Job states that mean "an agent is working on this right now". */
+const BUILDING_STATES: ReadonlySet<JobState> = new Set<JobState>(['queued', 'dispatched', 'building']);
+
+/** Job states that mean "sources exist and are waiting on the human review step". */
+const REVIEW_STATES: ReadonlySet<JobState> = new Set<JobState>(['submitted', 'gating', 'ready_for_review']);
+
+/** One open task — an IL-3 suggestion. Owner-only; carries no player-authored text. */
+export interface BoardOpenTask {
+  id: string;
+  /** `defect` | `friction` | `design-change` — the routed class, not free text. */
+  taskClass: string;
+  priority: number;
+  /** Platform-computed findings. Safe to render; never game- or player-authored. */
+  findings: string[];
+  createdAt: string;
+}
+
+/** One piece of work in flight or shipped. Public. */
+export interface BoardWorkItem {
+  title: string;
+  state: JobState;
+  /** When it entered its current state (or was created, for older records). */
+  since: string;
+  /** Present only for the owner — a job id is not a fact a visitor needs. */
+  jobId?: number;
+  /** True when the round was opened by the game's own agent rather than a person. */
+  agentOpened?: boolean;
+}
+
+export interface GameBoardResponse {
+  /** Owner-only. Empty for everyone else — read `openVisibility` to know why. */
+  open: BoardOpenTask[];
+  building: BoardWorkItem[];
+  review: BoardWorkItem[];
+  released: BoardWorkItem[];
+  /** `owner` when the open column is real; `private` when it is withheld. */
+  openVisibility: 'owner' | 'private';
+  viewerIsOwner: boolean;
+}
+
+export interface GameBoardRoutesOptions {
+  store: Store;
+  now?: () => number;
+}
+
+export async function registerGameBoardRoutes(app: FastifyInstance, options: GameBoardRoutesOptions): Promise<void> {
+  const { store } = options;
+
+  app.get('/api/games/:slug/board', async (request, reply) => {
+    const params = SlugParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug)) {
+      return reply.status(400).send({ error: 'invalid slug' });
+    }
+    const slug = params.data.slug;
+
+    try {
+      // Same existence gate as the page: a board for a game nobody can see is a 404,
+      // and publication (not the bucket, not a job) is what decides that. A takedown
+      // is decisive — an archived or disabled publication 404s even though the job
+      // that shipped it still carries `publishedAt`, or the board would outlive the
+      // game it describes. Only a game with no publication record at all falls back
+      // to the job, which is how repo-migrated games reach this route.
+      const publication = await store.getPublication(slug);
+      const published = await store.getPublishedSubmissionBySlug(slug);
+      const visible = publication ? publication.state === 'published' : Boolean(published);
+      if (!visible) return reply.status(404).send({ error: 'not_found' });
+
+      const uid = request.user?.uid ?? null;
+      const viewerIsOwner = Boolean(uid && published?.ownerUid && published.ownerUid === uid);
+
+      const submissions = await store.listSubmissionsBySlug(slug);
+      const open = viewerIsOwner ? await readOpenTasks(store, slug, uid!) : [];
+
+      const body: GameBoardResponse = {
+        open,
+        building: projectWork(submissions, BUILDING_STATES, viewerIsOwner),
+        review: projectWork(submissions, REVIEW_STATES, viewerIsOwner),
+        released: projectReleased(submissions, viewerIsOwner),
+        openVisibility: viewerIsOwner ? 'owner' : 'private',
+        viewerIsOwner,
+      };
+      return reply.send(body);
+    } catch (error) {
+      request.log.error({ err: error, slug }, 'failed to build game board');
+      return reply.status(502).send({ error: 'failed to load board' });
+    }
+  });
+}
+
+async function readOpenTasks(store: Store, slug: string, ownerUid: string): Promise<BoardOpenTask[]> {
+  // Narrowed by owner in the query (an indexed field) and by slug in memory: a
+  // creator's open set is bounded by their own shelf, so this stays a small read.
+  const suggestions = await store.listSuggestions({
+    status: [...OPEN_SUGGESTION_STATUSES],
+    ownerUid,
+    limit: 100,
+  });
+  return suggestions
+    .filter((record) => record.slug === slug)
+    .slice(0, COLUMN_LIMIT)
+    .map(toOpenTask);
+}
+
+function toOpenTask(record: SuggestionRecord): BoardOpenTask {
+  return {
+    id: record.id,
+    taskClass: record.class,
+    priority: record.priority,
+    findings: record.evidence.map((item) => item.finding),
+    createdAt: record.createdAt,
+  };
+}
+
+function projectWork(
+  submissions: SubmissionRecord[],
+  states: ReadonlySet<JobState>,
+  includeJobId: boolean,
+): BoardWorkItem[] {
+  return submissions
+    .filter((record) => {
+      if (record.abandonedAt) return false;
+      const state = record.state;
+      return state !== undefined && states.has(state);
+    })
+    .slice(0, COLUMN_LIMIT)
+    .map((record) => toWorkItem(record, includeJobId));
+}
+
+function projectReleased(submissions: SubmissionRecord[], includeJobId: boolean): BoardWorkItem[] {
+  return submissions
+    .filter((record) => Boolean(record.publishedAt))
+    .sort((a, b) => (b.publishedAt ?? '').localeCompare(a.publishedAt ?? ''))
+    .slice(0, COLUMN_LIMIT)
+    .map((record) => ({
+      title: record.title,
+      state: 'published' as JobState,
+      since: record.publishedAt ?? record.createdAt,
+      ...(includeJobId ? { jobId: record.issueNumber } : {}),
+    }));
+}
+
+function toWorkItem(record: SubmissionRecord, includeJobId: boolean): BoardWorkItem {
+  // A round the game's own agent opened (MCP `open_round`) reads differently from one
+  // a person asked for — the mockup's "agent" byline, from data rather than a guess.
+  // Matched on the reason alone: `by: 'agent'` appears on every round an agent works,
+  // so it says who is building, not who asked for it.
+  const agentOpened = record.transitions?.some((transition) => transition.reason === 'agent_open_round');
+  return {
+    title: record.title,
+    state: (record.state ?? 'queued') as JobState,
+    since: record.stateSince ?? record.createdAt,
+    ...(includeJobId ? { jobId: record.issueNumber } : {}),
+    ...(agentOpened ? { agentOpened: true } : {}),
+  };
+}
+
+/** Exported for the tests that assert the column vocabulary stays in step with job states. */
+export const BOARD_STATE_SETS = { BUILDING_STATES, REVIEW_STATES, isTerminal };

--- a/apps/api/src/game-follow-notify.ts
+++ b/apps/api/src/game-follow-notify.ts
@@ -1,0 +1,86 @@
+import { emitFollowedGameNotification, type EmitDeps } from './notify.js';
+import type { Store } from './store.js';
+
+/**
+ * Fans a published version out to the game's followers.
+ *
+ * Kept beside the publish route rather than inside it because it is courtesy work with
+ * a different failure posture: publishing must be atomic and loud, this must be neither.
+ * Every property below exists to keep one operator click from becoming a write storm or
+ * a duplicate inbox:
+ *
+ *  - **The owner is skipped.** They already receive `submission.published` from the
+ *    notification sweep; a second note for their own game is noise they cannot turn off.
+ *  - **Bounded.** A cap on recipients, and a cap on how many go out at once. A game
+ *    with more followers than the cap is a good problem, and the right response to it
+ *    is a queue rather than a burst — until then the cap is honest about what shipped.
+ *  - **Best-effort per follower.** One failed write must not cost the rest theirs, so
+ *    failures are counted and logged, never thrown.
+ */
+
+/** How many followers one publish will notify. */
+export const MAX_FOLLOWER_FANOUT = 500;
+
+/** How many notification writes run at once. */
+export const FOLLOWER_FANOUT_CONCURRENCY = 8;
+
+export interface FollowerFanoutEvent {
+  slug: string;
+  version: string;
+  gameTitle: string;
+  ownerUid: string;
+}
+
+export interface FollowerFanoutOptions {
+  store: Store;
+  emitDeps: EmitDeps;
+  log?: { error: (context: object, message: string) => void };
+  maxFanout?: number;
+  concurrency?: number;
+}
+
+export function createFollowerFanout(
+  options: FollowerFanoutOptions,
+): (event: FollowerFanoutEvent) => Promise<{ notified: number; failed: number; truncated: boolean }> {
+  const maxFanout = options.maxFanout ?? MAX_FOLLOWER_FANOUT;
+  const concurrency = Math.max(1, options.concurrency ?? FOLLOWER_FANOUT_CONCURRENCY);
+
+  return async function notifyFollowers(event) {
+    // One over the cap, so "there were more than we told" is knowable rather than
+    // indistinguishable from "there were exactly the cap".
+    const followers = await options.store.listGameFollowers(event.slug, { limit: maxFanout + 1 });
+    const truncated = followers.length > maxFanout;
+    const recipients = followers.filter((uid) => uid !== event.ownerUid).slice(0, maxFanout);
+
+    let notified = 0;
+    let failed = 0;
+    for (let index = 0; index < recipients.length; index += concurrency) {
+      const batch = recipients.slice(index, index + concurrency);
+      await Promise.all(
+        batch.map(async (uid) => {
+          try {
+            const { created } = await emitFollowedGameNotification(options.emitDeps, {
+              uid,
+              slug: event.slug,
+              gameTitle: event.gameTitle,
+              version: event.version,
+              link: `/play/${event.slug}`,
+            });
+            if (created) notified += 1;
+          } catch (error) {
+            failed += 1;
+            options.log?.error({ err: error, slug: event.slug, uid }, 'could not notify a follower of a new version');
+          }
+        }),
+      );
+    }
+
+    if (truncated) {
+      options.log?.error(
+        { slug: event.slug, cap: maxFanout },
+        'follower fan-out hit its cap; some followers were not notified',
+      );
+    }
+    return { notified, failed, truncated };
+  };
+}

--- a/apps/api/src/game-follow-notify.ts
+++ b/apps/api/src/game-follow-notify.ts
@@ -46,18 +46,26 @@ export function createFollowerFanout(
   const concurrency = Math.max(1, options.concurrency ?? FOLLOWER_FANOUT_CONCURRENCY);
 
   return async function notifyFollowers(event) {
-    // One over the cap, so "there were more than we told" is knowable rather than
-    // indistinguishable from "there were exactly the cap".
-    const followers = await options.store.listGameFollowers(event.slug, { limit: maxFanout + 1 });
-    const truncated = followers.length > maxFanout;
-    const recipients = followers.filter((uid) => uid !== event.ownerUid).slice(0, maxFanout);
+    // Two over the cap, not one. The cap counts *recipients*, and the owner is dropped
+    // below — they can occupy at most one slot, so reading one extra beyond that is
+    // what makes "there were more than we notified" distinguishable from "there were
+    // exactly the cap". Deciding `truncated` before the owner is removed reports a
+    // truncation that never happened whenever the owner is the row past the cap.
+    const followers = await options.store.listGameFollowers(event.slug, { limit: maxFanout + 2 });
+    const candidates = followers.filter((uid) => uid !== event.ownerUid);
+    const truncated = candidates.length > maxFanout;
+    const recipients = candidates.slice(0, maxFanout);
 
     let notified = 0;
     let failed = 0;
     for (let index = 0; index < recipients.length; index += concurrency) {
       const batch = recipients.slice(index, index + concurrency);
-      await Promise.all(
-        batch.map(async (uid) => {
+      // Each task reports its own outcome and the batch is tallied after it settles.
+      // The previous shape incremented shared counters inside the mapper; that was in
+      // fact safe (a `+= 1` carries no await, so the event loop cannot interleave it),
+      // but "is this a race?" is a question the reader should not have to answer.
+      const outcomes = await Promise.all(
+        batch.map(async (uid): Promise<'created' | 'duplicate' | 'failed'> => {
           try {
             const { created } = await emitFollowedGameNotification(options.emitDeps, {
               uid,
@@ -66,13 +74,17 @@ export function createFollowerFanout(
               version: event.version,
               link: `/play/${event.slug}`,
             });
-            if (created) notified += 1;
+            return created ? 'created' : 'duplicate';
           } catch (error) {
-            failed += 1;
             options.log?.error({ err: error, slug: event.slug, uid }, 'could not notify a follower of a new version');
+            return 'failed';
           }
         }),
       );
+      for (const outcome of outcomes) {
+        if (outcome === 'created') notified += 1;
+        else if (outcome === 'failed') failed += 1;
+      }
     }
 
     if (truncated) {

--- a/apps/api/src/game-follow-routes.test.ts
+++ b/apps/api/src/game-follow-routes.test.ts
@@ -161,6 +161,32 @@ describe('follower fan-out', () => {
     expect(await store.listNotifications('g:one')).toHaveLength(2);
   });
 
+  it('does not count the skipped owner as a truncation, or let them cost a slot', async () => {
+    const store = fanoutStore();
+    // Exactly `maxFanout` real followers, plus the owner — who is dropped, not
+    // notified. Reporting `truncated` here would claim followers were missed when
+    // every one of them was reached.
+    await store.setGameFollow('neon-courier', 'g:owner', '2026-08-01T00:00:00.000Z');
+    await store.setGameFollow('neon-courier', 'g:a', '2026-08-02T00:00:00.000Z');
+    await store.setGameFollow('neon-courier', 'g:b', '2026-08-03T00:00:00.000Z');
+    const errors: string[] = [];
+    const fanout = createFollowerFanout({
+      store,
+      emitDeps: { store },
+      maxFanout: 2,
+      log: { error: (_context, message) => errors.push(message) },
+    });
+
+    const result = await fanout({ slug: 'neon-courier', version: 'v2', gameTitle: 'N', ownerUid: 'g:owner' });
+
+    expect(result).toMatchObject({ notified: 2, failed: 0, truncated: false });
+    expect(errors.join(' ')).not.toContain('cap');
+    // Both real followers heard about it — the owner did not displace one.
+    expect(await store.listNotifications('g:a')).toHaveLength(1);
+    expect(await store.listNotifications('g:b')).toHaveLength(1);
+    expect(await store.listNotifications('g:owner')).toEqual([]);
+  });
+
   it('caps the fan-out and says so rather than notifying silently short', async () => {
     const store = fanoutStore();
     for (let index = 0; index < 5; index += 1) {

--- a/apps/api/src/game-follow-routes.test.ts
+++ b/apps/api/src/game-follow-routes.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { createFollowerFanout } from './game-follow-notify.js';
+import { InMemoryStore } from './store.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+function authCookie(uid: string): string {
+  return `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}`;
+}
+
+async function publish(store: InMemoryStore): Promise<void> {
+  await store.setPublication({
+    slug: 'neon-courier',
+    state: 'published',
+    currentVersion: 'v-live',
+    publishedAt: '2026-08-01T12:00:00.000Z',
+  });
+}
+
+describe('game follow routes', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  async function appWith(store: InMemoryStore) {
+    const app = await buildApp({ store, sessionSecret });
+    apps.push(app);
+    return app;
+  }
+
+  it('shows the count to anyone and personal state only to a signed-in follower', async () => {
+    const store = new InMemoryStore();
+    await publish(store);
+    await store.upsertUser({ uid: 'g:player' });
+    const app = await appWith(store);
+
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/neon-courier/follow' });
+    expect(anonymous.json()).toEqual({ slug: 'neon-courier', followers: 0, following: null });
+
+    const follow = await app.inject({
+      method: 'PUT',
+      url: '/api/games/neon-courier/follow',
+      headers: { cookie: authCookie('g:player') },
+      payload: { following: true },
+    });
+    expect(follow.json()).toEqual({ slug: 'neon-courier', followers: 1, following: true });
+
+    // Following twice is not two followers.
+    await app.inject({
+      method: 'PUT',
+      url: '/api/games/neon-courier/follow',
+      headers: { cookie: authCookie('g:player') },
+      payload: { following: true },
+    });
+    const state = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/follow',
+      headers: { cookie: authCookie('g:player') },
+    });
+    expect(state.json()).toEqual({ slug: 'neon-courier', followers: 1, following: true });
+
+    // The count is public; who follows is not exposed by any route.
+    const stranger = await app.inject({ method: 'GET', url: '/api/games/neon-courier/follow' });
+    expect(stranger.json()).toEqual({ slug: 'neon-courier', followers: 1, following: null });
+
+    const unfollow = await app.inject({
+      method: 'PUT',
+      url: '/api/games/neon-courier/follow',
+      headers: { cookie: authCookie('g:player') },
+      payload: { following: false },
+    });
+    expect(unfollow.json()).toEqual({ slug: 'neon-courier', followers: 0, following: false });
+  });
+
+  it('refuses to follow an unpublished game, and refuses anonymously', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:player' });
+    const app = await appWith(store);
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/follow' })).statusCode).toBe(404);
+
+    await publish(store);
+    const anonymous = await app.inject({
+      method: 'PUT',
+      url: '/api/games/neon-courier/follow',
+      payload: { following: true },
+    });
+    expect(anonymous.statusCode).toBe(401);
+  });
+});
+
+describe('follower fan-out', () => {
+  function fanoutStore(): InMemoryStore {
+    return new InMemoryStore();
+  }
+
+  it('notifies followers once per version and skips the owner', async () => {
+    const store = fanoutStore();
+    for (const uid of ['g:one', 'g:two', 'g:owner']) {
+      await store.upsertUser({ uid });
+      await store.setGameFollow('neon-courier', uid, '2026-08-01T00:00:00.000Z');
+    }
+
+    const fanout = createFollowerFanout({ store, emitDeps: { store } });
+    const first = await fanout({
+      slug: 'neon-courier',
+      version: 'v2',
+      gameTitle: 'Neon Courier',
+      ownerUid: 'g:owner',
+    });
+
+    expect(first).toMatchObject({ notified: 2, failed: 0, truncated: false });
+    expect((await store.listNotifications('g:one')).map((n) => n.type)).toEqual(['game.new_version']);
+    // The creator gets their own submission.published note; a second one is noise.
+    expect(await store.listNotifications('g:owner')).toEqual([]);
+
+    // Re-running the same publish (a retried click) must not notify again.
+    const again = await fanout({
+      slug: 'neon-courier',
+      version: 'v2',
+      gameTitle: 'Neon Courier',
+      ownerUid: 'g:owner',
+    });
+    expect(again.notified).toBe(0);
+    expect(await store.listNotifications('g:one')).toHaveLength(1);
+
+    // A genuinely new version does notify.
+    const next = await fanout({
+      slug: 'neon-courier',
+      version: 'v3',
+      gameTitle: 'Neon Courier',
+      ownerUid: 'g:owner',
+    });
+    expect(next.notified).toBe(2);
+    expect(await store.listNotifications('g:one')).toHaveLength(2);
+  });
+
+  it('caps the fan-out and says so rather than notifying silently short', async () => {
+    const store = fanoutStore();
+    for (let index = 0; index < 5; index += 1) {
+      await store.setGameFollow('neon-courier', `g:p${index}`, `2026-08-0${index + 1}T00:00:00.000Z`);
+    }
+    const errors: string[] = [];
+    const fanout = createFollowerFanout({
+      store,
+      emitDeps: { store },
+      maxFanout: 2,
+      log: { error: (_context, message) => errors.push(message) },
+    });
+
+    const result = await fanout({ slug: 'neon-courier', version: 'v2', gameTitle: 'N', ownerUid: 'g:owner' });
+
+    expect(result).toMatchObject({ notified: 2, truncated: true });
+    expect(errors.join(' ')).toContain('cap');
+  });
+
+  it('keeps going when one follower cannot be notified', async () => {
+    const store = fanoutStore();
+    await store.setGameFollow('neon-courier', 'g:ok', '2026-08-01T00:00:00.000Z');
+    await store.setGameFollow('neon-courier', 'g:bad', '2026-08-02T00:00:00.000Z');
+    const failing = {
+      ...store,
+      createNotification: vi.fn(async (uid: string, notification: { id: string }) => {
+        if (uid === 'g:bad') throw new Error('write failed');
+        return store.createNotification(uid, notification as never);
+      }),
+      listGameFollowers: (slug: string, opts?: { limit?: number }) => store.listGameFollowers(slug, opts),
+    } as unknown as InMemoryStore;
+
+    const errors: string[] = [];
+    const fanout = createFollowerFanout({
+      store: failing,
+      emitDeps: { store: failing },
+      log: { error: (_context, message) => errors.push(message) },
+    });
+    const result = await fanout({ slug: 'neon-courier', version: 'v2', gameTitle: 'N', ownerUid: 'g:owner' });
+
+    expect(result).toMatchObject({ notified: 1, failed: 1 });
+    expect(errors.join(' ')).toContain('could not notify a follower');
+  });
+});

--- a/apps/api/src/game-follow-routes.test.ts
+++ b/apps/api/src/game-follow-routes.test.ts
@@ -75,6 +75,29 @@ describe('game follow routes', () => {
     expect(unfollow.json()).toEqual({ slug: 'neon-courier', followers: 0, following: false });
   });
 
+  it('shows the count through the private-beta wall, but still needs a session to follow', async () => {
+    const store = new InMemoryStore();
+    await publish(store);
+    await store.upsertUser({ uid: 'g:player' });
+    await store.setGameFollow('neon-courier', 'g:someone', '2026-08-01T00:00:00.000Z');
+    const app = await buildApp({ store, sessionSecret, betaAllowedUids: 'g:player' });
+    apps.push(app);
+
+    // The page is public during closed beta; a count missing from it would be a
+    // hole rather than a policy.
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/neon-courier/follow' });
+    expect(anonymous.statusCode).toBe(200);
+    expect(anonymous.json()).toEqual({ slug: 'neon-courier', followers: 1, following: null });
+
+    // Following is still a session action — the wall passing it does not grant it.
+    const write = await app.inject({
+      method: 'PUT',
+      url: '/api/games/neon-courier/follow',
+      payload: { following: true },
+    });
+    expect(write.statusCode).toBe(401);
+  });
+
   it('refuses to follow an unpublished game, and refuses anonymously', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:player' });

--- a/apps/api/src/game-follow-routes.ts
+++ b/apps/api/src/game-follow-routes.ts
@@ -1,0 +1,87 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { Store } from './store.js';
+
+/**
+ * Following a game — "Obserwuj".
+ *
+ * GitHub's Star is a bookmark; this is a subscription, and the difference is the whole
+ * reason it exists: the one message worth interrupting someone for is "a game you
+ * played has a new version" (ops `docs/game-page-plan.md`). Nothing else about a game
+ * somebody else owns is worth a notification, so nothing else sends one.
+ *
+ * The count is public — it is the honest version of a star count, and the page shows it
+ * beside the play numbers rather than as a trophy. Who follows is not: a follower list
+ * is a list of people, and no visitor needs one.
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SlugParamsSchema = z.object({ slug: z.string().trim().min(1).max(64) });
+
+export interface GameFollowResponse {
+  slug: string;
+  followers: number;
+  /** Null for a signed-out visitor: they see the count, and no state of their own. */
+  following: boolean | null;
+}
+
+export interface GameFollowRoutesOptions {
+  store: Store;
+  now?: () => number;
+}
+
+export async function registerGameFollowRoutes(app: FastifyInstance, options: GameFollowRoutesOptions): Promise<void> {
+  const { store } = options;
+  const now = options.now ?? Date.now;
+
+  function parseSlug(request: { params: unknown }): string | null {
+    const params = SlugParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug)) return null;
+    return params.data.slug;
+  }
+
+  /** A game has to exist and be live before anyone can follow it. */
+  async function isLive(slug: string): Promise<boolean> {
+    const publication = await store.getPublication(slug);
+    if (publication) return publication.state === 'published';
+    // Repo-migrated games have no publication record; a published job is the fallback
+    // proof, same as the board's existence gate.
+    return Boolean(await store.getPublishedSubmissionBySlug(slug));
+  }
+
+  app.get('/api/games/:slug/follow', async (request, reply) => {
+    const slug = parseSlug(request);
+    if (!slug) return reply.status(400).send({ error: 'invalid slug' });
+    if (!(await isLive(slug))) return reply.status(404).send({ error: 'not_found' });
+
+    const uid = request.user?.uid ?? null;
+    const [followers, following] = await Promise.all([
+      store.countGameFollowers(slug),
+      uid ? store.isFollowingGame(slug, uid) : Promise.resolve(null),
+    ]);
+    return reply.send({ slug, followers, following } satisfies GameFollowResponse);
+  });
+
+  app.put(
+    '/api/games/:slug/follow',
+    // Generous against real use — nobody follows a game thirty times an hour — and
+    // bounded against a loop toggling the tally.
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const slug = parseSlug(request);
+      if (!slug) return reply.status(400).send({ error: 'invalid slug' });
+      const uid = request.user?.uid;
+      if (!uid) return reply.status(401).send({ error: 'authentication required' });
+      if (!(await isLive(slug))) return reply.status(404).send({ error: 'not_found' });
+
+      const body = z.object({ following: z.boolean() }).safeParse(request.body);
+      if (!body.success) return reply.status(400).send({ error: 'invalid request' });
+
+      const followers = body.data.following
+        ? await store.setGameFollow(slug, uid, new Date(now()).toISOString())
+        : await store.clearGameFollow(slug, uid);
+
+      return reply.send({ slug, followers, following: body.data.following } satisfies GameFollowResponse);
+    },
+  );
+}

--- a/apps/api/src/game-page-routes.test.ts
+++ b/apps/api/src/game-page-routes.test.ts
@@ -152,6 +152,8 @@ describe('game page routes', () => {
       creatorHandle: 'nightshift',
     });
     expect(body.creator).toMatchObject({ handle: 'nightshift' });
+    // A game with a real creator is never platform-authored.
+    expect(body.platformAuthored).toBe(false);
     // Frontmatter is catalog data, not README content.
     expect(body.specMarkdown).toContain('# Neon Courier');
     expect(body.specMarkdown).not.toContain('title:');
@@ -202,6 +204,10 @@ describe('game page routes', () => {
     const body = response.json();
     expect(body.entry).toMatchObject({ slug: 'sky-dodge', title: 'Sky Dodge', submittedBy: 'gamedev-platform' });
     expect(body.creator).toBeNull();
+    // No creator to name, so it lives in the platform's namespace rather than having
+    // no address at all — most of the catalog predates creator profiles.
+    expect(body.entry.creatorHandle).toBe('gamedevpl');
+    expect(body.platformAuthored).toBe(true);
     expect(body.specMarkdown).toContain('Deliver packages');
     expect(body.modules).toEqual(['input', 'collision', 'gameplay', 'gfx']);
     expect(body.budget).toBeNull();
@@ -259,7 +265,10 @@ describe('game page routes', () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.entry.submittedBy).toBe('gamedev-platform');
-    expect(body.entry.creatorHandle).toBeNull();
+    // An erased owner leaves the game with nobody to name — it becomes platform-
+    // authored rather than losing its page.
+    expect(body.entry.creatorHandle).toBe('gamedevpl');
+    expect(body.platformAuthored).toBe(true);
     expect(body.creator).toBeNull();
   });
 });

--- a/apps/api/src/game-page-routes.test.ts
+++ b/apps/api/src/game-page-routes.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import { readGameModules, stripSpecFrontmatter } from './game-page-routes.js';
+import type { CatalogGameEntry, GitHubClient } from './github-client.js';
+import { InMemoryStore, type Scorecard } from './store.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+const SPEC = [
+  '---',
+  'title: Neon Courier',
+  'genre: arcade',
+  'controls: arrows',
+  '---',
+  '',
+  '# Neon Courier',
+  '',
+  'Deliver packages before the last neon goes out.',
+].join('\n');
+
+const GAME_JSON = JSON.stringify({
+  engine: { modules: ['gameplay', 'collision', 'gfx', 'input'] },
+});
+
+function manifest(overrides: Partial<VersionManifest> & { version: string }): VersionManifest {
+  return {
+    slug: 'neon-courier',
+    createdAt: '2026-08-01T12:00:00.000Z',
+    issueNumber: 42,
+    sourceFiles: ['SPEC.md', 'GAME.json', 'game.ts'],
+    ...overrides,
+  };
+}
+
+function scorecard(slug: string): Scorecard {
+  return {
+    slug,
+    computedAt: '2026-08-04T00:00:00.000Z',
+    window: { days: ['2026-08-01', '2026-08-02', '2026-08-03'], truncated: false },
+    sessions: { count: 4812, bounces: 12, closes: 480, medianPlaySeconds: 360, totalPlaySeconds: 100000 },
+    health: { errors: 0, aliveTicks: 10, stalledTicks: 0, stallRate: 0, medianFps: 60, resumeTicksIgnored: 0 },
+    depth: {
+      outcomes: { won: 1, lost: 2, quit: 3 },
+      sessionsWithEnding: 3,
+      finishRate: null,
+      winRate: null,
+      medianBestScore: null,
+    },
+    votes: { up: 128, down: 3 },
+    feedback: { count: 7 },
+    untrusted: { errorSamples: [], progressLabels: [] },
+  };
+}
+
+function storeGamesStore(overrides: Partial<GamesStore> = {}): GamesStore {
+  const sources: Record<string, string> = {
+    'SPEC.md': SPEC,
+    'GAME.json': GAME_JSON,
+    'game.ts': 'x'.repeat(1000),
+  };
+  return {
+    getSourceFile: async (_slug: string, _version: string, path: string) => sources[path] ?? null,
+    getManifest: async (_slug: string, version: string) => manifest({ version }),
+    getDerivedArtifact: async () => null,
+    listVersions: async () => [
+      manifest({
+        version: 'v3',
+        createdAt: '2026-08-03T12:00:00.000Z',
+        gate: { green: true, ranAt: '2026-08-03T12:05:00.000Z' },
+      }),
+      manifest({ version: 'v2', createdAt: '2026-08-02T12:00:00.000Z', deliveryMode: 'preview' }),
+      manifest({
+        version: 'v1',
+        createdAt: '2026-08-01T12:00:00.000Z',
+        origin: 'editor',
+        gate: { green: false, ranAt: '2026-08-01T12:05:00.000Z' },
+      }),
+    ],
+    ...overrides,
+  } as unknown as GamesStore;
+}
+
+async function publishStoreGame(store: InMemoryStore, slug = 'neon-courier'): Promise<void> {
+  await store.upsertUser({ uid: 'g:creator', name: 'Secret Google' });
+  await store.claimHandle('g:creator', 'nightshift', '2026-07-01T00:00:00.000Z');
+  await store.createSubmission(42, 'g:creator', 'Neon Courier');
+  await store.setSubmissionSlug(42, slug);
+  await store.setSubmissionPublishedAt(42, '2026-08-01T12:00:00.000Z');
+  await store.setPublication({
+    slug,
+    state: 'published',
+    currentVersion: 'v3',
+    publishedAt: '2026-08-01T12:00:00.000Z',
+  });
+}
+
+describe('game page routes', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  async function appWith(
+    store: InMemoryStore,
+    gamesStore?: GamesStore,
+    opts?: { repoCatalog?: CatalogGameEntry[]; gameFiles?: Record<string, string>; betaAllowedUids?: string },
+  ) {
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      betaAllowedUids: opts?.betaAllowedUids,
+      // Fresh cache per app: tests publish, then read, within one tick.
+      gamePageRoutes: { cacheTtlMs: 0 },
+      submissionRoutes:
+        gamesStore || opts?.repoCatalog
+          ? {
+              agentChannel: { gamesStore },
+              ...(opts?.repoCatalog
+                ? {
+                    githubToken: 'test-github-token',
+                    submissionTokenSecret: 'test-submission-secret',
+                    snapshotReader: null,
+                    githubClient: {
+                      getCatalog: async () => opts.repoCatalog,
+                      getGameFile: async (_ref: string, _slug: string, path: string) => opts.gameFiles?.[path] ?? null,
+                    } as unknown as GitHubClient,
+                  }
+                : {}),
+            }
+          : undefined,
+    });
+    apps.push(app);
+    return app;
+  }
+
+  it('serves the aggregate page for a store-published game', async () => {
+    const store = new InMemoryStore();
+    await publishStoreGame(store);
+    await store.putScorecard('neon-courier', scorecard('neon-courier'));
+    const app = await appWith(store, storeGamesStore());
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/page' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.entry).toMatchObject({
+      slug: 'neon-courier',
+      title: 'Neon Courier',
+      status: 'published',
+      submittedBy: 'nightshift',
+      creatorHandle: 'nightshift',
+    });
+    expect(body.creator).toMatchObject({ handle: 'nightshift' });
+    // Frontmatter is catalog data, not README content.
+    expect(body.specMarkdown).toContain('# Neon Courier');
+    expect(body.specMarkdown).not.toContain('title:');
+    // Canonical GameKit order, regardless of GAME.json order.
+    expect(body.modules).toEqual(['input', 'collision', 'gameplay', 'gfx']);
+    expect(body.budget.usedBytes).toBe(Buffer.byteLength(SPEC) + Buffer.byteLength(GAME_JSON) + 1000);
+    expect(body.budget.limitBytes).toBe(252 * 1024);
+    // Preview deliveries are not releases; current is flagged; provenance carried.
+    expect(body.releases).toEqual([
+      { version: 'v3', createdAt: '2026-08-03T12:00:00.000Z', current: true, gateGreen: true },
+      {
+        version: 'v1',
+        createdAt: '2026-08-01T12:00:00.000Z',
+        current: false,
+        gateGreen: false,
+        origin: 'editor',
+      },
+    ]);
+    expect(body.stats).toEqual({ plays: 4812, medianPlaySeconds: 360, windowDays: 3 });
+    // The Google account name must never appear on a public page.
+    expect(JSON.stringify(body)).not.toContain('Secret Google');
+  });
+
+  it('serves a repo-committed game from the published ref with no store history', async () => {
+    const store = new InMemoryStore();
+    const repoEntry: CatalogGameEntry = {
+      slug: 'sky-dodge',
+      title: 'Sky Dodge',
+      genre: 'arcade',
+      controls: '',
+      status: 'published',
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: 'any',
+      submittedBy: 'gamedev-platform',
+    };
+    const app = await appWith(store, undefined, {
+      repoCatalog: [repoEntry],
+      gameFiles: { 'SPEC.md': SPEC, 'GAME.json': GAME_JSON },
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/sky-dodge/page' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.entry).toMatchObject({ slug: 'sky-dodge', title: 'Sky Dodge', submittedBy: 'gamedev-platform' });
+    expect(body.creator).toBeNull();
+    expect(body.specMarkdown).toContain('Deliver packages');
+    expect(body.modules).toEqual(['input', 'collision', 'gameplay', 'gfx']);
+    expect(body.budget).toBeNull();
+    expect(body.releases).toEqual([]);
+  });
+
+  it('404s for unknown and archived games', async () => {
+    const store = new InMemoryStore();
+    await store.setPublication({
+      slug: 'gone-game',
+      state: 'archived',
+      currentVersion: 'v1',
+      publishedAt: '2026-08-01T12:00:00.000Z',
+    });
+    const app = await appWith(store, storeGamesStore());
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/never-was/page' })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/api/games/gone-game/page' })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/api/games/Not%20A%20Slug/page' })).statusCode).toBe(400);
+  });
+
+  it('stays reachable through the private-beta wall while play stays behind it', async () => {
+    const store = new InMemoryStore();
+    await publishStoreGame(store);
+    const app = await appWith(store, storeGamesStore(), { betaAllowedUids: 'g:creator' });
+
+    const page = await app.inject({ method: 'GET', url: '/api/games/neon-courier/page' });
+    expect(page.statusCode).toBe(200);
+
+    const play = await app.inject({ method: 'GET', url: '/api/games/neon-courier' });
+    expect(play.statusCode).toBe(401);
+  });
+
+  it('degrades when the games store fake has no listVersions and no scorecard exists', async () => {
+    const store = new InMemoryStore();
+    await publishStoreGame(store);
+    const app = await appWith(store, storeGamesStore({ listVersions: undefined }));
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/page' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.releases).toEqual([]);
+    expect(body.stats).toBeNull();
+  });
+
+  it('deattributes games whose owner deleted their account', async () => {
+    const store = new InMemoryStore();
+    await publishStoreGame(store);
+    await store.deleteAccountIdentity('g:creator', '2026-08-05T00:00:00.000Z');
+    const app = await appWith(store, storeGamesStore());
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/page' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.entry.submittedBy).toBe('gamedev-platform');
+    expect(body.entry.creatorHandle).toBeNull();
+    expect(body.creator).toBeNull();
+  });
+});
+
+describe('game page helpers', () => {
+  it('stripSpecFrontmatter removes only the leading block', () => {
+    expect(stripSpecFrontmatter(SPEC)).toBe('# Neon Courier\n\nDeliver packages before the last neon goes out.');
+    expect(stripSpecFrontmatter('no frontmatter here')).toBe('no frontmatter here');
+    // A later `---` is a horizontal rule, not frontmatter.
+    expect(stripSpecFrontmatter('intro\n\n---\n\nrest')).toBe('intro\n\n---\n\nrest');
+  });
+
+  it('readGameModules tolerates bad manifests and normalises order', () => {
+    expect(readGameModules(null)).toBeNull();
+    expect(readGameModules('not json')).toBeNull();
+    expect(readGameModules('{}')).toBeNull();
+    expect(readGameModules(JSON.stringify({ engine: { modules: ['gfx', 'nonsense', 'input'] } }))).toEqual([
+      'input',
+      'gfx',
+    ]);
+  });
+});

--- a/apps/api/src/game-page-routes.ts
+++ b/apps/api/src/game-page-routes.ts
@@ -1,0 +1,260 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { profileBylineName, toPublicCreatorProfile, type PublicCreatorProfile } from './creator-profile.js';
+import { GAME_BUDGET_BYTES, GAME_KIT_MODULES } from './games-repo-contract.js';
+import { catalogEntryFromSpec, type CatalogGameEntry, type GitHubClient } from './github-client.js';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import { DELETED_ACCOUNT_UID, type Store } from './store.js';
+
+/**
+ * The public game page — `GET /api/games/:slug/page`.
+ *
+ * One aggregate read behind the "repo page" layout at `/:handle/:slug` (see the ops
+ * plan `docs/game-page-plan.md`, private repo): catalog metadata, the SPEC.md body,
+ * GameKit module composition, the author byte budget, release history from the games
+ * store, and the public play aggregate. Exempted from the private-beta wall the same
+ * way `/api/creators/:handle` is — the page is a landing page, and only *playing*
+ * stays gated during closed beta.
+ *
+ * Everything textual here is agent- or creator-authored: the client must render it
+ * escaped (the SPEC body goes through the safe markdown renderer, never innerHTML).
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const SlugParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(64),
+});
+
+export interface GamePageRelease {
+  version: string;
+  createdAt: string;
+  /** True for the version the play route serves right now. */
+  current: boolean;
+  /** Acceptance verdict — provenance, not health. Null for legacy manifests. */
+  gateGreen: boolean | null;
+  /** `'editor'` marks a content-only Studio publish (no agent round). */
+  origin?: 'editor';
+}
+
+export interface GamePageStats {
+  /** Play sessions in the scorecard's rolling window (28 days), not lifetime. */
+  plays: number;
+  medianPlaySeconds: number | null;
+  windowDays: number;
+}
+
+export interface GamePageResponse {
+  entry: CatalogGameEntry;
+  creator: PublicCreatorProfile | null;
+  /**
+   * SPEC.md with the catalog frontmatter stripped — the game's own README.
+   * Agent-authored markdown; the client renders it through a sanitising renderer.
+   */
+  specMarkdown: string | null;
+  /** GameKit modules the game composes, canonical order. Null when unreadable. */
+  modules: string[] | null;
+  /** Author source bytes against the games-repo budget. Store-delivered games only. */
+  budget: { usedBytes: number; limitBytes: number } | null;
+  /** Newest first. Empty for repo-committed games (their history lives in git). */
+  releases: GamePageRelease[];
+  stats: GamePageStats | null;
+}
+
+export interface GamePageRoutesOptions {
+  store: Store;
+  gamesStore?: GamesStore | null;
+  getRepoPublishedCatalogEntry?: (slug: string) => Promise<CatalogGameEntry | null>;
+  /** Repo reads for migrated games (SPEC.md / GAME.json off the published ref). */
+  githubClient?: GitHubClient | null;
+  publishedRef?: string;
+  now?: () => number;
+  cacheTtlMs?: number;
+}
+
+/** Strip the flat `--- … ---` frontmatter block; what remains is the human half. */
+export function stripSpecFrontmatter(specMd: string): string {
+  return specMd.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim();
+}
+
+/**
+ * Tolerant module read: the page must render for a game whose GAME.json a stricter
+ * parser would refuse (older deliveries predate several validation rules). Unknown
+ * names are dropped, order is normalised to the canonical list, and any parse
+ * failure is "no module data", never a 500.
+ */
+export function readGameModules(gameJsonSource: string | null): string[] | null {
+  if (!gameJsonSource) return null;
+  try {
+    const parsed = JSON.parse(gameJsonSource) as { engine?: { modules?: unknown } };
+    const raw = parsed.engine?.modules;
+    if (!Array.isArray(raw)) return null;
+    const named = new Set(raw.filter((name): name is string => typeof name === 'string'));
+    return GAME_KIT_MODULES.filter((name) => named.has(name));
+  } catch {
+    return null;
+  }
+}
+
+export async function registerGamePageRoutes(app: FastifyInstance, options: GamePageRoutesOptions): Promise<void> {
+  const { store, gamesStore, getRepoPublishedCatalogEntry, githubClient } = options;
+  const publishedRef = options.publishedRef ?? 'main';
+  const now = options.now ?? Date.now;
+  const cacheTtlMs = options.cacheTtlMs ?? 60_000;
+
+  // Assembling a page costs a dozen store reads (budget = every source file's bytes).
+  // Cached whole, briefly and bounded: page data moves on publish, not per request.
+  const cache = new Map<string, { value: GamePageResponse; expiresAt: number }>();
+
+  app.get('/api/games/:slug/page', async (request, reply) => {
+    const params = SlugParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug)) {
+      return reply.status(400).send({ error: 'invalid slug' });
+    }
+    const slug = params.data.slug;
+
+    const cached = cache.get(slug);
+    if (cached && cached.expiresAt > now()) {
+      return reply.send(cached.value);
+    }
+
+    try {
+      const body = await buildGamePage(slug);
+      if (!body) return reply.status(404).send({ error: 'not_found' });
+      if (cache.size >= 500) cache.clear();
+      cache.set(slug, { value: body, expiresAt: now() + cacheTtlMs });
+      return reply.send(body);
+    } catch (error) {
+      request.log.error({ err: error, slug }, 'failed to build game page');
+      return reply.status(502).send({ error: 'failed to load game page' });
+    }
+  });
+
+  async function buildGamePage(slug: string): Promise<GamePageResponse | null> {
+    // Same precedence as the play and media routes: a migrated repo copy wins.
+    const repoEntry = getRepoPublishedCatalogEntry ? await getRepoPublishedCatalogEntry(slug) : null;
+    const publication = await store.getPublication(slug);
+    const storePublished = publication?.state === 'published' ? publication : null;
+    if (!repoEntry && !storePublished) return null;
+    if (repoEntry && repoEntry.status !== 'published' && !storePublished) return null;
+
+    // Attribution joins at read time from the owner's profile — never from SPEC.
+    const submission = await store.getSubmissionBySlug(slug);
+    const erased = submission?.ownerUid === DELETED_ACCOUNT_UID;
+    const owner = submission && !erased ? await store.getUser(submission.ownerUid) : null;
+    const creator = owner ? toPublicCreatorProfile(owner) : null;
+
+    let specMd: string | null = null;
+    let gameJson: string | null = null;
+    let entry: CatalogGameEntry | null = repoEntry;
+    let budget: GamePageResponse['budget'] = null;
+
+    if (storePublished && gamesStore) {
+      const version = storePublished.currentVersion;
+      const [storeSpec, storeGameJson, manifest, mediaMetadata] = await Promise.all([
+        gamesStore.getSourceFile(slug, version, 'SPEC.md'),
+        gamesStore.getSourceFile(slug, version, 'GAME.json'),
+        gamesStore.getManifest(slug, version),
+        gamesStore.getDerivedArtifact(slug, version, 'media/metadata.json'),
+      ]);
+      specMd = storeSpec;
+      gameJson = storeGameJson;
+      if (!entry && storeSpec) {
+        entry = catalogEntryFromSpec(slug, storeSpec, (name) =>
+          name === 'media/metadata.json' && mediaMetadata ? mediaMetadata.toString('utf8') : null,
+        );
+      }
+      budget = await sumAuthorBytes(gamesStore, slug, version, manifest);
+    }
+
+    if (repoEntry && githubClient) {
+      // Repo games: SPEC/GAME.json come off the published ref. The closed read list
+      // in getGameFile is the boundary — this route never names arbitrary paths.
+      const [repoSpec, repoGameJson] = await Promise.all([
+        specMd ? Promise.resolve(specMd) : githubClient.getGameFile(publishedRef, slug, 'SPEC.md'),
+        gameJson ? Promise.resolve(gameJson) : githubClient.getGameFile(publishedRef, slug, 'GAME.json'),
+      ]);
+      specMd = repoSpec ?? specMd;
+      gameJson = repoGameJson ?? gameJson;
+    }
+
+    if (!entry) return null;
+
+    const releases = await listReleases(gamesStore ?? null, slug, storePublished?.currentVersion ?? null);
+    const stats = await readStats(store, slug);
+
+    return {
+      entry: {
+        ...entry,
+        status: 'published',
+        submittedBy: erased ? 'gamedev-platform' : creator ? profileBylineName(creator) : entry.submittedBy,
+        creatorHandle: erased ? null : (creator?.handle ?? entry.creatorHandle ?? null),
+      },
+      creator: erased ? null : creator,
+      specMarkdown: specMd ? stripSpecFrontmatter(specMd) : null,
+      modules: readGameModules(gameJson),
+      budget,
+      releases,
+      stats,
+    };
+  }
+}
+
+async function sumAuthorBytes(
+  gamesStore: GamesStore,
+  slug: string,
+  version: string,
+  manifest: VersionManifest | null,
+): Promise<{ usedBytes: number; limitBytes: number } | null> {
+  if (!manifest || manifest.sourceFiles.length === 0) return null;
+  try {
+    const sizes = await Promise.all(
+      manifest.sourceFiles.map(async (path) => {
+        const content = await gamesStore.getSourceFile(slug, version, path);
+        return content === null ? 0 : Buffer.byteLength(content, 'utf8');
+      }),
+    );
+    return { usedBytes: sizes.reduce((sum, bytes) => sum + bytes, 0), limitBytes: GAME_BUDGET_BYTES };
+  } catch {
+    // The gauge is garnish; a store hiccup must not take the page down with it.
+    return null;
+  }
+}
+
+async function listReleases(
+  gamesStore: GamesStore | null,
+  slug: string,
+  currentVersion: string | null,
+): Promise<GamePageRelease[]> {
+  // `typeof` guard: hand-rolled test fakes predate listVersions, and a page for a
+  // repo game has no store history at all — both must degrade to an empty list.
+  if (!gamesStore || typeof gamesStore.listVersions !== 'function') return [];
+  try {
+    const manifests = await gamesStore.listVersions(slug, { limit: 30 });
+    return manifests
+      .filter((manifest) => manifest.deliveryMode !== 'preview')
+      .map((manifest) => ({
+        version: manifest.version,
+        createdAt: manifest.createdAt,
+        current: manifest.version === currentVersion,
+        gateGreen: manifest.gate ? manifest.gate.green : null,
+        ...(manifest.origin === 'editor' ? { origin: 'editor' as const } : {}),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function readStats(store: Store, slug: string): Promise<GamePageStats | null> {
+  try {
+    const scorecard = await store.getScorecard(slug);
+    if (!scorecard) return null;
+    return {
+      plays: scorecard.sessions.count,
+      medianPlaySeconds: scorecard.sessions.count > 0 ? scorecard.sessions.medianPlaySeconds : null,
+      windowDays: scorecard.window.days.length,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/game-page-routes.ts
+++ b/apps/api/src/game-page-routes.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { profileBylineName, toPublicCreatorProfile, type PublicCreatorProfile } from './creator-profile.js';
+import {
+  PLATFORM_HANDLE,
+  profileBylineName,
+  toPublicCreatorProfile,
+  type PublicCreatorProfile,
+} from './creator-profile.js';
 import { GAME_BUDGET_BYTES, GAME_KIT_MODULES } from './games-repo-contract.js';
 import { catalogEntryFromSpec, type CatalogGameEntry, type GitHubClient } from './github-client.js';
 import type { GamesStore, VersionManifest } from './games-store.js';
@@ -47,6 +52,12 @@ export interface GamePageStats {
 export interface GamePageResponse {
   entry: CatalogGameEntry;
   creator: PublicCreatorProfile | null;
+  /**
+   * True when the game has no creator to name and lives under the platform handle.
+   * The page shows the platform as the author rather than linking a profile that
+   * does not exist.
+   */
+  platformAuthored: boolean;
   /**
    * SPEC.md with the catalog frontmatter stripped — the game's own README.
    * Agent-authored markdown; the client renders it through a sanitising renderer.
@@ -183,14 +194,22 @@ export async function registerGamePageRoutes(app: FastifyInstance, options: Game
     const releases = await listReleases(gamesStore ?? null, slug, storePublished?.currentVersion ?? null);
     const stats = await readStats(store, slug);
 
+    // Every published game gets an address. A game with no creator to name — the
+    // pre-profiles catalog, a platform seed, an erased owner — resolves to the
+    // platform handle instead of to nothing, because a page that exists only for
+    // games made after profiles shipped is a page most of the catalog cannot use.
+    const resolvedHandle = erased ? PLATFORM_HANDLE : (creator?.handle ?? entry.creatorHandle ?? PLATFORM_HANDLE);
+    const platformAuthored = resolvedHandle === PLATFORM_HANDLE;
+
     return {
       entry: {
         ...entry,
         status: 'published',
         submittedBy: erased ? 'gamedev-platform' : creator ? profileBylineName(creator) : entry.submittedBy,
-        creatorHandle: erased ? null : (creator?.handle ?? entry.creatorHandle ?? null),
+        creatorHandle: resolvedHandle,
       },
       creator: erased ? null : creator,
+      platformAuthored,
       specMarkdown: specMd ? stripSpecFrontmatter(specMd) : null,
       modules: readGameModules(gameJson),
       budget,

--- a/apps/api/src/game-review-routes.test.ts
+++ b/apps/api/src/game-review-routes.test.ts
@@ -194,6 +194,34 @@ describe('game review routes', () => {
     expect(after.json().candidate.approvedAt).toEqual(expect.any(String));
   });
 
+  it('will not let an operator record the creator’s sign-off', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    const approve = await app.inject({
+      method: 'POST',
+      url: '/api/games/neon-courier/review/v-candidate/approve',
+      headers: { cookie: authCookie('g:operator') },
+    });
+
+    // The admin queue reads `reviewApproval` back as `creatorApprovedAt`, so an
+    // operator recording it would have the queue report that the creator accepted a
+    // change they have never seen.
+    expect(approve.statusCode).toBe(403);
+    expect(approve.json()).toEqual({ error: 'not_the_creator' });
+    expect((await store.getSubmission(1_000_002))?.reviewApproval).toBeUndefined();
+
+    // The owner is unaffected, and an operator who *is* the owner would be too.
+    const owner = await app.inject({
+      method: 'POST',
+      url: '/api/games/neon-courier/review/v-candidate/approve',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(owner.statusCode).toBe(200);
+    expect((await store.getSubmission(1_000_002))?.reviewApproval).toMatchObject({ by: 'g:creator' });
+  });
+
   it('refuses a sign-off on a candidate the gate did not pass', async () => {
     const store = new InMemoryStore();
     await seedReview(store);
@@ -236,7 +264,12 @@ describe('game review routes', () => {
       url: '/api/games/neon-courier/review',
       headers: { cookie: authCookie('g:operator') },
     });
-    expect(operator.json()).toMatchObject({ viewerIsOperator: true, candidate: { version: 'v-candidate' } });
+    expect(operator.json()).toMatchObject({
+      viewerIsOperator: true,
+      candidate: { version: 'v-candidate' },
+      // An operator reviews, but the sign-off speaks for the creator.
+      canSignOff: false,
+    });
 
     // Once that job publishes, there is nothing under review any more.
     await store.setSubmissionPublishedAt(1_000_002, '2026-08-05T00:00:00.000Z');

--- a/apps/api/src/game-review-routes.test.ts
+++ b/apps/api/src/game-review-routes.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import { InMemoryStore } from './store.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+function authCookie(uid: string): string {
+  return `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}`;
+}
+
+const LIVE_SOURCES: Record<string, string> = {
+  'SPEC.md': '---\ntitle: Neon Courier\n---\n\nDeliver packages.',
+  'game.ts': 'const speed = 1;\nconst grip = 2;\nrun();',
+};
+
+const CANDIDATE_SOURCES: Record<string, string> = {
+  'SPEC.md': '---\ntitle: Neon Courier\n---\n\nDeliver packages.',
+  // One line changed, one added.
+  'game.ts': 'const speed = 1;\nconst grip = 3;\nconst rain = true;\nrun();',
+  'wet.ts': 'export const wet = 1;',
+};
+
+function manifest(version: string, files: string[], gate?: VersionManifest['gate']): VersionManifest {
+  return {
+    slug: 'neon-courier',
+    version,
+    createdAt: version === 'v-live' ? '2026-08-01T12:00:00.000Z' : '2026-08-04T12:00:00.000Z',
+    issueNumber: version === 'v-live' ? 1_000_001 : 1_000_002,
+    sourceFiles: files,
+    ...(gate ? { gate } : {}),
+  };
+}
+
+function reviewGamesStore(overrides: Partial<GamesStore> = {}): GamesStore {
+  const trees: Record<string, Record<string, string>> = {
+    'v-live': LIVE_SOURCES,
+    'v-candidate': CANDIDATE_SOURCES,
+  };
+  return {
+    getSourceFile: async (_slug: string, version: string, path: string) => trees[version]?.[path] ?? null,
+    getManifest: async (_slug: string, version: string) =>
+      version === 'v-live'
+        ? manifest('v-live', Object.keys(LIVE_SOURCES))
+        : version === 'v-candidate'
+          ? manifest('v-candidate', Object.keys(CANDIDATE_SOURCES), {
+              green: true,
+              ranAt: '2026-08-04T12:05:00.000Z',
+              report: '31 checks passed',
+            })
+          : null,
+    getDerivedArtifact: async (_slug: string, version: string, name: string) =>
+      name === 'bundle.html' && version === 'v-candidate' ? Buffer.from('<html>candidate</html>') : null,
+    ...overrides,
+  } as unknown as GamesStore;
+}
+
+/** A published game plus a delivered, gate-green candidate awaiting review. */
+async function seedReview(store: InMemoryStore): Promise<void> {
+  await store.upsertUser({ uid: 'g:creator' });
+  await store.claimHandle('g:creator', 'nightshift', '2026-07-01T00:00:00.000Z');
+  await store.upsertUser({ uid: 'g:stranger' });
+  await store.upsertUser({ uid: 'g:operator' });
+
+  await store.createSubmission(1_000_001, 'g:creator', 'Neon Courier');
+  await store.setSubmissionSlug(1_000_001, 'neon-courier');
+  await store.setSubmissionPublishedAt(1_000_001, '2026-08-01T12:00:00.000Z');
+  await store.setPublication({
+    slug: 'neon-courier',
+    state: 'published',
+    currentVersion: 'v-live',
+    publishedAt: '2026-08-01T12:00:00.000Z',
+  });
+
+  await store.createSubmission(1_000_002, 'g:creator', 'Grip on wet asphalt');
+  await store.setSubmissionSlug(1_000_002, 'neon-courier');
+  await store.setSubmissionDeliveredVersion(1_000_002, 'v-candidate');
+  await store.recordJobTransition(1_000_002, { to: 'queued', by: 'creator' });
+  await store.recordJobTransition(1_000_002, { to: 'dispatched', by: 'platform' });
+  await store.recordJobTransition(1_000_002, { to: 'building', by: 'agent' });
+  await store.recordJobTransition(1_000_002, { to: 'submitted', by: 'agent', reason: 'sources_delivered' });
+  await store.recordJobTransition(1_000_002, { to: 'ready_for_review', by: 'platform', reason: 'gate_green' });
+}
+
+describe('game review routes', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  async function appWith(store: InMemoryStore, gamesStore?: GamesStore) {
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      adminUids: 'g:operator',
+      submissionRoutes: gamesStore ? { agentChannel: { gamesStore } } : undefined,
+    });
+    apps.push(app);
+    return app;
+  }
+
+  it('offers the owner both halves of the comparison, the gate verdict and the diff', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review',
+      headers: { cookie: authCookie('g:creator') },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.baselineVersion).toBe('v-live');
+    expect(body.candidate).toMatchObject({
+      version: 'v-candidate',
+      jobId: 1_000_002,
+      title: 'Grip on wet asphalt',
+      gate: { green: true, report: '31 checks passed' },
+    });
+    expect(body.candidate.approvedAt).toBeUndefined();
+    // The footnote: one file edited, one added, SPEC untouched and therefore absent.
+    expect(body.diff).toMatchObject({ filesChanged: 2, added: 3, removed: 1, truncated: false });
+    expect(body.diff.files.map((file: { path: string }) => file.path)).toEqual(['game.ts', 'wet.ts']);
+  });
+
+  it('serves the candidate bundle to the owner and to nobody else', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    const owner = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review/v-candidate',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(owner.statusCode).toBe(200);
+    expect(owner.json()).toEqual({
+      slug: 'neon-courier',
+      title: 'Grip on wet asphalt',
+      html: '<html>candidate</html>',
+    });
+
+    // Unreviewed output is not public, and "not yours" reads as "not there".
+    const stranger = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review/v-candidate',
+      headers: { cookie: authCookie('g:stranger') },
+    });
+    expect(stranger.statusCode).toBe(404);
+
+    const anonymous = await app.inject({ method: 'GET', url: '/api/games/neon-courier/review/v-candidate' });
+    expect(anonymous.statusCode).toBe(401);
+
+    // A version id the viewer's own candidate does not name is not readable either.
+    const otherVersion = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review/v-live',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(otherVersion.statusCode).toBe(404);
+  });
+
+  it('records a sign-off without publishing anything', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    const approve = await app.inject({
+      method: 'POST',
+      url: '/api/games/neon-courier/review/v-candidate/approve',
+      headers: { cookie: authCookie('g:creator') },
+    });
+
+    expect(approve.statusCode).toBe(200);
+    expect(approve.json()).toMatchObject({ ok: true, version: 'v-candidate' });
+
+    // The sign-off is recorded on the job...
+    const record = await store.getSubmission(1_000_002);
+    expect(record?.reviewApproval).toMatchObject({ version: 'v-candidate', by: 'g:creator' });
+    // ...and the game that is live has not moved. Publishing stays the operator action.
+    const publication = await store.getPublication('neon-courier');
+    expect(publication?.currentVersion).toBe('v-live');
+    expect(record?.publishedAt).toBeUndefined();
+    expect(record?.state).toBe('ready_for_review');
+
+    const after = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(after.json().candidate.approvedAt).toEqual(expect.any(String));
+  });
+
+  it('refuses a sign-off on a candidate the gate did not pass', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const redGate = reviewGamesStore({
+      getManifest: async (_slug: string, version: string) =>
+        version === 'v-candidate'
+          ? manifest('v-candidate', Object.keys(CANDIDATE_SOURCES), {
+              green: false,
+              ranAt: '2026-08-04T12:05:00.000Z',
+              report: '2 checks failed',
+            })
+          : manifest('v-live', Object.keys(LIVE_SOURCES)),
+    });
+    const app = await appWith(store, redGate);
+
+    const approve = await app.inject({
+      method: 'POST',
+      url: '/api/games/neon-courier/review/v-candidate/approve',
+      headers: { cookie: authCookie('g:creator') },
+    });
+
+    expect(approve.statusCode).toBe(409);
+    expect(approve.json()).toEqual({ error: 'gate_red' });
+    // A red candidate is still readable — you may look at what failed.
+    const review = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(review.json().candidate.gate).toMatchObject({ green: false, report: '2 checks failed' });
+  });
+
+  it('lets an operator review any game, and reports nothing when no candidate waits', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    const operator = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review',
+      headers: { cookie: authCookie('g:operator') },
+    });
+    expect(operator.json()).toMatchObject({ viewerIsOperator: true, candidate: { version: 'v-candidate' } });
+
+    // Once that job publishes, there is nothing under review any more.
+    await store.setSubmissionPublishedAt(1_000_002, '2026-08-05T00:00:00.000Z');
+    const settled = await app.inject({
+      method: 'GET',
+      url: '/api/games/neon-courier/review',
+      headers: { cookie: authCookie('g:creator') },
+    });
+    expect(settled.json()).toMatchObject({ candidate: null, diff: null, baselineVersion: 'v-live' });
+  });
+
+  it('404s a stranger and 401s an anonymous visitor on the review itself', async () => {
+    const store = new InMemoryStore();
+    await seedReview(store);
+    const app = await appWith(store, reviewGamesStore());
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/review' })).statusCode).toBe(401);
+    expect(
+      (
+        await app.inject({
+          method: 'GET',
+          url: '/api/games/neon-courier/review',
+          headers: { cookie: authCookie('g:stranger') },
+        })
+      ).statusCode,
+    ).toBe(404);
+  });
+});

--- a/apps/api/src/game-review-routes.ts
+++ b/apps/api/src/game-review-routes.ts
@@ -50,6 +50,11 @@ export interface GameReviewResponse {
   diff: SourceDiffSummary | null;
   /** True for an operator viewing somebody else's game. */
   viewerIsOperator: boolean;
+  /**
+   * Whether this viewer may record the sign-off. Owners can; operators looking at
+   * somebody else's game cannot, because the sign-off speaks for the creator.
+   */
+  canSignOff: boolean;
 }
 
 export interface GameReviewRoutesOptions {
@@ -74,7 +79,7 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
     request: { user?: { uid: string } | null },
     reply: { status: (code: number) => { send: (body: unknown) => unknown } },
     slug: string,
-  ): Promise<{ uid: string; isOperator: boolean; published: SubmissionRecord | null } | null> {
+  ): Promise<{ uid: string; isOperator: boolean; isOwner: boolean; published: SubmissionRecord | null } | null> {
     const uid = request.user?.uid;
     if (!uid) {
       reply.status(401).send({ error: 'authentication required' });
@@ -82,17 +87,22 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
     }
     const published = await store.getPublishedSubmissionBySlug(slug);
     const isOperator = adminUids.has(uid);
-    if (isOperator) return { uid, isOperator, published };
 
     // Ownership is asked of every job on the slug, not only the published one: the
     // candidate under review belongs to an improvement job, and on a game that has
     // never published there is no published record to ask at all.
+    //
+    // Asked of operators too, rather than short-circuiting on the admin list: an
+    // operator may *look* at any game, but the sign-off below means "the person who
+    // asked for this change played it and accepts it", and only the owner can say
+    // that. An operator who happens to own the game is still its owner.
     const submissions = await store.listSubmissionsBySlug(slug);
-    if (submissions.length === 0 || !submissions.some((record) => record.ownerUid === uid)) {
+    const isOwner = submissions.some((record) => record.ownerUid === uid);
+    if (!isOperator && !isOwner) {
       reply.status(404).send({ error: 'not_found' });
       return null;
     }
-    return { uid, isOperator: false, published };
+    return { uid, isOperator, isOwner, published };
   }
 
   /** The newest job on this slug that has delivered something awaiting review. */
@@ -126,6 +136,7 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
         candidate: null,
         diff: null,
         viewerIsOperator: actor.isOperator,
+        canSignOff: actor.isOwner,
       } satisfies GameReviewResponse);
     }
 
@@ -140,6 +151,7 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
           candidate: null,
           diff: null,
           viewerIsOperator: actor.isOperator,
+          canSignOff: actor.isOwner,
         } satisfies GameReviewResponse);
       }
 
@@ -167,6 +179,7 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
         },
         diff,
         viewerIsOperator: actor.isOperator,
+        canSignOff: actor.isOwner,
       };
       return reply.send(body);
     } catch (error) {
@@ -224,6 +237,13 @@ export async function registerGameReviewRoutes(app: FastifyInstance, options: Ga
       const actor = await authorize(request, reply, slug);
       if (!actor) return;
       if (!gamesStore) return reply.status(503).send({ error: 'games are not configured' });
+
+      // Operators review; only the owner signs off. The admin queue reads this back
+      // as `creatorApprovedAt`, so an operator recording it would have the queue
+      // report that the creator accepted a change they have never seen.
+      if (!actor.isOwner) {
+        return reply.status(403).send({ error: 'not_the_creator' });
+      }
 
       const record = await findCandidate(slug, actor.uid, actor.isOperator);
       if (!record || record.deliveredVersion !== version) {

--- a/apps/api/src/game-review-routes.ts
+++ b/apps/api/src/game-review-routes.ts
@@ -1,0 +1,284 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import { summarizeSourceDiff, type SourceDiffSummary } from './source-diff.js';
+import type { Store, SubmissionRecord } from './store.js';
+
+/**
+ * The review surface — "Do zagrania".
+ *
+ * A change to a game is judged by **playing it**, not by reading a diff: two playable
+ * frames side by side, what is live and what was just built, thirty seconds each. This
+ * serves the halves of that comparison, plus the gate's verdict and a line-count
+ * footnote (ops `docs/game-page-plan.md`).
+ *
+ * Two boundaries this route does not cross:
+ *
+ *  - **It never publishes.** Publishing is an operator action by design
+ *    (job-admin-routes.ts): the gate answers "does this run", a human answers "may this
+ *    be on the site", and the second is the moderation boundary the DSA and the AI Act
+ *    care about. What the creator can record here is a *sign-off* — they asked for the
+ *    change, they played it, they accept it — which an operator sees when publishing.
+ *  - **It never serves a candidate to the public.** A delivered version is unreviewed
+ *    output. Only the game's owner and an operator can see it, and only ever as the
+ *    gate-built bundle inside the same sandbox every other game runs in.
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+/** Version ids are minted by the store (`v<compacted ISO>-<hex>`); never free text. */
+const VERSION_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+const SlugParamsSchema = z.object({ slug: z.string().trim().min(1).max(64) });
+const VersionParamsSchema = SlugParamsSchema.extend({ version: z.string().trim().min(1).max(64) });
+
+export interface ReviewCandidate {
+  version: string;
+  createdAt: string;
+  jobId: number;
+  title: string;
+  /** Gate verdict for this candidate. A red one can be looked at but never signed off. */
+  gate: { green: boolean; ranAt: string; report?: string } | null;
+  /** Present once the creator has played it and accepted it. */
+  approvedAt?: string;
+}
+
+export interface GameReviewResponse {
+  /** The version currently live — the left-hand frame. Null before a first publish. */
+  baselineVersion: string | null;
+  candidate: ReviewCandidate | null;
+  /** Line counts between baseline and candidate. Null when there is nothing to compare. */
+  diff: SourceDiffSummary | null;
+  /** True for an operator viewing somebody else's game. */
+  viewerIsOperator: boolean;
+}
+
+export interface GameReviewRoutesOptions {
+  store: Store;
+  gamesStore?: GamesStore | null;
+  adminUids?: Set<string>;
+  now?: () => number;
+}
+
+export async function registerGameReviewRoutes(app: FastifyInstance, options: GameReviewRoutesOptions): Promise<void> {
+  const { store, gamesStore } = options;
+  const adminUids = options.adminUids ?? new Set<string>();
+  const now = options.now ?? Date.now;
+
+  /**
+   * Resolves who is asking, or answers for us.
+   *
+   * 404 rather than 403 for a stranger, like the suggestion and editor-draft routes: a
+   * slug is public, and "exists but is not yours" says more than it needs to.
+   */
+  async function authorize(
+    request: { user?: { uid: string } | null },
+    reply: { status: (code: number) => { send: (body: unknown) => unknown } },
+    slug: string,
+  ): Promise<{ uid: string; isOperator: boolean; published: SubmissionRecord | null } | null> {
+    const uid = request.user?.uid;
+    if (!uid) {
+      reply.status(401).send({ error: 'authentication required' });
+      return null;
+    }
+    const published = await store.getPublishedSubmissionBySlug(slug);
+    const isOperator = adminUids.has(uid);
+    if (isOperator) return { uid, isOperator, published };
+
+    // Ownership is asked of every job on the slug, not only the published one: the
+    // candidate under review belongs to an improvement job, and on a game that has
+    // never published there is no published record to ask at all.
+    const submissions = await store.listSubmissionsBySlug(slug);
+    if (submissions.length === 0 || !submissions.some((record) => record.ownerUid === uid)) {
+      reply.status(404).send({ error: 'not_found' });
+      return null;
+    }
+    return { uid, isOperator: false, published };
+  }
+
+  /** The newest job on this slug that has delivered something awaiting review. */
+  async function findCandidate(slug: string, uid: string, isOperator: boolean): Promise<SubmissionRecord | null> {
+    const submissions = await store.listSubmissionsBySlug(slug);
+    const mine = isOperator ? submissions : submissions.filter((record) => record.ownerUid === uid);
+    const awaiting = mine.filter(
+      (record) =>
+        !record.abandonedAt &&
+        !record.publishedAt &&
+        Boolean(record.deliveredVersion) &&
+        (record.state === 'submitted' || record.state === 'gating' || record.state === 'ready_for_review'),
+    );
+    // Newest first: `listSubmissionsBySlug` promises that order, and a second delivery
+    // on the same job supersedes the first rather than queueing behind it.
+    return awaiting[0] ?? null;
+  }
+
+  app.get('/api/games/:slug/review', async (request, reply) => {
+    const params = SlugParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug)) {
+      return reply.status(400).send({ error: 'invalid slug' });
+    }
+    const slug = params.data.slug;
+    const actor = await authorize(request, reply, slug);
+    if (!actor) return;
+
+    if (!gamesStore) {
+      return reply.send({
+        baselineVersion: null,
+        candidate: null,
+        diff: null,
+        viewerIsOperator: actor.isOperator,
+      } satisfies GameReviewResponse);
+    }
+
+    try {
+      const publication = await store.getPublication(slug);
+      const baselineVersion = publication?.state === 'published' ? publication.currentVersion : null;
+      const record = await findCandidate(slug, actor.uid, actor.isOperator);
+
+      if (!record?.deliveredVersion) {
+        return reply.send({
+          baselineVersion,
+          candidate: null,
+          diff: null,
+          viewerIsOperator: actor.isOperator,
+        } satisfies GameReviewResponse);
+      }
+
+      const candidateVersion = record.deliveredVersion;
+      const manifest = await gamesStore.getManifest(slug, candidateVersion);
+      const diff = baselineVersion
+        ? await compareVersions(gamesStore, slug, baselineVersion, candidateVersion, manifest)
+        : null;
+
+      const body: GameReviewResponse = {
+        baselineVersion,
+        candidate: {
+          version: candidateVersion,
+          createdAt: manifest?.createdAt ?? record.stateSince ?? record.createdAt,
+          jobId: record.issueNumber,
+          title: record.title,
+          gate: manifest?.gate
+            ? {
+                green: manifest.gate.green,
+                ranAt: manifest.gate.ranAt,
+                ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
+              }
+            : null,
+          ...(record.reviewApproval?.version === candidateVersion ? { approvedAt: record.reviewApproval.at } : {}),
+        },
+        diff,
+        viewerIsOperator: actor.isOperator,
+      };
+      return reply.send(body);
+    } catch (error) {
+      request.log.error({ err: error, slug }, 'failed to build review');
+      return reply.status(502).send({ error: 'failed to load review' });
+    }
+  });
+
+  /**
+   * The candidate, playable. Same shape as `GET /api/games/:slug` so the client can
+   * hand it to the same frame — and, like that route, the document is the gate's own
+   * bundle rather than anything assembled here.
+   */
+  app.get('/api/games/:slug/review/:version', async (request, reply) => {
+    const params = VersionParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug) || !VERSION_PATTERN.test(params.data.version)) {
+      return reply.status(400).send({ error: 'invalid request' });
+    }
+    const { slug, version } = params.data;
+    const actor = await authorize(request, reply, slug);
+    if (!actor) return;
+    if (!gamesStore) return reply.status(503).send({ error: 'games are not configured' });
+
+    // The version has to belong to a job this viewer may see — otherwise any owner
+    // could name any version id and read another game's unpublished bundle.
+    const record = await findCandidate(slug, actor.uid, actor.isOperator);
+    if (!record || record.deliveredVersion !== version) {
+      return reply.status(404).send({ error: 'not_found' });
+    }
+
+    try {
+      const bundle = await gamesStore.getDerivedArtifact(slug, version, 'bundle.html');
+      if (!bundle) return reply.status(409).send({ error: 'not_built' });
+      return reply.send({ slug, title: record.title, html: bundle.toString('utf8') });
+    } catch (error) {
+      request.log.error({ err: error, slug, version }, 'failed to read candidate bundle');
+      return reply.status(502).send({ error: 'failed to load candidate' });
+    }
+  });
+
+  /**
+   * The creator's sign-off. Records that they played it and accept it; an operator
+   * still performs the publish. Refused on a candidate the gate has not passed —
+   * accepting something unverified is not a verdict anyone should be able to record.
+   */
+  app.post(
+    '/api/games/:slug/review/:version/approve',
+    { config: { rateLimit: { max: 30, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const params = VersionParamsSchema.safeParse(request.params);
+      if (!params.success || !SLUG_PATTERN.test(params.data.slug) || !VERSION_PATTERN.test(params.data.version)) {
+        return reply.status(400).send({ error: 'invalid request' });
+      }
+      const { slug, version } = params.data;
+      const actor = await authorize(request, reply, slug);
+      if (!actor) return;
+      if (!gamesStore) return reply.status(503).send({ error: 'games are not configured' });
+
+      const record = await findCandidate(slug, actor.uid, actor.isOperator);
+      if (!record || record.deliveredVersion !== version) {
+        return reply.status(404).send({ error: 'not_found' });
+      }
+
+      // Re-read from the manifest rather than trusting job state, for the same reason
+      // the publish route does: state is derived on a poll, the manifest is what the
+      // gate wrote, and this is the record an operator will act on.
+      const manifest = await gamesStore.getManifest(slug, version);
+      if (!manifest?.gate) return reply.status(409).send({ error: 'not_gated' });
+      if (!manifest.gate.green) return reply.status(409).send({ error: 'gate_red' });
+
+      const at = new Date(now()).toISOString();
+      await store.setSubmissionReviewApproval(record.issueNumber, { version, at, by: actor.uid });
+      return reply.send({ ok: true, version, approvedAt: at });
+    },
+  );
+}
+
+/** Reads both trees and counts the lines between them. Null when the base is unreadable. */
+async function compareVersions(
+  gamesStore: GamesStore,
+  slug: string,
+  baselineVersion: string,
+  candidateVersion: string,
+  candidateManifest: VersionManifest | null,
+): Promise<SourceDiffSummary | null> {
+  try {
+    const baselineManifest = await gamesStore.getManifest(slug, baselineVersion);
+    if (!baselineManifest || !candidateManifest) return null;
+    const [before, after] = await Promise.all([
+      readTree(gamesStore, slug, baselineVersion, baselineManifest),
+      readTree(gamesStore, slug, candidateVersion, candidateManifest),
+    ]);
+    return summarizeSourceDiff(before, after);
+  } catch {
+    // The footnote is the least important thing on the page; losing it must not cost
+    // the creator the comparison they came for.
+    return null;
+  }
+}
+
+async function readTree(
+  gamesStore: GamesStore,
+  slug: string,
+  version: string,
+  manifest: VersionManifest,
+): Promise<Map<string, string>> {
+  const entries = await Promise.all(
+    manifest.sourceFiles.map(async (path) => [path, await gamesStore.getSourceFile(slug, version, path)] as const),
+  );
+  const tree = new Map<string, string>();
+  for (const [path, content] of entries) {
+    if (content !== null) tree.set(path, content);
+  }
+  return tree;
+}

--- a/apps/api/src/game-sources-routes.test.ts
+++ b/apps/api/src/game-sources-routes.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import type { GamesStore, VersionManifest } from './games-store.js';
+import { languageOf, MAX_VIEWABLE_FILE_BYTES } from './game-sources-routes.js';
+import { InMemoryStore } from './store.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+const SOURCES: Record<string, string> = {
+  'SPEC.md': '---\ntitle: Neon Courier\n---\n\nDeliver packages.',
+  'GAME.json': '{"engine":{"modules":["gfx"]}}',
+  'game.ts': 'export function run() {\n  return 1;\n}\n',
+};
+
+function sourcesStore(overrides: Partial<GamesStore> = {}): GamesStore {
+  return {
+    getManifest: async (_slug: string, version: string) =>
+      version === 'v-live'
+        ? ({
+            slug: 'neon-courier',
+            version: 'v-live',
+            createdAt: '2026-08-01T12:00:00.000Z',
+            issueNumber: 1,
+            sourceFiles: Object.keys(SOURCES),
+          } satisfies VersionManifest)
+        : null,
+    getSourceFile: async (_slug: string, version: string, path: string) =>
+      version === 'v-live' ? (SOURCES[path] ?? null) : null,
+    ...overrides,
+  } as unknown as GamesStore;
+}
+
+async function publish(store: InMemoryStore): Promise<void> {
+  await store.setPublication({
+    slug: 'neon-courier',
+    state: 'published',
+    currentVersion: 'v-live',
+    publishedAt: '2026-08-01T12:00:00.000Z',
+  });
+}
+
+describe('game sources routes', () => {
+  const apps: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (apps.length) await apps.pop()!.close();
+  });
+
+  async function appWith(store: InMemoryStore, gamesStore?: GamesStore, betaAllowedUids?: string) {
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      betaAllowedUids,
+      gameSourcesRoutes: { cacheTtlMs: 0 },
+      submissionRoutes: gamesStore ? { agentChannel: { gamesStore } } : undefined,
+    });
+    apps.push(app);
+    return app;
+  }
+
+  it('lists the live version’s files to anyone, with sizes and languages', async () => {
+    const store = new InMemoryStore();
+    await publish(store);
+    const app = await appWith(store, sourcesStore());
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.version).toBe('v-live');
+    // Case-insensitive order, so GAME.json and game.ts sit together rather than being
+    // split by an uppercase-first comparison.
+    expect(body.files).toEqual([
+      { path: 'GAME.json', bytes: Buffer.byteLength(SOURCES['GAME.json']), language: 'json' },
+      { path: 'game.ts', bytes: Buffer.byteLength(SOURCES['game.ts']), language: 'typescript' },
+      { path: 'SPEC.md', bytes: Buffer.byteLength(SOURCES['SPEC.md']), language: 'markdown' },
+    ]);
+    expect(body.totalBytes).toBe(Object.values(SOURCES).reduce((sum, content) => sum + Buffer.byteLength(content), 0));
+  });
+
+  it('serves one file’s text to anyone, and only files the manifest names', async () => {
+    const store = new InMemoryStore();
+    await publish(store);
+    const app = await appWith(store, sourcesStore());
+
+    const file = await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources/file?path=game.ts' });
+    expect(file.statusCode).toBe(200);
+    expect(file.json()).toEqual({
+      path: 'game.ts',
+      version: 'v-live',
+      bytes: Buffer.byteLength(SOURCES['game.ts']),
+      language: 'typescript',
+      content: SOURCES['game.ts'],
+    });
+
+    // Not in the manifest → does not exist. No prefix join, so nothing to escape from.
+    for (const path of ['../../etc/passwd', 'secrets.env', '/etc/passwd', 'game.ts.map']) {
+      const denied = await app.inject({
+        method: 'GET',
+        url: `/api/games/neon-courier/sources/file?path=${encodeURIComponent(path)}`,
+      });
+      expect(denied.statusCode).toBe(404);
+    }
+  });
+
+  it('shows nothing for an unpublished, taken-down, or repo-only game', async () => {
+    const store = new InMemoryStore();
+    const app = await appWith(store, sourcesStore());
+
+    // Never published.
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources' })).statusCode).toBe(404);
+
+    await publish(store);
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources' })).statusCode).toBe(200);
+
+    // Taken down — the code goes with the game.
+    await store.takedownPublication('neon-courier', 'reported', '2026-08-05T00:00:00.000Z');
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources' })).statusCode).toBe(404);
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources/file?path=game.ts' })).statusCode,
+    ).toBe(404);
+  });
+
+  it('refuses to inline a file past the viewer ceiling', async () => {
+    const store = new InMemoryStore();
+    await publish(store);
+    const huge = 'x'.repeat(MAX_VIEWABLE_FILE_BYTES + 1);
+    const app = await appWith(
+      store,
+      sourcesStore({
+        getManifest: async () =>
+          ({
+            slug: 'neon-courier',
+            version: 'v-live',
+            createdAt: '2026-08-01T12:00:00.000Z',
+            issueNumber: 1,
+            sourceFiles: ['huge.ts'],
+          }) as VersionManifest,
+        getSourceFile: async () => huge,
+      }),
+    );
+
+    const response = await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources/file?path=huge.ts' });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.json()).toMatchObject({ error: 'too_large', limit: MAX_VIEWABLE_FILE_BYTES });
+  });
+
+  it('stays readable through the private-beta wall', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await publish(store);
+    const app = await appWith(store, sourcesStore(), 'g:creator');
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources' })).statusCode).toBe(200);
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/games/neon-courier/sources/file?path=SPEC.md' })).statusCode,
+    ).toBe(200);
+    // The playable document itself stays walled — only reading the code opened up.
+    expect((await app.inject({ method: 'GET', url: '/api/games/neon-courier' })).statusCode).toBe(401);
+  });
+});
+
+describe('languageOf', () => {
+  it('tags the file kinds a delivered game contains', () => {
+    expect(languageOf('game.ts')).toBe('typescript');
+    expect(languageOf('sim.tsx')).toBe('typescript');
+    expect(languageOf('GAME.json')).toBe('json');
+    expect(languageOf('style.css')).toBe('css');
+    expect(languageOf('index.html')).toBe('html');
+    expect(languageOf('SPEC.md')).toBe('markdown');
+    expect(languageOf('LICENSE')).toBe('text');
+  });
+});

--- a/apps/api/src/game-sources-routes.ts
+++ b/apps/api/src/game-sources-routes.ts
@@ -1,0 +1,182 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { GamesStore } from './games-store.js';
+import type { Store } from './store.js';
+
+/**
+ * Public read-only sources — "Źródła".
+ *
+ * Every published creator game shows its code, to anyone, without a session. That is a
+ * product decision the owner made deliberately (ops `docs/game-page-plan.md`): a game
+ * built by an agent from a prompt is more interesting, not less, when you can read what
+ * it actually is, and the creator checkout has always handed the same bytes to the
+ * person who commissioned it.
+ *
+ * What that decision does **not** extend to:
+ *
+ *  - **Platform and repo-migrated games.** Their sources live in the private games repo,
+ *    which is private for reasons this route does not get to revisit (resolved Q1/Q2 in
+ *    the risk register). Only games delivered through the store — the ones with a
+ *    creator behind them — are readable here.
+ *  - **Unpublished work.** Only the version that is currently live. A candidate under
+ *    review is unreviewed output and stays on the review route, owner-only.
+ *  - **Anything not in the manifest.** Paths are matched against the version's own file
+ *    list rather than being joined onto a prefix, so there is no traversal to defend
+ *    against — a path that is not one of the delivered files simply does not exist.
+ *
+ * Content is served as JSON strings and never as a document: this route hands over text
+ * for a client to render as text, and nothing here can be navigated to as HTML.
+ */
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const SlugParamsSchema = z.object({ slug: z.string().trim().min(1).max(64) });
+const FileQuerySchema = z.object({ path: z.string().trim().min(1).max(200) });
+
+/** Files past this are listed but not served inline — a viewer is not a download. */
+export const MAX_VIEWABLE_FILE_BYTES = 512 * 1024;
+
+export interface GameSourceFile {
+  path: string;
+  bytes: number;
+  /** Coarse language tag for the viewer's highlighter — derived from the extension. */
+  language: 'typescript' | 'json' | 'css' | 'html' | 'markdown' | 'text';
+}
+
+export interface GameSourcesResponse {
+  version: string;
+  files: GameSourceFile[];
+  totalBytes: number;
+}
+
+export interface GameSourcesRoutesOptions {
+  store: Store;
+  gamesStore?: GamesStore | null;
+  now?: () => number;
+  cacheTtlMs?: number;
+}
+
+export function languageOf(path: string): GameSourceFile['language'] {
+  if (path.endsWith('.ts') || path.endsWith('.tsx') || path.endsWith('.js')) return 'typescript';
+  if (path.endsWith('.json')) return 'json';
+  if (path.endsWith('.css')) return 'css';
+  if (path.endsWith('.html')) return 'html';
+  if (path.endsWith('.md')) return 'markdown';
+  return 'text';
+}
+
+export async function registerGameSourcesRoutes(
+  app: FastifyInstance,
+  options: GameSourcesRoutesOptions,
+): Promise<void> {
+  const { store, gamesStore } = options;
+  const now = options.now ?? Date.now;
+  const cacheTtlMs = options.cacheTtlMs ?? 300_000;
+
+  // A listing costs one read per file to size it; versions are immutable, so the only
+  // thing that invalidates this is a publish pointing the slug at a new one.
+  const listings = new Map<string, { value: GameSourcesResponse; expiresAt: number }>();
+
+  /** The live version of a store-published game, or null when there is nothing to show. */
+  async function liveVersion(slug: string): Promise<string | null> {
+    const publication = await store.getPublication(slug);
+    if (!publication || publication.state !== 'published') return null;
+    return publication.currentVersion;
+  }
+
+  app.get('/api/games/:slug/sources', async (request, reply) => {
+    const params = SlugParamsSchema.safeParse(request.params);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug)) {
+      return reply.status(400).send({ error: 'invalid slug' });
+    }
+    const slug = params.data.slug;
+    if (!gamesStore) return reply.status(404).send({ error: 'not_found' });
+
+    try {
+      const version = await liveVersion(slug);
+      if (!version) return reply.status(404).send({ error: 'not_found' });
+
+      const cacheKey = `${slug}@${version}`;
+      const cached = listings.get(cacheKey);
+      if (cached && cached.expiresAt > now()) return reply.send(cached.value);
+
+      const manifest = await gamesStore.getManifest(slug, version);
+      if (!manifest) return reply.status(404).send({ error: 'not_found' });
+
+      const sized = await Promise.all(
+        manifest.sourceFiles.map(async (path) => {
+          const content = await gamesStore.getSourceFile(slug, version, path);
+          return content === null
+            ? null
+            : ({
+                path,
+                bytes: Buffer.byteLength(content, 'utf8'),
+                language: languageOf(path),
+              } satisfies GameSourceFile);
+        }),
+      );
+      // Case-insensitive, with a raw tie-break so the order is deterministic across
+      // locales: a file list that reorders itself by who is reading it is a bad list.
+      const files = sized
+        .filter((file): file is GameSourceFile => file !== null)
+        .sort((a, b) => {
+          const left = a.path.toLowerCase();
+          const right = b.path.toLowerCase();
+          if (left !== right) return left < right ? -1 : 1;
+          return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+        });
+
+      const body: GameSourcesResponse = {
+        version,
+        files,
+        totalBytes: files.reduce((sum, file) => sum + file.bytes, 0),
+      };
+      if (listings.size >= 300) listings.clear();
+      listings.set(cacheKey, { value: body, expiresAt: now() + cacheTtlMs });
+      return reply.send(body);
+    } catch (error) {
+      request.log.error({ err: error, slug }, 'failed to list game sources');
+      return reply.status(502).send({ error: 'failed to load sources' });
+    }
+  });
+
+  app.get('/api/games/:slug/sources/file', async (request, reply) => {
+    const params = SlugParamsSchema.safeParse(request.params);
+    const query = FileQuerySchema.safeParse(request.query);
+    if (!params.success || !SLUG_PATTERN.test(params.data.slug) || !query.success) {
+      return reply.status(400).send({ error: 'invalid request' });
+    }
+    const slug = params.data.slug;
+    if (!gamesStore) return reply.status(404).send({ error: 'not_found' });
+
+    try {
+      const version = await liveVersion(slug);
+      if (!version) return reply.status(404).send({ error: 'not_found' });
+
+      const manifest = await gamesStore.getManifest(slug, version);
+      // Membership of the manifest is the whole authorization: the caller names one of
+      // the delivered files or names nothing at all.
+      if (!manifest?.sourceFiles.includes(query.data.path)) {
+        return reply.status(404).send({ error: 'not_found' });
+      }
+
+      const content = await gamesStore.getSourceFile(slug, version, query.data.path);
+      if (content === null) return reply.status(404).send({ error: 'not_found' });
+      const bytes = Buffer.byteLength(content, 'utf8');
+      if (bytes > MAX_VIEWABLE_FILE_BYTES) {
+        return reply.status(413).send({ error: 'too_large', bytes, limit: MAX_VIEWABLE_FILE_BYTES });
+      }
+
+      return reply.send({
+        path: query.data.path,
+        version,
+        bytes,
+        language: languageOf(query.data.path),
+        content,
+      });
+    } catch (error) {
+      request.log.error({ err: error, slug }, 'failed to read a game source file');
+      return reply.status(502).send({ error: 'failed to load source' });
+    }
+  });
+}

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -219,6 +219,20 @@ function stubGcs() {
       generations.delete(name);
       return new Response(null, { status: 200 });
     }
+    // Delimiter listing (`/o?prefix=...&delimiter=/`) — answers with the sub-prefixes,
+    // like GCS does, so listVersions can be exercised against the same object map.
+    if (!href.includes('/o/')) {
+      const parsed = new URL(href);
+      const prefix = parsed.searchParams.get('prefix') ?? '';
+      const prefixes = new Set<string>();
+      for (const name of objects.keys()) {
+        if (!name.startsWith(prefix)) continue;
+        const rest = name.slice(prefix.length);
+        const slash = rest.indexOf('/');
+        if (slash !== -1) prefixes.add(`${prefix}${rest.slice(0, slash + 1)}`);
+      }
+      return new Response(JSON.stringify({ prefixes: [...prefixes] }), { status: 200 });
+    }
     const name = decodeURIComponent(href.split('/o/')[1].split('?')[0]);
     const body = objects.get(name);
     if (!body) return new Response('', { status: 404 });
@@ -295,6 +309,27 @@ describe('GCS games store', () => {
     await store.putGateResult('g', version, { green: false, report: '3 checks failed' });
 
     expect((await store.getManifest('g', version))?.gate).toMatchObject({ green: false, report: '3 checks failed' });
+  });
+
+  it('lists versions newest first, skipping directories without a manifest', async () => {
+    const { impl, objects } = stubGcs();
+    let tick = 0;
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl, versionId: () => `v${++tick}` });
+    await store.putCandidateSources({ slug: 'g', issueNumber: 1, files: MINIMAL });
+    await store.putCandidateSources({ slug: 'g', issueNumber: 2, files: MINIMAL });
+    // An interrupted upload: source objects landed, the manifest never did.
+    objects.set('games/g/versions/v9/source/game.ts', Buffer.from('x'));
+
+    const versions = await store.listVersions('g');
+
+    expect(versions.map((manifest) => manifest.version)).toEqual(['v2', 'v1']);
+    expect(versions[0]).toMatchObject({ issueNumber: 2 });
+
+    const limited = await store.listVersions('g', { limit: 1 });
+    expect(limited.map((manifest) => manifest.version)).toEqual(['v2']);
+
+    await expect(store.listVersions('../evil')).rejects.toThrow(InvalidUploadError);
+    expect(await store.listVersions('never-delivered')).toEqual([]);
   });
 
   it('stages files one-by-one and assembles them for finalize', async () => {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -447,6 +447,15 @@ export interface GamesStore {
     paths?: string[];
   }): Promise<{ cleared: number }>;
   getManifest(slug: string, version: string): Promise<VersionManifest | null>;
+  /**
+   * Version history for one game, newest first — the manifests under
+   * `games/<slug>/versions/`. Version ids are sortable timestamps (see
+   * {@link defaultVersionId}), so bucket listing order *is* delivery order.
+   *
+   * `limit` bounds both the listing and the manifest reads: this exists for the
+   * public game page's release history, which is a paged read, not an audit.
+   */
+  listVersions(slug: string, opts?: { limit?: number }): Promise<VersionManifest[]>;
   getSourceFile(slug: string, version: string, path: string): Promise<string | null>;
   /**
    * Records our gate's verdict against a version. Only a green one may publish.
@@ -831,6 +840,44 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
     async getSourceFile(slug, version, path) {
       const body = await readObject(`${versionPrefix(slug, version)}/source/${path}`);
       return body ? body.toString('utf8') : null;
+    },
+
+    async listVersions(slug, opts) {
+      assertSlug(slug);
+      const limit = Math.max(1, Math.min(opts?.limit ?? 30, 100));
+      // Delimiter listing returns the version directories as prefixes without
+      // paging through every object under them — a game's versions each hold a
+      // dozen-plus source files, and this call wants one manifest per version.
+      const prefix = `games/${slug}/versions/`;
+      const url =
+        `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o` +
+        `?prefix=${encodeURIComponent(prefix)}&delimiter=${encodeURIComponent('/')}&fields=prefixes`;
+      const response = await fetchImpl(url, { headers: { authorization: `Bearer ${await getAccessToken()}` } });
+      if (response.status === 404) return [];
+      if (!response.ok) throw new Error(`games store list of ${prefix} failed: ${response.status}`);
+      const listing = (await response.json()) as { prefixes?: string[] };
+      const versions = (listing.prefixes ?? [])
+        .map((p) => p.slice(prefix.length).replace(/\/$/, ''))
+        .filter(Boolean)
+        // Timestamp ids sort lexicographically; newest first is reverse order.
+        .sort((a, b) => b.localeCompare(a));
+      // A version directory without a manifest is an interrupted upload, not a
+      // version (see putCandidateSources) — it must not appear in a history, and
+      // it must not consume a limit slot either. Read in limit-sized batches so an
+      // orphan-riddled prefix still costs bounded reads rather than the whole list.
+      const collected: VersionManifest[] = [];
+      for (let offset = 0; offset < versions.length && collected.length < limit; offset += limit) {
+        const batch = await Promise.all(
+          versions.slice(offset, offset + limit).map(async (version) => {
+            const body = await readObject(`${versionPrefix(slug, version)}/manifest.json`);
+            return body ? (JSON.parse(body.toString('utf8')) as VersionManifest) : null;
+          }),
+        );
+        for (const manifest of batch) {
+          if (manifest !== null) collected.push(manifest);
+        }
+      }
+      return collected.slice(0, limit);
     },
 
     async putGateResult(slug, version, result) {

--- a/apps/api/src/job-admin-routes.ts
+++ b/apps/api/src/job-admin-routes.ts
@@ -127,7 +127,17 @@ export function buildJobQueue(records: SubmissionRecord[], now: number): JobQueu
 
 export async function registerJobAdminRoutes(
   app: FastifyInstance,
-  options: { store?: Store; adminUids?: Set<string>; gamesStore?: GamesStore; now?: () => number },
+  options: {
+    store?: Store;
+    adminUids?: Set<string>;
+    gamesStore?: GamesStore;
+    now?: () => number;
+    /**
+     * Fans a new version out to the game's followers (game-follow-notify.ts). Optional:
+     * a deployment without it publishes exactly as before, silently.
+     */
+    notifyFollowers?: (event: { slug: string; version: string; gameTitle: string; ownerUid: string }) => Promise<void>;
+  },
 ): Promise<void> {
   const { store, adminUids, gamesStore } = options;
   const now = options.now ?? Date.now;
@@ -209,6 +219,23 @@ export async function registerJobAdminRoutes(
     // and a terminal job is one sweep away from falling out of that set. `lastNotifiedStatus`
     // is left alone so the next sweep can still emit the published notification.
     await store.setSubmissionLastStatus(issueNumber, 'published');
+
+    // Tell the people who follow this game that it moved. Best-effort and after the
+    // publish has already happened: a notification that fails must never leave a game
+    // half-published, and the creator's own `submission.published` note comes from the
+    // sweep on its own path. The owner is skipped — they would get two.
+    if (options.notifyFollowers) {
+      try {
+        await options.notifyFollowers({
+          slug: record.slug,
+          version: record.deliveredVersion,
+          gameTitle: record.title,
+          ownerUid: record.ownerUid,
+        });
+      } catch (error) {
+        request.log.error({ err: error, slug: record.slug }, 'follower notification fan-out failed after publish');
+      }
+    }
 
     return reply.send({ ok: true, slug: record.slug, version: record.deliveredVersion, publishedAt: at });
   });

--- a/apps/api/src/job-admin-routes.ts
+++ b/apps/api/src/job-admin-routes.ts
@@ -48,6 +48,13 @@ export interface JobQueueEntry {
   agentState?: string;
   /** Most recent transitions, newest first — how it got here. */
   recentTransitions: Array<{ to: JobState; at: string; by: string; reason?: string }>;
+  /**
+   * When the creator played the delivered candidate and signed off on it
+   * (game-review-routes.ts). Set only when the approval names the version this job
+   * actually delivered — an approval of a superseded candidate is not an approval of
+   * this one. Advisory: the operator still decides whether it may be on the site.
+   */
+  creatorApprovedAt?: string;
 }
 
 export interface JobQueueResponse {
@@ -104,6 +111,9 @@ export function buildJobQueue(records: SubmissionRecord[], now: number): JobQueu
         }),
         agentState: record.agentState,
         recentTransitions: (record.transitions ?? []).slice(-TRANSITIONS_SHOWN).reverse(),
+        ...(record.reviewApproval && record.reviewApproval.version === record.deliveredVersion
+          ? { creatorApprovedAt: record.reviewApproval.at }
+          : {}),
       };
     })
     .filter((entry): entry is JobQueueEntry => entry !== null)

--- a/apps/api/src/notify.ts
+++ b/apps/api/src/notify.ts
@@ -12,6 +12,7 @@ import {
   operatorNotificationMessage,
   operatorPushContent,
   submissionNotificationMessage,
+  followedGamePushContent,
   submissionPushContent,
   type DigestEmailParams,
   type OperatorEmailParams,
@@ -126,14 +127,21 @@ async function maybeSendEmail(deps: EmitDeps, uid: string, notification: StoredN
     );
     const locale = normalizeLocale(user.locale);
     const message =
-      notification.type === 'creator.digest'
-        ? digestNotificationMessage(user.email, locale, digestEmailParams(notification, actionUrl, unsubscribeUrl))
-        : submissionNotificationMessage(user.email, locale, notification.type, {
-            title: notification.params.title ?? '',
-            actionUrl,
-            unsubscribeUrl,
-          });
+      notification.type === 'game.new_version'
+        ? // Deliberately not emailed yet. An email about somebody else's game needs its
+          // own unsubscribe scope — the digest has one for exactly this reason — and a
+          // follow that silences "your game is published" would be a worse bug than the
+          // missing mail. In-app and push carry it until that scope exists.
+          null
+        : notification.type === 'creator.digest'
+          ? digestNotificationMessage(user.email, locale, digestEmailParams(notification, actionUrl, unsubscribeUrl))
+          : submissionNotificationMessage(user.email, locale, notification.type, {
+              title: notification.params.title ?? '',
+              actionUrl,
+              unsubscribeUrl,
+            });
 
+    if (!message) return;
     await mailer.send(message);
     await deps.store.markNotificationEmailed(uid, notification.id);
   } catch (err) {
@@ -164,12 +172,14 @@ async function maybePush(deps: EmitDeps, uid: string, notification: StoredNotifi
     const appBaseUrl = deps.appBaseUrl ?? process.env.APP_BASE_URL?.trim() ?? 'https://www.gamedev.pl';
     const locale = normalizeLocale(user?.locale);
     const { title, body } =
-      notification.type === 'creator.digest'
-        ? digestPushContent(locale, digestEmailParams(notification, '', ''))
-        : isOperatorNotification(notification.type)
-          ? // English regardless of the reader's locale — see the operator copy's comment.
-            operatorPushContent(notification.type, notification.params.title ?? '')
-          : submissionPushContent(locale, notification.type, notification.params.title ?? '');
+      notification.type === 'game.new_version'
+        ? followedGamePushContent(locale, notification.params.title ?? '')
+        : notification.type === 'creator.digest'
+          ? digestPushContent(locale, digestEmailParams(notification, '', ''))
+          : isOperatorNotification(notification.type)
+            ? // English regardless of the reader's locale — see the operator copy's comment.
+              operatorPushContent(notification.type, notification.params.title ?? '')
+            : submissionPushContent(locale, notification.type, notification.params.title ?? '');
     const payload = { title, body, url: absoluteAppUrl(appBaseUrl, notification.link), tag: notification.id };
 
     await Promise.all(
@@ -348,6 +358,45 @@ export interface SubmissionNotificationEvent {
   statusToken: string;
   /** Present for `submission.published`: deep-link straight to the playable game. */
   slug?: string;
+}
+
+export interface FollowedGameNotificationEvent {
+  /** The follower being told, never the creator — they have their own publish note. */
+  uid: string;
+  slug: string;
+  gameTitle: string;
+  /** The version that just went live; part of the id so each release notifies once. */
+  version: string;
+  link: string;
+}
+
+/**
+ * Tell one follower that a game they follow published a new version.
+ *
+ * Idempotent by `follow-<slug>-<version>`: a republish of the same version (a retried
+ * operator click, a reconciliation pass) must not notify twice, and a genuinely new
+ * version must. Emission is per-follower rather than batched because the store's
+ * notification model is per-user, and because a failure to reach one follower must not
+ * cost the rest theirs.
+ */
+export async function emitFollowedGameNotification(
+  deps: EmitDeps,
+  event: FollowedGameNotificationEvent,
+): Promise<{ created: boolean }> {
+  const { created, notification } = await deps.store.createNotification(event.uid, {
+    id: `follow-${event.slug}-${event.version}`,
+    type: 'game.new_version',
+    createdAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+    titleKey: 'notifications.game.new_version.title',
+    bodyKey: 'notifications.game.new_version.body',
+    params: { title: event.gameTitle, slug: event.slug },
+    link: event.link,
+  });
+
+  await maybeSendEmail(deps, event.uid, notification);
+  if (created) await maybePush(deps, event.uid, notification);
+
+  return { created };
 }
 
 export interface DigestNotificationEvent {

--- a/apps/api/src/source-diff.test.ts
+++ b/apps/api/src/source-diff.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { diffLines, DIFF_LINE_CAP, summarizeSourceDiff } from './source-diff.js';
+
+describe('diffLines', () => {
+  it('counts added and removed lines through an LCS, not a length delta', () => {
+    // One line replaced in the middle: 1 in, 1 out — not "same length, no change".
+    expect(diffLines('a\nb\nc', 'a\nB\nc')).toEqual({ added: 1, removed: 1 });
+    expect(diffLines('a\nb', 'a\nb\nc')).toEqual({ added: 1, removed: 0 });
+    expect(diffLines('a\nb\nc', 'a\nc')).toEqual({ added: 0, removed: 1 });
+    expect(diffLines('same', 'same')).toEqual({ added: 0, removed: 0 });
+    // A reordering is a move: LCS keeps the longest run and charges the rest.
+    expect(diffLines('a\nb\nc', 'c\nb\na')).toEqual({ added: 2, removed: 2 });
+  });
+
+  it('treats an empty side as a whole-file add or remove', () => {
+    expect(diffLines('', 'a\nb')).toEqual({ added: 2, removed: 0 });
+    expect(diffLines('a\nb', '')).toEqual({ added: 0, removed: 2 });
+    expect(diffLines('', '')).toEqual({ added: 0, removed: 0 });
+  });
+
+  it('normalises CRLF so a line-ending change is not a whole-file rewrite', () => {
+    expect(diffLines('a\r\nb', 'a\nb')).toEqual({ added: 0, removed: 0 });
+  });
+
+  it('refuses to count a file past the cap rather than building a huge table', () => {
+    const huge = Array.from({ length: DIFF_LINE_CAP + 1 }, (_, i) => `line ${i}`).join('\n');
+    expect(diffLines(huge, 'a')).toBeNull();
+    expect(diffLines('a', huge)).toBeNull();
+  });
+});
+
+describe('summarizeSourceDiff', () => {
+  it('classifies adds, removes and edits, and drops identical files', () => {
+    const before = new Map([
+      ['game.ts', 'a\nb\nc'],
+      ['style.css', 'body {}'],
+      ['gone.ts', 'x\ny'],
+    ]);
+    const after = new Map([
+      ['game.ts', 'a\nB\nc'],
+      ['style.css', 'body {}'],
+      ['new.ts', 'fresh'],
+    ]);
+
+    const summary = summarizeSourceDiff(before, after);
+
+    // style.css is untouched and must not appear at all.
+    expect(summary.files.map((file) => file.path)).toEqual(['game.ts', 'gone.ts', 'new.ts']);
+    expect(summary.files).toEqual([
+      { path: 'game.ts', status: 'modified', added: 1, removed: 1 },
+      { path: 'gone.ts', status: 'removed', added: 0, removed: 2 },
+      { path: 'new.ts', status: 'added', added: 1, removed: 0 },
+    ]);
+    expect(summary).toMatchObject({ filesChanged: 3, added: 2, removed: 3, truncated: false });
+  });
+
+  it('reports totals as a floor when a file was too large to count', () => {
+    const huge = Array.from({ length: DIFF_LINE_CAP + 1 }, (_, i) => `line ${i}`).join('\n');
+    const summary = summarizeSourceDiff(new Map([['big.ts', huge]]), new Map([['big.ts', `${huge}\nmore`]]));
+
+    expect(summary.truncated).toBe(true);
+    expect(summary.files[0]).toEqual({ path: 'big.ts', status: 'modified', added: null, removed: null });
+  });
+
+  it('is empty for identical trees', () => {
+    const tree = new Map([['game.ts', 'a']]);
+    expect(summarizeSourceDiff(tree, new Map(tree))).toEqual({
+      files: [],
+      filesChanged: 0,
+      added: 0,
+      removed: 0,
+      truncated: false,
+    });
+  });
+});

--- a/apps/api/src/source-diff.ts
+++ b/apps/api/src/source-diff.ts
@@ -1,0 +1,100 @@
+/**
+ * Line counts between two versions of a game's sources — the review tab's footnote.
+ *
+ * Deliberately a summary and not a diff view. The whole point of the review surface is
+ * that a change to a game is judged by playing it, not by reading it; the numbers exist
+ * so "how big is this" has an answer, and they are the last thing on the page rather
+ * than the first. Nothing here reconstructs a patch, and nothing renders source.
+ */
+
+/**
+ * Files longer than this report as changed without counts.
+ *
+ * The LCS table below is O(n×m) in memory, which is fine for the few-hundred-line files
+ * a game is made of and is not fine for a generated asset blob that happens to live in
+ * `source/`. Past the cap the honest answer is "changed", not a number that cost a
+ * hundred megabytes to compute.
+ */
+export const DIFF_LINE_CAP = 4_000;
+
+export interface FileDiffStat {
+  path: string;
+  status: 'added' | 'removed' | 'modified';
+  /** Null when the file was too large to count — see {@link DIFF_LINE_CAP}. */
+  added: number | null;
+  removed: number | null;
+}
+
+export interface SourceDiffSummary {
+  files: FileDiffStat[];
+  filesChanged: number;
+  added: number;
+  removed: number;
+  /** True when at least one file was past the cap, so the totals are a floor. */
+  truncated: boolean;
+}
+
+/** Added/removed line counts for one file, via a plain LCS over lines. */
+export function diffLines(before: string, after: string): { added: number; removed: number } | null {
+  const a = splitLines(before);
+  const b = splitLines(after);
+  if (a.length > DIFF_LINE_CAP || b.length > DIFF_LINE_CAP) return null;
+
+  // Rolling two-row LCS: the length is all that is needed, never the path itself, so
+  // the full table would be memory spent on an answer nobody reads.
+  let previous = new Array<number>(b.length + 1).fill(0);
+  let current = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      current[j] = a[i - 1] === b[j - 1] ? previous[j - 1] + 1 : Math.max(previous[j], current[j - 1]);
+    }
+    [previous, current] = [current, previous];
+    current.fill(0);
+  }
+  const common = previous[b.length];
+  return { removed: a.length - common, added: b.length - common };
+}
+
+function splitLines(text: string): string[] {
+  if (text === '') return [];
+  return text.replace(/\r\n/g, '\n').split('\n');
+}
+
+/**
+ * Compares two source trees, keyed by path. A file present on one side only is an
+ * add or a remove; the rest are compared line by line, and identical files are dropped.
+ */
+export function summarizeSourceDiff(before: Map<string, string>, after: Map<string, string>): SourceDiffSummary {
+  const paths = [...new Set([...before.keys(), ...after.keys()])].sort();
+  const files: FileDiffStat[] = [];
+  let added = 0;
+  let removed = 0;
+  let truncated = false;
+
+  for (const path of paths) {
+    const left = before.get(path);
+    const right = after.get(path);
+    if (left === undefined && right !== undefined) {
+      const counts = diffLines('', right);
+      truncated ||= counts === null;
+      added += counts?.added ?? 0;
+      files.push({ path, status: 'added', added: counts?.added ?? null, removed: counts ? 0 : null });
+      continue;
+    }
+    if (left !== undefined && right === undefined) {
+      const counts = diffLines(left, '');
+      truncated ||= counts === null;
+      removed += counts?.removed ?? 0;
+      files.push({ path, status: 'removed', added: counts ? 0 : null, removed: counts?.removed ?? null });
+      continue;
+    }
+    if (left === right) continue;
+    const counts = diffLines(left ?? '', right ?? '');
+    truncated ||= counts === null;
+    added += counts?.added ?? 0;
+    removed += counts?.removed ?? 0;
+    files.push({ path, status: 'modified', added: counts?.added ?? null, removed: counts?.removed ?? null });
+  }
+
+  return { files, filesChanged: files.length, added, removed, truncated };
+}

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -63,6 +63,10 @@ describe('isKnownSpaShellPath', () => {
     '/admin/waitlist',
     '/join/K7M3QP',
     '/nightshift/neon-courier',
+    // The platform's namespace is reserved against claiming but is a real address:
+    // it is where every game with no creator to name lives.
+    '/gamedevpl/brick-storm',
+    '/gamedevpl/brick-storm/releases',
     '/nightshift/neon-courier/board',
     '/nightshift/neon-courier/review',
     '/nightshift/neon-courier/releases',

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -62,6 +62,11 @@ describe('isKnownSpaShellPath', () => {
     '/admin/tokens',
     '/admin/waitlist',
     '/join/K7M3QP',
+    '/nightshift/neon-courier',
+    '/nightshift/neon-courier/board',
+    '/nightshift/neon-courier/review',
+    '/nightshift/neon-courier/releases',
+    '/nightshift/neon-courier/sources',
   ])('treats %s as a known shell path (HTTP 200)', (path) => {
     expect(isKnownSpaShellPath(path)).toBe(true);
   });
@@ -83,6 +88,12 @@ describe('isKnownSpaShellPath', () => {
     '/join/lower1',
     '/join/TOOLONG9',
     '/join/K7M3QP/extra',
+    // Game page: reserved first segments, bad slugs, and unknown tabs stay 404.
+    '/studio/neon-courier/releases/extra',
+    '/play/neon-courier/board',
+    '/nightshift/Neon%20Courier',
+    '/nightshift/neon-courier/nope',
+    '/nightshift/neon-courier/board/extra',
   ])('treats %s as unknown (HTTP 404)', (path) => {
     expect(isKnownSpaShellPath(path)).toBe(false);
   });

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -9,7 +9,7 @@
  * hash and never reaches the server (see docs/path-routing-plan.md § Join).
  */
 
-import { RESERVED_HANDLES } from './creator-profile.js';
+import { PLATFORM_HANDLE, RESERVED_HANDLES } from './creator-profile.js';
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
@@ -106,8 +106,12 @@ export function isKnownSpaShellPath(urlOrPath: string): boolean {
   if (CREATOR_ALIAS_PATTERN.test(pathname)) return true;
   if (ROOT_CREATOR_PATTERN.test(pathname)) return !RESERVED_HANDLES.has(pathname.slice(1));
 
+  // Reserved handles are not addresses — except the platform's own, which is where
+  // every game with no creator to name lives (creator-profile.ts PLATFORM_HANDLE).
   const gamePageMatch = pathname.match(GAME_PAGE_PATTERN);
-  if (gamePageMatch?.[1]) return !RESERVED_HANDLES.has(gamePageMatch[1]);
+  if (gamePageMatch?.[1]) {
+    return gamePageMatch[1] === PLATFORM_HANDLE || !RESERVED_HANDLES.has(gamePageMatch[1]);
+  }
 
   return false;
 }

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -20,6 +20,14 @@ const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
 const CREATOR_ALIAS_PATTERN = /^\/creators\/([a-z][a-z0-9_]{2,23})$/;
 const ROOT_CREATOR_PATTERN = /^\/([a-z][a-z0-9_]{2,23})$/;
 /**
+ * Public game page: `/:handle/:slug` with an optional tab segment — keep the tab
+ * vocabulary aligned with `GAME_PAGE_TABS` in apps/web/src/router.ts. The first
+ * segment shares the creator-handle grammar (and the reserved-handle check below),
+ * so `/play/x`, `/studio/x` etc. never reach this shape.
+ */
+const GAME_PAGE_PATTERN =
+  /^\/([a-z][a-z0-9_]{2,23})\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\/(?:board|review|releases|sources))?$/;
+/**
  * `/studio`, `/studio/:token`, `/studio/:token/:tab` — keep aligned with
  * `STUDIO_TAB_ALIASES` in apps/web/src/router.ts.
  *
@@ -97,6 +105,9 @@ export function isKnownSpaShellPath(urlOrPath: string): boolean {
 
   if (CREATOR_ALIAS_PATTERN.test(pathname)) return true;
   if (ROOT_CREATOR_PATTERN.test(pathname)) return !RESERVED_HANDLES.has(pathname.slice(1));
+
+  const gamePageMatch = pathname.match(GAME_PAGE_PATTERN);
+  if (gamePageMatch?.[1]) return !RESERVED_HANDLES.has(gamePageMatch[1]);
 
   return false;
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -848,6 +848,13 @@ export type NotificationType =
    */
   | 'creator.digest'
   /**
+   * A game someone follows published a new version. The one notification the follow
+   * button exists to send, and the reason it is a follow rather than a bookmark:
+   * "the game you played got better" is worth an interruption, and nothing else about
+   * a game someone else owns is.
+   */
+  | 'game.new_version'
+  /**
    * The operator's own queue, delivered instead of waited on
    * (`operator-alerts.ts`). These do not go to the creator: they go to every uid in
    * ADMIN_UIDS, because the thing being reported — a build waiting on the publish
@@ -1841,6 +1848,23 @@ export interface Store {
   castVote(slug: string, uid: string, value: VoteValue): Promise<GameVoteCounts>;
   /** Removes a user's vote. Returns the game's updated aggregate counts. */
   clearVote(slug: string, uid: string): Promise<GameVoteCounts>;
+  /**
+   * Follow / unfollow a game. Stored as `games/{slug}/followers/{uid}` beside votes,
+   * with the count denormalised onto the game document the same way vote tallies are —
+   * a follower count is read on every page view and must not cost a subcollection scan.
+   */
+  setGameFollow(slug: string, uid: string, at: string): Promise<number>;
+  clearGameFollow(slug: string, uid: string): Promise<number>;
+  isFollowingGame(slug: string, uid: string): Promise<boolean>;
+  countGameFollowers(slug: string): Promise<number>;
+  /**
+   * The uids to notify when a game publishes, newest follower first.
+   *
+   * Bounded rather than complete: fanout is best-effort courtesy beside a publish, and
+   * a game with more followers than the cap is a good problem that must not turn one
+   * operator click into an unbounded write burst.
+   */
+  listGameFollowers(slug: string, opts?: { limit?: number }): Promise<string[]>;
   /** A game's aggregate vote counts — the public read, no uid involved. */
   getVoteCounts(slug: string): Promise<GameVoteCounts>;
   /** One player's save for one game, or null if they have none. */
@@ -2236,6 +2260,8 @@ export class InMemoryStore implements Store {
   private pushSubs = new Map<string, Map<string, PushSubscriptionRecord>>();
   // slug -> (uid -> value)
   private votes = new Map<string, Map<string, VoteValue>>();
+  /** slug → uid → followedAt. Mirrors `games/{slug}/followers/{uid}` in Firestore. */
+  private follows = new Map<string, Map<string, string>>();
   // slug -> feedback rows, newest last (reversed on read)
   private playerFeedback = new Map<string, PlayerFeedbackRecord[]>();
   // uid -> (slug -> saved progress)
@@ -3392,6 +3418,36 @@ export class InMemoryStore implements Store {
     return this.voteCounts(slug);
   }
 
+  async setGameFollow(slug: string, uid: string, at: string): Promise<number> {
+    const forGame = this.follows.get(slug) ?? new Map<string, string>();
+    if (!forGame.has(uid)) forGame.set(uid, at);
+    this.follows.set(slug, forGame);
+    return forGame.size;
+  }
+
+  async clearGameFollow(slug: string, uid: string): Promise<number> {
+    const forGame = this.follows.get(slug);
+    forGame?.delete(uid);
+    return forGame?.size ?? 0;
+  }
+
+  async isFollowingGame(slug: string, uid: string): Promise<boolean> {
+    return this.follows.get(slug)?.has(uid) ?? false;
+  }
+
+  async countGameFollowers(slug: string): Promise<number> {
+    return this.follows.get(slug)?.size ?? 0;
+  }
+
+  async listGameFollowers(slug: string, opts?: { limit?: number }): Promise<string[]> {
+    const forGame = this.follows.get(slug);
+    if (!forGame) return [];
+    const sorted = Array.from(forGame.entries())
+      .sort((a, b) => b[1].localeCompare(a[1]))
+      .map(([uid]) => uid);
+    return opts?.limit ? sorted.slice(0, opts.limit) : sorted;
+  }
+
   async getGameSave(uid: string, slug: string): Promise<GameSaveRecord | null> {
     const found = this.gameSaves.get(uid)?.get(slug);
     return found ? { ...found } : null;
@@ -3661,6 +3717,7 @@ export class InMemoryStore implements Store {
     return [
       ...new Set([
         ...this.votes.keys(),
+        ...this.follows.keys(),
         ...this.playerFeedback.keys(),
         ...this.scorecards.keys(),
         ...this.suggestions.keys(),
@@ -5509,6 +5566,10 @@ export class FirestoreStore implements Store {
     return this.gameRef(slug).collection('playerFeedback');
   }
 
+  private followerRef(slug: string, uid: string) {
+    return this.gameRef(slug).collection('followers').doc(uid);
+  }
+
   private static readVoteCounts(data: DocumentData | undefined): GameVoteCounts {
     return { up: (data?.votesUp as number | undefined) ?? 0, down: (data?.votesDown as number | undefined) ?? 0 };
   }
@@ -5554,6 +5615,53 @@ export class FirestoreStore implements Store {
       transaction.set(gameRef, { votesUp: counts.up, votesDown: counts.down }, { merge: true });
       return counts;
     });
+  }
+
+  async setGameFollow(slug: string, uid: string, at: string): Promise<number> {
+    const gameRef = this.gameRef(slug);
+    const followerRef = this.followerRef(slug, uid);
+    return await this.db.runTransaction(async (transaction) => {
+      const gameSnap = await transaction.get(gameRef);
+      const followerSnap = await transaction.get(followerRef);
+      const count = (gameSnap.data()?.followers as number | undefined) ?? 0;
+      // Following twice is not two followers — only a genuine change moves the tally.
+      if (followerSnap.exists) return count;
+      transaction.set(followerRef, { followedAt: at });
+      transaction.set(gameRef, { followers: count + 1 }, { merge: true });
+      return count + 1;
+    });
+  }
+
+  async clearGameFollow(slug: string, uid: string): Promise<number> {
+    const gameRef = this.gameRef(slug);
+    const followerRef = this.followerRef(slug, uid);
+    return await this.db.runTransaction(async (transaction) => {
+      const gameSnap = await transaction.get(gameRef);
+      const followerSnap = await transaction.get(followerRef);
+      const count = (gameSnap.data()?.followers as number | undefined) ?? 0;
+      if (!followerSnap.exists) return count;
+      const next = Math.max(0, count - 1);
+      transaction.delete(followerRef);
+      transaction.set(gameRef, { followers: next }, { merge: true });
+      return next;
+    });
+  }
+
+  async isFollowingGame(slug: string, uid: string): Promise<boolean> {
+    const snap = await this.followerRef(slug, uid).get();
+    return snap.exists;
+  }
+
+  async countGameFollowers(slug: string): Promise<number> {
+    const snap = await this.gameRef(slug).get();
+    return (snap.data()?.followers as number | undefined) ?? 0;
+  }
+
+  async listGameFollowers(slug: string, opts?: { limit?: number }): Promise<string[]> {
+    let query = this.gameRef(slug).collection('followers').orderBy('followedAt', 'desc');
+    if (opts?.limit) query = query.limit(opts.limit);
+    const snap = await query.get();
+    return snap.docs.map((doc) => doc.id);
   }
 
   async getVoteCounts(slug: string): Promise<GameVoteCounts> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -354,6 +354,13 @@ export interface SubmissionRecord {
    * Empty when the creator skipped the panel or it had nothing to ask.
    */
   qa?: string[];
+  /**
+   * The creator's sign-off on a delivered candidate they played side by side with what
+   * is live (game-review-routes.ts). Advisory to the operator who publishes: it says the
+   * person who asked for the change has already accepted it. Never a publish itself, and
+   * never consulted as permission to become one.
+   */
+  reviewApproval?: ReviewApproval;
 }
 
 /**
@@ -1230,6 +1237,18 @@ export interface SuggestionRecord {
   updatedAt: string;
 }
 
+/**
+ * The creator's verdict after playing a delivered candidate side by side with what is
+ * live. Advisory to the operator who publishes; never a publish in itself.
+ */
+export interface ReviewApproval {
+  /** The version the creator played and accepted — not "the latest", which can move. */
+  version: string;
+  at: string;
+  /** The uid that signed off, so an approval is attributable rather than ambient. */
+  by: string;
+}
+
 export type WaitlistStatus = 'pending' | 'approved' | 'rejected';
 
 export interface WaitlistEntry {
@@ -1545,6 +1564,17 @@ export interface Store {
   setSubmissionPublishedAt(issueNumber: number, at: string): Promise<void>;
   /** Marks a submission abandoned by its creator. */
   setSubmissionAbandoned(issueNumber: number, at: string): Promise<void>;
+  /**
+   * Records that the creator played the candidate and signed off on it.
+   *
+   * Explicitly **not** a publish. Publishing stays the operator action it is
+   * (job-admin-routes.ts): the gate answers "does this run", a human answers "may this
+   * be on the site", and the second question is the moderation boundary the DSA and the
+   * AI Act care about. This records the *other* human's answer — the one who asked for
+   * the change and just played it — so an operator publishing sees that the creator has
+   * already accepted it rather than guessing.
+   */
+  setSubmissionReviewApproval(issueNumber: number, approval: ReviewApproval): Promise<void>;
   /** Turns the creator's shared draft link on (a timestamp) or off (null). */
   setDraftShared(issueNumber: number, at: string | null): Promise<void>;
   /**
@@ -2752,6 +2782,11 @@ export class InMemoryStore implements Store {
   async setSubmissionPreviewVersion(issueNumber: number, version: string): Promise<void> {
     const sub = this.submissions.get(issueNumber);
     if (sub) this.submissions.set(issueNumber, { ...sub, previewVersion: version });
+  }
+
+  async setSubmissionReviewApproval(issueNumber: number, approval: ReviewApproval): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (sub) this.submissions.set(issueNumber, { ...sub, reviewApproval: structuredClone(approval) });
   }
 
   async recordDeliveryNudge(issueNumber: number): Promise<number> {
@@ -4707,6 +4742,10 @@ export class FirestoreStore implements Store {
 
   async setSubmissionPreviewVersion(issueNumber: number, version: string): Promise<void> {
     await this.db.collection('submissions').doc(String(issueNumber)).set({ previewVersion: version }, { merge: true });
+  }
+
+  async setSubmissionReviewApproval(issueNumber: number, approval: ReviewApproval): Promise<void> {
+    await this.db.collection('submissions').doc(String(issueNumber)).set({ reviewApproval: approval }, { merge: true });
   }
 
   async recordDeliveryNudge(issueNumber: number): Promise<number> {

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -462,6 +462,15 @@ export interface SubmissionRoutesHandle {
    */
   getRepoPublishedCatalogEntry: (slug: string) => Promise<CatalogGameEntry | null>;
   /**
+   * The notification fan-out dependencies (mailer, base URL, unsubscribe secret) as
+   * this module resolved them.
+   *
+   * Exposed so a second emitter — the follower fan-out on publish — reaches the same
+   * mailer and the same unsubscribe secret rather than re-deriving them from env. Two
+   * derivations is two places for "respect the unsubscribe" to drift apart.
+   */
+  buildNotifyDeps: () => EmitDeps;
+  /**
    * Starts a post-publish improvement round, choosing job dispatch or a legacy issue.
    *
    * Exported rather than reimplemented so the suggestion inbox and the creator's own
@@ -1160,7 +1169,10 @@ export async function registerSubmissionRoutes(
    * chose to type them in; translating those would hand them back a paraphrase of their
    * own request, which is the bug the `origin` field exists to prevent.
    */
-  async function relayedMessageLocalization(origin: 'agent' | 'creator' | undefined, text: string): Promise<IntakeText> {
+  async function relayedMessageLocalization(
+    origin: 'agent' | 'creator' | undefined,
+    text: string,
+  ): Promise<IntakeText> {
     // A creator's own words are stored exactly as typed, in whatever language they chose.
     // Normalizing those would rewrite someone's own request back at them.
     if (origin !== 'agent') return { text };
@@ -4597,5 +4609,6 @@ export async function registerSubmissionRoutes(
     getRepoPublishedCatalogEntry: (slug) =>
       githubClient ? getPublishedCatalogEntry(githubClient, slug) : Promise.resolve(null),
     startImprovementRound,
+    buildNotifyDeps,
   };
 }

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -39,7 +39,18 @@ const MAX_BACKDATE_MS = 6 * 60 * 60 * 1000;
 const MAX_TRACKED_VISITS = 5000;
 const MAX_TRACKED_IPS = 20_000;
 
-const RouteKindSchema = z.enum(['home', 'play', 'draft', 'status', 'join', 'legal', 'health', 'studio', 'notFound']);
+const RouteKindSchema = z.enum([
+  'home',
+  'play',
+  'draft',
+  'status',
+  'join',
+  'legal',
+  'health',
+  'studio',
+  'game',
+  'notFound',
+]);
 /**
  * Creation-funnel steps. A closed enum rather than a free string, for the same reason
  * every other field here is bounded: this reaches a grouping key, and the endpoint is

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import type { PublicCreatorProfile } from './creatorProfileApi.js';
 import { LegalPage } from './LegalPage.js';
 import { ContactPage } from './ContactPage.js';
 import { CreatorProfilePage } from './CreatorProfilePage.js';
+import { GamePage } from './GamePage.js';
 import { NotFoundPage } from './NotFoundPage.js';
 import { AppUpdateBanner } from './AppUpdateBanner.js';
 import { InstallPrompt } from './InstallPrompt.js';
@@ -145,6 +146,7 @@ export function App() {
   const [draftTitle, setDraftTitle] = useState<string | null>(null);
   /** Display name for `/:handle` once the public profile loads. */
   const [creatorName, setCreatorName] = useState<string | null>(null);
+  const [gameTitle, setGameTitle] = useState<string | null>(null);
 
   // Tab title follows the route (and any known game/submission/draft name). App is
   // the single writer — children report names upward rather than touching document.title.
@@ -177,16 +179,18 @@ export function App() {
         draftNamed: t('pageTitle.draftNamed'),
         studioNamed: t('pageTitle.studioNamed'),
         creatorNamed: t('pageTitle.creatorNamed'),
+        gameNamed: t('pageTitle.gameNamed'),
       },
       playTitle,
       studioTitle,
       draftTitle: route.view === 'draft' ? draftTitle : null,
       creatorName: route.view === 'creator' ? creatorName : null,
+      gameTitle: route.view === 'game' ? gameTitle : null,
       // Only surface ephemeral theaters while still on home — `/play/<slug>` already
       // carries its own title via playTitle, and leaving home must restore the home title.
       stageTitle: route.view === 'home' ? stageTitle : null,
     });
-  }, [route, stageContent, catalogEntries, savedSpecs, draftTitle, creatorName, t]);
+  }, [route, stageContent, catalogEntries, savedSpecs, draftTitle, creatorName, gameTitle, t]);
 
   useDocumentTitle(documentTitle);
 
@@ -196,6 +200,12 @@ export function App() {
   useEffect(() => {
     setCreatorName(null);
   }, [creatorRouteHandle]);
+
+  // Same for the game page: title falls back to the humanized slug between games.
+  const gameRouteSlug = route.view === 'game' ? route.slug : null;
+  useEffect(() => {
+    setGameTitle(null);
+  }, [gameRouteSlug]);
 
   useEffect(() => {
     // popstate covers back/forward (and path changes via history API). hashchange
@@ -870,6 +880,37 @@ export function App() {
                 navigate(creatorPath(profile.handle), { replace: true });
               }
             }}
+          />
+        </main>
+        <SiteFooter />
+      </div>
+    );
+  }
+
+  // Public game page — the "repo page" nested under the creator profile. Same
+  // open-chrome posture as the profile: the page renders for anonymous visitors,
+  // and the frame pane inside it is what stays gated during closed beta.
+  if (route.view === 'game') {
+    return (
+      <div className="app app--game">
+        <NavHeader
+          activeBuildCount={activeBuildCount}
+          onNavigate={handleNavigateSection}
+          onHome={() => navigate('/')}
+          onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
+          upTarget={headerUp}
+          onUp={navigate}
+        />
+        <main className="content">
+          <GamePage
+            key={`${route.handle}/${route.slug}`}
+            handle={route.handle}
+            slug={route.slug}
+            tab={route.tab}
+            onNavigate={navigate}
+            onCanonicalPath={(path) => navigate(path, { replace: true })}
+            onGameLoaded={setGameTitle}
           />
         </main>
         <SiteFooter />

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -26,7 +26,7 @@ import {
 import { MascotMoment } from './Mascot.js';
 import { PixelIcon } from './PixelIcon.js';
 import { getRecentPlays } from './recentPlays.js';
-import { creatorPath } from './router.js';
+import { creatorPath, gamePath } from './router.js';
 import {
   fetchCatalogSortSignals,
   readCachedCatalogSortPayload,
@@ -450,6 +450,14 @@ function CatalogCard({
             <button className="primary-btn" onClick={() => onPlayGame(entry)}>
               <PixelIcon name="play" size={13} /> {t('catalog.play')}
             </button>
+            {/* Play stays the card's job — this is the way to the game's page, and it
+                only exists for games that resolve to a creator (platform games have no
+                address in the `/:handle/` namespace). */}
+            {entry.creatorHandle ? (
+              <a className="secondary-btn card-about-link" href={gamePath(entry.creatorHandle, entry.slug)}>
+                {t('catalog.about')}
+              </a>
+            ) : null}
             {entry.multiplayer && (
               <button className="secondary-btn party-btn" onClick={() => onPlayTogether(entry)}>
                 <PixelIcon name="phone" size={13} /> {t('party.playTogether')}

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
-import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
+import { catalogMediaUrl, gamePageHandle, isPlatformAuthor, type CatalogEntry } from './catalog.js';
 import {
   applyCatalogFilters,
   CATALOG_SORT_MODES,
@@ -450,14 +450,12 @@ function CatalogCard({
             <button className="primary-btn" onClick={() => onPlayGame(entry)}>
               <PixelIcon name="play" size={13} /> {t('catalog.play')}
             </button>
-            {/* Play stays the card's job — this is the way to the game's page, and it
-                only exists for games that resolve to a creator (platform games have no
-                address in the `/:handle/` namespace). */}
-            {entry.creatorHandle ? (
-              <a className="secondary-btn card-about-link" href={gamePath(entry.creatorHandle, entry.slug)}>
-                {t('catalog.about')}
-              </a>
-            ) : null}
+            {/* Play stays the card's job — this is the way to the game's page. Every
+                published game has one: a game with no creator to name lives under the
+                platform handle rather than having no address at all. */}
+            <a className="secondary-btn card-about-link" href={gamePath(gamePageHandle(entry), entry.slug)}>
+              {t('catalog.about')}
+            </a>
             {entry.multiplayer && (
               <button className="secondary-btn party-btn" onClick={() => onPlayTogether(entry)}>
                 <PixelIcon name="phone" size={13} /> {t('party.playTogether')}

--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -150,6 +150,24 @@ describe('CreatorProfilePage owner edit', () => {
     );
   });
 
+  it('sends both the title and the meta link to the game page, for anyone', async () => {
+    // The profile is the game page's strongest entry point: everything listed here has
+    // a handle by construction, so the address always resolves.
+    authUser = null;
+    fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
+
+    await renderPage();
+
+    const links = Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href="/ada/sky-dodge"]'));
+    expect(links.length).toBe(2);
+    expect(container.querySelector('.creator-profile-game-title a')?.textContent).toBe('Sky Dodge');
+    expect(links.some((link) => link.textContent?.includes('Game page'))).toBe(true);
+    // Play still goes straight to the theater — the card did not lose its job.
+    expect(
+      Array.from(container.querySelectorAll('button')).some((button) => button.textContent?.includes('Play')),
+    ).toBe(true);
+  });
+
   it('keeps per-game Studio links private to the owner', async () => {
     authUser = { uid: 'g:other', handle: 'bob' };
     fetchCreatorPage.mockResolvedValue(creatorPageWithGame());

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -5,7 +5,7 @@ import { catalogMediaUrl, isPlatformAuthor, normalizeCatalogEntry, type CatalogE
 import { fetchCreatorPage, type PublicCreatorProfile } from './creatorProfileApi.js';
 import { EditProfileModal } from './EditProfileModal.js';
 import { PixelIcon } from './PixelIcon.js';
-import { creatorPath, playPath, studioPath } from './router.js';
+import { creatorPath, gamePath, studioPath } from './router.js';
 import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 
 /**
@@ -72,6 +72,15 @@ export function CreatorProfilePage({
   }, [profile, onProfileLoaded]);
 
   const letter = (profile?.profileName || handle).charAt(0).toUpperCase();
+
+  /** In-app navigation for links that must still be real, copyable hrefs. */
+  const interceptTo = useCallback(
+    (path: string) => (event: { preventDefault: () => void }) => {
+      event.preventDefault();
+      onNavigate?.(path);
+    },
+    [onNavigate],
+  );
 
   return (
     <article className="creator-profile-page">
@@ -140,14 +149,24 @@ export function CreatorProfilePage({
                       <span className="creator-profile-game-thumb creator-profile-game-thumb--empty" aria-hidden />
                     )}
                     <div className="creator-profile-game-meta">
-                      <h3 className="creator-profile-game-title">{game.title}</h3>
+                      <h3 className="creator-profile-game-title">
+                        {/* Everything listed here has a handle by construction, so the
+                            game page always resolves — the title is its natural door. */}
+                        <a href={gamePath(handle, game.slug)} onClick={interceptTo(gamePath(handle, game.slug))}>
+                          {game.title}
+                        </a>
+                      </h3>
                       <p className="creator-profile-game-by">{t('player.byAuthor', { author })}</p>
                       <div className="creator-profile-game-actions">
                         <button type="button" className="primary-btn" onClick={() => onPlay(game.slug)}>
                           <PixelIcon name="play" size={13} /> {t('catalog.play')}
                         </button>
-                        <a className="creator-profile-game-link" href={playPath(game.slug)}>
-                          {t('creatorProfile.openPermalink')}
+                        <a
+                          className="creator-profile-game-link"
+                          href={gamePath(handle, game.slug)}
+                          onClick={interceptTo(gamePath(handle, game.slug))}
+                        >
+                          {t('creatorProfile.openGamePage')}
                         </a>
                         {isOwner ? (
                           <a className="creator-profile-game-link" href={studioPath(game.slug)}>

--- a/apps/web/src/GameBoard.test.tsx
+++ b/apps/web/src/GameBoard.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import type { GameBoard as GameBoardData } from './gameBoardApi.js';
+
+const fetchGameBoard = vi.fn();
+const assignTaskToAgent = vi.fn();
+
+vi.mock('./gameBoardApi.js', () => ({
+  fetchGameBoard: (...args: unknown[]) => fetchGameBoard(...args),
+  assignTaskToAgent: (...args: unknown[]) => assignTaskToAgent(...args),
+}));
+
+import { GameBoard } from './GameBoard.js';
+
+function boardData(overrides: Partial<GameBoardData> = {}): GameBoardData {
+  return {
+    open: [],
+    building: [
+      { title: 'Improve Neon Courier', state: 'building', since: '2026-08-04T10:00:00.000Z', agentOpened: true },
+    ],
+    review: [{ title: 'Touch controls on phones', state: 'ready_for_review', since: '2026-08-04T12:00:00.000Z' }],
+    released: [{ title: 'Neon Courier', state: 'published', since: '2026-08-01T12:00:00.000Z' }],
+    openVisibility: 'private',
+    viewerIsOwner: false,
+    ...overrides,
+  };
+}
+
+function ownerBoard(): GameBoardData {
+  return boardData({
+    open: [
+      {
+        id: 'sug-1',
+        taskClass: 'defect',
+        priority: 8,
+        findings: ['Crashes for 12% of sessions', 'Worst on phones'],
+        createdAt: '2026-08-04T01:00:00.000Z',
+      },
+    ],
+    openVisibility: 'owner',
+    viewerIsOwner: true,
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  fetchGameBoard.mockReset();
+  assignTaskToAgent.mockReset();
+  fetchGameBoard.mockResolvedValue(boardData());
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+async function renderBoard() {
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(GameBoard, { slug: 'neon-courier' }));
+  });
+  await act(async () => {
+    await fetchGameBoard.mock.results[0]?.value.catch(() => {});
+    await Promise.resolve();
+  });
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(label));
+}
+
+describe('GameBoard', () => {
+  it('renders the four columns from live work, and explains the private one', async () => {
+    await renderBoard();
+
+    const headings = Array.from(container.querySelectorAll('.game-board-column-heading')).map((h) =>
+      h.textContent?.replace(/\s+/g, ' ').trim(),
+    );
+    expect(headings).toEqual(['Up for grabs 0', 'Building 1', 'To play 1', 'Released 1']);
+    expect(container.textContent).toContain('Improve Neon Courier');
+    expect(container.textContent).toContain('Touch controls on phones');
+    // A visitor is told the column is private rather than shown an empty box.
+    expect(container.textContent).toContain('Open tasks are private');
+    // The agent-opened round is bylined as such.
+    expect(container.textContent).toContain('agent');
+    expect(findButton('Hand to the agent')).toBeUndefined();
+  });
+
+  it('shows open tasks to the owner and hands one to the agent', async () => {
+    fetchGameBoard.mockResolvedValue(ownerBoard());
+    assignTaskToAgent.mockResolvedValue(undefined);
+    await renderBoard();
+
+    expect(container.textContent).toContain('Crashes for 12% of sessions');
+    expect(container.textContent).toContain('Worst on phones');
+    expect(container.textContent).toContain('bug');
+
+    const assign = findButton('Hand to the agent');
+    expect(assign).toBeDefined();
+    await act(async () => {
+      assign!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(assignTaskToAgent).toHaveBeenCalledWith('sug-1');
+    // The board re-reads rather than patching: the task moves columns server-side.
+    expect(fetchGameBoard).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the quota refusal in the creator’s own words', async () => {
+    fetchGameBoard.mockResolvedValue(ownerBoard());
+    assignTaskToAgent.mockRejectedValue(Object.assign(new Error('quota_exceeded'), { code: 'quota_exceeded' }));
+    await renderBoard();
+
+    await act(async () => {
+      findButton('Hand to the agent')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('Daily improvement limit reached');
+  });
+
+  it('reports a failed load instead of rendering empty columns', async () => {
+    fetchGameBoard.mockRejectedValue(new Error('boom'));
+    await renderBoard();
+
+    expect(container.textContent).toContain('Could not load the board');
+    expect(container.querySelector('.game-board-columns')).toBeNull();
+  });
+});

--- a/apps/web/src/GameBoard.tsx
+++ b/apps/web/src/GameBoard.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  assignTaskToAgent,
+  fetchGameBoard,
+  type BoardOpenTask,
+  type BoardWorkItem,
+  type GameBoard as GameBoardData,
+} from './gameBoardApi.js';
+import { PixelIcon } from './PixelIcon.js';
+
+/**
+ * The task board — four columns, and nothing else.
+ *
+ * No epics, estimates, sprints or custom fields: each of those pulls the board
+ * toward a project tracker, and a tracker is what a hobbyist closes after half a
+ * minute (ops `docs/game-page-plan.md`). The columns are a projection of work that
+ * already exists — the job state machine — rather than a second place work is
+ * recorded.
+ *
+ * Handing a task to the agent is the only automation here, it is the owner's to
+ * press, and it goes through the suggestion inbox's approval endpoint so the quota
+ * and the attribution stay where they already live.
+ */
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+export function GameBoard({ slug }: { slug: string }) {
+  const { t, i18n } = useTranslation();
+  const [board, setBoard] = useState<GameBoardData | null>(null);
+  const [state, setState] = useState<LoadState>('loading');
+  const [assigning, setAssigning] = useState<string | null>(null);
+  const [assignError, setAssignError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    let cancelled = false;
+    setState('loading');
+    void fetchGameBoard(slug)
+      .then((loaded) => {
+        if (cancelled) return;
+        setBoard(loaded);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  useEffect(() => load(), [load]);
+
+  const assign = useCallback(
+    async (id: string) => {
+      setAssigning(id);
+      setAssignError(null);
+      try {
+        await assignTaskToAgent(id);
+        // Re-read rather than patch: the task leaves the open column and a new job
+        // appears in Building, and the server is the one that knows both.
+        load();
+      } catch (err) {
+        const code = (err as { code?: string }).code ?? 'unknown';
+        setAssignError(code);
+      } finally {
+        setAssigning(null);
+      }
+    },
+    [load],
+  );
+
+  if (state === 'loading') return <p className="game-page-status">{t('gamePage.board.loading')}</p>;
+  if (state === 'error' || !board) {
+    return <p className="game-page-status game-page-error">{t('gamePage.board.error')}</p>;
+  }
+
+  return (
+    <section className="game-board" aria-label={t('gamePage.tabs.board')}>
+      {assignError ? (
+        <p className="game-board-error" role="alert">
+          {t(`gamePage.board.assignError.${assignError}`, { defaultValue: t('gamePage.board.assignError.unknown') })}
+        </p>
+      ) : null}
+
+      <div className="game-board-columns">
+        <BoardColumn title={t('gamePage.board.columns.open')} count={board.open.length}>
+          {board.openVisibility === 'private' ? (
+            <p className="game-board-empty">{t('gamePage.board.openPrivate')}</p>
+          ) : board.open.length === 0 ? (
+            <p className="game-board-empty">{t('gamePage.board.openEmpty')}</p>
+          ) : (
+            board.open.map((task) => (
+              <OpenTaskCard
+                key={task.id}
+                task={task}
+                busy={assigning === task.id}
+                onAssign={() => void assign(task.id)}
+              />
+            ))
+          )}
+        </BoardColumn>
+
+        <BoardColumn title={t('gamePage.board.columns.building')} count={board.building.length}>
+          {board.building.length === 0 ? (
+            <p className="game-board-empty">{t('gamePage.board.buildingEmpty')}</p>
+          ) : (
+            board.building.map((item, index) => (
+              <WorkCard key={item.jobId ?? index} item={item} language={i18n.language} />
+            ))
+          )}
+        </BoardColumn>
+
+        <BoardColumn title={t('gamePage.board.columns.review')} count={board.review.length}>
+          {board.review.length === 0 ? (
+            <p className="game-board-empty">{t('gamePage.board.reviewEmpty')}</p>
+          ) : (
+            board.review.map((item, index) => (
+              <WorkCard key={item.jobId ?? index} item={item} language={i18n.language} />
+            ))
+          )}
+        </BoardColumn>
+
+        <BoardColumn title={t('gamePage.board.columns.released')} count={board.released.length}>
+          {board.released.length === 0 ? (
+            <p className="game-board-empty">{t('gamePage.board.releasedEmpty')}</p>
+          ) : (
+            board.released.map((item, index) => (
+              <WorkCard key={item.jobId ?? index} item={item} language={i18n.language} />
+            ))
+          )}
+        </BoardColumn>
+      </div>
+
+      <p className="game-board-note">{t('gamePage.board.note')}</p>
+    </section>
+  );
+}
+
+function BoardColumn({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <section className="game-board-column">
+      <h3 className="game-board-column-heading">
+        {title} <span className="game-board-column-count">{count}</span>
+      </h3>
+      <div className="game-board-cards">{children}</div>
+    </section>
+  );
+}
+
+function OpenTaskCard({ task, busy, onAssign }: { task: BoardOpenTask; busy: boolean; onAssign: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <article className="game-board-card">
+      <p className="game-board-card-title">{task.findings[0] ?? t('gamePage.board.taskFallback')}</p>
+      {task.findings.slice(1).map((finding) => (
+        <p key={finding} className="game-board-card-detail">
+          {finding}
+        </p>
+      ))}
+      <div className="game-board-card-foot">
+        <span className={`game-board-class game-board-class--${task.taskClass}`}>
+          {t(`gamePage.board.class.${task.taskClass}`, { defaultValue: task.taskClass })}
+        </span>
+        <button type="button" className="secondary-btn game-board-assign" onClick={onAssign} disabled={busy}>
+          <PixelIcon name="bolt" size={12} /> {busy ? t('gamePage.board.assigning') : t('gamePage.board.assign')}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function WorkCard({ item, language }: { item: BoardWorkItem; language: string }) {
+  const { t } = useTranslation();
+  return (
+    <article className="game-board-card">
+      <p className="game-board-card-title">{item.title}</p>
+      <div className="game-board-card-foot">
+        <span className="game-board-card-by">
+          {item.agentOpened ? t('gamePage.board.byAgent') : t('gamePage.board.byCreator')}
+        </span>
+        <span className="game-board-card-when">{formatWhen(item.since, language)}</span>
+      </div>
+    </article>
+  );
+}
+
+function formatWhen(iso: string, language: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return '';
+  try {
+    return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(parsed);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -71,6 +71,7 @@ function pageData(overrides: Partial<GamePageData> = {}): GamePageData {
       avatarUrl: null,
       profileCreatedAt: '2026-07-01T00:00:00.000Z',
     },
+    platformAuthored: false,
     specMarkdown: '# Neon Courier\n\nDeliver packages before the last neon goes out.\n\n## Controls\n\n- arrows',
     modules: ['input', 'gameplay', 'gfx'],
     budget: { usedBytes: 147 * 1024, limitBytes: 252 * 1024 },
@@ -184,17 +185,26 @@ describe('GamePage', () => {
     expect(onCanonicalPath).toHaveBeenCalledWith('/nightshift/neon-courier');
   });
 
-  it('404s a game with no creator handle, pointing at the play permalink', async () => {
+  it('renders a platform-authored game under the platform handle, with no profile link', async () => {
+    // Most of the catalog predates creator profiles. Those games get a page too —
+    // the platform is named as the author instead of linking a profile that does
+    // not exist.
     fetchGamePage.mockResolvedValue(
       pageData({
-        entry: { ...pageData().entry, creatorHandle: null, submittedBy: 'gamedev-platform' },
+        entry: { ...pageData().entry, creatorHandle: 'gamedevpl', submittedBy: 'gamedev-platform' },
         creator: null,
+        platformAuthored: true,
       }),
     );
-    await renderPage();
+    await renderPage({ handle: 'gamedevpl' });
 
-    expect(container.textContent).toContain('This game page does not exist.');
-    expect(container.querySelector('a[href="/play/neon-courier"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('This game page does not exist.');
+    expect(container.textContent).toContain('Neon Courier');
+    // The breadcrumb goes to the catalog, not to a profile page that would 404.
+    expect(container.querySelector('a[href="/gamedevpl"]')).toBeNull();
+    expect(container.querySelector('.game-page-breadcrumb a')?.getAttribute('href')).toBe('/');
+    // The team panel names the platform rather than an absent creator.
+    expect(container.querySelector('.game-page-team')?.textContent).toContain('built here');
   });
 
   it('follows a game for a signed-in visitor and shows the count', async () => {

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import type { GamePage as GamePageData } from './gamePageApi.js';
+
+const fetchGamePage = vi.fn();
+let authUser: { uid: string; handle?: string } | null = null;
+let privateBeta = false;
+
+vi.mock('./gamePageApi.js', () => ({
+  fetchGamePage: (...args: unknown[]) => fetchGamePage(...args),
+}));
+
+vi.mock('./AuthContext.js', () => ({
+  useAuth: () => ({ user: authUser, privateBeta, refreshUser: vi.fn(), logout: vi.fn() }),
+}));
+
+// The frame fetches the playable document and records a play session on mount;
+// neither belongs in this test. The stub records mounts instead.
+const frameMounts = vi.fn();
+vi.mock('./PublishedGameFrame.js', () => ({
+  PublishedGameFrame: (props: { slug: string }) => {
+    frameMounts(props.slug);
+    return createElement('div', { 'data-testid': 'frame', 'data-slug': props.slug });
+  },
+}));
+
+vi.mock('./VoteWidget.js', () => ({
+  VoteWidget: () => createElement('div', { 'data-testid': 'votes' }),
+}));
+
+vi.mock('./AuthModal.js', () => ({
+  AuthModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? createElement('div', { 'data-testid': 'auth-modal' }) : null,
+}));
+
+import { GamePage } from './GamePage.js';
+
+function pageData(overrides: Partial<GamePageData> = {}): GamePageData {
+  return {
+    entry: {
+      slug: 'neon-courier',
+      title: 'Neon Courier',
+      genre: 'arcade',
+      controls: 'arrows',
+      status: 'published',
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: 'any',
+      touch: null,
+      submittedBy: 'nightshift',
+      creatorHandle: 'nightshift',
+    },
+    creator: {
+      handle: 'nightshift',
+      profileName: 'Nocna Zmiana',
+      bio: '',
+      avatarUrl: null,
+      profileCreatedAt: '2026-07-01T00:00:00.000Z',
+    },
+    specMarkdown: '# Neon Courier\n\nDeliver packages before the last neon goes out.\n\n## Controls\n\n- arrows',
+    modules: ['input', 'gameplay', 'gfx'],
+    budget: { usedBytes: 147 * 1024, limitBytes: 252 * 1024 },
+    releases: [
+      { version: 'v3', createdAt: '2026-08-03T12:00:00.000Z', current: true, gateGreen: true },
+      { version: 'v1', createdAt: '2026-08-01T12:00:00.000Z', current: false, gateGreen: null },
+    ],
+    stats: { plays: 4812, medianPlaySeconds: 360, windowDays: 28 },
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  authUser = null;
+  privateBeta = false;
+  fetchGamePage.mockReset();
+  frameMounts.mockReset();
+  fetchGamePage.mockResolvedValue(pageData());
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+async function renderPage(props: Partial<Parameters<typeof GamePage>[0]> = {}) {
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(
+      createElement(GamePage, {
+        handle: 'nightshift',
+        slug: 'neon-courier',
+        onNavigate: vi.fn(),
+        ...props,
+      }),
+    );
+  });
+  await act(async () => {
+    await fetchGamePage.mock.results[0]?.value.catch(() => {});
+    await Promise.resolve();
+  });
+}
+
+describe('GamePage', () => {
+  it('renders header, playable frame, spec sidebar, modules and budget', async () => {
+    await renderPage();
+
+    expect(container.textContent).toContain('Neon Courier');
+    expect(container.textContent).toContain('Deliver packages before the last neon goes out.');
+    // The default tab mounts the game itself.
+    expect(container.querySelector('[data-testid="frame"]')?.getAttribute('data-slug')).toBe('neon-courier');
+    // Breadcrumb links to the owning studio.
+    expect(container.querySelector('a[href="/nightshift"]')).not.toBeNull();
+    // Sidebar facts.
+    expect(container.textContent).toContain('SPEC.md');
+    expect(container.textContent).toContain('gameplay');
+    expect(container.textContent).toContain('147 KiB of 252 KiB');
+    expect(container.textContent).toContain('4,812');
+    // Secondary tabs exist as real links.
+    expect(container.querySelector('a[href="/nightshift/neon-courier/releases"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/nightshift/neon-courier/board"]')).not.toBeNull();
+  });
+
+  it('lists releases on the releases tab and keeps the frame mounted', async () => {
+    await renderPage({ tab: 'releases' });
+
+    expect(container.textContent).toContain('v3');
+    expect(container.textContent).toContain('current');
+    expect(container.textContent).toContain('v1');
+    // Frame is lazy: never armed because the game tab was never active.
+    expect(container.querySelector('[data-testid="frame"]')).toBeNull();
+  });
+
+  it('gates the frame behind sign-in during closed beta but renders the page', async () => {
+    privateBeta = true;
+    await renderPage();
+
+    expect(container.querySelector('[data-testid="frame"]')).toBeNull();
+    expect(container.textContent).toContain('Playing is in closed beta');
+    // The page around the gate still renders for the anonymous visitor.
+    expect(container.textContent).toContain('Neon Courier');
+    expect(container.textContent).toContain('SPEC.md');
+
+    const cta = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Sign in'),
+    );
+    expect(cta).toBeDefined();
+    await act(async () => {
+      cta!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('[data-testid="auth-modal"]')).not.toBeNull();
+  });
+
+  it('replaces the URL when the handle is not the owning studio', async () => {
+    const onCanonicalPath = vi.fn();
+    await renderPage({ handle: 'somebody_else', onCanonicalPath });
+
+    expect(onCanonicalPath).toHaveBeenCalledWith('/nightshift/neon-courier');
+  });
+
+  it('404s a game with no creator handle, pointing at the play permalink', async () => {
+    fetchGamePage.mockResolvedValue(
+      pageData({
+        entry: { ...pageData().entry, creatorHandle: null, submittedBy: 'gamedev-platform' },
+        creator: null,
+      }),
+    );
+    await renderPage();
+
+    expect(container.textContent).toContain('This game page does not exist.');
+    expect(container.querySelector('a[href="/play/neon-courier"]')).not.toBeNull();
+  });
+
+  it('reports the loaded title upward for document.title', async () => {
+    const onGameLoaded = vi.fn();
+    await renderPage({ onGameLoaded });
+    expect(onGameLoaded).toHaveBeenCalledWith('Neon Courier');
+  });
+});

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -37,6 +37,13 @@ vi.mock('./AuthModal.js', () => ({
     isOpen ? createElement('div', { 'data-testid': 'auth-modal' }) : null,
 }));
 
+const fetchGameFollow = vi.fn();
+const setGameFollowApi = vi.fn();
+vi.mock('./gameFollowApi.js', () => ({
+  fetchGameFollow: (...args: unknown[]) => fetchGameFollow(...args),
+  setGameFollow: (...args: unknown[]) => setGameFollowApi(...args),
+}));
+
 import { GamePage } from './GamePage.js';
 
 function pageData(overrides: Partial<GamePageData> = {}): GamePageData {
@@ -86,7 +93,10 @@ beforeEach(async () => {
   privateBeta = false;
   fetchGamePage.mockReset();
   frameMounts.mockReset();
+  fetchGameFollow.mockReset();
+  setGameFollowApi.mockReset();
   fetchGamePage.mockResolvedValue(pageData());
+  fetchGameFollow.mockResolvedValue({ slug: 'neon-courier', followers: 12, following: false });
   container = document.createElement('div');
   document.body.appendChild(container);
 });
@@ -185,6 +195,48 @@ describe('GamePage', () => {
 
     expect(container.textContent).toContain('This game page does not exist.');
     expect(container.querySelector('a[href="/play/neon-courier"]')).not.toBeNull();
+  });
+
+  it('follows a game for a signed-in visitor and shows the count', async () => {
+    authUser = { uid: 'g:player' };
+    setGameFollowApi.mockResolvedValue({ slug: 'neon-courier', followers: 13, following: true });
+    await renderPage();
+
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent?.includes('Follow'),
+    );
+    expect(button?.textContent).toContain('12');
+    expect(button?.getAttribute('aria-pressed')).toBe('false');
+
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setGameFollowApi).toHaveBeenCalledWith('neon-courier', true);
+    const after = Array.from(container.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent?.includes('Following'),
+    );
+    expect(after?.getAttribute('aria-pressed')).toBe('true');
+    expect(after?.textContent).toContain('13');
+  });
+
+  it('invites a signed-out visitor to sign in rather than failing the follow', async () => {
+    authUser = null;
+    fetchGameFollow.mockResolvedValue({ slug: 'neon-courier', followers: 4, following: null });
+    await renderPage();
+
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent?.includes('Follow'),
+    );
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(setGameFollowApi).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="auth-modal"]')).not.toBeNull();
   });
 
   it('reports the loaded title upward for document.title', async () => {

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -22,9 +22,11 @@ import { VoteWidget } from './VoteWidget.js';
  * beta-wall-exempt block in App.tsx); during closed beta only *playing* is gated,
  * so the frame pane swaps for a sign-in card while everything around it renders.
  *
- * Board / review / sources render as named-but-empty surfaces for now — their
- * tranches follow. Keeping the tabs present keeps the URL vocabulary stable
- * (router, spa-paths and this file move together).
+ * Each secondary tab is its own component with its own access posture, which is why
+ * this file only routes to them: the board (GameBoard) is public with an owner-only
+ * column, the review (GameReview) is owner/operator only, and the sources
+ * (GameSources) are public. The URL vocabulary is shared with the router and the
+ * API's shell allowlist, so those three move together.
  */
 
 type LoadState = 'loading' | 'ready' | 'missing' | 'error';

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from './AuthContext.js';
+import { AuthModal } from './AuthModal.js';
+import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
+import { PixelIcon } from './PixelIcon.js';
+import { PublishedGameFrame } from './PublishedGameFrame.js';
+import { creatorPath, gamePath, playPath, type GamePageTab } from './router.js';
+import { parseSpecBlocks } from './specBlocks.js';
+import { SpecMarkdown } from './SpecMarkdown.js';
+import { VoteWidget } from './VoteWidget.js';
+
+/**
+ * Public game page — the "repo page" at `/:handle/:slug`.
+ *
+ * The layout borrows GitHub's repository page with one inversion: the default tab
+ * is the playable game, and sources come last. Reachable without a session (the
+ * beta-wall-exempt block in App.tsx); during closed beta only *playing* is gated,
+ * so the frame pane swaps for a sign-in card while everything around it renders.
+ *
+ * Board / review / sources render as named-but-empty surfaces for now — their
+ * tranches follow. Keeping the tabs present keeps the URL vocabulary stable
+ * (router, spa-paths and this file move together).
+ */
+
+type LoadState = 'loading' | 'ready' | 'missing' | 'error';
+
+/** Default surface (the playable game) — no URL segment, hence not a GamePageTab. */
+type ActiveTab = GamePageTab | 'game';
+
+export function GamePage({
+  handle,
+  slug,
+  tab,
+  onNavigate,
+  onCanonicalPath,
+  onGameLoaded,
+}: {
+  handle: string;
+  slug: string;
+  tab?: GamePageTab;
+  onNavigate: (path: string) => void;
+  /** Wrong-handle URLs resolve to the owning studio — App replaces, not pushes. */
+  onCanonicalPath?: (path: string) => void;
+  /** Lets App set document.title once the real game title is known. */
+  onGameLoaded?: (title: string) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const { user, privateBeta } = useAuth();
+  const [page, setPage] = useState<GamePageData | null>(null);
+  const [state, setState] = useState<LoadState>('loading');
+  const [authOpen, setAuthOpen] = useState(false);
+  const activeTab: ActiveTab = tab ?? 'game';
+  // The frame mounts on first visit to the Gra tab and then stays mounted (hidden
+  // by CSS on other tabs) so switching tabs never restarts a running game.
+  const [frameArmed, setFrameArmed] = useState(activeTab === 'game');
+
+  const playGated = privateBeta && !user;
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setPage(null);
+    void fetchGamePage(slug)
+      .then((loaded) => {
+        if (cancelled) return;
+        setPage(loaded);
+        setState('ready');
+      })
+      .catch((err: { code?: string }) => {
+        if (cancelled) return;
+        setState(err.code === 'not_found' ? 'missing' : 'error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  useEffect(() => {
+    if (activeTab === 'game') setFrameArmed(true);
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (page) onGameLoaded?.(page.entry.title);
+  }, [page, onGameLoaded]);
+
+  // The canonical address carries the owning studio's handle. A page with no
+  // creator handle has no address in this namespace — platform and repo games
+  // stay reachable at /play/<slug> only.
+  const canonicalHandle = page?.entry.creatorHandle ?? null;
+  useEffect(() => {
+    if (state !== 'ready' || !page) return;
+    if (!canonicalHandle) return;
+    if (canonicalHandle.toLowerCase() !== handle.toLowerCase()) {
+      onCanonicalPath?.(gamePath(canonicalHandle, slug, tab));
+    }
+  }, [state, page, canonicalHandle, handle, slug, tab, onCanonicalPath]);
+
+  const description = useMemo(() => {
+    if (!page?.specMarkdown) return null;
+    const firstParagraph = parseSpecBlocks(page.specMarkdown).find((block) => block.kind === 'paragraph');
+    return firstParagraph && firstParagraph.kind === 'paragraph' ? firstParagraph.text : null;
+  }, [page]);
+
+  if (state === 'loading') {
+    return <p className="game-page-status">{t('gamePage.loading')}</p>;
+  }
+  if (state === 'missing' || (state === 'ready' && !canonicalHandle)) {
+    return (
+      <div className="game-page-status">
+        <p>{t('gamePage.missing')}</p>
+        <p>
+          <a href={playPath(slug)} onClick={intercept(() => onNavigate(playPath(slug)))}>
+            {t('gamePage.missingPlayLink')}
+          </a>
+        </p>
+      </div>
+    );
+  }
+  if (state === 'error' || !page) {
+    return <p className="game-page-status game-page-error">{t('gamePage.error')}</p>;
+  }
+
+  const { entry, creator, releases, stats, modules, budget } = page;
+  const latestRelease = releases[0] ?? null;
+  const tabs: Array<{ id: ActiveTab; label: string; count?: number }> = [
+    { id: 'game', label: t('gamePage.tabs.game') },
+    { id: 'board', label: t('gamePage.tabs.board') },
+    { id: 'review', label: t('gamePage.tabs.review') },
+    { id: 'releases', label: t('gamePage.tabs.releases'), count: releases.length || undefined },
+    { id: 'sources', label: t('gamePage.tabs.sources') },
+  ];
+
+  return (
+    <article className="game-page">
+      <header className="game-page-header">
+        <nav className="game-page-breadcrumb" aria-label={t('gamePage.breadcrumbAria')}>
+          <a href={creatorPath(handle)} onClick={intercept(() => onNavigate(creatorPath(handle)))}>
+            {creator?.profileName ?? handle}
+          </a>
+          <span aria-hidden="true"> / </span>
+          <span className="game-page-breadcrumb-slug">{slug}</span>
+          {entry.genre ? <span className="game-page-genre-badge">{entry.genre}</span> : null}
+        </nav>
+        <h1 className="game-page-title">{entry.title}</h1>
+        {description ? <p className="game-page-description">{description}</p> : null}
+        <div className="game-page-actions">
+          <button type="button" className="primary-btn" onClick={() => onNavigate(playPath(slug))}>
+            <PixelIcon name="play" size={13} /> {t('gamePage.play')}
+          </button>
+          <button
+            type="button"
+            className="secondary-btn"
+            disabled
+            title={t('gamePage.followSoon')}
+            aria-label={`${t('gamePage.follow')} — ${t('gamePage.followSoon')}`}
+          >
+            <PixelIcon name="eye" size={13} /> {t('gamePage.follow')}
+          </button>
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={() => onNavigate(playPath(slug))}
+            title={t('gamePage.remixHint')}
+          >
+            <PixelIcon name="wrench" size={13} /> {t('gamePage.remix')}
+          </button>
+        </div>
+      </header>
+
+      <nav className="game-page-tabs" aria-label={t('gamePage.tabsAria')}>
+        {tabs.map(({ id, label, count }) => {
+          const path = id === 'game' ? gamePath(handle, slug) : gamePath(handle, slug, id);
+          return (
+            <a
+              key={id}
+              href={path}
+              className={`game-page-tab${activeTab === id ? ' is-active' : ''}`}
+              aria-current={activeTab === id ? 'page' : undefined}
+              onClick={intercept(() => onNavigate(path))}
+            >
+              {label}
+              {count !== undefined ? <span className="game-page-tab-count">{count}</span> : null}
+            </a>
+          );
+        })}
+      </nav>
+
+      <div className="game-page-layout">
+        <main className="game-page-main">
+          {frameArmed && !playGated ? (
+            <section className={`game-page-frame${activeTab === 'game' ? '' : ' is-hidden'}`}>
+              <PublishedGameFrame slug={slug} title={entry.title} embed />
+              <p className="game-page-sandbox-note">{t('gamePage.sandboxNote')}</p>
+            </section>
+          ) : null}
+          {activeTab === 'game' && playGated ? (
+            <section className="game-page-gated">
+              <h2>{t('gamePage.gatedTitle')}</h2>
+              <p>{t('gamePage.gatedBody')}</p>
+              <button type="button" className="primary-btn" onClick={() => setAuthOpen(true)}>
+                {t('gamePage.gatedCta')}
+              </button>
+            </section>
+          ) : null}
+
+          {activeTab === 'releases' ? (
+            <section className="game-page-releases" aria-label={t('gamePage.tabs.releases')}>
+              {releases.length === 0 ? (
+                <p className="game-page-empty">{t('gamePage.releasesEmpty')}</p>
+              ) : (
+                <ol className="game-page-release-list">
+                  {releases.map((release) => (
+                    <li key={release.version} className="game-page-release">
+                      <span className="game-page-release-version">
+                        {release.gateGreen !== null ? (
+                          <span
+                            className={`game-page-release-dot${release.gateGreen ? ' is-green' : ' is-red'}`}
+                            title={t(release.gateGreen ? 'gamePage.gateGreen' : 'gamePage.gateRed')}
+                          />
+                        ) : null}
+                        {release.version}
+                      </span>
+                      <span className="game-page-release-meta">
+                        {formatDate(release.createdAt, i18n.language)}
+                        {release.origin === 'editor' ? ` · ${t('gamePage.releaseEditor')}` : ''}
+                        {release.current ? (
+                          <span className="game-page-release-current">{t('gamePage.releaseCurrent')}</span>
+                        ) : null}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+          ) : null}
+
+          {activeTab === 'board' || activeTab === 'review' || activeTab === 'sources' ? (
+            <section className="game-page-placeholder">
+              <h2>{t(`gamePage.tabs.${activeTab}`)}</h2>
+              <p>{t(`gamePage.placeholder.${activeTab}`)}</p>
+            </section>
+          ) : null}
+        </main>
+
+        <aside className="game-page-side">
+          {page.specMarkdown ? (
+            <section className="game-page-panel game-page-spec">
+              <h2 className="game-page-panel-heading">
+                SPEC.md <span className="game-page-panel-hint">{t('gamePage.specHint')}</span>
+              </h2>
+              <SpecMarkdown markdown={page.specMarkdown} />
+            </section>
+          ) : null}
+
+          {stats ? (
+            <section className="game-page-panel">
+              <h2 className="game-page-panel-heading">{t('gamePage.statsHeading')}</h2>
+              <dl className="game-page-stats">
+                <div>
+                  <dt>{t('gamePage.statsPlays', { days: stats.windowDays })}</dt>
+                  <dd>{stats.plays.toLocaleString(i18n.language)}</dd>
+                </div>
+                {stats.medianPlaySeconds !== null ? (
+                  <div>
+                    <dt>{t('gamePage.statsMedian')}</dt>
+                    <dd>{formatDuration(stats.medianPlaySeconds)}</dd>
+                  </div>
+                ) : null}
+                <div>
+                  <dt>{t('gamePage.statsReleases')}</dt>
+                  <dd>{releases.length}</dd>
+                </div>
+              </dl>
+            </section>
+          ) : null}
+
+          <section className="game-page-panel">
+            <h2 className="game-page-panel-heading">{t('gamePage.teamHeading')}</h2>
+            <ul className="game-page-team">
+              {creator ? (
+                <li>
+                  {creator.avatarUrl ? (
+                    <img src={creator.avatarUrl} alt="" width={28} height={28} />
+                  ) : (
+                    <span className="game-page-lettermark" aria-hidden="true">
+                      {creator.profileName.charAt(0).toUpperCase()}
+                    </span>
+                  )}
+                  <a href={creatorPath(handle)} onClick={intercept(() => onNavigate(creatorPath(handle)))}>
+                    {creator.profileName}
+                  </a>
+                  <span className="game-page-team-role">{t('gamePage.roleOwner')}</span>
+                </li>
+              ) : null}
+              <li>
+                <span className="game-page-lettermark game-page-lettermark--agent" aria-hidden="true">
+                  ⚙
+                </span>
+                <span>{t('gamePage.agentMember')}</span>
+                <span className="game-page-team-role">{t('gamePage.agentReleases', { count: releases.length })}</span>
+              </li>
+            </ul>
+          </section>
+
+          {modules && modules.length > 0 ? (
+            <section className="game-page-panel">
+              <h2 className="game-page-panel-heading">{t('gamePage.modulesHeading')}</h2>
+              <ul className="game-page-modules">
+                {modules.map((moduleName) => (
+                  <li key={moduleName} className="game-page-module">
+                    {moduleName}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {budget ? (
+            <section className="game-page-panel">
+              <h2 className="game-page-panel-heading">{t('gamePage.budgetHeading')}</h2>
+              <div
+                className="game-page-budget-bar"
+                role="img"
+                aria-label={t('gamePage.budgetAria', {
+                  used: formatKib(budget.usedBytes),
+                  limit: formatKib(budget.limitBytes),
+                })}
+              >
+                <div
+                  className="game-page-budget-fill"
+                  style={{ width: `${Math.min(100, Math.round((budget.usedBytes / budget.limitBytes) * 100))}%` }}
+                />
+              </div>
+              <p className="game-page-budget-caption">
+                {t('gamePage.budgetOf', {
+                  used: formatKib(budget.usedBytes),
+                  limit: formatKib(budget.limitBytes),
+                })}
+              </p>
+            </section>
+          ) : null}
+
+          {latestRelease ? (
+            <section className="game-page-panel">
+              <h2 className="game-page-panel-heading">{t('gamePage.latestReleaseHeading')}</h2>
+              <p className="game-page-latest-release">
+                <span className="game-page-release-version">{latestRelease.version}</span>{' '}
+                {formatDate(latestRelease.createdAt, i18n.language)}
+              </p>
+            </section>
+          ) : null}
+
+          {!playGated ? (
+            <section className="game-page-panel">
+              <VoteWidget slug={slug} />
+            </section>
+          ) : null}
+        </aside>
+      </div>
+
+      <AuthModal isOpen={authOpen} onClose={() => setAuthOpen(false)} />
+    </article>
+  );
+}
+
+function intercept(action: () => void) {
+  return (event: { preventDefault: () => void }) => {
+    event.preventDefault();
+    action();
+  };
+}
+
+function formatDate(iso: string, language: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  try {
+    return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(parsed);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)} s`;
+  return `${Math.round(seconds / 60)} min`;
+}
+
+function formatKib(bytes: number): string {
+  return `${Math.round(bytes / 1024)} KiB`;
+}

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -243,7 +243,9 @@ export function GamePage({
         <main className="game-page-main">
           {frameArmed && !playGated ? (
             <section className={`game-page-frame${activeTab === 'game' ? '' : ' is-hidden'}`}>
-              <PublishedGameFrame slug={slug} title={entry.title} embed />
+              {/* Stays mounted across tab switches so a run is not restarted, and is
+                  told when it is hidden so play time stops accruing behind another tab. */}
+              <PublishedGameFrame slug={slug} title={entry.title} embed active={activeTab === 'game'} />
               <p className="game-page-sandbox-note">{t('gamePage.sandboxNote')}</p>
             </section>
           ) : null}

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -126,9 +126,9 @@ export function GamePage({
     }
   }, [user, slug, follow]);
 
-  // The canonical address carries the owning studio's handle. A page with no
-  // creator handle has no address in this namespace — platform and repo games
-  // stay reachable at /play/<slug> only.
+  // The canonical address carries the owning studio's handle, or the platform's for
+  // a game with no creator to name. The server decides which; the client only keeps
+  // the URL in step with it.
   const canonicalHandle = page?.entry.creatorHandle ?? null;
   useEffect(() => {
     if (state !== 'ready' || !page) return;
@@ -147,7 +147,7 @@ export function GamePage({
   if (state === 'loading') {
     return <p className="game-page-status">{t('gamePage.loading')}</p>;
   }
-  if (state === 'missing' || (state === 'ready' && !canonicalHandle)) {
+  if (state === 'missing') {
     return (
       <div className="game-page-status">
         <p>{t('gamePage.missing')}</p>
@@ -177,9 +177,17 @@ export function GamePage({
     <article className="game-page">
       <header className="game-page-header">
         <nav className="game-page-breadcrumb" aria-label={t('gamePage.breadcrumbAria')}>
-          <a href={creatorPath(handle)} onClick={intercept(() => onNavigate(creatorPath(handle)))}>
-            {creator?.profileName ?? handle}
-          </a>
+          {/* A platform-authored game has no profile to link to, so its breadcrumb
+              goes to the catalog — the place those games actually come from. */}
+          {page.platformAuthored ? (
+            <a href="/" onClick={intercept(() => onNavigate('/'))}>
+              {t('catalog.platformAuthor')}
+            </a>
+          ) : (
+            <a href={creatorPath(handle)} onClick={intercept(() => onNavigate(creatorPath(handle)))}>
+              {creator?.profileName ?? handle}
+            </a>
+          )}
           <span aria-hidden="true"> / </span>
           <span className="game-page-breadcrumb-slug">{slug}</span>
           {entry.genre ? <span className="game-page-genre-badge">{entry.genre}</span> : null}
@@ -321,7 +329,15 @@ export function GamePage({
           <section className="game-page-panel">
             <h2 className="game-page-panel-heading">{t('gamePage.teamHeading')}</h2>
             <ul className="game-page-team">
-              {creator ? (
+              {page.platformAuthored ? (
+                <li>
+                  <span className="game-page-lettermark" aria-hidden="true">
+                    ▲
+                  </span>
+                  <span>{t('catalog.platformAuthor')}</span>
+                  <span className="game-page-team-role">{t('gamePage.rolePlatform')}</span>
+                </li>
+              ) : creator ? (
                 <li>
                   {creator.avatarUrl ? (
                     <img src={creator.avatarUrl} alt="" width={28} height={28} />

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
+import { fetchGameFollow, setGameFollow, type GameFollowState } from './gameFollowApi.js';
 import { GameBoard } from './GameBoard.js';
 import { GameReview } from './GameReview.js';
 import { GameSources } from './GameSources.js';
@@ -53,6 +54,8 @@ export function GamePage({
   const [page, setPage] = useState<GamePageData | null>(null);
   const [state, setState] = useState<LoadState>('loading');
   const [authOpen, setAuthOpen] = useState(false);
+  const [follow, setFollow] = useState<GameFollowState | null>(null);
+  const [followBusy, setFollowBusy] = useState(false);
   const activeTab: ActiveTab = tab ?? 'game';
   // The frame mounts on first visit to the Gra tab and then stays mounted (hidden
   // by CSS on other tabs) so switching tabs never restarts a running game.
@@ -86,6 +89,39 @@ export function GamePage({
   useEffect(() => {
     if (page) onGameLoaded?.(page.entry.title);
   }, [page, onGameLoaded]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchGameFollow(slug)
+      .then((state) => {
+        if (!cancelled) setFollow(state);
+      })
+      .catch(() => {
+        // A follow count nobody can read is not worth a visible error on a page that
+        // is otherwise fine — the button simply stays countless.
+        if (!cancelled) setFollow(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, user]);
+
+  const toggleFollow = useCallback(async () => {
+    // Signed out: the button is an invitation to sign in rather than a dead control.
+    if (!user) {
+      setAuthOpen(true);
+      return;
+    }
+    setFollowBusy(true);
+    try {
+      const next = await setGameFollow(slug, !(follow?.following ?? false));
+      setFollow(next);
+    } catch {
+      // Leave the previous state showing; the next load reconciles.
+    } finally {
+      setFollowBusy(false);
+    }
+  }, [user, slug, follow]);
 
   // The canonical address carries the owning studio's handle. A page with no
   // creator handle has no address in this namespace — platform and repo games
@@ -153,12 +189,13 @@ export function GamePage({
           </button>
           <button
             type="button"
-            className="secondary-btn"
-            disabled
-            title={t('gamePage.followSoon')}
-            aria-label={`${t('gamePage.follow')} — ${t('gamePage.followSoon')}`}
+            className={`secondary-btn${follow?.following ? ' is-following' : ''}`}
+            onClick={() => void toggleFollow()}
+            disabled={followBusy}
+            aria-pressed={follow?.following ?? false}
           >
-            <PixelIcon name="eye" size={13} /> {t('gamePage.follow')}
+            <PixelIcon name="eye" size={13} /> {follow?.following ? t('gamePage.following') : t('gamePage.follow')}
+            {follow && follow.followers > 0 ? <span className="game-page-follow-count">{follow.followers}</span> : null}
           </button>
           <button
             type="button"

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
 import { GameBoard } from './GameBoard.js';
+import { GameReview } from './GameReview.js';
 import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
@@ -237,8 +238,9 @@ export function GamePage({
           ) : null}
 
           {activeTab === 'board' ? <GameBoard slug={slug} /> : null}
+          {activeTab === 'review' ? <GameReview slug={slug} /> : null}
 
-          {activeTab === 'review' || activeTab === 'sources' ? (
+          {activeTab === 'sources' ? (
             <section className="game-page-placeholder">
               <h2>{t(`gamePage.tabs.${activeTab}`)}</h2>
               <p>{t(`gamePage.placeholder.${activeTab}`)}</p>

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
 import { GameBoard } from './GameBoard.js';
 import { GameReview } from './GameReview.js';
+import { GameSources } from './GameSources.js';
 import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
@@ -240,12 +241,7 @@ export function GamePage({
           {activeTab === 'board' ? <GameBoard slug={slug} /> : null}
           {activeTab === 'review' ? <GameReview slug={slug} /> : null}
 
-          {activeTab === 'sources' ? (
-            <section className="game-page-placeholder">
-              <h2>{t(`gamePage.tabs.${activeTab}`)}</h2>
-              <p>{t(`gamePage.placeholder.${activeTab}`)}</p>
-            </section>
-          ) : null}
+          {activeTab === 'sources' ? <GameSources slug={slug} /> : null}
         </main>
 
         <aside className="game-page-side">

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -9,6 +9,7 @@ import { GameSources } from './GameSources.js';
 import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
+import { ShareGameButton } from './ShareGameButton.js';
 import { creatorPath, gamePath, playPath, type GamePageTab } from './router.js';
 import { parseSpecBlocks } from './specBlocks.js';
 import { SpecMarkdown } from './SpecMarkdown.js';
@@ -207,6 +208,8 @@ export function GamePage({
           >
             <PixelIcon name="wrench" size={13} /> {t('gamePage.remix')}
           </button>
+          {/* Shares this page, not the play permalink — see ShareGameButton. */}
+          <ShareGameButton slug={slug} title={entry.title} path={gamePath(handle, slug)} />
         </div>
       </header>
 

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
+import { GameBoard } from './GameBoard.js';
 import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
@@ -235,7 +236,9 @@ export function GamePage({
             </section>
           ) : null}
 
-          {activeTab === 'board' || activeTab === 'review' || activeTab === 'sources' ? (
+          {activeTab === 'board' ? <GameBoard slug={slug} /> : null}
+
+          {activeTab === 'review' || activeTab === 'sources' ? (
             <section className="game-page-placeholder">
               <h2>{t(`gamePage.tabs.${activeTab}`)}</h2>
               <p>{t(`gamePage.placeholder.${activeTab}`)}</p>

--- a/apps/web/src/GameReview.test.tsx
+++ b/apps/web/src/GameReview.test.tsx
@@ -51,6 +51,7 @@ function reviewData(overrides: Partial<GameReviewData> = {}): GameReviewData {
       truncated: false,
     },
     viewerIsOperator: false,
+    canSignOff: true,
     ...overrides,
   };
 }
@@ -150,6 +151,16 @@ describe('GameReview', () => {
     expect(approveCandidate).toHaveBeenCalledWith('neon-courier', 'v-candidate');
     expect(container.textContent).toContain('You signed off on this');
     expect(findButton('Looks good')).toBeUndefined();
+  });
+
+  it('tells an operator the sign-off is the creator’s, and offers no button', async () => {
+    fetchGameReview.mockResolvedValue(reviewData({ viewerIsOperator: true, canSignOff: false }));
+    await renderReview();
+
+    expect(container.textContent).toContain('sign-off is the creator');
+    expect(findButton('Looks good')).toBeUndefined();
+    // The comparison itself is still there — operators review, they just do not sign.
+    expect(container.querySelectorAll('[data-testid="frame"]')).toHaveLength(2);
   });
 
   it('will not offer a sign-off on a build the gate refused', async () => {

--- a/apps/web/src/GameReview.test.tsx
+++ b/apps/web/src/GameReview.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import type { GameReview as GameReviewData } from './gameReviewApi.js';
+
+const fetchGameReview = vi.fn();
+const fetchReviewCandidate = vi.fn();
+const approveCandidate = vi.fn();
+const fetchPublishedGame = vi.fn();
+
+vi.mock('./gameReviewApi.js', () => ({
+  fetchGameReview: (...args: unknown[]) => fetchGameReview(...args),
+  fetchReviewCandidate: (...args: unknown[]) => fetchReviewCandidate(...args),
+  approveCandidate: (...args: unknown[]) => approveCandidate(...args),
+}));
+
+vi.mock('./catalog.js', () => ({
+  fetchPublishedGame: (...args: unknown[]) => fetchPublishedGame(...args),
+}));
+
+// The real frame is a sandboxed iframe; what matters here is which document each
+// pane was handed, so the stub records that and nothing else.
+vi.mock('./GameFrame.js', () => ({
+  GameFrame: (props: { title: string; html?: string }) =>
+    createElement('div', { 'data-testid': 'frame', 'data-title': props.title, 'data-html': props.html }),
+}));
+
+import { GameReview } from './GameReview.js';
+
+function reviewData(overrides: Partial<GameReviewData> = {}): GameReviewData {
+  return {
+    baselineVersion: 'v-live',
+    candidate: {
+      version: 'v-candidate',
+      createdAt: '2026-08-04T12:00:00.000Z',
+      jobId: 1_000_002,
+      title: 'Grip on wet asphalt',
+      gate: { green: true, ranAt: '2026-08-04T12:05:00.000Z', report: '31 checks passed' },
+    },
+    diff: {
+      files: [
+        { path: 'game.ts', status: 'modified', added: 3, removed: 1 },
+        { path: 'wet.ts', status: 'added', added: 1, removed: 0 },
+      ],
+      filesChanged: 2,
+      added: 4,
+      removed: 1,
+      truncated: false,
+    },
+    viewerIsOperator: false,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  fetchGameReview.mockReset();
+  fetchReviewCandidate.mockReset();
+  approveCandidate.mockReset();
+  fetchPublishedGame.mockReset();
+  fetchGameReview.mockResolvedValue(reviewData());
+  fetchPublishedGame.mockResolvedValue({ slug: 'neon-courier', title: 'Neon Courier', html: '<html>live</html>' });
+  fetchReviewCandidate.mockResolvedValue({
+    slug: 'neon-courier',
+    title: 'Grip on wet asphalt',
+    html: '<html>candidate</html>',
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+async function renderReview() {
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(GameReview, { slug: 'neon-courier' }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(label));
+}
+
+describe('GameReview', () => {
+  it('puts the live game and the candidate side by side, both playable', async () => {
+    await renderReview();
+
+    const frames = Array.from(container.querySelectorAll('[data-testid="frame"]'));
+    expect(frames).toHaveLength(2);
+    expect(frames[0].getAttribute('data-html')).toBe('<html>live</html>');
+    expect(frames[1].getAttribute('data-html')).toBe('<html>candidate</html>');
+    expect(container.textContent).toContain('Play both for thirty seconds');
+    expect(container.textContent).toContain('gate passed');
+    // Publishing is not on offer here, and the page says who does it.
+    expect(container.textContent).toContain('an operator does the publishing');
+  });
+
+  it('keeps the diff a collapsed footnote', async () => {
+    await renderReview();
+
+    expect(container.querySelector('.game-review-diff-list')).toBeNull();
+    const toggle = findButton('show what changed in the code');
+    expect(toggle?.textContent).toContain('2 files');
+    expect(toggle?.textContent).toContain('+4');
+
+    await act(async () => {
+      toggle!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.game-review-diff-list')?.textContent).toContain('game.ts');
+    expect(container.textContent).toContain('+3 −1');
+  });
+
+  it('records a sign-off and re-reads the verdict', async () => {
+    approveCandidate.mockResolvedValue({ approvedAt: '2026-08-05T00:00:00.000Z' });
+    fetchGameReview
+      .mockResolvedValueOnce(reviewData())
+      .mockResolvedValueOnce(
+        reviewData({ candidate: { ...reviewData().candidate!, approvedAt: '2026-08-05T00:00:00.000Z' } }),
+      );
+    await renderReview();
+
+    await act(async () => {
+      findButton('Looks good')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(approveCandidate).toHaveBeenCalledWith('neon-courier', 'v-candidate');
+    expect(container.textContent).toContain('You signed off on this');
+    expect(findButton('Looks good')).toBeUndefined();
+  });
+
+  it('will not offer a sign-off on a build the gate refused', async () => {
+    fetchGameReview.mockResolvedValue(
+      reviewData({
+        candidate: {
+          ...reviewData().candidate!,
+          gate: { green: false, ranAt: '2026-08-04T12:05:00.000Z', report: '2 checks failed' },
+        },
+      }),
+    );
+    await renderReview();
+
+    expect(container.textContent).toContain('gate failed');
+    expect(findButton('Looks good')?.disabled).toBe(true);
+  });
+
+  it('explains itself to a signed-out visitor rather than erroring', async () => {
+    fetchGameReview.mockRejectedValue(Object.assign(new Error('unauthorized'), { code: 'unauthorized' }));
+    await renderReview();
+
+    expect(container.textContent).toContain('Sign in as the game’s creator');
+    expect(container.querySelector('[data-testid="frame"]')).toBeNull();
+    // No candidate is fetched for someone who may not see one.
+    expect(fetchReviewCandidate).not.toHaveBeenCalled();
+  });
+
+  it('says so when nothing is waiting to be played', async () => {
+    fetchGameReview.mockResolvedValue(reviewData({ candidate: null, diff: null }));
+    await renderReview();
+
+    expect(container.textContent).toContain('Nothing waiting to be played');
+    expect(fetchPublishedGame).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/GameReview.tsx
+++ b/apps/web/src/GameReview.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { fetchPublishedGame } from './catalog.js';
+import { GameFrame } from './GameFrame.js';
+import {
+  approveCandidate,
+  fetchGameReview,
+  fetchReviewCandidate,
+  type GameReview as GameReviewData,
+} from './gameReviewApi.js';
+import { PixelIcon } from './PixelIcon.js';
+import { studioPath } from './router.js';
+
+/**
+ * "Do zagrania" — a change reviewed by playing it, not by reading it.
+ *
+ * Two playable frames side by side: what is live on the left, what was just built on
+ * the right, both running in the same sandbox any other game runs in. Thirty seconds
+ * of each answers the question a diff cannot, which is whether the change is *better*.
+ * The line counts are underneath, collapsed, because they are a footnote here rather
+ * than the subject (ops `docs/game-page-plan.md`).
+ *
+ * Signing off records that the creator played it and accepts it. It is deliberately
+ * **not** a publish: putting a game on the site stays an operator action, because the
+ * gate answers "does this run" and a human answers "may this be on the site", and only
+ * the second is the moderation boundary. Asking for changes and walking away both live
+ * in the Studio thread, where they already carry moderation and quota — this surface
+ * links there rather than growing a second copy of them.
+ */
+
+type LoadState = 'loading' | 'ready' | 'unauthorized' | 'forbidden' | 'error';
+
+export function GameReview({ slug }: { slug: string }) {
+  const { t, i18n } = useTranslation();
+  const [review, setReview] = useState<GameReviewData | null>(null);
+  const [state, setState] = useState<LoadState>('loading');
+  const [live, setLive] = useState<string | null>(null);
+  const [candidate, setCandidate] = useState<string | null>(null);
+  const [approving, setApproving] = useState(false);
+  const [approveError, setApproveError] = useState<string | null>(null);
+  const [showDiff, setShowDiff] = useState(false);
+
+  const load = useCallback(() => {
+    let cancelled = false;
+    setState('loading');
+    void fetchGameReview(slug)
+      .then((loaded) => {
+        if (cancelled) return;
+        setReview(loaded);
+        setState('ready');
+      })
+      .catch((err: { code?: string }) => {
+        if (cancelled) return;
+        setState(err.code === 'unauthorized' ? 'unauthorized' : err.code === 'forbidden' ? 'forbidden' : 'error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  useEffect(() => load(), [load]);
+
+  // Both documents are fetched only once a candidate exists — there is no comparison
+  // to make otherwise, and the published half is a real play session's worth of bytes.
+  const candidateVersion = review?.candidate?.version ?? null;
+  useEffect(() => {
+    if (!candidateVersion) return;
+    let cancelled = false;
+    void fetchPublishedGame(slug)
+      .then((game) => {
+        if (!cancelled) setLive(game.html);
+      })
+      .catch(() => {
+        // A game with no published version yet simply has no left-hand frame.
+        if (!cancelled) setLive(null);
+      });
+    void fetchReviewCandidate(slug, candidateVersion)
+      .then((game) => {
+        if (!cancelled) setCandidate(game.html);
+      })
+      .catch(() => {
+        if (!cancelled) setCandidate(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, candidateVersion]);
+
+  const approve = useCallback(async () => {
+    if (!review?.candidate) return;
+    setApproving(true);
+    setApproveError(null);
+    try {
+      await approveCandidate(slug, review.candidate.version);
+      load();
+    } catch (err) {
+      setApproveError((err as { code?: string }).code ?? 'unknown');
+    } finally {
+      setApproving(false);
+    }
+  }, [review, slug, load]);
+
+  if (state === 'loading') return <p className="game-page-status">{t('gamePage.review.loading')}</p>;
+  if (state === 'unauthorized' || state === 'forbidden') {
+    return (
+      <section className="game-page-placeholder">
+        <h2>{t('gamePage.tabs.review')}</h2>
+        <p>{t(state === 'unauthorized' ? 'gamePage.review.signedOut' : 'gamePage.review.notYours')}</p>
+      </section>
+    );
+  }
+  if (state === 'error' || !review) {
+    return <p className="game-page-status game-page-error">{t('gamePage.review.error')}</p>;
+  }
+
+  if (!review.candidate) {
+    return (
+      <section className="game-page-placeholder">
+        <h2>{t('gamePage.tabs.review')}</h2>
+        <p>{t('gamePage.review.empty')}</p>
+      </section>
+    );
+  }
+
+  const { candidate: pending, diff } = review;
+  const gateRed = pending.gate ? !pending.gate.green : false;
+
+  return (
+    <section className="game-review" aria-label={t('gamePage.tabs.review')}>
+      <header className="game-review-header">
+        <h2 className="game-review-title">{pending.title}</h2>
+        <p className="game-review-meta">
+          {t('gamePage.review.builtOn', { date: formatDate(pending.createdAt, i18n.language) })}
+          {pending.gate ? (
+            <span className={`game-review-gate${pending.gate.green ? ' is-green' : ' is-red'}`}>
+              {t(pending.gate.green ? 'gamePage.review.gatePassed' : 'gamePage.review.gateFailed')}
+            </span>
+          ) : (
+            <span className="game-review-gate">{t('gamePage.review.gatePending')}</span>
+          )}
+        </p>
+        <p className="game-review-instruction">{t('gamePage.review.instruction')}</p>
+      </header>
+
+      <div className="game-review-panes">
+        <figure className="game-review-pane">
+          <figcaption className="game-review-caption">
+            {t('gamePage.review.liveCaption')}
+            {review.baselineVersion ? <span className="game-review-version">{review.baselineVersion}</span> : null}
+          </figcaption>
+          {live ? (
+            <GameFrame title={t('gamePage.review.liveCaption')} html={live} embed />
+          ) : (
+            <p className="game-review-missing">{t('gamePage.review.noLive')}</p>
+          )}
+        </figure>
+
+        <figure className="game-review-pane">
+          <figcaption className="game-review-caption is-candidate">
+            {t('gamePage.review.candidateCaption')}
+            <span className="game-review-version">{pending.version}</span>
+          </figcaption>
+          {candidate ? (
+            <GameFrame title={t('gamePage.review.candidateCaption')} html={candidate} embed />
+          ) : (
+            <p className="game-review-missing">{t('gamePage.review.noCandidate')}</p>
+          )}
+        </figure>
+      </div>
+
+      {approveError ? (
+        <p className="game-board-error" role="alert">
+          {t(`gamePage.review.approveError.${approveError}`, {
+            defaultValue: t('gamePage.review.approveError.unknown'),
+          })}
+        </p>
+      ) : null}
+
+      <div className="game-review-verdict">
+        {pending.approvedAt ? (
+          <p className="game-review-approved">
+            <PixelIcon name="check" size={13} />{' '}
+            {t('gamePage.review.approved', { date: formatDate(pending.approvedAt, i18n.language) })}
+          </p>
+        ) : (
+          <button
+            type="button"
+            className="primary-btn"
+            onClick={() => void approve()}
+            disabled={approving || gateRed}
+            title={gateRed ? t('gamePage.review.gateFailedHint') : undefined}
+          >
+            <PixelIcon name="check" size={13} />{' '}
+            {approving ? t('gamePage.review.approving') : t('gamePage.review.approve')}
+          </button>
+        )}
+        <a className="secondary-btn" href={studioPath(slug, 'thread')}>
+          <PixelIcon name="pencil" size={13} /> {t('gamePage.review.requestChanges')}
+        </a>
+      </div>
+      <p className="game-review-note">{t('gamePage.review.publishNote')}</p>
+
+      {diff && diff.filesChanged > 0 ? (
+        <div className="game-review-diff">
+          <button type="button" className="game-review-diff-toggle" onClick={() => setShowDiff((open) => !open)}>
+            {t('gamePage.review.diffSummary', {
+              files: diff.filesChanged,
+              added: diff.added,
+              removed: diff.removed,
+            })}
+            {diff.truncated ? ` ${t('gamePage.review.diffTruncated')}` : ''}
+          </button>
+          {showDiff ? (
+            <ul className="game-review-diff-list">
+              {diff.files.map((file) => (
+                <li key={file.path}>
+                  <code>{file.path}</code>
+                  <span className="game-review-diff-counts">
+                    {file.added === null || file.removed === null
+                      ? t('gamePage.review.diffUncounted')
+                      : `+${file.added} −${file.removed}`}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function formatDate(iso: string, language: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  try {
+    return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(parsed);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}

--- a/apps/web/src/GameReview.tsx
+++ b/apps/web/src/GameReview.tsx
@@ -177,7 +177,11 @@ export function GameReview({ slug }: { slug: string }) {
       ) : null}
 
       <div className="game-review-verdict">
-        {pending.approvedAt ? (
+        {!review.canSignOff ? (
+          // An operator reviews but does not sign off: the sign-off speaks for the
+          // creator, and the admin queue reads it back as exactly that.
+          <p className="game-review-note">{t('gamePage.review.operatorCannotSignOff')}</p>
+        ) : pending.approvedAt ? (
           <p className="game-review-approved">
             <PixelIcon name="check" size={13} />{' '}
             {t('gamePage.review.approved', { date: formatDate(pending.approvedAt, i18n.language) })}

--- a/apps/web/src/GameSources.test.tsx
+++ b/apps/web/src/GameSources.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { tokenizeLine } from './codeTokens.js';
+
+const fetchGameSources = vi.fn();
+const fetchGameSourceFile = vi.fn();
+
+vi.mock('./gameSourcesApi.js', () => ({
+  fetchGameSources: (...args: unknown[]) => fetchGameSources(...args),
+  fetchGameSourceFile: (...args: unknown[]) => fetchGameSourceFile(...args),
+}));
+
+import { GameSources } from './GameSources.js';
+
+const LISTING = {
+  version: 'v-live',
+  files: [
+    { path: 'GAME.json', bytes: 120, language: 'json' as const },
+    { path: 'game.ts', bytes: 2048, language: 'typescript' as const },
+    { path: 'SPEC.md', bytes: 800, language: 'markdown' as const },
+  ],
+  totalBytes: 2968,
+};
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  fetchGameSources.mockReset();
+  fetchGameSourceFile.mockReset();
+  fetchGameSources.mockResolvedValue(LISTING);
+  fetchGameSourceFile.mockResolvedValue({
+    path: 'game.ts',
+    version: 'v-live',
+    bytes: 2048,
+    language: 'typescript',
+    content: 'const speed = 1; // go\nexport function run() {\n  return "<b>hi</b>";\n}',
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+async function renderSources() {
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(GameSources, { slug: 'neon-courier' }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('GameSources', () => {
+  it('lists every file and opens the game entry point first', async () => {
+    await renderSources();
+
+    const paths = Array.from(container.querySelectorAll('.game-sources-file-path')).map((el) => el.textContent);
+    expect(paths).toEqual(['GAME.json', 'game.ts', 'SPEC.md']);
+    // game.ts is what a curious reader wants, so it opens rather than the first row.
+    expect(fetchGameSourceFile).toHaveBeenCalledWith('neon-courier', 'game.ts');
+    expect(container.querySelector('.game-sources-file.is-active .game-sources-file-path')?.textContent).toBe(
+      'game.ts',
+    );
+    expect(container.textContent).toContain('3 files');
+  });
+
+  it('renders code as numbered text, never as markup', async () => {
+    await renderSources();
+
+    const gutters = Array.from(container.querySelectorAll('.game-sources-gutter')).map((el) => el.textContent);
+    expect(gutters).toEqual(['1', '2', '3', '4']);
+    // The source contains HTML; it must appear as characters, not as elements.
+    expect(container.querySelector('.game-sources-code b')).toBeNull();
+    expect(container.querySelector('.game-sources-code')?.textContent).toContain('<b>hi</b>');
+    // Highlighting happened, and did so as elements with classes.
+    expect(container.querySelector('.tok-comment')?.textContent).toBe('// go');
+    expect(container.querySelector('.tok-keyword')).not.toBeNull();
+  });
+
+  it('switches files on click', async () => {
+    await renderSources();
+    fetchGameSourceFile.mockResolvedValue({
+      path: 'SPEC.md',
+      version: 'v-live',
+      bytes: 800,
+      language: 'markdown',
+      content: '# Neon Courier',
+    });
+
+    const specButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('SPEC.md'),
+    );
+    await act(async () => {
+      specButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchGameSourceFile).toHaveBeenLastCalledWith('neon-courier', 'SPEC.md');
+    expect(container.querySelector('.game-sources-code')?.textContent).toContain('# Neon Courier');
+  });
+
+  it('explains a game whose sources are not published', async () => {
+    fetchGameSources.mockRejectedValue(Object.assign(new Error('not_found'), { code: 'not_found' }));
+    await renderSources();
+
+    expect(container.textContent).toContain('sources are not published');
+    expect(container.querySelector('.game-sources-code')).toBeNull();
+  });
+
+  it('says when a file is too large to show', async () => {
+    fetchGameSourceFile.mockRejectedValue(Object.assign(new Error('too_large'), { code: 'too_large' }));
+    await renderSources();
+
+    expect(container.textContent).toContain('too large to show');
+  });
+});
+
+describe('tokenizeLine', () => {
+  it('tags comments, strings, numbers and keywords in TypeScript', () => {
+    expect(tokenizeLine('const x = 1; // note', 'typescript')).toEqual([
+      { kind: 'keyword', text: 'const' },
+      { kind: 'plain', text: ' x = ' },
+      { kind: 'number', text: '1' },
+      { kind: 'plain', text: '; ' },
+      { kind: 'comment', text: '// note' },
+    ]);
+    expect(tokenizeLine('return "hi";', 'typescript')).toEqual([
+      { kind: 'keyword', text: 'return' },
+      { kind: 'plain', text: ' ' },
+      { kind: 'string', text: '"hi"' },
+      { kind: 'plain', text: ';' },
+    ]);
+  });
+
+  it('separates JSON keys from values', () => {
+    expect(tokenizeLine('  "title": "Neon",', 'json')).toEqual([
+      { kind: 'plain', text: '  ' },
+      { kind: 'key', text: '"title"' },
+      { kind: 'plain', text: ': ' },
+      { kind: 'string', text: '"Neon"' },
+      { kind: 'plain', text: ',' },
+    ]);
+  });
+
+  it('never drops or invents characters, whatever the input', () => {
+    for (const language of ['typescript', 'json', 'css', 'markdown', 'text'] as const) {
+      for (const line of ['', 'plain text', '</script><img src=x>', '`${a}` /* c */', '- item', '@media screen {']) {
+        const tokens = tokenizeLine(line, language);
+        expect(tokens.map((token) => token.text).join('')).toBe(line);
+      }
+    }
+  });
+});

--- a/apps/web/src/GameSources.tsx
+++ b/apps/web/src/GameSources.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { tokenizeLine, type CodeLanguage } from './codeTokens.js';
+import {
+  fetchGameSourceFile,
+  fetchGameSources,
+  type GameSourceFile,
+  type GameSources as GameSourcesData,
+} from './gameSourcesApi.js';
+import { PixelIcon } from './PixelIcon.js';
+
+/**
+ * "Źródła" — the code, readable by anyone.
+ *
+ * A game built from a prompt is more interesting when you can read what it actually
+ * is, so this is a first-class view rather than an escape hatch: the file list, the
+ * bytes, and a numbered, highlighted reader.
+ *
+ * Highlighting is built from tokens as React elements (codeTokens.ts) — never from
+ * HTML strings — so source that contains markup renders as source. The same reason
+ * SpecMarkdown is hand-rolled: this file displays text an agent wrote, and the only
+ * safe way to display it is as text.
+ */
+
+type LoadState = 'loading' | 'ready' | 'missing' | 'error';
+
+/** Read first — it is the file a curious visitor is actually looking for. */
+const PREFERRED_FIRST = ['game.ts', 'SPEC.md', 'index.html'];
+
+export function GameSources({ slug }: { slug: string }) {
+  const { t, i18n } = useTranslation();
+  const [listing, setListing] = useState<GameSourcesData | null>(null);
+  const [state, setState] = useState<LoadState>('loading');
+  const [selected, setSelected] = useState<string | null>(null);
+  const [content, setContent] = useState<string | null>(null);
+  const [fileState, setFileState] = useState<'idle' | 'loading' | 'too_large' | 'error'>('idle');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    void fetchGameSources(slug)
+      .then((loaded) => {
+        if (cancelled) return;
+        setListing(loaded);
+        setState('ready');
+        const first =
+          PREFERRED_FIRST.find((path) => loaded.files.some((file) => file.path === path)) ??
+          loaded.files[0]?.path ??
+          null;
+        setSelected(first);
+      })
+      .catch((err: { code?: string }) => {
+        if (cancelled) return;
+        setState(err.code === 'not_found' ? 'missing' : 'error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  useEffect(() => {
+    if (!selected) return;
+    let cancelled = false;
+    setFileState('loading');
+    setContent(null);
+    setCopied(false);
+    void fetchGameSourceFile(slug, selected)
+      .then((file) => {
+        if (cancelled) return;
+        setContent(file.content);
+        setFileState('idle');
+      })
+      .catch((err: { code?: string }) => {
+        if (cancelled) return;
+        setFileState(err.code === 'too_large' ? 'too_large' : 'error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, selected]);
+
+  const current = useMemo(() => listing?.files.find((file) => file.path === selected) ?? null, [listing, selected]);
+
+  const copy = useCallback(() => {
+    if (!content) return;
+    void navigator.clipboard
+      ?.writeText(content)
+      .then(() => setCopied(true))
+      .catch(() => setCopied(false));
+  }, [content]);
+
+  if (state === 'loading') return <p className="game-page-status">{t('gamePage.sources.loading')}</p>;
+  if (state === 'missing') {
+    return (
+      <section className="game-page-placeholder">
+        <h2>{t('gamePage.tabs.sources')}</h2>
+        <p>{t('gamePage.sources.unavailable')}</p>
+      </section>
+    );
+  }
+  if (state === 'error' || !listing) {
+    return <p className="game-page-status game-page-error">{t('gamePage.sources.error')}</p>;
+  }
+
+  return (
+    <section className="game-sources" aria-label={t('gamePage.tabs.sources')}>
+      <p className="game-sources-intro">
+        {t('gamePage.sources.intro', {
+          files: listing.files.length,
+          size: formatBytes(listing.totalBytes, i18n.language),
+        })}
+        <span className="game-sources-version">{listing.version}</span>
+      </p>
+
+      <div className="game-sources-layout">
+        <nav className="game-sources-list" aria-label={t('gamePage.sources.filesAria')}>
+          <ul>
+            {listing.files.map((file) => (
+              <li key={file.path}>
+                <button
+                  type="button"
+                  className={`game-sources-file${file.path === selected ? ' is-active' : ''}`}
+                  aria-current={file.path === selected ? 'true' : undefined}
+                  onClick={() => setSelected(file.path)}
+                >
+                  <span className="game-sources-file-path">{file.path}</span>
+                  <span className="game-sources-file-bytes">{formatBytes(file.bytes, i18n.language)}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="game-sources-viewer">
+          {current ? (
+            <div className="game-sources-viewer-head">
+              <code className="game-sources-viewer-path">{current.path}</code>
+              <button type="button" className="secondary-btn game-sources-copy" onClick={copy} disabled={!content}>
+                <PixelIcon name="check" size={12} />{' '}
+                {copied ? t('gamePage.sources.copied') : t('gamePage.sources.copy')}
+              </button>
+            </div>
+          ) : null}
+
+          {fileState === 'loading' ? <p className="game-sources-note">{t('gamePage.sources.fileLoading')}</p> : null}
+          {fileState === 'too_large' ? <p className="game-sources-note">{t('gamePage.sources.tooLarge')}</p> : null}
+          {fileState === 'error' ? (
+            <p className="game-sources-note game-page-error">{t('gamePage.sources.fileError')}</p>
+          ) : null}
+          {fileState === 'idle' && content !== null && current ? (
+            <CodeView content={content} language={current.language} />
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CodeView({ content, language }: { content: string; language: GameSourceFile['language'] }) {
+  const lines = useMemo(() => content.replace(/\r\n/g, '\n').split('\n'), [content]);
+  return (
+    <pre className="game-sources-code">
+      <code>
+        {lines.map((line, index) => (
+          <span className="game-sources-line" key={index}>
+            <span className="game-sources-gutter" aria-hidden="true">
+              {index + 1}
+            </span>
+            <span className="game-sources-line-text">
+              {tokenizeLine(line, language as CodeLanguage).map((token, tokenIndex) =>
+                token.kind === 'plain' ? (
+                  token.text
+                ) : (
+                  <span key={tokenIndex} className={`tok-${token.kind}`}>
+                    {token.text}
+                  </span>
+                ),
+              )}
+              {'\n'}
+            </span>
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
+function formatBytes(bytes: number, language: string): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kib = bytes / 1024;
+  const rounded = kib < 10 ? Math.round(kib * 10) / 10 : Math.round(kib);
+  try {
+    return `${rounded.toLocaleString(language)} KiB`;
+  } catch {
+    return `${rounded} KiB`;
+  }
+}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isPlatformAuthor, type CatalogTouch } from './catalog.js';
+import { gamePageHandle, isPlatformAuthor, type CatalogTouch } from './catalog.js';
 import { GameFrame } from './GameFrame.js';
 import { HowToPlayPanel } from './HowToPlayPanel.js';
 import { PublishedGameFrame } from './PublishedGameFrame.js';
@@ -716,12 +716,10 @@ export function GameTheater({
                       <div className="theater-menu-divider theater-mobile-chrome" role="separator" />
                       <PlayerFeedbackWidget slug={reportSlug} />
                       {/* The way out of the player and onto the game's own page —
-                          releases, code, the board. Only for games that have one. */}
-                      {creatorHandle ? (
-                        <a className="theater-menu-item" href={gamePath(creatorHandle, reportSlug)}>
-                          <PixelIcon name="folder" size={13} /> {t('player.aboutGame')}
-                        </a>
-                      ) : null}
+                          releases, code, the board. Every published game has one. */}
+                      <a className="theater-menu-item" href={gamePath(gamePageHandle({ creatorHandle }), reportSlug)}>
+                        <PixelIcon name="folder" size={13} /> {t('player.aboutGame')}
+                      </a>
                       {/* Shares the play permalink: someone handed a game link expects
                           to land in the game. The game page shares itself instead. */}
                       <ShareGameButton slug={reportSlug} title={displayTitle} />

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -19,7 +19,7 @@ import { useVoiceMeterBridge } from './voiceMeter.js';
 import { useWorldBridge } from './world.js';
 import { useZoneBridge } from './zone.js';
 import { useScreenWakeLock } from './useScreenWakeLock.js';
-import { creatorPath } from './router.js';
+import { creatorPath, gamePath } from './router.js';
 
 /**
  * Shell-owned camera feed under the game iframe. Kept as a tiny component so the
@@ -715,6 +715,15 @@ export function GameTheater({
                     <>
                       <div className="theater-menu-divider theater-mobile-chrome" role="separator" />
                       <PlayerFeedbackWidget slug={reportSlug} />
+                      {/* The way out of the player and onto the game's own page —
+                          releases, code, the board. Only for games that have one. */}
+                      {creatorHandle ? (
+                        <a className="theater-menu-item" href={gamePath(creatorHandle, reportSlug)}>
+                          <PixelIcon name="folder" size={13} /> {t('player.aboutGame')}
+                        </a>
+                      ) : null}
+                      {/* Shares the play permalink: someone handed a game link expects
+                          to land in the game. The game page shares itself instead. */}
                       <ShareGameButton slug={reportSlug} title={displayTitle} />
                       <ReportGameButton slug={reportSlug} title={displayTitle} />
                     </>

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -18,6 +18,12 @@ type PublishedGameFrameProps = {
   /** Connected controller slots, when this game was opened as a party session. */
   slots?: number;
   /**
+   * Whether this frame is currently on screen. The game page keeps it mounted behind
+   * another tab so a run is not restarted; play time must not accrue while it is
+   * hidden. Defaults true — every other caller shows the frame it mounts.
+   */
+  active?: boolean;
+  /**
    * Whether this surface offers Remix. Off for party mode and embeds, where the
    * frame is not the player's alone to bend.
    */
@@ -45,6 +51,7 @@ export function PublishedGameFrame({
   frameRef,
   embed,
   slots,
+  active = true,
   remixable,
   remixOpenNonce,
   painterNonce,
@@ -83,7 +90,7 @@ export function PublishedGameFrame({
   // Starts only once the document is in hand, so a session means "a game was handed
   // to a player" rather than "a card was clicked". A fetch that never resolves is a
   // catalog problem, and this is not the place that would report it.
-  useGameTelemetry(slug, html !== null, slots);
+  useGameTelemetry(slug, html !== null, slots, active);
 
   // Account play affinity (signed-in) + device-local recent list (everyone). Both are
   // best-effort and separate from anonymous play telemetry — see docs/recommendations.md.

--- a/apps/web/src/ShareGameButton.test.tsx
+++ b/apps/web/src/ShareGameButton.test.tsx
@@ -27,10 +27,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function draw() {
+function draw(path?: string) {
   root = createRoot(container);
   act(() => {
-    root!.render(<ShareGameButton slug="brick-storm" title="Brick Storm" />);
+    root!.render(<ShareGameButton slug="brick-storm" title="Brick Storm" path={path} />);
   });
   return container.querySelector('button')!;
 }
@@ -68,5 +68,22 @@ describe('ShareGameButton', () => {
 
     expect(writeText).toHaveBeenCalledWith(expect.stringMatching(/\/play\/brick-storm$/));
     expect(button.getAttribute('aria-label')).toMatch(/copied/i);
+  });
+
+  // Each surface shares itself: the player shares the play permalink, the game page
+  // shares the game page. Neither is the right link in general — the right link is the
+  // one the sharer was looking at.
+  it('shares the path it was handed instead of the play permalink', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, share, canShare: () => true, clipboard: navigator.clipboard });
+
+    const button = draw('/nightshift/brick-storm');
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({ url: `${window.location.origin}/nightshift/brick-storm` }),
+    );
   });
 });

--- a/apps/web/src/ShareGameButton.tsx
+++ b/apps/web/src/ShareGameButton.tsx
@@ -3,21 +3,36 @@ import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 
 /**
- * One-tap share of a published game's `/play/<slug>` permalink.
+ * One-tap share of a published game.
+ *
+ * **Shares where you are.** Pressed in the player it shares the `/play/<slug>`
+ * permalink — someone who was handed a game expects to land in the game. Pressed on
+ * the game page it shares that page, which is the surface with the description, the
+ * releases and the code on it. Neither is the "right" link in general; the right link
+ * is the one the sharer was looking at, so the caller passes it.
  *
  * Prefers the OS share sheet (`navigator.share`) so phones get their native
  * targets; falls back to copying the URL when the sheet is unavailable or the
  * user dismisses it without sharing. Either way the control stays useful —
  * a share button that only works on some browsers is worse than a quiet copy.
  */
-export function ShareGameButton({ slug, title }: { slug: string; title: string }) {
+export function ShareGameButton({
+  slug,
+  title,
+  path,
+}: {
+  slug: string;
+  title: string;
+  /** In-app path to share. Defaults to the play permalink. */
+  path?: string;
+}) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
 
-  const playUrl = () => `${window.location.origin}/play/${encodeURIComponent(slug)}`;
+  const shareUrl = () => `${window.location.origin}${path ?? `/play/${encodeURIComponent(slug)}`}`;
 
   const share = async () => {
-    const url = playUrl();
+    const url = shareUrl();
     const canShare =
       typeof navigator.share === 'function' && (!navigator.canShare || navigator.canShare({ url, title, text: title }));
 

--- a/apps/web/src/SpecMarkdown.test.tsx
+++ b/apps/web/src/SpecMarkdown.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseSpecBlocks } from './specBlocks.js';
+import { SpecMarkdown } from './SpecMarkdown.js';
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+});
+
+function render(markdown: string) {
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(SpecMarkdown, { markdown }));
+  });
+}
+
+describe('SpecMarkdown', () => {
+  it('renders the SPEC dialect: headings, paragraphs, lists, code, rules', () => {
+    render(
+      [
+        '# Title',
+        '',
+        'A paragraph with **bold**, *italic* and `code`.',
+        '',
+        '- one',
+        '- two',
+        '',
+        '1. first',
+        '2. second',
+        '',
+        '---',
+        '',
+        '```',
+        'const x = 1;',
+        '```',
+      ].join('\n'),
+    );
+
+    // `#` shifts down so the page's own chrome keeps the outline.
+    expect(container.querySelector('h3')?.textContent).toBe('Title');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+    expect(container.querySelector('p code')?.textContent).toBe('code');
+    expect(Array.from(container.querySelectorAll('ul li')).map((li) => li.textContent)).toEqual(['one', 'two']);
+    expect(Array.from(container.querySelectorAll('ol li')).map((li) => li.textContent)).toEqual(['first', 'second']);
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(container.querySelector('pre code')?.textContent).toBe('const x = 1;');
+  });
+
+  it('renders raw HTML as visible text, never as markup', () => {
+    render('Hello <img src=x onerror=alert(1)> and <script>alert(2)</script>');
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('links http(s) targets only, with a nofollow noopener rel', () => {
+    render('See [docs](https://example.com/x) and [bad](javascript:alert(1)).');
+
+    const anchor = container.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/x');
+    expect(anchor?.getAttribute('rel')).toBe('nofollow noopener noreferrer');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+    // The javascript: form never becomes a token, so it stays literal text.
+    expect(container.querySelectorAll('a').length).toBe(1);
+    expect(container.textContent).toContain('[bad](javascript:alert(1))');
+  });
+});
+
+describe('parseSpecBlocks', () => {
+  it('finds the first paragraph for the page description', () => {
+    const blocks = parseSpecBlocks('# T\n\nThe description.\n\n## More\n\ntext');
+    const paragraph = blocks.find((block) => block.kind === 'paragraph');
+    expect(paragraph).toEqual({ kind: 'paragraph', text: 'The description.' });
+  });
+
+  it('survives an unclosed code fence', () => {
+    expect(parseSpecBlocks('```\nunclosed')).toEqual([{ kind: 'code', text: 'unclosed' }]);
+  });
+});

--- a/apps/web/src/SpecMarkdown.tsx
+++ b/apps/web/src/SpecMarkdown.tsx
@@ -21,6 +21,9 @@ interface SpecMarkdownProps {
   markdown: string;
 }
 
+/** The heading levels a shifted SPEC heading can land on. */
+type HeadingTag = 'h3' | 'h4' | 'h5' | 'h6';
+
 const INLINE_TOKEN = /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)\s]+\))/g;
 
 function renderInline(text: string): ReactNode[] {
@@ -62,8 +65,10 @@ export function SpecMarkdown({ markdown }: SpecMarkdownProps) {
         switch (block.kind) {
           case 'heading': {
             // Shifted down one level: the page already has its own h1/h2 chrome,
-            // and a SPEC's `#` title must not outrank it in the outline.
-            const Tag = `h${Math.min(block.level + 2, 6)}` as 'h3';
+            // and a SPEC's `#` title must not outrank it in the outline. Typed as the
+            // union of what the clamp can actually produce, rather than asserting one
+            // member of it — the levels are the contract, not `h3` specifically.
+            const Tag: HeadingTag = `h${Math.min(block.level + 2, 6) as 3 | 4 | 5 | 6}`;
             return <Tag key={index}>{renderInline(block.text)}</Tag>;
           }
           case 'paragraph':

--- a/apps/web/src/SpecMarkdown.tsx
+++ b/apps/web/src/SpecMarkdown.tsx
@@ -1,0 +1,89 @@
+import { Fragment, type ReactNode } from 'react';
+import { parseSpecBlocks } from './specBlocks.js';
+
+/**
+ * Renders a game's SPEC.md body as React elements — the game page's README pane.
+ *
+ * Hand-rolled on purpose. SPEC text is agent-authored and prompt-influenced, so it
+ * is untrusted (games-repo risk R4: injected spec text), and the repo's standing
+ * answer to prose is structured rendering rather than a markdown dependency (see
+ * apps/web/src/legal/types.ts). Everything here is built as elements — no
+ * `dangerouslySetInnerHTML` anywhere — so React's own escaping is the sanitiser
+ * and there is no HTML parse step for hostile input to reach. Raw HTML in the
+ * source renders as visible text, which is the correct fate for it.
+ *
+ * The dialect is the small subset SPECs actually use: headings, paragraphs,
+ * unordered/ordered lists, fenced code blocks, horizontal rules, and inline
+ * bold / italic / code / http(s) links.
+ */
+
+interface SpecMarkdownProps {
+  markdown: string;
+}
+
+const INLINE_TOKEN = /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)\s]+\))/g;
+
+function renderInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const match of text.matchAll(INLINE_TOKEN)) {
+    const index = match.index ?? 0;
+    if (index > last) nodes.push(text.slice(last, index));
+    const token = match[0];
+    if (token.startsWith('**')) {
+      nodes.push(<strong key={key++}>{token.slice(2, -2)}</strong>);
+    } else if (token.startsWith('`')) {
+      nodes.push(<code key={key++}>{token.slice(1, -1)}</code>);
+    } else if (token.startsWith('*')) {
+      nodes.push(<em key={key++}>{token.slice(1, -1)}</em>);
+    } else {
+      const split = token.indexOf('](');
+      const label = token.slice(1, split);
+      const href = token.slice(split + 2, -1);
+      // http(s) only, enforced by the token pattern; never a trust signal.
+      nodes.push(
+        <a key={key++} href={href} target="_blank" rel="nofollow noopener noreferrer">
+          {label}
+        </a>,
+      );
+    }
+    last = index + token.length;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+export function SpecMarkdown({ markdown }: SpecMarkdownProps) {
+  const blocks = parseSpecBlocks(markdown);
+  return (
+    <div className="spec-markdown">
+      {blocks.map((block, index) => {
+        switch (block.kind) {
+          case 'heading': {
+            // Shifted down one level: the page already has its own h1/h2 chrome,
+            // and a SPEC's `#` title must not outrank it in the outline.
+            const Tag = `h${Math.min(block.level + 2, 6)}` as 'h3';
+            return <Tag key={index}>{renderInline(block.text)}</Tag>;
+          }
+          case 'paragraph':
+            return <p key={index}>{renderInline(block.text)}</p>;
+          case 'list': {
+            const items = block.items.map((item, itemIndex) => <li key={itemIndex}>{renderInline(item)}</li>);
+            return block.ordered ? <ol key={index}>{items}</ol> : <ul key={index}>{items}</ul>;
+          }
+          case 'code':
+            return (
+              <pre key={index}>
+                <code>{block.text}</code>
+              </pre>
+            );
+          case 'rule':
+            return <hr key={index} />;
+          default:
+            return <Fragment key={index} />;
+        }
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -73,12 +73,29 @@ export interface CatalogEntry {
 /** Platform sentinel used in fixture / seed SPECs for games with no human creator. */
 export const PLATFORM_SUBMITTED_BY = 'gamedev-platform';
 
+/** Re-exported so callers reach one name for "the platform's namespace". */
+export { PLATFORM_HANDLE } from './router.js';
+import { PLATFORM_HANDLE } from './router.js';
+
 /**
  * True when the byline should read as the site itself rather than a named person —
  * missing values and the platform sentinel both mean "built here, no human creator".
  */
 export function isPlatformAuthor(submittedBy: string | null | undefined): boolean {
   return !submittedBy || submittedBy === PLATFORM_SUBMITTED_BY;
+}
+
+/**
+ * The handle a game's page lives under: its creator's, or the platform's when there
+ * is no creator to name.
+ *
+ * Every published game has a page, so this never returns null — which is what lets
+ * the catalog and the player link to one unconditionally. The server applies the same
+ * fallback (`game-page-routes.ts`), and a wrong guess here is corrected by the page's
+ * own canonical redirect rather than by a 404.
+ */
+export function gamePageHandle(entry: Pick<CatalogEntry, 'creatorHandle'>): string {
+  return entry.creatorHandle ?? PLATFORM_HANDLE;
 }
 
 /** A published game assembled by the API, ready for the sandboxed iframe's srcDoc. */

--- a/apps/web/src/codeTokens.ts
+++ b/apps/web/src/codeTokens.ts
@@ -1,0 +1,217 @@
+/**
+ * A very small tokenizer for the source viewer.
+ *
+ * Built for one job: turning a line of a delivered game file into spans a React
+ * component can render. It emits *tokens*, never markup — the viewer builds elements
+ * from them, so highlighting can never become an injection route the way a
+ * regex-to-HTML highlighter can. Anything it fails to classify stays plain text, which
+ * is always a correct answer.
+ *
+ * Line-at-a-time by design: the viewer renders a numbered line per row, and a
+ * whole-file tokenizer would have to be re-run to render any window of it. The cost is
+ * that a block comment or a template literal spanning lines is only highlighted on the
+ * line it opens — a cosmetic miss, not a correctness one.
+ */
+
+export type CodeTokenKind = 'plain' | 'comment' | 'string' | 'number' | 'keyword' | 'key';
+
+export interface CodeToken {
+  kind: CodeTokenKind;
+  text: string;
+}
+
+export type CodeLanguage = 'typescript' | 'json' | 'css' | 'html' | 'markdown' | 'text';
+
+const TS_KEYWORDS = new Set([
+  'as',
+  'async',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'from',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'of',
+  'private',
+  'protected',
+  'public',
+  'readonly',
+  'return',
+  'satisfies',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'type',
+  'typeof',
+  'undefined',
+  'var',
+  'void',
+  'while',
+  'yield',
+]);
+
+const CSS_ATRULES = /^\s*@[a-z-]+/i;
+
+/** Splits one line into tokens for the given language. Never throws. */
+export function tokenizeLine(line: string, language: CodeLanguage): CodeToken[] {
+  if (line === '') return [];
+  switch (language) {
+    case 'typescript':
+      return tokenizeCode(line, TS_KEYWORDS);
+    case 'json':
+      return tokenizeJson(line);
+    case 'css':
+      return tokenizeCss(line);
+    case 'markdown':
+      return tokenizeMarkdown(line);
+    case 'html':
+    case 'text':
+    default:
+      return [{ kind: 'plain', text: line }];
+  }
+}
+
+function tokenizeCode(line: string, keywords: ReadonlySet<string>): CodeToken[] {
+  const tokens: CodeToken[] = [];
+  let index = 0;
+  while (index < line.length) {
+    const rest = line.slice(index);
+
+    const lineComment = /^\/\/.*$/.exec(rest);
+    if (lineComment) {
+      tokens.push({ kind: 'comment', text: lineComment[0] });
+      break;
+    }
+    // Opening (or whole) block comment: the rest of the line reads as comment.
+    const blockComment = /^\/\*.*$/.exec(rest);
+    if (blockComment) {
+      tokens.push({ kind: 'comment', text: blockComment[0] });
+      break;
+    }
+    const string = /^(['"`])(?:\\.|(?!\1)[^\\])*\1?/.exec(rest);
+    if (string) {
+      tokens.push({ kind: 'string', text: string[0] });
+      index += string[0].length;
+      continue;
+    }
+    const number = /^\b\d[\d_]*(?:\.\d+)?(?:e[+-]?\d+)?\b/i.exec(rest);
+    if (number) {
+      tokens.push({ kind: 'number', text: number[0] });
+      index += number[0].length;
+      continue;
+    }
+    const word = /^[A-Za-z_$][\w$]*/.exec(rest);
+    if (word) {
+      tokens.push({ kind: keywords.has(word[0]) ? 'keyword' : 'plain', text: word[0] });
+      index += word[0].length;
+      continue;
+    }
+    // Anything else — punctuation, whitespace — travels as plain text one run at a time.
+    const other = /^[^A-Za-z_$\d'"`/]+|^\//.exec(rest);
+    const chunk = other ? other[0] : rest[0];
+    tokens.push({ kind: 'plain', text: chunk });
+    index += chunk.length;
+  }
+  return merge(tokens);
+}
+
+function tokenizeJson(line: string): CodeToken[] {
+  const tokens: CodeToken[] = [];
+  let index = 0;
+  while (index < line.length) {
+    const rest = line.slice(index);
+    const string = /^"(?:\\.|[^"\\])*"?/.exec(rest);
+    if (string) {
+      // A string immediately followed by a colon is a key, not a value.
+      const isKey = /^\s*:/.test(rest.slice(string[0].length));
+      tokens.push({ kind: isKey ? 'key' : 'string', text: string[0] });
+      index += string[0].length;
+      continue;
+    }
+    const literal = /^\b(?:true|false|null)\b/.exec(rest);
+    if (literal) {
+      tokens.push({ kind: 'keyword', text: literal[0] });
+      index += literal[0].length;
+      continue;
+    }
+    const number = /^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?/i.exec(rest);
+    if (number) {
+      tokens.push({ kind: 'number', text: number[0] });
+      index += number[0].length;
+      continue;
+    }
+    tokens.push({ kind: 'plain', text: rest[0] });
+    index += 1;
+  }
+  return merge(tokens);
+}
+
+function tokenizeCss(line: string): CodeToken[] {
+  const comment = /^\s*\/\*.*$/.exec(line);
+  if (comment) return [{ kind: 'comment', text: line }];
+  if (CSS_ATRULES.test(line)) return [{ kind: 'keyword', text: line }];
+  const declaration = /^(\s*)([a-z-]+)(\s*:\s*)(.*)$/i.exec(line);
+  if (declaration) {
+    return merge([
+      { kind: 'plain', text: declaration[1] },
+      { kind: 'key', text: declaration[2] },
+      { kind: 'plain', text: declaration[3] },
+      { kind: 'string', text: declaration[4] },
+    ]);
+  }
+  return [{ kind: 'plain', text: line }];
+}
+
+function tokenizeMarkdown(line: string): CodeToken[] {
+  if (/^\s*#{1,6}\s/.test(line)) return [{ kind: 'keyword', text: line }];
+  if (/^\s*(?:[-*]|\d+[.)])\s/.test(line)) {
+    const marker = /^\s*(?:[-*]|\d+[.)])\s/.exec(line)![0];
+    return merge([
+      { kind: 'key', text: marker },
+      { kind: 'plain', text: line.slice(marker.length) },
+    ]);
+  }
+  if (/^\s*```/.test(line)) return [{ kind: 'comment', text: line }];
+  return [{ kind: 'plain', text: line }];
+}
+
+/** Collapses neighbouring tokens of the same kind, so the DOM stays small. */
+function merge(tokens: CodeToken[]): CodeToken[] {
+  const merged: CodeToken[] = [];
+  for (const token of tokens) {
+    if (token.text === '') continue;
+    const last = merged[merged.length - 1];
+    if (last && last.kind === token.kind) {
+      last.text += token.text;
+      continue;
+    }
+    merged.push({ ...token });
+  }
+  return merged;
+}

--- a/apps/web/src/gameBoardApi.ts
+++ b/apps/web/src/gameBoardApi.ts
@@ -1,0 +1,68 @@
+/**
+ * Game board client — the four columns on `/:handle/:slug/board`.
+ *
+ * Credentialed, unlike the page read: the open column exists only for the game's
+ * owner, and the server decides that from the session rather than the client asking.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface BoardOpenTask {
+  id: string;
+  taskClass: string;
+  priority: number;
+  /** Platform-computed findings — never player- or game-authored text. */
+  findings: string[];
+  createdAt: string;
+}
+
+export interface BoardWorkItem {
+  title: string;
+  state: string;
+  since: string;
+  jobId?: number;
+  agentOpened?: boolean;
+}
+
+export interface GameBoard {
+  open: BoardOpenTask[];
+  building: BoardWorkItem[];
+  review: BoardWorkItem[];
+  released: BoardWorkItem[];
+  openVisibility: 'owner' | 'private';
+  viewerIsOwner: boolean;
+}
+
+export async function fetchGameBoard(slug: string): Promise<GameBoard> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/board`, {
+    credentials: 'include',
+  });
+  if (response.status === 404) throw Object.assign(new Error('not_found'), { code: 'not_found' });
+  if (!response.ok) throw new Error(`game board request failed: ${response.status}`);
+  return (await response.json()) as GameBoard;
+}
+
+/**
+ * Hand an open task to the agent. This is the board's one automation, and it is the
+ * suggestion inbox's existing approval endpoint — which charges the improvement
+ * quota, captures the measurement baseline, and records who decided.
+ */
+export async function assignTaskToAgent(id: string): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/me/suggestions/${encodeURIComponent(id)}/approve`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (response.ok) return;
+  const code = await readErrorCode(response);
+  throw Object.assign(new Error(code), { code, status: response.status });
+}
+
+async function readErrorCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: string };
+    if (typeof body.error === 'string' && body.error.trim()) return body.error;
+  } catch {
+    // fall through to the status-derived code
+  }
+  return response.status === 429 ? 'quota_exceeded' : 'unknown';
+}

--- a/apps/web/src/gameFollowApi.ts
+++ b/apps/web/src/gameFollowApi.ts
@@ -1,0 +1,33 @@
+/**
+ * Follow client. Credentialed: the count is the same for everyone, but whether *you*
+ * follow is a fact about the session, and the server decides it.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface GameFollowState {
+  slug: string;
+  followers: number;
+  /** Null when signed out — the count still shows. */
+  following: boolean | null;
+}
+
+export async function fetchGameFollow(slug: string): Promise<GameFollowState> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/follow`, {
+    credentials: 'include',
+  });
+  if (!response.ok) throw new Error(`follow state request failed: ${response.status}`);
+  return (await response.json()) as GameFollowState;
+}
+
+export async function setGameFollow(slug: string, following: boolean): Promise<GameFollowState> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/follow`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ following }),
+  });
+  if (response.status === 401) throw Object.assign(new Error('unauthorized'), { code: 'unauthorized' });
+  if (!response.ok) throw new Error(`follow request failed: ${response.status}`);
+  return (await response.json()) as GameFollowState;
+}

--- a/apps/web/src/gamePageApi.ts
+++ b/apps/web/src/gamePageApi.ts
@@ -28,6 +28,8 @@ export interface GamePageStats {
 export interface GamePage {
   entry: CatalogEntry;
   creator: PublicCreatorProfile | null;
+  /** The game lives under the platform handle — no profile to link to. */
+  platformAuthored: boolean;
   /** Agent-authored markdown — render only through SpecMarkdown, never innerHTML. */
   specMarkdown: string | null;
   modules: string[] | null;
@@ -46,6 +48,7 @@ export async function fetchGamePage(slug: string): Promise<GamePage> {
   return {
     entry,
     creator: body.creator ?? null,
+    platformAuthored: body.platformAuthored === true,
     specMarkdown: typeof body.specMarkdown === 'string' ? body.specMarkdown : null,
     modules: Array.isArray(body.modules) ? body.modules.filter((m): m is string => typeof m === 'string') : null,
     budget: body.budget ?? null,

--- a/apps/web/src/gamePageApi.ts
+++ b/apps/web/src/gamePageApi.ts
@@ -1,0 +1,55 @@
+/**
+ * Public game page client — the aggregate read behind `/:handle/:slug`.
+ *
+ * Uncredentialed on purpose (same as `fetchCreatorPage`): the endpoint is exempt
+ * from the private-beta wall, and the page must render identically for a visitor
+ * with no session.
+ */
+
+import { normalizeCatalogEntry, type CatalogEntry } from './catalog.js';
+import type { PublicCreatorProfile } from './creatorProfileApi.js';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface GamePageRelease {
+  version: string;
+  createdAt: string;
+  current: boolean;
+  gateGreen: boolean | null;
+  origin?: 'editor';
+}
+
+export interface GamePageStats {
+  plays: number;
+  medianPlaySeconds: number | null;
+  windowDays: number;
+}
+
+export interface GamePage {
+  entry: CatalogEntry;
+  creator: PublicCreatorProfile | null;
+  /** Agent-authored markdown — render only through SpecMarkdown, never innerHTML. */
+  specMarkdown: string | null;
+  modules: string[] | null;
+  budget: { usedBytes: number; limitBytes: number } | null;
+  releases: GamePageRelease[];
+  stats: GamePageStats | null;
+}
+
+export async function fetchGamePage(slug: string): Promise<GamePage> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/page`);
+  if (response.status === 404) throw Object.assign(new Error('not_found'), { code: 'not_found' });
+  if (!response.ok) throw new Error(`game page request failed: ${response.status}`);
+  const body = (await response.json()) as Omit<GamePage, 'entry'> & { entry: unknown };
+  const entry = normalizeCatalogEntry(body.entry);
+  if (!entry) throw Object.assign(new Error('not_found'), { code: 'not_found' });
+  return {
+    entry,
+    creator: body.creator ?? null,
+    specMarkdown: typeof body.specMarkdown === 'string' ? body.specMarkdown : null,
+    modules: Array.isArray(body.modules) ? body.modules.filter((m): m is string => typeof m === 'string') : null,
+    budget: body.budget ?? null,
+    releases: Array.isArray(body.releases) ? body.releases : [],
+    stats: body.stats ?? null,
+  };
+}

--- a/apps/web/src/gamePlayer.hiddenFrame.test.tsx
+++ b/apps/web/src/gamePlayer.hiddenFrame.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The game page keeps the frame mounted while the visitor reads another tab, so a run
+ * is not restarted. That makes "is it on screen" a separate question from "is it
+ * mounted", and play time must follow the first: a hidden frame that kept beating
+ * would inflate focused play time and every scorecard derived from it.
+ */
+
+const recorded: Array<{ type: string }> = [];
+
+vi.mock('./telemetry.js', () => ({
+  isPlayTimeAccruing: () => true,
+  TelemetrySession: class {
+    constructor() {
+      /* identity is irrelevant here */
+    }
+    record(event: { type: string }) {
+      recorded.push(event);
+    }
+    flush() {}
+    close() {}
+  },
+}));
+
+vi.mock('./visitTelemetry.js', () => ({ recordVisitEvent: vi.fn() }));
+
+import { useGameTelemetry } from './gamePlayer.js';
+
+const HEARTBEAT_MS = 15_000;
+
+function Harness({ initialActive }: { initialActive: boolean }) {
+  const [active, setActive] = useState(initialActive);
+  useGameTelemetry('neon-courier', true, undefined, active);
+  return createElement('button', { onClick: () => setActive((value) => !value) }, 'toggle');
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  recorded.length = 0;
+  vi.useFakeTimers();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+  vi.useRealTimers();
+});
+
+function playTimeBeats(): number {
+  return recorded.filter((event) => event.type === 'play_time').length;
+}
+
+function opens(): number {
+  return recorded.filter((event) => event.type === 'game_opened').length;
+}
+
+describe('useGameTelemetry while the frame is hidden', () => {
+  it('accrues play time only while the frame is on screen', () => {
+    root = createRoot(container);
+    act(() => {
+      root!.render(createElement(Harness, { initialActive: true }));
+    });
+    expect(opens()).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(HEARTBEAT_MS * 2);
+    });
+    expect(playTimeBeats()).toBe(2);
+
+    // Visitor switches to another tab of the game page — the frame stays mounted.
+    act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(HEARTBEAT_MS * 4);
+    });
+    expect(playTimeBeats()).toBe(2);
+
+    // Back to the game: the clock resumes.
+    act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(HEARTBEAT_MS);
+    });
+    expect(playTimeBeats()).toBe(3);
+  });
+
+  it('does not re-open the session when visibility toggles', () => {
+    root = createRoot(container);
+    act(() => {
+      root!.render(createElement(Harness, { initialActive: true }));
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      act(() => {
+        container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+
+    // Tearing the session down and rebuilding it per tab switch would emit a fresh
+    // `game_opened` each time, inflating the denominator of every ratio downstream.
+    expect(opens()).toBe(1);
+  });
+});

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -471,7 +471,21 @@ export function bindPlayRecorder(): (event: TelemetryEvent) => void {
   return (event) => void session.record(event);
 }
 
-export function useGameTelemetry(slug: string, enabled: boolean, slots?: number) {
+/**
+ * @param active Whether the frame is actually on screen. The game page keeps the frame
+ *   mounted while the visitor reads another tab so their run is not restarted, and a
+ *   hidden frame that kept accruing `play_time` would inflate focused play time and
+ *   every scorecard derived from it. Deliberately **not** folded into `enabled`:
+ *   tearing the session down and rebuilding it on each tab switch would emit a fresh
+ *   `game_opened` and `play_started` every time, inflating the denominators instead.
+ *   Read through a ref so toggling it never re-runs the effect.
+ */
+export function useGameTelemetry(slug: string, enabled: boolean, slots?: number, active = true) {
+  const activeRef = useRef(active);
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
   useEffect(() => {
     if (!enabled) return;
 
@@ -493,7 +507,9 @@ export function useGameTelemetry(slug: string, enabled: boolean, slots?: number)
     // the interval has actually elapsed with the page focused.
     const heartbeatSec = 15;
     const timer = window.setInterval(() => {
-      if (isPlayTimeAccruing(document)) session.record({ type: 'play_time', seconds: heartbeatSec });
+      if (activeRef.current && isPlayTimeAccruing(document)) {
+        session.record({ type: 'play_time', seconds: heartbeatSec });
+      }
     }, heartbeatSec * 1000);
 
     // Health and depth from inside the frame. `progress`/`score`/`end` arrive only

--- a/apps/web/src/gameReviewApi.ts
+++ b/apps/web/src/gameReviewApi.ts
@@ -36,6 +36,8 @@ export interface GameReview {
   candidate: ReviewCandidate | null;
   diff: ReviewDiff | null;
   viewerIsOperator: boolean;
+  /** Owners sign off; an operator looking at somebody else's game may not. */
+  canSignOff: boolean;
 }
 
 /** Thrown shape shared by the review reads, so the component can branch on access. */

--- a/apps/web/src/gameReviewApi.ts
+++ b/apps/web/src/gameReviewApi.ts
@@ -1,0 +1,86 @@
+/**
+ * Review client — the two halves of the side-by-side comparison.
+ *
+ * Credentialed throughout: a delivered candidate is unreviewed output, visible to the
+ * game's owner and to an operator and to nobody else.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface ReviewFileStat {
+  path: string;
+  status: 'added' | 'removed' | 'modified';
+  added: number | null;
+  removed: number | null;
+}
+
+export interface ReviewDiff {
+  files: ReviewFileStat[];
+  filesChanged: number;
+  added: number;
+  removed: number;
+  truncated: boolean;
+}
+
+export interface ReviewCandidate {
+  version: string;
+  createdAt: string;
+  jobId: number;
+  title: string;
+  gate: { green: boolean; ranAt: string; report?: string } | null;
+  approvedAt?: string;
+}
+
+export interface GameReview {
+  baselineVersion: string | null;
+  candidate: ReviewCandidate | null;
+  diff: ReviewDiff | null;
+  viewerIsOperator: boolean;
+}
+
+/** Thrown shape shared by the review reads, so the component can branch on access. */
+export type ReviewErrorCode = 'unauthorized' | 'forbidden' | 'unknown';
+
+export async function fetchGameReview(slug: string): Promise<GameReview> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/review`, {
+    credentials: 'include',
+  });
+  if (!response.ok) throw reviewError(response.status);
+  return (await response.json()) as GameReview;
+}
+
+/** The candidate document — same shape as the published-game read, for the same frame. */
+export async function fetchReviewCandidate(
+  slug: string,
+  version: string,
+): Promise<{ slug: string; title: string; html: string }> {
+  const response = await fetch(
+    `${API_BASE}/api/games/${encodeURIComponent(slug)}/review/${encodeURIComponent(version)}`,
+    { credentials: 'include' },
+  );
+  if (!response.ok) throw reviewError(response.status);
+  return (await response.json()) as { slug: string; title: string; html: string };
+}
+
+export async function approveCandidate(slug: string, version: string): Promise<{ approvedAt: string }> {
+  const response = await fetch(
+    `${API_BASE}/api/games/${encodeURIComponent(slug)}/review/${encodeURIComponent(version)}/approve`,
+    { method: 'POST', credentials: 'include' },
+  );
+  if (!response.ok) {
+    let code = 'unknown';
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (typeof body.error === 'string' && body.error.trim()) code = body.error;
+    } catch {
+      // keep the status-derived code
+    }
+    throw Object.assign(new Error(code), { code });
+  }
+  return (await response.json()) as { approvedAt: string };
+}
+
+function reviewError(status: number): Error & { code: ReviewErrorCode } {
+  const code: ReviewErrorCode = status === 401 ? 'unauthorized' : status === 404 ? 'forbidden' : 'unknown';
+  return Object.assign(new Error(code), { code });
+}

--- a/apps/web/src/gameSourcesApi.ts
+++ b/apps/web/src/gameSourcesApi.ts
@@ -1,0 +1,43 @@
+/**
+ * Sources client — the public read-only view of a published game's code.
+ *
+ * Uncredentialed, like the page read: the code of a published creator game is public
+ * (ops `docs/game-page-plan.md`), so the request carries nothing that identifies a
+ * reader and the response is the same for everyone.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export interface GameSourceFile {
+  path: string;
+  bytes: number;
+  language: 'typescript' | 'json' | 'css' | 'html' | 'markdown' | 'text';
+}
+
+export interface GameSources {
+  version: string;
+  files: GameSourceFile[];
+  totalBytes: number;
+}
+
+export interface GameSourceContent extends GameSourceFile {
+  version: string;
+  content: string;
+}
+
+export async function fetchGameSources(slug: string): Promise<GameSources> {
+  const response = await fetch(`${API_BASE}/api/games/${encodeURIComponent(slug)}/sources`);
+  if (response.status === 404) throw Object.assign(new Error('not_found'), { code: 'not_found' });
+  if (!response.ok) throw new Error(`sources request failed: ${response.status}`);
+  return (await response.json()) as GameSources;
+}
+
+export async function fetchGameSourceFile(slug: string, path: string): Promise<GameSourceContent> {
+  const response = await fetch(
+    `${API_BASE}/api/games/${encodeURIComponent(slug)}/sources/file?path=${encodeURIComponent(path)}`,
+  );
+  if (response.status === 404) throw Object.assign(new Error('not_found'), { code: 'not_found' });
+  if (response.status === 413) throw Object.assign(new Error('too_large'), { code: 'too_large' });
+  if (!response.ok) throw new Error(`source file request failed: ${response.status}`);
+  return (await response.json()) as GameSourceContent;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1295,6 +1295,7 @@
       "fileError": "Could not load that file.",
       "tooLarge": "This file is too large to show here."
     },
-    "following": "Following"
+    "following": "Following",
+    "rolePlatform": "built here"
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1199,7 +1199,6 @@
     "gateGreen": "Accepted by the gate",
     "gateRed": "Gate run failed",
     "placeholder": {
-      "board": "The task board lands here: open tasks anyone can pick up, tasks being built by the agent, and changes waiting to be played. In the works.",
       "review": "Reviewing a change here will mean playing two versions side by side for thirty seconds — not reading a diff. In the works.",
       "sources": "A read-only view of the game’s sources. Deliberately the last tab — the game is the product. In the works."
     },
@@ -1217,6 +1216,38 @@
     "budgetHeading": "Author budget",
     "budgetOf": "{{used}} of {{limit}}",
     "budgetAria": "Author budget: {{used}} of {{limit}}",
-    "latestReleaseHeading": "Latest release"
+    "latestReleaseHeading": "Latest release",
+    "board": {
+      "loading": "Loading the board…",
+      "error": "Could not load the board. Try again in a moment.",
+      "columns": {
+        "open": "Up for grabs",
+        "building": "Building",
+        "review": "To play",
+        "released": "Released"
+      },
+      "openPrivate": "Open tasks are private to the game’s creator — they come from play data this page does not publish.",
+      "openEmpty": "Nothing open. The nightly pass opens a task when the play data shows one.",
+      "buildingEmpty": "Nothing being built right now.",
+      "reviewEmpty": "Nothing waiting to be played.",
+      "releasedEmpty": "Nothing released yet.",
+      "assign": "Hand to the agent",
+      "assigning": "Handing over…",
+      "taskFallback": "Task",
+      "byAgent": "agent",
+      "byCreator": "creator",
+      "class": {
+        "defect": "bug",
+        "friction": "friction",
+        "design-change": "design"
+      },
+      "assignError": {
+        "unknown": "Could not hand that task over. Try again in a moment.",
+        "quota_exceeded": "Daily improvement limit reached. Try again tomorrow.",
+        "authentication required": "Sign in as the game’s creator to hand tasks over.",
+        "not found": "That task is gone — the board may have moved on."
+      },
+      "note": "Four columns and nothing else. Handing a task to the agent starts a build; that is the only automation here."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1277,11 +1277,13 @@
         "unknown": "Could not record that. Try again in a moment.",
         "gate_red": "The gate refused this build, so it cannot be signed off.",
         "not_gated": "The gate has not finished with this build yet.",
-        "not_found": "That version is gone — the agent may have delivered a newer one."
+        "not_found": "That version is gone — the agent may have delivered a newer one.",
+        "not_the_creator": "Only the game’s creator can sign off on a change."
       },
       "diffSummary": "{{files}} files · +{{added}} −{{removed}} · show what changed in the code",
       "diffTruncated": "(at least)",
-      "diffUncounted": "changed"
+      "diffUncounted": "changed",
+      "operatorCannotSignOff": "Reviewing as an operator. The sign-off is the creator’s to give — it says they played this and accept it."
     },
     "sources": {
       "loading": "Loading the sources…",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -78,7 +78,8 @@
     "navFeed": "Agent Stream",
     "activeBuilds": "{{count}} in progress",
     "upHome": "Back to home",
-    "upStudio": "Back to Studio"
+    "upStudio": "Back to Studio",
+    "upCreator": "Back to the creator's page"
   },
   "hero": {
     "mainTitle": "Turn any idea into a playable web game",
@@ -894,7 +895,8 @@
     "draftNamed": "Draft {{title}}",
     "statusNamed": "Status · {{title}}",
     "studioNamed": "Studio · {{title}}",
-    "creatorNamed": "{{title}}"
+    "creatorNamed": "{{title}}",
+    "gameNamed": "{{title}}"
   },
   "creatorProfile": {
     "back": "Back",
@@ -1167,5 +1169,54 @@
     "undoFailed": "Couldn't go back just now.",
     "brokeIt": "That change stopped the game working. Put it back?",
     "changeStanding": "Your change is running."
+  },
+  "gamePage": {
+    "loading": "Loading the game page…",
+    "missing": "This game page does not exist.",
+    "missingPlayLink": "Try the direct play link instead",
+    "error": "Could not load the game page. Try again in a moment.",
+    "breadcrumbAria": "Game location",
+    "play": "Play",
+    "follow": "Follow",
+    "followSoon": "Coming soon — new-release notifications",
+    "remix": "Remix",
+    "remixHint": "Open the game and press the wrench to remix it",
+    "tabsAria": "Game page sections",
+    "tabs": {
+      "game": "Game",
+      "board": "Board",
+      "review": "To play",
+      "releases": "Releases",
+      "sources": "Sources"
+    },
+    "sandboxNote": "The game runs in a sandbox — no access to your account, files, or network.",
+    "gatedTitle": "Playing is in closed beta",
+    "gatedBody": "This page is public, but playing needs a beta account. Sign in or join the waitlist on the homepage.",
+    "gatedCta": "Sign in",
+    "releasesEmpty": "No recorded releases yet — this game predates the release history.",
+    "releaseCurrent": "current",
+    "releaseEditor": "editor publish",
+    "gateGreen": "Accepted by the gate",
+    "gateRed": "Gate run failed",
+    "placeholder": {
+      "board": "The task board lands here: open tasks anyone can pick up, tasks being built by the agent, and changes waiting to be played. In the works.",
+      "review": "Reviewing a change here will mean playing two versions side by side for thirty seconds — not reading a diff. In the works.",
+      "sources": "A read-only view of the game’s sources. Deliberately the last tab — the game is the product. In the works."
+    },
+    "specHint": "this is the game’s README",
+    "statsHeading": "Activity",
+    "statsPlays": "Plays (last {{days}} days)",
+    "statsMedian": "Median session",
+    "statsReleases": "Releases",
+    "teamHeading": "Team",
+    "roleOwner": "owner",
+    "agentMember": "agent",
+    "agentReleases_one": "{{count}} release",
+    "agentReleases_other": "{{count}} releases",
+    "modulesHeading": "GameKit modules",
+    "budgetHeading": "Author budget",
+    "budgetOf": "{{used}} of {{limit}}",
+    "budgetAria": "Author budget: {{used}} of {{limit}}",
+    "latestReleaseHeading": "Latest release"
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -63,6 +63,12 @@
         "title": "Someone joined the beta waitlist",
         "body": "“{{title}}” asked to join the closed beta."
       }
+    },
+    "game": {
+      "new_version": {
+        "title": "A game you follow was updated",
+        "body": "“{{title}}” has a new version."
+      }
     }
   },
   "header": {
@@ -1178,7 +1184,6 @@
     "breadcrumbAria": "Game location",
     "play": "Play",
     "follow": "Follow",
-    "followSoon": "Coming soon — new-release notifications",
     "remix": "Remix",
     "remixHint": "Open the game and press the wrench to remix it",
     "tabsAria": "Game page sections",
@@ -1287,6 +1292,7 @@
       "fileLoading": "Loading…",
       "fileError": "Could not load that file.",
       "tooLarge": "This file is too large to show here."
-    }
+    },
+    "following": "Following"
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1198,9 +1198,6 @@
     "releaseEditor": "editor publish",
     "gateGreen": "Accepted by the gate",
     "gateRed": "Gate run failed",
-    "placeholder": {
-      "sources": "A read-only view of the game’s sources. Deliberately the last tab — the game is the product. In the works."
-    },
     "specHint": "this is the game’s README",
     "statsHeading": "Activity",
     "statsPlays": "Plays (last {{days}} days)",
@@ -1278,6 +1275,18 @@
       "diffSummary": "{{files}} files · +{{added}} −{{removed}} · show what changed in the code",
       "diffTruncated": "(at least)",
       "diffUncounted": "changed"
+    },
+    "sources": {
+      "loading": "Loading the sources…",
+      "error": "Could not load the sources. Try again in a moment.",
+      "unavailable": "This game’s sources are not published. Games that came from the platform’s own repository keep their code there.",
+      "intro": "{{files}} files · {{size}} · read-only, exactly what is running",
+      "filesAria": "Source files",
+      "copy": "Copy",
+      "copied": "Copied",
+      "fileLoading": "Loading…",
+      "fileError": "Could not load that file.",
+      "tooLarge": "This file is too large to show here."
     }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1199,7 +1199,6 @@
     "gateGreen": "Accepted by the gate",
     "gateRed": "Gate run failed",
     "placeholder": {
-      "review": "Reviewing a change here will mean playing two versions side by side for thirty seconds — not reading a diff. In the works.",
       "sources": "A read-only view of the game’s sources. Deliberately the last tab — the game is the product. In the works."
     },
     "specHint": "this is the game’s README",
@@ -1248,6 +1247,37 @@
         "not found": "That task is gone — the board may have moved on."
       },
       "note": "Four columns and nothing else. Handing a task to the agent starts a build; that is the only automation here."
+    },
+    "review": {
+      "loading": "Loading the review…",
+      "error": "Could not load the review. Try again in a moment.",
+      "signedOut": "Sign in as the game’s creator to review changes waiting to be played.",
+      "notYours": "Only this game’s creator can review changes waiting to be played.",
+      "empty": "Nothing waiting to be played. When the agent delivers a change, it lands here beside the live game so you can play both.",
+      "builtOn": "Built {{date}}",
+      "gatePassed": "gate passed",
+      "gateFailed": "gate failed",
+      "gatePending": "gate has not run yet",
+      "gateFailedHint": "The gate refused this build — ask for changes instead.",
+      "instruction": "Play both for thirty seconds. The one on the right is the change.",
+      "liveCaption": "Now",
+      "candidateCaption": "With this change",
+      "noLive": "Nothing is live yet — this would be the game’s first version.",
+      "noCandidate": "The built version could not be loaded.",
+      "approve": "Looks good",
+      "approving": "Recording…",
+      "approved": "You signed off on this {{date}}. An operator publishes it from here.",
+      "requestChanges": "Ask for changes",
+      "publishNote": "Signing off records that you played it and accept it. Putting a game on the site is a separate human check, so an operator does the publishing.",
+      "approveError": {
+        "unknown": "Could not record that. Try again in a moment.",
+        "gate_red": "The gate refused this build, so it cannot be signed off.",
+        "not_gated": "The gate has not finished with this build yet.",
+        "not_found": "That version is gone — the agent may have delivered a newer one."
+      },
+      "diffSummary": "{{files}} files · +{{added}} −{{removed}} · show what changed in the code",
+      "diffTruncated": "(at least)",
+      "diffUncounted": "changed"
     }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -172,7 +172,8 @@
     "howToPlayDismiss": "Press Escape, or click or tap anywhere outside, to close",
     "howToPlayTouch": "Touch",
     "howToPlayTouchPad": "On-screen pad on touch screens",
-    "howToPlayOther": "Control"
+    "howToPlayOther": "Control",
+    "aboutGame": "About this game"
   },
   "catalog": {
     "title": "Games",
@@ -224,7 +225,8 @@
       "most_played": "Most played",
       "last_played": "Last played",
       "alpha": "A–Z"
-    }
+    },
+    "about": "About"
   },
   "recommendations": {
     "reasonContinue": "Continue playing",
@@ -913,7 +915,6 @@
     "gamesAria": "Published games",
     "gamesHeading": "Games ({{count}})",
     "noGames": "No published games yet.",
-    "openPermalink": "Open game page",
     "openStudio": "Open in Studio",
     "editorTitle": "Your public profile",
     "publishGateTitle": "Claim a handle to publish",
@@ -960,7 +961,8 @@
       "cooldown": "You renamed recently — try again after the cooldown.",
       "unchanged": "That is already your handle.",
       "unknown": "Could not update the profile."
-    }
+    },
+    "openGamePage": "Game page"
   },
   "pwa": {
     "ariaLabel": "Install this app",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -172,7 +172,8 @@
     "howToPlayDismiss": "Naciśnij Escape lub kliknij obok, aby zamknąć",
     "howToPlayTouch": "Dotyk",
     "howToPlayTouchPad": "Pad ekranowy na ekranach dotykowych",
-    "howToPlayOther": "Sterowanie"
+    "howToPlayOther": "Sterowanie",
+    "aboutGame": "O tej grze"
   },
   "catalog": {
     "title": "Gry",
@@ -224,7 +225,8 @@
       "most_played": "Najczęściej grane",
       "last_played": "Ostatnio grane",
       "alpha": "A–Z"
-    }
+    },
+    "about": "O grze"
   },
   "recommendations": {
     "reasonContinue": "Kontynuuj grę",
@@ -917,7 +919,6 @@
     "gamesAria": "Opublikowane gry",
     "gamesHeading": "Gry ({{count}})",
     "noGames": "Brak opublikowanych gier.",
-    "openPermalink": "Otwórz stronę gry",
     "openStudio": "Otwórz w Studio",
     "editorTitle": "Twój publiczny profil",
     "publishGateTitle": "Zajmij handle, żeby opublikować",
@@ -964,7 +965,8 @@
       "cooldown": "Niedawno zmieniałeś handle — spróbuj ponownie po okresie oczekiwania.",
       "unchanged": "To już jest Twój handle.",
       "unknown": "Nie udało się zaktualizować profilu."
-    }
+    },
+    "openGamePage": "Strona gry"
   },
   "pwa": {
     "ariaLabel": "Zainstaluj tę aplikację",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1202,9 +1202,6 @@
     "releaseEditor": "publikacja z edytora",
     "gateGreen": "Zaakceptowane przez bramkę",
     "gateRed": "Bramka odrzuciła to wydanie",
-    "placeholder": {
-      "sources": "Podgląd źródeł gry tylko do odczytu. Celowo ostatnia zakładka — produktem jest gra. W budowie."
-    },
     "specHint": "to jest README gry",
     "statsHeading": "Aktywność",
     "statsPlays": "Rozegrania (ostatnie {{days}} dni)",
@@ -1284,6 +1281,18 @@
       "diffSummary": "plików: {{files}} · +{{added}} −{{removed}} · pokaż zmiany w kodzie",
       "diffTruncated": "(co najmniej)",
       "diffUncounted": "zmieniony"
+    },
+    "sources": {
+      "loading": "Wczytywanie źródeł…",
+      "error": "Nie udało się wczytać źródeł. Spróbuj za chwilę.",
+      "unavailable": "Źródła tej gry nie są publikowane. Gry z własnego repozytorium platformy trzymają kod tam.",
+      "intro": "plików: {{files}} · {{size}} · tylko do odczytu, dokładnie to, co działa",
+      "filesAria": "Pliki źródłowe",
+      "copy": "Kopiuj",
+      "copied": "Skopiowano",
+      "fileLoading": "Wczytywanie…",
+      "fileError": "Nie udało się wczytać tego pliku.",
+      "tooLarge": "Ten plik jest za duży, aby go tu pokazać."
     }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1203,7 +1203,6 @@
     "gateGreen": "Zaakceptowane przez bramkę",
     "gateRed": "Bramka odrzuciła to wydanie",
     "placeholder": {
-      "board": "Tu pojawi się tablica zadań: zadania do wzięcia, zadania budowane przez agenta i zmiany czekające na zagranie. W budowie.",
       "review": "Recenzja zmiany będzie tu oznaczać trzydzieści sekund grania w dwie wersje obok siebie — nie czytanie diffa. W budowie.",
       "sources": "Podgląd źródeł gry tylko do odczytu. Celowo ostatnia zakładka — produktem jest gra. W budowie."
     },
@@ -1223,6 +1222,38 @@
     "budgetHeading": "Budżet autora",
     "budgetOf": "{{used}} z {{limit}}",
     "budgetAria": "Budżet autora: {{used}} z {{limit}}",
-    "latestReleaseHeading": "Ostatnie wydanie"
+    "latestReleaseHeading": "Ostatnie wydanie",
+    "board": {
+      "loading": "Wczytywanie tablicy…",
+      "error": "Nie udało się wczytać tablicy. Spróbuj za chwilę.",
+      "columns": {
+        "open": "Do wzięcia",
+        "building": "Buduje się",
+        "review": "Do zagrania",
+        "released": "Wydane"
+      },
+      "openPrivate": "Zadania do wzięcia widzi tylko twórca gry — pochodzą z danych o rozgrywce, których ta strona nie publikuje.",
+      "openEmpty": "Nic otwartego. Nocny przebieg otworzy zadanie, gdy dane o rozgrywce je pokażą.",
+      "buildingEmpty": "Nic się teraz nie buduje.",
+      "reviewEmpty": "Nic nie czeka na zagranie.",
+      "releasedEmpty": "Nic jeszcze nie wydano.",
+      "assign": "Przekaż agentowi",
+      "assigning": "Przekazywanie…",
+      "taskFallback": "Zadanie",
+      "byAgent": "agent",
+      "byCreator": "twórca",
+      "class": {
+        "defect": "błąd",
+        "friction": "tarcie",
+        "design-change": "projekt"
+      },
+      "assignError": {
+        "unknown": "Nie udało się przekazać zadania. Spróbuj za chwilę.",
+        "quota_exceeded": "Wyczerpany dzienny limit ulepszeń. Spróbuj jutro.",
+        "authentication required": "Zaloguj się jako twórca gry, aby przekazywać zadania.",
+        "not found": "Tego zadania już nie ma — tablica mogła się zmienić."
+      },
+      "note": "Cztery kolumny i nic więcej. Przekazanie zadania agentowi uruchamia budowę; to jedyna automatyka na tej tablicy."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -78,7 +78,8 @@
     "navFeed": "Strumień Agentów",
     "activeBuilds": "w trakcie: {{count}}",
     "upHome": "Wróć do strony głównej",
-    "upStudio": "Wróć do Studio"
+    "upStudio": "Wróć do Studio",
+    "upCreator": "Wróć do strony twórcy"
   },
   "hero": {
     "mainTitle": "Zamień dowolny pomysł w grywalną grę",
@@ -898,7 +899,8 @@
     "draftNamed": "Szkic: {{title}}",
     "statusNamed": "Status · {{title}}",
     "studioNamed": "Studio · {{title}}",
-    "creatorNamed": "{{title}}"
+    "creatorNamed": "{{title}}",
+    "gameNamed": "{{title}}"
   },
   "creatorProfile": {
     "back": "Wróć",
@@ -1171,5 +1173,56 @@
     "undoFailed": "Nie udało się cofnąć.",
     "brokeIt": "Ta zmiana zepsuła grę. Cofnąć?",
     "changeStanding": "Twoja zmiana działa."
+  },
+  "gamePage": {
+    "loading": "Wczytywanie strony gry…",
+    "missing": "Ta strona gry nie istnieje.",
+    "missingPlayLink": "Spróbuj bezpośredniego linku do gry",
+    "error": "Nie udało się wczytać strony gry. Spróbuj za chwilę.",
+    "breadcrumbAria": "Położenie gry",
+    "play": "Zagraj",
+    "follow": "Obserwuj",
+    "followSoon": "Wkrótce — powiadomienia o nowych wydaniach",
+    "remix": "Odbij",
+    "remixHint": "Otwórz grę i użyj klucza, aby ją odbić",
+    "tabsAria": "Sekcje strony gry",
+    "tabs": {
+      "game": "Gra",
+      "board": "Tablica",
+      "review": "Do zagrania",
+      "releases": "Wydania",
+      "sources": "Źródła"
+    },
+    "sandboxNote": "Gra działa w piaskownicy — bez dostępu do twojego konta, plików i sieci.",
+    "gatedTitle": "Granie jest w zamkniętej becie",
+    "gatedBody": "Ta strona jest publiczna, ale do grania potrzebne jest konto w becie. Zaloguj się albo dołącz do listy oczekujących na stronie głównej.",
+    "gatedCta": "Zaloguj się",
+    "releasesEmpty": "Brak zapisanych wydań — ta gra powstała przed historią wydań.",
+    "releaseCurrent": "aktualne",
+    "releaseEditor": "publikacja z edytora",
+    "gateGreen": "Zaakceptowane przez bramkę",
+    "gateRed": "Bramka odrzuciła to wydanie",
+    "placeholder": {
+      "board": "Tu pojawi się tablica zadań: zadania do wzięcia, zadania budowane przez agenta i zmiany czekające na zagranie. W budowie.",
+      "review": "Recenzja zmiany będzie tu oznaczać trzydzieści sekund grania w dwie wersje obok siebie — nie czytanie diffa. W budowie.",
+      "sources": "Podgląd źródeł gry tylko do odczytu. Celowo ostatnia zakładka — produktem jest gra. W budowie."
+    },
+    "specHint": "to jest README gry",
+    "statsHeading": "Aktywność",
+    "statsPlays": "Rozegrania (ostatnie {{days}} dni)",
+    "statsMedian": "Mediana sesji",
+    "statsReleases": "Wydania",
+    "teamHeading": "Skład",
+    "roleOwner": "właściciel",
+    "agentMember": "agent",
+    "agentReleases_one": "{{count}} wydanie",
+    "agentReleases_few": "{{count}} wydania",
+    "agentReleases_many": "{{count}} wydań",
+    "agentReleases_other": "{{count}} wydania",
+    "modulesHeading": "Moduły GameKit",
+    "budgetHeading": "Budżet autora",
+    "budgetOf": "{{used}} z {{limit}}",
+    "budgetAria": "Budżet autora: {{used}} z {{limit}}",
+    "latestReleaseHeading": "Ostatnie wydanie"
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1301,6 +1301,7 @@
       "fileError": "Nie udało się wczytać tego pliku.",
       "tooLarge": "Ten plik jest za duży, aby go tu pokazać."
     },
-    "following": "Obserwujesz"
+    "following": "Obserwujesz",
+    "rolePlatform": "zbudowane tutaj"
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1203,7 +1203,6 @@
     "gateGreen": "Zaakceptowane przez bramkę",
     "gateRed": "Bramka odrzuciła to wydanie",
     "placeholder": {
-      "review": "Recenzja zmiany będzie tu oznaczać trzydzieści sekund grania w dwie wersje obok siebie — nie czytanie diffa. W budowie.",
       "sources": "Podgląd źródeł gry tylko do odczytu. Celowo ostatnia zakładka — produktem jest gra. W budowie."
     },
     "specHint": "to jest README gry",
@@ -1254,6 +1253,37 @@
         "not found": "Tego zadania już nie ma — tablica mogła się zmienić."
       },
       "note": "Cztery kolumny i nic więcej. Przekazanie zadania agentowi uruchamia budowę; to jedyna automatyka na tej tablicy."
+    },
+    "review": {
+      "loading": "Wczytywanie recenzji…",
+      "error": "Nie udało się wczytać recenzji. Spróbuj za chwilę.",
+      "signedOut": "Zaloguj się jako twórca gry, aby recenzować zmiany czekające na zagranie.",
+      "notYours": "Tylko twórca tej gry może recenzować zmiany czekające na zagranie.",
+      "empty": "Nic nie czeka na zagranie. Gdy agent dostarczy zmianę, pojawi się tutaj obok żywej gry, żebyś mógł zagrać w obie.",
+      "builtOn": "Zbudowane {{date}}",
+      "gatePassed": "bramka zaliczona",
+      "gateFailed": "bramka odrzuciła",
+      "gatePending": "bramka jeszcze nie sprawdziła",
+      "gateFailedHint": "Bramka odrzuciła tę budowę — poproś o poprawki.",
+      "instruction": "Zagraj w obie po trzydzieści sekund. Po prawej jest zmiana.",
+      "liveCaption": "Teraz",
+      "candidateCaption": "Z tą zmianą",
+      "noLive": "Nic jeszcze nie jest wydane — to byłaby pierwsza wersja gry.",
+      "noCandidate": "Nie udało się wczytać zbudowanej wersji.",
+      "approve": "Wygląda dobrze",
+      "approving": "Zapisywanie…",
+      "approved": "Zaakceptowano {{date}}. Publikacją zajmuje się operator.",
+      "requestChanges": "Poproś o poprawki",
+      "publishNote": "Akceptacja zapisuje, że zagrałeś i przyjmujesz zmianę. Wpuszczenie gry na stronę to osobne sprawdzenie przez człowieka, więc publikuje operator.",
+      "approveError": {
+        "unknown": "Nie udało się tego zapisać. Spróbuj za chwilę.",
+        "gate_red": "Bramka odrzuciła tę budowę, więc nie można jej zaakceptować.",
+        "not_gated": "Bramka jeszcze nie skończyła sprawdzać tej budowy.",
+        "not_found": "Tej wersji już nie ma — agent mógł dostarczyć nowszą."
+      },
+      "diffSummary": "plików: {{files}} · +{{added}} −{{removed}} · pokaż zmiany w kodzie",
+      "diffTruncated": "(co najmniej)",
+      "diffUncounted": "zmieniony"
     }
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -63,6 +63,12 @@
         "title": "Ktoś dołączył do listy oczekujących",
         "body": "„{{title}}” chce dołączyć do zamkniętej bety."
       }
+    },
+    "game": {
+      "new_version": {
+        "title": "Nowa wersja gry, którą obserwujesz",
+        "body": "„{{title}}” ma nową wersję."
+      }
     }
   },
   "header": {
@@ -1182,7 +1188,6 @@
     "breadcrumbAria": "Położenie gry",
     "play": "Zagraj",
     "follow": "Obserwuj",
-    "followSoon": "Wkrótce — powiadomienia o nowych wydaniach",
     "remix": "Odbij",
     "remixHint": "Otwórz grę i użyj klucza, aby ją odbić",
     "tabsAria": "Sekcje strony gry",
@@ -1293,6 +1298,7 @@
       "fileLoading": "Wczytywanie…",
       "fileError": "Nie udało się wczytać tego pliku.",
       "tooLarge": "Ten plik jest za duży, aby go tu pokazać."
-    }
+    },
+    "following": "Obserwujesz"
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1283,11 +1283,13 @@
         "unknown": "Nie udało się tego zapisać. Spróbuj za chwilę.",
         "gate_red": "Bramka odrzuciła tę budowę, więc nie można jej zaakceptować.",
         "not_gated": "Bramka jeszcze nie skończyła sprawdzać tej budowy.",
-        "not_found": "Tej wersji już nie ma — agent mógł dostarczyć nowszą."
+        "not_found": "Tej wersji już nie ma — agent mógł dostarczyć nowszą.",
+        "not_the_creator": "Tylko twórca gry może zaakceptować zmianę."
       },
       "diffSummary": "plików: {{files}} · +{{added}} −{{removed}} · pokaż zmiany w kodzie",
       "diffTruncated": "(co najmniej)",
-      "diffUncounted": "zmieniony"
+      "diffUncounted": "zmieniony",
+      "operatorCannotSignOff": "Przeglądasz jako operator. Akceptacja należy do twórcy — oznacza, że zagrał i przyjmuje zmianę."
     },
     "sources": {
       "loading": "Wczytywanie źródeł…",

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -21,6 +21,7 @@ const copy: DocumentTitleCopy = {
   draftNamed: 'Draft {{title}}',
   studioNamed: 'Studio · {{title}}',
   creatorNamed: '{{title}}',
+  gameNamed: '{{title}}',
 };
 
 describe('brandedPageTitle', () => {
@@ -93,5 +94,17 @@ describe('resolveDocumentTitle', () => {
     );
     expect(resolveDocumentTitle({ view: 'creator', handle: 'ada' }, { copy })).toBe('ada — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'notFound' }, { copy })).toBe('Page not found — Gamedev.pl');
+  });
+
+  it('titles the public game page with the loaded title, else the humanized slug', () => {
+    expect(
+      resolveDocumentTitle(
+        { view: 'game', handle: 'nightshift', slug: 'neon-courier' },
+        { copy, gameTitle: 'Neon Courier' },
+      ),
+    ).toBe('Neon Courier — Gamedev.pl');
+    expect(resolveDocumentTitle({ view: 'game', handle: 'nightshift', slug: 'neon-courier' }, { copy })).toBe(
+      'Neon Courier — Gamedev.pl',
+    );
   });
 });

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -42,6 +42,8 @@ export type DocumentTitleCopy = {
   studioNamed: string;
   /** Prefixed template for a creator profile, e.g. "{{title}}" (same placeholder as playNamed). */
   creatorNamed: string;
+  /** Prefixed template for a public game page, e.g. "{{title}}". */
+  gameNamed: string;
 };
 
 export type DocumentTitleContext = {
@@ -56,6 +58,8 @@ export type DocumentTitleContext = {
   stageTitle?: string | null;
   /** Display name for `/:handle` once the profile loads. */
   creatorName?: string | null;
+  /** Real game title for `/:handle/:slug` once the page loads. */
+  gameTitle?: string | null;
 };
 
 /**
@@ -86,6 +90,8 @@ export function resolveDocumentTitle(route: AppRoute, ctx: DocumentTitleContext)
       return brandedPageTitle(ctx.copy.contact);
     case 'creator':
       return brandedNamedTitle(ctx.copy.creatorNamed, ctx.creatorName?.trim() || route.handle);
+    case 'game':
+      return brandedNamedTitle(ctx.copy.gameNamed, ctx.gameTitle?.trim() || humanizeSlug(route.slug));
     case 'notFound':
       return brandedPageTitle(ctx.copy.notFound);
     default: {

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -133,6 +133,16 @@ describe('parsePathRoute', () => {
         tab,
       });
     }
+    // The platform namespace is an address even though nobody can claim it — it is
+    // where games with no creator to name live.
+    expect(parsePathRoute('/gamedevpl/brick-storm')).toEqual({
+      view: 'game',
+      handle: 'gamedevpl',
+      slug: 'brick-storm',
+    });
+    // Other reserved segments stay closed.
+    expect(parsePathRoute('/health/brick-storm')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/studio/brick-storm')).toEqual({ view: 'studio', game: 'brick-storm' });
     // Unknown tab is a 404, not a silent fallback — same rule as the studio tabs.
     expect(parsePathRoute('/nightshift/neon-courier/nope')).toEqual({ view: 'notFound' });
     // Handle and slug keep their own grammars.

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -4,6 +4,7 @@ import {
   canonicalPlayPath,
   creatorPath,
   draftPath,
+  gamePath,
   joinPath,
   legalAnchor,
   legalPath,
@@ -118,6 +119,31 @@ describe('parsePathRoute', () => {
     expect(parsePathRoute('/NotAHandle')).toEqual({ view: 'notFound' });
   });
 
+  it('parses public game page routes', () => {
+    expect(parsePathRoute('/nightshift/neon-courier')).toEqual({
+      view: 'game',
+      handle: 'nightshift',
+      slug: 'neon-courier',
+    });
+    for (const tab of ['board', 'review', 'releases', 'sources'] as const) {
+      expect(parsePathRoute(`/nightshift/neon-courier/${tab}`)).toEqual({
+        view: 'game',
+        handle: 'nightshift',
+        slug: 'neon-courier',
+        tab,
+      });
+    }
+    // Unknown tab is a 404, not a silent fallback — same rule as the studio tabs.
+    expect(parsePathRoute('/nightshift/neon-courier/nope')).toEqual({ view: 'notFound' });
+    // Handle and slug keep their own grammars.
+    expect(parsePathRoute('/Nightshift/neon-courier')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/nightshift/Neon%20Courier')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute('/nightshift/-bad')).toEqual({ view: 'notFound' });
+    // First-class product segments keep their meaning; they never become handles.
+    expect(parsePathRoute('/play/neon-courier')).toEqual({ view: 'play', slug: 'neon-courier' });
+    expect(parsePathRoute('/creators/ada')).toEqual({ view: 'creator', handle: 'ada' });
+  });
+
   it('parses the legal routes', () => {
     expect(parsePathRoute('/privacy')).toEqual({ view: 'legal', doc: 'privacy' });
     expect(parsePathRoute('/terms')).toEqual({ view: 'legal', doc: 'terms' });
@@ -203,6 +229,29 @@ describe('path builders', () => {
   it('builds a root creator path that round-trips', () => {
     expect(creatorPath('ada')).toBe('/ada');
     expect(parsePathRoute(creatorPath('ada'))).toEqual({ view: 'creator', handle: 'ada' });
+  });
+
+  it('builds a game page path that round-trips', () => {
+    expect(gamePath('nightshift', 'neon-courier')).toBe('/nightshift/neon-courier');
+    expect(gamePath('nightshift', 'neon-courier', 'releases')).toBe('/nightshift/neon-courier/releases');
+    expect(parsePathRoute(gamePath('nightshift', 'neon-courier'))).toEqual({
+      view: 'game',
+      handle: 'nightshift',
+      slug: 'neon-courier',
+    });
+    expect(parsePathRoute(gamePath('nightshift', 'neon-courier', 'board'))).toEqual({
+      view: 'game',
+      handle: 'nightshift',
+      slug: 'neon-courier',
+      tab: 'board',
+    });
+  });
+
+  it('sends game page Up to the owning creator profile', () => {
+    expect(navUpTarget({ view: 'game', handle: 'nightshift', slug: 'neon-courier' })).toEqual({
+      path: '/nightshift',
+      labelKey: 'upCreator',
+    });
   });
 
   it('percent-encodes status tokens into studio paths', () => {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -466,8 +466,8 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
       }
       return { path: '/', labelKey: 'upHome' };
     case 'game':
-      // The page is nested under the creator profile the way a repo nests under
-      // its owner — Up is the studio, not the homepage.
+      // The page is nested under the creator profile the way a repo nests under its
+      // owner, so Up goes to that profile rather than to the homepage.
       return { path: creatorPath(route.handle), labelKey: 'upCreator' };
     case 'admin':
     case 'legal':

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -43,6 +43,19 @@ export function isStudioTab(value: string): value is StudioTab {
 }
 
 /**
+ * Public game page tabs — the "repo page" layout at `/:handle/:slug`. The default
+ * surface (the playable game) carries no URL segment, so only the four secondary
+ * tabs appear here. Keep the vocabulary aligned with `GAME_PAGE_PATTERN` in
+ * apps/api/src/spa-paths.ts.
+ */
+export const GAME_PAGE_TABS = ['board', 'review', 'releases', 'sources'] as const;
+export type GamePageTab = (typeof GAME_PAGE_TABS)[number];
+
+export function isGamePageTab(value: string): value is GamePageTab {
+  return (GAME_PAGE_TABS as readonly string[]).includes(value);
+}
+
+/**
  * Operator console sections, in the order they are offered.
  *
  * `queue` leads because it is the only one with something to do in it; the rest are
@@ -102,6 +115,12 @@ export type AppRoute =
   // an alias for links minted before profiles moved to the root namespace. Handle shape
   // matches the API (`^[a-z][a-z0-9_]{2,23}$`).
   | { view: 'creator'; handle: string }
+  // Public game page — the "repo page" nested under the creator profile, GitHub-style
+  // (`/:handle/:slug`). Reachable without a session, same as the profile above: the
+  // page is a landing page, and only *playing* is gated during closed beta. `tab`
+  // absent is the default surface (the playable game); the named tabs are the
+  // board / review / releases / sources secondary surfaces.
+  | { view: 'game'; handle: string; slug: string; tab?: GamePageTab }
   // Unknown / invalid path. Kept as its own view so a typo or stale bookmark shows a
   // real 404 instead of silently dumping the visitor on the home catalog.
   | { view: 'notFound' };
@@ -112,6 +131,44 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /** Creator handles — keep aligned with apps/api/src/creator-profile.ts HANDLE_PATTERN. */
 const CREATOR_HANDLE_PATTERN = /^[a-z][a-z0-9_]{2,23}$/;
+
+/**
+ * Handles nobody can claim — keep aligned with `RESERVED_HANDLES` in
+ * apps/api/src/creator-profile.ts (same duplication contract as spa-paths.ts).
+ * The game-page matcher checks it so `/health/<slug>`-shaped typos stay 404s on
+ * the client exactly as the API's shell allowlist answers them.
+ */
+const RESERVED_HANDLE_SEGMENTS = new Set([
+  'admin',
+  'administrator',
+  'anonymous',
+  'api',
+  'auth',
+  'contact',
+  'creator',
+  'creators',
+  'dev',
+  'draft',
+  'gamedev',
+  'gamedevpl',
+  'health',
+  'help',
+  'join',
+  'me',
+  'null',
+  'official',
+  'play',
+  'platform',
+  'privacy',
+  'root',
+  'status',
+  'studio',
+  'support',
+  'system',
+  'terms',
+  'undefined',
+  'www',
+]);
 
 // Canonical play prefix is `/play`. `/ay` and `/ai` are accepted aliases (same view);
 // the app rewrites them to `/play/<slug>` so shared URLs stay consistent.
@@ -254,6 +311,33 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     return { view: 'creator', handle: rootHandle };
   }
 
+  // Public game page: `/:handle/:slug` (+ optional tab). Last for the same reason the
+  // root profile is late — every first-class segment above keeps its meaning, and the
+  // product segments are additionally reserved at handle-claim time, so a real handle
+  // can never collide with them. An unknown tab segment is a 404, not a fallback,
+  // matching the studio tabs and the API's shell allowlist.
+  const gameMatch = normalizedPath.match(/^\/([^/]+)\/([^/]+)(?:\/([^/]+))?$/);
+  if (gameMatch?.[1] && gameMatch[2]) {
+    const handle = decodeSegment(gameMatch[1]);
+    const slug = decodeSegment(gameMatch[2]);
+    const tabSegment = gameMatch[3] ? decodeSegment(gameMatch[3]) : undefined;
+    if (
+      handle &&
+      CREATOR_HANDLE_PATTERN.test(handle) &&
+      !RESERVED_HANDLE_SEGMENTS.has(handle) &&
+      slug &&
+      SLUG_PATTERN.test(slug) &&
+      tabSegment !== null
+    ) {
+      if (!tabSegment) {
+        return { view: 'game', handle, slug };
+      }
+      if (isGamePageTab(tabSegment)) {
+        return { view: 'game', handle, slug, tab: tabSegment };
+      }
+    }
+  }
+
   return { view: 'notFound' };
 }
 
@@ -311,6 +395,8 @@ export function canonicalPath(pathname: string): string | null {
         return route.game ? studioPath(route.game, route.tab) : null;
       case 'creator':
         return creatorPath(route.handle);
+      case 'game':
+        return gamePath(route.handle, route.slug, route.tab);
       default:
         return null;
     }
@@ -355,7 +441,7 @@ export function studioPath(game?: string, tab?: StudioTab): string {
 export type NavUpTarget = {
   path: string;
   /** i18n key under `header.*` for the button's accessible name. */
-  labelKey: 'upHome' | 'upStudio';
+  labelKey: 'upHome' | 'upStudio' | 'upCreator';
 };
 
 export function navUpTarget(route: AppRoute): NavUpTarget | null {
@@ -379,6 +465,10 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
         return { path: studioPath(), labelKey: 'upStudio' };
       }
       return { path: '/', labelKey: 'upHome' };
+    case 'game':
+      // The page is nested under the creator profile the way a repo nests under
+      // its owner — Up is the studio, not the homepage.
+      return { path: creatorPath(route.handle), labelKey: 'upCreator' };
     case 'admin':
     case 'legal':
     case 'contact':
@@ -430,6 +520,12 @@ export function contactPath(): string {
 /** URL for a public creator profile. */
 export function creatorPath(handle: string): string {
   return `/${handle}`;
+}
+
+/** URL for a public game page, optionally deep-linked into a secondary tab. */
+export function gamePath(handle: string, slug: string, tab?: GamePageTab): string {
+  const base = `/${encodeURIComponent(handle)}/${encodeURIComponent(slug)}`;
+  return tab ? `${base}/${tab}` : base;
 }
 
 /**

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -133,6 +133,12 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const CREATOR_HANDLE_PATTERN = /^[a-z][a-z0-9_]{2,23}$/;
 
 /**
+ * Where games with no creator to name live — keep aligned with `PLATFORM_HANDLE` in
+ * apps/api/src/creator-profile.ts. Reserved against claiming, but a real address.
+ */
+export const PLATFORM_HANDLE = 'gamedevpl';
+
+/**
  * Handles nobody can claim — keep aligned with `RESERVED_HANDLES` in
  * apps/api/src/creator-profile.ts (same duplication contract as spa-paths.ts).
  * The game-page matcher checks it so `/health/<slug>`-shaped typos stay 404s on
@@ -324,7 +330,9 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
     if (
       handle &&
       CREATOR_HANDLE_PATTERN.test(handle) &&
-      !RESERVED_HANDLE_SEGMENTS.has(handle) &&
+      // The platform handle is reserved against claiming but *is* an address: it is
+      // where games with no creator to name live. Keep aligned with spa-paths.ts.
+      (handle === PLATFORM_HANDLE || !RESERVED_HANDLE_SEGMENTS.has(handle)) &&
       slug &&
       SLUG_PATTERN.test(slug) &&
       tabSegment !== null

--- a/apps/web/src/specBlocks.ts
+++ b/apps/web/src/specBlocks.ts
@@ -1,0 +1,76 @@
+/**
+ * The SPEC.md block parser behind SpecMarkdown — its own module so the component
+ * file exports only components (react-refresh) and so GamePage can derive the
+ * page description from the first paragraph without importing the renderer.
+ */
+
+export type SpecBlock =
+  | { kind: 'heading'; level: number; text: string }
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'list'; ordered: boolean; items: string[] }
+  | { kind: 'code'; text: string }
+  | { kind: 'rule' };
+
+export function parseSpecBlocks(markdown: string): SpecBlock[] {
+  const blocks: SpecBlock[] = [];
+  const lines = markdown.split(/\r?\n/);
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+    if (line.startsWith('```')) {
+      const code: string[] = [];
+      index += 1;
+      while (index < lines.length && !lines[index].startsWith('```')) {
+        code.push(lines[index]);
+        index += 1;
+      }
+      index += 1; // closing fence (or EOF)
+      blocks.push({ kind: 'code', text: code.join('\n') });
+      continue;
+    }
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      blocks.push({ kind: 'heading', level: heading[1].length, text: heading[2].trim() });
+      index += 1;
+      continue;
+    }
+    if (/^(-{3,}|\*{3,})\s*$/.test(line.trim())) {
+      blocks.push({ kind: 'rule' });
+      index += 1;
+      continue;
+    }
+    const listMatch = /^\s*([-*]|\d+[.)])\s+/.exec(line);
+    if (listMatch) {
+      const ordered = /^\d/.test(listMatch[1]);
+      const items: string[] = [];
+      while (index < lines.length) {
+        const item = /^\s*(?:[-*]|\d+[.)])\s+(.*)$/.exec(lines[index]);
+        if (!item) break;
+        items.push(item[1]);
+        index += 1;
+      }
+      blocks.push({ kind: 'list', ordered, items });
+      continue;
+    }
+    const paragraph: string[] = [];
+    while (index < lines.length) {
+      const current = lines[index];
+      if (
+        !current.trim() ||
+        current.startsWith('```') ||
+        /^(#{1,6})\s+/.test(current) ||
+        /^\s*([-*]|\d+[.)])\s+/.test(current)
+      ) {
+        break;
+      }
+      paragraph.push(current.trim());
+      index += 1;
+    }
+    blocks.push({ kind: 'paragraph', text: paragraph.join(' ') });
+  }
+  return blocks;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13040,3 +13040,168 @@ a.user-name--profile:focus-visible {
   color: var(--muted);
   max-width: 70ch;
 }
+
+/* The review surface — two playable frames, and the diff as a footnote. */
+
+.game-review-title {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+}
+
+.game-review-meta {
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.game-review-gate {
+  padding: 1px 8px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.game-review-gate.is-green {
+  border-color: rgba(74, 222, 128, 0.5);
+  color: #4ade80;
+}
+
+.game-review-gate.is-red {
+  border-color: rgba(242, 162, 162, 0.5);
+  color: #f2a2a2;
+}
+
+.game-review-instruction {
+  margin: 0 0 14px;
+  font-size: 0.9rem;
+}
+
+.game-review-panes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 760px) {
+  .game-review-panes {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.game-review-pane {
+  margin: 0;
+  min-width: 0;
+}
+
+/* Half-width frames: the standalone .game-frame height would tower over them. */
+.game-review-pane .game-frame {
+  height: min(42vh, 420px);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: #000;
+}
+
+.game-review-caption {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.game-review-caption.is-candidate {
+  color: var(--turquoise);
+}
+
+.game-review-version {
+  font-family: ui-monospace, monospace;
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.game-review-missing {
+  margin: 0;
+  padding: 32px 16px;
+  border: 1px dashed var(--panel-border);
+  border-radius: 8px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.game-review-verdict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.game-review-verdict .secondary-btn {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.game-review-approved {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: #4ade80;
+}
+
+.game-review-note {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+.game-review-diff {
+  margin-top: 16px;
+  border-top: 1px solid var(--panel-border);
+  padding-top: 10px;
+}
+
+.game-review-diff-toggle {
+  padding: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  text-decoration: underline;
+}
+
+.game-review-diff-toggle:hover {
+  color: var(--text);
+}
+
+.game-review-diff-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+}
+
+.game-review-diff-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.game-review-diff-counts {
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13176,8 +13176,12 @@ a.user-name--profile:focus-visible {
 .game-review-diff-toggle {
   padding: 0;
   font-size: 0.8rem;
+  font-weight: 400;
   color: var(--muted);
   text-decoration: underline;
+  /* Same UA-default guard as the sources file list — this is a text control. */
+  background: transparent;
+  border: 0;
 }
 
 .game-review-diff-toggle:hover {
@@ -13255,8 +13259,13 @@ a.user-name--profile:focus-visible {
   padding: 5px 8px;
   border-radius: 5px;
   font-size: 0.8rem;
+  font-weight: 400;
   text-align: left;
   color: var(--muted);
+  /* The global `button` rule sets no background, so a bare button falls back to the
+     UA's light `buttonface` — which on this dark theme reads as an inverted pill. */
+  background: transparent;
+  border: 1px solid transparent;
 }
 
 .game-sources-file:hover {
@@ -13268,6 +13277,7 @@ a.user-name--profile:focus-visible {
   background: var(--panel-card);
   color: var(--text);
   font-weight: 600;
+  border-color: var(--panel-border);
 }
 
 .game-sources-file-path {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12914,3 +12914,129 @@ a.user-name--profile:focus-visible {
   color: var(--muted);
   font-size: 0.9rem;
 }
+
+/* The task board — four columns, and deliberately nothing else. */
+
+.game-board-columns {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  .game-board-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .game-board-columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.game-board-column {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 10px;
+  min-width: 0;
+}
+
+.game-board-column-heading {
+  margin: 0 0 10px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.game-board-column-count {
+  margin-left: 4px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--panel-card);
+  color: var(--text);
+}
+
+.game-board-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.game-board-card {
+  background: var(--panel-card);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.game-board-card-title {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  overflow-wrap: break-word;
+}
+
+.game-board-card-detail {
+  margin: 6px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.game-board-card-foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.game-board-card-by,
+.game-board-card-when {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.game-board-class {
+  padding: 1px 8px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  text-transform: lowercase;
+}
+
+.game-board-class--defect {
+  border-color: rgba(242, 162, 162, 0.5);
+  color: #f2a2a2;
+}
+
+.game-board-assign {
+  padding: 3px 10px;
+  font-size: 0.78rem;
+}
+
+.game-board-empty {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.game-board-error {
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--error);
+  border-radius: 6px;
+  color: var(--error);
+  font-size: 0.85rem;
+}
+
+.game-board-note {
+  margin: 14px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  max-width: 70ch;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13363,3 +13363,16 @@ a.user-name--profile:focus-visible {
 .tok-key {
   color: #c9a3e0;
 }
+
+.game-page-follow-count {
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--panel-card);
+  font-size: 0.75rem;
+}
+
+.game-page-actions .secondary-btn.is-following {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13386,3 +13386,11 @@ a.user-name--profile:focus-visible {
   border-color: var(--turquoise);
   color: var(--turquoise);
 }
+
+/* Catalog card's route to the game page — quiet beside the green Play button. */
+.card-about-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  font-size: 0.85rem;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13205,3 +13205,161 @@ a.user-name--profile:focus-visible {
   font-family: ui-monospace, monospace;
   white-space: nowrap;
 }
+
+/* Sources — code as a first-class view, not an escape hatch. */
+
+.game-sources-intro {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.game-sources-version {
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+}
+
+.game-sources-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+@media (max-width: 760px) {
+  .game-sources-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.game-sources-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.game-sources-file {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  text-align: left;
+  color: var(--muted);
+}
+
+.game-sources-file:hover {
+  background: var(--panel);
+  color: var(--text);
+}
+
+.game-sources-file.is-active {
+  background: var(--panel-card);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.game-sources-file-path {
+  font-family: ui-monospace, monospace;
+  overflow-wrap: anywhere;
+}
+
+.game-sources-file-bytes {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  opacity: 0.75;
+}
+
+.game-sources-viewer {
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: var(--panel);
+  min-width: 0;
+}
+
+.game-sources-viewer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.game-sources-viewer-path {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.game-sources-copy {
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.game-sources-note {
+  margin: 0;
+  padding: 20px 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.game-sources-code {
+  margin: 0;
+  padding: 10px 0;
+  max-height: 70vh;
+  overflow: auto;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.game-sources-line {
+  display: flex;
+}
+
+.game-sources-gutter {
+  flex: 0 0 3.5em;
+  padding-right: 10px;
+  text-align: right;
+  color: var(--muted);
+  opacity: 0.55;
+  user-select: none;
+}
+
+.game-sources-line-text {
+  white-space: pre;
+  padding-right: 12px;
+}
+
+.tok-comment {
+  color: #7f8ea3;
+  font-style: italic;
+}
+
+.tok-string {
+  color: #9ad39a;
+}
+
+.tok-number {
+  color: #e0b978;
+}
+
+.tok-keyword {
+  color: var(--turquoise);
+}
+
+.tok-key {
+  color: #c9a3e0;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12501,3 +12501,416 @@ a.user-name--profile:focus-visible {
   background: rgba(242, 162, 162, 0.16);
   color: #f2a2a2;
 }
+
+/* ============================================================
+   Public game page — the "repo page" at /:handle/:slug.
+   Layout borrowed from a repository page: header, tabs, main
+   pane + sidebar. The default pane is the playable game.
+   ============================================================ */
+
+.game-page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+.game-page-status {
+  max-width: 640px;
+  margin: 48px auto;
+  text-align: center;
+  color: var(--muted);
+}
+
+.game-page-error {
+  color: var(--error);
+}
+
+.game-page-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.game-page-breadcrumb a {
+  color: var(--turquoise);
+  text-decoration: none;
+}
+
+.game-page-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.game-page-breadcrumb-slug {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.game-page-genre-badge {
+  margin-left: 8px;
+  padding: 1px 8px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: lowercase;
+}
+
+.game-page-title {
+  margin: 8px 0 4px;
+  font-size: 1.6rem;
+  line-height: 1.2;
+}
+
+.game-page-description {
+  margin: 0 0 14px;
+  max-width: 70ch;
+  color: var(--muted);
+}
+
+.game-page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.game-page-actions .secondary-btn[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.game-page-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin: 18px 0 0;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.game-page-tab {
+  padding: 8px 14px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+}
+
+.game-page-tab:hover {
+  color: var(--text);
+  background: var(--panel);
+}
+
+.game-page-tab.is-active {
+  color: var(--text);
+  font-weight: 600;
+  background: var(--panel);
+  border-color: var(--panel-border);
+  /* Sits on the border so the active tab reads as part of the pane below. */
+  margin-bottom: -1px;
+  border-bottom: 1px solid var(--bg);
+}
+
+.game-page-tab-count {
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--panel-card);
+  font-size: 0.75rem;
+}
+
+.game-page-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+@media (max-width: 900px) {
+  .game-page-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.game-page-frame .game-frame {
+  /* The standalone .game-frame height applies; keep the pane self-contained. */
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: #000;
+}
+
+.game-page-frame.is-hidden {
+  display: none;
+}
+
+.game-page-sandbox-note {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.game-page-gated {
+  border: 1px dashed var(--panel-border);
+  border-radius: 8px;
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.game-page-gated h2 {
+  margin: 0 0 8px;
+}
+
+.game-page-gated p {
+  margin: 0 auto 16px;
+  max-width: 46ch;
+  color: var(--muted);
+}
+
+.game-page-empty {
+  color: var(--muted);
+}
+
+.game-page-release-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.game-page-release {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.game-page-release-version {
+  font-family: ui-monospace, monospace;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.game-page-release-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.game-page-release-dot.is-green {
+  background: #4ade80;
+}
+
+.game-page-release-dot.is-red {
+  background: #f2a2a2;
+}
+
+.game-page-release-meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.game-page-release-current {
+  padding: 0 8px;
+  border: 1px solid var(--turquoise);
+  border-radius: 999px;
+  color: var(--turquoise);
+  font-size: 0.75rem;
+}
+
+.game-page-placeholder {
+  border: 1px dashed var(--panel-border);
+  border-radius: 8px;
+  padding: 32px 24px;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.game-page-placeholder h2 {
+  margin: 0 0 8px;
+  color: var(--text);
+}
+
+.game-page-side {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.game-page-panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+
+.game-page-panel-heading {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+}
+
+.game-page-panel-hint {
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.spec-markdown {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  overflow-wrap: break-word;
+}
+
+.spec-markdown h3,
+.spec-markdown h4,
+.spec-markdown h5,
+.spec-markdown h6 {
+  margin: 14px 0 6px;
+  font-size: 0.95rem;
+}
+
+.spec-markdown p {
+  margin: 0 0 10px;
+}
+
+.spec-markdown ul,
+.spec-markdown ol {
+  margin: 0 0 10px;
+  padding-left: 20px;
+}
+
+.spec-markdown pre {
+  background: var(--panel-card);
+  border-radius: 6px;
+  padding: 10px;
+  overflow-x: auto;
+  font-size: 0.8rem;
+}
+
+.spec-markdown code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
+}
+
+.spec-markdown hr {
+  border: none;
+  border-top: 1px solid var(--panel-border);
+  margin: 12px 0;
+}
+
+.game-page-stats {
+  margin: 0;
+}
+
+.game-page-stats div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.game-page-stats dt {
+  color: var(--muted);
+}
+
+.game-page-stats dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.game-page-team {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.game-page-team li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.game-page-team img {
+  border-radius: 50%;
+}
+
+.game-page-team a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.game-page-team a:hover {
+  text-decoration: underline;
+}
+
+.game-page-team-role {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.game-page-lettermark {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--panel-card);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.game-page-modules {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.game-page-module {
+  padding: 2px 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+}
+
+.game-page-budget-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--panel-card);
+  overflow: hidden;
+}
+
+.game-page-budget-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--turquoise);
+}
+
+.game-page-budget-caption {
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.game-page-latest-release {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -119,7 +119,15 @@ describe('route kinds follow the real router', () => {
     ['/studio', 'studio'],
     ['/studio/some-token', 'studio'],
     ['/gtanczyk', 'legal'],
-    ['/nope/more', 'notFound'],
+    // The public game page is its own acquisition bucket (funnel question 2). A
+    // handle-shaped pair parses as one whether or not the game exists — same as a
+    // profile URL for a handle nobody claimed reporting `legal`.
+    ['/nightshift/neon-courier', 'game'],
+    ['/nightshift/neon-courier/releases', 'game'],
+    ['/nope/more', 'game'],
+    // Reserved first segments never become game pages.
+    ['/health/brick-storm', 'notFound'],
+    ['/nope/more/than/three', 'notFound'],
   ])('reads %s as %s', (pathname, expected) => {
     expect(routeKind(parsePathRoute(pathname, '').view)).toBe(expected);
   });

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -26,7 +26,8 @@ const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
  */
 
 /** Where a visit is, coarsely. Route parameters (tokens, slugs) never travel. */
-export type VisitRouteKind = 'home' | 'play' | 'draft' | 'status' | 'join' | 'legal' | 'health' | 'studio' | 'notFound';
+export type VisitRouteKind =
+  'home' | 'play' | 'draft' | 'status' | 'join' | 'legal' | 'health' | 'studio' | 'game' | 'notFound';
 
 export type VisitEvent =
   | {
@@ -335,6 +336,11 @@ export function routeKind(view: string): VisitRouteKind {
     case 'studio':
     case 'notFound':
       return view;
+    // The public game page is its own acquisition surface — the funnel's question 2
+    // ("does a visit that arrives on a game page play a second game") needs it
+    // distinguishable from a direct /play deep link, so it does not fold into `play`.
+    case 'game':
+      return 'game';
     // The console reports as `health`, the name it had when the funnel started
     // recording it. Renaming the bucket would split one surface's history in two.
     case 'admin':


### PR DESCRIPTION
## Summary
Implements the public game page (`/:handle/:slug`) as a landing page for published games, borrowing GitHub's repository page layout with header, tabs, playable frame, and sidebar panels. The page is reachable without authentication during closed beta (only playing is gated), and aggregates catalog metadata, SPEC.md content, module composition, release history, and play statistics.

## Key Changes

### Frontend (apps/web/src)
- **GamePage.tsx**: New component rendering the public game page with:
  - Breadcrumb navigation and game metadata (title, genre, description)
  - Action buttons (Play, Follow, Remix)
  - Tab navigation (Game, Board, Review, Releases, Sources)
  - Conditional frame mounting to preserve game state across tab switches
  - Auth gating for play during private beta
  - Canonical URL handling for creator handle mismatches

- **SpecMarkdown.tsx & specBlocks.ts**: Safe markdown renderer for SPEC.md body:
  - Hand-rolled parser (no external markdown dependency) to prevent injection attacks
  - Supports headings, paragraphs, lists, code blocks, rules, and inline formatting
  - All content rendered as React elements (no `dangerouslySetInnerHTML`)

- **gamePageApi.ts**: Client-side API integration for uncredentialed game page fetch

- **router.ts**: Added `GamePageTab` type and `gamePath()` helper; updated route parsing to recognize `/:handle/:slug[/:tab]` patterns

- **Styling (styles.css)**: ~420 lines of new CSS for game page layout, tabs, panels, release list, team display, and budget visualization

- **i18n**: Added English and Polish translations for game page UI

### Backend (apps/api/src)
- **game-page-routes.ts**: New endpoint `GET /api/games/:slug/page` that aggregates:
  - Catalog entry and creator profile
  - SPEC.md body (frontmatter stripped)
  - GameKit module composition from GAME.json
  - Author byte budget usage
  - Release history (newest first, with gate verdicts)
  - Play statistics from scorecard

- **games-store.ts**: Added `listVersions()` method to retrieve version history with optional limit

- **app.ts & spa-paths.ts**: Registered game page routes and updated SPA path patterns

### Tests
- **GamePage.test.tsx**: Component tests covering rendering, tab navigation, frame mounting, auth gating, and canonical path handling
- **SpecMarkdown.test.tsx**: Markdown parser tests for all supported syntax
- **game-page-routes.test.ts**: API endpoint tests for store-published and repo-committed games, including module reading and budget calculation

## Notable Implementation Details

- **Frame persistence**: The game frame mounts on first visit to the Game tab and stays mounted (hidden by CSS) on other tabs, preserving running game state during navigation
- **Safe markdown**: SPEC.md rendering avoids external dependencies and HTML parsing; React's element escaping is the sole sanitizer
- **Canonical URLs**: Pages with mismatched creator handles redirect to the canonical address (App replaces, not pushes)
- **Tolerant module reading**: GAME.json parsing is lenient to handle older deliveries; unknown modules are dropped and order is normalized
- **Caching**: Brief, bounded cache (60s default, 500-entry limit) for the expensive multi-read aggregation
- **Beta gating**: Page renders for all visitors; only the playable frame is gated behind auth during closed beta

https://claude.ai/code/session_01LiKSAoa7JbFb2565xqrsce