### PR TITLE
Unblock deploys: accept the preview-first copy for an unknown game slug

### DIFF
--- a/apps/e2e/src/resilience.test.ts
+++ b/apps/e2e/src/resilience.test.ts
@@ -68,9 +68,17 @@ describe.skipIf(!prereq.ok)('error and edge routes', () => {
     const text = await bodyText();
     expect(text.length).toBeGreaterThan(0);
     // Preview-first `/play/<slug>`: an unknown slug is a missing game page, not a
-    // failed theater fetch. Keep the older "could not load / retry" wording too so
-    // a loadError state (catalog fetch failure) still passes this gate.
-    expect(text).toMatch(/does not exist|nie istnieje|could not load|nie udało|retry|ponów/i);
+    // failed theater fetch, so it renders `draft.notFound` ("isn't available yet…").
+    // The older "could not load / retry" wording stays accepted so a loadError state
+    // (catalog fetch failure) still passes this gate.
+    //
+    // What is being asserted is the *category* — the visitor gets an explanation rather
+    // than a blank or a crash. Pinning exact sentences is why this test went red on a
+    // copy change (#602) and blocked every deploy behind it, so match on the stable
+    // fragments of both locales rather than whole strings.
+    expect(text).toMatch(
+      /does not exist|nie istnieje|could not load|nie udało|retry|ponów|isn't available yet|nie jest jeszcze dostępna/i,
+    );
 
     expect(describeProblems(watcher.drain())).toBe('');
   });


### PR DESCRIPTION
Superseded by #608, which landed the same fix first and explains it better — it names `UnpublishedPlayView` as what actually mounts for an unknown slug, where mine only described the symptom.

Both widened the assertion to the same locale fragments (`isn't available yet` / `nie jest jeszcze dostępna`) while keeping the older `could not load / retry` wording so a genuine `loadError` path still fails the gate. No reason to prefer this one. Closing unmerged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_