### PR TITLE
Simplify published game pages and add screenshot previews

### DIFF
--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -750,8 +750,8 @@ export interface VisitEvent {
   via?: string;
   /**
    * `remix_step` with `step: 'offered'` or `'opened'`: which control it was —
-   * `bar` (the chrome bar) or `more` (the overflow menu it sheds into on narrow
-   * screens).
+   * `page` (the preview-first game page), `bar` (the chrome bar), or `more` (the
+   * overflow menu it sheds into on narrow screens).
    *
    * Its own field rather than a new meaning for `via` (what led someone to the
    * painter) or `entry` (the route a visit landed on) — both already mean

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -271,18 +271,22 @@ describe('summarizeVisitFunnel', () => {
       // Shown it and never touched it — the whole reason `offered` exists.
       started('d'),
       remix('d', 'offered'),
+      started('e'),
+      remix('e', 'offered'),
+      remix('e', 'opened', { control: 'page', msSinceStart: 40_000 }),
     ]);
 
-    expect(funnel.remixEntry.offered).toBe(4);
-    expect(funnel.remixEntry.opened).toBe(3);
+    expect(funnel.remixEntry.offered).toBe(5);
+    expect(funnel.remixEntry.opened).toBe(4);
     expect(funnel.remixEntry.byControl).toEqual([
+      { control: 'page', visits: 1 },
       { control: 'bar', visits: 1 },
       { control: 'more', visits: 1 },
       { control: 'unknown', visits: 1 },
     ]);
-    // Median of the three that opened one — the visit that never did contributes
+    // Median of the four that opened one — the visit that never did contributes
     // no delay, because including it would measure the window rather than them.
-    expect(funnel.remixEntry.medianSecondsToOpen).toBe(60);
+    expect(funnel.remixEntry.medianSecondsToOpen).toBe(50);
   });
 
   it('never reports more opens than offers, even while old clients are still running', () => {
@@ -317,6 +321,7 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.remixEntry.opened).toBeLessThanOrEqual(funnel.remixEntry.offered);
     // The splits come from the same cohort, or they would disagree with the ratio.
     expect(funnel.remixEntry.byControl).toEqual([
+      { control: 'page', visits: 0 },
       { control: 'bar', visits: 1 },
       { control: 'more', visits: 0 },
     ]);

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -99,8 +99,8 @@ export interface VisitFunnel {
    * Whether the remix entry is worth the space it takes.
    *
    * `offered` is every visit shown the control; `opened` is every visit that
-   * pressed it; `byControl` splits the presses between the chrome bar and the
-   * overflow menu it sheds into on narrow screens. `medianSecondsToOpen` is
+   * pressed it; `byControl` splits the presses between the game page, chrome bar,
+   * and overflow menu. `medianSecondsToOpen` is
    * measured among visits that opened it — how long a player plays before they
    * want to change something.
    *
@@ -111,7 +111,7 @@ export interface VisitFunnel {
   remixEntry: {
     offered: number;
     opened: number;
-    byControl: Array<{ control: 'bar' | 'more' | 'unknown'; visits: number }>;
+    byControl: Array<{ control: 'page' | 'bar' | 'more' | 'unknown'; visits: number }>;
     medianSecondsToOpen: number | null;
   };
   /**
@@ -535,11 +535,13 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
        * it reports only the visits we know were shown the control.
        */
       const opened = offered.filter((rollup) => rollup.remixSteps.has('opened'));
-      const doors = ['bar', 'more'] as const;
-      const byControl: Array<{ control: 'bar' | 'more' | 'unknown'; visits: number }> = doors.map((control) => ({
-        control,
-        visits: opened.filter((rollup) => rollup.remixControl === control).length,
-      }));
+      const doors = ['page', 'bar', 'more'] as const;
+      const byControl: Array<{ control: 'page' | 'bar' | 'more' | 'unknown'; visits: number }> = doors.map(
+        (control) => ({
+          control,
+          visits: opened.filter((rollup) => rollup.remixControl === control).length,
+        }),
+      );
       const unknown = opened.filter((rollup) => !doors.includes(rollup.remixControl as (typeof doors)[number])).length;
       if (unknown > 0) byControl.push({ control: 'unknown', visits: unknown });
       // Only visits that actually opened one carry a delay, so the median is over

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -245,13 +245,13 @@ describe('POST /api/telemetry/visit', () => {
       flushMsSinceStart: 30_000,
       events: [
         { type: 'remix_step', step: 'offered', msSinceStart: 0 },
-        { type: 'remix_step', step: 'opened', control: 'bar', msSinceStart: 28_000 },
+        { type: 'remix_step', step: 'opened', control: 'page', msSinceStart: 28_000 },
       ],
     });
     expect(ok.statusCode).toBe(202);
     const stored = await store.listVisitEvents(today());
     expect(stored[0]).toMatchObject({ type: 'remix_step', step: 'offered' });
-    expect(stored[1]).toMatchObject({ type: 'remix_step', step: 'opened', control: 'bar', msSinceStart: 28_000 });
+    expect(stored[1]).toMatchObject({ type: 'remix_step', step: 'opened', control: 'page', msSinceStart: 28_000 });
 
     // Closed enum, like every other value that reaches a grouping key on an
     // endpoint anyone can reach.

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -137,7 +137,7 @@ const RemixViaSchema = z.enum(['redirect', 'menu', 'panel']);
  * button they pressed, and collapsing the two would make every stored row
  * ambiguous the first time a third door exists.
  */
-const RemixControlSchema = z.enum(['bar', 'more']);
+const RemixControlSchema = z.enum(['bar', 'more', 'page']);
 /**
  * Which chrome surface opened How to play. Optional so a tab still running the previous
  * client can record the open without `via` — the aggregate treats missing as unknown

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -105,9 +105,8 @@ describe('catalog playback', () => {
     expect(previewButton?.textContent).toContain('Pause preview');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
-    // history.pushState fires nothing, so in-app navigation is announced explicitly
-    // for listeners outside App (analytics). Without it their only option is to
-    // monkey-patch history — see NAVIGATE_EVENT in router.ts.
+    // Explicit Play opens theater in place. `/play/:slug` is the shareable preview
+    // page now, so a catalog click must not navigate through it before starting.
     const navigations: string[] = [];
     const onNavigate = (event: Event) => {
       navigations.push((event as CustomEvent<NavigateEventDetail>).detail.path);
@@ -120,10 +119,8 @@ describe('catalog playback', () => {
       await flushEffects();
     });
 
-    expect(navigations).toEqual(['/play/sky-dodge']);
-    // Announced only after the URL is already the new one, so a listener that reads
-    // window.location instead of trusting `detail` still sees the same place.
-    expect(window.location.pathname).toBe('/play/sky-dodge');
+    expect(navigations).toEqual([]);
+    expect(window.location.pathname).toBe('/');
     window.removeEventListener(NAVIGATE_EVENT, onNavigate);
 
     const iframe = container.querySelector('iframe[title="Sky Dodge"]');
@@ -207,7 +204,7 @@ describe('catalog playback', () => {
     });
   });
 
-  it('opens game theater for direct play path routes even before catalog is loaded', async () => {
+  it('renders a static game page for direct play paths without loading the game iframe', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const fetched: string[] = [];
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
@@ -220,7 +217,19 @@ describe('catalog playback', () => {
         return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
       }
       if (url.endsWith('/api/catalog')) {
-        return new Response(JSON.stringify([]));
+        return new Response(
+          JSON.stringify([
+            {
+              slug: 'football-3d-lite',
+              title: 'Football 3D Lite',
+              genre: 'sports',
+              controls: 'Arrow keys move',
+              status: 'published',
+              media: { screenshots: [{ name: 'match', file: 'match.png' }], video: null },
+              multiplayer: null,
+            },
+          ]),
+        );
       }
       if (url.includes('/api/recommendations')) {
         return new Response(JSON.stringify({ items: [] }));
@@ -229,6 +238,9 @@ describe('catalog playback', () => {
         return new Response(
           JSON.stringify({ slug: 'football-3d-lite', title: 'Football 3D Lite', html: '<canvas>football</canvas>' }),
         );
+      }
+      if (url.endsWith('/api/games/football-3d-lite/votes')) {
+        return new Response(JSON.stringify({ up: 2, down: 0, mine: null }));
       }
       if (/\/api\/games\/[^/]+\/played$/.test(new URL(url, 'http://localhost').pathname)) {
         return new Response(null, { status: 204 });
@@ -249,30 +261,14 @@ describe('catalog playback', () => {
       await flushEffects();
     });
 
-    const iframe = container.querySelector('iframe');
-    expect(iframe).not.toBeNull();
-    const srcdoc = iframe?.getAttribute('srcdoc') ?? '';
-    expect(srcdoc).toContain('<canvas>football</canvas>');
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector('.game-page h1')?.textContent).toBe('Football 3D Lite');
+    expect(container.querySelector<HTMLImageElement>('.game-page-preview img')?.src).toContain('match.png?w=1280');
 
-    // A direct game link costs the game and nothing else: the gallery and the
-    // "your games" rail sit behind a full-viewport player, so they must not load.
-    expect(fetched.some((url) => url.includes('/api/catalog'))).toBe(false);
-    expect(fetched.some((url) => url.includes('/api/submissions/mine'))).toBe(false);
-    expect(fetched.some((url) => url.includes('/api/games/football-3d-lite'))).toBe(true);
-
-    // The header title comes from the game itself over the player bridge, since a
-    // direct link has no catalog entry to take one from.
-    await act(async () => {
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          origin: 'null',
-          data: { source: 'gdpl-player', type: 'meta', title: 'Football 3D Lite', desc: 'Score a goal', muted: false },
-        }),
-      );
-      await flushEffects();
-    });
-    expect(container.querySelector('.theater-title-text')?.textContent).toBe('Football 3D Lite');
-    expect(container.querySelector('.theater-author')?.textContent).toMatch(/gamedev\.pl/);
+    // The page needs catalog metadata, but game code does not load until a deliberate
+    // Play/preview click crosses into theater.
+    expect(fetched.some((url) => url.includes('/api/catalog'))).toBe(true);
+    expect(fetched.some((url) => url.endsWith('/api/games/football-3d-lite'))).toBe(false);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.overlayExit.test.ts
+++ b/apps/web/src/App.overlayExit.test.ts
@@ -8,14 +8,12 @@ import { AuthProvider } from './AuthContext.js';
 import i18n from './i18n/index.js';
 
 /**
- * Closing a game returns you to where you opened it from.
+ * Closing a game reveals the page that opened it.
  *
- * The exit used to be an unconditional trip home, which quietly threw away context
- * every time: a creator who opened their build from Creator Studio and closed it landed
- * on the catalog, several clicks away from the game they were in the middle of making.
- * Back is only safe when this tab has an in-app entry to go back to, so both halves are
- * guarded here — the deep link that must not walk off the site is as much the point as
- * the in-app open that must not lose its place.
+ * Published play is an in-place theater now: catalog/profile buttons open over their
+ * current page, while a shared `/play/<slug>` link first renders a static game page.
+ * Closing must therefore dismiss the theater without mutating browser history in either
+ * case. That keeps catalog position and leaves a shared link shareable after play.
  */
 
 async function flushEffects() {
@@ -78,7 +76,7 @@ describe('closing a full-viewport game', () => {
     vi.restoreAllMocks();
   });
 
-  it('goes back to whatever opened it, rather than home', async () => {
+  it('reveals the catalog that opened it without changing history', async () => {
     mockApi();
     window.history.pushState(null, '', '/');
     const { container, root } = await renderApp();
@@ -91,28 +89,7 @@ describe('closing a full-viewport game', () => {
       play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
-    expect(window.location.pathname).toBe('/play/sky-dodge');
-
-    const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
-    expect(exit).not.toBeNull();
-    await act(async () => {
-      exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
-
-    expect(back).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      root.unmount();
-    });
-  });
-
-  it('goes home from a cold deep link, where Back would leave the site', async () => {
-    mockApi();
-    window.history.pushState(null, '', '/play/sky-dodge');
-    const { container, root } = await renderApp();
-
-    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+    expect(window.location.pathname).toBe('/');
 
     const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
     expect(exit).not.toBeNull();
@@ -123,6 +100,37 @@ describe('closing a full-viewport game', () => {
 
     expect(back).not.toHaveBeenCalled();
     expect(window.location.pathname).toBe('/');
+    expect(container.querySelector('.exit-btn')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('reveals the static game page behind a cold deep-link theater', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/play/sky-dodge');
+    const { container, root } = await renderApp();
+
+    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+
+    const play = container.querySelector<HTMLButtonElement>('.game-page-actions .primary-btn');
+    expect(play).not.toBeNull();
+    await act(async () => {
+      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
+    expect(exit).not.toBeNull();
+    await act(async () => {
+      exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(back).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/play/sky-dodge');
+    expect(container.querySelector('.game-page h1')?.textContent).toBe('Sky Dodge');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import { ContactPage } from './ContactPage.js';
 import { ProposalsPage } from './ProposalsPage.js';
 import { CreatorProfilePage } from './CreatorProfilePage.js';
 import { GamePage } from './GamePage.js';
+import { GameDetailPage } from './GameDetailPage.js';
 import { NotFoundPage } from './NotFoundPage.js';
 import { AppUpdateBanner } from './AppUpdateBanner.js';
 import { InstallPrompt } from './InstallPrompt.js';
@@ -66,7 +67,7 @@ import { createPartySession, type PartySession } from './mp/mpApi.js';
 import { parseOAuthReturnParam } from './oauthReturn.js';
 
 type StageContent =
-  | { type: 'catalog'; game: CatalogEntry }
+  | { type: 'catalog'; game: CatalogEntry; initialRemixOpen?: boolean }
   | { type: 'generated'; game: GeneratedGame; prompt: string }
   | { type: 'party'; game: CatalogEntry; session: PartySession };
 
@@ -99,8 +100,7 @@ export function App() {
   // Stage content
   const [stageContent, setStageContent] = useState<StageContent | null>(null);
   // Builds actually in flight, from the server — the header badge's source of truth.
-  // Paused while a game is on screen: the player covers the header, and a direct
-  // /play/<slug> link is meant to cost the game and nothing else.
+  // Paused while a game is on screen because the player covers the header.
   const activeBuildCount = useActiveBuildCount(myGamesRefreshKey, !stageContent);
 
   // Greenfield submission state
@@ -234,51 +234,6 @@ export function App() {
     return () => document.body.classList.remove('player-open');
   }, [stageContent]);
 
-  // The URL is the source of truth for playing a *published* game: opening
-  // `/play/<slug>` (via a click, a refresh, or a shared link) shows that game,
-  // and navigating away from it closes the player. Generated/party stages are
-  // ephemeral and are not represented in the route, so we only reconcile the
-  // 'catalog' stage here and leave those untouched.
-  useEffect(() => {
-    if (route.view === 'play') {
-      const entry = catalogEntries.find((game) => game.slug === route.slug);
-      if (stageContent?.type === 'catalog' && stageContent.game.slug === route.slug) {
-        if (entry && stageContent.game !== entry) {
-          setStageContent({ type: 'catalog', game: entry });
-        }
-        return;
-      }
-      const initialGame: CatalogEntry = entry ?? {
-        slug: route.slug,
-        title: route.slug
-          .split('-')
-          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-          .join(' '),
-        genre: '',
-        controls: '',
-        status: 'published',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        sensing: null,
-        world: null,
-        // A deep link that beat the catalog: assume no preference rather than
-        // nagging someone to rotate for a game whose spec we haven't read yet.
-        // The effect above swaps in the real entry once the catalog lands.
-        orientation: 'any',
-        // Same reasoning: unknown, not "keyboard only". The badge is a warning, and
-        // a deep link is no reason to show one.
-        touch: null,
-        submittedBy: null,
-      };
-      setStageContent({ type: 'catalog', game: initialGame });
-      document.getElementById('stage')?.scrollIntoView?.({ behavior: 'smooth' });
-    } else if (stageContent?.type === 'catalog') {
-      // Route moved off this game (Exit, back button, home) — close the player.
-      setStageContent(null);
-    }
-  }, [route, catalogEntries, stageContent]);
-
   // Guard against accidental reload/close while a game is open. The browser shows
   // its native "Leave site?" confirmation; games run in a sandboxed iframe with no
   // access to parent storage, so their internal progress can't be persisted here —
@@ -302,11 +257,9 @@ export function App() {
     // would just 401. Don't fetch (and don't render an error) until signed in.
     // Outside private beta, catalog reads stay public (owner decision).
     if (privateBeta && !user) return;
-    // Only the home page shows the gallery. On `/play/<slug>` the theater covers the
-    // whole viewport, so fetching the catalog (and, through it, every entry's media)
-    // is work nobody can see — a direct game link should cost the game, and nothing
-    // else. Leaving the route loads it, which is the first moment it's visible.
-    if (route.view !== 'home') return;
+    // Home renders the gallery; `/play/<slug>` renders one preview-first game page.
+    // Both need catalog metadata, but only Home mounts the grid itself.
+    if (route.view !== 'home' && route.view !== 'play') return;
 
     let cancelled = false;
     // Soft refreshes (Retry, pull-to-refresh) keep the last-good grid on screen —
@@ -754,7 +707,7 @@ export function App() {
   }, []);
 
   /**
-   * Closing a full-viewport overlay that owns the URL — a game, a draft.
+   * Closing a full-viewport overlay that owns the URL — currently a draft.
    *
    * Home was the unconditional answer, and it threw away context every time: a creator
    * who opened their build from Creator Studio and closed it landed on the catalog,
@@ -772,7 +725,7 @@ export function App() {
 
   // Header Up chevron — Android-style parent path, never history.back(). Hidden
   // while App owns a theater (`stageContent`) and on routes whose child owns one
-  // (`/play`, `/draft`, studio playtest — see navUpTarget).
+  // (`/draft`, studio playtest — see navUpTarget).
   const headerUp = useMemo(() => {
     if (stageContent) return null;
     const target = navUpTarget(route);
@@ -781,11 +734,18 @@ export function App() {
   }, [route, stageContent, t]);
 
   function handlePlayGame(game: CatalogEntry) {
-    // Published games are permalinked: drive play through the URL so a refresh or
-    // a shared link reopens the same game. The route→stage effect opens the stage.
-    navigate(playPath(game.slug));
+    // Explicit Play is the execution boundary. Shared `/play/<slug>` links land on a
+    // static preview first; catalog/profile Play buttons open the sandboxed theater
+    // immediately without making the preview page masquerade as a running game.
+    setStageContent({ type: 'catalog', game });
     // Soft refresh so "continue" / genre picks update after the next home visit.
     setRecommendationsRefreshKey((n) => n + 1);
+  }
+
+  function handleRemixGame(game: CatalogEntry) {
+    // The game still has to be mounted for Remix to swap and preview its document,
+    // but the sheet opens on the first frame — no theater detour and second wrench.
+    setStageContent({ type: 'catalog', game, initialRemixOpen: true });
   }
 
   async function handlePlayTogether(game: CatalogEntry) {
@@ -874,7 +834,7 @@ export function App() {
           <CreatorProfilePage
             handle={route.handle}
             onBack={() => navigate('/')}
-            onPlay={(slug) => navigate(playPath(slug))}
+            onPlay={handlePlayGame}
             onNavigate={navigate}
             onProfileLoaded={(profile: PublicCreatorProfile) => {
               setCreatorName(profile.profileName);
@@ -1009,41 +969,53 @@ export function App() {
           <DraftView slug={route.slug} onExit={exitOverlay} onDraftTitle={setDraftTitle} />
         ) : (
           <>
-            <div id="hero-prompt">
-              <HeroPromptSection
-                // Remount when a retry loads a new idea, so the prompt box picks it up.
-                key={retryPrompt ?? 'blank'}
-                initialPrompt={retryPrompt ?? ''}
-                catalogEntries={catalogEntries}
-                onPlayGame={handlePlayGame}
-                submissionStatus={submissionStatus}
-                submissionError={submissionError}
-                onSubmitSpec={(concept) => void handleSubmitSpec(concept)}
-                mockStatus={mockStatus}
-                mockError={mockError}
-                onGenerateMock={(prompt) => void handleGenerateMock(prompt)}
+            {route.view === 'play' ? (
+              <GameDetailPage
+                game={catalogEntries.find((game) => game.slug === route.slug) ?? null}
+                state={catalogStatus}
+                onPlay={handlePlayGame}
+                onRemix={handleRemixGame}
+                onRetry={handleRetryCatalog}
               />
-            </div>
+            ) : (
+              <>
+                <div id="hero-prompt">
+                  <HeroPromptSection
+                    // Remount when a retry loads a new idea, so the prompt box picks it up.
+                    key={retryPrompt ?? 'blank'}
+                    initialPrompt={retryPrompt ?? ''}
+                    catalogEntries={catalogEntries}
+                    onPlayGame={handlePlayGame}
+                    submissionStatus={submissionStatus}
+                    submissionError={submissionError}
+                    onSubmitSpec={(concept) => void handleSubmitSpec(concept)}
+                    mockStatus={mockStatus}
+                    mockError={mockError}
+                    onGenerateMock={(prompt) => void handleGenerateMock(prompt)}
+                  />
+                </div>
 
-            {/* Gated on the pending spec alone: the wizard is the naming step, which
+                {/* Gated on the pending spec alone: the wizard is the naming step, which
                 always happens, and the questions are the part that is sometimes empty.
                 It portals itself to a full-screen overlay, so nothing here positions it. */}
-            {pendingSpec && (
-              <CreatorQA
-                key={qaFormKey}
-                questions={qaQuestions}
-                initialConcept={pendingSpec.concept}
-                initialTitle={pendingSpec.title}
-                onSubmitWithConcept={handleQaComplete}
-                onTitleChange={handleQaTitleChange}
-                onCancel={handleQaCancel}
-                submitting={submissionStatus === 'loading' || submissionStatus === 'refining'}
-                error={submissionError}
-                initialAnswers={latestAnswersRef.current}
-                onAnswersChange={handleQaAnswersChange}
-                initialBuilder={qaBuilder}
-                onBuilderChange={handleQaBuilderChange}
-              />
+                {pendingSpec && (
+                  <CreatorQA
+                    key={qaFormKey}
+                    questions={qaQuestions}
+                    initialConcept={pendingSpec.concept}
+                    initialTitle={pendingSpec.title}
+                    onSubmitWithConcept={handleQaComplete}
+                    onTitleChange={handleQaTitleChange}
+                    onCancel={handleQaCancel}
+                    submitting={submissionStatus === 'loading' || submissionStatus === 'refining'}
+                    error={submissionError}
+                    initialAnswers={latestAnswersRef.current}
+                    onAnswersChange={handleQaAnswersChange}
+                    initialBuilder={qaBuilder}
+                    onBuilderChange={handleQaBuilderChange}
+                  />
+                )}
+              </>
             )}
 
             {stageContent?.type === 'party' && (
@@ -1085,13 +1057,14 @@ export function App() {
                 // it short so the title stays the hero of the bar.
                 badge={{ icon: 'sparkle', label: t('ai.generatedShort') }}
                 source={{ slug: stageContent.game.slug }}
-                onExit={exitOverlay}
+                onExit={() => setStageContent(null)}
                 orientation={stageContent.game.orientation}
                 reportSlug={stageContent.game.slug}
                 submittedBy={stageContent.game.submittedBy}
                 creatorHandle={stageContent.game.creatorHandle}
                 controls={stageContent.game.controls}
                 touch={stageContent.game.touch}
+                initialRemixOpen={stageContent.initialRemixOpen}
               />
             )}
 
@@ -1112,8 +1085,8 @@ export function App() {
 
             {partyError && <p className="error party-error">{partyError}</p>}
 
-            {/* Same reasoning as the catalog fetch: skip while /play covers the viewport. */}
-            {route.view !== 'play' && (
+            {/* The gallery is home content; game pages have their own compact surface. */}
+            {route.view === 'home' && (
               <ArcadeCatalog
                 catalogStatus={catalogStatus}
                 catalogError={catalogError}

--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -145,9 +145,14 @@ describe('CreatorProfilePage owner edit', () => {
     expect(container.querySelector<HTMLImageElement>('.creator-profile-game-thumb')?.getAttribute('src')).toBe(
       '/api/games/sky-dodge/media/opening.png',
     );
+    expect(container.querySelector<HTMLAnchorElement>('a.creator-profile-game-thumb-link')?.getAttribute('href')).toBe(
+      '/play/sky-dodge',
+    );
+    expect(container.textContent).not.toContain('Open game page');
     expect(container.querySelector<HTMLAnchorElement>('a[href="/studio/sky-dodge"]')?.textContent).toContain(
       'Open in Studio',
     );
+    expect(container.querySelector('a[href="/studio/sky-dodge"]')?.classList.contains('secondary-btn')).toBe(true);
   });
 
   it('sends both the title and the meta link to the game page, for anyone', async () => {

--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -155,18 +155,19 @@ describe('CreatorProfilePage owner edit', () => {
     expect(container.querySelector('a[href="/studio/sky-dodge"]')?.classList.contains('secondary-btn')).toBe(true);
   });
 
-  it('sends both the title and the meta link to the game page, for anyone', async () => {
-    // The profile is the game page's strongest entry point: everything listed here has
-    // a handle by construction, so the address always resolves.
+  it('makes the title the game-page link and keeps Play as the theater action', async () => {
+    // The thumbnail is also a game-page link; a separate text link beside Play is
+    // deliberately omitted so the row has one clear navigation target.
     authUser = null;
     fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
 
     await renderPage();
 
     const links = Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href="/ada/sky-dodge"]'));
-    expect(links.length).toBe(2);
+    expect(links.length).toBe(1);
     expect(container.querySelector('.creator-profile-game-title a')?.textContent).toBe('Sky Dodge');
-    expect(links.some((link) => link.textContent?.includes('Game page'))).toBe(true);
+    expect(container.querySelector('a.creator-profile-game-thumb-link')?.getAttribute('href')).toBe('/play/sky-dodge');
+    expect(container.textContent).not.toContain('Game page');
     // Play still goes straight to the theater — the card did not lose its job.
     expect(
       Array.from(container.querySelectorAll('button')).some((button) => button.textContent?.includes('Play')),

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -5,7 +5,7 @@ import { catalogMediaUrl, isPlatformAuthor, normalizeCatalogEntry, type CatalogE
 import { fetchCreatorPage, type PublicCreatorProfile } from './creatorProfileApi.js';
 import { EditProfileModal } from './EditProfileModal.js';
 import { PixelIcon } from './PixelIcon.js';
-import { creatorPath, gamePath, studioPath } from './router.js';
+import { creatorPath, gamePath, playPath, studioPath } from './router.js';
 import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 
 /**

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -22,7 +22,7 @@ export function CreatorProfilePage({
 }: {
   handle: string;
   onBack: () => void;
-  onPlay: (slug: string) => void;
+  onPlay: (game: CatalogEntry) => void;
   /** After the owner renames their handle — App should route to the new URL. */
   onNavigate?: (path: string) => void;
   /** Lets App set document.title once the display name is known. */
@@ -137,17 +137,23 @@ export function CreatorProfilePage({
                   : (game.submittedBy ?? profile?.profileName);
                 return (
                   <li key={game.slug} className="creator-profile-game">
-                    {poster ? (
-                      <img
-                        className="creator-profile-game-thumb"
-                        src={catalogMediaUrl(game.slug, poster)}
-                        alt=""
-                        width={160}
-                        height={90}
-                      />
-                    ) : (
-                      <span className="creator-profile-game-thumb creator-profile-game-thumb--empty" aria-hidden />
-                    )}
+                    <a
+                      className="creator-profile-game-thumb-link"
+                      href={playPath(game.slug)}
+                      aria-label={t('creatorProfile.openGamePage', { title: game.title })}
+                    >
+                      {poster ? (
+                        <img
+                          className="creator-profile-game-thumb"
+                          src={catalogMediaUrl(game.slug, poster)}
+                          alt=""
+                          width={160}
+                          height={90}
+                        />
+                      ) : (
+                        <span className="creator-profile-game-thumb creator-profile-game-thumb--empty" aria-hidden />
+                      )}
+                    </a>
                     <div className="creator-profile-game-meta">
                       <h3 className="creator-profile-game-title">
                         {/* Everything listed here has a handle by construction, so the
@@ -158,19 +164,12 @@ export function CreatorProfilePage({
                       </h3>
                       <p className="creator-profile-game-by">{t('player.byAuthor', { author })}</p>
                       <div className="creator-profile-game-actions">
-                        <button type="button" className="primary-btn" onClick={() => onPlay(game.slug)}>
+                        <button type="button" className="primary-btn" onClick={() => onPlay(game)}>
                           <PixelIcon name="play" size={13} /> {t('catalog.play')}
                         </button>
-                        <a
-                          className="creator-profile-game-link"
-                          href={gamePath(handle, game.slug)}
-                          onClick={interceptTo(gamePath(handle, game.slug))}
-                        >
-                          {t('creatorProfile.openGamePage')}
-                        </a>
                         {isOwner ? (
-                          <a className="creator-profile-game-link" href={studioPath(game.slug)}>
-                            {t('creatorProfile.openStudio')}
+                          <a className="secondary-btn creator-profile-studio-btn" href={studioPath(game.slug)}>
+                            <PixelIcon name="wrench" size={12} /> {t('creatorProfile.openStudio')}
                           </a>
                         ) : null}
                       </div>

--- a/apps/web/src/GameDetailPage.test.tsx
+++ b/apps/web/src/GameDetailPage.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CatalogEntry } from './catalog.js';
+import i18n from './i18n/index.js';
+
+const { recordRemixStep } = vi.hoisted(() => ({ recordRemixStep: vi.fn() }));
+
+vi.mock('./visitTelemetry.js', () => ({ recordRemixStep }));
+vi.mock('./VoteWidget.js', () => ({ VoteWidget: () => <button data-testid="vote">Like 7</button> }));
+vi.mock('./ShareGameButton.js', () => ({
+  ShareGameButton: () => <button data-testid="share">Share</button>,
+}));
+
+import { GameDetailPage } from './GameDetailPage.js';
+
+const game: CatalogEntry = {
+  slug: 'bridge-builder',
+  title: 'Bridge Builder',
+  genre: 'strategy',
+  controls: 'Arrow keys move. Space places a bridge segment.',
+  status: 'published',
+  media: {
+    screenshots: [
+      { name: 'opening', file: 'opening.png' },
+      { name: 'building', file: 'building.png' },
+    ],
+    video: 'gameplay.mp4',
+  },
+  multiplayer: null,
+  saves: null,
+  world: null,
+  sensing: null,
+  orientation: 'any',
+  touch: 'gamekit',
+  submittedBy: 'Grzegorz',
+  creatorHandle: 'gtanczyk',
+};
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  recordRemixStep.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  container.remove();
+});
+
+function render(overrides: { onPlay?: (entry: CatalogEntry) => void; onRemix?: (entry: CatalogEntry) => void } = {}) {
+  const onPlay = overrides.onPlay ?? vi.fn();
+  const onRemix = overrides.onRemix ?? vi.fn();
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      createElement(GameDetailPage, {
+        game,
+        state: 'ready',
+        onPlay,
+        onRemix,
+        onRetry: vi.fn(),
+      }),
+    );
+  });
+  return { onPlay, onRemix };
+}
+
+describe('GameDetailPage', () => {
+  it('is preview-first and keeps the player-only actions in one visible row', () => {
+    const { onPlay } = render();
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector<HTMLImageElement>('.game-page-preview img')?.src).toContain(
+      '/api/games/bridge-builder/media/building.png?w=1280',
+    );
+    expect(container.querySelectorAll('.game-page-screenshot')).toHaveLength(2);
+    expect(container.querySelectorAll('.game-page-screenshot img')[0]?.getAttribute('src')).toContain(
+      'opening.png?w=320',
+    );
+    expect(container.querySelector('[data-testid="vote"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="share"]')).not.toBeNull();
+    expect(container.textContent).toContain('Arrow keys move');
+
+    // None of the speculative/empty old tabs or the agent-facing spec reach this page.
+    expect(container.textContent).not.toMatch(/Board|To Play|Releases|Sources|Follow|SPEC\.md/);
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.game-page-preview')!.click();
+    });
+    expect(onPlay).toHaveBeenCalledWith(game);
+  });
+
+  it('switches the main preview when a screenshot is selected', () => {
+    render();
+
+    const thumbnails = container.querySelectorAll<HTMLButtonElement>('.game-page-screenshot');
+    act(() => thumbnails[0]?.click());
+
+    expect(container.querySelector<HTMLImageElement>('.game-page-preview img')?.src).toContain(
+      '/api/games/bridge-builder/media/opening.png?w=1280',
+    );
+    expect(thumbnails[0]?.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('opens Remix directly from the page and records the dedicated entry', () => {
+    const { onRemix } = render();
+
+    expect(recordRemixStep).toHaveBeenCalledWith('offered', { control: 'page' });
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.game-page-remix')!.click();
+    });
+    expect(recordRemixStep).toHaveBeenCalledWith('opened', { control: 'page' });
+    expect(onRemix).toHaveBeenCalledWith(game);
+  });
+
+  it('does not autoplay when the only preview asset is a video', () => {
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        createElement(GameDetailPage, {
+          game: { ...game, media: { screenshots: [], video: 'gameplay.mp4' } },
+          state: 'ready',
+          onPlay: vi.fn(),
+          onRemix: vi.fn(),
+          onRetry: vi.fn(),
+        }),
+      );
+    });
+
+    const video = container.querySelector<HTMLVideoElement>('.game-page-preview video');
+    expect(video).not.toBeNull();
+    expect(video?.autoplay).toBe(false);
+    expect(video?.getAttribute('preload')).toBe('metadata');
+  });
+});

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
+import { PixelIcon } from './PixelIcon.js';
+import { ShareGameButton } from './ShareGameButton.js';
+import { VoteWidget } from './VoteWidget.js';
+import { creatorPath } from './router.js';
+import { recordRemixStep } from './visitTelemetry.js';
+
+type GameDetailPageProps = {
+  game: CatalogEntry | null;
+  state: 'loading' | 'ready' | 'error';
+  onPlay: (game: CatalogEntry) => void;
+  onRemix: (game: CatalogEntry) => void;
+  onRetry: () => void;
+};
+
+/** Prefer a gameplay moment over an opening/title capture. */
+function previewScreenshot(game: CatalogEntry) {
+  const screenshots = game.media?.screenshots ?? [];
+  return screenshots.find((shot) => shot.name !== 'opening') ?? screenshots[0] ?? null;
+}
+
+/**
+ * A published game's shareable landing page.
+ *
+ * This surface deliberately never mounts the game iframe. A shared link should let a
+ * visitor understand what they are about to open before untrusted game code starts,
+ * and it should stay useful on a phone where an autoplaying game consumes the whole
+ * viewport. Play is the explicit boundary that opens the sandboxed theater.
+ *
+ * The page is intentionally not a rendering of SPEC.md. The spec is an agent-facing
+ * source of truth, not player copy; the compact controls line is the only part a player
+ * needs here. Releases, source, follow and comparison queues do not appear until the
+ * product has real data and behaviour behind them.
+ */
+export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDetailPageProps) {
+  const { t } = useTranslation();
+  const [selectedScreenshotName, setSelectedScreenshotName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!game) return;
+    recordRemixStep('offered', { control: 'page' });
+  }, [game]);
+
+  if (state === 'loading') {
+    return <p className="game-page-state">{t('gamePage.loading')}</p>;
+  }
+
+  if (state === 'error') {
+    return (
+      <section className="game-page-state" role="alert">
+        <p>{t('gamePage.loadError')}</p>
+        <button type="button" className="secondary-btn" onClick={onRetry}>
+          <PixelIcon name="undo" size={13} /> {t('catalog.retry')}
+        </button>
+      </section>
+    );
+  }
+
+  if (!game) {
+    return <p className="game-page-state">{t('gamePage.missing')}</p>;
+  }
+
+  const screenshots = game.media?.screenshots ?? [];
+  const primaryScreenshot = previewScreenshot(game);
+  const screenshot = screenshots.find((candidate) => candidate.name === selectedScreenshotName) ?? primaryScreenshot;
+  const authorLabel = isPlatformAuthor(game.submittedBy) ? t('catalog.platformAuthor') : game.submittedBy;
+  const authorPath = game.creatorHandle ? creatorPath(game.creatorHandle) : null;
+
+  const play = () => onPlay(game);
+  const remix = () => {
+    recordRemixStep('opened', { control: 'page' });
+    onRemix(game);
+  };
+
+  return (
+    <article className="game-page">
+      <header className="game-page-header">
+        <div className="game-page-kicker">
+          {authorPath ? <a href={authorPath}>{authorLabel}</a> : <span>{authorLabel}</span>}
+          {game.genre ? <span className="game-page-genre">{game.genre}</span> : null}
+        </div>
+        <h1>{game.title}</h1>
+
+        <div className="game-page-actions" aria-label={t('gamePage.actions')}>
+          <button type="button" className="primary-btn" onClick={play}>
+            <PixelIcon name="play" size={13} /> {t('catalog.play')}
+          </button>
+          <VoteWidget slug={game.slug} />
+          <button type="button" className="secondary-btn game-page-remix" onClick={remix}>
+            <PixelIcon name="wrench" size={13} /> {t('catalog.remix')}
+          </button>
+          <ShareGameButton slug={game.slug} title={game.title} />
+        </div>
+      </header>
+
+      <button
+        type="button"
+        className="game-page-preview"
+        onClick={play}
+        aria-label={t('gamePage.playPreview', { title: game.title })}
+      >
+        {screenshot ? (
+          <img src={catalogMediaUrl(game.slug, screenshot.file, 1280)} alt="" decoding="async" />
+        ) : game.media?.video ? (
+          <video
+            src={catalogMediaUrl(game.slug, game.media.video)}
+            muted
+            playsInline
+            preload="metadata"
+            aria-hidden="true"
+          />
+        ) : (
+          <span className="game-page-preview-empty" aria-hidden="true">
+            <PixelIcon name="play" size={28} />
+          </span>
+        )}
+        <span className="game-page-preview-cta">
+          <PixelIcon name="play" size={14} /> {t('gamePage.openTheater')}
+        </span>
+      </button>
+
+      {screenshots.length > 1 ? (
+        <section className="game-page-screenshots" aria-labelledby="game-page-screenshots-title">
+          <h2 id="game-page-screenshots-title">{t('gamePage.screenshots')}</h2>
+          <div className="game-page-screenshot-grid">
+            {screenshots.map((candidate, index) => (
+              <button
+                key={candidate.file}
+                type="button"
+                className={`game-page-screenshot${candidate.file === screenshot?.file ? ' is-selected' : ''}`}
+                onClick={() => setSelectedScreenshotName(candidate.name)}
+                aria-label={t('gamePage.viewScreenshot', { number: index + 1 })}
+                aria-pressed={candidate.file === screenshot?.file}
+              >
+                <img
+                  src={catalogMediaUrl(game.slug, candidate.file, 320)}
+                  alt=""
+                  width={320}
+                  height={180}
+                  loading="lazy"
+                  decoding="async"
+                />
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {game.controls.trim() ? (
+        <section className="game-page-controls" aria-labelledby="game-page-controls-title">
+          <h2 id="game-page-controls-title">{t('player.howToPlay')}</h2>
+          <p>{game.controls}</p>
+        </section>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -26,8 +26,19 @@ vi.mock('./gamePlayer', async () => {
 });
 
 vi.mock('./PublishedGameFrame', () => ({
-  PublishedGameFrame: ({ frameRef }: { frameRef?: { current: HTMLIFrameElement | null } }) => (
-    <iframe className="game-frame" title="game" ref={frameRef as React.Ref<HTMLIFrameElement>} />
+  PublishedGameFrame: ({
+    frameRef,
+    remixOpenNonce,
+  }: {
+    frameRef?: { current: HTMLIFrameElement | null };
+    remixOpenNonce?: number;
+  }) => (
+    <iframe
+      className="game-frame"
+      title="game"
+      ref={frameRef as React.Ref<HTMLIFrameElement>}
+      data-remix-open={remixOpenNonce ?? 0}
+    />
   ),
 }));
 
@@ -59,7 +70,7 @@ afterEach(() => {
   container.remove();
 });
 
-async function draw(props: { controls?: string; onExit?: () => void } = {}) {
+async function draw(props: { controls?: string; onExit?: () => void; initialRemixOpen?: boolean } = {}) {
   root = createRoot(container);
   await act(async () => {
     root!.render(
@@ -70,6 +81,7 @@ async function draw(props: { controls?: string; onExit?: () => void } = {}) {
         reportSlug="brick-storm"
         onExit={props.onExit ?? (() => undefined)}
         controls={props.controls}
+        initialRemixOpen={props.initialRemixOpen}
       />,
     );
   });
@@ -91,6 +103,11 @@ async function pressEscape() {
 }
 
 describe('GameTheater more menu', () => {
+  it('opens the remix surface immediately when entered from the game page', async () => {
+    await draw({ initialRemixOpen: true });
+    expect(container.querySelector('.game-frame')?.getAttribute('data-remix-open')).toBe('1');
+  });
+
   it('keeps the hamburger icon when open and highlights it instead of turning into an X', async () => {
     await draw();
     const more = container.querySelector('.theater-more-btn') as HTMLButtonElement;

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -91,6 +91,8 @@ type GameTheaterProps = {
   controls?: string;
   /** Catalog touch support; `none` adds the keyboard-only line to the panel. */
   touch?: CatalogTouch | null;
+  /** Open the remix sheet on the first frame (the game-page Remix entry). */
+  initialRemixOpen?: boolean;
 };
 
 // Long enough that the bar never reacts like a hover tooltip, short enough to clear
@@ -140,6 +142,7 @@ export function GameTheater({
   creatorHandle = null,
   controls,
   touch = null,
+  initialRemixOpen = false,
 }: GameTheaterProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
@@ -160,7 +163,7 @@ export function GameTheater({
    * declares paintable content — a door that opens onto nothing is the
    * `no_lane` lesson, and this menu does not repeat it.
    */
-  const [remixOpenNonce, setRemixOpenNonce] = useState(0);
+  const [remixOpenNonce, setRemixOpenNonce] = useState(initialRemixOpen ? 1 : 0);
   const [painterNonce, setPainterNonce] = useState(0);
   const [remixHasPainter, setRemixHasPainter] = useState(false);
   const onRemixCapabilities = useCallback((caps: { painter: boolean }) => setRemixHasPainter(caps.painter), []);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -928,6 +928,16 @@
     "gameNamed": "{{title}}",
     "proposals": "My proposals"
   },
+  "gamePage": {
+    "loading": "Loading game…",
+    "loadError": "Could not load this game page.",
+    "missing": "This game is not available.",
+    "actions": "Game actions",
+    "playPreview": "Play {{title}} in theater mode",
+    "openTheater": "Play in theater",
+    "screenshots": "Screenshots",
+    "viewScreenshot": "View screenshot {{number}}"
+  },
   "creatorProfile": {
     "back": "Back",
     "loading": "Loading profile…",
@@ -937,6 +947,7 @@
     "gamesAria": "Published games",
     "gamesHeading": "Games ({{count}})",
     "noGames": "No published games yet.",
+    "openGamePage": "Open {{title}} game page",
     "openStudio": "Open in Studio",
     "editorTitle": "Your public profile",
     "publishGateTitle": "Claim a handle to publish",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -932,6 +932,16 @@
     "gameNamed": "{{title}}",
     "proposals": "Moje propozycje"
   },
+  "gamePage": {
+    "loading": "Ładowanie gry…",
+    "loadError": "Nie udało się wczytać strony gry.",
+    "missing": "Ta gra nie jest dostępna.",
+    "actions": "Akcje gry",
+    "playPreview": "Zagraj w {{title}} w trybie kinowym",
+    "openTheater": "Graj w trybie kinowym",
+    "screenshots": "Zrzuty ekranu",
+    "viewScreenshot": "Pokaż zrzut ekranu {{number}}"
+  },
   "creatorProfile": {
     "back": "Wróć",
     "loading": "Ładowanie profilu…",
@@ -941,6 +951,7 @@
     "gamesAria": "Opublikowane gry",
     "gamesHeading": "Gry ({{count}})",
     "noGames": "Brak opublikowanych gier.",
+    "openGamePage": "Otwórz stronę gry {{title}}",
     "openStudio": "Otwórz w Studio",
     "editorTitle": "Twój publiczny profil",
     "publishGateTitle": "Zajmij handle, żeby opublikować",

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -327,10 +327,10 @@ describe('path builders', () => {
 });
 
 describe('navUpTarget', () => {
-  it('hides Up on home, join, play, draft, and studio playtest', () => {
+  it('hides Up on overlays and gives the static play page a home parent', () => {
     expect(navUpTarget({ view: 'home' })).toBeNull();
     expect(navUpTarget({ view: 'join', code: 'ABC123', token: 'tok' })).toBeNull();
-    expect(navUpTarget({ view: 'play', slug: 'sky-dodge' })).toBeNull();
+    expect(navUpTarget({ view: 'play', slug: 'sky-dodge' })).toEqual({ path: '/', labelKey: 'upHome' });
     expect(navUpTarget({ view: 'draft', slug: 'space-runner' })).toBeNull();
     expect(navUpTarget({ view: 'studio', game: 'tok', tab: 'playtest' })).toBeNull();
   });

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -466,8 +466,8 @@ export function studioPath(game?: string, tab?: StudioTab): string {
  * Parent path for the NavHeader "Up" chevron — Android-style Up, not browser Back.
  *
  * Always a real in-app parent so a deep link still has somewhere safe to go.
- * Returns null when the surface owns its own escape (home, join, play/draft
- * theater, studio playtest overlay) or when Up would be meaningless.
+ * Returns null when the surface owns its own escape (home, join, draft theater,
+ * studio playtest overlay) or when Up would be meaningless.
  */
 export type NavUpTarget = {
   path: string;
@@ -482,9 +482,12 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
     // the error-page home link own escape here, same as `/play`.
     case 'home':
     case 'join':
-    case 'play':
     case 'draft':
       return null;
+    // `/play/:slug` is now a preview-first page. The theater it opens hides the
+    // header through `stageContent`, so the visible static page gets a normal Up.
+    case 'play':
+      return { path: '/', labelKey: 'upHome' };
     case 'studio':
       // Playtest is a full-viewport theater with its own Close back to overview.
       if (route.tab === 'playtest') return null;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12357,7 +12357,188 @@ a.user-name--profile:focus-visible {
    that fed it went with it. `offered` / `opened` on the visit stream is what now
    answers whether the quieter door still gets used. */
 
+/* —— Published game page —— */
+.game-page {
+  width: min(1080px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3.5rem) 0 4rem;
+}
+
+.game-page-header {
+  max-width: 850px;
+  margin-bottom: 1.25rem;
+}
+
+.game-page-kicker {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.game-page-kicker a {
+  color: var(--turquoise);
+}
+
+.game-page-genre {
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.game-page h1 {
+  margin: 0.4rem 0 1rem;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1;
+}
+
+.game-page-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.game-page-actions > .primary-btn,
+.game-page-actions > .secondary-btn,
+.game-page-actions .vote-btn {
+  min-height: 44px;
+}
+
+.game-page-actions .vote-widget {
+  display: contents;
+}
+
+.game-page-remix {
+  border-color: var(--turquoise);
+}
+
+.game-page-preview {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: #07101e;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.game-page-preview:hover,
+.game-page-preview:focus-visible {
+  border-color: var(--turquoise);
+  box-shadow: 0 0 0 2px var(--turquoise-glow);
+}
+
+.game-page-preview img,
+.game-page-preview video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.game-page-preview-empty {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  color: var(--turquoise);
+  background: radial-gradient(circle at 50% 45%, rgba(0, 229, 183, 0.12), transparent 45%);
+}
+
+.game-page-preview-cta {
+  position: absolute;
+  left: 50%;
+  bottom: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(5, 12, 20, 0.88);
+  color: #fff;
+  font-weight: 700;
+  transform: translateX(-50%);
+  backdrop-filter: blur(8px);
+}
+
+.game-page-screenshots {
+  margin-top: 1.25rem;
+}
+
+.game-page-screenshots h2 {
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+}
+
+.game-page-screenshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.65rem;
+}
+
+.game-page-screenshot {
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: #07101e;
+  cursor: pointer;
+}
+
+.game-page-screenshot:hover,
+.game-page-screenshot:focus-visible,
+.game-page-screenshot.is-selected {
+  border-color: var(--turquoise);
+  box-shadow: 0 0 0 2px var(--turquoise-glow);
+}
+
+.game-page-screenshot img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.game-page-controls {
+  max-width: 760px;
+  margin-top: 1.25rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.game-page-controls h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.game-page-controls p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.game-page-state {
+  max-width: 720px;
+  margin: 4rem auto;
+  padding: 1rem;
+  text-align: center;
+}
+
 /* —— Creator profiles —— */
+
 .creator-profile-page {
   max-width: 720px;
   margin: 0 auto;
@@ -12459,6 +12640,18 @@ a.user-name--profile:focus-visible {
   flex: 0 0 auto;
 }
 
+.creator-profile-game-thumb-link {
+  display: block;
+  flex: 0 0 auto;
+  border-radius: 6px;
+}
+
+.creator-profile-game-thumb-link:hover,
+.creator-profile-game-thumb-link:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 3px;
+}
+
 .creator-profile-game-thumb--empty {
   display: block;
 }
@@ -12483,6 +12676,14 @@ a.user-name--profile:focus-visible {
 
 .creator-profile-game-link {
   font-size: 0.85rem;
+}
+
+.creator-profile-studio-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 44px;
+  text-decoration: none;
 }
 
 .card-author-link,
@@ -12861,6 +13062,31 @@ a.user-name--profile:focus-visible {
     width: 100%;
     height: auto;
     aspect-ratio: 16 / 9;
+  }
+
+  .creator-profile-game-thumb-link {
+    width: 100%;
+  }
+
+  .game-page {
+    width: min(100% - 1rem, 1080px);
+    padding-top: 1rem;
+  }
+
+  .game-page-actions > .primary-btn,
+  .game-page-actions > .secondary-btn,
+  .game-page-actions .vote-btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
+  .game-page-preview {
+    border-radius: 8px;
+  }
+
+  .game-page-preview-cta {
+    bottom: 0.6rem;
+    white-space: nowrap;
   }
 }
 

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -225,15 +225,16 @@ export type RemixStep =
 export type RemixPaintedVia = 'redirect' | 'menu' | 'panel';
 
 /**
- * Which door was used to open a remix: the chrome bar, or the overflow menu it
- * sheds into on narrow screens. Recorded on `offered` and `opened` only.
+ * Which door was used to open a remix: the game page, the theater chrome bar,
+ * or the overflow menu it sheds into on narrow screens. Recorded on `offered`
+ * and `opened` only.
  *
  * A separate field from `via` rather than more members on it. `via` answers
  * "what led someone to the painter" and this answers "which control did they
  * press"; one name covering both would make every historical row ambiguous the
- * day a third door appears.
+ * day another door appears.
  */
-export type RemixControl = 'bar' | 'more';
+export type RemixControl = 'bar' | 'more' | 'page';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;


### PR DESCRIPTION
## What changed

- Add a preview-first published game page with a screenshot/video preview and no autoplaying game iframe.
- Add selectable screenshot thumbnails when catalog media includes multiple screenshots.
- Keep Play, vote, Remix, and Share in the top action row.
- Open Remix directly into theater with the remix panel already open.
- Remove empty/speculative detail surfaces such as Board, To play, Releases, Sources, and Follow.
- Make creator-profile thumbnails link to game pages and expose an owner-only Studio button.
- Track game-page Remix entry in the existing visit funnel telemetry.

## Why

The previous game page exposed too much agent-facing content, mounted games before the visitor chose to play, and placed important actions below the fold or behind extra navigation. This keeps the public page focused on deciding whether to play, while preserving the existing sandboxed theater for actual execution.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- Browser verification of preview-first loading, theater sandboxing, direct Remix entry, and responsive layout.
