### PR TITLE
Fix deploy browser gate for preview-first /play pages

### DIFF
--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -138,8 +138,10 @@ roughly in order of how often they turn up real issues:
 
 - **Home** (`/`) — scroll to the bottom too; lazy-loaded catalog cards fetch media on scroll.
 - **Play a real game** (`/play/<slug>` for a `single-player` catalog entry from
-  `GET /api/catalog`) — click into the game's iframe and send keyboard input; a game that
-  never responds to input is the most user-visible failure mode there is.
+  `GET /api/catalog`) — the shareable page is **preview-first** (screenshot + Play;
+  no autoplaying iframe). Click Play (or the preview) to open the sandboxed theater,
+  then click into the game's iframe and send keyboard input; a game that never
+  responds to input is the most user-visible failure mode there is.
 - **Play alias rewrite** (`/ai/<slug>` or `/ay/<slug>`) — should 30x/rewrite to the canonical
   `/play/<slug>` (see `apps/web/src/router.ts`).
 - **Multiplayer lobby** — click "Play together" on a catalog entry with `multiplayer` set;
@@ -152,7 +154,8 @@ roughly in order of how often they turn up real issues:
 - **Language toggle** (EN/PL) — check strings actually swap, not just the button state.
 - **Static/legal routes** — `/privacy`, `/terms`.
 - **Error paths** — an unknown path (→ `notFound` view, real 404), an unknown game slug at
-  `/play/<garbage>` (→ in-page "Could not load this game" error state, not a crash),
+  `/play/<garbage>` (→ in-page "This game page does not exist." on the preview page, not a
+  crash or a blank theater),
   `/draft/<slug>` for something already published, a bogus `/status/<token>`, a bogus
   `/join/<CODE>#<token>`. These should all render a friendly state, never a blank page or an
   unhandled console exception.

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -68,6 +68,14 @@ Two concrete instances of that (observed 2026-07-23):
 - **`actions/runs?head_sha=<short-sha>` silently returns zero runs.** The API needs the
   full 40-char SHA; a short SHA is not an error, just an empty list — a monitor polling it
   waits forever while everything already completed. Always `git rev-parse` to full length.
+- **A green unit suite + "I checked it in a browser" can still fail the deploy browser
+  gate when the UX flow changed and e2e was not updated.** Observed (#599, 2026-08-05):
+  published `/play/<slug>` became preview-first (screenshot + Play, no autoplaying
+  iframe). Unit tests and claimed manual browser checks were green; deploy's
+  `npm run e2e` still waited for `iframe` / `.game-theater-bar` on bare navigation and
+  blocked promotion. When a PR changes _when_ a frame mounts (or the copy of an error
+  state the gate asserts), update `apps/e2e` in the same PR — the unit suite never
+  drives that path.
 - **An agent can weaken the gate in the same commit as a requested fix.** Observed: a
   commit that legitimately restored Basic-Auth also changed the deploy smoke's negative
   check to accept the failure state (401-only became 401-or-503, and the auth header was

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -309,7 +309,10 @@ export async function visit(page: Page, path: string, settleMs = 3_000) {
  */
 export async function openPlayTheater(page: Page, slug: string, settleMs = 4_000): Promise<void> {
   await visit(page, `/play/${encodeURIComponent(slug)}`, settleMs);
-  const play = page.locator('.game-page-actions button.primary-btn');
+  // Class within the actions row, not `button.primary-btn` — the control is the
+  // primary action by role in the layout; tying the gate to the element type would
+  // fail a deploy over a harmless `<a class="primary-btn">` restyle.
+  const play = page.locator('.game-page-actions .primary-btn');
   await play.waitFor({ state: 'visible', timeout: 30_000 });
   await play.click();
   await page.locator('.game-theater-bar').waitFor({ state: 'visible', timeout: 30_000 });

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -297,3 +297,20 @@ export async function visit(page: Page, path: string, settleMs = 3_000) {
   await page.waitForTimeout(settleMs);
   return response;
 }
+
+/**
+ * Open a published game's sandboxed theater from its shareable preview page.
+ *
+ * `/play/<slug>` is preview-first (`GameDetailPage`): screenshot/actions only, no
+ * iframe. Play is the explicit execution boundary that mounts `GameTheater`. The
+ * deploy browser gate must cross that boundary before asserting on frames, canvas
+ * liveness, or theater chrome — otherwise every check fails against a page that is
+ * working as designed.
+ */
+export async function openPlayTheater(page: Page, slug: string, settleMs = 4_000): Promise<void> {
+  await visit(page, `/play/${encodeURIComponent(slug)}`, settleMs);
+  const play = page.locator('.game-page-actions button.primary-btn');
+  await play.waitFor({ state: 'visible', timeout: 30_000 });
+  await play.click();
+  await page.locator('.game-theater-bar').waitFor({ state: 'visible', timeout: 30_000 });
+}

--- a/apps/e2e/src/games-playable.test.ts
+++ b/apps/e2e/src/games-playable.test.ts
@@ -1,6 +1,12 @@
 import type { APIRequestContext, Browser, BrowserContext, Frame, Page } from 'playwright-core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { e2ePrerequisites, launchSiteBrowser, signedInApiContext, signedInContext, visit } from './browser.js';
+import {
+  e2ePrerequisites,
+  launchSiteBrowser,
+  openPlayTheater,
+  signedInApiContext,
+  signedInContext,
+} from './browser.js';
 
 /**
  * Are published games actually playable on this deployment?
@@ -11,7 +17,8 @@ import { e2ePrerequisites, launchSiteBrowser, signedInApiContext, signedInContex
  * like. Every other check in `deploy.yml` stops at HTTP, and proving
  * `/api/games/<slug>` returns HTML says nothing about whether that HTML runs — a CSP
  * header, a sandbox change, a bundle regression or a broken assembler each return a
- * healthy 200 and a black screen.
+ * healthy 200 and a black screen. Visiting `/play/<slug>` alone is also not enough
+ * anymore: that URL is a preview page, and Play must be clicked before a frame exists.
  *
  * The verdict is by **breadth**, and that is the whole point of this file existing
  * separately. Games live in a separate, agent-maintained repo and change independently
@@ -108,7 +115,8 @@ async function sampleCanvas(frame: Frame): Promise<CanvasSample | null> {
 async function inspectGame(page: Page, slug: string): Promise<GameReport> {
   const report: GameReport = { slug, frameAppeared: false, sandbox: null, litPixels: -1, animated: false };
 
-  await visit(page, `/play/${encodeURIComponent(slug)}`, 4_000);
+  // Preview page first, then Play — the iframe does not exist until the theater opens.
+  await openPlayTheater(page, slug);
 
   const iframe = page.locator('iframe').first();
   report.sandbox = await iframe.getAttribute('sandbox').catch(() => null);
@@ -247,7 +255,7 @@ describe.skipIf(!prereq.ok)('published games are playable', () => {
     // code this app's DOM, storage and cookies.
     const sandboxes = new Set<string | null>();
     for (const slug of slugs) {
-      await visit(page, `/play/${encodeURIComponent(slug)}`, 2_000);
+      await openPlayTheater(page, slug, 2_000);
       // Wait for attachment before reading. On a cold start the frame arrives a moment
       // after the settle, and `getAttribute` on a not-yet-present element returns null —
       // which would read as "sandbox missing" and block promotion over a slow revision

--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -67,9 +67,10 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
 
     const text = await bodyText();
     expect(text.length).toBeGreaterThan(0);
-    // The player chrome stays up and offers a way out; the API's 404 underneath is
-    // expected and declared above.
-    expect(text).toMatch(/could not load|nie udało|retry|ponów/i);
+    // Preview-first `/play/<slug>`: an unknown slug is a missing game page, not a
+    // failed theater fetch. Keep the older "could not load / retry" wording too so
+    // a loadError state (catalog fetch failure) still passes this gate.
+    expect(text).toMatch(/does not exist|nie istnieje|could not load|nie udało|retry|ponów/i);
 
     expect(describeProblems(watcher.drain())).toBe('');
   });

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -6,6 +6,7 @@ import {
   describeProblems,
   e2ePrerequisites,
   launchSiteBrowser,
+  openPlayTheater,
   signedInApiContext,
   signedInContext,
   visit,
@@ -84,7 +85,8 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
 
     let frame: Frame | undefined;
     for (const candidate of candidates) {
-      await visit(page, `/play/${candidate.slug}`, 6_000);
+      // Preview page → Play → theater. The iframe is not on the shareable page.
+      await openPlayTheater(page, candidate.slug, 6_000);
       const found = page.frames().find((f) => f !== page.mainFrame());
       if (!found) continue;
       // Games run in a sandboxed iframe (allow-scripts, no allow-same-origin). The
@@ -201,7 +203,8 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
 
   it('offers a reportable path for illegal content (DSA art. 16)', async () => {
     const { slug } = singlePlayer();
-    await visit(page, `/play/${slug}`, 5_000);
+    // Report lives on the theater chrome (More menu), not the preview page.
+    await openPlayTheater(page, slug, 5_000);
 
     // The theater bar stays visible throughout play, so the report path in More
     // never requires recovering hidden chrome first.

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -87,6 +87,15 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
     for (const candidate of candidates) {
       // Preview page → Play → theater. The iframe is not on the shareable page.
       await openPlayTheater(page, candidate.slug, 6_000);
+      // The theater bar mounts before PublishedGameFrame attaches the iframe, so a
+      // bare frames() scan right after openPlayTheater can miss a healthy game.
+      const attached = await page
+        .locator('iframe')
+        .first()
+        .waitFor({ state: 'attached', timeout: 30_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!attached) continue;
       const found = page.frames().find((f) => f !== page.mainFrame());
       if (!found) continue;
       // Games run in a sandboxed iframe (allow-scripts, no allow-same-origin). The

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -928,16 +928,6 @@
     "gameNamed": "{{title}}",
     "proposals": "My proposals"
   },
-  "gamePage": {
-    "loading": "Loading game…",
-    "loadError": "Could not load this game page.",
-    "missing": "This game is not available.",
-    "actions": "Game actions",
-    "playPreview": "Play {{title}} in theater mode",
-    "openTheater": "Play in theater",
-    "screenshots": "Screenshots",
-    "viewScreenshot": "View screenshot {{number}}"
-  },
   "creatorProfile": {
     "back": "Back",
     "loading": "Loading profile…",
@@ -1229,6 +1219,12 @@
     "missing": "This game page does not exist.",
     "missingPlayLink": "Try the direct play link instead",
     "error": "Could not load the game page. Try again in a moment.",
+    "loadError": "Could not load this game page.",
+    "actions": "Game actions",
+    "playPreview": "Play {{title}} in theater mode",
+    "openTheater": "Play in theater",
+    "screenshots": "Screenshots",
+    "viewScreenshot": "View screenshot {{number}}",
     "breadcrumbAria": "Game location",
     "play": "Play",
     "follow": "Follow",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -932,16 +932,6 @@
     "gameNamed": "{{title}}",
     "proposals": "Moje propozycje"
   },
-  "gamePage": {
-    "loading": "Ładowanie gry…",
-    "loadError": "Nie udało się wczytać strony gry.",
-    "missing": "Ta gra nie jest dostępna.",
-    "actions": "Akcje gry",
-    "playPreview": "Zagraj w {{title}} w trybie kinowym",
-    "openTheater": "Graj w trybie kinowym",
-    "screenshots": "Zrzuty ekranu",
-    "viewScreenshot": "Pokaż zrzut ekranu {{number}}"
-  },
   "creatorProfile": {
     "back": "Wróć",
     "loading": "Ładowanie profilu…",
@@ -1233,6 +1223,12 @@
     "missing": "Ta strona gry nie istnieje.",
     "missingPlayLink": "Spróbuj bezpośredniego linku do gry",
     "error": "Nie udało się wczytać strony gry. Spróbuj za chwilę.",
+    "loadError": "Nie udało się wczytać strony gry.",
+    "actions": "Akcje gry",
+    "playPreview": "Zagraj w {{title}} w trybie kinowym",
+    "openTheater": "Graj w trybie kinowym",
+    "screenshots": "Zrzuty ekranu",
+    "viewScreenshot": "Pokaż zrzut ekranu {{number}}",
     "breadcrumbAria": "Położenie gry",
     "play": "Zagraj",
     "follow": "Obserwuj",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[Deploy run 31042630341](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/31042630341) failed at **Browser gate against the candidate** after #599 landed. Curl smoke (anonymous + authenticated) passed; promotion was blocked because e2e still assumed `/play/<slug>` auto-mounts a sandboxed iframe and theater bar.

Failures:
- `games-playable` / walkthrough: no iframe / no `.game-theater-bar` (preview page by design)
- `resilience`: unknown slug shows `This game page does not exist.` instead of the old load-error copy

Also: #599 introduced a second `gamePage` key in `en.json` / `pl.json`; JSON keeps the last one, so DetailPage strings (`openTheater`, `loadError`, …) were wiped at runtime.

## Fix

- Add `openPlayTheater()` — visit `/play/<slug>`, click Play, wait for theater chrome — and use it in the deploy e2e playability/walkthrough gates
- Accept missing-page copy for unknown slugs (keep load-error wording too)
- Merge the duplicate `gamePage` i18n objects so both GamePage and GameDetailPage keys survive
- Update browse/verify agent skills so the next pass does not reintroduce this

## Copilot review follow-up

- Play control selected as `.game-page-actions .primary-btn` (not tied to `<button>`)
- Walkthrough waits for iframe attach after theater open before scanning `page.frames()`

## Validation

- `npm run type-check && npm run lint && npm run test && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-091a2e4d-d026-4c54-89f3-a4b2416d91c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-091a2e4d-d026-4c54-89f3-a4b2416d91c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

