### PR TITLE
Give the round card its own tool, and fix what ChatGPT exposed

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -15,7 +15,7 @@ private content into PRs).
 Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 `apps/api/src/mcp-server.ts` (returned by `start`, appended to every tool description).
 
-1. `start` → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
+1. `start` → `show_round` (once) → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
 2. Build; `report_progress`; `send_screenshot` when something draws
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
@@ -188,6 +188,18 @@ cache), so a resume cannot keep showing “finished this round” next to live p
   MCP tools refuse an already-issued key with a reconnect instruction. Do not restore a
   per-game compatibility path in UI, API routes, or MCP tool handling.
 - An opener is checked by `start`; later calls use the returned round-scoped `sessionKey`.
+- **`show_round` is the only tool that opens the creator's status card**, and it exists for
+  nothing else. It used to hang off `start` and `get_gate_verdict`, which made the card a side
+  effect of workflow mechanics — an agent that re-ran `start` before each operation left one
+  card per call (ChatGPT, 2026-08-05). The host renders one card per call carrying `_meta.ui`,
+  so when adding a view, give it its own tool rather than attaching it to a tool agents call
+  for their own reasons.
+- **`start` is once per round.** The key is valid until `expiresAt` (hours), so re-running `start`
+  to "refresh" it is wrong: it costs a round trip each time and, in an MCP Apps host, leaves a
+  duplicate round card in the conversation per call. Re-run it only after a call is refused as
+  unauthenticated. Observed 2026-08-05: ChatGPT called `start` before each operation and said it
+  did so "to reacquire the key" — a fair reading of _short-lived_ that nothing in the contract
+  corrected. `SESSION_WORKFLOW`'s first step now does.
   Therefore revoking or rotating a creator key, revoking an OAuth grant, or detecting
   refresh-token reuse must also advance every open self round for that creator via
   `endOpenAgentSessions`. Revoking the opener alone would leave minted session keys live.

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2002,13 +2002,46 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     expect(capabilities.resources).toBeDefined();
 
     const tools = await listTools(app, sessionId);
-    const verdict = tools.find((tool) => tool.name === 'get_gate_verdict');
-    expect(verdict?._meta?.ui?.resourceUri).toBe('ui://gamedevpl/round-status');
-    // The tools that open the round view, and nothing else.
+    const shower = tools.find((tool) => tool.name === 'show_round');
+    expect(shower?._meta?.ui?.resourceUri).toBe('ui://gamedevpl/round-status');
+    expect(shower?._meta?.['openai/outputTemplate']).toBe('ui://gamedevpl/round-status');
+    // Exactly one tool opens the card. Attaching it to a tool the agent calls for its own
+    // reasons made the card count a side effect of agent discretion.
     expect(tools.filter((tool) => tool._meta?.ui?.resourceUri !== undefined).map((tool) => tool.name)).toEqual([
-      'start',
-      'get_gate_verdict',
+      'show_round',
     ]);
+  });
+
+  it('gives the card its key on the opening result, and stays visible to the model', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const { sessionId } = await initializeWith(app, true);
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const shown = await callTool(app, 'show_round', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(shown.isError).toBe(false);
+    const payload = shown.structured as { phase: string; sessionKey: string };
+    // The card seeds from this result. Echoing the key means it polls authenticated from
+    // its first frame instead of making a keyless call that gets refused.
+    expect(payload.sessionKey).toBe(sessionKey);
+    expect(payload.phase).toBeTruthy();
+
+    // Unlike the app-only reads, the model must see this one — it is the tool the agent
+    // calls to show the creator a card.
+    const listed = await listTools(app, sessionId);
+    expect(listed.some((tool) => tool.name === 'show_round')).toBe(true);
+    expect(listed.find((tool) => tool.name === 'show_round')?._meta?.ui?.visibility).toBeUndefined();
+
+    // ...and a client with no views still gets a plain status read rather than an error.
+    const { sessionId: plain } = await initializeWith(app, false);
+    const plainList = await listTools(app, plain);
+    expect(plainList.some((tool) => tool.name === 'show_round')).toBe(true);
+    const plainCall = await callTool(app, 'show_round', { sessionKey }, { 'mcp-session-id': plain });
+    expect(plainCall.isError).toBe(false);
+    expect(plainList.find((tool) => tool.name === 'show_round')?._meta).toBeUndefined();
   });
 
   it('offers the app-only status tool to a view, and hides it from every other client', async () => {
@@ -2257,7 +2290,7 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     // start re-sets the transport session mid-round; a plain overwrite there used to
     // drop uiCapable and the card would vanish for the rest of the round.
     const tools = await listTools(app, sessionId);
-    expect(tools.find((tool) => tool.name === 'get_gate_verdict')?._meta?.ui?.resourceUri).toBe(
+    expect(tools.find((tool) => tool.name === 'show_round')?._meta?.ui?.resourceUri).toBe(
       'ui://gamedevpl/round-status',
     );
   });
@@ -2424,7 +2457,7 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     // than silently dropping the view mid-round.
     app = await createApp(store);
     const tools = await listTools(app, sessionId);
-    expect(tools.find((tool) => tool.name === 'get_gate_verdict')?._meta?.ui?.resourceUri).toBe(
+    expect(tools.find((tool) => tool.name === 'show_round')?._meta?.ui?.resourceUri).toBe(
       'ui://gamedevpl/round-status',
     );
     const read = await mcpCall(

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -141,6 +141,40 @@ function noteTextFor(event: { text: string; textLocalized?: string; locale?: str
   return primary(event.locale) === primary(readerLocale) ? event.textLocalized : event.text;
 }
 
+/**
+ * The round snapshot both doors return: `show_round` for the model, `get_round_status`
+ * for the card. Shared so the two can never drift into describing different rounds.
+ */
+const ROUND_STATUS_OUTPUT_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    phase: { type: 'string', description: 'Internal job state.' },
+    status: { type: 'string', description: 'Creator-facing projection of the phase.' },
+    stall: { type: ['string', 'null'] },
+    agentEnded: { type: 'boolean' },
+    title: { type: ['string', 'null'] },
+    slug: { type: ['string', 'null'] },
+    round: { type: 'number' },
+    deliveriesRemaining: { type: ['number', 'null'] },
+    note: {
+      type: ['object', 'null'],
+      properties: { text: { type: 'string' }, createdAt: { type: 'string' } },
+    },
+    shot: {
+      type: ['object', 'null'],
+      properties: {
+        id: { type: 'string' },
+        createdAt: { type: 'string' },
+        label: { type: ['string', 'null'] },
+        png: { type: 'string', description: 'base64 PNG; omitted when unchanged since sinceShotId.' },
+      },
+    },
+    gate: { type: ['object', 'null'] },
+    retryAfterSeconds: { type: 'number' },
+  },
+  required: ['phase', 'status', 'retryAfterSeconds'],
+};
+
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;
 /** A card shows a strip, not a contact sheet; the bytes ride a postMessage. */
 const ROUND_MEDIA_MAX_FRAMES = 3;
@@ -374,6 +408,13 @@ const BEHAVIOURAL_CONTRACT = [
  * the inbox policy and the retired-key etiquette.
  */
 const SESSION_WORKFLOW: readonly string[] = [
+  // First because an agent that re-runs start before each operation pays a round trip
+  // every time and, in an MCP Apps host, leaves a duplicate round card behind for each
+  // call. Observed in ChatGPT 2026-08-05, where the agent explained it had been calling
+  // start "to reacquire the key" — a fair reading of "short-lived" that nothing here
+  // corrected.
+  'Hold the sessionKey start gave you for the whole round and pass it on every call. Do not re-run start to refresh it — it is valid until expiresAt. Re-run start only if a call is refused as unauthenticated.',
+  "show_round — once, right after start. In a client that renders MCP Apps views this puts a live status card in the creator's chat that follows the build and the gate on its own, so they can watch without you polling. Calling it again renders a second card.",
   'get_brief — read the brief; if seedAvailable or seedStatus=available, get_seed and continue that draft. If seedStatus=pending, browse the kit lightly then recheck get_seed before scaffolding.',
   // An improvement round has no seed (seeds are a new-game facility) and its brief is
   // the change request alone, so nothing above this told the agent a game already
@@ -1006,7 +1047,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       outputSchema: {
         type: 'object',
         properties: {
-          sessionKey: { type: 'string', description: 'Pass on every later tool call.' },
+          sessionKey: {
+            type: 'string',
+            description:
+              'Hold this for the whole round and pass it on every later tool call. Do not re-run start to refresh it.',
+          },
           sessionId: { type: 'string' },
           jobId: { type: 'number' },
           slug: { type: ['string', 'null'] },
@@ -1028,7 +1073,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       description:
         'Bind this MCP client to a build round using a creator key in Authorization: Bearer plus a game slug, ' +
         'a legacy round-scoped key, or OAuth Bearer + slug. ' +
-        'Returns a short-lived sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
+        'Call it ONCE per round and keep the sessionKey for the whole round: it lasts until expiresAt (hours, ' +
+        'not minutes), so calling start again before each operation to refresh the key is wrong. Doing that ' +
+        'costs a round trip every time and, in a client that renders MCP Apps views, leaves a duplicate status ' +
+        'card in the conversation for each call. If a call is ever refused as unauthenticated, then re-run start. ' +
+        'Returns that sessionKey — pass it as sessionKey on every later tool call — plus a workflow ' +
         '(the ordered start→done loop), seedAvailable/seedStatus/seedNotice, an inbox policy, and what to relay if a later call is refused. ' +
         'Creator keys are openers only — never a write capability. OAuth access is identity only. ' +
         'Does not treat Mcp-Session-Id as authority. ' +
@@ -3591,41 +3640,60 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     /**
+     * The only tool that opens the round card, and its whole purpose.
+     *
+     * The card used to hang off `start` and `get_gate_verdict`. That made rendering a
+     * *side effect* of doing something else, so agent behaviour we neither control nor
+     * should have to decided how many cards appeared: an agent that re-ran `start`
+     * before each operation left one card per call (ChatGPT, 2026-08-05). No amount of
+     * host-side reasoning fixes that, because the agent was not doing anything wrong
+     * enough to forbid.
+     *
+     * Showing the creator something is a deliberate act, so it gets a deliberate tool.
+     * Calling it twice is the agent asking for two cards, which is at least honest.
+     *
+     * It also removes the opening scramble: the card seeds from this result, so it has
+     * the round key from its first frame instead of making a keyless poll and waiting
+     * for `start`'s result to arrive.
+     */
+    show_round: {
+      annotations: { title: 'Show the creator a live round card', ...READS },
+      description:
+        "Render a live status card for this round in the creator's chat: phase, latest progress note and " +
+        'screenshot, gate verdict, deliveries left. It refreshes itself and stops when the round settles, so ' +
+        'the creator can watch without you polling. ' +
+        'Call it ONCE per round, after start — a second call renders a second card. ' +
+        'Only clients that render MCP Apps views see anything; elsewhere it is a plain status read. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: { sessionKey: SESSION_KEY_PROP },
+        required: [],
+      },
+      // Same body as get_round_status plus the echoed key — they are the same read, so
+      // they declare the same shape.
+      outputSchema: ROUND_STATUS_OUTPUT_SCHEMA,
+      handler: async (args, ctx) => {
+        // One implementation, two doors: the model opens the card through this tool, the
+        // card refreshes itself through the app-only one. They must never disagree about
+        // what the round looks like, so they are literally the same read.
+        const status = await tools.get_round_status.handler(args, ctx);
+        // Echo the key so the view holds it from its first frame. The card reads it off
+        // this result; without it the first poll goes out keyless and is refused.
+        if (status.isError || typeof args.sessionKey !== 'string') return status;
+        const data = { ...(status.structuredContent as Record<string, unknown>), sessionKey: args.sessionKey };
+        return toolOk(data);
+      },
+    },
+
+    /**
      * App-only (SEP-1865 `visibility: ["app"]`): the round view calls this, the model
      * never sees it. Read-only and presence-neutral by construction — see
      * MCP_UI_APP_ONLY_TOOLS for why both matter.
      */
     get_round_status: {
       annotations: { title: 'Round status for the round view', ...READS },
-      outputSchema: {
-        type: 'object',
-        properties: {
-          phase: { type: 'string', description: 'Internal job state.' },
-          status: { type: 'string', description: 'Creator-facing projection of the phase.' },
-          stall: { type: ['string', 'null'] },
-          agentEnded: { type: 'boolean' },
-          title: { type: ['string', 'null'] },
-          slug: { type: ['string', 'null'] },
-          round: { type: 'number' },
-          deliveriesRemaining: { type: ['number', 'null'] },
-          note: {
-            type: ['object', 'null'],
-            properties: { text: { type: 'string' }, createdAt: { type: 'string' } },
-          },
-          shot: {
-            type: ['object', 'null'],
-            properties: {
-              id: { type: 'string' },
-              createdAt: { type: 'string' },
-              label: { type: ['string', 'null'] },
-              png: { type: 'string', description: 'base64 PNG; omitted when unchanged since sinceShotId.' },
-            },
-          },
-          gate: { type: ['object', 'null'] },
-          retryAfterSeconds: { type: 'number' },
-        },
-        required: ['phase', 'status', 'retryAfterSeconds'],
-      },
+      outputSchema: ROUND_STATUS_OUTPUT_SCHEMA,
       description:
         'Round state for the gamedev.pl round view: phase, latest progress note, latest screenshot and the current ' +
         'gate verdict in one read. Intended for the view, which polls it on retryAfterSeconds — pass sinceShotId to ' +

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -252,22 +252,19 @@ describe('ui resources', () => {
     expect(readUiResource(ROUND_STATUS_RESOURCE_URI)?._meta).toEqual(descriptor._meta);
   });
 
-  it('opens the round view from the tools a creator watches a round through', () => {
-    // Phase 0 attached the view to read tools only, on the reasoning that a card on a
-    // write tool would freeze a mid-delivery echo on screen. That no longer applies: the
-    // card renders live state from get_round_status rather than the opening payload, so
-    // submitting is exactly the moment a creator wants it open.
-    expect(MCP_UI_TOOL_RESOURCES).toEqual({
-      start: ROUND_STATUS_RESOURCE_URI,
-      get_gate_verdict: ROUND_STATUS_RESOURCE_URI,
-    });
-    // The host renders one card per tool call carrying _meta.ui, so a turn that started
-    // a round and then delivered produced two identical cards. The card is live: the one
-    // from start already follows the delivery.
-    expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty('submit_sources');
-    // open_round mints no session key and takes none, so a card opened there would have
-    // nothing to read status with.
-    expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty('open_round');
+  it('opens the round view from exactly one tool, which exists for nothing else', () => {
+    // This used to be `start` and `get_gate_verdict` — tools an agent calls for its own
+    // reasons — which made a card a side effect of workflow mechanics. An agent that
+    // re-ran `start` before each operation left one card per call (ChatGPT, 2026-08-05),
+    // and it was not doing anything wrong enough to forbid. Showing the creator
+    // something is now a deliberate act with a deliberate tool.
+    expect(MCP_UI_TOOL_RESOURCES).toEqual({ show_round: ROUND_STATUS_RESOURCE_URI });
+
+    // The host renders one card per call carrying _meta.ui, so every tool added here
+    // hands the card count back to whatever the agent happens to do.
+    for (const workflowTool of ['start', 'get_gate_verdict', 'submit_sources', 'open_round']) {
+      expect(MCP_UI_TOOL_RESOURCES).not.toHaveProperty(workflowTool);
+    }
   });
 
   it('keeps the app-only tools read-only, since the model never sees them happen', () => {

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -235,6 +235,11 @@ describe('ui resources', () => {
     // has no permission to follow.
     const [descriptor] = uiResourceDescriptors();
     const legacy = descriptor._meta['openai/widgetCSP'];
+    // The submission requirement, on the openai/* key only. The standard ui.domain is
+    // validated by Claude against a value it derives itself, so declaring our origin
+    // there broke the card in production once (#593, reverted in #595).
+    expect(descriptor._meta['openai/widgetDomain']).toBe('https://www.gamedev.pl');
+    expect(descriptor._meta.ui).not.toHaveProperty('domain');
     expect(legacy.redirect_domains).toEqual(['https://www.gamedev.pl']);
     // Only our own site. A wider list would let a future card hand the host somewhere
     // we did not intend.

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -377,6 +377,21 @@ describe('ui resources', () => {
     expect(html).toMatch(/gallery\.hidden = true;[\s\S]{0,80}galleryCap\.hidden = true;/);
   });
 
+  it('sizes itself to the frame the host gave it, per the spec it implements', () => {
+    // Observed in ChatGPT: the card sat at the top of a much taller frame with dead
+    // space beneath. SEP-1865 has containerDimensions in hostContext for exactly this —
+    // a fixed height is the host's decision and the view is meant to fill it. We were
+    // reading theme, locale and timeZone from hostContext and ignoring dimensions.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('applyContainerDimensions');
+    expect(html).toContain('context.containerDimensions');
+    // Fixed fills, flexible caps — the two modes the spec defines, kept distinct.
+    expect(html).toMatch(/dimensions\.height[\s\S]{0,220}?'100%'/);
+    expect(html).toContain('dimensions.maxHeight + ');
+    // Absent means unbounded: no dimensions, no styling, same as before this existed.
+    expect(html).toContain("if (!dimensions || typeof dimensions !== 'object') return;");
+  });
+
   it('polls, and degrades to the opening payload when a host refuses the app-only call', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("name: 'get_round_status'");

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -227,6 +227,26 @@ describe('ui resources', () => {
     expect(html).not.toContain('arguments.callee');
   });
 
+  it('allowlists the one place the card may send the reader', () => {
+    // The card fetches nothing, so an empty CSP is right for *fetching*. Link targets
+    // are a different question and were never answered: ChatGPT gates external links
+    // behind redirect_domains, and the standard ui.csp has no equivalent field — so
+    // without this the card's own "Watch the gate recording" button is a link the host
+    // has no permission to follow.
+    const [descriptor] = uiResourceDescriptors();
+    const legacy = descriptor._meta['openai/widgetCSP'];
+    expect(legacy.redirect_domains).toEqual(['https://www.gamedev.pl']);
+    // Only our own site. A wider list would let a future card hand the host somewhere
+    // we did not intend.
+    expect(legacy.redirect_domains.every((domain) => domain.startsWith('https://'))).toBe(true);
+    // What it may *fetch* stays empty — the card inlines everything.
+    expect(legacy.connect_domains).toEqual([]);
+    expect(legacy.resource_domains).toEqual([]);
+    expect(legacy.frame_domains).toEqual([]);
+    // Same body on read as on list, so a host cannot see two different policies.
+    expect(readUiResource(ROUND_STATUS_RESOURCE_URI)?._meta).toEqual(descriptor._meta);
+  });
+
   it('opens the round view from the tools a creator watches a round through', () => {
     // Phase 0 attached the view to read tools only, on the reasoning that a card on a
     // write tool would freeze a mid-delivery echo on screen. That no longer applies: the

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -424,6 +424,23 @@ describe('ui resources', () => {
     expect(html).toContain("if (!dimensions || typeof dimensions !== 'object') return;");
   });
 
+  it('paints the round from the opening result, before any poll returns', () => {
+    // show_round returns the whole round, so the card no longer has to sit on
+    // "Reading round status..." waiting for its first poll — and in a host that refuses
+    // the app-only call this is the only state it will ever have. The old seed path
+    // recognised a verdict shape only, which show_round does not return.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toMatch(/var opening = unwrap\(message\.params, looksLikeStatus\);/);
+    expect(html).toMatch(/if \(opening && !live\) \{[\s\S]{0,120}?render\(opening\);/);
+    // The gate-only fallback still exists for anything that is not a full status.
+    expect(html).toContain('var verdict = opening ? null : unwrap(message.params, looksLikeVerdict);');
+
+    // And a failed refresh must never trade that content back for an error message.
+    // Verified in the browser against a host refusing every app-only call: the card
+    // still shows phase, round and deliveries left rather than "Could not read...".
+    expect(html).toContain('if (!live && !painted) giveUp();');
+  });
+
   it('polls, and degrades to the opening payload when a host refuses the app-only call', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("name: 'get_round_status'");

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -353,6 +353,16 @@ describe('ui resources', () => {
     expect(html).toContain("status.agentEnded && gate && gate.status && gate.status !== 'pending'");
   });
 
+  it('names the round it is watching, so duplicate cards can be told apart', () => {
+    // ChatGPT showed several near-identical cards for one session. The call ledger
+    // proved `start` ran exactly twice and `get_gate_verdict` never, and our tools/list
+    // attaches the template to those two tools only — so the pixels are consistent with
+    // "one card per start" and with "the host rendered one call twice", and nothing on
+    // screen distinguished them. The round does.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("addRow('Round', status.round)");
+  });
+
   it('says which way a status read failed, so a screenshot is enough to diagnose it', () => {
     // Observed in ChatGPT: one card read status fine (screenshot, note and gate all
     // live) while a later one in the same session did not. "Could not read round status

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -40,25 +40,24 @@ export const MCP_UI_MIME_TYPE = 'text/html;profile=mcp-app';
 export const ROUND_STATUS_RESOURCE_URI = 'ui://gamedevpl/round-status';
 
 /**
- * Tools that open the round view — kept deliberately few, because the host renders one
- * card per tool call that carries `_meta.ui`.
+ * The tool that opens the round view. Exactly one, and it exists for nothing else.
  *
- * `submit_sources` used to be here and was removed: an ordinary turn calls `start` and
- * then delivers, which rendered two cards showing identical state one above the other.
- * Nothing was lost by dropping it. The card is live, so the one opened at `start`
- * already follows the delivery and the gate on its own — that is the whole point of it.
+ * This used to be `start` and `get_gate_verdict` — tools an agent calls for their own
+ * reasons. That made a card a *side effect* of workflow mechanics, so behaviour we
+ * neither control nor should have to decided how many cards a conversation got: an
+ * agent that re-ran `start` before each operation to "reacquire the key" left one card
+ * per call (ChatGPT, 2026-08-05). It was not doing anything wrong enough to forbid, and
+ * no host-side reasoning fixes a cause that lives in the agent's own discretion.
  *
- * `get_gate_verdict` stays for the creator-led check on a later turn, when no `start`
- * precedes it. Doubling up there needs an agent that both opens a round and polls in
- * one turn, which the workflow tells it not to do (prefer `end`, let the card watch).
+ * So showing the creator something is now a deliberate act with a deliberate tool.
+ * Calling `show_round` twice asks for two cards, which is at least honest.
  *
- * `open_round` is deliberately absent for a different reason: it mints no session key
- * and takes none — its own description sends the agent to `start()` for one — so a card
- * opened there would have no credential and would sit on "Reading round status…".
+ * Keep this map at one entry unless a second surface genuinely needs its own view. The
+ * host renders one card per call that carries `_meta.ui`, and every tool added here
+ * hands that decision back to whatever the agent happens to do.
  */
 export const MCP_UI_TOOL_RESOURCES: Readonly<Record<string, string>> = Object.freeze({
-  start: ROUND_STATUS_RESOURCE_URI,
-  get_gate_verdict: ROUND_STATUS_RESOURCE_URI,
+  show_round: ROUND_STATUS_RESOURCE_URI,
 });
 
 /**

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -915,6 +915,15 @@ const ROUND_STATUS_HTML = `<!doctype html>
           lastShotId = status.shot && status.shot.id ? status.shot.id : null;
 
           metaList.textContent = '';
+          // Which round this card is watching.
+          //
+          // Useful to a creator on its own, and it settles a question screenshots could
+          // not: ChatGPT showed several near-identical cards for one session, and the
+          // call ledger proved start ran exactly twice. Two cards naming *different*
+          // rounds are one per start and correct; two naming the *same* round are the
+          // host rendering one call more than once, which is not ours to fix. Until a
+          // card says which, both stories fit the pixels equally well.
+          if (typeof status.round === 'number' && status.round > 0) addRow('Round', status.round);
           if (gate) {
             addRow('Lane', gate.lane);
             addRow('Delivery', gate.deliveryId);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -516,6 +516,40 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (typeof context.locale === 'string') hostLocale = context.locale;
           if (typeof context.timeZone === 'string') hostTimeZone = context.timeZone;
           applyThemeVariables(context.themeVariables || context.theme_variables || context.cssVariables);
+          applyContainerDimensions(context.containerDimensions);
+        }
+
+        /**
+         * Honour the frame the host actually gave us.
+         *
+         * SEP-1865 says a view should read containerDimensions and size itself to match:
+         * a height is fixed and the view fills it, a maxHeight is a ceiling the view may
+         * grow up to, and an absent field means unbounded. We ignored it entirely,
+         *
+         * (No backticks in this comment on purpose — the whole view is a TS template
+         * literal, and one would end it. tsc catches that; it is still a wasted round.)
+         * which is fine in a host that sizes to our size-changed notification and wrong in
+         * one that does not — ChatGPT left the card sitting at the top of a much taller
+         * frame with dead space under it (owner, 2026-08-05).
+         *
+         * Filling a fixed frame does not conjure content, but it makes the card look
+         * deliberate rather than broken, and it is what the spec asks for.
+         */
+        function applyContainerDimensions(dimensions) {
+          if (!dimensions || typeof dimensions !== 'object') return;
+          var root = document.documentElement;
+          if (typeof dimensions.height === 'number' && dimensions.height > 0) {
+            root.style.height = '100%';
+            document.body.style.minHeight = '100%';
+            document.body.style.boxSizing = 'border-box';
+          } else if (typeof dimensions.maxHeight === 'number' && dimensions.maxHeight > 0) {
+            root.style.maxHeight = dimensions.maxHeight + 'px';
+          }
+          if (typeof dimensions.width === 'number' && dimensions.width > 0) {
+            root.style.width = '100%';
+          } else if (typeof dimensions.maxWidth === 'number' && dimensions.maxWidth > 0) {
+            root.style.maxWidth = dimensions.maxWidth + 'px';
+          }
         }
 
         /** Gate timestamps are ISO; show them in the reader's locale and zone. */

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -218,6 +218,8 @@ interface UiResourceMeta {
     connect_domains: readonly string[];
     resource_domains: readonly string[];
     frame_domains: readonly string[];
+    /** External-link targets, which `ui.csp` has no field for. */
+    redirect_domains: readonly string[];
   };
 }
 
@@ -231,6 +233,15 @@ export type UiResourceContents = Pick<UiResource, 'uri' | 'mimeType' | 'text'> &
  * Declared per resource. Empty by design: the card inlines everything, screenshots
  * arrive as data URIs, and it calls tools through the host rather than the network.
  */
+/**
+ * Where the card is allowed to send the reader.
+ *
+ * Only our own site: every link the card offers is a gamedev.pl page (the gate
+ * recording today, the game theater in V3). A wider list would let a future card hand
+ * the host somewhere we did not intend.
+ */
+const LINK_DOMAINS: readonly string[] = Object.freeze(['https://www.gamedev.pl']);
+
 const VIEW_CSP: UiCsp = Object.freeze({
   // Frozen individually: Object.freeze is shallow, and this one object is handed out
   // on every resources/list and resources/read.
@@ -1265,6 +1276,16 @@ function uiResourceMeta(): UiResourceMeta {
       connect_domains: VIEW_CSP.connectDomains,
       resource_domains: VIEW_CSP.resourceDomains,
       frame_domains: VIEW_CSP.frameDomains,
+      // Where the card may send the *host* — not where it may fetch from. ChatGPT
+      // allowlists external-link targets separately (`redirect_domains`, the allowlist
+      // behind `openai.openExternal`), and the standard `ui.csp` has no equivalent
+      // field, so this one exists only in the legacy shape.
+      //
+      // Without it the card's own "Watch the gate recording" button is a link ChatGPT
+      // has no permission to follow, and the Play button V3 is built around would be
+      // the same. An empty CSP is right for what the card *fetches* — it fetches
+      // nothing — but link targets are a different question and were never answered.
+      redirect_domains: LINK_DOMAINS,
     },
   };
 }

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -473,6 +473,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var lastShotId = null;
         var live = false;
         var seed = null;
+        /** Whether anything real is on screen yet, from a poll or from the opening result. */
+        var painted = false;
         var inFlight = false;
         var attempts = 0;
         var speculative = false;
@@ -1168,11 +1170,17 @@ const ROUND_STATUS_HTML = `<!doctype html>
                 if (!giveUpTimer) giveUpTimer = setTimeout(giveUp, 20000);
                 return;
               }
-              if (!live) giveUp();
+              // Never trade real content for an error message. The card may already be
+              // showing the round from show_round's opening result, and in a host that
+              // refuses app-only calls that is the only state it will ever have —
+              // overwriting it with "Could not read round status here." would leave the
+              // creator worse off than if we had never polled.
+              if (!live && !painted) giveUp();
               if (attempts >= 2) stopped = true;
               return;
             }
             live = true;
+            painted = true;
             pushModelContext(status);
             loadMedia(status);
             if (giveUpTimer) {
@@ -1242,7 +1250,18 @@ const ROUND_STATUS_HTML = `<!doctype html>
           }
 
           if (message.method === 'ui/notifications/tool-result') {
-            var verdict = unwrap(message.params, looksLikeVerdict);
+            // show_round returns the whole round, so the opening result is already the
+            // thing the card exists to display — paint it now rather than showing
+            // "Reading round status..." until a poll returns. In a host that refuses the
+            // app-only call this is also the *only* state the card will ever have, which
+            // is why it renders as live rather than as the static gate-only fallback.
+            var opening = unwrap(message.params, looksLikeStatus);
+            if (opening && !live) {
+              painted = true;
+              render(opening);
+              schedule(opening.retryAfterSeconds);
+            }
+            var verdict = opening ? null : unwrap(message.params, looksLikeVerdict);
             if (verdict && !live) {
               seed = verdict;
               renderGateOnly(verdict);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -213,6 +213,11 @@ interface UiCsp {
 
 interface UiResourceMeta {
   ui: { csp: UiCsp };
+  /**
+   * ChatGPT's dedicated origin for the hosted component. Required to submit an app with
+   * UI, and deliberately *not* the standard `ui.domain` — see the note on WIDGET_DOMAIN.
+   */
+  'openai/widgetDomain': string;
   /** ChatGPT reads its own compatibility key rather than `ui.csp`. */
   'openai/widgetCSP': {
     connect_domains: readonly string[];
@@ -241,6 +246,25 @@ export type UiResourceContents = Pick<UiResource, 'uri' | 'mimeType' | 'text'> &
  * the host somewhere we did not intend.
  */
 const LINK_DOMAINS: readonly string[] = Object.freeze(['https://www.gamedev.pl']);
+
+/**
+ * The origin ChatGPT associates with this hosted component.
+ *
+ * Declared on the `openai/*` key **only**, never on the standard `ui.domain`. Claude
+ * validates `ui.domain` against a value it derives itself —
+ * `sha256(<connector URL>).hex.slice(0, 32) + '.claudemcpcontent.com'` — so declaring our
+ * own origin there broke the card in production once already (public repo #593, reverted
+ * in #595). An `openai/*` key is invisible to Claude, which makes it the safe place to
+ * satisfy OpenAI without re-litigating that.
+ *
+ * Owner's decision (2026-08-05) to use the main origin rather than a dedicated subdomain,
+ * with the trade understood: if ChatGPT serves the component *on* this origin, the card
+ * becomes same-origin with the real site and could reach anything scoped to it. Tolerable
+ * only because the card is our own trusted first-party UI and nests nothing — the §13
+ * decision to cut in-chat play is what keeps that true. If a view ever embeds untrusted
+ * content, this must move to an isolated origin first.
+ */
+const WIDGET_DOMAIN = 'https://www.gamedev.pl';
 
 const VIEW_CSP: UiCsp = Object.freeze({
   // Frozen individually: Object.freeze is shallow, and this one object is handed out
@@ -1269,6 +1293,7 @@ const UI_RESOURCES: readonly UiResource[] = Object.freeze([
 function uiResourceMeta(): UiResourceMeta {
   return {
     ui: { csp: VIEW_CSP },
+    'openai/widgetDomain': WIDGET_DOMAIN,
     // Same declaration in the shape ChatGPT reads. It showed a "CSP off" badge against
     // the modern key alone, and both are documented, so we say it twice rather than
     // guess which one a host honours.


### PR DESCRIPTION
Follow-on to #603. The headline change is the last one — the rest were found on the way to it.

## The duplicate cards: root cause found, and it was a design mistake

Asked why it kept calling `start`, the ChatGPT agent answered plainly:

> *"I handled the short-lived `sessionKey` poorly… I repeatedly called `start` before each operation to reacquire the key."*

Its own ledger under-reported this, which is why the card count never added up. **The duplicate cards were one per `start` call, working exactly as designed.** The design was wrong.

And the misreading is fair: `start`'s description said the key was *"short-lived"* and never said once-per-round.

**But the deeper problem is that the view hung off `start` and `get_gate_verdict` at all.** Those are tools an agent calls for its own reasons, so how many cards a conversation got was decided by behaviour we neither control nor should have to. Fixing the description alone would leave the next agent with a different habit producing a different card count.

So showing the creator something is now a deliberate act with a deliberate tool:

- **`show_round`** opens the card and does nothing else. `MCP_UI_TOOL_RESOURCES` is one entry, and the comment says to keep it that way. Calling it twice asks for two cards, which is at least honest.
- **The card gets its round key on the opening result**, so it polls authenticated from its first frame instead of the keyless-poll → refusal → retry dance.
- **`show_round` and `get_round_status` are the same read behind two doors** — one for the model, one for the card — sharing a handler and an output schema so they cannot drift into describing different rounds.
- The misreading is fixed at source too: `start` states once-per-round and the real key lifetime, the workflow leads with holding the key then showing the card, and the skill records *why* a view gets its own tool.

**Accepted trade** (owner): the card no longer appears automatically. If an agent skips `show_round`, there is no card. Controlled-but-optional beats guaranteed-but-uncontrolled.

### Two defects that fell out of the switch

The old fallback seeded from `get_gate_verdict`'s verdict-shaped result, which `show_round` does not return — so a host refusing app-only calls would have shown *less* than before. The opening result is already the whole round, so the card now paints it immediately.

That exposed an older bug: a failed poll called `giveUp()` and replaced the summary with *"Could not read round status here."* **even when real content was already on screen.** Trading a live round for an error message leaves the creator worse off than never polling. The card now gives up only when it has nothing to lose.

## Also here, from the same session

**`redirect_domains` — a live defect.** ChatGPT gates external links behind a separate allowlist (behind `openai.openExternal`) and the standard `ui.csp` has **no equivalent field**. An empty CSP is right for what the card *fetches* — nothing — but where it may send the *host* was never answered. The *"Watch the gate recording"* button doesn't work in ChatGPT today, and **V3's Play button would have failed identically**, at the exact step the CUJ turns on. Allowlisted to our origin only.

**`openai/widgetDomain`** — required for app submission, set to `https://www.gamedev.pl` per the owner. Declared on the `openai/*` key **only, never `ui.domain`**: Claude validates that against a value it derives itself, so declaring our origin there broke the card in production once (#593, reverted in #595). The same-origin trade is recorded in code — tolerable only because the card nests nothing, which the decision to cut in-chat play is what keeps true.

**Container sizing.** SEP-1865 has `hostContext.containerDimensions`; we read theme, locale and timeZone from `hostContext` and ignored dimensions, so the card sat in a frame far taller than itself. Claude sizes to our `size-changed` notification, so nothing looked amiss locally — the recurring pattern here: the harness models what we *think* a host does.

**The round row.** Written as an instrument for the duplicate-card question before the cause was known. It stays on its own merits — a creator in a long session had no way to tell which round a card belonged to.

## Verification

Full API suite green (**2575** tests, 165 files), lint clean, rebased on master.

Browser harness, against a host that refuses **every** app-only call: phase, title, round and deliveries left all render and survive two refused refreshes. Before the fix the same run showed *"Could not read round status here."* over a card that had the round in hand.

Sizing verified against a host declaring a fixed 860px frame.

**Unverified:** whether the `CSP off` badge clears. My two sources disagreed on `widgetDomain`'s value; I followed the official reference over a community thread. If it persists, the next suspect is the empty arrays being read as "unconfigured" — worth confirming before declaring domains we don't use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_