### PR TITLE
Round card: right language, right size — two fixes from watching real hosts

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2166,6 +2166,45 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     expect(repeat?.png).toBeUndefined();
   });
 
+  it('shows a localized progress note only to a reader who can read it', async () => {
+    // Observed by the owner 2026-08-05: the same note rendered Polish in the ChatGPT card
+    // and English in Studio. Studio was right — it matches the event's locale against the
+    // reader's; the card preferred textLocalized unconditionally.
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const { sessionId } = await initializeWith(app, true);
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    await callTool(
+      app,
+      'report_progress',
+      { sessionKey, text: 'Adding a landing HUD', textLocalized: 'Dodaje interfejs HUD', locale: 'pl' },
+      { 'mcp-session-id': sessionId },
+    );
+
+    const noteFor = async (locale?: string) => {
+      const res = await callTool(
+        app,
+        'get_round_status',
+        { sessionKey, ...(locale ? { locale } : {}) },
+        { 'mcp-session-id': sessionId },
+      );
+      return (res.structured as { note: { text: string } | null }).note?.text;
+    };
+
+    expect(await noteFor('pl')).toBe('Dodaje interfejs HUD');
+    // Primary subtag only, so pl-PL still matches pl.
+    expect(await noteFor('pl-PL')).toBe('Dodaje interfejs HUD');
+    // A reader who cannot read Polish gets the English the agent also sent.
+    expect(await noteFor('en')).toBe('Adding a landing HUD');
+    expect(await noteFor('en-GB')).toBe('Adding a landing HUD');
+    // No locale from the host is no claim about the reader — English is the safe answer.
+    expect(await noteFor()).toBe('Adding a landing HUD');
+  });
+
   it('serves the card over resources/list and resources/read', async () => {
     process.env.MCP_UI = 'true';
     const store = new InMemoryStore();

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -122,6 +122,25 @@ const MAX_SCREENSHOT_BYTES = 700 * 1024;
 const MAX_SUBMIT_FILES = MAX_UPLOAD_FILES;
 
 /** How often the round view should re-read status. Matches the gate's own backoff. */
+/**
+ * The progress note in the language the *reader* is using.
+ *
+ * Same rule as the creator's thread (`submissions.ts`): an agent may send both an English
+ * `text` and a `textLocalized` in the creator's language, and the localized one is shown
+ * only when its locale matches the reader's. The card used to prefer `textLocalized`
+ * unconditionally, which handed a Polish note to a reader whose surface was English —
+ * the same event rendered in two languages depending on where you looked (owner, 2026-08-05).
+ *
+ * Locales are compared on the primary subtag, so `pl` matches `pl-PL`. No locale from the
+ * host means no claim about the reader, so English is the safe answer.
+ */
+function noteTextFor(event: { text: string; textLocalized?: string; locale?: string }, readerLocale: unknown): string {
+  if (!event.textLocalized || typeof event.locale !== 'string') return event.text;
+  if (typeof readerLocale !== 'string' || !readerLocale) return event.text;
+  const primary = (value: string) => value.trim().toLowerCase().split(/[-_]/)[0];
+  return primary(event.locale) === primary(readerLocale) ? event.textLocalized : event.text;
+}
+
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;
 /** A card shows a strip, not a contact sheet; the bytes ride a postMessage. */
 const ROUND_MEDIA_MAX_FRAMES = 3;
@@ -3616,6 +3635,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
+          locale: {
+            type: 'string',
+            description:
+              "The reader's language (BCP-47), so a localized progress note is shown only to who can read it.",
+          },
           sinceShotId: {
             type: 'string',
             description: 'Screenshot id you already have; bytes are omitted when the latest shot still matches it.',
@@ -3688,9 +3712,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           slug: record.slug ?? null,
           round: record.roundGeneration ?? 1,
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
-          note: latestEvent
-            ? { text: latestEvent.textLocalized ?? latestEvent.text, createdAt: latestEvent.createdAt }
-            : null,
+          note: latestEvent ? { text: noteTextFor(latestEvent, args.locale), createdAt: latestEvent.createdAt } : null,
           shot,
           gate,
           retryAfterSeconds: ROUND_STATUS_RETRY_AFTER_SECONDS,

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -1059,6 +1059,10 @@ const ROUND_STATUS_HTML = `<!doctype html>
           var args = {};
           if (sessionKey) args.sessionKey = sessionKey;
           if (lastShotId) args.sinceShotId = lastShotId;
+          // The reader's language, so the server can apply the same rule Studio does:
+          // show the agent's localized note only when it matches who is reading. Without
+          // it the card showed a Polish note to an English reader.
+          if (hostLocale) args.locale = hostLocale;
           var id = nextId++;
           pendingCalls[id] = function (result, error) {
             inFlight = false;


### PR DESCRIPTION
Two defects the owner surfaced by watching Studio and ChatGPT side by side. Both are ours, and both are cases of the card ignoring something the host already told it.

## 1. A localized progress note shown to a reader who cannot read it

**The same note rendered Polish in the ChatGPT card and English in Studio.** One event, two surfaces, two languages.

Studio was right. An agent may send both an English `text` and a `textLocalized` in the creator's language, and the creator's thread shows the localized one **only when its locale matches the reader's**:

```js
// apps/api/src/submissions.ts:1584
const text = event.locale === locale && event.textLocalized ? event.textLocalized : event.text;
```

The card had no such check — it preferred `textLocalized` unconditionally.

**The card already knew the answer and never sent it.** `hostContext.locale` arrives at `ui/initialize` and was being used for date formatting only. It now rides every `get_round_status` poll, and the server applies Studio's rule — so the two surfaces agree *by construction* rather than by coincidence.

- Matching on the **primary subtag**: `pl` matches `pl-PL`, `en` matches `en-GB`.
- **No locale from the host is no claim about the reader**, so English is the safe answer and a host that sends no `hostContext` behaves exactly as before.

## 2. The card sat in a frame far taller than itself

In ChatGPT the card rendered at the top of a much taller frame with dead space beneath, repeated down the transcript.

SEP-1865 has `hostContext.containerDimensions` for exactly this: a fixed `height` is the host's decision and **the view is meant to fill it**, a `maxHeight` is a ceiling it may grow up to, an absent field means unbounded. We were reading theme, locale, timeZone and themeVariables from `hostContext` and ignoring dimensions entirely.

That is fine in a host that sizes to our `size-changed` notification and wrong in one that does not. Claude sized to us, so nothing looked amiss locally — **the same pattern as every other defect in this workstream: the harness models what we think a host does.**

Filling a fixed frame does not conjure content, but it makes the card look deliberate rather than broken, and it is what the spec asks for.

## Not fixed here, and worth recording

The owner also saw **several near-identical cards for one round**. A redacted call ledger settles the cause: `start` was called **exactly twice** across the session — once per round — and `get_gate_verdict` **never**. So two tool calls carried `_meta.ui` and produced more cards than that.

This is host-side card persistence, not our launcher set. Narrowing `MCP_UI_TOOL_RESOURCES` — the fix I was about to make — would have changed nothing, and the spec offers no dedupe key (`2026-01-26` only lets hosts dedupe identical `ui/update-model-context` calls). Left alone rather than guessed at.

## Verification

Full API suite green (**2571** tests, 165 files), lint clean.

The locale fix drives the real tool through a real round and pins all five cases: `pl` → Polish, `pl-PL` → Polish, `en` → English, `en-GB` → English, absent → English.

The sizing fix is verified in the browser harness with a host declaring a fixed 860px frame: the root fills it, gallery and summary still render, no page error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_