### PR TITLE
Kit window by semver, and an honest action button when the host won't send

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -100,6 +100,16 @@ When the gate returns `kit_outdated` (or soft copy says the kit rotated):
    copies the last candidate; optional `files[]` only for paths you actually changed
 3. Do **not** `get_sources` + `stage_source_file` every path again (burns connector tokens)
 
+The window is **same-major semver**, not the last two published kits. `shared/kit-version.json`
+in the games repo declares the kit's contract version; the gate accepts any delivery whose kit
+shares its major, however many kits have landed since. So a `kit_outdated` verdict now means a
+genuine breaking change, not that the repo merged twice while the agent was working.
+
+It used to mean the latter, and often did: on 2026-08-05 seven kits published in ten hours, a
+`get_kit` answer was good for 45–90 minutes, and three consecutive rounds were refused for age —
+one over a commit that added an internal probe script. `apps/api/src/kit-window.ts` is the rule;
+the games repo's `docs/kit-versioning.md` is when to bump.
+
 ### Staging is creator-visible (live staged preview)
 
 `apps/api/src/staged-preview.ts` assembles the **staging buffer itself** and stores it as

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -26,6 +26,7 @@ import {
   DELIVERY_MAX_UPLOAD_BYTES,
   DELIVERY_RESERVED_SEGMENTS,
 } from './games-repo-contract.js';
+import { parseKitSidecar } from './kit-registry.js';
 import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from './kit-window.js';
 
 /**
@@ -581,6 +582,13 @@ export interface GamesStore {
    * not been published yet — callers must not invent a window from listing order.
    */
   getKitRegistry(): Promise<KitRegistry | null>;
+  /**
+   * The semver a given kit was packed at, from `kits/<engineRef>.json`.
+   *
+   * Null when the sidecar is missing, unreadable, or predates versioning — all of
+   * which mean "fall back to the N/N−1 window", never "refuse".
+   */
+  getKitVersion(engineRef: string): Promise<string | null>;
 }
 
 export interface GcsGamesStoreOptions {
@@ -1047,6 +1055,19 @@ export function createGcsGamesStore(options: GcsGamesStoreOptions): GamesStore {
       const body = await readObject(KIT_REGISTRY_OBJECT);
       if (!body) return null;
       return parseKitRegistry(body.toString('utf8'));
+    },
+
+    async getKitVersion(engineRef) {
+      // The ref reaches here from a delivery manifest, so it is interpolated into an
+      // object path only after a shape check — never trust a claim to be a commit sha.
+      if (!/^[A-Za-z0-9-]+$/.test(engineRef)) return null;
+      const body = await readObject(`kits/${engineRef}.json`);
+      if (!body) return null;
+      try {
+        return parseKitSidecar(body.toString('utf8')).version ?? null;
+      } catch {
+        return null;
+      }
     },
   };
 }

--- a/apps/api/src/gate-runner.test.ts
+++ b/apps/api/src/gate-runner.test.ts
@@ -381,6 +381,92 @@ describe('runGate', () => {
     expect(run).toHaveBeenCalled();
   });
 
+  it('accepts a two-generations-old kit when it shares the current major', async () => {
+    // The case that cost three consecutive rounds: seven kits landed in ten hours, so
+    // the agent's ref was out of N/N−1 by the time it submitted. Nothing about those
+    // merges could break a game, and now nothing about them refuses one.
+    const old = 'cccccccccccccccccccccccccccccccccccccccc';
+    const { store } = stubStore({ getManifest: async () => ({ ...MANIFEST, kitEngineRef: old }) });
+    const run = vi.fn(async () => ({ code: 0, output: '' }));
+    const readKitVersion = vi.fn(async () => '1.0.0');
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run,
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({
+        current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        currentVersion: '1.4.2',
+        updatedAt: '2026-08-05T11:48:00.000Z',
+      }),
+      readKitVersion,
+    });
+
+    expect(outcome.green).toBe(true);
+    expect(outcome.status).toBeUndefined();
+    expect(readKitVersion).toHaveBeenCalledWith(old);
+    expect(run).toHaveBeenCalled();
+  });
+
+  it('still refuses a delivery from a previous major', async () => {
+    // A major bump means existing creator sources no longer compile — the one case the
+    // window exists to catch, and widening must not swallow it.
+    const old = 'cccccccccccccccccccccccccccccccccccccccc';
+    const { store } = stubStore({ getManifest: async () => ({ ...MANIFEST, kitEngineRef: old }) });
+    const prepareHarness = vi.fn(async () => harnessDir());
+    const run = vi.fn(async () => ({ code: 0, output: '' }));
+
+    const outcome = await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness,
+      run,
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({
+        current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        currentVersion: '2.0.0',
+        updatedAt: '2026-08-05T11:48:00.000Z',
+      }),
+      readKitVersion: async () => '1.4.2',
+    });
+
+    expect(outcome).toMatchObject({ green: false, status: 'kit_outdated' });
+    expect(outcome.report).toContain('current kit is v2.0.0');
+    expect(prepareHarness).not.toHaveBeenCalled();
+  });
+
+  it('does not spend a sidecar read when the registry is unversioned or the ref is current', async () => {
+    // The common paths must cost nothing extra, and an unversioned registry cannot
+    // compare majors — reading would buy only latency.
+    const readKitVersion = vi.fn(async () => '1.0.0');
+    const current = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const { store } = stubStore({ getManifest: async () => ({ ...MANIFEST, kitEngineRef: current }) });
+    await runGate('comet-courier', 'v1', {
+      store,
+      prepareHarness: harnessDir,
+      run: async () => ({ code: 0, output: '' }),
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({ current, previous: null, currentVersion: '1.4.2', updatedAt: 'x' }),
+      readKitVersion,
+    });
+    expect(readKitVersion).not.toHaveBeenCalled();
+
+    const { store: store2 } = stubStore({
+      getManifest: async () => ({ ...MANIFEST, kitEngineRef: 'cccccccccccccccccccccccccccccccccccccccc' }),
+    });
+    await runGate('comet-courier', 'v1', {
+      store: store2,
+      prepareHarness: harnessDir,
+      run: async () => ({ code: 0, output: '' }),
+      assembleBundle: stubAssemble,
+      readKitRegistry: async () => ({ current, previous: null, updatedAt: 'x' }),
+      readKitVersion,
+    });
+    expect(readKitVersion).not.toHaveBeenCalled();
+  });
+
   it('serves the assembler’s document, not the games repo’s own build output', async () => {
     // The repo's `dist/` build is its idea of a playable page. Serve-time policy — the
     // restrictive CSP, the provenance marking, the credential scan, the byte budget —

--- a/apps/api/src/gate-runner.ts
+++ b/apps/api/src/gate-runner.ts
@@ -105,10 +105,19 @@ export interface GateRunnerDeps {
    */
   assembleBundle?: (harness: string, slug: string) => Promise<string | null>;
   /**
-   * The Creator Kit N/N−1 window. Injected so tests can fix the registry without GCS;
+   * The Creator Kit window. Injected so tests can fix the registry without GCS;
    * production reads `kits/current.json` via {@link GamesStore.getKitRegistry}.
    */
   readKitRegistry?: () => Promise<KitRegistry | null>;
+  /**
+   * The semver a given kit was packed at, from that ref's own sidecar.
+   *
+   * Read per-ref rather than kept in the registry because the registry cannot carry a
+   * list long enough to date an arbitrarily old delivery, and the sidecar is already
+   * immutable and written once per kit. Only consulted when the ref is neither current
+   * nor previous, so the common paths cost no extra read.
+   */
+  readKitVersion?: (engineRef: string) => Promise<string | null>;
 }
 
 const DEFAULT_ARTIFACT_ROOTS = {
@@ -199,7 +208,20 @@ export async function runGate(
   const previewStills = previewRun && process.env.GATE_PREVIEW_STILLS !== '0';
   if (!healthRun && manifest.kitEngineRef) {
     const registry = await (deps.readKitRegistry ?? (() => deps.store.getKitRegistry()))().catch(() => null);
-    if (registry && !isKitEngineRefSupported(manifest.kitEngineRef, registry)) {
+    // Only when the cheap checks did not already settle it, and only when the registry
+    // is versioned at all — an unversioned one cannot compare majors, so the read
+    // would buy nothing.
+    const needsVersion =
+      registry !== null &&
+      Boolean(registry.currentVersion) &&
+      manifest.kitEngineRef !== registry.current &&
+      manifest.kitEngineRef !== registry.previous;
+    const claimedVersion = needsVersion
+      ? await (deps.readKitVersion ?? ((ref: string) => deps.store.getKitVersion(ref)))(manifest.kitEngineRef).catch(
+          () => null,
+        )
+      : null;
+    if (registry && !isKitEngineRefSupported(manifest.kitEngineRef, registry, claimedVersion)) {
       return {
         green: false,
         status: 'kit_outdated',

--- a/apps/api/src/kit-files.test.ts
+++ b/apps/api/src/kit-files.test.ts
@@ -250,4 +250,73 @@ describe('createKitFileStore', () => {
       code: 'kit_revision_unsupported',
     });
   });
+
+  it('lets an agent keep reading the kit it is building against, same rule as the gate', async () => {
+    // Browse used to enforce N/N−1 on its own, so in a long round two same-major kits
+    // could publish and the agent could no longer read the kit whose delivery the gate
+    // would still accept — forcing exactly the mid-round kit churn semver removes.
+    const OLD = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const OLD_SHA = 'c'.repeat(64);
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(
+          JSON.stringify({
+            current: ENGINE,
+            previous: PREV,
+            currentVersion: '1.4.2',
+            updatedAt: '2026-08-05T11:48:00.000Z',
+          }),
+        ),
+      ],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA, version: '1.4.2' }))],
+      [`kits/${ENGINE}.tgz`, kitTarball({ 'SKILL.md': '# current\n' })],
+      // Two generations back, same major.
+      [`kits/${OLD}.json`, Buffer.from(JSON.stringify({ sha256: OLD_SHA, version: '1.0.0' }))],
+      [`kits/${OLD}.tgz`, kitTarball({ 'SKILL.md': '# old\n' })],
+    ]);
+    const store: GcsObjectStore = {
+      readObject: async (name) => objects.get(name) ?? null,
+      objectExists: async (name) => objects.has(name),
+      signReadUrl: async () => 'https://signed.example/kit.tgz',
+    };
+    const kits = createKitFileStore(store);
+
+    const tree = await kits.loadTree(OLD);
+    expect(tree.engineRef).toBe(OLD);
+    expect(tree.files.get(`${KIT_ROOT_DIR}/SKILL.md`)?.toString('utf8')).toBe('# old\n');
+
+    // A different major is still refused, and says the rule rather than two SHAs.
+    const BREAKING = 'f'.repeat(40);
+    objects.set(`kits/${BREAKING}.json`, Buffer.from(JSON.stringify({ sha256: 'd'.repeat(64), version: '0.9.0' })));
+    objects.set(`kits/${BREAKING}.tgz`, kitTarball({ 'SKILL.md': '# breaking\n' }));
+    await expect(kits.loadTree(BREAKING)).rejects.toMatchObject({ code: 'kit_revision_unsupported' });
+    await expect(kits.loadTree(BREAKING)).rejects.toThrow(/major version/);
+  });
+
+  it('falls back to N/N−1 for browse when the registry is unversioned', async () => {
+    const OLD = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: PREV, updatedAt: '2026-08-03T00:00:00.000Z' })),
+      ],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA }))],
+      [`kits/${ENGINE}.tgz`, kitTarball({ 'SKILL.md': '# current\n' })],
+      // Versioned sidecar, unversioned registry: nothing to compare against, so the
+      // old floor must hold rather than the claim being taken at face value.
+      [`kits/${OLD}.json`, Buffer.from(JSON.stringify({ sha256: 'c'.repeat(64), version: '1.0.0' }))],
+      [`kits/${OLD}.tgz`, kitTarball({ 'SKILL.md': '# old\n' })],
+      [`kits/${PREV}.json`, Buffer.from(JSON.stringify({ sha256: PREV_SHA }))],
+      [`kits/${PREV}.tgz`, kitTarball({ 'SKILL.md': '# previous\n' })],
+    ]);
+    const store: GcsObjectStore = {
+      readObject: async (name) => objects.get(name) ?? null,
+      objectExists: async (name) => objects.has(name),
+      signReadUrl: async () => 'https://signed.example/kit.tgz',
+    };
+    const kits = createKitFileStore(store);
+    await expect(kits.loadTree(OLD)).rejects.toMatchObject({ code: 'kit_revision_unsupported' });
+    expect((await kits.loadTree(PREV)).engineRef).toBe(PREV);
+  });
 });

--- a/apps/api/src/kit-files.ts
+++ b/apps/api/src/kit-files.ts
@@ -12,6 +12,7 @@ import { Readable } from 'node:stream';
 import { createGunzip } from 'node:zlib';
 import type { GcsObjectStore } from './gcs-sign.js';
 import { KIT_ENTRY, KIT_ROOT_DIR, KitRegistryError, parseKitRegistry, parseKitSidecar } from './kit-registry.js';
+import { isKitEngineRefSupported } from './kit-window.js';
 import { readTarEntries } from './tar.js';
 
 /** Whole-file reads above this must use fragments instead. */
@@ -503,7 +504,7 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
     return tree;
   }
 
-  async function readWindow(): Promise<{ current: string; previous: string | null }> {
+  async function readWindow(): Promise<{ current: string; previous: string | null; currentVersion?: string }> {
     const registryBody = await objectStore.readObject('kits/current.json');
     if (!registryBody) {
       throw new KitFilesError(
@@ -513,7 +514,11 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
     }
     try {
       const registry = parseKitRegistry(registryBody.toString('utf8'));
-      return { current: registry.current, previous: registry.previous };
+      return {
+        current: registry.current,
+        previous: registry.previous,
+        ...(registry.currentVersion ? { currentVersion: registry.currentVersion } : {}),
+      };
     } catch (error) {
       if (error instanceof KitRegistryError) {
         throw new KitFilesError(error.code, error.message, { cause: error });
@@ -546,14 +551,55 @@ export function createKitFileStore(objectStore: GcsObjectStore): KitFileStore {
     return { engineRef: window.current, previous: window.previous, sha256 };
   }
 
+  /**
+   * The semver a kit was packed at, or null when it cannot be read.
+   *
+   * Null is the safe answer everywhere it is used: it drops the caller back to the
+   * N/N−1 floor rather than granting a compatibility claim the sidecar never made.
+   */
+  async function loadSidecarVersion(engineRef: string): Promise<string | null> {
+    const sidecarBody = await objectStore.readObject(`kits/${engineRef}.json`);
+    if (!sidecarBody) return null;
+    try {
+      return parseKitSidecar(sidecarBody.toString('utf8')).version ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   async function loadTree(engineRef?: string): Promise<KitTree> {
     const window = await readWindow();
     const requested = engineRef?.trim() || window.current;
-    if (requested !== window.current && requested !== window.previous) {
+    // Same window as the gate, deliberately.
+    //
+    // Browsing used to enforce N/N−1 on its own, which put an agent in the position of
+    // being unable to *read* the kit it is building against while the gate would still
+    // accept the delivery — and the only way out was to re-fetch the kit mid-round,
+    // which is exactly the churn the semver window exists to stop. Read and verdict
+    // have to agree about which kits are alive.
+    const sidecarVersion =
+      requested !== window.current && requested !== window.previous && window.currentVersion
+        ? await loadSidecarVersion(requested)
+        : null;
+    const supported = isKitEngineRefSupported(
+      requested,
+      {
+        current: window.current,
+        previous: window.previous,
+        ...(window.currentVersion ? { currentVersion: window.currentVersion } : {}),
+        // Not read by the window rule; the registry document's own timestamp is
+        // irrelevant to whether a ref is compatible.
+        updatedAt: '',
+      },
+      sidecarVersion,
+    );
+    if (!supported) {
       throw new KitFilesError(
         'kit_revision_unsupported',
-        `engineRef ${requested} is outside the supported N/N−1 window (current=${window.current}` +
-          (window.previous ? `, previous=${window.previous}` : '') +
+        `engineRef ${requested} is outside the supported window (` +
+          (window.currentVersion
+            ? `current kit is v${window.currentVersion}; reads must share its major version`
+            : `current=${window.current}` + (window.previous ? `, previous=${window.previous}` : '')) +
           ') — re-run get_kit',
       );
     }

--- a/apps/api/src/kit-registry.ts
+++ b/apps/api/src/kit-registry.ts
@@ -5,9 +5,13 @@
  * in the bucket; it never invents an engineRef.
  */
 
+import { semverMajor } from './kit-window.js';
+
 export interface KitRegistry {
   current: string;
   previous: string | null;
+  /** Semver of `current`. Absent on documents written before versioning shipped. */
+  currentVersion?: string;
   updatedAt: string;
 }
 
@@ -48,9 +52,15 @@ export function parseKitRegistry(raw: string): KitRegistry {
   if (typeof obj.updatedAt !== 'string' || !obj.updatedAt) {
     throw new KitRegistryError('kit_registry_invalid', 'kits/current.json.updatedAt must be a non-empty string');
   }
+  // Dropped rather than rejected when malformed — see the same decision in
+  // kit-window.ts. A corrupt optional field must degrade to the narrower N/N−1 rule,
+  // never take the whole document down with it.
+  const currentVersion =
+    typeof obj.currentVersion === 'string' && semverMajor(obj.currentVersion) !== null ? obj.currentVersion : undefined;
   return {
     current: obj.current,
     previous: obj.previous,
+    ...(currentVersion === undefined ? {} : { currentVersion }),
     updatedAt: obj.updatedAt,
   };
 }

--- a/apps/api/src/kit-registry.ts
+++ b/apps/api/src/kit-registry.ts
@@ -14,6 +14,8 @@ export interface KitRegistry {
 export interface KitSidecar {
   sha256: string;
   packedAt?: string;
+  /** Semver this kit was packed at. Absent on kits published before versioning. */
+  version?: string;
 }
 
 export class KitRegistryError extends Error {
@@ -70,6 +72,7 @@ export function parseKitSidecar(raw: string): KitSidecar {
   return {
     sha256: obj.sha256.toLowerCase(),
     ...(typeof obj.packedAt === 'string' ? { packedAt: obj.packedAt } : {}),
+    ...(typeof obj.version === 'string' && obj.version ? { version: obj.version } : {}),
   };
 }
 

--- a/apps/api/src/kit-window.test.ts
+++ b/apps/api/src/kit-window.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { isKitEngineRefSupported, kitOutdatedReport, parseKitRegistry, type KitRegistry } from './kit-window.js';
+import {
+  isKitEngineRefSupported,
+  kitOutdatedReport,
+  parseKitRegistry,
+  semverMajor,
+  type KitRegistry,
+} from './kit-window.js';
 
 const REGISTRY: KitRegistry = {
   current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -44,5 +50,75 @@ describe('kit window (kits/current.json)', () => {
     expect(report).toMatch(/get_kit/i);
     expect(report).toMatch(/fromLatestDelivery/);
     expect(report).toMatch(/do not re-stage|do not re-upload/i);
+  });
+
+  describe('semver window (compatibility, not commit count)', () => {
+    // The day that produced this rule: seven kits in ten hours, so a get_kit answer was
+    // good for 45–90 minutes and three consecutive rounds were refused for age. Almost
+    // none of those merges could have broken a game — one merely added a probe script.
+    const VERSIONED: KitRegistry = {
+      current: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      previous: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      currentVersion: '1.4.2',
+      updatedAt: '2026-08-05T11:48:00.000Z',
+    };
+    const OLD = 'cccccccccccccccccccccccccccccccccccccccc';
+
+    it('accepts a ref that fell out of N/N−1 only because we merged', () => {
+      // Two generations back, same major: nothing about it could have broken.
+      expect(isKitEngineRefSupported(OLD, VERSIONED, '1.0.0')).toBe(true);
+      expect(isKitEngineRefSupported(OLD, VERSIONED, '1.4.1')).toBe(true);
+      // Age is irrelevant now — only the contract is.
+      expect(isKitEngineRefSupported(OLD, VERSIONED, '1.0.0-rc.1')).toBe(true);
+    });
+
+    it('refuses a delivery from a different major, which is what a break looks like', () => {
+      expect(isKitEngineRefSupported(OLD, VERSIONED, '0.9.9')).toBe(false);
+      // Newer major means the engine was rolled back and those APIs are gone.
+      expect(isKitEngineRefSupported(OLD, VERSIONED, '2.0.0')).toBe(false);
+    });
+
+    it('falls back to N/N−1 when either side is unversioned', () => {
+      // Old publisher, new API — and new publisher, kit packed before versioning.
+      // Both must behave exactly as they did before this existed.
+      expect(isKitEngineRefSupported(OLD, VERSIONED, null)).toBe(false);
+      expect(isKitEngineRefSupported(OLD, VERSIONED, 'not-a-semver')).toBe(false);
+      expect(isKitEngineRefSupported(OLD, REGISTRY, '1.0.0')).toBe(false);
+      // ...and the floor still stands in both cases.
+      expect(isKitEngineRefSupported(VERSIONED.current, VERSIONED, null)).toBe(true);
+      expect(isKitEngineRefSupported(VERSIONED.previous!, VERSIONED, null)).toBe(true);
+    });
+
+    it('never narrows: current and previous pass with no version at all', () => {
+      const noVersion: KitRegistry = { ...VERSIONED, currentVersion: undefined };
+      expect(isKitEngineRefSupported(noVersion.current, noVersion)).toBe(true);
+      expect(isKitEngineRefSupported(noVersion.previous!, noVersion)).toBe(true);
+    });
+
+    it('parses a semver major, and refuses to guess at anything else', () => {
+      expect(semverMajor('1.4.2')).toBe(1);
+      expect(semverMajor('12.0.0')).toBe(12);
+      expect(semverMajor('2.0.0-rc.1')).toBe(2);
+      expect(semverMajor('2.0.0+build.5')).toBe(2);
+      expect(semverMajor(' 1.0.0 ')).toBe(1);
+      for (const bad of ['1.4', '1', 'v1.4.2', '', 'latest', null, undefined]) {
+        expect(semverMajor(bad)).toBeNull();
+      }
+    });
+
+    it('rejects a malformed currentVersion loudly, since it gates every delivery', () => {
+      expect(() => parseKitRegistry(JSON.stringify({ ...VERSIONED, currentVersion: '' }))).toThrow(/currentVersion/);
+      expect(() => parseKitRegistry(JSON.stringify({ ...VERSIONED, currentVersion: 7 }))).toThrow(/currentVersion/);
+      expect(parseKitRegistry(JSON.stringify(VERSIONED)).currentVersion).toBe('1.4.2');
+    });
+
+    it('tells the agent the rule, not two opaque SHAs', () => {
+      const report = kitOutdatedReport(OLD, VERSIONED);
+      expect(report).toContain('current kit is v1.4.2');
+      expect(report).toContain('share its major version');
+      // Unversioned registries keep the old wording — there is no major to share.
+      expect(kitOutdatedReport(OLD, REGISTRY)).toContain(REGISTRY.current);
+      expect(kitOutdatedReport(OLD, REGISTRY)).not.toContain('major version');
+    });
   });
 });

--- a/apps/api/src/kit-window.test.ts
+++ b/apps/api/src/kit-window.test.ts
@@ -106,9 +106,18 @@ describe('kit window (kits/current.json)', () => {
       }
     });
 
-    it('rejects a malformed currentVersion loudly, since it gates every delivery', () => {
-      expect(() => parseKitRegistry(JSON.stringify({ ...VERSIONED, currentVersion: '' }))).toThrow(/currentVersion/);
-      expect(() => parseKitRegistry(JSON.stringify({ ...VERSIONED, currentVersion: 7 }))).toThrow(/currentVersion/);
+    it('drops a malformed currentVersion instead of taking the whole registry down', () => {
+      // The trap: the gate reads this registry through `.catch(() => null)`, and a null
+      // registry SKIPS the kit check entirely. Throwing here would not refuse a corrupt
+      // document — it would wave every delivery through, including a different major.
+      // Degrading to N/N−1 is the narrow answer; throwing was the wide one.
+      for (const bad of ['', 7, '1.4', 'v1.4.2', null, {}]) {
+        const parsed = parseKitRegistry(JSON.stringify({ ...VERSIONED, currentVersion: bad }));
+        expect(parsed.currentVersion).toBeUndefined();
+        // ...and with no version to compare, the old floor is what remains.
+        expect(isKitEngineRefSupported(OLD, parsed, '1.0.0')).toBe(false);
+        expect(isKitEngineRefSupported(parsed.current, parsed)).toBe(true);
+      }
       expect(parseKitRegistry(JSON.stringify(VERSIONED)).currentVersion).toBe('1.4.2');
     });
 

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -70,13 +70,22 @@ export function parseKitRegistry(raw: string): KitRegistry {
   if (typeof obj.updatedAt !== 'string' || !obj.updatedAt) {
     throw new Error('kits/current.json.updatedAt must be a non-empty string');
   }
-  if (!(obj.currentVersion === undefined || (typeof obj.currentVersion === 'string' && obj.currentVersion))) {
-    throw new Error('kits/current.json.currentVersion must be a non-empty string when present');
-  }
+  // Deliberately NOT loud, unlike the fields above.
+  //
+  // The gate reads this registry through a `.catch(() => null)`, and a null registry
+  // skips the kit check entirely — so throwing here would not refuse a bad document, it
+  // would wave *every* delivery through, including one from a different major. A
+  // corrupt optional field must degrade to the narrower rule, never the wider one.
+  // Dropping it falls back to N/N−1, which is what this ref had before versions existed.
+  //
+  // The publisher validates the same value strictly, which is the right asymmetry:
+  // loud where a human is watching a build, safe where a verdict depends on it.
+  const currentVersion =
+    typeof obj.currentVersion === 'string' && semverMajor(obj.currentVersion) !== null ? obj.currentVersion : undefined;
   return {
     current: obj.current,
     previous: obj.previous,
-    ...(obj.currentVersion === undefined ? {} : { currentVersion: obj.currentVersion }),
+    ...(currentVersion === undefined ? {} : { currentVersion }),
     updatedAt: obj.updatedAt,
   };
 }

--- a/apps/api/src/kit-window.ts
+++ b/apps/api/src/kit-window.ts
@@ -1,18 +1,50 @@
 /**
- * Creator Kit support window — N / N−1 from `kits/current.json`.
+ * Creator Kit support window — same-major semver, with N / N−1 as the floor.
  *
  * The registry document is the only authority for which engine refs a delivery may
  * claim. Do not infer previous from git parents (the packer is path-filtered, so a
  * parent commit usually is not the previous kit) or from bucket listing order
  * (undefined). BY-10 owns the publisher; this module is the consumer rule the gate
  * and delivery path share.
+ *
+ * ## Why counting commits was the wrong measure
+ *
+ * N/N−1 measures *our merge rate*, not the creator's elapsed time. On 2026-08-05 the
+ * games repo published seven kits in ten hours, so a `get_kit` answer was good for
+ * 45–90 minutes mid-day: an agent that fetched a ref, wrote code and submitted was
+ * routinely two generations behind by the time the gate looked, and three consecutive
+ * rounds were refused that way. One was spent on a commit that added an internal probe
+ * script — a file no creator ever calls, costing a delivery all the same.
+ *
+ * Almost none of those merges could have broken a game, which is the point: commit
+ * count was never a proxy for compatibility. The kit now declares a semver
+ * (`shared/kit-version.json` in the games repo) and the gate accepts **any kit sharing
+ * the current major**.
+ *
+ * What makes the declaration trustworthy is not discipline but CI: the games repo
+ * typechecks its whole catalog against the engine on every push to main, so a change
+ * that breaks the engine's surface cannot land without its author also fixing every
+ * game — which is exactly the situation that warrants a major.
+ *
+ * N/N−1 remains the floor for kits published before versions existed, so this is
+ * strictly a widening: nothing accepted before is refused now.
  */
 
 export type KitRegistry = {
   current: string;
   previous: string | null;
+  /** Semver of `current`. Absent on documents written before versioning shipped. */
+  currentVersion?: string;
   updatedAt: string;
 };
+
+/** Major component of a semver string, or null when it is not one. */
+export function semverMajor(version: string | null | undefined): number | null {
+  if (typeof version !== 'string') return null;
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version.trim());
+  if (!match) return null;
+  return Number(match[1]);
+}
 
 export const KIT_REGISTRY_OBJECT = 'kits/current.json';
 
@@ -38,19 +70,43 @@ export function parseKitRegistry(raw: string): KitRegistry {
   if (typeof obj.updatedAt !== 'string' || !obj.updatedAt) {
     throw new Error('kits/current.json.updatedAt must be a non-empty string');
   }
+  if (!(obj.currentVersion === undefined || (typeof obj.currentVersion === 'string' && obj.currentVersion))) {
+    throw new Error('kits/current.json.currentVersion must be a non-empty string when present');
+  }
   return {
     current: obj.current,
     previous: obj.previous,
+    ...(obj.currentVersion === undefined ? {} : { currentVersion: obj.currentVersion }),
     updatedAt: obj.updatedAt,
   };
 }
 
-/** True when `engineRef` is the registry's current or previous kit. */
-export function isKitEngineRefSupported(engineRef: string, registry: KitRegistry): boolean {
+/**
+ * True when `engineRef` is the current kit, the previous one, or was packed at a
+ * version sharing the current major.
+ *
+ * `claimedVersion` is the version recorded in that ref's own sidecar — the gate reads
+ * it, because the registry cannot carry a list long enough to date arbitrarily old
+ * refs and the sidecar is already immutable and per-ref.
+ *
+ * Both versions must parse and both must be present. An unversioned kit falls through
+ * to N/N−1, which is what it had before versions existed.
+ */
+export function isKitEngineRefSupported(
+  engineRef: string,
+  registry: KitRegistry,
+  claimedVersion?: string | null,
+): boolean {
   if (!engineRef) return false;
   if (engineRef === registry.current) return true;
   if (registry.previous !== null && engineRef === registry.previous) return true;
-  return false;
+
+  const claimedMajor = semverMajor(claimedVersion);
+  const currentMajor = semverMajor(registry.currentVersion);
+  if (claimedMajor === null || currentMajor === null) return false;
+  // A ref from a *newer* major than current means the engine was rolled back, and the
+  // APIs that delivery was written against are gone. Same-major only, both directions.
+  return claimedMajor === currentMajor;
 }
 
 /**
@@ -58,8 +114,10 @@ export function isKitEngineRefSupported(engineRef: string, registry: KitRegistry
  * the refresh action — re-running get_kit is cheaper than guessing a commit.
  */
 export function kitOutdatedReport(kitEngineRef: string, registry: KitRegistry): string {
-  const window =
-    registry.previous === null
+  const window = registry.currentVersion
+    ? // Say the rule, not the refs: "same major" is actionable, two opaque SHAs are not.
+      `current kit is v${registry.currentVersion}; deliveries must share its major version`
+    : registry.previous === null
       ? `current=${registry.current}`
       : `current=${registry.current}, previous=${registry.previous}`;
   return (

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -303,6 +303,11 @@ describe('ui resources', () => {
     // that silently fails is the dead button one level down.
     expect(html).toContain('selection.addRange(range)');
     expect(html).toContain("'Selected — press Ctrl/Cmd+C'");
+    // ...but only claimed when it actually took. A missing element or a host that
+    // returns no Selection would otherwise throw inside the click handler and leave the
+    // dead button this whole path exists to remove.
+    expect(html).toMatch(/if \(selected\) actionBtn\.textContent/);
+    expect(html).toContain('window.getSelection && window.getSelection()');
     // Clipboard is the shortcut, never the mechanism — it needs a sandbox permission the
     // host may not have granted, and rejects unhandled would be an unhandled rejection.
     expect(html).toMatch(/navigator\.clipboard[\s\S]{0,400}?function \(\) \{\}/);

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -288,6 +288,26 @@ describe('ui resources', () => {
     expect(html).toContain('actionHint.hidden = false');
   });
 
+  it('turns the button into a copy control when the host refuses to post for us', () => {
+    // Claude refuses ui/message (owner test, 2026-08-05), and the spec version we target
+    // has no host capability to ask in advance — so this is the normal path, not the
+    // exception. Restoring the original label and printing the text underneath read as
+    // "the button did nothing": nothing told the creator the words were now theirs.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('offerToCopy');
+    expect(html).toContain("'Copy for your agent'");
+    expect(html).toContain('This chat app will not send it for you');
+
+    // Selection first and unconditionally: it needs no permission and always works, so
+    // the click visibly does something whatever the clipboard decides. A Copy button
+    // that silently fails is the dead button one level down.
+    expect(html).toContain('selection.addRange(range)');
+    expect(html).toContain("'Selected — press Ctrl/Cmd+C'");
+    // Clipboard is the shortcut, never the mechanism — it needs a sandbox permission the
+    // host may not have granted, and rejects unhandled would be an unhandled rejection.
+    expect(html).toMatch(/navigator\.clipboard[\s\S]{0,400}?function \(\) \{\}/);
+  });
+
   it('does not print the gate detail twice, or lead with instructions meant for the agent', () => {
     // kit_outdated returns the same long agent-facing text as both summary and report,
     // which the card printed twice — once as its headline.

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -397,6 +397,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
         white-space: pre-wrap;
         color: var(--gd-muted);
       }
+      /* One click selects the whole instruction. The creator is copying this by hand
+         on every host that will not post for them, so make that the easy path. */
+      .hintText { display: block; margin-top: 6px; color: var(--gd-fg); user-select: all; }
       .foot { margin: 12px 0 0; font-size: 11.5px; color: var(--gd-muted); }
       .live { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--gd-accent); margin-right: 6px; vertical-align: middle; }
       [hidden] { display: none !important; }
@@ -445,6 +448,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var mediaKey = null;
         var mediaTriesFor = null;
         var mediaTries = 0;
+        var hostCaps = null;
         var REPORT_CONTEXT_LIMIT = 4000;
         var stopped = false;
         var timer = null;
@@ -662,12 +666,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             var id = nextId++;
             pendingCalls[id] = function (result, error) {
               if (error) {
-                // The host will not post for us — show the words so the creator can
-                // paste them rather than leaving a dead button.
-                actionBtn.textContent = action.label;
-                actionBtn.disabled = false;
-                actionHint.textContent = action.text;
-                actionHint.hidden = false;
+                offerToCopy(action);
               } else {
                 actionBtn.textContent = 'Sent to the agent';
               }
@@ -680,6 +679,53 @@ const ROUND_STATUS_HTML = `<!doctype html>
               params: { role: 'user', content: { type: 'text', text: action.text } }
             });
           };
+        }
+
+        /**
+         * What the button becomes when the host will not post for us.
+         *
+         * Claude refuses ui/message (owner test, 2026-08-05), and the spec version we
+         * target has no host capability to ask in advance — so this path is the normal
+         * one, not the exception. Restoring the original label and quietly printing the
+         * text below it read as "the button did nothing": the creator has no idea the
+         * words are now theirs to carry. So the button changes job instead, and says so.
+         */
+        function offerToCopy(action) {
+          actionBtn.disabled = false;
+          actionBtn.textContent = 'Copy for your agent';
+          actionBtn.onclick = function () {
+            // Selecting the text always works and needs no permission, so do that first
+            // and unconditionally: whatever the clipboard does, the click visibly did
+            // something. A Copy button that silently fails is the dead button again.
+            var range = document.createRange();
+            range.selectNodeContents(document.getElementById('hintText'));
+            var selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            actionBtn.textContent = 'Selected — press Ctrl/Cmd+C';
+
+            // Clipboard access needs a sandbox permission the host may not have granted,
+            // so this is the shortcut, never the mechanism.
+            try {
+              var written = navigator.clipboard && navigator.clipboard.writeText(action.text);
+              if (written && written.then) {
+                written.then(function () {
+                  actionBtn.textContent = 'Copied — paste it to your agent';
+                }, function () {});
+              }
+            } catch (e) {}
+          };
+
+          actionHint.textContent = '';
+          var lead = document.createElement('span');
+          lead.textContent = 'This chat app will not send it for you. Give your agent these words:';
+          var body = document.createElement('span');
+          body.className = 'hintText';
+          body.id = 'hintText';
+          body.textContent = action.text;
+          actionHint.appendChild(lead);
+          actionHint.appendChild(body);
+          actionHint.hidden = false;
         }
 
         /** Terminal for a *round*: nothing further will arrive, so stop polling. */
@@ -1077,7 +1123,13 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
           if (initializeId !== null && message.id === initializeId && !initialized) {
             initialized = true;
-            if (message.result) applyHostContext(message.result.hostContext);
+            if (message.result) {
+              applyHostContext(message.result.hostContext);
+              // Kept for the action button. The stable spec's HostCapabilities has no
+              // field for ui/message support at all — the draft adds one — so absence
+              // proves nothing today and we still have to try and see.
+              hostCaps = message.result.capabilities || null;
+            }
             notify('ui/notifications/initialized', {});
             log('debug', 'round view initialized');
             reportSize();

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -694,15 +694,24 @@ const ROUND_STATUS_HTML = `<!doctype html>
           actionBtn.disabled = false;
           actionBtn.textContent = 'Copy for your agent';
           actionBtn.onclick = function () {
-            // Selecting the text always works and needs no permission, so do that first
-            // and unconditionally: whatever the clipboard does, the click visibly did
-            // something. A Copy button that silently fails is the dead button again.
-            var range = document.createRange();
-            range.selectNodeContents(document.getElementById('hintText'));
-            var selection = window.getSelection();
-            selection.removeAllRanges();
-            selection.addRange(range);
-            actionBtn.textContent = 'Selected — press Ctrl/Cmd+C';
+            // Selecting the text needs no permission, so try it first: whatever the
+            // clipboard does, the click should visibly do something. A Copy button that
+            // silently fails is the dead button again — which is the whole bug here, so
+            // the recovery must not be able to reintroduce it. Hence: attempt, verify,
+            // and only claim success when the selection actually took.
+            var selected = false;
+            try {
+              var target = document.getElementById('hintText');
+              var selection = window.getSelection && window.getSelection();
+              if (target && selection) {
+                var range = document.createRange();
+                range.selectNodeContents(target);
+                selection.removeAllRanges();
+                selection.addRange(range);
+                selected = String(selection).length > 0;
+              }
+            } catch (e) {}
+            if (selected) actionBtn.textContent = 'Selected — press Ctrl/Cmd+C';
 
             // Clipboard access needs a sandbox permission the host may not have granted,
             // so this is the shortcut, never the mechanism.


### PR DESCRIPTION
Two independent changes that share the branch. Pairs with gamedevpl/www.gamedev.pl-games#582 — **merge that one first**, though either order is safe.

## 1. The gate accepts any kit sharing the current major

The gate refused a delivery whose `kitEngineRef` was not the current or previous published kit. That rule measures *our merge rate*, not the creator's elapsed time.

On 2026-08-05 the games repo published **seven kits in ten hours**, so a `get_kit` answer was good for **45–90 minutes** and **three consecutive rounds were refused for age**. One was spent on a commit that added an internal probe script — a file no creator ever calls. Almost none of those merges could have broken a game; commit count was never a proxy for compatibility.

The kit now declares a semver (games repo, `shared/kit-version.json`) and the gate accepts anything sharing its major. A `kit_outdated` verdict means a genuine breaking change again.

Details worth keeping:

- **The claimed ref's version comes from its own sidecar**, read only when the ref is neither current nor previous *and* the registry is versioned at all. The common paths cost no extra request.
- **A ref from a newer major is refused too** — that means the engine was rolled back and the APIs the delivery was written against are gone.
- **Strictly a widening.** `current` and `previous` are accepted however old, and an unversioned kit or registry falls back to exactly the N/N−1 behaviour it had before. Nothing accepted before is refused now.
- `getKitVersion` **shape-checks the ref** before interpolating it into an object path. It arrives from a delivery manifest — a claim, not a fact.
- `kit_outdated` now states the rule — *"current kit is v1.4.2; deliveries must share its major version"* — rather than two opaque SHAs. The report is what the agent acts on.

What makes the version trustworthy is CI, not discipline: the games repo typechecks its whole catalog against the engine on every push to main, so a breaking change cannot land without its author also fixing every game.

## 2. The action button, when the host will not send for it

From an owner test in Claude: pressing **"Rebuild against the new kit"** sent nothing. *"No prompt was sent, nothing happened, only the text appeared below the button."*

The card behaved as designed — request refused, fallback fired, text appeared. **The design was wrong.** The fallback restored the button's original label, so it still looked like a live control that had silently failed, and it printed raw agent-facing instructions with nothing saying those words were now the creator's to carry.

The button changes job instead of pretending: label becomes **"Copy for your agent"**, the hint reads *"This chat app will not send it for you"*, and the instruction renders as a select-all block.

Clicking it **selects the text unconditionally before touching the clipboard**. Clipboard access needs a sandbox permission the host may not have granted — in a frame without `allow-same-origin` it simply does nothing — and a Copy button that silently fails is the same dead button one level down.

`ui/message` support cannot be negotiated in the spec version we target: `HostCapabilities` in `2026-01-26` has **no field for it**, and the draft adds `message?: SupportedContentBlockModalities` — fairly direct evidence the spec authors hit the same wall. This PR keeps `HostCapabilities` from `ui/initialize` for when hosts catch up; it cannot help yet.

## Verification

Full API suite green (**2567** tests, 165 files), lint clean.

Both layers of the semver rule mutation-verified: neutering the same-major check fails tests in `kit-window` and `gate-runner` alike. The button fix verified in the browser harness with a host that refuses `ui/message` the way Claude does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_