### PR TITLE
Declare the view's CSP and origin, and tell the model what the view learned

### DIFF
--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3796,7 +3796,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               const uiMeta = appOnly
                 ? { visibility: ['app'] }
                 : uiResourceUri
-                  ? { resourceUri: uiResourceUri, visibility: ['model', 'app'] }
+                  ? // visibility defaults to ["model", "app"], so a launcher says nothing.
+                    { resourceUri: uiResourceUri }
                   : null;
               return {
                 name,

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -152,6 +152,31 @@ describe('ui resources', () => {
     expect(readUiResource('')).toBeNull();
   });
 
+  it('declares its CSP and origin rather than relying on the host default', () => {
+    // Same effect as the deny-all default, but stated: ChatGPT will not accept a
+    // template for submission without it, and an empty frameDomains is a deliberate
+    // signal that nothing is nested yet (declaring one triggers stricter review).
+    for (const meta of [uiResourceDescriptors()[0]?._meta, readUiResource(ROUND_STATUS_RESOURCE_URI)?._meta]) {
+      expect(meta).toMatchObject({
+        ui: {
+          csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
+          domain: 'https://www.gamedev.pl',
+        },
+      });
+    }
+  });
+
+  it('tells the model what the view learned, once per verdict', () => {
+    // When a verdict lands the agent is usually gone, so nothing in the conversation
+    // knows it. The host holds this until the next user message.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text as string;
+    expect(html).toContain("request('ui/update-model-context'");
+    // Polling must not re-announce the same verdict on every pass.
+    expect(html).toContain('if (key === contextKey) return;');
+    // Nothing to say while the gate is still running.
+    expect(html).toContain("gate.status === 'pending') return;");
+  });
+
   it('is self-contained, because the host CSP is deny-all and we declare no domains', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).not.toMatch(/<script[^>]+src=/i);

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -169,12 +169,39 @@ describe('ui resources', () => {
   it('tells the model what the view learned, once per verdict', () => {
     // When a verdict lands the agent is usually gone, so nothing in the conversation
     // knows it. The host holds this until the next user message.
-    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text as string;
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("request('ui/update-model-context'");
     // Polling must not re-announce the same verdict on every pass.
     expect(html).toContain('if (key === contextKey) return;');
     // Nothing to say while the gate is still running.
     expect(html).toContain("gate.status === 'pending') return;");
+    // The report is what a follow-up turn needs; the summary alone would still cost a
+    // tool call to find out what broke. Bounded, since it lands in the model's context.
+    expect(html).toContain('report: report || null');
+    expect(html).toContain('REPORT_CONTEXT_LIMIT');
+    expect(html).toContain('truncated; call get_gate_verdict for the rest');
+  });
+
+  it('hands out a CSP nobody can mutate, since one object serves every response', () => {
+    const csp = uiResourceDescriptors()[0]?._meta.ui.csp as unknown as Record<string, string[]>;
+    // Object.freeze is shallow: the arrays needed freezing too.
+    expect(() => csp.connectDomains.push('https://evil.example')).toThrow();
+    expect(uiResourceDescriptors()[0]?._meta.ui.csp.connectDomains).toEqual([]);
+  });
+
+  it('parses as JavaScript — the whole view lives inside a TS template literal', () => {
+    // This file is uniquely prone to a class of bug nothing else catches: a backtick,
+    // a ${, or a \n written in a comment or string is consumed by TypeScript and lands
+    // in the emitted view as a real character, breaking its script. tsc is happy, the
+    // string-matching tests below are happy, and the card renders blank in production.
+    // Caught exactly this way once, by the browser harness rather than by CI.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    const open = html.indexOf('<script>');
+    const close = html.lastIndexOf('</script>');
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    const script = html.slice(open + '<script>'.length, close);
+    expect(() => new Function(script)).not.toThrow();
   });
 
   it('is self-contained, because the host CSP is deny-all and we declare no domains', () => {

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -23,9 +23,11 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
  *    frame that owns that bridge. Playable-preview views nest the game one iframe
  *    deeper instead (Phase 2); nothing here does that yet.
  *
- * CSP metadata is deliberately omitted from the resource descriptors: the host default
- * is deny-all, which is exactly right for a card that fetches nothing. Declaring
- * `connectDomains` / `frameDomains` is a Phase 2 concern.
+ * The view declares an empty CSP rather than leaning on the host default. Same effect —
+ * it fetches nothing — but stated rather than assumed, and ChatGPT refuses to accept a
+ * template for submission without it. `frameDomains` stays empty until Phase 2 needs a
+ * nested frame, and opting into it is documented to trigger stricter review, so it is
+ * not something to declare speculatively.
  */
 
 /** Extension id hosts advertise in `initialize` and we echo back when we support it. */
@@ -184,6 +186,23 @@ interface UiResource {
   mimeType: string;
   text: string;
 }
+
+/**
+ * Origin the view is attributed to. Required by ChatGPT when submitting a plugin with
+ * UI; inert everywhere else. It identifies the view, and grants it nothing on our site —
+ * the card is served as inline HTML and never runs with our origin's authority.
+ */
+const VIEW_DOMAIN = 'https://www.gamedev.pl';
+
+/**
+ * Declared per resource. Empty by design: the card inlines everything, screenshots
+ * arrive as data URIs, and it calls tools through the host rather than the network.
+ */
+const VIEW_CSP = Object.freeze({
+  connectDomains: [] as string[],
+  resourceDomains: [] as string[],
+  frameDomains: [] as string[],
+});
 
 /**
  * The round-status card. Self-contained by necessity — the host CSP is `default-src
@@ -366,6 +385,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var attempts = 0;
         var speculative = false;
         var giveUpTimer = null;
+        var contextKey = null;
         var stopped = false;
         var timer = null;
 
@@ -756,6 +776,33 @@ const ROUND_STATUS_HTML = `<!doctype html>
           reportSize();
         }
 
+        /**
+         * The last piece of watching-without-polling: when a verdict lands the agent is
+         * usually gone, so nothing in the conversation knows it. The host holds this
+         * until the next user message, so if the creator then says "fix it" the agent
+         * already has the verdict instead of spending a call to discover it. Sent once
+         * per distinct verdict — polling must not re-announce the same thing.
+         */
+        function pushModelContext(status) {
+          var gate = status.gate;
+          if (!gate || typeof gate.status !== 'string' || gate.status === 'pending') return;
+          var key = gate.status + ':' + (gate.deliveryId || '');
+          if (key === contextKey) return;
+          contextKey = key;
+          request('ui/update-model-context', {
+            structuredContent: {
+              slug: status.slug || null,
+              phase: status.phase,
+              gate: {
+                status: gate.status,
+                lane: gate.lane || null,
+                deliveryId: gate.deliveryId || null,
+                summary: typeof gate.summary === 'string' ? gate.summary : null
+              }
+            }
+          });
+        }
+
         function schedule(seconds) {
           if (stopped || timer) return;
           var delay = Math.max(10, Number(seconds) || 30) * 1000;
@@ -803,6 +850,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
               return;
             }
             live = true;
+            pushModelContext(status);
             if (giveUpTimer) {
               clearTimeout(giveUpTimer);
               giveUpTimer = null;
@@ -916,14 +964,19 @@ const UI_RESOURCES: readonly UiResource[] = Object.freeze([
   },
 ]);
 
+/** What a host reads about a view: its CSP and the origin it belongs to. */
+function uiResourceMeta(): Record<string, unknown> {
+  return { ui: { csp: VIEW_CSP, domain: VIEW_DOMAIN } };
+}
+
 /** Descriptors for `resources/list` — no bodies. */
-export function uiResourceDescriptors(): Array<Omit<UiResource, 'text'>> {
-  return UI_RESOURCES.map(({ text: _text, ...descriptor }) => descriptor);
+export function uiResourceDescriptors(): Array<Record<string, unknown>> {
+  return UI_RESOURCES.map(({ text: _text, ...descriptor }) => ({ ...descriptor, _meta: uiResourceMeta() }));
 }
 
 /** One `resources/read` content entry, or null when the URI is not ours. */
-export function readUiResource(uri: string): { uri: string; mimeType: string; text: string } | null {
+export function readUiResource(uri: string): Record<string, unknown> | null {
   const found = UI_RESOURCES.find((resource) => resource.uri === uri);
   if (!found) return null;
-  return { uri: found.uri, mimeType: found.mimeType, text: found.text };
+  return { uri: found.uri, mimeType: found.mimeType, text: found.text, _meta: uiResourceMeta() };
 }

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -194,14 +194,32 @@ interface UiResource {
  */
 const VIEW_DOMAIN = 'https://www.gamedev.pl';
 
+interface UiCsp {
+  readonly connectDomains: readonly string[];
+  readonly resourceDomains: readonly string[];
+  readonly frameDomains: readonly string[];
+}
+
+interface UiResourceMeta {
+  ui: { csp: UiCsp; domain: string };
+}
+
+/** What `resources/list` returns per view: everything but the body. */
+export type UiResourceDescriptor = Omit<UiResource, 'text'> & { _meta: UiResourceMeta };
+
+/** What `resources/read` returns: the body, plus the same declared metadata. */
+export type UiResourceContents = Pick<UiResource, 'uri' | 'mimeType' | 'text'> & { _meta: UiResourceMeta };
+
 /**
  * Declared per resource. Empty by design: the card inlines everything, screenshots
  * arrive as data URIs, and it calls tools through the host rather than the network.
  */
-const VIEW_CSP = Object.freeze({
-  connectDomains: [] as string[],
-  resourceDomains: [] as string[],
-  frameDomains: [] as string[],
+const VIEW_CSP: UiCsp = Object.freeze({
+  // Frozen individually: Object.freeze is shallow, and this one object is handed out
+  // on every resources/list and resources/read.
+  connectDomains: Object.freeze([]) as readonly string[],
+  resourceDomains: Object.freeze([]) as readonly string[],
+  frameDomains: Object.freeze([]) as readonly string[],
 });
 
 /**
@@ -386,6 +404,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var speculative = false;
         var giveUpTimer = null;
         var contextKey = null;
+        var REPORT_CONTEXT_LIMIT = 4000;
         var stopped = false;
         var timer = null;
 
@@ -789,6 +808,14 @@ const ROUND_STATUS_HTML = `<!doctype html>
           var key = gate.status + ':' + (gate.deliveryId || '');
           if (key === contextKey) return;
           contextKey = key;
+          // The report, not the summary, is what says what broke — and the app-only
+          // status result never reaches the transcript, so without it here a follow-up
+          // 'fix it' still costs a tool call to discover the failure. Bounded, because
+          // this lands in the model's context whether or not it is ever used.
+          var report = typeof gate.report === 'string' ? gate.report.trim() : '';
+          if (report.length > REPORT_CONTEXT_LIMIT) {
+            report = report.slice(0, REPORT_CONTEXT_LIMIT) + '\\n… (truncated; call get_gate_verdict for the rest)';
+          }
           request('ui/update-model-context', {
             structuredContent: {
               slug: status.slug || null,
@@ -797,7 +824,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
                 status: gate.status,
                 lane: gate.lane || null,
                 deliveryId: gate.deliveryId || null,
-                summary: typeof gate.summary === 'string' ? gate.summary : null
+                summary: typeof gate.summary === 'string' ? gate.summary : null,
+                report: report || null
               }
             }
           });
@@ -965,17 +993,17 @@ const UI_RESOURCES: readonly UiResource[] = Object.freeze([
 ]);
 
 /** What a host reads about a view: its CSP and the origin it belongs to. */
-function uiResourceMeta(): Record<string, unknown> {
+function uiResourceMeta(): UiResourceMeta {
   return { ui: { csp: VIEW_CSP, domain: VIEW_DOMAIN } };
 }
 
 /** Descriptors for `resources/list` — no bodies. */
-export function uiResourceDescriptors(): Array<Record<string, unknown>> {
+export function uiResourceDescriptors(): UiResourceDescriptor[] {
   return UI_RESOURCES.map(({ text: _text, ...descriptor }) => ({ ...descriptor, _meta: uiResourceMeta() }));
 }
 
 /** One `resources/read` content entry, or null when the URI is not ours. */
-export function readUiResource(uri: string): Record<string, unknown> | null {
+export function readUiResource(uri: string): UiResourceContents | null {
   const found = UI_RESOURCES.find((resource) => resource.uri === uri);
   if (!found) return null;
   return { uri: found.uri, mimeType: found.mimeType, text: found.text, _meta: uiResourceMeta() };


### PR DESCRIPTION
Three follow-ups, each checked against the specs rather than assumed.

## 1. The ChatGPT warnings — fixed

ChatGPT's plugin settings flagged our template with *"Widget CSP is not set"* and *"Widget domain is not set… required for app submission."* The resource now declares both, using the modern standard form:

```json
"_meta": { "ui": { "csp": { "connectDomains": [], "resourceDomains": [], "frameDomains": [] }, "domain": "https://www.gamedev.pl" } }
```

Empty by design and identical in effect to the deny-all host default — the card inlines everything and reaches the network only through the host — but **stated rather than assumed**, which is what ChatGPT wants before accepting a template for submission. `frameDomains` stays empty until Phase 2 actually needs a nested frame; opting in is documented to trigger stricter app review, so it isn't something to declare speculatively.

The `domain` identifies the view and grants it nothing on our site: the card is served as inline HTML and never runs with our origin's authority.

## 2. Tool visibility — we were marking it correctly, with one redundancy

Checked against the spec: `_meta.ui` is the right key, and `visibility` **defaults to `["model", "app"]` when omitted**. So spelling that out on a launcher said nothing. Launchers now carry just `resourceUri`; the app-only tool keeps its explicit `["app"]`, which is the part that isn't the default.

## 3. `ui/update-model-context` — yes, and it closes the loop

This turned out to be the missing piece of watching-without-polling. By the time a gate answers, the agent has usually ended, so **nothing in the conversation knows the outcome** — the creator can see it on the card, but the model can't.

The view now pushes the verdict when it lands. Per the spec the host holds it until the next user message rather than waking the model, so it costs no turn: a creator who then says "fix it" is talking to an agent that already has the verdict instead of one that must spend a call discovering it. Sent once per distinct verdict — polling must not re-announce the same thing — and never while the gate is still pending.

## Verification

Headless Chromium: exactly one context update carrying the verdict, and the action button still posting its `ui/message`. Full API suite green (2369), lint clean.

## One thing still unverified

Screenshots travel as `data:` URIs, and no real host has yet rendered a card that had one — every Claude round so far has had no frame at the moment the card polled. If a host's CSP blocks `data:` images, that path fails silently. Not fixable by declaring domains (a `data:` URI has none); it would need observing a round that actually has a frame.

Sources: [MCP Apps spec](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx) · [OpenAI Apps SDK reference](https://developers.openai.com/apps-sdk/reference)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_