### PR TITLE
Make creator thumbnails open game pages

### DIFF
--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -66,15 +66,15 @@ afterEach(() => {
   document.body.querySelectorAll('.claim-handle-modal-card, .modal-backdrop').forEach((node) => node.remove());
 });
 
-async function renderPage() {
+async function renderPage({ onNavigate = vi.fn(), onPlay = vi.fn() } = {}) {
   root = createRoot(container);
   await act(async () => {
     root!.render(
       createElement(CreatorProfilePage, {
         handle: 'ada',
         onBack: vi.fn(),
-        onPlay: vi.fn(),
-        onNavigate: vi.fn(),
+        onPlay,
+        onNavigate,
       }),
     );
   });
@@ -146,7 +146,7 @@ describe('CreatorProfilePage owner edit', () => {
       '/api/games/sky-dodge/media/opening.png',
     );
     expect(container.querySelector<HTMLAnchorElement>('a.creator-profile-game-thumb-link')?.getAttribute('href')).toBe(
-      '/play/sky-dodge',
+      '/ada/sky-dodge',
     );
     expect(container.textContent).not.toContain('Open game page');
     expect(container.querySelector<HTMLAnchorElement>('a[href="/studio/sky-dodge"]')?.textContent).toContain(
@@ -161,17 +161,36 @@ describe('CreatorProfilePage owner edit', () => {
     authUser = null;
     fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
 
-    await renderPage();
+    const onNavigate = vi.fn();
+    const onPlay = vi.fn();
+    await renderPage({ onNavigate, onPlay });
 
     const links = Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href="/ada/sky-dodge"]'));
-    expect(links.length).toBe(1);
+    expect(links.length).toBe(2);
     expect(container.querySelector('.creator-profile-game-title a')?.textContent).toBe('Sky Dodge');
-    expect(container.querySelector('a.creator-profile-game-thumb-link')?.getAttribute('href')).toBe('/play/sky-dodge');
+    const thumbnail = container.querySelector<HTMLAnchorElement>('a.creator-profile-game-thumb-link');
+    expect(thumbnail?.getAttribute('href')).toBe('/ada/sky-dodge');
+
+    await act(async () => {
+      thumbnail!.click();
+    });
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledWith('/ada/sky-dodge');
+    expect(onPlay).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain('Game page');
     // Play still goes straight to the theater — the card did not lose its job.
-    expect(
-      Array.from(container.querySelectorAll('button')).some((button) => button.textContent?.includes('Play')),
-    ).toBe(true);
+    const play = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Play'),
+    );
+    expect(play).toBeTruthy();
+
+    await act(async () => {
+      play!.click();
+    });
+
+    expect(onPlay).toHaveBeenCalledOnce();
+    expect(onPlay).toHaveBeenCalledWith(expect.objectContaining({ slug: 'sky-dodge' }));
   });
 
   it('keeps per-game Studio links private to the owner', async () => {

--- a/apps/web/src/CreatorProfilePage.test.tsx
+++ b/apps/web/src/CreatorProfilePage.test.tsx
@@ -193,6 +193,46 @@ describe('CreatorProfilePage owner edit', () => {
     expect(onPlay).toHaveBeenCalledWith(expect.objectContaining({ slug: 'sky-dodge' }));
   });
 
+  it('preserves native modified-click behavior on game-page links', async () => {
+    fetchCreatorPage.mockResolvedValue(creatorPageWithGame());
+
+    const onNavigate = vi.fn();
+    await renderPage({ onNavigate });
+
+    const links = Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href="/ada/sky-dodge"]'));
+    expect(links).toHaveLength(2);
+
+    const nativeDefaults: boolean[] = [];
+    const preventJsdomNavigation = (event: Event) => {
+      nativeDefaults.push(event.defaultPrevented);
+      event.preventDefault();
+    };
+    document.addEventListener('click', preventJsdomNavigation);
+    try {
+      for (const link of links) {
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            metaKey: true,
+          }),
+        );
+        link.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+            button: 1,
+            cancelable: true,
+          }),
+        );
+      }
+    } finally {
+      document.removeEventListener('click', preventJsdomNavigation);
+    }
+
+    expect(nativeDefaults).toEqual([false, false, false, false]);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
   it('keeps per-game Studio links private to the owner', async () => {
     authUser = { uid: 'g:other', handle: 'bob' };
     fetchCreatorPage.mockResolvedValue(creatorPageWithGame());

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { catalogMediaUrl, isPlatformAuthor, normalizeCatalogEntry, type CatalogEntry } from './catalog.js';
@@ -75,7 +75,11 @@ export function CreatorProfilePage({
 
   /** In-app navigation for links that must still be real, copyable hrefs. */
   const interceptTo = useCallback(
-    (path: string) => (event: { preventDefault: () => void }) => {
+    (path: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+      // Keep native link behavior for new-tab/window gestures and non-primary
+      // buttons. SPA navigation is only the plain left-click path.
+      if (event.defaultPrevented || event.button !== 0) return;
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
       event.preventDefault();
       onNavigate?.(path);
     },

--- a/apps/web/src/CreatorProfilePage.tsx
+++ b/apps/web/src/CreatorProfilePage.tsx
@@ -5,7 +5,7 @@ import { catalogMediaUrl, isPlatformAuthor, normalizeCatalogEntry, type CatalogE
 import { fetchCreatorPage, type PublicCreatorProfile } from './creatorProfileApi.js';
 import { EditProfileModal } from './EditProfileModal.js';
 import { PixelIcon } from './PixelIcon.js';
-import { creatorPath, gamePath, playPath, studioPath } from './router.js';
+import { creatorPath, gamePath, studioPath } from './router.js';
 import { StudioCreatorProfileProvider } from './studioCreatorProfile.js';
 
 /**
@@ -132,6 +132,7 @@ export function CreatorProfilePage({
             <ul className="creator-profile-game-list">
               {games.map((game) => {
                 const poster = game.media?.screenshots[0]?.file;
+                const pagePath = gamePath(handle, game.slug);
                 const author = isPlatformAuthor(game.submittedBy)
                   ? t('catalog.platformAuthor')
                   : (game.submittedBy ?? profile?.profileName);
@@ -139,7 +140,8 @@ export function CreatorProfilePage({
                   <li key={game.slug} className="creator-profile-game">
                     <a
                       className="creator-profile-game-thumb-link"
-                      href={playPath(game.slug)}
+                      href={pagePath}
+                      onClick={interceptTo(pagePath)}
                       aria-label={t('creatorProfile.openGamePage', { title: game.title })}
                     >
                       {poster ? (
@@ -158,7 +160,7 @@ export function CreatorProfilePage({
                       <h3 className="creator-profile-game-title">
                         {/* Everything listed here has a handle by construction, so the
                             game page always resolves — the title is its natural door. */}
-                        <a href={gamePath(handle, game.slug)} onClick={interceptTo(gamePath(handle, game.slug))}>
+                        <a href={pagePath} onClick={interceptTo(pagePath)}>
                           {game.title}
                         </a>
                       </h3>


### PR DESCRIPTION
## What changed

- creator-profile thumbnails now open the canonical `/:handle/:slug` game page
- title and thumbnail share the same route and SPA navigation behavior
- the Play button still opens the theater directly, and owner-only Studio links are unchanged

## Why

The thumbnail looked like a browse affordance but sent visitors straight into `/play/:slug`, unlike the title. The card now has one consistent browse destination while retaining an explicit Play action.

## Measurement

No telemetry vocabulary changes. This preserves the existing visit funnel: thumbnail clicks produce the normal game-page `route_viewed`, and only the explicit Play action produces `play_started`. Questions 1–3 (first minute, session depth, acquisition) remain answerable from visit telemetry.

## Validation

Independent clean checkout:

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`