### PR TITLE
Stop declaring ui.domain — Claude validates it, and ours was wrong

### DIFF
--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3817,13 +3817,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
                   ? // visibility defaults to ["model", "app"], so a launcher says nothing.
                     { resourceUri: uiResourceUri }
                   : null;
+              // ChatGPT rendered the card but could not call the app-only tool from it.
+              // Its own compatibility keys say the same things as `_meta.ui`, so declare
+              // both rather than guess which one a host actually reads.
+              const openAiMeta = appOnly
+                ? { 'openai/widgetAccessible': true }
+                : uiResourceUri
+                  ? { 'openai/outputTemplate': uiResourceUri }
+                  : null;
               return {
                 name,
                 description: tool.description,
                 inputSchema: tool.inputSchema,
                 outputSchema: tool.outputSchema,
                 ...(tool.annotations ? { annotations: tool.annotations } : {}),
-                ...(uiMeta ? { _meta: { ui: uiMeta } } : {}),
+                ...(uiMeta ? { _meta: { ui: uiMeta, ...openAiMeta } } : {}),
               };
             }),
         }),

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -152,17 +152,18 @@ describe('ui resources', () => {
     expect(readUiResource('')).toBeNull();
   });
 
-  it('declares its CSP and origin rather than relying on the host default', () => {
+  it('declares its CSP in both shapes, and no origin', () => {
     // Same effect as the deny-all default, but stated: ChatGPT will not accept a
     // template for submission without it, and an empty frameDomains is a deliberate
     // signal that nothing is nested yet (declaring one triggers stricter review).
     for (const meta of [uiResourceDescriptors()[0]?._meta, readUiResource(ROUND_STATUS_RESOURCE_URI)?._meta]) {
       expect(meta).toMatchObject({
-        ui: {
-          csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
-          domain: 'https://www.gamedev.pl',
-        },
+        ui: { csp: { connectDomains: [], resourceDomains: [], frameDomains: [] } },
+        'openai/widgetCSP': { connect_domains: [], resource_domains: [], frame_domains: [] },
       });
+      // Not declared on purpose: Claude validates ui.domain against a hash of the
+      // connector URL the user typed, which a static resource cannot know.
+      expect(meta).not.toHaveProperty('ui.domain');
     }
   });
 

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -1009,7 +1009,10 @@ const UI_RESOURCES: readonly UiResource[] = Object.freeze([
   },
 ]);
 
-/** What a host reads about a view: its CSP and the origin it belongs to. */
+/**
+ * What a host reads about a view: its CSP, twice — once in the standard shape and once
+ * in ChatGPT's. Deliberately no origin; see the note on `ui.domain` above.
+ */
 function uiResourceMeta(): UiResourceMeta {
   return {
     ui: { csp: VIEW_CSP },

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -187,12 +187,23 @@ interface UiResource {
   text: string;
 }
 
-/**
- * Origin the view is attributed to. Required by ChatGPT when submitting a plugin with
- * UI; inert everywhere else. It identifies the view, and grants it nothing on our site —
- * the card is served as inline HTML and never runs with our origin's authority.
+/*
+ * `ui.domain` is deliberately NOT declared, after declaring it broke Claude.
+ *
+ * It is not our origin. Claude validates it against a value derived from the connector
+ * URL the *user* typed:
+ *
+ *   sha256(<connector URL>).hex.slice(0, 32) + '.claudemcpcontent.com'
+ *
+ * — so `https://www.gamedev.pl/api/mcp`, the same with a trailing slash, and the apex
+ * spelling each produce a different expected domain. A static resource cannot know which
+ * one a given creator configured, and a wrong value fails validation exactly as ours did
+ * ("ui.domain validation failed for connector …" in the Claude console).
+ *
+ * Omitting it is what worked before. The only thing it gates is ChatGPT plugin
+ * submission, which is owner-gated and not imminent; when that day comes this needs to be
+ * derived per request from the URL the client actually called, not hardcoded.
  */
-const VIEW_DOMAIN = 'https://www.gamedev.pl';
 
 interface UiCsp {
   readonly connectDomains: readonly string[];
@@ -201,7 +212,13 @@ interface UiCsp {
 }
 
 interface UiResourceMeta {
-  ui: { csp: UiCsp; domain: string };
+  ui: { csp: UiCsp };
+  /** ChatGPT reads its own compatibility key rather than `ui.csp`. */
+  'openai/widgetCSP': {
+    connect_domains: readonly string[];
+    resource_domains: readonly string[];
+    frame_domains: readonly string[];
+  };
 }
 
 /** What `resources/list` returns per view: everything but the body. */
@@ -994,7 +1011,17 @@ const UI_RESOURCES: readonly UiResource[] = Object.freeze([
 
 /** What a host reads about a view: its CSP and the origin it belongs to. */
 function uiResourceMeta(): UiResourceMeta {
-  return { ui: { csp: VIEW_CSP, domain: VIEW_DOMAIN } };
+  return {
+    ui: { csp: VIEW_CSP },
+    // Same declaration in the shape ChatGPT reads. It showed a "CSP off" badge against
+    // the modern key alone, and both are documented, so we say it twice rather than
+    // guess which one a host honours.
+    'openai/widgetCSP': {
+      connect_domains: VIEW_CSP.connectDomains,
+      resource_domains: VIEW_CSP.resourceDomains,
+      frame_domains: VIEW_CSP.frameDomains,
+    },
+  };
 }
 
 /** Descriptors for `resources/list` — no bodies. */


### PR DESCRIPTION
A live regression from #593, surfaced by the Claude console:

```
[mcp-ext-apps-host] ui.domain validation failed for connector "https://www.gamedev.pl/api/mcp"
```

## What I got wrong

I read "widget domain: string (origin)" and declared our origin. **It isn't ours.** Claude derives the expected value from the connector URL *the user typed*:

```
sha256(<connector URL>).hex.slice(0, 32) + '.claudemcpcontent.com'
```

Which means it varies per user, not just per host:

| connector URL as configured | expected domain |
| --- | --- |
| `https://www.gamedev.pl/api/mcp` | `f05e7b02…claudemcpcontent.com` |
| same, trailing slash | `96230950…claudemcpcontent.com` |
| apex spelling | `8935003b…claudemcpcontent.com` |

A static resource cannot know which one a given creator configured, so **any hardcoded value is wrong for somebody**. Omitting it is what worked before #593, and the only thing it gates is ChatGPT plugin submission — owner-gated and not imminent. When that day comes it has to be derived per request from the URL the client actually called. The formula and the three-way table are recorded at the site so nobody rediscovers this the hard way.

## Also: two ChatGPT compatibility keys

Separately, ChatGPT **rendered the card** for the first time — a real step forward — but showed a `CSP off` badge and *"Could not read round status here."*, i.e. it would not let the view call the app-only tool.

Both of its documented compatibility keys are now declared beside the standard ones:

- `openai/widgetCSP` on the resource (it showed `CSP off` against `_meta.ui.csp` alone)
- `openai/widgetAccessible` on the app-only tool
- `openai/outputTemplate` on the launchers

They say exactly what `_meta.ui` already says. Declaring both beats guessing which one a host actually reads — and this is a hypothesis to test in ChatGPT, not a confirmed fix.

Full API suite green (2371), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_