### PR TITLE
remix: conversation history for the model + mini sidebar chat

### DIFF
--- a/apps/api/src/code-lane.test.ts
+++ b/apps/api/src/code-lane.test.ts
@@ -277,4 +277,24 @@ describe('code lane', () => {
     expect(codeLaneEnabled({} as NodeJS.ProcessEnv)).toBe(false);
     expect(codeLaneEnabled({ CODE_LANE: 'true' } as unknown as NodeJS.ProcessEnv)).toBe(true);
   });
+
+  it('puts prior remix turns into the pick and edit prompts', async () => {
+    const { client, prompts } = stubClient([
+      { decision: 'edit', file: 'game/runtime.ts', name: 'startGame' },
+      { replacement: 'export function startGame() {\n  return 0.08;\n}' },
+    ]);
+    await new VertexCodeLane({ client }).run(
+      {
+        slug: 'g',
+        sources: SOURCES,
+        utterance: 'again',
+        history: [{ utterance: 'make it faster', summary: 'Raised the pace.' }],
+      },
+      async () => ({ ok: true }),
+    );
+    expect(prompts[0]).toContain('make it faster');
+    expect(prompts[0]).toContain('Raised the pace.');
+    expect(prompts[1]).toContain('make it faster');
+    expect(prompts[1]).toContain("The player's request");
+  });
 });

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -10,6 +10,7 @@ import {
   spliceRegion,
   type SymbolRegion,
 } from './symbol-map.js';
+import { formatRemixTurns } from './remix-turns.js';
 
 /**
  * The code lane: a sentence becomes one scoped source edit, rebuilt server-side.
@@ -101,6 +102,11 @@ export interface CodeLaneRequest {
   /** Game-relative sources of the version being remixed. */
   sources: Record<string, string>;
   utterance: string;
+  /**
+   * Prior remix turns (oldest first). Optional — a first ask has nothing prior.
+   * Distinct from repair rounds inside this request.
+   */
+  history?: Array<{ utterance: string; summary?: string }>;
   game?: { title?: string; genre?: string };
   /**
    * `shared/game-kit.d.ts`, when the caller has it.
@@ -526,6 +532,7 @@ export class VertexCodeLane {
   }
 
   private pickPrompt(request: CodeLaneRequest, regions: SymbolRegion[]): string {
+    const prior = formatRemixTurns(request.history ?? []);
     return `You are choosing WHERE a change to a small browser game belongs. You do not write code in this step.
 
 Game: ${request.game?.title ?? request.slug}${request.game?.genre ? ` (${request.game.genre})` : ''}
@@ -547,7 +554,7 @@ Rules:
   one instead.
 - If the request is not about changing this game, or asks for something harmful, sexual, hateful, or aimed at a real person, answer {"decision":"reject"}.
 - "summary" is one short sentence in English (en) and Polish (pl) describing the change you expect to make.
-
+${prior ? `\n${prior}` : ''}
 Respond STRICTLY as JSON:
 {"decision":"edit","file":"game/runtime.ts","name":"startGame","summary":{"en":"...","pl":"..."}}
 
@@ -607,6 +614,7 @@ Respond STRICTLY as JSON and nothing else — no code fence before or after it, 
 every newline inside a string written as \\n:
 {"replacement":"...","summary":{"en":"...","pl":"..."}}`;
     }
+    const prior = formatRemixTurns(request.history ?? []);
     return `You are editing ONE region of a small browser game written in TypeScript.
 
 Game: ${request.game?.title ?? request.slug}
@@ -625,7 +633,7 @@ Rules:
 - You may only use what the region already has access to: this game's own modules (relative imports) and the global \`GameKit\`. There is no network, no external library, and no DOM outside the game canvas.
 - Change as little as possible. This is a tweak, not a rewrite.
 - "summary" is one short sentence in English (en) and Polish (pl) saying what you changed.
-
+${prior ? `\n${prior}` : ''}
 Respond STRICTLY as JSON and nothing else — no code fence before or after it, and
 every newline inside a string written as \\n:
 {"replacement":"export function startGame() {\\n  …\\n}","summary":{"en":"...","pl":"..."}}

--- a/apps/api/src/editor-assist.ts
+++ b/apps/api/src/editor-assist.ts
@@ -8,6 +8,7 @@ import {
   type ParamSpec,
   type ParamValue,
 } from './editor-contract.js';
+import { formatRemixTurns } from './remix-turns.js';
 
 /**
  * The assist router: one utterance in, a validated params patch out.
@@ -63,6 +64,11 @@ export interface AssistRequest {
   /** Title/genre grounding, so "the dog" has something to attach to. */
   game?: { title?: string; genre?: string };
   locale?: string;
+  /**
+   * Prior remix turns (oldest first). Optional — Studio drafts have no thread,
+   * and a first remix ask has nothing prior.
+   */
+  history?: Array<{ utterance: string; summary?: string }>;
 }
 
 export interface EditorAssistant {
@@ -192,6 +198,7 @@ export class VertexEditorAssistant implements EditorAssistant {
       .map(([key, spec]) => describeParam(key, spec, values[key]))
       .join('\n');
     const collections = Object.keys(request.definition.content);
+    const prior = formatRemixTurns(request.history ?? []);
 
     const prompt = `You route a creator's request about their own small browser game into one lane. You never write code and never invent settings.
 
@@ -212,7 +219,7 @@ Rules:
 - Relative requests ("a bit faster", "much bigger") move the CURRENT value by a sensible amount: roughly 15% of the range for "a bit", roughly 40% for a strong request.
 - If the request names no setting you can map it to, do NOT guess — use "code".
 - "summary" is one short sentence, written in both English (en) and Polish (pl), saying what you changed or why you could not.
-
+${prior ? `\n${prior}` : ''}
 Respond STRICTLY as JSON:
 {"lane":"params","patches":[{"key":"someKey","value":1.3}],"summary":{"en":"...","pl":"..."}}
 

--- a/apps/api/src/remix-turns.test.ts
+++ b/apps/api/src/remix-turns.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatRemixTurns, MAX_REMIX_TURNS, rememberRemixTurn } from './remix-turns.js';
+
+describe('remix turns', () => {
+  it('formats prior turns for the model, including summaries', () => {
+    const block = formatRemixTurns([
+      { utterance: 'make it faster', summary: 'Raised the speed.' },
+      { utterance: 'again' },
+    ]);
+    expect(block).toContain('Earlier in this remix');
+    expect(block).toContain('1. Player: make it faster');
+    expect(block).toContain('→ Raised the speed.');
+    expect(block).toContain('2. Player: again');
+  });
+
+  it('returns empty when there is nothing prior', () => {
+    expect(formatRemixTurns([])).toBe('');
+  });
+
+  it('keeps only the newest turns past the ceiling', () => {
+    let turns = rememberRemixTurn([], { utterance: 'first' });
+    for (let i = 2; i <= MAX_REMIX_TURNS + 2; i += 1) {
+      turns = rememberRemixTurn(turns, { utterance: `turn-${i}` });
+    }
+    expect(turns).toHaveLength(MAX_REMIX_TURNS);
+    expect(turns[0]?.utterance).toBe('turn-3');
+    expect(turns.at(-1)?.utterance).toBe(`turn-${MAX_REMIX_TURNS + 2}`);
+  });
+});

--- a/apps/api/src/remix-turns.ts
+++ b/apps/api/src/remix-turns.ts
@@ -1,0 +1,42 @@
+/**
+ * Prior turns in a remix session — what the model needs for "again", "more",
+ * and pronouns that only make sense against the conversation so far.
+ *
+ * Distinct from `session.history`, which is an undo stack of source overrides.
+ * These are words, not files.
+ */
+
+export type RemixTurn = {
+  utterance: string;
+  /** English summary when the assistant described what it did. */
+  summary?: string;
+};
+
+/** Bound the prompt: eight turns is plenty of "again" context without drowning the request. */
+export const MAX_REMIX_TURNS = 8;
+
+export function rememberRemixTurn(turns: RemixTurn[], turn: RemixTurn): RemixTurn[] {
+  const next = [...turns, turn];
+  return next.length > MAX_REMIX_TURNS ? next.slice(next.length - MAX_REMIX_TURNS) : next;
+}
+
+/**
+ * Block for the model prompt, or empty when there is nothing prior.
+ *
+ * The latest request is still appended separately by the caller — this is only
+ * the backlog, so "again" has something to resolve against.
+ */
+export function formatRemixTurns(turns: RemixTurn[]): string {
+  if (turns.length === 0) return '';
+  const lines = turns.map((turn, index) => {
+    const reply = turn.summary?.trim() ? `\n   → ${turn.summary.trim().slice(0, 200)}` : '';
+    return `${index + 1}. Player: ${turn.utterance.trim().slice(0, 400)}${reply}`;
+  });
+  return [
+    'Earlier in this remix (oldest first). Use this for pronouns and relative',
+    'follow-ups ("again", "more", "also", "undo that look") — the latest request',
+    'below is what to do *now*:',
+    ...lines,
+    '',
+  ].join('\n');
+}

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -269,6 +269,38 @@ describe('remix routes', () => {
     expect(response.json()).toMatchObject({ lane: 'params', patches: [{ key: 'dogScale', value: 1.4 }] });
   });
 
+  it('hands the assist lane prior turns on a follow-up', async () => {
+    const seen: Array<Array<{ utterance: string; summary?: string }> | undefined> = [];
+    const built = await buildTestApp({
+      assistant: {
+        assist: async (request) => {
+          seen.push(request.history);
+          return {
+            lane: 'params',
+            patches: [{ key: 'dogScale', value: 1.4 }],
+            summary: { en: 'Made the dog bigger.', pl: 'Pies większy.' },
+          };
+        },
+      } as EditorAssistant,
+    });
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+    await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/assist`,
+      headers: alice,
+      payload: { utterance: 'bigger dog', params: { dogScale: 1, tagline: 'go!' } },
+    });
+    await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/assist`,
+      headers: alice,
+      payload: { utterance: 'again', params: { dogScale: 1.4, tagline: 'go!' } },
+    });
+    expect(seen[0]).toEqual([]);
+    expect(seen[1]).toEqual([{ utterance: 'bigger dog', summary: 'Made the dog bigger.' }]);
+  });
+
   it('rebuilds a whole document for a code edit, and only after it builds', async () => {
     const codeLane = {
       run: async (_request: unknown, build: (o: Record<string, string>) => Promise<{ ok: boolean }>) => {

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { PARAMS_KEY, parseEditorDefinition, type EditorDefinition } from './editor-contract.js';
 import { EDITOR_FILE } from './editor-contract.js';
 import { applyAssistPatches, assistEnabled, MAX_UTTERANCE_LENGTH, type EditorAssistant } from './editor-assist.js';
+import { rememberRemixTurn, type RemixTurn } from './remix-turns.js';
 import { codeLaneDebugEnabled, codeLaneEnabled, type VertexCodeLane } from './code-lane.js';
 import { typeCheckGame } from './type-check.js';
 import { buildSuggestions } from './remix-suggestions.js';
@@ -99,6 +100,13 @@ interface RemixSession {
    * by the same ceiling as the edits themselves.
    */
   history: Array<Record<string, string>>;
+  /**
+   * Successful remix asks this session has already answered (oldest first).
+   *
+   * Fed into assist/code prompts so "again" / "more" / pronouns resolve against
+   * the conversation. Not the undo stack — that is `history` above.
+   */
+  turns: RemixTurn[];
   /**
    * Whether the game's authoritative copy is the store's. It decides where a
    * rebuild's base comes from: a store game's files replace the ref's entirely,
@@ -341,6 +349,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       sourcesLoaded: loaded.fromStore,
       overrides: {},
       history: [],
+      turns: [],
       definition: editorJson ? parseEditorDefinition(editorJson).definition : null,
       title: claims.slug,
       codeEdits: 0,
@@ -474,6 +483,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         sourcesLoaded: loaded.fromStore,
         overrides: {},
         history: [],
+        turns: [],
         definition,
         title: params.data.slug,
         codeEdits: 0,
@@ -549,6 +559,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           content,
           utterance: body.data.utterance,
           game: { title: session.title },
+          history: session.turns,
         });
         if (result.lane !== 'params' || !result.patches?.length) {
           return reply.send({
@@ -560,6 +571,11 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         if (applied.patches.length === 0) {
           return reply.send({ lane: 'code', ...(result.summary ? { summary: result.summary } : {}) });
         }
+        session.turns = rememberRemixTurn(session.turns, {
+          utterance: body.data.utterance,
+          ...(result.summary?.en ? { summary: result.summary.en } : {}),
+        });
+        session.expiresAt = now() + REMIX_TTL_MS;
         return reply.send({
           lane: 'params',
           patches: applied.patches,
@@ -687,6 +703,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
             slug: session.slug,
             sources: current,
             utterance: body.data.utterance,
+            history: session.turns,
             game: { title: session.title },
             ...(kit ? { kit } : {}),
             modules,
@@ -761,6 +778,10 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         if (session.history.length > MAX_CODE_EDITS) session.history.shift();
         session.overrides = { ...session.overrides, ...outcome.overrides };
         session.codeEdits += 1;
+        session.turns = rememberRemixTurn(session.turns, {
+          utterance: body.data.utterance,
+          ...(outcome.summary?.en ? { summary: outcome.summary.en } : {}),
+        });
         session.expiresAt = now() + REMIX_TTL_MS;
         const html = await rebuild(session);
         if (!html) return reply.status(500).send({ ok: false, reason: 'error' });

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -725,6 +725,33 @@ describe('RemixPanel', () => {
     expect(buttonNamed(container, 'Keep…')).toBeNull();
   });
 
+  it('docks into a mini chat after the second landing', async () => {
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: { dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'dog size' } } },
+      values: { dogScale: 1 },
+      canAssist: true,
+      canCode: false,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist
+      .mockResolvedValueOnce({ lane: 'params', values: { dogScale: 1.2 }, summary: { en: 'Bigger.' } })
+      .mockResolvedValueOnce({ lane: 'params', values: { dogScale: 1.4 }, summary: { en: 'Bigger still.' } });
+    await draw();
+
+    expect(container.querySelector('.remix-panel.is-chat')).toBeNull();
+    await send('a bit bigger');
+    expect(container.querySelector('.remix-panel.is-chat')).toBeNull();
+    await send('again');
+
+    expect(container.querySelector('.remix-panel.is-chat')).not.toBeNull();
+    expect(container.querySelector('.remix-transcript')).not.toBeNull();
+    const bubbles = Array.from(container.querySelectorAll('.remix-bubble')).map((el) => el.textContent);
+    expect(bubbles).toEqual(['a bit bigger', 'Bigger.', 'again', 'Bigger still.']);
+    expect(container.querySelector('.remix-title')?.textContent).toBe('Remix chat');
+  });
+
   it('offers to keep the remix after a few successful landings, with a name', async () => {
     remixApi.startRemix.mockResolvedValue({
       remixId: 'r1',
@@ -752,7 +779,7 @@ describe('RemixPanel', () => {
     expect(container.querySelector('.remix-keep-offer')).not.toBeNull();
     expect(container.querySelector('.remix-keep-heading')?.textContent).toBe('Keep this remix?');
     const name = container.querySelector<HTMLInputElement>('.remix-keep-field input');
-    expect(name?.value).toBe('Dog Dash');
+    expect(name?.value).toBe('Remix of Dog Dash');
     expect(buttonNamed(container, 'Keep in Studio')).not.toBeNull();
     expect(buttonNamed(container, 'Not now')).not.toBeNull();
     // Composer and Share/Undo wait behind the offer.

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -28,11 +28,15 @@ import type {
   EditorParamValue,
 } from './studioApi.js';
 import type { RemixPaintedVia } from './visitTelemetry.js';
-import { humanizeSlug } from './pageTitle.js';
+import { suggestedKeepTitle } from './pageTitle.js';
 import { NAVIGATE_EVENT, playPath } from './router.js';
 
 /** Successful landings before we offer to keep the remix in Studio. */
 const KEEP_OFFER_AFTER = 3;
+/** After this many landings the sheet becomes a mini sidebar chat. */
+const CHAT_MODE_AFTER = 2;
+
+type ChatTurn = { id: string; role: 'user' | 'assistant'; text: string };
 
 /**
  * Remix: a player bends a published game while playing it.
@@ -259,6 +263,11 @@ export function RemixPanel(props: {
   const [keepOfferDismissed, setKeepOfferDismissed] = useState(false);
   const [keepSaved, setKeepSaved] = useState(false);
   const [keepTitle, setKeepTitle] = useState('');
+  /**
+   * Visible conversation for the mini-chat. Server session.turns feeds the
+   * model; this list is what the player reads after the panel docks.
+   */
+  const [chatTurns, setChatTurns] = useState<ChatTurn[]>([]);
   /**
    * Whether this game takes proposals from this player.
    *
@@ -572,9 +581,20 @@ export function RemixPanel(props: {
   // Dismissed stays dismissed for the session; the header "Keep…" is the escape.
   useEffect(() => {
     if (successCount < KEEP_OFFER_AFTER || keepOfferDismissed || keepSaved || keepOfferOpen) return;
-    setKeepTitle((current) => current.trim() || humanizeSlug(props.slug));
+    setKeepTitle((current) => current.trim() || suggestedKeepTitle(props.slug, user?.handle));
     setKeepOfferOpen(true);
-  }, [successCount, keepOfferDismissed, keepSaved, keepOfferOpen, props.slug]);
+  }, [successCount, keepOfferDismissed, keepSaved, keepOfferOpen, props.slug, user?.handle]);
+
+  const chatMode = successCount >= CHAT_MODE_AFTER;
+  const transcriptRef = useRef<HTMLOListElement | null>(null);
+
+  // Keep the newest bubble in view when the mini-chat grows.
+  useEffect(() => {
+    if (!chatMode) return;
+    const el = transcriptRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [chatMode, chatTurns, lane]);
 
   // A panel that opened onto nothing. Recorded against the same `opened`
   // denominator so the share of visits that met a game with no way in is a
@@ -626,8 +646,14 @@ export function RemixPanel(props: {
   }
 
   function openKeepOffer() {
-    setKeepTitle((current) => current.trim() || humanizeSlug(props.slug));
+    setKeepTitle((current) => current.trim() || suggestedKeepTitle(props.slug, user?.handle));
     setKeepOfferOpen(true);
+  }
+
+  function appendChat(role: ChatTurn['role'], text: string) {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setChatTurns((prev) => [...prev, { id: `${Date.now()}-${prev.length}`, role, text: trimmed }]);
   }
 
   function dismissKeepOffer() {
@@ -680,6 +706,7 @@ export function RemixPanel(props: {
     // here loses its Undo the moment a follow-up fails — and a follow-up that
     // fails is exactly when the player most wants the last good state back.
     setAsked(text);
+    appendChat('user', text);
     recordRemixStep('asked');
 
     // The tuning lane first: it is cheaper, faster, and covers most of what
@@ -697,11 +724,13 @@ export function RemixPanel(props: {
           setUtterance('');
           setLane('idle');
           recordRemixStep('applied');
+          const summary = label(result.summary) || t('remix.applied');
+          appendChat('assistant', summary);
           // Share is offered whenever there is anything shareable — a link
           // carries declared values, so a game with no declaration has nothing
           // to put in one, and offering it there would be a broken promise.
           setChanged({
-            text: label(result.summary) || t('remix.applied'),
+            text: summary,
             canShare: hasShareableValues(active.params, next),
           });
           noteSuccessfulChange();
@@ -710,7 +739,9 @@ export function RemixPanel(props: {
         if (result.lane === 'reject') {
           setLane('idle');
           recordRemixStep('refused');
-          setNote({ kind: 'error', text: label(result.summary) || t('remix.refused') });
+          const textOut = label(result.summary) || t('remix.refused');
+          appendChat('assistant', textOut);
+          setNote({ kind: 'error', text: textOut });
           return;
         }
         // A content-shaped request, and this game has a painter: the honest
@@ -721,26 +752,33 @@ export function RemixPanel(props: {
         if (result.lane === 'content' && active.content) {
           setLane('idle');
           setPainterOffer(true);
-          setNote({ kind: 'info', text: label(result.summary) || t('remix.editorOffer') });
+          const textOut = label(result.summary) || t('remix.editorOffer');
+          appendChat('assistant', textOut);
+          setNote({ kind: 'info', text: textOut });
           return;
         }
         // `code` (or `content` with nothing to paint): falls through to the code lane below.
         if (!active.canCode) {
           setLane('idle');
           recordRemixStep('handoff');
-          setNote({ kind: 'info', text: label(result.summary) || t('remix.needsCode') });
+          const textOut = label(result.summary) || t('remix.needsCode');
+          appendChat('assistant', textOut);
+          setNote({ kind: 'info', text: textOut });
           return;
         }
       } catch (error) {
         setLane('idle');
         const status = (error as RemixApiError).status;
-        setNote({ kind: 'error', text: status === 429 ? t('remix.quota') : t('remix.unavailable') });
+        const textOut = status === 429 ? t('remix.quota') : t('remix.unavailable');
+        appendChat('assistant', textOut);
+        setNote({ kind: 'error', text: textOut });
         return;
       }
     }
 
     if (!active.canCode) {
       recordRemixStep('handoff');
+      appendChat('assistant', t('remix.needsCode'));
       setNote({ kind: 'info', text: t('remix.needsCode') });
       return;
     }
@@ -758,11 +796,13 @@ export function RemixPanel(props: {
         failStreakRef.current = 0;
         recordRemixStep('applied');
         setUtterance('');
+        const summary = `${label(result.summary) || t('remix.rebuilt')} ${t('remix.restarted')}`;
+        appendChat('assistant', summary);
         // A code change cannot travel in a link (the gate exists so generated
         // code never reaches a stranger), but the settings can — and the share
         // copy says exactly that rather than implying the whole remix went.
         setChanged({
-          text: `${label(result.summary) || t('remix.rebuilt')} ${t('remix.restarted')}`,
+          text: summary,
           // A code change on its own carries nothing: the link is a diff of
           // declared values, and this one moved none of them.
           canShare: hasShareableValues(active.params, valuesRef.current),
@@ -781,18 +821,20 @@ export function RemixPanel(props: {
       } else {
         recordRemixStep(result.reason === 'refused' ? 'refused' : 'handoff');
         props.frameRef.current?.contentWindow?.postMessage({ source: 'gdpl-host', type: 'resume' }, '*');
+        const textOut =
+          label(result.summary) ||
+          // Each reason gets its own words. A refusal was reading as "too big",
+          // which tells the player to try something smaller for a request that
+          // size had nothing to do with.
+          (result.reason === 'refused'
+            ? t('remix.refused')
+            : result.reason === 'did_not_compile'
+              ? t('remix.couldNotBuild')
+              : t('remix.tooBig'));
+        appendChat('assistant', textOut);
         setNote({
           kind: result.reason === 'refused' ? 'error' : 'info',
-          text:
-            label(result.summary) ||
-            // Each reason gets its own words. A refusal was reading as "too big",
-            // which tells the player to try something smaller for a request that
-            // size had nothing to do with.
-            (result.reason === 'refused'
-              ? t('remix.refused')
-              : result.reason === 'did_not_compile'
-                ? t('remix.couldNotBuild')
-                : t('remix.tooBig')),
+          text: textOut,
         });
       }
     } catch (error) {
@@ -802,15 +844,17 @@ export function RemixPanel(props: {
       failStreakRef.current += 1;
       const status = (error as RemixApiError).status;
       const timedOut = controller.signal.aborted;
+      const textOut = timedOut
+        ? t('remix.tookTooLong')
+        : status === 429
+          ? t('remix.quota')
+          : failStreakRef.current >= 2
+            ? t('remix.napping')
+            : t('remix.unavailable');
+      appendChat('assistant', textOut);
       setNote({
         kind: timedOut ? 'info' : 'error',
-        text: timedOut
-          ? t('remix.tookTooLong')
-          : status === 429
-            ? t('remix.quota')
-            : failStreakRef.current >= 2
-              ? t('remix.napping')
-              : t('remix.unavailable'),
+        text: textOut,
       });
     } finally {
       window.clearTimeout(slowTimer);
@@ -1050,6 +1094,53 @@ export function RemixPanel(props: {
     );
   }
 
+  /** Mini-chat scrollback — only after the panel has docked into chat mode. */
+  function transcript() {
+    if (!chatMode || chatTurns.length === 0) return null;
+    return (
+      <ol ref={transcriptRef} className="remix-transcript" aria-label={t('remix.chatAria')}>
+        {chatTurns.map((turn) => (
+          <li key={turn.id} className={`remix-bubble is-${turn.role}`}>
+            {turn.text}
+          </li>
+        ))}
+        {lane === 'asking' || lane === 'building' ? (
+          <li className="remix-bubble is-assistant is-pending" aria-live="polite">
+            {lane === 'building' ? t('remix.building') : t('remix.asking')}
+          </li>
+        ) : null}
+      </ol>
+    );
+  }
+
+  function actionRow() {
+    if (!changed || !(changed.canShare || canPropose || undo || changed.undoCode)) return null;
+    return (
+      <div className="remix-actions-row">
+        {changed.canShare ? (
+          <button type="button" className="remix-btn is-primary" onClick={() => void share()}>
+            {t('remix.share')}
+          </button>
+        ) : null}
+        {canPropose && !proposing && !proposed ? (
+          <button type="button" className="remix-btn is-quiet" onClick={() => setProposing(true)}>
+            {t('propose.action')}
+          </button>
+        ) : null}
+        {undo || changed.undoCode ? (
+          <button
+            type="button"
+            className={`remix-btn ${changed.broke ? 'is-primary' : 'is-quiet'}`}
+            disabled={lane !== 'idle' || saving}
+            onClick={() => (changed.undoCode ? void undoCode() : undoLast())}
+          >
+            {t('remix.undo')}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
   /*
    * Level editor owns the theater — not a widget inside the remix sheet.
    * Done returns to the sheet (Keep/Share stay earned there). Edit ↔ Play only
@@ -1157,12 +1248,12 @@ export function RemixPanel(props: {
   }
 
   return (
-    <div className="remix-panel">
+    <div className={`remix-panel${chatMode ? ' is-chat' : ''}`}>
       {/* The sheet's own handle. Decorative — closing is the labelled button. */}
       <span className="remix-grip" aria-hidden="true" />
 
       <div className="remix-head">
-        <span className="remix-title">{t('remix.title')}</span>
+        <span className="remix-title">{chatMode ? t('remix.chatTitle') : t('remix.title')}</span>
         <div className="remix-head-actions">
           {/*
            * Escape hatch once they've earned a landing: the auto-offer waits for
@@ -1181,7 +1272,9 @@ export function RemixPanel(props: {
         </div>
       </div>
 
-      {lane === 'building' ? (
+      {transcript()}
+
+      {lane === 'building' && !chatMode ? (
         /*
          * The wait has a subject. The game is frozen and dimmed behind the sheet
          * rather than replaced, and the player's own words are echoed back, so
@@ -1202,57 +1295,43 @@ export function RemixPanel(props: {
           </span>
           <p className="remix-note">{slow ? t('remix.buildingSlow') : t('remix.buildingWait')}</p>
         </>
+      ) : lane === 'building' && chatMode ? (
+        <>
+          <span className="remix-bar" aria-hidden="true">
+            <i />
+          </span>
+          <p className="remix-note">{slow ? t('remix.buildingSlow') : t('remix.buildingWait')}</p>
+        </>
       ) : changed ? (
         /*
          * The reward, and it is earned: share is the loudest thing here only
          * because a change has actually landed. Undo sits beside it, quiet, and
          * the composer shrinks to a line and waits — the second change is the
-         * one that turns a remix into a habit.
+         * one that turns a remix into a habit. After that landing the sheet
+         * docks into a mini chat and the transcript carries the story instead
+         * of a single status line.
          */
         <>
-          <p className={`remix-result${changed.broke ? ' is-broken' : ''}`} role="status">
-            <span className="remix-tick" aria-hidden="true">
-              {changed.broke ? '!' : '✓'}
-            </span>
-            <span>{changed.broke ? t('remix.brokeIt') : changed.text}</span>
-          </p>
+          {!chatMode ? (
+            <p className={`remix-result${changed.broke ? ' is-broken' : ''}`} role="status">
+              <span className="remix-tick" aria-hidden="true">
+                {changed.broke ? '!' : '✓'}
+              </span>
+              <span>{changed.broke ? t('remix.brokeIt') : changed.text}</span>
+            </p>
+          ) : changed.broke ? (
+            <p className="remix-result is-broken" role="status">
+              <span className="remix-tick" aria-hidden="true">
+                !
+              </span>
+              <span>{t('remix.brokeIt')}</span>
+            </p>
+          ) : null}
           {keepOfferOpen && !changed.broke ? (
             keepOfferForm()
           ) : (
             <>
-              {changed.canShare || canPropose || undo || changed.undoCode ? (
-                <div className="remix-actions-row">
-                  {changed.canShare ? (
-                    <button type="button" className="remix-btn is-primary" onClick={() => void share()}>
-                      {t('remix.share')}
-                    </button>
-                  ) : null}
-                  {/*
-                   * The third exit. Remix's two originals — save as yours, share — are
-                   * unchanged and still never publish; this one asks the owner, who may say
-                   * no. It appears only once a change has landed and only for a game whose
-                   * owner opted in, so it is offered when there is something to offer and to
-                   * somebody who can receive it.
-                   */}
-                  {canPropose && !proposing && !proposed ? (
-                    <button type="button" className="remix-btn is-quiet" onClick={() => setProposing(true)}>
-                      {t('propose.action')}
-                    </button>
-                  ) : null}
-                  {undo || changed.undoCode ? (
-                    <button
-                      type="button"
-                      // A broken game makes going back the only thing worth doing,
-                      // so it stops being the quiet option.
-                      className={`remix-btn ${changed.broke ? 'is-primary' : 'is-quiet'}`}
-                      disabled={lane !== 'idle' || saving}
-                      onClick={() => (changed.undoCode ? void undoCode() : undoLast())}
-                    >
-                      {t('remix.undo')}
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
+              {actionRow()}
               {composer(true)}
             </>
           )}
@@ -1261,7 +1340,7 @@ export function RemixPanel(props: {
         keepOfferForm()
       ) : canType ? (
         <>
-          {composer(false)}
+          {composer(chatMode)}
           {showSuggestions ? (
             /*
              * Three things worth saying, derived from what this game can

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1157,6 +1157,8 @@
   },
   "remix": {
     "title": "Remix",
+    "chatTitle": "Remix chat",
+    "chatAria": "Remix conversation",
     "close": "Close",
     "starting": "Starting your remix…",
     "placeholder": "Say what to change…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1161,6 +1161,8 @@
   },
   "remix": {
     "title": "Remiks",
+    "chatTitle": "Czat remiksu",
+    "chatAria": "Rozmowa remiksu",
     "close": "Zamknij",
     "starting": "Przygotowuję remiks…",
     "placeholder": "Powiedz, co zmienić…",

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -4,6 +4,7 @@ import {
   brandedPageTitle,
   humanizeSlug,
   resolveDocumentTitle,
+  suggestedKeepTitle,
   type DocumentTitleCopy,
 } from './pageTitle.js';
 
@@ -49,6 +50,13 @@ describe('humanizeSlug', () => {
   it('title-cases kebab segments', () => {
     expect(humanizeSlug('sky-dodge')).toBe('Sky Dodge');
     expect(humanizeSlug('dodge')).toBe('Dodge');
+  });
+});
+
+describe('suggestedKeepTitle', () => {
+  it('prefers an edit-by handle when claimed', () => {
+    expect(suggestedKeepTitle('dog-dash')).toBe('Remix of Dog Dash');
+    expect(suggestedKeepTitle('dog-dash', 'alice')).toBe('Dog Dash (edit by @alice)');
   });
 });
 

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -95,6 +95,13 @@ export function resolveDocumentTitle(route: AppRoute, ctx: DocumentTitleContext)
   }
 }
 
+/** Default name when keeping a remix — handle when claimed, otherwise a clear remix label. */
+export function suggestedKeepTitle(slug: string, handle?: string): string {
+  const base = humanizeSlug(slug);
+  const title = handle ? `${base} (edit by @${handle})` : `Remix of ${base}`;
+  return title.slice(0, 80);
+}
+
 /** Turn `sky-dodge` into `Sky Dodge` when the catalog hasn't loaded yet. */
 export function humanizeSlug(slug: string): string {
   return slug

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12286,10 +12286,77 @@ button.builder-mode-selector:disabled {
   overflow-y: auto;
 }
 
+/*
+ * After the second landing the sheet docks as a mini chat: taller, with its
+ * own scroller for the transcript so the composer stays pinned at the bottom.
+ * Written once outside media queries — phone and desktop share the shape;
+ * only the dock edge differs at 720px.
+ */
+.remix-host .remix-panel.is-chat {
+  max-height: min(78%, calc(100% - 16px));
+  overflow: hidden;
+  gap: 10px;
+}
+
+.remix-transcript {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-height: 72px;
+  max-height: 40vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.remix-panel.is-chat .remix-transcript {
+  max-height: none;
+}
+
+.remix-bubble {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  max-width: 92%;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.remix-bubble.is-user {
+  align-self: flex-end;
+  background: var(--panel-card, #1a2430);
+  border: 1px solid var(--panel-border, #2b333f);
+  color: var(--text);
+}
+
+.remix-bubble.is-assistant {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+  padding-left: 2px;
+}
+
+.remix-bubble.is-pending {
+  font-style: italic;
+}
+
 @media (min-width: 720px) {
   .remix-host .remix-panel {
     left: auto;
     width: 320px;
+  }
+
+  .remix-host .remix-panel.is-chat {
+    top: 8px;
+    bottom: 8px;
+    max-height: none;
+    width: 300px;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the Keep-in-Studio offer work:

1. **Conversation → model** — Successful remix turns are stored on the session and passed into assist/code prompts (`formatRemixTurns`), so follow-ups like “again” / “more” / pronouns resolve against the thread. Distinct from the undo stack of source overrides.
2. **Smarter Keep title** — Prefills `Remix of Dog Dash`, or `Dog Dash (edit by @handle)` when the player has claimed a handle.
3. **Mini sidebar chat** — After the **second** successful landing, the panel docks into a scrollable chat (`is-chat`) with the transcript + compact composer. Desktop pins it as a tall right rail.

## Test plan

- [x] `remix-turns` unit tests (format + ceiling)
- [x] Assist follow-up receives prior turns (`remix.test`)
- [x] Code lane pick/edit prompts include history (`code-lane.test`)
- [x] Panel docks to chat after 2 landings; Keep still offers on the 3rd with new title default
- [ ] Manual: remix a game twice → sidebar chat; third landing → Keep sheet with suggested title; ask “again” and check it applies relative to the previous change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d098e4e3-9654-4d03-9d84-49b081734799?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d098e4e3-9654-4d03-9d84-49b081734799&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

