### PR TITLE
Round card: stop showing a stale verdict, say what it means, offer the next move

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2007,7 +2007,6 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     // The tools that open the round view, and nothing else.
     expect(tools.filter((tool) => tool._meta?.ui?.resourceUri !== undefined).map((tool) => tool.name)).toEqual([
       'start',
-      'submit_sources',
       'get_gate_verdict',
     ]);
   });

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2110,6 +2110,9 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
       retryAfterSeconds: number;
     };
     expect(status.phase).toBeTruthy();
+    // Nothing delivered this round, so there is no verdict for it. The channel would
+    // happily answer with the previous round's, which read as "this round was refused".
+    expect((first.structured as { gate: unknown }).gate).toBeNull();
     expect(status.note?.text).toContain('wiring the HUD');
     expect(status.shot?.png).toBe(TINY_PNG);
     expect(status.retryAfterSeconds).toBeGreaterThan(0);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2082,6 +2082,40 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     expect(after?.agentEndedAt).toBe(before?.agentEndedAt);
   });
 
+  it('still reports the verdict that closed the round, when read as a terminal receipt', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore({ green: true, ranAt: '2026-08-01T12:00:00.000Z' });
+    app = await createApp(store, gamesStore);
+    const { sessionId } = await initializeWith(app, true);
+
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    // A green publish closes the round — which also resets roundDeliveryCount to 0, so
+    // the "no deliveries, no verdict" rule would wrongly hide the verdict that just
+    // closed it and send the card back to polling a finished round.
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    await store.recordJobTransition(ISSUE, {
+      to: 'submitted',
+      at: '2026-08-01T11:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+    await store.recordJobTransition(ISSUE, {
+      to: 'ready_for_review',
+      at: '2026-08-01T12:00:00.000Z',
+      by: 'gate',
+      reason: 'gate_green',
+    });
+    expect((await store.getSubmission(ISSUE))?.roundDeliveryCount ?? 0).toBe(0);
+
+    const status = await callTool(app, 'get_round_status', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(status.isError).toBe(false);
+    expect((status.structured as { gate: { status?: string } | null }).gate).toMatchObject({ status: 'green' });
+  });
+
   it('reports round state, and sends screenshot bytes only when the frame is new', async () => {
     process.env.MCP_UI = 'true';
     const store = new InMemoryStore();

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3321,13 +3321,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           };
         }
 
-        // The gate goes through the channel exactly as get_gate_verdict does, so both
-        // read one implementation of what a verdict means.
-        const gateRes = await injectChannel(ctx.request, 'GET', '/api/agent/build/gate', auth.channelToken);
-        const gate = gateRes.statusCode === 200 ? gateRes.json() : null;
-
         const cap = record.builder === 'self' ? selfBuildDeliveryCap() : null;
         const used = record.roundDeliveryCount ?? 0;
+
+        // The gate goes through the channel exactly as get_gate_verdict does, so both
+        // read one implementation of what a verdict means — but the channel answers for
+        // the job's latest delivery whatever round produced it. A round that has
+        // delivered nothing has no verdict, and showing the previous round's told the
+        // creator their fresh round had already been refused.
+        let gate: unknown = null;
+        if (used > 0) {
+          const gateRes = await injectChannel(ctx.request, 'GET', '/api/agent/build/gate', auth.channelToken);
+          if (gateRes.statusCode === 200) gate = gateRes.json();
+        }
 
         return toolOk({
           phase: state,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3329,8 +3329,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         // the job's latest delivery whatever round produced it. A round that has
         // delivered nothing has no verdict, and showing the previous round's told the
         // creator their fresh round had already been refused.
+        //
+        // Terminal receipts are the exception, and the delivery count cannot see it:
+        // closing a round resets that count to 0 (store.ts, `closes`), so a card reading
+        // the green verdict that just closed the round would find nothing and go back to
+        // polling. A receipt is a closed round being read, not a fresh one.
         let gate: unknown = null;
-        if (used > 0) {
+        if (used > 0 || auth.access === 'terminal_receipt') {
           const gateRes = await injectChannel(ctx.request, 'GET', '/api/agent/build/gate', auth.channelToken);
           if (gateRes.statusCode === 200) gate = gateRes.json();
         }

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -215,6 +215,31 @@ describe('ui resources', () => {
     expect(html).toMatch(/if \(speculative\) \{[\s\S]{0,400}?if \(sessionKey\) \{[\s\S]{0,80}?poll\(\);/);
   });
 
+  it('offers the creator the next move, in the exact ui/message shape the spec defines', () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("method: 'ui/message'");
+    // SEP-1865: params are { role, content: { type, text } } — a guessed shape would
+    // produce a button that silently does nothing.
+    expect(html).toContain("params: { role: 'user', content: { type: 'text', text: action.text } }");
+    // One action per gate outcome a creator can actually respond to.
+    for (const status of ['kit_outdated', 'red', 'preview_failed', 'preview_passed']) {
+      expect(html).toContain(`${status}: {`);
+    }
+    // Only once the agent has stopped: while it is still working it acts on a red gate
+    // itself, and a second instruction would talk over it.
+    expect(html).toContain('gateStatus && status.agentEnded ? ACTIONS[gateStatus] : null');
+    // A host that will not post for us must leave the words on screen to copy.
+    expect(html).toContain('actionHint.hidden = false');
+  });
+
+  it('does not print the gate detail twice, or lead with instructions meant for the agent', () => {
+    // kit_outdated returns the same long agent-facing text as both summary and report,
+    // which the card printed twice — once as its headline.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('gateSummary.length <= 180');
+    expect(html).toContain('detail !== summary.textContent');
+  });
+
   it('stops polling once the agent has stopped and the gate has settled', () => {
     // Nothing further can arrive, so an open tab must not cost a request every 30s
     // for as long as it stays open.

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -181,9 +181,12 @@ describe('ui resources', () => {
     // submitting is exactly the moment a creator wants it open.
     expect(MCP_UI_TOOL_RESOURCES).toEqual({
       start: ROUND_STATUS_RESOURCE_URI,
-      submit_sources: ROUND_STATUS_RESOURCE_URI,
       get_gate_verdict: ROUND_STATUS_RESOURCE_URI,
     });
+    // The host renders one card per tool call carrying _meta.ui, so a turn that started
+    // a round and then delivered produced two identical cards. The card is live: the one
+    // from start already follows the delivery.
+    expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty('submit_sources');
     // open_round mints no session key and takes none, so a card opened there would have
     // nothing to read status with.
     expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty('open_round');

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -311,6 +311,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         cursor: pointer;
       }
       .action:hover:not(:disabled) { background: rgba(0, 228, 172, 0.12); }
+      /* Custom colours can leave the platform focus ring invisible on this card. */
+      .action:focus-visible { outline: 2px solid var(--gd-accent); outline-offset: 2px; }
       .action:disabled { color: var(--gd-muted); border-color: var(--gd-border); cursor: default; }
       .hint {
         margin: 8px 0 0;

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -294,6 +294,31 @@ const ROUND_STATUS_HTML = `<!doctype html>
         max-height: 220px;
         overflow: auto;
       }
+      .actions { margin: 12px 0 0; }
+      .action {
+        font: inherit;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--gd-accent);
+        background: transparent;
+        border: 1px solid var(--gd-accent);
+        border-radius: 999px;
+        padding: 7px 14px;
+        cursor: pointer;
+      }
+      .action:hover:not(:disabled) { background: rgba(0, 228, 172, 0.12); }
+      .action:disabled { color: var(--gd-muted); border-color: var(--gd-border); cursor: default; }
+      .hint {
+        margin: 8px 0 0;
+        padding: 8px;
+        border: 1px solid var(--gd-border);
+        border-radius: 8px;
+        font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+        font-size: 11.5px;
+        line-height: 1.45;
+        white-space: pre-wrap;
+        color: var(--gd-muted);
+      }
       .foot { margin: 12px 0 0; font-size: 11.5px; color: var(--gd-muted); }
       .live { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--gd-accent); margin-right: 6px; vertical-align: middle; }
       [hidden] { display: none !important; }
@@ -311,6 +336,10 @@ const ROUND_STATUS_HTML = `<!doctype html>
       <figure id="shot" class="shot" hidden><img id="shotImg" alt="Latest frame from the build" /><figcaption id="shotCap"></figcaption></figure>
       <dl id="meta" class="meta"></dl>
       <pre id="report" class="report" hidden></pre>
+      <div id="actionRow" class="actions" hidden>
+        <button id="actionBtn" type="button" class="action"></button>
+        <p id="actionHint" class="hint" hidden></p>
+      </div>
       <p id="foot" class="foot"></p>
     </main>
     <script>
@@ -341,6 +370,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var shotEl = document.getElementById('shot');
         var shotImg = document.getElementById('shotImg');
         var shotCap = document.getElementById('shotCap');
+        var actionRow = document.getElementById('actionRow');
+        var actionBtn = document.getElementById('actionBtn');
+        var actionHint = document.getElementById('actionHint');
         var metaList = document.getElementById('meta');
         var report = document.getElementById('report');
         var foot = document.getElementById('foot');
@@ -488,7 +520,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           red: 'Publish gate red. The report below says what failed.',
           preview_passed: 'Preview gate passed — the build runs. Publish still needs a green publish gate.',
           preview_failed: 'Preview gate failed. The report below says what broke.',
-          kit_outdated: 'The Creator Kit rotated mid-round. Re-run get_kit, then resubmit with fromLatestDelivery.'
+          kit_outdated: 'The Creator Kit changed mid-round, so this delivery has to be rebuilt against the new one.'
         };
 
         var STALL_COPY = {
@@ -499,6 +531,68 @@ const ROUND_STATUS_HTML = `<!doctype html>
           gate_not_started: 'The gate did not start.',
           awaiting_input: 'Waiting on the creator.'
         };
+
+        var ACTIONS = {
+          kit_outdated: {
+            label: 'Rebuild against the new kit',
+            text:
+              'The gate refused the last delivery with kit_outdated. Re-run get_kit for a fresh engineRef, then ' +
+              'submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) using the same mode as that ' +
+              'delivery. Do not re-stage or re-upload the whole tree.'
+          },
+          red: {
+            label: 'Ask the agent to fix it',
+            text: 'The publish gate came back red. Read the gate report, fix what failed, and resubmit on the same key.'
+          },
+          preview_failed: {
+            label: 'Ask the agent to fix it',
+            text: 'The preview gate failed. Read the gate report, fix what broke, and re-preview on the same key.'
+          },
+          preview_passed: {
+            label: 'Ask the agent to publish',
+            text:
+              'The preview gate passed. Record TRACE and PLAYTEST, then submit_sources with mode=publish to seal ' +
+              'this round.'
+          }
+        };
+
+        function renderAction(status, gateStatus) {
+          // Only once the agent has stopped: while it is still working it will act on a
+          // red gate itself, and a second instruction would just talk over it.
+          var action = gateStatus && status.agentEnded ? ACTIONS[gateStatus] : null;
+          if (!action) {
+            actionRow.hidden = true;
+            return;
+          }
+          actionBtn.textContent = action.label;
+          actionBtn.disabled = false;
+          actionHint.hidden = true;
+          actionRow.hidden = false;
+          actionBtn.onclick = function () {
+            actionBtn.disabled = true;
+            actionBtn.textContent = 'Sending…';
+            var id = nextId++;
+            pendingCalls[id] = function (result, error) {
+              if (error) {
+                // The host will not post for us — show the words so the creator can
+                // paste them rather than leaving a dead button.
+                actionBtn.textContent = action.label;
+                actionBtn.disabled = false;
+                actionHint.textContent = action.text;
+                actionHint.hidden = false;
+              } else {
+                actionBtn.textContent = 'Sent to the agent';
+              }
+              reportSize();
+            };
+            post({
+              jsonrpc: '2.0',
+              id: id,
+              method: 'ui/message',
+              params: { role: 'user', content: { type: 'text', text: action.text } }
+            });
+          };
+        }
 
         /** Terminal for a *round*: nothing further will arrive, so stop polling. */
         function isFinished(status) {
@@ -537,6 +631,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             report.hidden = true;
           }
 
+          actionRow.hidden = true;
           foot.textContent =
             status === 'pending'
               ? verdict.deliveryId
@@ -561,9 +656,18 @@ const ROUND_STATUS_HTML = `<!doctype html>
             titleEl.hidden = true;
           }
 
+          // Order matters, and the job's own phase comes last: it lags reality. An agent
+          // that has delivered and called end still reads as 'building' for a while, so
+          // leading with the phase told a creator the agent was working while the note
+          // right below it said the agent had stopped.
           var line = null;
           if (gateStatus && gateStatus !== 'pending') {
-            line = (typeof gate.summary === 'string' && gate.summary) || GATE_COPY[gateStatus];
+            var gateSummary = typeof gate.summary === 'string' ? gate.summary : '';
+            line = (gateSummary.length && gateSummary.length <= 180 ? gateSummary : '') || GATE_COPY[gateStatus] || gateSummary;
+          } else if (gate && gate.deliveryId) {
+            line = 'Delivered — the gate is checking it.';
+          } else if (status.agentEnded) {
+            line = 'The agent has stopped without delivering.';
           }
           if (!line) line = PHASE_COPY[status.phase];
           if (!line && gateStatus) line = GATE_COPY[gateStatus];
@@ -605,14 +709,24 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (typeof status.deliveriesRemaining === 'number') {
             addRow('Deliveries left', status.deliveriesRemaining);
           }
-          if (status.stall && STALL_COPY[status.stall]) addRow('Note', STALL_COPY[status.stall]);
+          if (status.stall && STALL_COPY[status.stall] && STALL_COPY[status.stall] !== summary.textContent) {
+            addRow('Note', STALL_COPY[status.stall]);
+          }
 
-          if (gate && typeof gate.report === 'string' && gate.report.trim()) {
-            report.textContent = gate.report;
+          var detail = gate && typeof gate.report === 'string' ? gate.report.trim() : '';
+          if (!detail && gate && typeof gate.summary === 'string' && gate.summary.length > 180) {
+            // A long agent-facing summary is the detail, even when the gate sent no
+            // separate report.
+            detail = gate.summary.trim();
+          }
+          if (detail && detail !== summary.textContent) {
+            report.textContent = detail;
             report.hidden = false;
           } else {
             report.hidden = true;
           }
+
+          renderAction(status, gateStatus);
 
           if (isFinished(status)) {
             foot.textContent = '';

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -38,20 +38,24 @@ export const MCP_UI_MIME_TYPE = 'text/html;profile=mcp-app';
 export const ROUND_STATUS_RESOURCE_URI = 'ui://gamedevpl/round-status';
 
 /**
- * Tools that open the round view. `submit_sources` is here deliberately: the card is
- * where a creator watches the round from, and the moment a delivery is submitted is
- * exactly when they want to. It renders live state from `get_round_status`, not from
- * the opening tool's payload, so opening it mid-delivery shows the build rather than a
- * frozen echo of the call.
+ * Tools that open the round view — kept deliberately few, because the host renders one
+ * card per tool call that carries `_meta.ui`.
  *
- * `open_round` is deliberately absent. It mints no session key and takes none — its own
- * description sends the agent to `start()` for one — so a card opened there would have
- * no credential to read status with, and would sit on "Reading round status…" forever.
- * `start()` follows immediately and opens the view properly.
+ * `submit_sources` used to be here and was removed: an ordinary turn calls `start` and
+ * then delivers, which rendered two cards showing identical state one above the other.
+ * Nothing was lost by dropping it. The card is live, so the one opened at `start`
+ * already follows the delivery and the gate on its own — that is the whole point of it.
+ *
+ * `get_gate_verdict` stays for the creator-led check on a later turn, when no `start`
+ * precedes it. Doubling up there needs an agent that both opens a round and polls in
+ * one turn, which the workflow tells it not to do (prefer `end`, let the card watch).
+ *
+ * `open_round` is deliberately absent for a different reason: it mints no session key
+ * and takes none — its own description sends the agent to `start()` for one — so a card
+ * opened there would have no credential and would sit on "Reading round status…".
  */
 export const MCP_UI_TOOL_RESOURCES: Readonly<Record<string, string>> = Object.freeze({
   start: ROUND_STATUS_RESOURCE_URI,
-  submit_sources: ROUND_STATUS_RESOURCE_URI,
   get_gate_verdict: ROUND_STATUS_RESOURCE_URI,
 });
 


### PR DESCRIPTION
Everything here came from watching real rounds in Claude, not from tests. The live view works — a gate verdict reached the creator after the agent's turn had ended, with no polling and no tokens — but three things it said were wrong, and it never said what to do about any of them.

## A fresh round showed the previous round's verdict

The worst of the three. A new round opened with the **last** round's `kit_outdated` on the card — same delivery id, same timestamp — telling a creator their fresh round had already been refused.

`get_round_status` asked the channel for the gate, and the channel answers for the job's latest delivery whatever round produced it. A round with `roundDeliveryCount === 0` has no verdict of its own, so none is reported now.

## The card contradicted itself

*"The agent is building."* directly above *"The agent has stopped."* The headline led with the job phase, which lags; the note came from the stall state, which is current. Phase is now the last resort: a delivery sitting in a pending gate reads "Delivered — the gate is checking it", and an agent that stopped without delivering says exactly that. The stall row is dropped when it would only repeat the headline.

## The headline was instructions the creator can't act on

`kit_outdated` returns the same long agent-facing text as **both** summary and report, so the card printed it twice — once as its headline, where "submit_sources({ fromLatestDelivery: true, mode, kitEngineRef })" is not something a human can do. Long summaries now go to the detail block and the headline uses our own copy; the detail is skipped when it would duplicate the headline.

## And the missing half: what now?

The card knows things Studio doesn't. Studio says only *"your agent finished this round, send a note to continue"* — it doesn't know the gate refused the delivery. So the card now offers one contextual action per outcome: rebuild against a rotated kit, ask for a fix on red or a failed preview, ask to publish after a green preview.

Sent as `ui/message` in the shape SEP-1865 defines — `{ role, content: { type, text } }` — **read from the spec rather than guessed**, since a wrong shape means a button that silently does nothing. It appears only once the agent has stopped, because a live agent acts on a red gate itself and a second instruction would talk over it. If a host won't post for us, the text stays on screen to copy rather than leaving a dead button.

## Verification

Headless Chromium against a fake host: the button posts the documented payload and settles to "Sent to the agent"; `kit_outdated` renders a short headline with the detail below it once, not twice. Full API suite green (2365), lint clean.

## Unrelated finding worth recording

ChatGPT **does** discover the template — `ui://gamedevpl/round-status` is listed under its Plugins → Templates with no Apps-SDK-specific metadata, which answers the open Q3 about whether pure SEP-1865 is enough. It does flag that a widget CSP and a unique widget domain are required *for app submission*. Not addressed here: I would rather look up the exact metadata contract than guess at field names.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_