### PR TITLE
byoca-mcp: note that stop is point-in-time, not a latch

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -80,6 +80,15 @@ check, not a wait loop. When `status` is `pending`:
 - Back-to-back calls emit soft `warnings.code=gate_poll_backoff` (and keep
   re-emitting `call_end` after submit until `end`)
 
+**`stop` describes the round now, not forever.** It is point-in-time state, not a
+latch: a `stop: true` from an earlier poll is spent once that run stops. A later
+delivery makes the round live again and the next check answers `stop: false` /
+`access: active`. So a creator-led run does not inherit a previous run's stop, and an
+agent should read the `stop` in the response it just got rather than the one it
+remembers. (Observed 2026-08-05: an agent treated a stale `stop: true` as a standing
+prohibition and reported a protocol violation, while the response in front of it said
+`stop: false`.)
+
 ### `kit_outdated` — do not re-upload the tree
 
 When the gate returns `kit_outdated` (or soft copy says the kit rotated):


### PR DESCRIPTION
Observed during a real self-build round on 2026-08-05: an agent treated a `stop: true` from an earlier poll as a standing prohibition, spent reasoning on whether it was allowed to call `get_gate_verdict` at all, and reported a protocol violation to the creator — while the response in front of it said `stop: false` / `access: active`. A later delivery had made the round live again.

Nothing was actually violated. The skill told agents to honour `stop` but never said **how long it binds**, and "honour stop" reads as permanent when it isn't.

This adds one short paragraph under the busy-poll section: `stop` binds the run that received it, a later delivery clears it, a creator-led run does not inherit a previous run's stop, and an agent should read the `stop` in the response it just got rather than the one it remembers.

Documentation only — no behaviour change. The server side is already correct and deliberate: a readable verdict after stop is what terminal receipt exists for, so a verdict stays readable if the round closes between polls.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_