### PR TITLE
Add a dedicated Remix entry flow

### DIFF
--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -391,6 +391,17 @@ describe('catalog playback', () => {
     );
     expect(container.querySelector('.remix-panel')).not.toBeNull();
 
+    // The landing-page request is one-shot. Closing and reopening the in-game
+    // sheet must not spend or apply that same request again.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.remix-close')!.click();
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.remix-btn')!.click();
+    });
+    await flushEffects();
+    expect(assistBodies).toEqual([{ utterance: 'make it faster', params: {} }]);
+
     await act(async () => {
       root.unmount();
     });

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -274,4 +274,125 @@ describe('catalog playback', () => {
       root.unmount();
     });
   });
+
+  it('opens the theater from a canonical game page and auto-starts its carried Remix request', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const assistBodies: unknown[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:test', tier: 'standard' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/catalog')) {
+        return new Response(JSON.stringify([]));
+      }
+      if (url.includes('/api/recommendations')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      if (url.endsWith('/api/games/neon-courier/page')) {
+        return new Response(
+          JSON.stringify({
+            entry: {
+              slug: 'neon-courier',
+              title: 'Neon Courier',
+              genre: 'arcade',
+              controls: 'Arrows move',
+              status: 'published',
+              media: null,
+              multiplayer: null,
+              submittedBy: 'nightshift',
+              creatorHandle: 'nightshift',
+            },
+            creator: {
+              handle: 'nightshift',
+              profileName: 'Night Shift',
+              bio: '',
+              avatarUrl: null,
+              profileCreatedAt: '2026-07-01T00:00:00.000Z',
+            },
+            platformAuthored: false,
+            description: 'Deliver the last package before the city goes dark.',
+          }),
+        );
+      }
+      if (url.endsWith('/api/games/neon-courier/votes')) {
+        return new Response(JSON.stringify({ up: 2, down: 0, mine: null }));
+      }
+      if (url.endsWith('/api/games/neon-courier')) {
+        return new Response(
+          JSON.stringify({ slug: 'neon-courier', title: 'Neon Courier', html: '<canvas>neon</canvas>' }),
+        );
+      }
+      if (url.endsWith('/api/games/neon-courier/remix')) {
+        return new Response(
+          JSON.stringify({
+            remixId: 'r1',
+            params: null,
+            values: null,
+            canAssist: true,
+            canCode: true,
+            suggestions: [],
+            expiresInMs: 3_600_000,
+          }),
+        );
+      }
+      if (url.endsWith('/api/remixes/r1/assist')) {
+        assistBodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({ lane: 'params', values: {} }));
+      }
+      if (url.endsWith('/api/games/neon-courier/contributions')) {
+        return new Response(JSON.stringify({ canPropose: false, reason: 'contributions_off' }));
+      }
+      if (/\/api\/games\/[^/]+\/played$/.test(new URL(url, 'http://localhost').pathname)) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/nightshift/neon-courier');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(App)));
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const remixButton = Array.from(container.querySelectorAll<HTMLButtonElement>('.game-page-actions button')).find(
+      (button) => button.textContent?.includes('Remix'),
+    );
+    await act(async () => {
+      remixButton?.click();
+    });
+    const request = container.querySelector<HTMLTextAreaElement>('#game-page-remix-request')!;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(request, 'make it faster');
+      request.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>('.game-page-remix-form')!
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(assistBodies).toEqual([{ utterance: 'make it faster', params: {} }]);
+    });
+    expect(container.querySelector('iframe[title="Neon Courier"]')?.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-pointer-lock',
+    );
+    expect(container.querySelector('.remix-panel')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/apps/web/src/App.gamePageTheater.test.ts
+++ b/apps/web/src/App.gamePageTheater.test.ts
@@ -8,11 +8,12 @@ import { AuthProvider } from './AuthContext.js';
 import i18n from './i18n/index.js';
 
 /**
- * Play/Remix on `/:handle/:slug` must mount the full-viewport theater.
+ * Play and a submitted Remix request on `/:handle/:slug` must mount the
+ * full-viewport theater.
  *
  * That route is an open-chrome early return in App. The handlers still set
  * `stageContent` (and `body.player-open`), so if the overlay is only rendered
- * in the signed-in main branch, Remix locks scroll and shows nothing — the
+ * in the signed-in main branch, the page locks scroll and shows nothing — the
  * bug that shipped with the public game page.
  */
 
@@ -102,7 +103,7 @@ describe('theater from the public game page', () => {
     vi.restoreAllMocks();
   });
 
-  it('opens the theater (and remix sheet) from Remix without trapping page scroll alone', async () => {
+  it('keeps Remix on the page until the request is submitted, then opens the theater', async () => {
     mockApi();
     window.history.pushState(null, '', '/nightshift/sky-dodge');
     const { container, root } = await renderApp();
@@ -118,15 +119,30 @@ describe('theater from the public game page', () => {
       await flushEffects();
     });
 
-    // The failure mode was: player-open with no theater. Both must be present.
-    expect(document.body.classList.contains('player-open')).toBe(true);
-    expect(container.querySelector('.stage.is-playing-full-viewport')).not.toBeNull();
-    expect(container.querySelector('.exit-btn')).not.toBeNull();
-    // initialRemixOpen hands the sheet to the frame once the document loads.
+    expect(document.body.classList.contains('player-open')).toBe(false);
+    expect(container.querySelector('.stage.is-playing-full-viewport')).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+
+    const request = container.querySelector<HTMLTextAreaElement>('#game-page-remix-request');
+    expect(document.activeElement).toBe(request);
     await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      setter?.call(request, 'make it faster');
+      request?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>('.game-page-remix-form')
+        ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
       await flushEffects();
       await flushEffects();
     });
+
+    // The failure mode was: player-open with no theater. Once the request is
+    // submitted, both the scroll lock and theater must be present.
+    expect(document.body.classList.contains('player-open')).toBe(true);
+    expect(container.querySelector('.stage.is-playing-full-viewport')).not.toBeNull();
+    expect(container.querySelector('.exit-btn')).not.toBeNull();
     expect(container.querySelector('.remix-panel, .remix-host')).not.toBeNull();
 
     const exit = container.querySelector<HTMLButtonElement>('.exit-btn');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -67,7 +67,7 @@ import { createPartySession, type PartySession } from './mp/mpApi.js';
 import { parseOAuthReturnParam } from './oauthReturn.js';
 
 type StageContent =
-  | { type: 'catalog'; game: CatalogEntry; initialRemixOpen?: boolean }
+  | { type: 'catalog'; game: CatalogEntry; initialRemixOpen?: boolean; initialRemixRequest?: string }
   | { type: 'generated'; game: GeneratedGame; prompt: string }
   | { type: 'party'; game: CatalogEntry; session: PartySession };
 
@@ -746,10 +746,10 @@ export function App() {
     setRecommendationsRefreshKey((n) => n + 1);
   }
 
-  function handleRemixGame(game: CatalogEntry) {
+  function handleRemixGame(game: CatalogEntry, initialRemixRequest?: string) {
     // The game still has to be mounted for Remix to swap and preview its document,
     // but the sheet opens on the first frame — no theater detour and second wrench.
-    setStageContent({ type: 'catalog', game, initialRemixOpen: true });
+    setStageContent({ type: 'catalog', game, initialRemixOpen: true, initialRemixRequest });
   }
 
   async function handlePlayTogether(game: CatalogEntry) {
@@ -823,6 +823,7 @@ export function App() {
           controls={stageContent.game.controls}
           touch={stageContent.game.touch}
           initialRemixOpen={stageContent.initialRemixOpen}
+          initialRemixRequest={stageContent.initialRemixRequest}
         />
       )}
 

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -70,6 +70,7 @@ let container: HTMLDivElement;
 let root: Root | null = null;
 let playAction: ReturnType<typeof vi.fn>;
 let remixAction: ReturnType<typeof vi.fn>;
+const originalVisualViewport = window.visualViewport;
 
 beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -90,6 +91,15 @@ afterEach(() => {
   });
   root = null;
   container.remove();
+  if (originalVisualViewport === undefined) {
+    Reflect.deleteProperty(window, 'visualViewport');
+  } else {
+    Object.defineProperty(window, 'visualViewport', {
+      value: originalVisualViewport,
+      configurable: true,
+      writable: true,
+    });
+  }
 });
 
 async function renderPage(props: Partial<Parameters<typeof GamePage>[0]> = {}) {
@@ -110,6 +120,31 @@ async function renderPage(props: Partial<Parameters<typeof GamePage>[0]> = {}) {
     await fetchGamePage.mock.results[0]?.value.catch(() => {});
     await Promise.resolve();
   });
+}
+
+function stubVisualViewport(height: number, offsetTop = 0) {
+  const listeners = new Map<string, Set<() => void>>();
+  const viewport = {
+    height,
+    offsetTop,
+    addEventListener: (type: string, listener: () => void) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener: (type: string, listener: () => void) => listeners.get(type)?.delete(listener),
+  };
+  Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true, writable: true });
+  return {
+    async emit(type: 'resize' | 'scroll', next: { height?: number; offsetTop?: number }) {
+      if (next.height !== undefined) viewport.height = next.height;
+      if (next.offsetTop !== undefined) viewport.offsetTop = next.offsetTop;
+      await act(async () => {
+        listeners.get(type)?.forEach((listener) => listener());
+        await Promise.resolve();
+      });
+    },
+    listenerCount: () => (listeners.get('resize')?.size ?? 0) + (listeners.get('scroll')?.size ?? 0),
+  };
 }
 
 describe('GamePage', () => {
@@ -170,6 +205,32 @@ describe('GamePage', () => {
     expect(document.activeElement).toBe(container.querySelector('#game-page-remix-request'));
     expect(remixAction).not.toHaveBeenCalled();
     expect(container.querySelector('iframe')).toBeNull();
+  });
+
+  it('follows the visual viewport so the mobile keyboard cannot cover the actions', async () => {
+    const viewport = stubVisualViewport(844);
+    await renderPage();
+
+    await act(async () => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('Remix'))!
+        .click();
+    });
+
+    const backdrop = container.querySelector<HTMLElement>('.game-page-remix-backdrop')!;
+    expect(backdrop.classList.contains('is-viewport-tracked')).toBe(true);
+    expect(backdrop.style.getPropertyValue('--remix-entry-viewport-height')).toBe('844px');
+
+    await viewport.emit('resize', { height: 480 });
+    expect(backdrop.style.getPropertyValue('--remix-entry-viewport-height')).toBe('480px');
+
+    await viewport.emit('scroll', { offsetTop: 54 });
+    expect(backdrop.style.getPropertyValue('--remix-entry-viewport-offset')).toBe('54px');
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.game-page-remix-close')!.click();
+    });
+    expect(viewport.listenerCount()).toBe(0);
   });
 
   it('blocks a blank Remix request', async () => {

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -153,7 +153,7 @@ describe('GamePage', () => {
     expect(playAction).not.toHaveBeenCalled();
   });
 
-  it('opens Remix directly through the theater handoff', async () => {
+  it('opens a focused Remix entry without handing off to the theater', async () => {
     await renderPage();
 
     const remix = Array.from(container.querySelectorAll('button')).find((button) =>
@@ -164,7 +164,54 @@ describe('GamePage', () => {
       remix!.click();
     });
 
-    expect(remixAction).toHaveBeenCalledWith(expect.objectContaining({ slug: 'neon-courier' }));
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    expect(document.activeElement).toBe(container.querySelector('#game-page-remix-request'));
+    expect(remixAction).not.toHaveBeenCalled();
+    expect(container.querySelector('iframe')).toBeNull();
+  });
+
+  it('blocks a blank Remix request', async () => {
+    await renderPage();
+    await act(async () => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('Remix'))!
+        .click();
+    });
+
+    const form = container.querySelector<HTMLFormElement>('.game-page-remix-form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(remixAction).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('.game-page-remix-form .primary-btn')?.disabled).toBe(true);
+  });
+
+  it('hands a non-empty request to the theater exactly once', async () => {
+    await renderPage();
+    await act(async () => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('Remix'))!
+        .click();
+    });
+
+    const input = container.querySelector<HTMLTextAreaElement>('#game-page-remix-request')!;
+    await act(async () => {
+      nativeSetValue(input, '  make the game faster  ');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>('.game-page-remix-form')!
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(remixAction).toHaveBeenCalledTimes(1);
+    expect(remixAction).toHaveBeenCalledWith(expect.objectContaining({ slug: 'neon-courier' }), 'make the game faster');
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
     expect(container.querySelector('iframe')).toBeNull();
   });
 
@@ -208,3 +255,8 @@ describe('GamePage', () => {
     expect(onGameLoaded).toHaveBeenCalledWith('Neon Courier');
   });
 });
+
+function nativeSetValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+}

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -52,7 +52,9 @@ export function GamePage({
   const [selectedScreenshotFile, setSelectedScreenshotFile] = useState<string | null>(null);
   const [remixEntryOpen, setRemixEntryOpen] = useState(false);
   const [remixRequest, setRemixRequest] = useState('');
+  const [remixTracksViewport, setRemixTracksViewport] = useState(false);
   const remixButtonRef = useRef<HTMLButtonElement | null>(null);
+  const remixBackdropRef = useRef<HTMLDivElement | null>(null);
   const remixInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const playGated = privateBeta && !user;
@@ -94,7 +96,28 @@ export function GamePage({
   useEffect(() => {
     if (!remixEntryOpen) return;
     const trigger = remixButtonRef.current;
+    const backdrop = remixBackdropRef.current;
+    const viewport = window.visualViewport;
+    let syncViewport: (() => void) | null = null;
+
     document.body.classList.add('remix-entry-open');
+
+    // `100dvh` follows mobile browser chrome, but iOS only shrinks the visual
+    // viewport for its keyboard. Measure that viewport directly so the action row
+    // remains above the keys, including when Safari pans to reveal the textarea.
+    if (viewport && backdrop) {
+      syncViewport = () => {
+        backdrop.style.setProperty('--remix-entry-viewport-height', `${viewport.height}px`);
+        backdrop.style.setProperty('--remix-entry-viewport-offset', `${viewport.offsetTop}px`);
+      };
+      syncViewport();
+      setRemixTracksViewport(true);
+      viewport.addEventListener('resize', syncViewport);
+      viewport.addEventListener('scroll', syncViewport);
+    } else {
+      setRemixTracksViewport(false);
+    }
+
     remixInputRef.current?.focus();
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -122,6 +145,10 @@ export function GamePage({
     return () => {
       document.body.classList.remove('remix-entry-open');
       window.removeEventListener('keydown', onKeyDown);
+      if (viewport && syncViewport) {
+        viewport.removeEventListener('resize', syncViewport);
+        viewport.removeEventListener('scroll', syncViewport);
+      }
       trigger?.focus();
     };
   }, [remixEntryOpen]);
@@ -271,7 +298,11 @@ export function GamePage({
       ) : null}
 
       {remixEntryOpen ? (
-        <div className="game-page-remix-backdrop" onClick={closeRemixEntry}>
+        <div
+          ref={remixBackdropRef}
+          className={`game-page-remix-backdrop${remixTracksViewport ? ' is-viewport-tracked' : ''}`}
+          onClick={closeRemixEntry}
+        >
           <section
             className="game-page-remix-dialog"
             role="dialog"

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
@@ -42,7 +42,7 @@ export function GamePage({
   onCanonicalPath?: (path: string) => void;
   onGameLoaded?: (title: string) => void;
   onPlay?: (game: CatalogEntry) => void;
-  onRemix?: (game: CatalogEntry) => void;
+  onRemix: (game: CatalogEntry, request: string) => void;
 }) {
   const { t } = useTranslation();
   const { user, privateBeta } = useAuth();
@@ -50,6 +50,10 @@ export function GamePage({
   const [state, setState] = useState<LoadState>('loading');
   const [authOpen, setAuthOpen] = useState(false);
   const [selectedScreenshotFile, setSelectedScreenshotFile] = useState<string | null>(null);
+  const [remixEntryOpen, setRemixEntryOpen] = useState(false);
+  const [remixRequest, setRemixRequest] = useState('');
+  const remixButtonRef = useRef<HTMLButtonElement | null>(null);
+  const remixInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const playGated = privateBeta && !user;
 
@@ -86,6 +90,41 @@ export function GamePage({
       onCanonicalPath?.(gamePath(canonicalHandle, slug));
     }
   }, [state, page, canonicalHandle, handle, slug, onCanonicalPath]);
+
+  useEffect(() => {
+    if (!remixEntryOpen) return;
+    const trigger = remixButtonRef.current;
+    document.body.classList.add('remix-entry-open');
+    remixInputRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setRemixEntryOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const dialog = remixInputRef.current?.closest<HTMLElement>('[role="dialog"]');
+      if (!dialog) return;
+      const stops = [...dialog.querySelectorAll<HTMLElement>('textarea, button:not(:disabled)')];
+      const first = stops[0];
+      const last = stops[stops.length - 1];
+      if (!first || !last) return;
+      const outside = !dialog.contains(document.activeElement);
+      if (event.shiftKey && (document.activeElement === first || outside)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (document.activeElement === last || outside)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.classList.remove('remix-entry-open');
+      window.removeEventListener('keydown', onKeyDown);
+      trigger?.focus();
+    };
+  }, [remixEntryOpen]);
 
   if (state === 'loading') {
     return <p className="game-page-state">{t('gamePage.loading')}</p>;
@@ -125,14 +164,19 @@ export function GamePage({
     if (!onPlay) onNavigate(playPath(slug));
   };
 
-  const remix = () => {
-    if (playGated) {
-      setAuthOpen(true);
-      return;
-    }
+  const openRemixEntry = () => {
     recordRemixStep('opened', { control: 'page' });
-    onRemix?.(entry);
-    if (!onRemix) onNavigate(playPath(slug));
+    setRemixEntryOpen(true);
+  };
+
+  const closeRemixEntry = () => setRemixEntryOpen(false);
+
+  const startRemix = (event: FormEvent) => {
+    event.preventDefault();
+    const request = remixRequest.trim();
+    if (request.length < 2) return;
+    setRemixEntryOpen(false);
+    onRemix(entry, request);
   };
 
   return (
@@ -159,7 +203,7 @@ export function GamePage({
             <PixelIcon name="play" size={13} /> {t('gamePage.play')}
           </button>
           <VoteWidget slug={slug} />
-          <button type="button" className="secondary-btn game-page-remix" onClick={remix}>
+          <button type="button" className="secondary-btn game-page-remix" onClick={openRemixEntry} ref={remixButtonRef}>
             <PixelIcon name="wrench" size={13} /> {t('gamePage.remix')}
           </button>
           <ShareGameButton slug={slug} title={entry.title} path={gamePath(shareHandle, slug)} />
@@ -224,6 +268,54 @@ export function GamePage({
           <h2 id="game-page-controls-title">{t('player.howToPlay')}</h2>
           <p>{entry.controls}</p>
         </section>
+      ) : null}
+
+      {remixEntryOpen ? (
+        <div className="game-page-remix-backdrop" onClick={closeRemixEntry}>
+          <section
+            className="game-page-remix-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="game-page-remix-title"
+            aria-describedby="game-page-remix-description"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="game-page-remix-dialog-head">
+              <div>
+                <h2 id="game-page-remix-title">{t('gamePage.remixEntryTitle')}</h2>
+                <p id="game-page-remix-description">{t('gamePage.remixEntryDescription')}</p>
+              </div>
+              <button
+                type="button"
+                className="game-page-remix-close"
+                onClick={closeRemixEntry}
+                aria-label={t('gamePage.remixEntryClose')}
+              >
+                <PixelIcon name="close" size={14} />
+              </button>
+            </div>
+            <form className="game-page-remix-form" onSubmit={startRemix}>
+              <label htmlFor="game-page-remix-request">{t('gamePage.remixEntryLabel')}</label>
+              <textarea
+                id="game-page-remix-request"
+                ref={remixInputRef}
+                value={remixRequest}
+                onChange={(event) => setRemixRequest(event.target.value)}
+                placeholder={t('gamePage.remixEntryPlaceholder')}
+                maxLength={240}
+                rows={4}
+              />
+              <div className="game-page-remix-form-actions">
+                <button type="button" className="secondary-btn" onClick={closeRemixEntry}>
+                  {t('gamePage.remixEntryCancel')}
+                </button>
+                <button type="submit" className="primary-btn" disabled={remixRequest.trim().length < 2}>
+                  <PixelIcon name="wrench" size={13} /> {t('gamePage.remixEntrySubmit')}
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
       ) : null}
 
       <AuthModal isOpen={authOpen} onClose={() => setAuthOpen(false)} />

--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -29,15 +29,18 @@ vi.mock('./PublishedGameFrame', () => ({
   PublishedGameFrame: ({
     frameRef,
     remixOpenNonce,
+    initialRemixRequest,
   }: {
     frameRef?: { current: HTMLIFrameElement | null };
     remixOpenNonce?: number;
+    initialRemixRequest?: string;
   }) => (
     <iframe
       className="game-frame"
       title="game"
       ref={frameRef as React.Ref<HTMLIFrameElement>}
       data-remix-open={remixOpenNonce ?? 0}
+      data-remix-request={initialRemixRequest ?? ''}
     />
   ),
 }));
@@ -70,7 +73,9 @@ afterEach(() => {
   container.remove();
 });
 
-async function draw(props: { controls?: string; onExit?: () => void; initialRemixOpen?: boolean } = {}) {
+async function draw(
+  props: { controls?: string; onExit?: () => void; initialRemixOpen?: boolean; initialRemixRequest?: string } = {},
+) {
   root = createRoot(container);
   await act(async () => {
     root!.render(
@@ -82,6 +87,7 @@ async function draw(props: { controls?: string; onExit?: () => void; initialRemi
         onExit={props.onExit ?? (() => undefined)}
         controls={props.controls}
         initialRemixOpen={props.initialRemixOpen}
+        initialRemixRequest={props.initialRemixRequest}
       />,
     );
   });
@@ -103,9 +109,10 @@ async function pressEscape() {
 }
 
 describe('GameTheater more menu', () => {
-  it('opens the remix surface immediately when entered from the game page', async () => {
-    await draw({ initialRemixOpen: true });
+  it('opens the remix surface with the request entered on the game page', async () => {
+    await draw({ initialRemixOpen: true, initialRemixRequest: 'make it faster' });
     expect(container.querySelector('.game-frame')?.getAttribute('data-remix-open')).toBe('1');
+    expect(container.querySelector('.game-frame')?.getAttribute('data-remix-request')).toBe('make it faster');
   });
 
   it('keeps the hamburger icon when open and highlights it instead of turning into an X', async () => {

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -93,6 +93,8 @@ type GameTheaterProps = {
   touch?: CatalogTouch | null;
   /** Open the remix sheet on the first frame (the game-page Remix entry). */
   initialRemixOpen?: boolean;
+  /** A request written before theater entry; RemixPanel starts it once safely ready. */
+  initialRemixRequest?: string;
 };
 
 // Long enough that the bar never reacts like a hover tooltip, short enough to clear
@@ -143,6 +145,7 @@ export function GameTheater({
   controls,
   touch = null,
   initialRemixOpen = false,
+  initialRemixRequest,
 }: GameTheaterProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
@@ -759,6 +762,7 @@ export function GameTheater({
             embed
             remixable
             remixOpenNonce={remixOpenNonce}
+            initialRemixRequest={initialRemixRequest}
             painterNonce={painterNonce}
             onRemixCapabilities={onRemixCapabilities}
           />

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -85,6 +85,10 @@ export function PublishedGameFrame({
   const [remixSession, setRemixSession] = useState<RemixSession | null>(null);
   const [remixUndoable, setRemixUndoable] = useState(false);
   const [remixOpen, setRemixOpen] = useState(false);
+  // The landing-page request is a one-shot handoff. Keep consumption above the
+  // panel because closing the sheet unmounts it; leaving the request on props
+  // would replay the same (potentially paid) change when the player reopened it.
+  const [pendingInitialRemixRequest, setPendingInitialRemixRequest] = useState(initialRemixRequest ?? null);
   /**
    * Level-editor stage: the painter leaves the remix sheet and owns the theater.
    * Focus flips Edit ↔ Play without unmounting the iframe or the painter — the
@@ -179,7 +183,8 @@ export function PublishedGameFrame({
           slug={slug}
           frameRef={activeFrameRef}
           initialParams={sharedParams}
-          initialRequest={initialRemixRequest}
+          initialRequest={pendingInitialRemixRequest}
+          onInitialRequestConsumed={() => setPendingInitialRemixRequest(null)}
           onSwapDocument={setRemixHtml}
           session={remixSession}
           onSession={setRemixSession}

--- a/apps/web/src/PublishedGameFrame.tsx
+++ b/apps/web/src/PublishedGameFrame.tsx
@@ -35,6 +35,8 @@ type PublishedGameFrameProps = {
    * is untouched by either — these add doors, they do not move the invitation.
    */
   remixOpenNonce?: number;
+  /** A landing-page request to start after the remix session is ready. */
+  initialRemixRequest?: string;
   painterNonce?: number;
   /** Reports whether this game's remix has a painter, for the menu to show its entry. */
   onRemixCapabilities?: (caps: { painter: boolean }) => void;
@@ -54,6 +56,7 @@ export function PublishedGameFrame({
   active = true,
   remixable,
   remixOpenNonce,
+  initialRemixRequest,
   painterNonce,
   onRemixCapabilities,
 }: PublishedGameFrameProps) {
@@ -176,6 +179,7 @@ export function PublishedGameFrame({
           slug={slug}
           frameRef={activeFrameRef}
           initialParams={sharedParams}
+          initialRequest={initialRemixRequest}
           onSwapDocument={setRemixHtml}
           session={remixSession}
           onSession={setRemixSession}

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -15,8 +15,9 @@ import i18n from './i18n/index.js';
 // A stable identity, as the real context has: `user` is state there, so it does
 // not change on every render.
 const alice = { uid: 'g:alice' };
+let authUser: typeof alice | null = alice;
 vi.mock('./AuthContext', () => ({
-  useAuth: () => ({ user: alice, signInWithGoogleToken: vi.fn(), logout: vi.fn() }),
+  useAuth: () => ({ user: authUser, signInWithGoogleToken: vi.fn(), logout: vi.fn() }),
 }));
 
 const remixApi = vi.hoisted(() => ({
@@ -49,6 +50,8 @@ let swapped: string[] = [];
 beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   await i18n.changeLanguage('en');
+  authUser = alice;
+  window.sessionStorage.clear();
   container = document.createElement('div');
   document.body.appendChild(container);
   swapped = [];
@@ -67,17 +70,22 @@ afterEach(() => {
 const frameWindow = { postMessage: () => {} } as unknown as Window;
 const frameRef = { current: { contentWindow: frameWindow } } as unknown as React.RefObject<HTMLIFrameElement>;
 
-async function draw() {
+function panel(props: { initialRequest?: string } = {}) {
+  return (
+    <RemixPanel
+      slug="dog-dash"
+      frameRef={frameRef as never}
+      onSwapDocument={(html) => swapped.push(html)}
+      onClose={() => {}}
+      initialRequest={props.initialRequest}
+    />
+  );
+}
+
+async function draw(props: { initialRequest?: string } = {}) {
   root = createRoot(container);
   await act(async () => {
-    root!.render(
-      <RemixPanel
-        slug="dog-dash"
-        frameRef={frameRef as never}
-        onSwapDocument={(html) => swapped.push(html)}
-        onClose={() => {}}
-      />,
-    );
+    root!.render(panel(props));
   });
   await act(async () => {
     await Promise.resolve();
@@ -85,6 +93,61 @@ async function draw() {
 }
 
 describe('RemixPanel', () => {
+  it('auto-starts a carried request exactly once after the session is ready', async () => {
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: { speed: { type: 'number', min: 1, max: 3, default: 1, label: { en: 'speed' } } },
+      values: { speed: 1 },
+      canAssist: true,
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist.mockResolvedValue({ lane: 'params', values: { speed: 2 } });
+
+    await draw({ initialRequest: '  make it faster  ' });
+    await vi.waitFor(() => {
+      expect(remixApi.remixAssist).toHaveBeenCalledTimes(1);
+    });
+
+    expect(remixApi.remixAssist).toHaveBeenCalledWith('r1', 'make it faster', { speed: 1 });
+    expect(remixApi.remixCode).not.toHaveBeenCalled();
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('typed');
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('asked');
+  });
+
+  it('carries a signed-out request through the existing pending-request wall', async () => {
+    authUser = null;
+    remixApi.startRemix.mockResolvedValue({
+      remixId: 'r1',
+      params: null,
+      values: null,
+      canAssist: true,
+      canCode: true,
+      suggestions: [],
+      expiresInMs: 3_600_000,
+    });
+    remixApi.remixAssist.mockResolvedValue({ lane: 'params', values: {} });
+
+    await draw({ initialRequest: 'make it faster' });
+
+    expect(remixApi.startRemix).not.toHaveBeenCalled();
+    expect(remixApi.remixAssist).not.toHaveBeenCalled();
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('typed');
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('wall_shown');
+
+    authUser = alice;
+    await act(async () => {
+      root!.render(panel({ initialRequest: 'make it faster' }));
+    });
+    await vi.waitFor(() => {
+      expect(remixApi.remixAssist).toHaveBeenCalledTimes(1);
+    });
+
+    expect(remixApi.remixAssist).toHaveBeenCalledWith('r1', 'make it faster', {});
+    expect(telemetry.recordRemixStep).toHaveBeenCalledWith('signed_in');
+  });
+
   it('says why there is no prompt when no lane answers for this game', async () => {
     remixApi.startRemix.mockResolvedValue({
       remixId: 'r1',

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -200,6 +200,8 @@ export function RemixPanel(props: {
   onClose: () => void;
   /** Shared values from a `?remix=` link, already parsed. */
   initialParams?: Record<string, EditorParamValue> | null;
+  /** A request written before theater entry. It is consumed at most once. */
+  initialRequest?: string | null;
   /**
    * The session, owned by the parent so it outlives this sheet.
    *
@@ -544,19 +546,34 @@ export function RemixPanel(props: {
     if (painterRequest > 0) openPainter('menu');
   }, [painterRequest, openPainter]);
 
-  // The reward lands the second they're through the wall: once the session
-  // exists and a stashed request is waiting, run it with no further taps.
-  const ranPendingRef = useRef(false);
+  // A landing-page request follows the same wall as a request typed here. Ask
+  // once while signed out so the words enter the existing tab-scoped stash;
+  // no session or model request is created before sign-in.
+  const stashedInitialRef = useRef(false);
+  const initialRequest = props.initialRequest?.trim().slice(0, MAX_UTTERANCE) ?? '';
   useEffect(() => {
-    if (!session || ranPendingRef.current) return;
+    if (user || stashedInitialRef.current || initialRequest.length < 2) return;
+    stashedInitialRef.current = true;
+    setUtterance(initialRequest);
+    void ask(initialRequest);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one carried request, through the existing ask path
+  }, [user, initialRequest]);
+
+  // The reward lands the second they're through the wall: once the session
+  // exists, prefer a stashed request and otherwise start the carried request.
+  // One ref guards both sources so a stale stash and a new entry cannot spend twice.
+  const ranAutomaticRequestRef = useRef(false);
+  useEffect(() => {
+    if (!session || ranAutomaticRequestRef.current) return;
     const pending = takePending(props.slug);
-    if (pending === null) return;
-    ranPendingRef.current = true;
-    recordRemixStep('signed_in');
-    setUtterance(pending);
-    void ask(pending, session);
+    const request = pending ?? (initialRequest.length >= 2 ? initialRequest : null);
+    if (request === null) return;
+    ranAutomaticRequestRef.current = true;
+    if (pending !== null) recordRemixStep('signed_in');
+    setUtterance(request);
+    void ask(request, session);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once per session arrival
-  }, [session, props.slug]);
+  }, [session, props.slug, initialRequest]);
 
   // The field grows to the sentence rather than scrolling it out of sight: a
   // one-line box teaches people to write search terms, and search terms are the

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -202,6 +202,8 @@ export function RemixPanel(props: {
   initialParams?: Record<string, EditorParamValue> | null;
   /** A request written before theater entry. It is consumed at most once. */
   initialRequest?: string | null;
+  /** Clears the one-shot request in the frame that outlives this panel. */
+  onInitialRequestConsumed?: () => void;
   /**
    * The session, owned by the parent so it outlives this sheet.
    *
@@ -554,6 +556,7 @@ export function RemixPanel(props: {
   useEffect(() => {
     if (user || stashedInitialRef.current || initialRequest.length < 2) return;
     stashedInitialRef.current = true;
+    props.onInitialRequestConsumed?.();
     setUtterance(initialRequest);
     void ask(initialRequest);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one carried request, through the existing ask path
@@ -570,6 +573,7 @@ export function RemixPanel(props: {
     if (request === null) return;
     ranAutomaticRequestRef.current = true;
     if (pending !== null) recordRemixStep('signed_in');
+    if (pending === null) props.onInitialRequestConsumed?.();
     setUtterance(request);
     void ask(request, session);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once per session arrival

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1246,7 +1246,14 @@
     "screenshots": "Screenshots",
     "viewScreenshot": "View screenshot {{number}}",
     "breadcrumbAria": "Game location",
-    "remix": "Remix"
+    "remix": "Remix",
+    "remixEntryTitle": "What would you change?",
+    "remixEntryDescription": "Describe one change. We'll open the game and start the remix for you.",
+    "remixEntryLabel": "Change request",
+    "remixEntryPlaceholder": "For example: make the game faster",
+    "remixEntryClose": "Close remix request",
+    "remixEntryCancel": "Cancel",
+    "remixEntrySubmit": "Start remix"
   },
   "propose": {
     "action": "Propose this change",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1250,7 +1250,14 @@
     "screenshots": "Zrzuty ekranu",
     "viewScreenshot": "Pokaż zrzut ekranu {{number}}",
     "breadcrumbAria": "Położenie gry",
-    "remix": "Odbij"
+    "remix": "Odbij",
+    "remixEntryTitle": "Co chcesz zmienić?",
+    "remixEntryDescription": "Opisz jedną zmianę. Otworzymy grę i od razu rozpoczniemy remiks.",
+    "remixEntryLabel": "Opis zmiany",
+    "remixEntryPlaceholder": "Na przykład: przyspiesz grę",
+    "remixEntryClose": "Zamknij opis remiksu",
+    "remixEntryCancel": "Anuluj",
+    "remixEntrySubmit": "Rozpocznij remiks"
   },
   "propose": {
     "action": "Zaproponuj tę zmianę",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13521,23 +13521,78 @@ body.remix-entry-open {
   }
 
   .game-page-remix-backdrop {
-    align-items: end;
+    align-items: stretch;
     padding: 0;
+    background: var(--bg);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
   }
 
   .game-page-remix-dialog {
+    display: flex;
+    flex-direction: column;
     width: 100%;
-    max-height: min(88dvh, 620px);
+    height: 100dvh;
+    max-height: none;
     overflow-y: auto;
-    border-right: 0;
-    border-bottom: 0;
-    border-left: 0;
-    border-radius: 16px 16px 0 0;
+    padding-top: max(1.25rem, env(safe-area-inset-top));
+    padding-right: max(1rem, env(safe-area-inset-right));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+    padding-left: max(1rem, env(safe-area-inset-left));
+    border: 0;
+    border-radius: 0;
+    background:
+      radial-gradient(circle at 100% 0, rgba(0, 229, 183, 0.1), transparent 36%),
+      var(--panel);
+    box-shadow: none;
+  }
+
+  .game-page-remix-dialog-head {
+    gap: 0.75rem;
+  }
+
+  .game-page-remix-dialog h2 {
+    font-size: clamp(1.5rem, 7vw, 1.85rem);
+  }
+
+  .game-page-remix-dialog-head p {
+    max-width: 32rem;
+    font-size: 1rem;
+  }
+
+  .game-page-remix-form {
+    flex: 1;
+    grid-template-rows: auto minmax(8rem, 1fr) auto;
+    min-height: 0;
+    margin-top: clamp(1.5rem, 7dvh, 3.5rem);
+  }
+
+  .game-page-remix-form textarea {
+    height: 100%;
+    min-height: clamp(8rem, 34dvh, 18rem);
+    resize: none;
+    border-color: rgba(0, 229, 183, 0.45);
+    background: rgba(5, 10, 16, 0.72);
+    font-size: 1rem;
+  }
+
+  .game-page-remix-form-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 0.65fr) minmax(0, 1.55fr);
+    gap: 0.75rem;
+    width: 100%;
+    margin-top: 0.75rem;
   }
 
   .game-page-remix-form-actions > button {
-    flex: 1;
+    min-height: 52px;
     justify-content: center;
+    padding-inline: 0.75rem;
+    font-size: clamp(0.85rem, 4vw, 0.95rem);
+  }
+
+  .game-page-remix-form-actions > button[type='submit'] {
+    white-space: nowrap;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12749,6 +12749,99 @@ button.builder-mode-selector:disabled {
   border-color: var(--turquoise);
 }
 
+body.remix-entry-open {
+  overflow: hidden;
+}
+
+.game-page-remix-backdrop {
+  position: fixed;
+  z-index: 1100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(2, 7, 13, 0.78);
+  backdrop-filter: blur(6px);
+}
+
+.game-page-remix-dialog {
+  width: min(520px, 100%);
+  padding: clamp(1.2rem, 4vw, 1.75rem);
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+}
+
+.game-page-remix-dialog-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.game-page-remix-dialog h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 4vw, 1.75rem);
+}
+
+.game-page-remix-dialog-head p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.game-page-remix-close {
+  display: grid;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid var(--panel-border);
+  border-radius: 9px;
+  background: var(--panel-raised);
+  color: var(--text);
+  cursor: pointer;
+  place-items: center;
+}
+
+.game-page-remix-form {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+
+.game-page-remix-form label {
+  font-weight: 700;
+}
+
+.game-page-remix-form textarea {
+  width: 100%;
+  min-height: 112px;
+  resize: vertical;
+  padding: 0.85rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.45;
+}
+
+.game-page-remix-form textarea:focus-visible,
+.game-page-remix-close:focus-visible {
+  border-color: var(--turquoise);
+  outline: 2px solid var(--turquoise-glow);
+  outline-offset: 2px;
+}
+
+.game-page-remix-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.65rem;
+  margin-top: 0.35rem;
+}
+
 .game-page-preview {
   position: relative;
   display: block;
@@ -13424,6 +13517,26 @@ button.builder-mode-selector:disabled {
   .game-page-preview-cta {
     bottom: 0.6rem;
     white-space: nowrap;
+  }
+
+  .game-page-remix-backdrop {
+    align-items: end;
+    padding: 0;
+  }
+
+  .game-page-remix-dialog {
+    width: 100%;
+    max-height: min(88dvh, 620px);
+    overflow-y: auto;
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 16px 16px 0 0;
+  }
+
+  .game-page-remix-form-actions > button {
+    flex: 1;
+    justify-content: center;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12761,6 +12761,7 @@ body.remix-entry-open {
   place-items: center;
   padding: 1rem;
   background: rgba(2, 7, 13, 0.78);
+  -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13521,18 +13521,29 @@ body.remix-entry-open {
   }
 
   .game-page-remix-backdrop {
+    top: 0;
+    right: 0;
+    bottom: auto;
+    left: 0;
     align-items: stretch;
+    height: 100vh;
+    height: 100dvh;
     padding: 0;
     background: var(--bg);
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
   }
 
+  .game-page-remix-backdrop.is-viewport-tracked {
+    height: var(--remix-entry-viewport-height, 100dvh);
+    transform: translateY(var(--remix-entry-viewport-offset, 0px));
+  }
+
   .game-page-remix-dialog {
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 100dvh;
+    height: 100%;
     max-height: none;
     overflow-y: auto;
     padding-top: max(1.25rem, env(safe-area-inset-top));

--- a/apps/web/src/styles.gamePageRemix.test.ts
+++ b/apps/web/src/styles.gamePageRemix.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+const phoneStart = css.lastIndexOf('@media (max-width: 600px)');
+const phoneEnd = css.indexOf('/* ---------------------------------------------------------------------------', phoneStart);
+const phoneCss = css.slice(phoneStart, phoneEnd);
+
+function phoneRule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]+)\\}`).exec(phoneCss);
+  expect(match, `no phone ${selector} rule in styles.css`).not.toBeNull();
+  return match![1]!;
+}
+
+describe('game-page Remix entry on phones', () => {
+  it('uses a full-screen, opaque composer instead of a bottom sheet', () => {
+    const backdrop = phoneRule('.game-page-remix-backdrop');
+    const dialog = phoneRule('.game-page-remix-dialog');
+
+    expect(backdrop).toMatch(/background:\s*var\(--bg\)/);
+    expect(backdrop).toMatch(/backdrop-filter:\s*none/);
+    expect(dialog).toMatch(/height:\s*100dvh/);
+    expect(dialog).toMatch(/max-height:\s*none/);
+    expect(dialog).toMatch(/border:\s*0/);
+    expect(dialog).toMatch(/border-radius:\s*0/);
+  });
+
+  it('keeps the composer and actions usable with safe areas and a shrinking viewport', () => {
+    const dialog = phoneRule('.game-page-remix-dialog');
+    const form = phoneRule('.game-page-remix-form');
+    const actions = phoneRule('.game-page-remix-form-actions');
+
+    expect(dialog).toMatch(/safe-area-inset-top/);
+    expect(dialog).toMatch(/safe-area-inset-bottom/);
+    expect(form).toMatch(/grid-template-rows:\s*auto minmax\(8rem,\s*1fr\) auto/);
+    expect(form).toMatch(/min-height:\s*0/);
+    expect(actions).toMatch(/grid-template-columns:\s*minmax\(0,\s*0\.65fr\) minmax\(0,\s*1\.55fr\)/);
+    expect(phoneRule('.game-page-remix-form-actions > button')).toMatch(/min-height:\s*52px/);
+    expect(phoneRule(".game-page-remix-form-actions > button[type='submit']")).toMatch(/white-space:\s*nowrap/);
+  });
+});

--- a/apps/web/src/styles.gamePageRemix.test.ts
+++ b/apps/web/src/styles.gamePageRemix.test.ts
@@ -21,7 +21,10 @@ describe('game-page Remix entry on phones', () => {
 
     expect(backdrop).toMatch(/background:\s*var\(--bg\)/);
     expect(backdrop).toMatch(/backdrop-filter:\s*none/);
-    expect(dialog).toMatch(/height:\s*100dvh/);
+    expect(backdrop).toMatch(/bottom:\s*auto/);
+    expect(backdrop).toMatch(/height:\s*100vh/);
+    expect(backdrop).toMatch(/height:\s*100dvh/);
+    expect(dialog).toMatch(/height:\s*100%/);
     expect(dialog).toMatch(/max-height:\s*none/);
     expect(dialog).toMatch(/border:\s*0/);
     expect(dialog).toMatch(/border-radius:\s*0/);
@@ -39,5 +42,12 @@ describe('game-page Remix entry on phones', () => {
     expect(actions).toMatch(/grid-template-columns:\s*minmax\(0,\s*0\.65fr\) minmax\(0,\s*1\.55fr\)/);
     expect(phoneRule('.game-page-remix-form-actions > button')).toMatch(/min-height:\s*52px/);
     expect(phoneRule(".game-page-remix-form-actions > button[type='submit']")).toMatch(/white-space:\s*nowrap/);
+  });
+
+  it('hands sizing to the visual viewport when the keyboard changes it', () => {
+    const tracked = phoneRule('.game-page-remix-backdrop.is-viewport-tracked');
+
+    expect(tracked).toMatch(/height:\s*var\(--remix-entry-viewport-height,\s*100dvh\)/);
+    expect(tracked).toMatch(/transform:\s*translateY\(var\(--remix-entry-viewport-offset,\s*0px\)\)/);
   });
 });


### PR DESCRIPTION
## What changed

- The canonical game-page Remix action now opens a focused request sheet on the landing page.
- No theater or game iframe mounts until the visitor submits a non-empty request.
- The submitted request is carried into theater and starts through the existing Remix flow once the session is ready.
- The carried request is consumed exactly once, so closing and reopening the Remix panel cannot replay it.
- Existing in-theater wrench behavior is unchanged.
- Added English and Polish copy, keyboard/focus handling, and integration coverage.
- Phones use a full-screen, safe-area-aware Remix composer instead of a cramped bottom sheet, with a flexible request field and a primary action sized for the longest Polish label.
- The composer tracks the mobile visual viewport during keyboard resize and Safari pan events, keeping its action row above the keys.

## Why

Opening theater before the visitor has said what they want to change made Remix feel like an indirect play action. This gives Remix a dedicated entry experience and delays the expensive/immersive player transition until intent is clear.

## Measurement

No telemetry event names, payload schemas, or privacy behavior changed. The existing Remix funnel remains queryable: `opened` represents entry into this dedicated request step, followed by the existing `typed → wall_shown/signed_in → asked → applied` progression. Request text is not added to telemetry. Existing visit and play instrumentation continues to answer the first-minute, session, and acquisition questions.

## Validation

- `npm install`
- `npm run type-check && npm run lint && npm run test && npm run build`
- Focused Remix/theater/mobile suite: 62 passing
- Production web build
- Browser QA:
  - 390×844 composer fills the viewport with no horizontal overflow
  - visual viewport resize from 844px to 480px updates the overlay to 480px
  - actions end at 464px in the 480px keyboard-height viewport
  - Safari-style visual viewport offsets are applied to the overlay
  - 320px Polish primary action remains on one line
  - URL remains canonical and no iframe mounts when the composer opens
  - request field receives focus
  - game iframe sandbox remains exactly `allow-scripts allow-pointer-lock`
