### PR TITLE
feat(studio): keep prior improve rounds as collapsed chat history

### DIFF
--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -249,6 +249,37 @@ export interface SubmissionStatusResponseBase {
    * round the creator did not initiate in the UI (BY-24).
    */
   openedBy?: 'creator' | 'agent';
+  /**
+   * Older jobs on the same slug (same owner), oldest first — so Studio can keep prior
+   * rounds in the chat as collapsed history instead of dropping them when an improve
+   * opens a new job. Absent when this is the only job, or the job has no slug yet.
+   */
+  priorRounds?: PriorRoundHistory[];
+}
+
+/**
+ * One finished (or superseded) build job's transcript, summarized for the tip job's
+ * status page. Entries are oldest→newest and capped; the full per-job store remains
+ * the source of truth.
+ */
+export interface PriorRoundHistory {
+  /** Stable id for client dismiss keys — the job number as a string. */
+  id: string;
+  createdAt: string;
+  /** Set when this job itself shipped. */
+  publishedAt?: string;
+  status: SubmissionStatus;
+  entries: PriorRoundEntry[];
+}
+
+/** One row inside a {@link PriorRoundHistory} block. */
+export interface PriorRoundEntry {
+  kind: 'revision' | 'event';
+  text: string;
+  createdAt: string;
+  /** Present on revisions an agent wrote on the creator's behalf. */
+  origin?: 'agent';
+  step?: BuildStep;
 }
 
 /**

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -3849,6 +3849,60 @@ describe('POST /api/submissions/:token/improve', () => {
     expect(await store.listPendingCreatorMessages(jobId)).toEqual([]);
     await app.close();
   });
+
+  it('attaches prior sibling rounds on the tip job’s status so Studio can keep history', async () => {
+    // Publishing is terminal → improve = new job with an empty live thread. Prior days of
+    // chat still live on the old job; status must surface them as priorRounds rather than
+    // looking deleted.
+    const stub = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+    });
+
+    const published = await store.allocateJobId();
+    await store.createSubmission(published, 'g:test-user', 'History Game');
+    await store.setSubmissionSlug(published, 'history-game');
+    await store.setSubmissionPublishedAt(published, '2026-07-01T00:00:00.000Z');
+    await store.appendCreatorMessage(published, 'Make the lobby louder.');
+    await store.appendBuildEvent(published, {
+      kind: 'done',
+      step: 'polishing',
+      text: 'Lobby volume bumped for the opening scene.',
+      createdAt: '2026-07-01T01:00:00.000Z',
+    });
+
+    // Another creator's job on the same slug must never appear.
+    const foreign = await store.allocateJobId();
+    await store.createSubmission(foreign, 'g:other-user', 'History Game');
+    await store.setSubmissionSlug(foreign, 'history-game');
+    await store.appendCreatorMessage(foreign, 'Secret foreign note.');
+
+    const improve = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(published, secret)}/improve`,
+      headers: authHeaders,
+      payload: { feedback: 'Add a pause button on the schedule screen.' },
+    });
+    expect(improve.statusCode).toBe(200);
+    const tipToken = improve.json().token as string;
+
+    const status = await app.inject({ method: 'GET', url: `/api/submissions/${tipToken}` });
+    expect(status.statusCode).toBe(200);
+    const prior = status.json().priorRounds as
+      | Array<{ id: string; publishedAt?: string; entries: Array<{ kind: string; text: string }> }>
+      | undefined;
+    expect(prior).toHaveLength(1);
+    expect(prior![0]!.id).toBe(String(published));
+    expect(prior![0]!.publishedAt).toBe('2026-07-01T00:00:00.000Z');
+    expect(prior![0]!.entries.map((e) => e.text)).toEqual(
+      expect.arrayContaining(['Make the lobby louder.', 'Lobby volume bumped for the opening scene.']),
+    );
+    expect(prior![0]!.entries.some((e) => e.text.includes('foreign'))).toBe(false);
+    await app.close();
+  });
 });
 
 /**

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -3892,8 +3892,7 @@ describe('POST /api/submissions/:token/improve', () => {
     const status = await app.inject({ method: 'GET', url: `/api/submissions/${tipToken}` });
     expect(status.statusCode).toBe(200);
     const prior = status.json().priorRounds as
-      | Array<{ id: string; publishedAt?: string; entries: Array<{ kind: string; text: string }> }>
-      | undefined;
+      Array<{ id: string; publishedAt?: string; entries: Array<{ kind: string; text: string }> }> | undefined;
     expect(prior).toHaveLength(1);
     expect(prior![0]!.id).toBe(String(published));
     expect(prior![0]!.publishedAt).toBe('2026-07-01T00:00:00.000Z');
@@ -3901,6 +3900,16 @@ describe('POST /api/submissions/:token/improve', () => {
       expect.arrayContaining(['Make the lobby louder.', 'Lobby volume bumped for the opening scene.']),
     );
     expect(prior![0]!.entries.some((e) => e.text.includes('foreign'))).toBe(false);
+
+    // An old status token must not list later improve rounds as "earlier" history
+    // (Codex): the published job's status stays its own thread only.
+    const oldStatus = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(published, secret)}`,
+    });
+    expect(oldStatus.statusCode).toBe(200);
+    expect(oldStatus.json().priorRounds).toBeUndefined();
+
     await app.close();
   });
 });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -82,6 +82,8 @@ import {
   type BuildMediaItem,
   type BuildPlayableItem,
   type CreatorRevision,
+  type PriorRoundEntry,
+  type PriorRoundHistory,
   type SubmissionStatus,
   type SubmissionStatusResponse,
 } from './submission-status.js';
@@ -1578,6 +1580,81 @@ export async function registerSubmissionRoutes(
    * Serving a cached `stall: ended` beside fresh "now" events made Studio claim the
    * round finished while the thread was still moving.
    */
+  // Prior-round history is read on every status poll for a tip job, but changes only
+  // when a sibling gains messages — so a short cache avoids N sibling reads every 3s.
+  const priorRoundsCacheTtlMs = 30_000;
+  const maxPriorRounds = 6;
+  const maxPriorEntriesPerRound = 10;
+  const priorRoundsCache = new Map<string, { expiresAt: number; value: PriorRoundHistory[] }>();
+
+  /**
+   * Older jobs on the same slug, owned by the same creator — transcripts only, capped.
+   * Publishing is terminal, so an improve opens a new empty thread; without this the
+   * previous days of Studio chat look deleted even though they still live on those jobs.
+   */
+  async function loadPriorRounds(record: SubmissionRecord, locale: string): Promise<PriorRoundHistory[]> {
+    if (!store || !record.slug) return [];
+    const cacheKey = `${record.slug}:${record.issueNumber}:${locale}`;
+    const cached = priorRoundsCache.get(cacheKey);
+    const currentTime = now();
+    if (cached && cached.expiresAt > currentTime) return cached.value;
+
+    // Newest-first from the store; keep the most recent superseded jobs, then reverse
+    // so the chat log reads oldest → newest above the live round.
+    const siblings = (await store.listSubmissionsBySlug(record.slug))
+      .filter((sibling) => sibling.issueNumber !== record.issueNumber && sibling.ownerUid === record.ownerUid)
+      .slice(0, maxPriorRounds)
+      .reverse();
+
+    const rounds = await Promise.all(
+      siblings.map(async (sibling): Promise<PriorRoundHistory | null> => {
+        const [messages, rawEvents] = await Promise.all([
+          store!.listCreatorMessages(sibling.issueNumber, { limit: maxPriorEntriesPerRound }),
+          store!.listBuildEvents(sibling.issueNumber, { limit: maxPriorEntriesPerRound }),
+        ]);
+        const events = rawEvents.filter((event) => !isMcpPresenceEventText(event.text));
+        const revisionEntries: PriorRoundEntry[] = localizeRevisions(
+          messages.map((message) => ({
+            text: stripPlaytestContext(message.text),
+            createdAt: message.createdAt,
+            ...(message.origin === 'agent' ? { origin: 'agent' as const } : {}),
+            ...(message.textLocalized && message.locale
+              ? { textLocalized: stripPlaytestContext(message.textLocalized), locale: message.locale }
+              : {}),
+          })),
+          locale,
+        ).map((revision) => ({
+          kind: 'revision' as const,
+          text: revision.text,
+          createdAt: revision.createdAt,
+          ...(revision.origin === 'agent' ? { origin: 'agent' as const } : {}),
+        }));
+        const eventEntries: PriorRoundEntry[] = localizeEvents(events, locale).map((event) => ({
+          kind: 'event' as const,
+          text: event.text,
+          createdAt: event.createdAt,
+          ...(event.step ? { step: event.step } : {}),
+        }));
+        const entries = [...revisionEntries, ...eventEntries]
+          .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+          .slice(-maxPriorEntriesPerRound);
+        if (entries.length === 0) return null;
+        const state = sibling.state ?? 'queued';
+        return {
+          id: String(sibling.issueNumber),
+          createdAt: sibling.createdAt,
+          ...(sibling.publishedAt ? { publishedAt: sibling.publishedAt } : {}),
+          status: sibling.abandonedAt ? 'abandoned' : toSubmissionStatus(state),
+          entries,
+        };
+      }),
+    );
+
+    const value = rounds.filter((round): round is PriorRoundHistory => round !== null);
+    priorRoundsCache.set(cacheKey, { value, expiresAt: currentTime + priorRoundsCacheTtlMs });
+    return value;
+  }
+
   async function attachBuildEvents(
     status: SubmissionStatusResponse,
     issueNumber: number,
@@ -1625,6 +1702,15 @@ export async function registerSubmissionRoutes(
     });
     if (stall) next.stall = stall;
     else delete next.stall;
+
+    // Soft: sibling history must not 500 the live thread poll.
+    try {
+      const priorRounds = await loadPriorRounds(record, locale);
+      if (priorRounds.length > 0) next.priorRounds = priorRounds;
+      else delete next.priorRounds;
+    } catch {
+      delete next.priorRounds;
+    }
 
     return next;
   }

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1162,7 +1162,10 @@ export async function registerSubmissionRoutes(
    * chose to type them in; translating those would hand them back a paraphrase of their
    * own request, which is the bug the `origin` field exists to prevent.
    */
-  async function relayedMessageLocalization(origin: 'agent' | 'creator' | undefined, text: string): Promise<IntakeText> {
+  async function relayedMessageLocalization(
+    origin: 'agent' | 'creator' | undefined,
+    text: string,
+  ): Promise<IntakeText> {
     // A creator's own words are stored exactly as typed, in whatever language they chose.
     // Normalizing those would rewrite someone's own request back at them.
     if (origin !== 'agent') return { text };
@@ -1585,7 +1588,24 @@ export async function registerSubmissionRoutes(
   const priorRoundsCacheTtlMs = 30_000;
   const maxPriorRounds = 6;
   const maxPriorEntriesPerRound = 10;
+  const maxCachedPriorRounds = 100;
   const priorRoundsCache = new Map<string, { expiresAt: number; value: PriorRoundHistory[] }>();
+
+  function rememberPriorRounds(cacheKey: string, entry: { expiresAt: number; value: PriorRoundHistory[] }): void {
+    // Drop expired keys first so TTL is not a soft leak on a busy instance (Copilot).
+    const nowMs = entry.expiresAt - priorRoundsCacheTtlMs;
+    for (const [key, cached] of priorRoundsCache) {
+      if (cached.expiresAt <= nowMs) priorRoundsCache.delete(key);
+    }
+    // Insertion-order Map: delete-before-set moves this key to newest; drop the oldest
+    // when full, matching draftPreviewCache.
+    priorRoundsCache.delete(cacheKey);
+    if (priorRoundsCache.size >= maxCachedPriorRounds) {
+      const oldestKey = priorRoundsCache.keys().next().value;
+      if (oldestKey !== undefined) priorRoundsCache.delete(oldestKey);
+    }
+    priorRoundsCache.set(cacheKey, entry);
+  }
 
   /**
    * Older jobs on the same slug, owned by the same creator — transcripts only, capped.
@@ -1599,10 +1619,17 @@ export async function registerSubmissionRoutes(
     const currentTime = now();
     if (cached && cached.expiresAt > currentTime) return cached.value;
 
-    // Newest-first from the store; keep the most recent superseded jobs, then reverse
-    // so the chat log reads oldest → newest above the live round.
+    // Only jobs that started *before* this one (Codex): an old status token must not
+    // surface later improve rounds as "earlier" history. Newest-first from the store;
+    // keep the most recent superseded jobs, then reverse so the chat log reads
+    // oldest → newest above the live round.
     const siblings = (await store.listSubmissionsBySlug(record.slug))
-      .filter((sibling) => sibling.issueNumber !== record.issueNumber && sibling.ownerUid === record.ownerUid)
+      .filter(
+        (sibling) =>
+          sibling.issueNumber !== record.issueNumber &&
+          sibling.ownerUid === record.ownerUid &&
+          sibling.createdAt < record.createdAt,
+      )
       .slice(0, maxPriorRounds)
       .reverse();
 
@@ -1651,7 +1678,7 @@ export async function registerSubmissionRoutes(
     );
 
     const value = rounds.filter((round): round is PriorRoundHistory => round !== null);
-    priorRoundsCache.set(cacheKey, { value, expiresAt: currentTime + priorRoundsCacheTtlMs });
+    rememberPriorRounds(cacheKey, { value, expiresAt: currentTime + priorRoundsCacheTtlMs });
     return value;
   }
 

--- a/apps/web/src/StudioPriorRounds.tsx
+++ b/apps/web/src/StudioPriorRounds.tsx
@@ -1,0 +1,76 @@
+import { useState, type MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isPriorRoundDismissed, setPriorRoundDismissed } from './priorRoundDismiss.js';
+import type { PriorRoundEntry, PriorRoundHistory } from './submissionApi.js';
+import { formatRelativeTime } from './relativeTime.js';
+
+/**
+ * Superseded build jobs for this game, as collapsed blocks above the live thread.
+ *
+ * Publishing is terminal, so each improve opens a new empty job. Without these, days of
+ * Studio chat look deleted even though they still live on the older job ids. Collapsed
+ * by default; dismissible per round (local preference only).
+ */
+export function StudioPriorRounds({ slug, rounds }: { slug: string; rounds: PriorRoundHistory[] }) {
+  const { t, i18n } = useTranslation();
+  // Re-render after dismiss; visibility still reads localStorage so a remount stays honest.
+  const [, bump] = useState(0);
+  const visible = rounds.filter((round) => !isPriorRoundDismissed(slug, round.id));
+  if (visible.length === 0) return null;
+
+  const dismiss = (roundId: string, event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setPriorRoundDismissed(slug, roundId, true);
+    bump((n) => n + 1);
+  };
+
+  return (
+    <div className="studio-prior-rounds" data-testid="studio-prior-rounds">
+      {visible.map((round) => (
+        <details key={round.id} className="studio-prior-round">
+          <summary className="studio-prior-round-summary">
+            <span className="studio-prior-round-label">
+              {round.publishedAt ? t('statusView.history.summaryPublished') : t('statusView.history.summary')}
+              <time dateTime={round.createdAt}>{formatRelativeTime(round.createdAt, i18n.language)}</time>
+            </span>
+            <button
+              type="button"
+              className="studio-prior-round-dismiss"
+              onClick={(event) => dismiss(round.id, event)}
+              aria-label={t('statusView.history.dismissAria')}
+            >
+              {t('statusView.history.dismiss')}
+            </button>
+          </summary>
+          <ol className="studio-prior-round-turns">
+            {round.entries.map((entry, index) => (
+              <PriorRoundTurn key={`${entry.kind}-${entry.createdAt}-${index}`} entry={entry} />
+            ))}
+          </ol>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function PriorRoundTurn({ entry }: { entry: PriorRoundEntry }) {
+  const { t, i18n } = useTranslation();
+  const mine = entry.kind === 'revision';
+  return (
+    <li className={`studio-turn studio-prior-turn${mine ? ' is-mine' : ''}`}>
+      <div className="studio-turn-body">
+        {!mine && entry.step ? (
+          <span className="studio-turn-kicker">{t(`statusView.progress.steps.${entry.step}`)}</span>
+        ) : null}
+        {mine && entry.origin === 'agent' ? (
+          <span className="studio-turn-kicker">{t('statusView.progress.relayedRequest')}</span>
+        ) : null}
+        <p className="studio-turn-text">{entry.text}</p>
+      </div>
+      <time className="studio-turn-time" dateTime={entry.createdAt}>
+        {formatRelativeTime(entry.createdAt, i18n.language)}
+      </time>
+    </li>
+  );
+}

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -2383,4 +2383,61 @@ describe('SubmissionStatusView stop & retry', () => {
       root.unmount();
     });
   });
+
+  it('shows prior rounds collapsed above the live thread, and dismiss hides them', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.clear();
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      slug: 'tv-tycoon',
+      events: [{ id: 'e1', kind: 'step', step: 'mechanics', text: 'Working on the current round.', createdAt: '2026-08-05T08:00:00.000Z' }],
+      priorRounds: [
+        {
+          id: '101',
+          createdAt: '2026-08-01T10:00:00.000Z',
+          publishedAt: '2026-08-02T12:00:00.000Z',
+          status: 'published',
+          entries: [
+            { kind: 'revision', text: 'Make TVMAX louder.', createdAt: '2026-08-01T11:00:00.000Z' },
+            { kind: 'event', step: 'polishing', text: 'Competitor volume tuned.', createdAt: '2026-08-01T12:00:00.000Z' },
+          ],
+        },
+      ],
+    });
+    window.history.pushState(null, '', '/studio/history-token');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'history-token', embedded: true }));
+      await flushEffects();
+    });
+
+    const prior = container.querySelector('[data-testid="studio-prior-rounds"]');
+    expect(prior).not.toBeNull();
+    const details = prior?.querySelector('details.studio-prior-round');
+    expect(details).not.toBeNull();
+    expect(details?.hasAttribute('open')).toBe(false);
+    expect(prior?.textContent).toContain(i18n.t('statusView.history.summaryPublished'));
+    // Collapsed: entry text is in the DOM for expand, live round is separate.
+    expect(container.textContent).toContain('Make TVMAX louder.');
+    expect(container.textContent).toContain('Working on the current round.');
+
+    const dismiss = prior?.querySelector('.studio-prior-round-dismiss') as HTMLButtonElement;
+    expect(dismiss).not.toBeNull();
+    await act(async () => {
+      dismiss.click();
+      await flushEffects();
+    });
+    expect(container.querySelector('[data-testid="studio-prior-rounds"]')).toBeNull();
+    expect(localStorage.getItem('gamedev_prior_round_hide:tv-tycoon:101')).toBe('1');
+    expect(container.textContent).toContain('Working on the current round.');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -16,6 +16,7 @@ import {
   type BuildEventKind,
   type BuildProgress,
   type BuildStep,
+  type PriorRoundHistory,
   type SubmissionApiError,
   type SubmissionPreview,
   type SubmissionStatus,
@@ -25,6 +26,7 @@ import { formatRelativeTime } from './relativeTime.js';
 import { connectCardMode, selfComposerRoute, selfStatusCopy, shouldShowConnectCard } from './selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { StudioLivePreview } from './StudioLivePreview.js';
+import { StudioPriorRounds } from './StudioPriorRounds.js';
 import { submitImprovement } from './studioApi.js';
 import { pollDelayMs } from './studioStatusPoll.js';
 import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
@@ -703,6 +705,8 @@ export function SubmissionStatusView({
                 token={token}
                 entries={activity}
                 emptyLabel={stateDescription}
+                priorRounds={status.slug && status.priorRounds?.length ? status.priorRounds : undefined}
+                priorSlug={status.slug}
                 stickNonce={isAwaitingOwnAgent(status) ? pendingRevisions.length + 1 : 0}
                 after={
                   isAwaitingOwnAgent(status) ? (
@@ -1566,12 +1570,17 @@ function ThreadStream({
   token,
   entries,
   emptyLabel,
+  priorRounds,
+  priorSlug,
   after,
   stickNonce = 0,
 }: {
   token: string;
   entries: ActivityEntry[];
   emptyLabel: string;
+  /** Superseded jobs on this game — collapsed above the live turns. */
+  priorRounds?: PriorRoundHistory[];
+  priorSlug?: string;
   /** Renders inside the scroller after the turns — tall surfaces (connect card) belong
    *  here, not in the pinned foot, or a phone has no room left for the conversation. */
   after?: ReactNode;
@@ -1600,6 +1609,9 @@ function ThreadStream({
 
   return (
     <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
+      {priorSlug && priorRounds && priorRounds.length > 0 ? (
+        <StudioPriorRounds slug={priorSlug} rounds={priorRounds} />
+      ) : null}
       {entries.length === 0 ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
       <ol className="studio-thread-turns">
         {entries.map((entry, index) => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -597,6 +597,12 @@
       "notice": "Improvement round started — this is the new build thread.",
       "agentOpened": "Your agent opened this improvement round — same daily limit as starting one in Studio."
     },
+    "history": {
+      "summary": "Earlier round",
+      "summaryPublished": "Published version",
+      "dismiss": "Hide",
+      "dismissAria": "Hide this earlier round from the thread"
+    },
     "progress": {
       "checklistTitle": "What the agent is doing",
       "activityTitle": "Build activity",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -601,6 +601,12 @@
       "notice": "Runda ulepszeń rozpoczęta — to jest wątek nowej wersji.",
       "agentOpened": "Twój agent otworzył tę rundę ulepszeń — ten sam dzienny limit co przy starcie w Studio."
     },
+    "history": {
+      "summary": "Wcześniejsza runda",
+      "summaryPublished": "Opublikowana wersja",
+      "dismiss": "Ukryj",
+      "dismissAria": "Ukryj tę wcześniejszą rundę w wątku"
+    },
     "progress": {
       "checklistTitle": "Nad czym pracuje agent",
       "activityTitle": "Przebieg prac",

--- a/apps/web/src/priorRoundDismiss.test.ts
+++ b/apps/web/src/priorRoundDismiss.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { isPriorRoundDismissed, setPriorRoundDismissed } from './priorRoundDismiss.js';
+
+describe('priorRoundDismiss', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to visible and remembers a dismiss per slug + round', () => {
+    expect(isPriorRoundDismissed('tv-tycoon', '101')).toBe(false);
+    setPriorRoundDismissed('tv-tycoon', '101', true);
+    expect(isPriorRoundDismissed('tv-tycoon', '101')).toBe(true);
+    expect(isPriorRoundDismissed('tv-tycoon', '102')).toBe(false);
+    expect(isPriorRoundDismissed('other-game', '101')).toBe(false);
+    setPriorRoundDismissed('tv-tycoon', '101', false);
+    expect(isPriorRoundDismissed('tv-tycoon', '101')).toBe(false);
+  });
+});

--- a/apps/web/src/priorRoundDismiss.test.ts
+++ b/apps/web/src/priorRoundDismiss.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it, beforeEach } from 'vitest';
 import { isPriorRoundDismissed, setPriorRoundDismissed } from './priorRoundDismiss.js';
 

--- a/apps/web/src/priorRoundDismiss.ts
+++ b/apps/web/src/priorRoundDismiss.ts
@@ -1,0 +1,28 @@
+/**
+ * Per-game preference: hide a superseded round's collapsed history block.
+ * Dismiss is local only — the store still keeps the messages.
+ */
+
+const STORAGE_PREFIX = 'gamedev_prior_round_hide:';
+
+function storageKey(slug: string, roundId: string): string {
+  return `${STORAGE_PREFIX}${slug}:${roundId}`;
+}
+
+export function isPriorRoundDismissed(slug: string, roundId: string): boolean {
+  try {
+    return localStorage.getItem(storageKey(slug, roundId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setPriorRoundDismissed(slug: string, roundId: string, dismissed: boolean): void {
+  try {
+    const key = storageKey(slug, roundId);
+    if (dismissed) localStorage.setItem(key, '1');
+    else localStorage.removeItem(key);
+  } catch {
+    // Preference only — private mode must not break the thread.
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5130,6 +5130,105 @@ a.user-name--profile:focus-visible {
   padding: 8px 2px;
 }
 
+/* Superseded improve jobs — collapsed above the live round so history does not vanish. */
+.studio-prior-rounds {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0 0 18px;
+  padding: 0 2px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.studio-prior-round {
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.studio-prior-round-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  cursor: pointer;
+  list-style: none;
+  padding: 10px 12px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  user-select: none;
+}
+
+.studio-prior-round-summary::-webkit-details-marker {
+  display: none;
+}
+
+.studio-prior-round-summary::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 5px solid currentColor;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  opacity: 0.7;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.studio-prior-round[open] > .studio-prior-round-summary::before {
+  transform: rotate(90deg);
+}
+
+.studio-prior-round-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.45em 0.75em;
+  flex: 1;
+  min-width: 0;
+}
+
+.studio-prior-round-label time {
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.studio-prior-round-dismiss {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.studio-prior-round-dismiss:hover,
+.studio-prior-round-dismiss:focus-visible {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  outline: none;
+}
+
+.studio-prior-round-turns {
+  list-style: none;
+  margin: 0;
+  padding: 4px 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  opacity: 0.88;
+}
+
+.studio-prior-turn .studio-turn-text {
+  font-size: 0.92em;
+}
+
 .studio-thread-turns {
   list-style: none;
   margin: 0;

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -163,6 +163,30 @@ export type SubmissionStatus = {
   failure?: { reason: string };
   /** Who opened this improvement round, when reported (BY-24). */
   openedBy?: 'creator' | 'agent';
+  /**
+   * Older jobs on the same game (same slug), oldest first — collapsed history so a
+   * new improve round does not make prior Studio chat look deleted. Optional: older
+   * API deploys omit it.
+   */
+  priorRounds?: PriorRoundHistory[];
+};
+
+/** One superseded build job's transcript, for the collapsed history blocks. */
+export type PriorRoundHistory = {
+  id: string;
+  createdAt: string;
+  publishedAt?: string;
+  status: SubmissionState;
+  entries: PriorRoundEntry[];
+};
+
+export type PriorRoundEntry = {
+  kind: 'revision' | 'event';
+  /** Untrusted text — render escaped. */
+  text: string;
+  createdAt: string;
+  origin?: 'agent';
+  step?: BuildStep;
 };
 
 export type BuildPlayableItem = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After publish, each improve / `open_round` is a **new job** with an empty thread. Prior days of Studio chat still live on the old job ids, but the tip thread (and shelf collapse) made them look deleted.

## Change

- **API:** `GET /api/submissions/:token` attaches `priorRounds` — same-slug sibling jobs owned by the same creator, **created before this job**, oldest first, with capped revisions + agent events.
- **Studio:** collapsed `<details>` blocks above the live thread; per-round **Hide** dismiss (localStorage only; data stays in the store).

## Review follow-ups

- **Codex:** restrict siblings to `createdAt < current` so an old status token cannot list later improve rounds as “earlier” history.
- **Copilot:** evict expired `priorRoundsCache` entries and cap map size.

## Notes

- Caps: 6 prior rounds, 10 entries each; 30s TTL + size cap 100 on the status poll path.
- Foreign owners on the same slug are excluded.
- BYOCA Cursor/Claude chat was never in Studio; this restores **Studio**-recorded history across jobs.

## Verification

- `npm run type-check` / `lint` / `test` / `build` green locally (pre-review).
- Focused API regression for priorRounds + old-token case green after review fixes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-757c4bf3-0ada-4126-84c7-f58df31c6d76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-757c4bf3-0ada-4126-84c7-f58df31c6d76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

