### PR TITLE
Play button on the round card, and a nudge to open it

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -189,7 +189,10 @@ cache), so a resume cannot keep showing “finished this round” next to live p
   per-game compatibility path in UI, API routes, or MCP tool handling.
 - An opener is checked by `start`; later calls use the returned round-scoped `sessionKey`.
 - **`show_round` is the only tool that opens the creator's status card**, and it exists for
-  nothing else. It used to hang off `start` and `get_gate_verdict`, which made the card a side
+  nothing else. Agents do not call it on their own — ChatGPT never did until the creator
+  asked (2026-08-05) — so a view-capable session that has not opened one gets a bounded
+  `warnings.code=card_unopened` nudge, the same remedy `call_end` needed. Never sent to a
+  client with no views. It used to hang off `start` and `get_gate_verdict`, which made the card a side
   effect of workflow mechanics — an agent that re-ran `start` before each operation left one
   card per call (ChatGPT, 2026-08-05). The host renders one card per call carrying `_meta.ui`,
   so when adding a view, give it its own tool rather than attaching it to a tool agents call

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2012,6 +2012,63 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     ]);
   });
 
+  it('reminds a view-capable agent to open the card, then stops asking', async () => {
+    // Observed 2026-08-05: ChatGPT never called show_round on its own — the creator had
+    // to ask for it, which makes the card non-existent rather than occasionally missing.
+    // Same lesson call_end taught: a workflow step alone does not reach these agents.
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const { sessionId } = await initializeWith(app, true);
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const codes = async () => {
+      const res = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+      return ((res.structured as { warnings?: Array<{ code: string }> }).warnings ?? []).map((w) => w.code);
+    };
+
+    expect(await codes()).toContain('card_unopened');
+
+    // Bounded: the card is for the creator, not the build. An agent that ignores it is
+    // not doing anything wrong, and a warning on every response would crowd out the
+    // ones that matter.
+    await codes();
+    await codes();
+    expect(await codes()).not.toContain('card_unopened');
+  });
+
+  it('stops reminding once the card is open, and never reminds a client with no views', async () => {
+    process.env.MCP_UI = 'true';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const { sessionId } = await initializeWith(app, true);
+    const started = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    await callTool(app, 'show_round', { sessionKey }, { 'mcp-session-id': sessionId });
+    const after = await callTool(app, 'get_brief', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(
+      ((after.structured as { warnings?: Array<{ code: string }> }).warnings ?? []).map((w) => w.code),
+    ).not.toContain('card_unopened');
+
+    // A client with no views has no card to open. Telling Claude Code or a headless
+    // agent to call show_round is noise about a surface it does not have.
+    const store2 = new InMemoryStore();
+    await seedJob(store2);
+    await app.close();
+    app = await createApp(store2);
+    const { sessionId: plain } = await initializeWith(app, false);
+    const plainStart = await callTool(app, 'start', { key: roundKey(1) }, { 'mcp-session-id': plain });
+    const plainKey = (plainStart.structured as { sessionKey: string }).sessionKey;
+    const plainRes = await callTool(app, 'get_brief', { sessionKey: plainKey }, { 'mcp-session-id': plain });
+    expect(
+      ((plainRes.structured as { warnings?: Array<{ code: string }> }).warnings ?? []).map((w) => w.code),
+    ).not.toContain('card_unopened');
+  });
+
   it('gives the card its key on the opening result, and stays visible to the model', async () => {
     process.env.MCP_UI = 'true';
     const store = new InMemoryStore();

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -925,7 +925,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     if (toolName === 'submit_sources' && data.ok === true) {
       nudgeTracker.noteSubmitSuccess(jobId, nowMs);
     }
-    const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs);
+    if (toolName === 'show_round') nudgeTracker.noteCardOpened(jobId, nowMs);
+    const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs, {
+      // Only nudge toward a card in a client that can render one.
+      uiCapable: sessionWantsUi((ctx.request.headers['mcp-session-id'] as string | undefined) ?? null),
+    });
     const prior = Array.isArray(data.warnings)
       ? (data.warnings as NudgeWarning[]).filter(
           (w) => w && typeof w === 'object' && typeof w.code === 'string' && typeof w.message === 'string',
@@ -995,7 +999,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, card_unopened). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. card_unopened means the creator has no status card yet — call show_round once.',
       items: {
         type: 'object',
         properties: {
@@ -1009,6 +1013,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'gate_not_started',
               'gate_poll_backoff',
               'module_too_large',
+              'card_unopened',
             ],
           },
           message: { type: 'string' },

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -8,7 +8,13 @@
  */
 
 export type NudgeCode =
-  'progress_stale' | 'inbox_pending' | 'seed_unread' | 'call_end' | 'gate_not_started' | 'gate_poll_backoff';
+  | 'progress_stale'
+  | 'inbox_pending'
+  | 'seed_unread'
+  | 'call_end'
+  | 'gate_not_started'
+  | 'gate_poll_backoff'
+  | 'card_unopened';
 
 export interface NudgeWarning {
   code: NudgeCode;
@@ -32,12 +38,26 @@ export interface JobNudgeState {
   awaitingEnd: boolean;
   /** Wall-clock ms of the last successful get_gate_verdict in this tracker. */
   lastGatePollAt: number | null;
+  /** True once show_round has opened the creator's card in this round. */
+  cardOpened: boolean;
+  /** How many times we have asked for it, so the reminder cannot become noise. */
+  cardRemindersSent: number;
 }
 
 /** Minimum wall-clock gap used to detect repeated gate checks inside one agent run. */
 export const GATE_POLL_MIN_INTERVAL_MS = 25_000;
 /** Informational delay before a later creator-led run checks a pending gate again. */
 export const GATE_POLL_RETRY_AFTER_SECONDS = 30;
+
+/**
+ * How many times to ask an agent to open the creator's card before letting it go.
+ *
+ * Bounded because the card is for the creator, not the build: an agent that ignores it
+ * is not doing anything wrong, and a warning repeated on every response would crowd out
+ * the ones that matter. Three is enough to catch an agent that simply did not notice
+ * the step.
+ */
+export const CARD_REMINDER_LIMIT = 3;
 
 /** No progress for this long (wall clock) → `progress_stale`. */
 export const PROGRESS_STALE_MS = 90_000;
@@ -99,7 +119,9 @@ export interface McpNudgeTracker {
   /** `nowMs` is only used if the job has never been ensured — callers should pass the injected clock. */
   notePendingCount(jobId: number, count: number, nowMs: number): void;
   noteToolSuccess(jobId: number, toolName: string, nowMs: number): void;
-  warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[];
+  /** Called when show_round has put a card in front of the creator. */
+  noteCardOpened(jobId: number, nowMs: number): void;
+  warningsFor(jobId: number, toolName: string, nowMs: number, options?: { uiCapable?: boolean }): NudgeWarning[];
   /** Test helper. */
   peek(jobId: number): JobNudgeState | undefined;
 }
@@ -124,10 +146,16 @@ export function createMcpNudgeTracker(
         seedStatus: null,
         awaitingEnd: false,
         lastGatePollAt: null,
+        cardOpened: false,
+        cardRemindersSent: 0,
       };
       states.set(jobId, state);
     }
     return state;
+  }
+
+  function noteCardOpened(jobId: number, nowMs: number): void {
+    ensure(jobId, nowMs).cardOpened = true;
   }
 
   function noteProgress(jobId: number, nowMs: number): void {
@@ -186,9 +214,37 @@ export function createMcpNudgeTracker(
     }
   }
 
-  function warningsFor(jobId: number, toolName: string, nowMs: number): NudgeWarning[] {
+  function warningsFor(
+    jobId: number,
+    toolName: string,
+    nowMs: number,
+    options: { uiCapable?: boolean } = {},
+  ): NudgeWarning[] {
     const state = ensure(jobId, nowMs);
     const warnings: NudgeWarning[] = [];
+
+    // Only where a card can actually render. Telling Claude Code or a headless agent to
+    // call show_round is noise about a surface it does not have.
+    //
+    // Observed 2026-08-05: ChatGPT never called show_round on its own and the creator
+    // had to ask for it, which makes the card effectively non-existent rather than
+    // occasionally missing. The workflow step alone was not enough — the same lesson
+    // `call_end` taught, so it gets the same remedy.
+    if (
+      options.uiCapable &&
+      !state.cardOpened &&
+      state.cardRemindersSent < CARD_REMINDER_LIMIT &&
+      toolName !== 'show_round' &&
+      toolName !== 'start'
+    ) {
+      state.cardRemindersSent += 1;
+      warnings.push({
+        code: 'card_unopened',
+        message:
+          'The creator has no status card for this round — call show_round once so they can watch the build ' +
+          'and the gate without asking you. It is a read; it changes nothing.',
+      });
+    }
 
     if (!PROGRESS_NUDGE_EXEMPT.has(toolName)) {
       const anchor = state.lastProgressAt ?? state.startedAt;
@@ -259,6 +315,7 @@ export function createMcpNudgeTracker(
     noteEnded,
     notePendingCount,
     noteToolSuccess,
+    noteCardOpened,
     warningsFor,
     peek: (jobId) => states.get(jobId),
   };


### PR DESCRIPTION
From the owner's test of #606 in production, and a screenshot of a `READY FOR REVIEW` card with the observation: *"here we could have a PLAY button"*.

## The Play button

This is the step the whole flow exists for — the card shows what the agent built, the theater is where it gets played — and **the mechanism was only proven an hour ago**. `redirect_domains` (#606) is what gives ChatGPT permission to follow the link, and the `CSP off` badge clearing is what confirmed it landed.

A **link rather than an embedded game**, deliberately. gamedev.pl's theater already does fullscreen, pointer lock and touch; a chat card cannot. That is the same reasoning that cut in-chat play from Phase 2 — and this button is what replaced it. It is now real rather than designed.

Only offered when there is genuinely something to play (`ready_for_review` / `published` / `needs_changes`, or a green/`preview_passed` gate). A round that has delivered nothing would open a page saying the game is not available, which is a worse answer than no button.

**The URL is built server-side.** My first version hardcoded `https://www.gamedev.pl` in the view — wrong, because the view is one string served to every environment, so a staging card's Play button would have pointed at production. `playUrlFor` reads `WEB_ORIGIN` (falling back to `APP_BASE_URL`) and answers null when neither is configured, so the card offers no button rather than a link to nowhere.

That mistake was caught by the existing **"is self-contained"** test, which forbids any URL literal in the view. It was written to stop the card *fetching* anything, and it held a case it was never written for.

## The nudge, from the same test

Three of four #606 fixes confirmed working — one card per round, `CSP off` badge **gone**, sizing correct. The fourth did not: **ChatGPT never called `show_round` on its own.** The creator had to ask.

We accepted that an agent *might* skip it. But "occasionally skips" leaves the card mostly present, while "never calls it unprompted" makes the feature non-existent — and a creator who has to ask for a status card would rather just ask for the status.

The workflow step alone does not reach these agents; `call_end` taught that lesson already (its comment says *"ChatGPT often stops on the submit reply itself"*). So the card gets the same remedy: `warnings.code=card_unopened`, through the mechanism agents demonstrably read.

Two limits, because this is guidance and not correctness:

- **Only in a session that negotiated views.** Telling Claude Code or a headless agent to call `show_round` is noise about a surface it does not have.
- **Bounded to three reminders.** An agent that ignores it is not doing anything wrong, and a warning on every response would crowd out the ones that matter.

## Verification

Full API suite green (**2552** tests, 161 files), lint clean, branch on current master.

Browser harness: the Play button renders on a `ready_for_review` round and posts `ui/open-link` with that round's play URL.

Nudge tests cover all four cases — appears for a view-capable session, stops after three, stops immediately once `show_round` is called, never appears without views.

One contract detail worth noting: `card_unopened` had to be added to the declared `warnings` enum, because tool output is validated against its own `outputSchema`. A new nudge code is a contract change, not just a string.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_