### PR TITLE
Progressive disclosure for Studio builder choice

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -235,17 +235,17 @@ queued.
 
 ## Key code
 
-| Area                         | Path                                                        |
-| ---------------------------- | ----------------------------------------------------------- |
-| MCP tools                    | `apps/api/src/mcp-server.ts`                                |
-| Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                  |
-| Channel (`POST …/end`, …)    | `apps/api/src/agent-channel.ts`                             |
-| Stall / `ended`              | `apps/api/src/job-state.ts` (`detectStall`)                 |
-| Handoff gate                 | `apps/api/src/builder.ts` (`allowsSelfToPlatformHandoff`)   |
-| Live staged preview          | `apps/api/src/staged-preview.ts`                            |
-| Studio live-preview frame    | `apps/web/src/StudioLivePreview.tsx`                        |
-| Feedback / resume            | `apps/api/src/submissions.ts`                               |
-| Studio copy / builder choice | `apps/web/src/selfBuildCopy.ts`, `SubmissionStatusView.tsx` |
+| Area                         | Path                                                                                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP tools                    | `apps/api/src/mcp-server.ts`                                                                                                                                              |
+| Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |
+| Channel (`POST …/end`, …)    | `apps/api/src/agent-channel.ts`                                                                                                                                           |
+| Stall / `ended`              | `apps/api/src/job-state.ts` (`detectStall`)                                                                                                                               |
+| Handoff gate                 | `apps/api/src/builder.ts` (`allowsSelfToPlatformHandoff`)                                                                                                                 |
+| Live staged preview          | `apps/api/src/staged-preview.ts`                                                                                                                                          |
+| Studio live-preview frame    | `apps/web/src/StudioLivePreview.tsx`                                                                                                                                      |
+| Feedback / resume            | `apps/api/src/submissions.ts`                                                                                                                                             |
+| Studio copy / builder choice | `apps/web/src/selfBuildCopy.ts`, `BuilderModeBadge.tsx`, `SubmissionStatusView.tsx` (sticky badge + Change modal at round boundaries; full two-up stays in create wizard) |
 
 ## Safety invariant (unchanged)
 

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -19,8 +19,9 @@ type BuilderChoiceProps = {
 /**
  * Who builds this round — platform team or the creator's own coding agent.
  *
- * Shown on the creation confirm screen and again whenever a new round is about to
- * start. Selection is a pair of pressed options, not a settings dig.
+ * Full two-up choice for the create wizard and the Change modal. Round-boundary
+ * Studio chrome uses {@link BuilderModeBadge} instead — sticky continuity with
+ * progressive disclosure, not a permanent peer fork above the composer.
  */
 export function BuilderChoice({
   value,

--- a/apps/web/src/BuilderModeBadge.test.tsx
+++ b/apps/web/src/BuilderModeBadge.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BuilderModeBadge } from './BuilderModeBadge.js';
+import type { BuilderKind } from './builderKind.js';
+import i18n from './i18n/index.js';
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('BuilderModeBadge', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('shows the sticky self label and opens the choice modal on Change', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    let value: BuilderKind = 'self';
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const render = () =>
+      act(async () => {
+        root.render(
+          createElement(BuilderModeBadge, {
+            value,
+            onChange: (next: BuilderKind) => {
+              value = next;
+            },
+            canChange: true,
+          }),
+        );
+        await flush();
+      });
+
+    await render();
+
+    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
+    expect(container.querySelector('.builder-choice')).toBeNull();
+    expect(document.body.querySelector('.builder-choice-modal')).toBeNull();
+
+    await act(async () => {
+      container.querySelector('.builder-mode-badge-change')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+
+    const modal = document.body.querySelector('.builder-choice-modal');
+    expect(modal).not.toBeNull();
+    expect(modal?.textContent).toMatch(/Who builds this round/i);
+    const options = modal!.querySelectorAll<HTMLButtonElement>('.builder-choice-option');
+    expect(options).toHaveLength(2);
+
+    await act(async () => {
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    expect(value).toBe('platform');
+
+    await render();
+    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Gamedev.pl agent');
+
+    await act(async () => root.unmount());
+  });
+
+  it('hides Change while an agent is working', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(BuilderModeBadge, {
+          value: 'self',
+          onChange: () => undefined,
+          canChange: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
+    expect(container.querySelector('.builder-mode-badge-change')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/BuilderModeBadge.test.tsx
+++ b/apps/web/src/BuilderModeBadge.test.tsx
@@ -18,7 +18,7 @@ describe('BuilderModeBadge', () => {
     vi.restoreAllMocks();
   });
 
-  it('shows the sticky self label and opens the choice modal on Change', async () => {
+  it('renders a toolbar selector and opens the choice modal on click', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -43,12 +43,14 @@ describe('BuilderModeBadge', () => {
 
     await render();
 
-    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
+    const selector = container.querySelector('.builder-mode-selector');
+    expect(selector?.textContent).toContain('Your agent');
+    expect(selector?.tagName).toBe('BUTTON');
     expect(container.querySelector('.builder-choice')).toBeNull();
     expect(document.body.querySelector('.builder-choice-modal')).toBeNull();
 
     await act(async () => {
-      container.querySelector('.builder-mode-badge-change')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      selector!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
     });
 
@@ -65,12 +67,12 @@ describe('BuilderModeBadge', () => {
     expect(value).toBe('platform');
 
     await render();
-    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Gamedev.pl agent');
+    expect(container.querySelector('.builder-mode-selector')?.textContent).toContain('Gamedev.pl');
 
     await act(async () => root.unmount());
   });
 
-  it('hides Change while an agent is working', async () => {
+  it('stays a static label while an agent is working', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -89,8 +91,10 @@ describe('BuilderModeBadge', () => {
       await flush();
     });
 
-    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
-    expect(container.querySelector('.builder-mode-badge-change')).toBeNull();
+    const selector = container.querySelector('.builder-mode-selector');
+    expect(selector?.textContent).toContain('Your agent');
+    expect(selector?.tagName).toBe('SPAN');
+    expect(container.querySelector('button.builder-mode-selector')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/BuilderModeBadge.tsx
+++ b/apps/web/src/BuilderModeBadge.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useId, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { BuilderChoice } from './BuilderChoice.js';
+import type { BuilderKind } from './builderKind.js';
+
+type BuilderModeBadgeProps = {
+  value: BuilderKind;
+  onChange: (next: BuilderKind) => void;
+  /**
+   * Round is silent — the next send can open a new round, so Change is offered.
+   * While an agent is mid-work the badge stays informational only.
+   */
+  canChange: boolean;
+  disabled?: boolean;
+};
+
+/**
+ * Sticky builder signal for the Studio composer.
+ *
+ * The create wizard keeps the full two-up choice. At round boundaries the
+ * composer only shows this badge; Change opens the same decision in a modal so
+ * "who builds" is progressive disclosure, not permanent chrome.
+ */
+export function BuilderModeBadge({ value, onChange, canChange, disabled = false }: BuilderModeBadgeProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  const label = t(value === 'self' ? 'builder.badge.self' : 'builder.badge.platform');
+
+  return (
+    <>
+      <div className={`builder-mode-badge${value === 'self' ? ' is-self' : ' is-platform'}`}>
+        <span className="builder-mode-badge-label">{label}</span>
+        {canChange ? (
+          <button type="button" className="builder-mode-badge-change" disabled={disabled} onClick={() => setOpen(true)}>
+            {t('builder.badge.change')}
+          </button>
+        ) : null}
+      </div>
+      {open
+        ? createPortal(
+            <div className="modal-backdrop builder-choice-modal-backdrop" onClick={() => setOpen(false)}>
+              <div
+                className="builder-choice-modal"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  className="modal-close-btn"
+                  onClick={() => setOpen(false)}
+                  aria-label={t('builder.badge.modalClose')}
+                >
+                  &times;
+                </button>
+                <h2 id={titleId} className="builder-choice-modal-title">
+                  {t('builder.legend')}
+                </h2>
+                <p className="builder-choice-modal-lede">{t('builder.badge.modalLede')}</p>
+                <BuilderChoice value={value} onChange={onChange} disabled={disabled} hideLegend />
+                <button type="button" className="primary-btn builder-choice-modal-done" onClick={() => setOpen(false)}>
+                  {t('builder.badge.modalDone')}
+                </button>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/apps/web/src/BuilderModeBadge.tsx
+++ b/apps/web/src/BuilderModeBadge.tsx
@@ -3,24 +3,25 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { BuilderChoice } from './BuilderChoice.js';
 import type { BuilderKind } from './builderKind.js';
+import { PixelIcon } from './PixelIcon.js';
 
 type BuilderModeBadgeProps = {
   value: BuilderKind;
   onChange: (next: BuilderKind) => void;
   /**
-   * Round is silent — the next send can open a new round, so Change is offered.
-   * While an agent is mid-work the badge stays informational only.
+   * Round is silent — the next send can open a new round, so the selector opens
+   * the choice modal. While an agent is mid-work it stays a read-only label.
    */
   canChange: boolean;
   disabled?: boolean;
 };
 
 /**
- * Sticky builder signal for the Studio composer.
+ * Builder control for the Studio composer toolbar (Claude / Cursor / Copilot shape).
  *
- * The create wizard keeps the full two-up choice. At round boundaries the
- * composer only shows this badge; Change opens the same decision in a modal so
- * "who builds" is progressive disclosure, not permanent chrome.
+ * Lives in the bottom toolbar of the prompt card — left side, like a model picker —
+ * not as a floating badge over the textarea. Changeable only while generation is
+ * silent; opens the same two-up choice the create wizard uses.
  */
 export function BuilderModeBadge({ value, onChange, canChange, disabled = false }: BuilderModeBadgeProps) {
   const { t } = useTranslation();
@@ -37,17 +38,29 @@ export function BuilderModeBadge({ value, onChange, canChange, disabled = false 
   }, [open]);
 
   const label = t(value === 'self' ? 'builder.badge.self' : 'builder.badge.platform');
+  const className = `builder-mode-selector${value === 'self' ? ' is-self' : ' is-platform'}${
+    canChange ? '' : ' is-static'
+  }`;
 
   return (
     <>
-      <div className={`builder-mode-badge${value === 'self' ? ' is-self' : ' is-platform'}`}>
-        <span className="builder-mode-badge-label">{label}</span>
-        {canChange ? (
-          <button type="button" className="builder-mode-badge-change" disabled={disabled} onClick={() => setOpen(true)}>
-            {t('builder.badge.change')}
-          </button>
-        ) : null}
-      </div>
+      {canChange ? (
+        <button
+          type="button"
+          className={className}
+          disabled={disabled}
+          onClick={() => setOpen(true)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+        >
+          <span className="builder-mode-selector-label">{label}</span>
+          <PixelIcon name="chevronDown" size={11} />
+        </button>
+      ) : (
+        <span className={className} title={label}>
+          <span className="builder-mode-selector-label">{label}</span>
+        </span>
+      )}
       {open
         ? createPortal(
             <div className="modal-backdrop builder-choice-modal-backdrop" onClick={() => setOpen(false)}>

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -924,9 +924,9 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
       expect(container.querySelector('.builder-mode-badge-change')).not.toBeNull();
       expect(container.querySelector('.builder-choice')).toBeNull();
-      // Handoff, not mid-build — do not spin "Writing code" beside the finished chip.
-      expect(container.querySelector('.studio-thread-context.is-active')).toBeNull();
-      expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
+      // Handoff, not mid-build — no live working turn and no foot "Writing code".
+      expect(container.querySelector('.studio-turn.is-working')).toBeNull();
+      expect(container.querySelector('.studio-thread-context')).toBeNull();
     } finally {
       await act(async () => {
         root.unmount();
@@ -1425,7 +1425,7 @@ describe('SubmissionStatusView', () => {
     });
   });
 
-  it('keeps build pulse in the foot without checklist fraction, stop, or Play', async () => {
+  it('keeps build pulse as the last transcript turn without checklist fraction, stop, or Play', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -1456,20 +1456,23 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector('.studio-thread-context.is-active')).not.toBeNull();
-    expect(container.querySelector('.studio-context-phase-spinner')).not.toBeNull();
-    // Abandon / checklist / Play stay out of the foot — Claude-shaped chrome.
+    // Claude-shaped: "Writing code" is the last transcript turn with a pulse, not a foot bar.
+    const working = container.querySelector('.studio-turn.is-working');
+    expect(working).not.toBeNull();
+    expect(working?.textContent).toContain('Writing code');
+    expect(container.querySelector('.studio-turn-working-pulse')).not.toBeNull();
+    expect(container.querySelector('.studio-thread-context')).toBeNull();
+    // Abandon / checklist / Play stay out of the foot.
     expect(container.querySelector('.studio-context-stop')).toBeNull();
     expect(container.querySelector('.studio-context-progress')).toBeNull();
     expect(container.querySelector('.status-play-cta')).toBeNull();
-    expect(container.querySelector('.studio-thread-context .studio-slug')).toBeNull();
 
     await act(async () => {
       root.unmount();
     });
   });
 
-  it('flashes a presence thought in the thread bar without adding a chat turn', async () => {
+  it('flashes a presence thought on the live working turn, not as a permanent chat bubble', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const at = new Date().toISOString();
     mockedGetSubmissionStatus.mockResolvedValue({
@@ -1492,10 +1495,53 @@ describe('SubmissionStatusView', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector('.studio-thread-context.is-thought')).not.toBeNull();
-    expect(container.querySelector('.studio-context-phase')?.textContent).toContain('Browsing the Creator Kit');
-    // Thought stays out of the transcript.
-    expect(container.querySelector('.studio-turn')).toBeNull();
+    const working = container.querySelector('.studio-turn.is-working.is-thought');
+    expect(working).not.toBeNull();
+    expect(working?.textContent).toContain('Browsing the Creator Kit');
+    // Thought is the live working line — not a durable event bubble, and not the foot bar.
+    expect(container.querySelectorAll('.studio-turn:not(.is-working)')).toHaveLength(0);
+    expect(container.querySelector('.studio-thread-context')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('does not leave Writing code in the foot after the self agent ends', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      stall: 'ended',
+      builder: 'self',
+      agentEndedAt: '2026-08-05T12:15:00.000Z',
+      events: [
+        {
+          id: 'e1',
+          kind: 'step',
+          step: 'testing',
+          text: 'Preview build sent for checks.',
+          createdAt: '2026-08-05T12:10:00.000Z',
+        },
+      ],
+    });
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'ended-no-writing', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.studio-turn.is-working')).toBeNull();
+    expect(container.querySelector('.studio-thread-context')).toBeNull();
+    expect(container.querySelector('.status-warning')?.textContent).toMatch(/finished this round/i);
+    // The finished event stays; the live "Writing code" line must not linger under it.
+    expect(container.textContent).toContain('Preview build sent for checks.');
+    expect(container.querySelector('.studio-thread-turns')?.textContent).not.toMatch(/Writing code/i);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -685,8 +685,8 @@ describe('SubmissionStatusView', () => {
     });
 
     // Routed from the state the server reported, not from a mode the creator picked.
-    // Published starts a new round, so the builder choice travels with the request
-    // (default: platform — the Gamedev.pl coding agent).
+    // Published starts a new round, so the sticky builder travels with the request
+    // (default: platform — the Gamedev.pl coding agent). Choice tiles stay in Change.
     expect(mockedSubmitImprovement).toHaveBeenCalledWith(
       'live-token',
       'The second level is far too hard, please add a checkpoint.',
@@ -694,7 +694,8 @@ describe('SubmissionStatusView', () => {
       'platform',
     );
     expect(mockedSubmitFeedback).not.toHaveBeenCalled();
-    expect(container.querySelector('.builder-choice')).not.toBeNull();
+    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Gamedev.pl agent');
+    expect(container.querySelector('.builder-choice')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -868,9 +869,19 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.studio-connect.is-resume')).not.toBeNull();
       expect(container.textContent).toContain('Continue with your agent');
       expect(container.textContent).not.toContain('Connect your coding agent');
-      // Quiet escape hatch: pick Gamedev.pl and send — API kills the self token.
-      expect(container.querySelector('.builder-choice')).not.toBeNull();
-      expect(container.textContent).toMatch(/Who builds this round/i); // Full first-time install stays under a closed disclosure — continue, not a reset.
+      // Quiet escape hatch: Change opens the builder modal — API kills the self token
+      // when platform is chosen and a note is sent. Tiles are not permanent chrome.
+      expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
+      expect(container.querySelector('.builder-mode-badge-change')).not.toBeNull();
+      expect(container.querySelector('.builder-choice')).toBeNull();
+      await act(async () => {
+        container
+          .querySelector('.builder-mode-badge-change')!
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+      });
+      expect(document.body.querySelector('.builder-choice-modal')?.textContent).toMatch(/Who builds this round/i);
+      // Full first-time install stays under a closed disclosure — continue, not a reset.
       const details = container.querySelector<HTMLDetailsElement>('[data-testid="connect-setup-details"]');
       expect(details).not.toBeNull();
       expect(details?.open).toBe(false);
@@ -910,7 +921,9 @@ describe('SubmissionStatusView', () => {
 
       expect(container.querySelector('.studio-connect')).toBeNull();
       expect(container.querySelector('.status-warning')?.textContent).toMatch(/finished this round/i);
-      expect(container.querySelector('.builder-choice')).not.toBeNull();
+      expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
+      expect(container.querySelector('.builder-mode-badge-change')).not.toBeNull();
+      expect(container.querySelector('.builder-choice')).toBeNull();
       // Handoff, not mid-build — do not spin "Writing code" beside the finished chip.
       expect(container.querySelector('.studio-thread-context.is-active')).toBeNull();
       expect(container.querySelector('.studio-context-phase-spinner')).toBeNull();
@@ -985,6 +998,7 @@ describe('SubmissionStatusView', () => {
     expect(container.textContent).toContain('Needs a tweak');
     // Active repair round — builder is locked server-side; do not offer a switch that 409s.
     expect(container.querySelector('.builder-choice')).toBeNull();
+    expect(container.querySelector('.builder-mode-badge-change')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -2369,7 +2383,7 @@ describe('SubmissionStatusView stop & retry', () => {
     });
   });
 
-  it('published composer defaults its builder chooser to the status defaultBuilder, over stale local memory', async () => {
+  it('published composer defaults its builder badge to the status defaultBuilder, over stale local memory', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     // Memory is keyed by token in localStorage, and a new job has a new token — so the
     // remembered choice is gone at exactly this boundary. The status payload's
@@ -2388,7 +2402,12 @@ describe('SubmissionStatusView stop & retry', () => {
       await flushEffects();
     });
 
-    const selected = container.querySelector('.builder-choice-option[aria-checked="true"]');
+    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain(i18n.t('builder.badge.self'));
+    await act(async () => {
+      container.querySelector('.builder-mode-badge-change')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    const selected = document.body.querySelector('.builder-choice-option[aria-checked="true"]');
     expect(selected?.textContent).toContain(i18n.t('builder.self.title'));
 
     await act(async () => {

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -694,7 +694,7 @@ describe('SubmissionStatusView', () => {
       'platform',
     );
     expect(mockedSubmitFeedback).not.toHaveBeenCalled();
-    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Gamedev.pl agent');
+    expect(container.querySelector('.builder-mode-selector')?.textContent).toContain('Gamedev.pl');
     expect(container.querySelector('.builder-choice')).toBeNull();
 
     await act(async () => {
@@ -871,12 +871,12 @@ describe('SubmissionStatusView', () => {
       expect(container.textContent).not.toContain('Connect your coding agent');
       // Quiet escape hatch: Change opens the builder modal — API kills the self token
       // when platform is chosen and a note is sent. Tiles are not permanent chrome.
-      expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
-      expect(container.querySelector('.builder-mode-badge-change')).not.toBeNull();
+      expect(container.querySelector('.builder-mode-selector')?.textContent).toContain('Your agent');
+      expect(container.querySelector('button.builder-mode-selector')).not.toBeNull();
       expect(container.querySelector('.builder-choice')).toBeNull();
       await act(async () => {
         container
-          .querySelector('.builder-mode-badge-change')!
+          .querySelector('button.builder-mode-selector')!
           .dispatchEvent(new MouseEvent('click', { bubbles: true }));
         await flushEffects();
       });
@@ -921,8 +921,8 @@ describe('SubmissionStatusView', () => {
 
       expect(container.querySelector('.studio-connect')).toBeNull();
       expect(container.querySelector('.status-warning')?.textContent).toMatch(/finished this round/i);
-      expect(container.querySelector('.builder-mode-badge')?.textContent).toContain('Your agent (MCP)');
-      expect(container.querySelector('.builder-mode-badge-change')).not.toBeNull();
+      expect(container.querySelector('.builder-mode-selector')?.textContent).toContain('Your agent');
+      expect(container.querySelector('button.builder-mode-selector')).not.toBeNull();
       expect(container.querySelector('.builder-choice')).toBeNull();
       // Handoff, not mid-build — no live working turn and no foot "Writing code".
       expect(container.querySelector('.studio-turn.is-working')).toBeNull();
@@ -998,7 +998,7 @@ describe('SubmissionStatusView', () => {
     expect(container.textContent).toContain('Needs a tweak');
     // Active repair round — builder is locked server-side; do not offer a switch that 409s.
     expect(container.querySelector('.builder-choice')).toBeNull();
-    expect(container.querySelector('.builder-mode-badge-change')).toBeNull();
+    expect(container.querySelector('button.builder-mode-selector')).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -2448,9 +2448,11 @@ describe('SubmissionStatusView stop & retry', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector('.builder-mode-badge')?.textContent).toContain(i18n.t('builder.badge.self'));
+    expect(container.querySelector('.builder-mode-selector')?.textContent).toContain(i18n.t('builder.badge.self'));
     await act(async () => {
-      container.querySelector('.builder-mode-badge-change')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      container
+        .querySelector('button.builder-mode-selector')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
     const selected = document.body.querySelector('.builder-choice-option[aria-checked="true"]');

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BuilderChoice } from './BuilderChoice.js';
+import { BuilderModeBadge } from './BuilderModeBadge.js';
 import { defaultBuilderFor, isBuilderKind, saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
@@ -1427,6 +1427,22 @@ function FeedbackPanel({
       ? 'statusView.feedback.composerHintBuilding'
       : 'statusView.feedback.composerHint';
 
+  // Sticky builder signal: always when the next send can choose (Change gated on
+  // silence), and while a self round is mid-flight so routing stays visible without
+  // re-staging the create-wizard tiles. Platform mid-round stays chrome-free.
+  const effectiveBuilder = chooseBuilder ? builder : (roundBuilder ?? builder);
+  const showBuilderBadge = chooseBuilder || effectiveBuilder === 'self';
+  const builderBadge = showBuilderBadge ? (
+    <div className="builder-mode-row">
+      <BuilderModeBadge
+        value={effectiveBuilder}
+        onChange={handleBuilderChange}
+        canChange={chooseBuilder}
+        disabled={state === 'sending'}
+      />
+    </div>
+  ) : null;
+
   // Standalone status page still shows a brief receipt next to Send. The studio
   // composer does not: the message is echoed into the thread immediately, so a
   // second "Sent!" under the box is the same confirmation twice.
@@ -1460,9 +1476,7 @@ function FeedbackPanel({
         className={`status-feedback status-composer is-compact${sending ? ' is-sending' : ''}`}
         aria-busy={sending || undefined}
       >
-        {chooseBuilder ? (
-          <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={sending} compact />
-        ) : null}
+        {builderBadge}
         {routeNoteKey && !sending && state !== 'sent' && !error && !notice ? (
           <p className="status-feedback-route">{t(routeNoteKey)}</p>
         ) : null}
@@ -1527,9 +1541,7 @@ function FeedbackPanel({
     <div className="status-feedback status-composer">
       <h3 className="status-feedback-title">{t(titleKey)}</h3>
       <p className="status-feedback-hint">{t(hintKey)}</p>
-      {chooseBuilder ? (
-        <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={state === 'sending'} />
-      ) : null}
+      {builderBadge}
       {routeNoteKey && state !== 'sent' && !error && !notice ? (
         <p className="status-feedback-route">{t(routeNoteKey)}</p>
       ) : null}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1452,20 +1452,18 @@ function FeedbackPanel({
       ? 'statusView.feedback.composerHintBuilding'
       : 'statusView.feedback.composerHint';
 
-  // Sticky builder signal: always when the next send can choose (Change gated on
-  // silence), and while a self round is mid-flight so routing stays visible without
-  // re-staging the create-wizard tiles. Platform mid-round stays chrome-free.
+  // Sticky builder signal in the composer toolbar (Claude/Cursor shape): always when
+  // the next send can choose, and while a self round is mid-flight so routing stays
+  // visible. Platform mid-round stays chrome-free — no selector until a boundary.
   const effectiveBuilder = chooseBuilder ? builder : (roundBuilder ?? builder);
   const showBuilderBadge = chooseBuilder || effectiveBuilder === 'self';
-  const builderBadge = showBuilderBadge ? (
-    <div className="builder-mode-row">
-      <BuilderModeBadge
-        value={effectiveBuilder}
-        onChange={handleBuilderChange}
-        canChange={chooseBuilder}
-        disabled={state === 'sending'}
-      />
-    </div>
+  const builderSelector = showBuilderBadge ? (
+    <BuilderModeBadge
+      value={effectiveBuilder}
+      onChange={handleBuilderChange}
+      canChange={chooseBuilder}
+      disabled={state === 'sending'}
+    />
   ) : null;
 
   // Standalone status page still shows a brief receipt next to Send. The studio
@@ -1489,11 +1487,9 @@ function FeedbackPanel({
       </div>
     ) : null;
 
-  // Compact is the thread's composer: a field and a send, the way a reply box looks
-  // everywhere else. The heading and the standing hint paragraph were page furniture —
-  // fine on a page read once, noise under a conversation you come back to. What the hint
-  // said still matters, so it becomes the placeholder: it is on screen exactly while the
-  // box is empty, which is when "where does this go?" is the open question.
+  // Compact is the thread's composer in the Claude / Cursor / Copilot shape: a clean
+  // field on top, controls in a bottom toolbar (builder selector left, send right).
+  // The heading and standing hint were page furniture — the placeholder carries them.
   if (compact) {
     const sending = state === 'sending';
     return (
@@ -1501,45 +1497,42 @@ function FeedbackPanel({
         className={`status-feedback status-composer is-compact${sending ? ' is-sending' : ''}`}
         aria-busy={sending || undefined}
       >
-        {builderBadge}
         {routeNoteKey && !sending && state !== 'sent' && !error && !notice ? (
           <p className="status-feedback-route">{t(routeNoteKey)}</p>
         ) : null}
-        {/* Field and send on one line. The button used to sit on a row of its own below
-            the box, which cost a phone screen an entire line to say what an arrow beside
-            the text says — and put the thing you tap furthest from the thing you typed.
-            Icon-only, so it stays a button rather than becoming a second column: the word
-            is longer in Polish than in English and would have set the width. */}
-        <div className="status-composer-row">
-          <textarea
-            ref={inputRef}
-            className="status-feedback-input"
-            value={text}
-            onChange={(event) => {
-              setText(event.target.value);
-              autoGrow();
-              if (state === 'sent') setState('idle');
-            }}
-            placeholder={t(composerHintKey)}
-            aria-label={t(titleKey)}
-            rows={1}
-            maxLength={2000}
-            disabled={sending}
-          />
-          <button
-            type="button"
-            className="primary-btn status-composer-send"
-            onClick={() => void send()}
-            disabled={sending || trimmed.length < 10}
-            aria-label={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
-            title={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
-          >
-            {sending ? (
-              <span className="status-composer-send-spinner" aria-hidden="true" />
-            ) : (
-              <PixelIcon name="arrowRight" size={13} />
-            )}
-          </button>
+        <textarea
+          ref={inputRef}
+          className="status-feedback-input"
+          value={text}
+          onChange={(event) => {
+            setText(event.target.value);
+            autoGrow();
+            if (state === 'sent') setState('idle');
+          }}
+          placeholder={t(composerHintKey)}
+          aria-label={t(titleKey)}
+          rows={1}
+          maxLength={2000}
+          disabled={sending}
+        />
+        <div className="status-composer-toolbar">
+          <div className="status-composer-toolbar-left">{builderSelector}</div>
+          <div className="status-composer-toolbar-right">
+            <button
+              type="button"
+              className="primary-btn status-composer-send"
+              onClick={() => void send()}
+              disabled={sending || trimmed.length < 10}
+              aria-label={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
+              title={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
+            >
+              {sending ? (
+                <span className="status-composer-send-spinner" aria-hidden="true" />
+              ) : (
+                <PixelIcon name="arrowRight" size={13} />
+              )}
+            </button>
+          </div>
         </div>
         {/* Failures, in-flight, and "kept but nothing started" still need a row — they
             ask the creator to wait or act. A plain Sent receipt does not: the thread
@@ -1566,7 +1559,7 @@ function FeedbackPanel({
     <div className="status-feedback status-composer">
       <h3 className="status-feedback-title">{t(titleKey)}</h3>
       <p className="status-feedback-hint">{t(hintKey)}</p>
-      {builderBadge}
+      {builderSelector ? <div className="builder-mode-row">{builderSelector}</div> : null}
       {routeNoteKey && state !== 'sent' && !error && !notice ? (
         <p className="status-feedback-route">{t(routeNoteKey)}</p>
       ) : null}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -142,7 +142,8 @@ function latestAgentActivityAt(status: SubmissionStatus | null): number | null {
 const PRESENCE_THOUGHT_MS = 90_000;
 
 /**
- * Ambient MCP presence for the thread bar — a thought headline, not a chat row.
+ * Ambient MCP presence for the live working turn — a thought headline on the
+ * pulsing last transcript row, not a durable chat bubble.
  * Fresh for {@link PRESENCE_THOUGHT_MS}; cleared server-side when real progress arrives.
  */
 function presenceThought(
@@ -684,6 +685,16 @@ export function SubmissionStatusView({
           t('statusView.gallery.caption'),
         )
       : [];
+    const agentWorking = Boolean(status && isAgentWorkActive(status));
+    const workingThought = status && agentWorking ? presenceThought(status) : null;
+    const workingThoughtLabel =
+      workingThought != null ? t(`statusView.presence.${workingThought.key}`, { defaultValue: '' }) : '';
+    const workingPhaseLabel =
+      status && agentWorking
+        ? status.phase === 'dispatched'
+          ? t('statusView.phaseLabels.dispatched')
+          : t(`statusView.states.${status.status}.label`)
+        : '';
     return (
       <>
         <div className="studio-thread">
@@ -713,7 +724,18 @@ export function SubmissionStatusView({
                 emptyLabel={stateDescription}
                 priorRounds={status.slug && status.priorRounds?.length ? status.priorRounds : undefined}
                 priorSlug={status.slug}
-                stickNonce={isAwaitingOwnAgent(status) ? pendingRevisions.length + 1 : 0}
+                stickNonce={(isAwaitingOwnAgent(status) ? pendingRevisions.length + 1 : 0) + (agentWorking ? 1 : 0)}
+                working={
+                  agentWorking
+                    ? {
+                        label: workingPhaseLabel,
+                        thoughtLabel: workingThoughtLabel || null,
+                        thoughtKey: workingThought?.key ?? null,
+                        thoughtAt: workingThought?.at ?? null,
+                        heartbeatAt,
+                      }
+                    : null
+                }
                 after={
                   isAwaitingOwnAgent(status) ? (
                     <StudioConnectCard
@@ -796,31 +818,34 @@ export function SubmissionStatusView({
                   </button>
                 ) : null}
 
-                {/* One waiting caption. While the connect card owns the thread, do not
-                    also spin "Writing code" — the agent is not writing; we are waiting. */}
-                <ThreadContextBar
-                  phase={
-                    isAwaitingOwnAgent(status)
-                      ? selfCopy === 'no_agent_yet'
-                        ? t('connect.waiting')
-                        : t('connect.resume.waiting')
-                      : isRemixDraft && (status.status === 'in_review' || status.phase === 'ready_for_review')
-                        ? t('statusView.remix.label')
-                        : status.phase === 'dispatched'
-                          ? t('statusView.phaseLabels.dispatched')
-                          : t(`statusView.states.${status.status}.label`)
-                  }
-                  thought={
-                    isAwaitingOwnAgent(status) ||
-                    TERMINAL_STATUSES.has(status.status) ||
-                    status.status === 'in_review' ||
-                    status.phase === 'ready_for_review'
-                      ? null
-                      : presenceThought(status)
-                  }
-                  heartbeatAt={isAwaitingOwnAgent(status) ? null : heartbeatAt}
-                  active={isAgentWorkActive(status)}
-                />
+                {/* Active "Writing code" lives as the last transcript turn (Claude-shaped).
+                    The foot bar is only for waiting / review captions — and never when the
+                    agent already called end (stall chip covers that; "Writing code" would lie). */}
+                {!isAgentWorkActive(status) && status.stall !== 'ended' && !status.agentEndedAt ? (
+                  <ThreadContextBar
+                    phase={
+                      isAwaitingOwnAgent(status)
+                        ? selfCopy === 'no_agent_yet'
+                          ? t('connect.waiting')
+                          : t('connect.resume.waiting')
+                        : isRemixDraft && (status.status === 'in_review' || status.phase === 'ready_for_review')
+                          ? t('statusView.remix.label')
+                          : status.phase === 'dispatched'
+                            ? t('statusView.phaseLabels.dispatched')
+                            : t(`statusView.states.${status.status}.label`)
+                    }
+                    thought={
+                      isAwaitingOwnAgent(status) ||
+                      TERMINAL_STATUSES.has(status.status) ||
+                      status.status === 'in_review' ||
+                      status.phase === 'ready_for_review'
+                        ? null
+                        : presenceThought(status)
+                    }
+                    heartbeatAt={isAwaitingOwnAgent(status) ? null : heartbeatAt}
+                    active={false}
+                  />
+                ) : null}
 
                 {/* Before the first agent signal there is nobody to receive a note — the
                     connect card is the only move. Quiet / gate-green still keep the box
@@ -1586,6 +1611,16 @@ function FeedbackPanel({
  * bottom as the agent talks — unless the reader has scrolled up, which is them saying
  * they are reading something and would like it to stay put.
  */
+type ThreadWorkingState = {
+  /** Coarse phase — "Writing code" / "Starting agent". */
+  label: string;
+  /** Fresh ambient presence thought, when one is flashing. */
+  thoughtLabel: string | null;
+  thoughtKey: string | null;
+  thoughtAt: number | null;
+  heartbeatAt: number | null;
+};
+
 function ThreadStream({
   token,
   entries,
@@ -1593,6 +1628,7 @@ function ThreadStream({
   priorRounds,
   priorSlug,
   after,
+  working = null,
   stickNonce = 0,
 }: {
   token: string;
@@ -1604,12 +1640,18 @@ function ThreadStream({
   /** Renders inside the scroller after the turns — tall surfaces (connect card) belong
    *  here, not in the pinned foot, or a phone has no room left for the conversation. */
   after?: ReactNode;
-  /** Bump when `after` appears/disappears so a stick-to-bottom reader still sees it. */
+  /**
+   * Live agent work — last row in the transcript (Claude-shaped), not a foot caption.
+   * Pulses while the agent is mid-build; cleared the moment work is no longer active.
+   */
+  working?: ThreadWorkingState | null;
+  /** Bump when `after` / `working` appears so a stick-to-bottom reader still sees it. */
   stickNonce?: number;
 }) {
   const { t, i18n } = useTranslation();
   const [zoomed, setZoomed] = useState<BuildMediaItem | null>(null);
   const [broken, setBroken] = useState<string[]>([]);
+  const [, setThoughtTick] = useState(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
 
@@ -1625,14 +1667,34 @@ function ThreadStream({
     const pane = scrollRef.current;
     if (!pane || !stickToBottomRef.current) return;
     pane.scrollTop = pane.scrollHeight;
-  }, [entries.length, stickNonce]);
+  }, [entries.length, stickNonce, working?.label, working?.thoughtLabel]);
+
+  // Presence ages out client-side; one timeout at expiry so the working line falls
+  // back to the coarse phase without waiting on the next status poll.
+  useEffect(() => {
+    if (!working?.thoughtAt || !working.thoughtLabel) return;
+    const remaining = working.thoughtAt + PRESENCE_THOUGHT_MS - Date.now();
+    if (remaining <= 0) {
+      setThoughtTick((n) => n + 1);
+      return;
+    }
+    const id = window.setTimeout(() => setThoughtTick((n) => n + 1), remaining);
+    return () => window.clearTimeout(id);
+  }, [working?.thoughtAt, working?.thoughtLabel]);
+
+  const thoughtFresh =
+    working?.thoughtAt != null &&
+    working.thoughtLabel != null &&
+    working.thoughtLabel.length > 0 &&
+    Date.now() - working.thoughtAt <= PRESENCE_THOUGHT_MS;
+  const workingHeadline = thoughtFresh && working?.thoughtLabel ? working.thoughtLabel : working?.label;
 
   return (
     <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
       {priorSlug && priorRounds && priorRounds.length > 0 ? (
         <StudioPriorRounds slug={priorSlug} rounds={priorRounds} />
       ) : null}
-      {entries.length === 0 ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
+      {entries.length === 0 && !working ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
       <ol className="studio-thread-turns">
         {entries.map((entry, index) => {
           const mine = entry.kind === 'revision';
@@ -1683,6 +1745,26 @@ function ThreadStream({
             </li>
           );
         })}
+        {working && workingHeadline ? (
+          <li className={`studio-turn is-working${thoughtFresh ? ' is-thought' : ''}`} aria-live="polite">
+            <div
+              className="studio-turn-working"
+              key={
+                thoughtFresh && working.thoughtKey
+                  ? `thought:${working.thoughtKey}:${working.thoughtAt}`
+                  : `phase:${working.label}`
+              }
+            >
+              <span className="studio-turn-working-pulse" aria-hidden="true" />
+              <span className="studio-turn-working-label">{workingHeadline}</span>
+            </div>
+            {working.heartbeatAt !== null ? (
+              <span className="studio-turn-time">
+                <BuildHeartbeat at={working.heartbeatAt} />
+              </span>
+            ) : null}
+          </li>
+        ) : null}
       </ol>
       {after}
       {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -728,8 +728,8 @@
       "not_dispatched": "The build hasn't been picked up by an agent yet. It's been waiting longer than expected — we're looking into it.",
       "quiet": "The agent has been quiet for a while. It may still be working — or you can send feedback below to start another round.",
       "quietSelf": "Your coding agent has been quiet. We can't start it from here — paste the prompt below into your agent when you're ready, or send a note that it will pick up on its next run.",
-      "ended": "Your coding agent finished this round. Send feedback below to continue, or switch to the platform builder.",
-      "endedSelf": "Your coding agent finished this round. Send a note below to continue with your agent, or choose the platform builder to hand the work over.",
+      "ended": "Your coding agent finished this round. Send feedback below to continue.",
+      "endedSelf": "Your coding agent finished this round. Send a note below to continue with your agent.",
       "gate_not_started": "The game was delivered, but verification hasn't started yet. This is on our side — no action needed from you.",
       "no_agent_yet": "No agent yet — this round waits for your coding agent. Follow the steps below to connect it."
     },
@@ -1013,6 +1013,14 @@
     "self": {
       "title": "My own coding agent",
       "detail": "You connect Claude Code, Codex, Cursor, or another agent."
+    },
+    "badge": {
+      "self": "Your agent (MCP)",
+      "platform": "Gamedev.pl agent",
+      "change": "Change",
+      "modalLede": "This applies to the next round. You can change again when no agent is working.",
+      "modalDone": "Done",
+      "modalClose": "Close"
     }
   },
   "connect": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1015,8 +1015,8 @@
       "detail": "You connect Claude Code, Codex, Cursor, or another agent."
     },
     "badge": {
-      "self": "Your agent (MCP)",
-      "platform": "Gamedev.pl agent",
+      "self": "Your agent",
+      "platform": "Gamedev.pl",
       "change": "Change",
       "modalLede": "This applies to the next round. You can change again when no agent is working.",
       "modalDone": "Done",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1019,8 +1019,8 @@
       "detail": "Podłączasz Claude Code, Codex, Cursor albo innego agenta."
     },
     "badge": {
-      "self": "Twój agent (MCP)",
-      "platform": "Agent Gamedev.pl",
+      "self": "Twój agent",
+      "platform": "Gamedev.pl",
       "change": "Zmień",
       "modalLede": "Dotyczy następnej rundy. Możesz zmienić ponownie, gdy żaden agent nie pracuje.",
       "modalDone": "Gotowe",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -732,8 +732,8 @@
       "not_dispatched": "Budowa nie została jeszcze podjęta przez agenta. Trwa to dłużej niż zwykle — sprawdzamy to.",
       "quiet": "Agent od dłuższej chwili nie daje znaku życia. Może wciąż pracuje — możesz też wysłać poniżej uwagi, aby rozpocząć kolejną rundę.",
       "quietSelf": "Twój agent od dłuższej chwili milczy. Nie możemy go stąd uruchomić — wklej poniżej prompt do swojego agenta, gdy będziesz gotowy, albo wyślij uwagę, którą odbierze przy następnym uruchomieniu.",
-      "ended": "Twój agent zakończył tę rundę. Wyślij uwagę poniżej, żeby kontynuować, albo przełącz na budowę platformową.",
-      "endedSelf": "Twój agent zakończył tę rundę. Wyślij uwagę poniżej, żeby kontynuować ze swoim agentem, albo wybierz budowę platformową, żeby przekazać pracę.",
+      "ended": "Twój agent zakończył tę rundę. Wyślij uwagę poniżej, żeby kontynuować.",
+      "endedSelf": "Twój agent zakończył tę rundę. Wyślij uwagę poniżej, żeby kontynuować ze swoim agentem.",
       "gate_not_started": "Gra została dostarczona, ale weryfikacja jeszcze się nie rozpoczęła. To po naszej stronie — nie musisz nic robić.",
       "no_agent_yet": "Nie ma jeszcze agenta — ta runda czeka na Twojego agenta. Wykonaj kroki poniżej, żeby go podłączyć."
     },
@@ -1017,6 +1017,14 @@
     "self": {
       "title": "Mój własny agent",
       "detail": "Podłączasz Claude Code, Codex, Cursor albo innego agenta."
+    },
+    "badge": {
+      "self": "Twój agent (MCP)",
+      "platform": "Agent Gamedev.pl",
+      "change": "Zmień",
+      "modalLede": "Dotyczy następnej rundy. Możesz zmienić ponownie, gdy żaden agent nie pracuje.",
+      "modalDone": "Gotowe",
+      "modalClose": "Zamknij"
     }
   },
   "connect": {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6170,7 +6170,94 @@ a.user-name--profile:focus-visible {
   }
 }
 
-/* Who builds this round — confirm screen and new-round composer. Two options, not a
+/* Sticky builder signal above the composer — continuity, not a peer fork. */
+.builder-mode-row {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 6px;
+  min-width: 0;
+}
+
+.builder-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 3px 4px 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border, #33383d);
+  background: color-mix(in srgb, var(--panel, #1a1d21) 88%, transparent);
+  font-size: 0.75rem;
+  line-height: 1.2;
+  color: var(--muted, #94a3b8);
+}
+
+.builder-mode-badge.is-self {
+  border-color: color-mix(in srgb, var(--turquoise, #00e4ac) 45%, var(--panel-border, #33383d));
+  color: color-mix(in srgb, var(--turquoise, #00e4ac) 70%, var(--muted, #94a3b8));
+}
+
+.builder-mode-badge-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.builder-mode-badge-change {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 14%, transparent);
+  color: var(--turquoise, #00e4ac);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.builder-mode-badge-change:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--turquoise, #00e4ac) 24%, transparent);
+}
+
+.builder-mode-badge-change:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.builder-choice-modal {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 28px 24px 20px;
+  max-width: 480px;
+  width: 92%;
+  position: relative;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  text-align: left;
+}
+
+.builder-choice-modal-title {
+  margin: 0 28px 8px 0;
+  font-size: 1.2rem;
+  color: var(--text-heading, #fff);
+}
+
+.builder-choice-modal-lede {
+  margin: 0 0 16px;
+  color: var(--muted, #94a3b8);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.builder-choice-modal-done {
+  width: 100%;
+  margin-top: 16px;
+}
+
+/* Who builds this round — create wizard and Change modal. Two options, not a
    settings dig; selection is a pressed state, matching the QA chip language. */
 .builder-choice {
   margin: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5684,12 +5684,16 @@ a.user-name--profile:focus-visible {
    below with nothing tying the two together. Moving it out here makes the box the thing
    you focus and the button something inside it — and the focus ring, now on the box,
    covers both. */
+/* Claude / Cursor / Copilot shape: one card, clean field on top, toolbar underneath. */
 .status-composer.is-compact {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   margin: 0;
-  padding: 5px 5px 5px 12px;
+  padding: 10px 12px 8px;
   border: 1px solid var(--panel-border);
-  border-radius: 18px;
+  border-radius: 16px;
   background: var(--panel-card);
   transition:
     border-color 0.2s,
@@ -5701,53 +5705,67 @@ a.user-name--profile:focus-visible {
   box-shadow: 0 0 0 3px rgba(0, 228, 172, 0.08);
 }
 
-/* Field and send share a line. `flex-end` rather than `center` so the button stays at
-   the bottom edge as the box grows into a paragraph, where the caret is — centred, it
-   drifts into the middle of a message. */
+/* Kept for any lingering standalone markup; compact uses the toolbar below. */
 .status-composer-row {
   display: flex;
   align-items: flex-end;
   gap: 8px;
 }
 
-.status-composer.is-compact .status-feedback-input {
+.status-composer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding-top: 2px;
+}
+
+.status-composer-toolbar-left,
+.status-composer-toolbar-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.status-composer-toolbar-left {
   flex: 1;
-  /* A flex item will not shrink below its content without this, and a long unbroken word
-     is enough to push the send button off the edge of a phone. */
+}
+
+.status-composer-toolbar-right {
+  flex: none;
+}
+
+.status-composer.is-compact .status-feedback-input {
+  width: 100%;
   min-width: 0;
   border: 0;
   border-radius: 0;
   background: none;
-  padding: 7px 0;
-  /* The box grows with the text instead (see autoGrow). A drag handle sitting in the
-     middle of the composer's right edge, now that the border belongs to the box rather
-     than the field, looked like something had gone wrong. */
+  padding: 2px 0 6px;
+  /* The box grows with the text instead (see autoGrow). */
   resize: none;
   overflow-y: auto;
-  line-height: 1.4;
-  /* One line at rest. It was five rems back when the placeholder ran to four lines; the
-     placeholder is one line now, so an empty box the height of a paragraph is just a
-     paragraph of the thread that nobody can read. */
-  min-height: 2.4rem;
+  line-height: 1.45;
+  /* One line at rest — empty box should not look like a paragraph of the thread. */
+  min-height: 1.6rem;
 }
 
 .status-composer.is-compact .status-feedback-input:focus {
-  /* The ring belongs to the box now — two of them nested looked like a bug. */
+  /* The ring belongs to the card — two nested rings looked like a bug. */
   outline: none;
   box-shadow: none;
 }
 
-/* A round tap target the size of the line beside it, holding an arrow instead of a verb.
-   The verb is what forced the button onto its own row: "Wyślij uwagi" is half the width
-   of a phone, and a label that long beside the field would have left the field narrower
-   than the message going into it. */
+/* Round send in the toolbar — icon-only so Polish labels never steal field width. */
 .status-composer.is-compact .status-composer-send {
   flex: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   padding: 0;
   border-radius: 50%;
 }
@@ -6231,61 +6249,62 @@ a.user-name--profile:focus-visible {
   }
 }
 
-/* Sticky builder signal above the composer — continuity, not a peer fork. */
+/* Standalone status page: builder control above the field. Compact uses the toolbar. */
 .builder-mode-row {
   display: flex;
-  justify-content: flex-end;
-  margin: 0 0 6px;
+  justify-content: flex-start;
+  margin: 0 0 8px;
   min-width: 0;
 }
 
-.builder-mode-badge {
+/* Model-picker shaped control — left of the send button, not a pill over the field. */
+.builder-mode-selector {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 5px;
   max-width: 100%;
   min-width: 0;
-  padding: 3px 4px 3px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--panel-border, #33383d);
-  background: color-mix(in srgb, var(--panel, #1a1d21) 88%, transparent);
-  font-size: 0.75rem;
-  line-height: 1.2;
+  margin: 0;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
   color: var(--muted, #94a3b8);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: default;
 }
 
-.builder-mode-badge.is-self {
-  border-color: color-mix(in srgb, var(--turquoise, #00e4ac) 45%, var(--panel-border, #33383d));
-  color: color-mix(in srgb, var(--turquoise, #00e4ac) 70%, var(--muted, #94a3b8));
+button.builder-mode-selector {
+  cursor: pointer;
 }
 
-.builder-mode-badge-label {
+button.builder-mode-selector:hover:not(:disabled) {
+  color: var(--text, #e8eef5);
+  background: color-mix(in srgb, var(--panel-border, #33383d) 55%, transparent);
+}
+
+button.builder-mode-selector:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.builder-mode-selector.is-self {
+  color: color-mix(in srgb, var(--turquoise, #00e4ac) 78%, var(--muted, #94a3b8));
+}
+
+.builder-mode-selector-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 
-.builder-mode-badge-change {
-  flex: 0 0 auto;
-  margin: 0;
-  padding: 4px 10px;
-  border: 0;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--turquoise, #00e4ac) 14%, transparent);
-  color: var(--turquoise, #00e4ac);
-  font: inherit;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.builder-mode-badge-change:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--turquoise, #00e4ac) 24%, transparent);
-}
-
-.builder-mode-badge-change:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
+.builder-mode-selector .pixel-icon {
+  flex: none;
+  opacity: 0.75;
 }
 
 .builder-choice-modal {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5333,6 +5333,67 @@ a.user-name--profile:focus-visible {
   opacity: 0.7;
 }
 
+/* Live agent work — last transcript row, Claude-shaped. Pulse is a mascot-colour
+   square so motion reads without another spinner next to the composer. */
+.studio-turn.is-working {
+  margin-top: 2px;
+}
+
+.studio-turn-working {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.studio-turn-working-pulse {
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border-radius: 2px;
+  background: var(--turquoise, #00e4ac);
+  box-shadow: 0 0 0 0 var(--turquoise-glow, rgba(0, 228, 172, 0.35));
+  animation: studio-working-pulse 1.4s ease-in-out infinite;
+}
+
+.studio-turn-working-label {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text);
+  line-height: 1.35;
+}
+
+.studio-turn.is-working.is-thought .studio-turn-working-label {
+  color: var(--turquoise);
+  animation: studio-thought-flash 0.55s ease-out;
+}
+
+@keyframes studio-working-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.92);
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+    box-shadow: 0 0 0 4px var(--turquoise-glow, rgba(0, 228, 172, 0.28));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .studio-turn-working-pulse {
+    animation: none;
+    opacity: 1;
+    box-shadow: none;
+  }
+
+  .studio-turn.is-working.is-thought .studio-turn-working-label {
+    animation: none;
+  }
+}
+
 .studio-turn-shots {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Round-boundary Studio no longer restages the create-wizard “Who builds this round?” dual tiles above the composer.

- **Create wizard (CUJ1):** unchanged — full builder step stays in `CreatorQA`.
- **Revisit / next round (CUJ2):** sticky last builder continues by default.
- **Composer (Claude / Cursor / Copilot shape):** clean textarea on top; bottom toolbar with builder selector left (`Your agent ▾` / `Gamedev.pl ▾`) and send right. Opens the same two-up choice in a modal. Changeable only while generation is silent; mid-work shows a static label.
- **Live work in the transcript:** while the agent is mid-build, “Writing code” (or a fresh presence thought) is the last thread turn with a pulsing turquoise square — not a foot caption. Ended rounds no longer leave a stale Writing code line.

## Test plan

- [x] `BuilderModeBadge` / `SubmissionStatusView` / locale unit tests
- [x] Green gate (`type-check`, `lint`, `test`, `build`)
- [x] Screenshot: Claude-shaped composer toolbar (working + ended)
- [x] Screenshot: Change modal from selector
- [ ] Manual: create wizard still shows full builder stage
- [ ] Manual: mid-build self round shows static selector without chevron
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e47ff7f-aa74-4961-a06a-2841f6b3a7a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e47ff7f-aa74-4961-a06a-2841f6b3a7a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

