### PR TITLE
Round card: the gate's own frames, and a diagnostic for failed status reads

### DIFF
--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -29,6 +29,7 @@ const NO_PULSE = new Set([
   // is not an agent working: pulsing here would refresh the heartbeat, hold off the
   // quiet stall, and keep self→platform handoff locked for as long as the tab is open.
   'get_round_status',
+  'get_round_media',
 ]);
 /**
  * Closed vocabulary for Studio thought headlines. Client translates via

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2024,10 +2024,14 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     expect(status?._meta?.ui).toEqual({ visibility: ['app'] });
     expect(status?._meta?.ui?.resourceUri).toBeUndefined();
 
-    // A client with no views must not even see it: it would hand it to its model.
+    const media = withUi.find((tool) => tool.name === 'get_round_media');
+    expect(media?._meta?.ui).toEqual({ visibility: ['app'] });
+
+    // A client with no views must not even see them: it would hand them to its model.
     const { sessionId: plain } = await initializeWith(app, false);
     const withoutUi = await listTools(app, plain);
     expect(withoutUi.some((tool) => tool.name === 'get_round_status')).toBe(false);
+    expect(withoutUi.some((tool) => tool.name === 'get_round_media')).toBe(false);
 
     // Absent from the listing is not the same as unreachable. visibility:["app"] is a
     // contract, so a client that guesses the name is refused rather than served — and
@@ -2232,6 +2236,138 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
 
     const listed = await mcpCall(app, 'resources/list', {}, { 'mcp-session-id': foreign });
     expect(listed.json().error?.code).toBe(-32601);
+  });
+
+  describe('get_round_media (Phase 2 — the frames the agent cannot take)', () => {
+    /** A preview gate run that stored four frames and a video for delivery v1. */
+    function framesGamesStore() {
+      const artifacts = new Map<string, Buffer>([
+        [
+          'media/metadata.json',
+          Buffer.from(
+            JSON.stringify({
+              captures: {
+                opening: { file: 'opening.png' },
+                mid: { file: 'mid.png' },
+                late: { file: 'late.png' },
+                last: { file: 'last.png' },
+              },
+              video: { file: 'gameplay.mp4' },
+            }),
+          ),
+        ],
+        ['media/opening.png', Buffer.from(TINY_PNG, 'base64')],
+        ['media/mid.png', Buffer.from(TINY_PNG, 'base64')],
+        ['media/late.png', Buffer.from(TINY_PNG, 'base64')],
+        ['media/last.png', Buffer.from(TINY_PNG, 'base64')],
+        ['media/gameplay.mp4', Buffer.from('mp4-bytes')],
+      ]);
+      return {
+        // previewGate only: a preview pass is the case that matters during a round,
+        // and it is the one that carries lane 'preview'.
+        getManifest: async (slug: string, version: string) =>
+          slug === 'comet-courier' && version === 'v1'
+            ? { slug, version, issueNumber: ISSUE, previewGate: { green: true, ranAt: '2026-08-01T12:00:00.000Z' } }
+            : null,
+        getDerivedArtifact: async (slug: string, version: string, name: string) =>
+          slug === 'comet-courier' && version === 'v1' ? (artifacts.get(name) ?? null) : null,
+        getSourceFile: async () => null,
+        putCandidateSources: async () => ({ version: 'v1', manifest: {} as never }),
+        putGateResult: async () => {},
+        putDerivedArtifact: async () => {},
+        getKitRegistry: async () => null,
+      } as unknown as GamesStore;
+    }
+
+    const objectStore = (): GcsObjectStore => ({
+      readObject: async () => null,
+      objectExists: async () => true,
+      signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+    });
+
+    it('carries the frames as base64 the card can render, with the lane that took them', async () => {
+      process.env.MCP_UI = 'true';
+      const store = new InMemoryStore();
+      await seedJob(store);
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      app = await createApp(store, framesGamesStore(), objectStore());
+      const { sessionId } = await initializeWith(app, true);
+      const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      const res = await callTool(app, 'get_round_media', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(res.isError).toBe(false);
+      const media = res.structured as {
+        available: boolean;
+        lane: string | null;
+        frames: Array<{ file: string; name: string; png: string }>;
+        video: { url: string } | null;
+        framesOmitted?: number;
+      };
+      expect(media.available).toBe(true);
+      // A green preview is not publish readiness; the card says which run it is showing.
+      expect(media.lane).toBe('preview');
+      expect(media.frames.map((frame) => frame.name)).toEqual(['opening', 'mid', 'late']);
+      expect(media.frames.every((frame) => frame.png === TINY_PNG)).toBe(true);
+      // Four were captured, three fit — said out loud rather than silently dropped.
+      expect(media.framesOmitted).toBe(1);
+      expect(media.video?.url).toContain('gameplay.mp4');
+
+      // Bytes ride structuredContent, not image blocks: the model never sees this call,
+      // and what the view needs is a data URI rather than an attachment.
+      expect(res.content?.some((part: { type: string }) => part.type === 'image')).toBeFalsy();
+    });
+
+    it('is app-only and presence-neutral, exactly like the status read', async () => {
+      process.env.MCP_UI = 'true';
+      const store = new InMemoryStore();
+      await seedJob(store);
+      await store.setSubmissionPreviewVersion(ISSUE, 'v1');
+      app = await createApp(store, framesGamesStore(), objectStore());
+      const { sessionId } = await initializeWith(app, true);
+      const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+      await callTool(app, 'report_progress', { sessionKey, text: 'agent is here' }, { 'mcp-session-id': sessionId });
+      const before = await store.getSubmission(ISSUE);
+
+      // A client with no views that guesses the name is refused by the tool's own gate,
+      // not merely left out of tools/list.
+      const { sessionId: plain } = await initializeWith(app, false);
+      const guessed = await mcpCall(
+        app,
+        'tools/call',
+        { name: 'get_round_media', arguments: { sessionKey } },
+        { 'mcp-session-id': plain, authorization: `Bearer ${roundKey(1)}` },
+      );
+      expect(guessed.json().error?.code).toBe(-32601);
+
+      // A creator watching frames is not an agent working.
+      for (let i = 0; i < 4; i += 1) {
+        const polled = await callTool(app, 'get_round_media', { sessionKey }, { 'mcp-session-id': sessionId });
+        expect(polled.isError).toBe(false);
+        expect((polled.structured as { warnings?: unknown }).warnings).toBeUndefined();
+      }
+      const after = await store.getSubmission(ISSUE);
+      expect(after?.lastAgentSignalAt).toBe(before?.lastAgentSignalAt);
+    });
+
+    it('says why there is nothing to show rather than answering with an empty strip', async () => {
+      process.env.MCP_UI = 'true';
+      const store = new InMemoryStore();
+      await seedJob(store);
+      app = await createApp(store, framesGamesStore(), objectStore());
+      const { sessionId } = await initializeWith(app, true);
+      const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+      const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+      // Nothing delivered yet, so no version resolves.
+      const res = await callTool(app, 'get_round_media', { sessionKey }, { 'mcp-session-id': sessionId });
+      expect(res.isError).toBe(false);
+      const media = res.structured as { available: boolean; frames: unknown[]; reason?: string };
+      expect(media.available).toBe(false);
+      expect(media.frames).toEqual([]);
+      expect(media.reason).toContain('produced by the gate');
+    });
   });
 
   it('honours a correlator negotiated on another instance', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -119,6 +119,9 @@ const MAX_SUBMIT_FILES = MAX_UPLOAD_FILES;
 
 /** How often the round view should re-read status. Matches the gate's own backoff. */
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;
+/** A card shows a strip, not a contact sheet; the bytes ride a postMessage. */
+const ROUND_MEDIA_MAX_FRAMES = 3;
+const ROUND_MEDIA_BYTE_BUDGET = 1_500_000;
 const TRANSPORT_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_TRANSPORT_SESSIONS = 10_000;
 
@@ -3466,6 +3469,121 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolOk({ ...body, stop: true, reason: 'gate_green' });
         }
         return toolOk({ ...body, stop: false });
+      },
+    },
+
+    /**
+     * App-only companion to get_gate_media, for the round view.
+     *
+     * The agent cannot screenshot a game it has no browser to run — observed repeatedly,
+     * and correctly: the alternative is drawing an approximation and calling it a
+     * capture. The gate does run a browser and captures on both lanes, so its frames are
+     * the only honest picture of the build. Reaching them through the agent means waiting
+     * for a verdict, which the workflow tells it not to do. The card is already waiting,
+     * so it fetches them itself.
+     *
+     * Unlike get_gate_media this returns the bytes inside structuredContent rather than
+     * as image blocks: a view needs data URIs, and there is no model context to protect
+     * because the model never sees this call.
+     */
+    get_round_media: {
+      annotations: { title: 'Gate frames for the round view', ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          available: { type: 'boolean' },
+          deliveryId: { type: ['string', 'null'] },
+          lane: { type: ['string', 'null'] },
+          frames: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                file: { type: 'string' },
+                name: { type: 'string' },
+                png: { type: 'string', description: 'base64 PNG' },
+              },
+            },
+          },
+          video: { type: ['object', 'null'], properties: { file: { type: 'string' }, url: { type: 'string' } } },
+          framesOmitted: { type: 'number', description: 'Frames the gate captured but this reply could not carry.' },
+          reason: { type: 'string', description: 'Why there is nothing to show, when there is nothing to show.' },
+        },
+        required: ['available', 'frames'],
+      },
+      description:
+        "The gate's own frames for a delivery, as base64 PNGs the round view can render, plus the gameplay " +
+        'video link when one exists. Read-only, app-only, and presence-neutral like get_round_status.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          deliveryId: { type: 'string', description: "Delivery version id; default is the job's latest." },
+        },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args, { allowTerminalReceipt: true });
+        if (!('channelToken' in auth)) return auth;
+
+        const deliveryId =
+          typeof args.deliveryId === 'string' && args.deliveryId.trim() ? args.deliveryId.trim() : null;
+        const query = new URLSearchParams({ frames: 'all' });
+        if (deliveryId) query.set('version', deliveryId);
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/media?${query.toString()}`,
+          auth.channelToken,
+        );
+        const body = res.json() as Record<string, unknown> & {
+          error?: string;
+          frames?: Array<{ file?: string; name?: string; png?: string }>;
+          video?: unknown;
+          framesOmitted?: number;
+          // The lane lives under the verdict, not at the top level: which run captured
+          // these frames is a property of the gate that took them.
+          gate?: { lane?: unknown };
+          reason?: string;
+        };
+        if (res.statusCode !== 200) {
+          return toolErr(body.error ?? `gate media failed (${res.statusCode})`);
+        }
+
+        // Bounded again on our side, in base64 rather than in bytes.
+        //
+        // The channel already caps what it inlines, but it caps *decoded* size for the
+        // sake of a model's context. What binds here is different: these frames ride a
+        // JSON-RPC postMessage through the host into a sandboxed iframe, base64 and all,
+        // which is a third larger than the channel measured. So the channel's ceiling is
+        // not this one's, and a run that squeaks under it can still be too much to send.
+        // Whatever is dropped is counted, never silently lost.
+        let budget = ROUND_MEDIA_BYTE_BUDGET;
+        const frames: Array<{ file: string; name: string; png: string }> = [];
+        let omitted = typeof body.framesOmitted === 'number' ? body.framesOmitted : 0;
+        for (const frame of body.frames ?? []) {
+          const png = typeof frame.png === 'string' ? frame.png : '';
+          if (!png) continue;
+          if (frames.length >= ROUND_MEDIA_MAX_FRAMES || png.length > budget) {
+            omitted += 1;
+            continue;
+          }
+          budget -= png.length;
+          frames.push({ file: String(frame.file ?? ''), name: String(frame.name ?? frame.file ?? ''), png });
+        }
+
+        const lane = typeof body.gate?.lane === 'string' ? body.gate.lane : null;
+        return toolOk({
+          available: frames.length > 0 || Boolean(body.video),
+          deliveryId: (body.deliveryId as string | undefined) ?? deliveryId,
+          lane,
+          frames,
+          video: (body.video as Record<string, unknown> | undefined) ?? null,
+          ...(omitted > 0 ? { framesOmitted: omitted } : {}),
+          // Why there is nothing to show, when there is nothing to show. The card can
+          // say "the gate stored no media" instead of rendering an empty strip.
+          ...(frames.length === 0 && !body.video && body.reason ? { reason: body.reason } : {}),
+        });
       },
     },
 

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -303,6 +303,18 @@ describe('ui resources', () => {
     expect(html).toContain("status.agentEnded && gate && gate.status && gate.status !== 'pending'");
   });
 
+  it('says which way a status read failed, so a screenshot is enough to diagnose it', () => {
+    // Observed in ChatGPT: one card read status fine (screenshot, note and gate all
+    // live) while a later one in the same session did not. "Could not read round status
+    // here." cannot distinguish "this view was never handed a round key" from "the host
+    // refused the call", and those need opposite fixes.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('lastFailure');
+    expect(html).toContain('was never given a round key');
+    expect(html).toContain('The status call was refused.');
+    expect(html).toContain("'with a round key, ' : 'without a round key, '");
+  });
+
   it('polls, and degrades to the opening payload when a host refuses the app-only call', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("name: 'get_round_status'");

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -313,6 +313,15 @@ describe('ui resources', () => {
     expect(html).toContain('was never given a round key');
     expect(html).toContain('The status call was refused.');
     expect(html).toContain("'with a round key, ' : 'without a round key, '");
+
+    // Appended, not substituted: the static fallback may have just put the gate's own
+    // report in that block, and a note about our polling must not evict it.
+    expect(html).toContain("report.textContent + '\\n\\n' + diagnostic");
+
+    // Never JSON.stringify a value the host handed us. Structured clone carries cycles,
+    // and this runs inside the message handler — a throw there takes the card's whole
+    // update path down, turning a failed read into a frozen card.
+    expect(html).not.toContain('JSON.stringify(error)');
   });
 
   it("shows the gate's own frames, which the agent has no browser to capture", () => {

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -245,9 +245,9 @@ describe('ui resources', () => {
     expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty('open_round');
   });
 
-  it('keeps the app-only tool read-only, since the model never sees it happen', () => {
+  it('keeps the app-only tools read-only, since the model never sees them happen', () => {
     // A hidden tool that writes is an audit hole: nothing in the transcript records it.
-    expect([...MCP_UI_APP_ONLY_TOOLS]).toEqual(['get_round_status']);
+    expect([...MCP_UI_APP_ONLY_TOOLS]).toEqual(['get_round_status', 'get_round_media']);
     expect([...MCP_UI_APP_ONLY_TOOLS].every((name) => name.startsWith('get_'))).toBe(true);
   });
 
@@ -313,6 +313,34 @@ describe('ui resources', () => {
     expect(html).toContain('was never given a round key');
     expect(html).toContain('The status call was refused.');
     expect(html).toContain("'with a round key, ' : 'without a round key, '");
+  });
+
+  it("shows the gate's own frames, which the agent has no browser to capture", () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("name: 'get_round_media'");
+    // data: URIs render in both hosts (verified in Claude and ChatGPT), which is what
+    // makes carrying the bytes viable at all — a signed URL would be blocked by the CSP.
+    expect(html).toContain("'data:image/png;base64,'");
+    // Fetched once per delivery, not once per poll: the strip does not change between
+    // polls and each frame is hundreds of kilobytes through the host.
+    expect(html).toContain('mediaKey === gate.deliveryId');
+    expect(html).toContain("gate.status === 'pending'");
+    // A frame written a moment after the verdict loses the first read; one retry, then
+    // stop, so a card cannot re-ask forever.
+    expect(html).toContain('mediaTries < 2');
+    // Megabytes cannot ride a postMessage and the CSP declares no domains, so the video
+    // is handed to the host to open rather than embedded.
+    expect(html).toContain("request('ui/open-link'");
+    // Never claims a complete strip when the budget dropped frames.
+    expect(html).toContain('framesOmitted');
+    // A run with no media says so instead of rendering an empty strip.
+    expect(html).toContain("'No frames: '");
+  });
+
+  it("clears a previous delivery's frames when it falls back to the opening payload", () => {
+    // Otherwise the strip from the last round stays on screen under a fresh verdict.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toMatch(/gallery\.hidden = true;[\s\S]{0,80}galleryCap\.hidden = true;/);
   });
 
   it('polls, and degrades to the opening payload when a host refuses the app-only call', () => {

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -421,6 +421,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var speculative = false;
         var giveUpTimer = null;
         var contextKey = null;
+        var lastFailure = null;
         var REPORT_CONTEXT_LIMIT = 4000;
         var stopped = false;
         var timer = null;
@@ -807,8 +808,20 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function giveUp() {
           giveUpTimer = null;
           if (live) return;
-          if (seed) renderGateOnly(seed);
-          else summary.textContent = 'Could not read round status here.';
+          if (seed) {
+            renderGateOnly(seed);
+          } else {
+            summary.textContent = 'Could not read round status here.';
+          }
+          // Say which of the two ways it failed. Without this a screenshot of a broken
+          // card is indistinguishable between "the host never gave this view a round
+          // key" and "the host refused the call", and those need opposite fixes.
+          report.textContent =
+            lastFailure ||
+            (sessionKey
+              ? 'The status call was refused.'
+              : 'This view was never given a round key, so it could not ask.');
+          report.hidden = false;
           reportSize();
         }
 
@@ -875,7 +888,11 @@ const ROUND_STATUS_HTML = `<!doctype html>
             inFlight = false;
             var status = error ? null : unwrap(result, looksLikeStatus);
             if (!status) {
-              log('warning', 'round status unavailable: ' + String(error || 'unrecognised shape'));
+              var reason = error
+                ? 'call refused: ' + (error.message || JSON.stringify(error)).slice(0, 200)
+                : 'the reply was not round status';
+              lastFailure = (sessionKey ? 'with a round key, ' : 'without a round key, ') + reason;
+              log('warning', 'round status unavailable: ' + lastFailure);
               if (speculative) {
                 // The key can land while this very request is in flight, in which case
                 // noteSessionKey's own poll() was dropped as already in flight. Retry

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -843,11 +843,19 @@ const ROUND_STATUS_HTML = `<!doctype html>
           // Say which of the two ways it failed. Without this a screenshot of a broken
           // card is indistinguishable between "the host never gave this view a round
           // key" and "the host refused the call", and those need opposite fixes.
-          report.textContent =
+          var diagnostic =
             lastFailure ||
             (sessionKey
               ? 'The status call was refused.'
               : 'This view was never given a round key, so it could not ask.');
+          // Appended, never substituted. renderGateOnly may have just put the gate's own
+          // report here, and that is what the creator came to read — a diagnostic about
+          // our polling is the footnote, not the headline.
+          // The escapes are doubled on purpose: this file is a template literal, so a
+          // bare \\n here would emit a real line break inside a JS string and break the
+          // view. tsc and lint both pass it; only the browser notices.
+          report.textContent =
+            report.hidden || !report.textContent ? diagnostic : report.textContent + '\\n\\n' + diagnostic;
           report.hidden = false;
           reportSize();
         }
@@ -1001,8 +1009,12 @@ const ROUND_STATUS_HTML = `<!doctype html>
             inFlight = false;
             var status = error ? null : unwrap(result, looksLikeStatus);
             if (!status) {
+              // Never JSON.stringify a value the host handed us: structured clone
+              // carries cycles, and a throw here is inside the message handler, which
+              // would take the card's whole update path down with it. A plain coercion
+              // says less and cannot fail.
               var reason = error
-                ? 'call refused: ' + (error.message || JSON.stringify(error)).slice(0, 200)
+                ? 'call refused: ' + String(error.message || error.code || error).slice(0, 200)
                 : 'the reply was not round status';
               lastFailure = (sessionKey ? 'with a round key, ' : 'without a round key, ') + reason;
               log('warning', 'round status unavailable: ' + lastFailure);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -74,7 +74,7 @@ export const MCP_UI_TOOL_RESOURCES: Readonly<Record<string, string>> = Object.fr
  * watching, not an agent working, so polls must not refresh the heartbeat, clear
  * `agentEndedAt`, or hold off the quiet stall that unlocks self→platform handoff.
  */
-export const MCP_UI_APP_ONLY_TOOLS: ReadonlySet<string> = new Set(['get_round_status']);
+export const MCP_UI_APP_ONLY_TOOLS: ReadonlySet<string> = new Set(['get_round_status', 'get_round_media']);
 
 /** Off unless explicitly enabled — production stays on today's contract until the spike lands. */
 export function mcpUiEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -352,6 +352,24 @@ const ROUND_STATUS_HTML = `<!doctype html>
         max-height: 220px;
         overflow: auto;
       }
+      /* The gate's own frames: a strip, so several fit without pushing the verdict off. */
+      .gallery {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: 1fr;
+        gap: 6px;
+        margin: 12px 0 0;
+      }
+      .gallery img {
+        width: 100%;
+        max-height: 150px;
+        object-fit: contain;
+        background: #0c0e0f;
+        border: 1px solid var(--gd-border);
+        border-radius: 6px;
+        display: block;
+      }
+      .galleryCap { margin: 6px 0 0; font-size: 11.5px; color: var(--gd-muted); }
       .actions { margin: 12px 0 0; }
       .action {
         font: inherit;
@@ -394,6 +412,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
       <p id="summary" class="summary">Reading round status…</p>
       <blockquote id="note" class="note" hidden></blockquote>
       <figure id="shot" class="shot" hidden><img id="shotImg" alt="Latest frame from the build" /><figcaption id="shotCap"></figcaption></figure>
+      <div id="gallery" class="gallery" hidden></div>
+      <p id="galleryCap" class="galleryCap" hidden></p>
       <dl id="meta" class="meta"></dl>
       <pre id="report" class="report" hidden></pre>
       <div id="actionRow" class="actions" hidden>
@@ -422,6 +442,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var giveUpTimer = null;
         var contextKey = null;
         var lastFailure = null;
+        var mediaKey = null;
+        var mediaTriesFor = null;
+        var mediaTries = 0;
         var REPORT_CONTEXT_LIMIT = 4000;
         var stopped = false;
         var timer = null;
@@ -436,6 +459,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var actionRow = document.getElementById('actionRow');
         var actionBtn = document.getElementById('actionBtn');
         var actionHint = document.getElementById('actionHint');
+        var gallery = document.getElementById('gallery');
+        var galleryCap = document.getElementById('galleryCap');
         var metaList = document.getElementById('meta');
         var report = document.getElementById('report');
         var foot = document.getElementById('foot');
@@ -695,6 +720,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
           }
 
           actionRow.hidden = true;
+          gallery.hidden = true;
+          galleryCap.hidden = true;
           foot.textContent =
             status === 'pending'
               ? verdict.deliveryId
@@ -861,6 +888,92 @@ const ROUND_STATUS_HTML = `<!doctype html>
           });
         }
 
+        /**
+         * The gate's frames, fetched once per delivery when a verdict exists.
+         *
+         * This is the picture the agent cannot take: it has no browser to run the game
+         * in, so its only honest options are a real gate capture or nothing. The gate
+         * captures on both lanes; the card is already here when the verdict lands.
+         */
+        function loadMedia(status) {
+          var gate = status.gate;
+          if (!gate || !gate.deliveryId || gate.status === 'pending') return;
+          if (mediaKey === gate.deliveryId) return;
+          if (mediaTriesFor !== gate.deliveryId) {
+            mediaTriesFor = gate.deliveryId;
+            mediaTries = 0;
+          }
+          mediaKey = gate.deliveryId;
+          var id = nextId++;
+          pendingCalls[id] = function (result, error) {
+            if (error) {
+              log('warning', 'gate media unavailable: ' + String(error));
+              // Frames are written by the gate a moment after the verdict, so the first
+              // read can lose a race it will win next poll. Retry once, then stop —
+              // a card that re-asks every 30s forever is worse than a card without a
+              // picture.
+              mediaTries++;
+              if (mediaTries < 2) mediaKey = null;
+              return;
+            }
+            var media = unwrap(result, function (value) {
+              return Array.isArray(value.frames);
+            });
+            if (!media) return;
+            renderMedia(media);
+          };
+          var args = { deliveryId: gate.deliveryId };
+          if (sessionKey) args.sessionKey = sessionKey;
+          post({ jsonrpc: '2.0', id: id, method: 'tools/call', params: { name: 'get_round_media', arguments: args } });
+        }
+
+        function renderMedia(media) {
+          gallery.textContent = '';
+          var frames = media.frames || [];
+          for (var i = 0; i < frames.length; i++) {
+            if (!frames[i] || typeof frames[i].png !== 'string') continue;
+            var img = document.createElement('img');
+            img.src = 'data:image/png;base64,' + frames[i].png;
+            img.alt = frames[i].name || 'Frame captured by the gate';
+            gallery.appendChild(img);
+          }
+          gallery.hidden = gallery.childNodes.length === 0;
+
+          galleryCap.textContent = '';
+          galleryCap.hidden = true;
+          if (!gallery.hidden) {
+            var omitted = Number(media.framesOmitted) || 0;
+            galleryCap.textContent =
+              'Captured by the gate' +
+              (media.lane ? ' on the ' + media.lane + ' run' : '') +
+              '.' +
+              (omitted > 0 ? ' ' + omitted + ' more frame' + (omitted === 1 ? '' : 's') + ' too large to show.' : '');
+            galleryCap.hidden = false;
+          } else if (typeof media.reason === 'string' && media.reason) {
+            // No strip is a fact about the run, not a rendering failure. Say which.
+            galleryCap.textContent = 'No frames: ' + media.reason + '.';
+            galleryCap.hidden = false;
+          }
+          // A video is megabytes; it cannot ride a postMessage and the CSP declares no
+          // domains, so hand it to the host to open rather than trying to play it here.
+          if (media.video && typeof media.video.url === 'string' && media.video.url) {
+            var link = document.createElement('button');
+            link.type = 'button';
+            link.className = 'action';
+            link.style.marginTop = '8px';
+            link.textContent = 'Watch the gate recording';
+            link.onclick = (function (url) {
+              return function () {
+                request('ui/open-link', { url: url });
+              };
+            })(media.video.url);
+            galleryCap.hidden = false;
+            galleryCap.appendChild(document.createElement('br'));
+            galleryCap.appendChild(link);
+          }
+          reportSize();
+        }
+
         function schedule(seconds) {
           if (stopped || timer) return;
           var delay = Math.max(10, Number(seconds) || 30) * 1000;
@@ -913,6 +1026,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             }
             live = true;
             pushModelContext(status);
+            loadMedia(status);
             if (giveUpTimer) {
               clearTimeout(giveUpTimer);
               giveUpTimer = null;


### PR DESCRIPTION
Two changes to the round card, both from watching real host sessions.

## 1. Show the gate's frames (the V2 payoff)

The agent building the game has no browser. It cannot look at what it built, so "how does it look" has only ever had two honest answers: a real gate capture, or nothing. Reaching a capture *through the agent* means waiting for a verdict — which the workflow explicitly tells it not to do.

The card is already waiting. It polls, it sees the verdict land, so it fetches the frames itself. Once a delivery settles it calls a new app-only `get_round_media` and renders a data-URI strip under the summary, with the lane that captured them and a button that hands the gameplay video to the host to open.

This closes a gap the agent structurally cannot close.

Notes on the shape:

- **App-only and presence-neutral**, exactly like `get_round_status`. A creator watching a strip is not an agent working, so it must not refresh the heartbeat or hold off the quiet stall. The model never sees the call, which is also why the tool is read-only — a hidden tool that writes is an audit hole.
- **Bytes ride `structuredContent`, not image blocks.** The view needs a data URI, and there is no model context to protect here.
- **Bounded again on our side, in base64 rather than bytes.** The channel already caps what it inlines, but it caps *decoded* size for a model's context. What binds here is different: these frames ride a JSON-RPC postMessage through the host into a sandboxed iframe, base64 and all, a third larger than the channel measured. Whatever the budget drops is counted and said in the caption — a strip that silently claims to be complete is worse than one that admits it isn't.
- **Lane comes from `gate.lane`**, not the top level. Which run captured a frame is a property of the gate that took it, and a green *preview* is not publish readiness.
- **One retry, then stop.** Frames are written a moment after the verdict, so the first read can lose a race it wins next poll. A card that re-asks every 30s forever is worse than a card without a picture.
- **A run that stored no media says so** rather than rendering an empty strip.

The `data:` URI question — open since Phase 0 and blocking this — was answered by the ChatGPT session below: the host renders them.

## 2. Say which way a status read failed

In that same ChatGPT session, a later card sat on "Reading round status…" and then gave up. Not a host that can't do it — a host that did it once and then didn't.

`Could not read round status here.` cannot distinguish the two possible causes, and they need opposite responses:

- **the view was never handed a round key** — ours to solve, by getting the key to the view another way
- **the host refused the app-only call** — a host limitation to design around

The card now records which happened and shows it in the detail block, so one screenshot names the cause instead of costing another round of guessing. Deliberately not a fix for the underlying failure — I'd rather learn what it is than guess a third time.

## Verification

Full API suite green (2396 tests, 153 files), lint clean.

Verified in the browser harness — the only thing that has caught the real defects in this workstream: three frames render, the caption reports the two the budget dropped, the recording button posts `ui/open-link`, and the view still parses as JavaScript. The lane assertion was mutation-checked (reverting to a top-level `body.lane` read fails it).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_