### PR TITLE
Thread MCP_UI through both deploy paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,8 +196,9 @@ jobs:
           # rather than hand-set for the same reason as everything above. Turning it on is
           # inert for every client that does not declare the extension — they get the same
           # initialize result and tools/list they got before views existed — so the blast
-          # radius is limited to hosts that opted in. Absent or not "true" is that
-          # pre-views state, which is how the endpoint has always run in production.
+          # radius is limited to hosts that opted in. Enabled by "true" or "1",
+          # case-insensitive (mcpUiEnabled, apps/api/src/mcp-ui.ts); absent or any other
+          # value is the pre-views state the endpoint has always run in production.
           MCP_UI_VAL="${{ vars.MCP_UI }}"
           if [ -n "$MCP_UI_VAL" ]; then
             ENV_VARS="${ENV_VARS}|MCP_UI=${MCP_UI_VAL}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,6 +191,18 @@ jobs:
             ENV_VARS="${ENV_VARS}|CODE_LANE=${CODE_LANE_VAL}"
           fi
 
+          # MCP Apps views (SEP-1865) on /api/mcp: a ui:// resource registry and _meta.ui
+          # for clients that negotiate the io.modelcontextprotocol/ui extension. Threaded
+          # rather than hand-set for the same reason as everything above. Turning it on is
+          # inert for every client that does not declare the extension — they get the same
+          # initialize result and tools/list they got before views existed — so the blast
+          # radius is limited to hosts that opted in. Absent or not "true" is that
+          # pre-views state, which is how the endpoint has always run in production.
+          MCP_UI_VAL="${{ vars.MCP_UI }}"
+          if [ -n "$MCP_UI_VAL" ]; then
+            ENV_VARS="${ENV_VARS}|MCP_UI=${MCP_UI_VAL}"
+          fi
+
           # The remix code-lane trace: every step of a run, in the log and in the
           # response — which region call 1 picked, what call 2 was shown, what it
           # wrote back, and every build error. On by owner decision (2026-08-03)

--- a/apps/api/src/mcp-ui-flag.test.ts
+++ b/apps/api/src/mcp-ui-flag.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * `MCP_UI` opens MCP Apps views (SEP-1865) on `/api/mcp`.
+ *
+ * Same threading rule as every other feature flag here, for the reason the deploy
+ * script records in its own comments: `--set-env-vars` replaces the whole env map, so a
+ * value set by hand on the service — or threaded by only one of the two supported deploy
+ * paths — is dropped by the next deploy from the other one, silently. On 2026-08-04 that
+ * cost a hand-set `TRANSLATE_BUILD_LOG=false`, and the spend leak it had fixed resumed
+ * unnoticed.
+ *
+ * Views are a poor thing to lose that way: the flag turns off between one deploy and the
+ * next, and the only symptom is a card that used to render and now does not, in someone
+ * else's client, where we cannot see it.
+ */
+
+const workflow = readFileSync(new URL('../../../.github/workflows/deploy.yml', import.meta.url), 'utf8');
+const script = readFileSync(new URL('../../../infra/deploy-api.sh', import.meta.url), 'utf8');
+
+describe('the MCP Apps views flag', () => {
+  it('is threaded by both deploy paths, so neither drops what the other set', () => {
+    expect(workflow).toContain('MCP_UI_VAL="${{ vars.MCP_UI }}"');
+    expect(workflow).toContain('ENV_VARS="${ENV_VARS}|MCP_UI=${MCP_UI_VAL}"');
+    // The script threads it through the shared flag loop rather than its own block.
+    expect(script).toMatch(/for FLAG_VAR in [^;]*\bMCP_UI\b/);
+  });
+
+  it('is never pinned on in either path', () => {
+    // A literal would survive every attempt to turn it off from the settings page,
+    // which is the only place anyone will think to look.
+    expect(workflow).not.toMatch(/MCP_UI=(true|"true")/);
+    expect(script).not.toMatch(/MCP_UI=(true|"true")/);
+  });
+});

--- a/apps/api/src/mcp-ui-flag.test.ts
+++ b/apps/api/src/mcp-ui-flag.test.ts
@@ -29,8 +29,19 @@ describe('the MCP Apps views flag', () => {
 
   it('is never pinned on in either path', () => {
     // A literal would survive every attempt to turn it off from the settings page,
-    // which is the only place anyone will think to look.
-    expect(workflow).not.toMatch(/MCP_UI=(true|"true")/);
-    expect(script).not.toMatch(/MCP_UI=(true|"true")/);
+    // which is the only place anyone will think to look. Both spellings the parser
+    // accepts count as a pin, not just "true".
+    //
+    // Comments are stripped first: a pin is code, and the env-header docs legitimately
+    // name the values that switch views on. Matching unanchored matters — in the
+    // workflow a pin would sit mid-string inside the ENV_VARS list, not at line end.
+    const code = (source: string) =>
+      source
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n');
+    const pinned = /MCP_UI=("?)(true|1)\1/i;
+    expect(code(workflow)).not.toMatch(pinned);
+    expect(code(script)).not.toMatch(pinned);
   });
 });

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -27,9 +27,10 @@
 #                               store app exists. Empty = /api/auth/apple returns 503)
 #   WEB_ORIGIN=...             (CORS allowed origins)
 #   PRIVATE_BETA=true          (gate all data reads behind a session + allowlist)
-#   MCP_UI=...                 ("true" opens MCP Apps views on /api/mcp — SEP-1865.
-#                               Inert for any client that does not negotiate the
-#                               extension; anything else keeps the pre-views contract)
+#   MCP_UI=...                 ("true" or "1", case-insensitive, opens MCP Apps views on
+#                               /api/mcp — SEP-1865. Inert for any client that does not
+#                               negotiate the extension; any other value keeps the
+#                               pre-views contract)
 #   BETA_ALLOWED_UIDS=...      (comma-separated g:<sub> values)
 #   ADMIN_UIDS=...             (comma-separated g:<sub> values; operator telemetry view)
 #   BETA_ALLOWED_EMAILS=...    (comma-separated verified email addresses)

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -27,6 +27,9 @@
 #                               store app exists. Empty = /api/auth/apple returns 503)
 #   WEB_ORIGIN=...             (CORS allowed origins)
 #   PRIVATE_BETA=true          (gate all data reads behind a session + allowlist)
+#   MCP_UI=...                 ("true" opens MCP Apps views on /api/mcp — SEP-1865.
+#                               Inert for any client that does not negotiate the
+#                               extension; anything else keeps the pre-views contract)
 #   BETA_ALLOWED_UIDS=...      (comma-separated g:<sub> values)
 #   ADMIN_UIDS=...             (comma-separated g:<sub> values; operator telemetry view)
 #   BETA_ALLOWED_EMAILS=...    (comma-separated verified email addresses)
@@ -252,7 +255,7 @@ done
 #
 # The rule this file already states for REMIX_DEBUG applies to every one of them: both
 # supported paths carry a flag, or neither should.
-for FLAG_VAR in SEED_DISPATCH CODE_LANE EDITOR_ASSIST MCP_AUTHORIZATION_SERVERS; do
+for FLAG_VAR in SEED_DISPATCH CODE_LANE EDITOR_ASSIST MCP_AUTHORIZATION_SERVERS MCP_UI; do
   eval "FLAG_VAL=\${${FLAG_VAR}:-}"
   if [ -n "${FLAG_VAL}" ]; then
     ENV_VARS="${ENV_VARS}|${FLAG_VAR}=${FLAG_VAL}"


### PR DESCRIPTION
MCP Apps views (SEP-1865) shipped in #573 behind `MCP_UI`, but nothing carried that flag to Cloud Run — so there was no way to turn views on in production without the change reverting itself.

`--set-env-vars` replaces the whole env map, so a value set by hand on the service, or threaded by only one of the two supported deploy paths, is dropped by the next deploy from the other one, silently. That is the failure this repo already paid for on 2026-08-04, when a hand-set `TRANSLATE_BUILD_LOG=false` vanished under an unrelated deploy and the spend leak it had fixed resumed unnoticed. `deploy-api.sh` records that incident in its own comments; this follows the rule it states.

## Changes

- **`.github/workflows/deploy.yml`** — threads `MCP_UI` from the repo variable, alongside `SEED_DISPATCH` / `EDITOR_ASSIST` / `CODE_LANE`.
- **`infra/deploy-api.sh`** — adds `MCP_UI` to the shared flag loop, so a deploy from the script cannot drop what the workflow set. Documented in the script's env header.
- **`apps/api/src/mcp-ui-flag.test.ts`** — pins both directions, and asserts neither path pins the flag on with a literal. Mirrors the guard `remix-debug-flag.test.ts` already carries. (The literal check caught a real slip while writing this: the env-header doc line originally read `MCP_UI=true`.)

## Blast radius

Absent, or anything other than `"true"`, leaves the endpoint exactly as it runs today. Even switched on, it is inert for any client that does not negotiate the `io.modelcontextprotocol/ui` extension — those clients get the same `initialize` result and `tools/list` they got before views existed, which #573's tests pin. So the exposure is limited to hosts that explicitly opted in.

## Verification

`bash -n` on the script, YAML parse on the workflow, new tests plus the existing MCP suites green, lint clean. Production probed before the change: `initialize` returns only `{"tools":{"listChanged":false}}`, confirming views are off there today — that same probe is the after-check once this deploys with the variable set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_