### PR TITLE
Stop the round view flashing a failure, and polling a settled round

### DIFF
--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -206,6 +206,15 @@ describe('ui resources', () => {
     expect(html).toContain('Could not read round status here.');
   });
 
+  it('retries when the key lands while the keyless poll is still in flight', () => {
+    // noteSessionKey's own poll() is dropped as already-in-flight, so the refusal
+    // handler has to retry or the card waits out the whole give-up timer holding a
+    // usable credential. Reproduced in the browser harness: without this, the view
+    // makes exactly one call and never recovers.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toMatch(/if \(speculative\) \{[\s\S]{0,400}?if \(sessionKey\) \{[\s\S]{0,80}?poll\(\);/);
+  });
+
   it('stops polling once the agent has stopped and the gate has settled', () => {
     // Nothing further can arrive, so an open tab must not cost a request every 30s
     // for as long as it stays open.

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -195,6 +195,24 @@ describe('ui resources', () => {
     expect([...MCP_UI_APP_ONLY_TOOLS].every((name) => name.startsWith('get_'))).toBe(true);
   });
 
+  it('does not paint a failure for the poll it makes before it has a key', () => {
+    // Observed in Claude: the first poll goes out before the opening tool's key
+    // arrives, and Claude refuses it. Rendering that as an error flashed
+    // "Could not read round status here." across the card a moment before it filled in.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('speculative');
+    // A key that never arrives is still a real failure — but on a timer, not instantly.
+    expect(html).toContain('giveUpTimer');
+    expect(html).toContain('Could not read round status here.');
+  });
+
+  it('stops polling once the agent has stopped and the gate has settled', () => {
+    // Nothing further can arrive, so an open tab must not cost a request every 30s
+    // for as long as it stays open.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("status.agentEnded && gate && gate.status && gate.status !== 'pending'");
+  });
+
   it('polls, and degrades to the opening payload when a host refuses the app-only call', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("name: 'get_round_status'");

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -652,9 +652,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
           // Without a key this is a guess: hosts differ on whether they carry the
           // connection's own credential into an app-only call, and Claude does not.
           speculative = !sessionKey;
-          // sessionKey is an optimisation, not a precondition: a Bearer-authenticated
-          // client never passes one, and the host proxies this call over the same
-          // authenticated connection either way.
+          // Observed in Claude: a view does not inherit the connection's credential, so
+          // a keyless call is refused. We still make it — a host that does carry the
+          // credential answers immediately, and the refusal costs nothing visible.
           var args = {};
           if (sessionKey) args.sessionKey = sessionKey;
           if (lastShotId) args.sinceShotId = lastShotId;
@@ -665,6 +665,14 @@ const ROUND_STATUS_HTML = `<!doctype html>
             if (!status) {
               log('warning', 'round status unavailable: ' + String(error || 'unrecognised shape'));
               if (speculative) {
+                // The key can land while this very request is in flight, in which case
+                // noteSessionKey's own poll() was dropped as already in flight. Retry
+                // here, or the card waits out the whole give-up timer while holding a
+                // usable credential.
+                if (sessionKey) {
+                  poll();
+                  return;
+                }
                 // Stay quiet and wait for the opening tool to hand us its key. Only if
                 // one never arrives is this a real failure worth showing.
                 if (!giveUpTimer) giveUpTimer = setTimeout(giveUp, 20000);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -329,6 +329,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var seed = null;
         var inFlight = false;
         var attempts = 0;
+        var speculative = false;
+        var giveUpTimer = null;
         var stopped = false;
         var timer = null;
 
@@ -502,6 +504,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function isFinished(status) {
           var gate = status.gate;
           if (gate && gate.status === 'green') return true;
+          // Agent gone and a verdict already in: nothing further will arrive until
+          // somebody acts, and that act opens a fresh card.
+          if (status.agentEnded && gate && gate.status && gate.status !== 'pending') return true;
           return (
             status.phase === 'published' ||
             status.phase === 'canceled' ||
@@ -623,6 +628,14 @@ const ROUND_STATUS_HTML = `<!doctype html>
           reportSize();
         }
 
+        function giveUp() {
+          giveUpTimer = null;
+          if (live) return;
+          if (seed) renderGateOnly(seed);
+          else summary.textContent = 'Could not read round status here.';
+          reportSize();
+        }
+
         function schedule(seconds) {
           if (stopped || timer) return;
           var delay = Math.max(10, Number(seconds) || 30) * 1000;
@@ -636,6 +649,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (stopped || inFlight) return;
           inFlight = true;
           attempts += 1;
+          // Without a key this is a guess: hosts differ on whether they carry the
+          // connection's own credential into an app-only call, and Claude does not.
+          speculative = !sessionKey;
           // sessionKey is an optimisation, not a precondition: a Bearer-authenticated
           // client never passes one, and the host proxies this call over the same
           // authenticated connection either way.
@@ -647,19 +663,22 @@ const ROUND_STATUS_HTML = `<!doctype html>
             inFlight = false;
             var status = error ? null : unwrap(result, looksLikeStatus);
             if (!status) {
-              // A host that refuses app-only calls, or a credential this view does not
-              // hold. Show what we were opened with rather than a card that never
-              // resolves, and stop after a couple of tries instead of looping.
               log('warning', 'round status unavailable: ' + String(error || 'unrecognised shape'));
-              if (!live) {
-                if (seed) renderGateOnly(seed);
-                else summary.textContent = 'Could not read round status here.';
-                reportSize();
+              if (speculative) {
+                // Stay quiet and wait for the opening tool to hand us its key. Only if
+                // one never arrives is this a real failure worth showing.
+                if (!giveUpTimer) giveUpTimer = setTimeout(giveUp, 20000);
+                return;
               }
+              if (!live) giveUp();
               if (attempts >= 2) stopped = true;
               return;
             }
             live = true;
+            if (giveUpTimer) {
+              clearTimeout(giveUpTimer);
+              giveUpTimer = null;
+            }
             render(status);
             if (isFinished(status)) stopped = true;
             else schedule(status.retryAfterSeconds);
@@ -675,9 +694,12 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function noteSessionKey(value) {
           if (typeof value !== 'string' || !value || sessionKey === value) return;
           sessionKey = value;
-          // Worth one more attempt: the keyless poll may have been refused for want of
-          // exactly this.
+          // Worth another attempt: the keyless poll was refused for want of exactly this.
           if (!live) {
+            if (giveUpTimer) {
+              clearTimeout(giveUpTimer);
+              giveUpTimer = null;
+            }
             stopped = false;
             attempts = 0;
             poll();
@@ -735,6 +757,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (message.method === 'ui/resource-teardown') {
             stopped = true;
             if (timer) clearTimeout(timer);
+            if (giveUpTimer) clearTimeout(giveUpTimer);
             window.removeEventListener('message', onHostMessage);
             window.removeEventListener('resize', reportSize);
           }


### PR DESCRIPTION
Two bugs in the live round view, both found by watching the card in Claude rather than in tests. A screen recording of a real round caught the first; the second was visible in a still.

## The card flashed an error that was never true

The card went **"Reading round status…" → "Could not read round status here." → the full verdict**, all within about a second.

My own review fix on #589 caused it. I made the view poll as soon as it initializes, reasoning that a Bearer-authenticated host would carry the connection's credential into an app-only call. **Claude does not** — it refuses the keyless call. I was rendering that refusal as a user-visible failure. The session key then arrives with the opening tool's result, the retry succeeds, and the card fills in correctly — so the card was right within a second, having shown the user an error that was never true.

A poll made before the view has a key is now **speculative**: a refusal is logged, not painted. Only if no key arrives within 20s does it become a real failure worth showing — which keeps the honest message for the case it was written for (a host that genuinely refuses app-only calls).

This also answers a question the code was guessing at: **a view does not inherit the connection's credential in Claude.** The session key is required, not an optimisation.

## The card polled forever

`preview_passed` is not terminal, so a card left open kept polling every 30 seconds even though the agent had stopped and the verdict had settled — roughly 120 requests an hour per open tab, for state that cannot change until someone acts, and that act opens a fresh card. It now stops when the agent has ended and the gate is no longer pending.

## Verification

Reproduced in headless Chromium against a host that refuses keyless calls the way Claude does: the summary goes `Reading round status…` → the verdict with **no error in between**, and the call count stops rising once the settled read lands.

Worth noting how nearly this verification failed: my first harness sampled the summary text from inside the page and silently observed nothing, because the sandboxed frame blocks `contentDocument` — it reported "no flash" from an empty list. Sampling now runs from the driver side, so an empty observation cannot be mistaken for a clean one.

Full API suite green (2362), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_