### PR TITLE
Dedupe creator profile games when a slug was republished

### DIFF
--- a/apps/api/src/creator-profile-routes.test.ts
+++ b/apps/api/src/creator-profile-routes.test.ts
@@ -115,6 +115,33 @@ describe('creator profile routes', () => {
     expect(JSON.stringify(body)).not.toContain('Secret Google');
   });
 
+  it('lists one card per slug when a published improvement shares the slug', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await store.claimHandle('g:creator', 'ada', '2026-07-01T00:00:00.000Z');
+    await store.createSubmission(42, 'g:creator', 'TV Tycoon');
+    await store.setSubmissionSlug(42, 'tv-tycoon');
+    await store.setSubmissionPublishedAt(42, '2026-07-01T12:00:00.000Z');
+    // Improvement job: same slug, newer, also published — the Studio shelf collapses
+    // these; the public profile must too.
+    await store.createSubmission(43, 'g:creator', 'TV Tycoon');
+    await store.setSubmissionSlug(43, 'tv-tycoon');
+    await store.setSubmissionPublishedAt(43, '2026-08-01T12:00:00.000Z');
+    await store.setPublication({
+      slug: 'tv-tycoon',
+      state: 'published',
+      currentVersion: 'v2',
+      publishedAt: '2026-08-01T12:00:00.000Z',
+    });
+    const app = await appWith(store);
+
+    const publicPage = await app.inject({ method: 'GET', url: '/api/creators/ada' });
+    expect(publicPage.statusCode).toBe(200);
+    expect(publicPage.json().games).toEqual([
+      expect.objectContaining({ slug: 'tv-tycoon', title: 'TV Tycoon', creatorHandle: 'ada' }),
+    ]);
+  });
+
   it('includes gate screenshots in published game cards', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:creator' });

--- a/apps/api/src/creator-profile-routes.ts
+++ b/apps/api/src/creator-profile-routes.ts
@@ -245,11 +245,19 @@ async function listCreatorPublishedGames(
   profile: PublicCreatorProfile,
 ): Promise<CatalogGameEntry[]> {
   const records = await store.listSubmissionsByOwner(ownerUid, { limit: 100 });
+  // An improvement is a new job on an existing slug. When it publishes, both the
+  // original and the revise tip carry `publishedAt`, so listing every published
+  // record would put the same game on the profile twice. One card per slug —
+  // same collapse the Studio shelf already does. `listSubmissionsByOwner` is
+  // newest-first, so the first hit is the tip that won.
   const candidates = records.filter((record) => record.publishedAt && record.slug && !record.abandonedAt);
   const games: CatalogGameEntry[] = [];
+  const seenSlugs = new Set<string>();
 
   for (const record of candidates) {
     const slug = record.slug!;
+    if (seenSlugs.has(slug)) continue;
+    seenSlugs.add(slug);
     // archived / disabled publications must not stay on the public profile with a
     // dead Play button — same gate the play endpoint uses.
     const publication = await store.getPublication(slug);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TV Tycoon showed twice on `/gtanczyk` because the public creator profile listed every published *submission* for the owner. An improvement that later publishes leaves two records with the same slug and `publishedAt`, so the same game became two cards.

This collapses to one card per slug (newest first), matching the Studio shelf.

## Test plan

- [x] Unit test: two published submissions for `tv-tycoon` → one game on `GET /api/creators/:handle`
- [x] Green gate (`type-check`, `lint`, `test`, `build`)
- [ ] After deploy: `/gtanczyk` shows TV Tycoon once
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25df63cd-caad-4977-8046-15532ec4c44e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25df63cd-caad-4977-8046-15532ec4c44e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

