### PR TITLE
fix deploy browser gate for unpublished /play missing copy

### DIFF
--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -154,8 +154,8 @@ roughly in order of how often they turn up real issues:
 - **Language toggle** (EN/PL) — check strings actually swap, not just the button state.
 - **Static/legal routes** — `/privacy`, `/terms`.
 - **Error paths** — an unknown path (→ `notFound` view, real 404), an unknown game slug at
-  `/play/<garbage>` (→ in-page "This game page does not exist." on the preview page, not a
-  crash or a blank theater),
+  `/play/<garbage>` (→ in-page "This game isn't available yet…" via UnpublishedPlayView —
+  same lifetime permalink as drafts; not a crash or a blank theater),
   a legacy `/draft/<slug>` (must rewrite to `/play/<slug>`), a bogus `/status/<token>`, a
   bogus `/join/<CODE>#<token>`. These should all render a friendly state, never a blank page
   or an unhandled console exception.

--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -67,10 +67,13 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
 
     const text = await bodyText();
     expect(text.length).toBeGreaterThan(0);
-    // Preview-first `/play/<slug>`: an unknown slug is a missing game page, not a
-    // failed theater fetch. Keep the older "could not load / retry" wording too so
-    // a loadError state (catalog fetch failure) still passes this gate.
-    expect(text).toMatch(/does not exist|nie istnieje|could not load|nie udało|retry|ponów/i);
+    // Lifetime `/play/<slug>`: an unknown slug is not in the catalog, so App mounts
+    // UnpublishedPlayView ("isn't available yet") rather than the published preview
+    // page's "does not exist". Keep the older missing / loadError wording too so a
+    // catalog-error path that still renders GameDetailPage passes this gate.
+    expect(text).toMatch(
+      /isn't available yet|nie jest jeszcze dostępna|does not exist|nie istnieje|could not load|nie udało|retry|ponów/i,
+    );
 
     expect(describeProblems(watcher.drain())).toBe('');
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deploys are failing at **Browser gate against the candidate** on:

`error and edge routes > shows an in-page error for an unknown game slug, not a crash`

After #604, `/play/<unknown>` mounts `UnpublishedPlayView`, which shows:

> This game isn't available yet. It may still be starting up, or it has already been published.

The resilience e2e still expected `does not exist` / `nie istnieje` (the old `GameDetailPage` missing string from #601). Smoke and auth checks passed; only this assertion blocked promotion.

Seen on e.g. https://github.com/gamedevpl/www.gamedev.pl/actions/runs/31056215400

## Fix

- Accept the unpublished missing copy (EN + PL) in `apps/e2e/src/resilience.test.ts`, while keeping the older missing / loadError patterns for catalog-error paths.
- Update `.claude/skills/browse-live-site/SKILL.md` so the error-path checklist matches the lifetime `/play` permalink behaviour.

No product code change — the UI is already correct; the gate was stale.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f692a39f-f816-4183-a14b-3364cff29898?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f692a39f-f816-4183-a14b-3364cff29898&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

