### PR TITLE
fix: Remix/Play from game page opens theater (was scroll-lock only)

### DIFF
--- a/apps/web/src/App.gamePageTheater.test.ts
+++ b/apps/web/src/App.gamePageTheater.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
+
+/**
+ * Play/Remix on `/:handle/:slug` must mount the full-viewport theater.
+ *
+ * That route is an open-chrome early return in App. The handlers still set
+ * `stageContent` (and `body.player-open`), so if the overlay is only rendered
+ * in the signed-in main branch, Remix locks scroll and shows nothing — the
+ * bug that shipped with the public game page.
+ */
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const catalogEntry = {
+  slug: 'sky-dodge',
+  title: 'Sky Dodge',
+  genre: 'Arcade',
+  controls: 'Arrow keys',
+  status: 'published',
+  media: null,
+  multiplayer: null,
+  saves: null,
+  world: null,
+  sensing: null,
+  orientation: 'any',
+  touch: null,
+  submittedBy: 'nightshift',
+  creatorHandle: 'nightshift',
+};
+
+function mockApi() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/api/auth/me')) {
+      return new Response(JSON.stringify({ user: { uid: 'creator-1', tier: 'beta' } }));
+    }
+    if (url.endsWith('/api/health')) {
+      return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+    }
+    if (url.endsWith('/api/catalog')) {
+      return new Response(JSON.stringify([catalogEntry]));
+    }
+    if (url.endsWith('/api/games/sky-dodge/page')) {
+      return new Response(
+        JSON.stringify({
+          entry: catalogEntry,
+          creator: {
+            handle: 'nightshift',
+            profileName: 'Night Shift',
+            bio: '',
+            avatarUrl: null,
+            profileCreatedAt: '2026-07-01T00:00:00.000Z',
+          },
+          platformAuthored: false,
+          description: 'Dodge the sky.',
+        }),
+      );
+    }
+    if (url.endsWith('/api/games/sky-dodge/remix')) {
+      return new Response(JSON.stringify({ remixId: 'r1', values: {}, params: {}, suggestions: [] }));
+    }
+    if (url.endsWith('/api/games/sky-dodge')) {
+      return new Response(JSON.stringify({ slug: 'sky-dodge', title: 'Sky Dodge', html: '<!doctype html><canvas>' }));
+    }
+    return new Response(JSON.stringify({}), { status: 404 });
+  });
+}
+
+async function renderApp() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AuthProvider, null, createElement(App)));
+    await flushEffects();
+  });
+  await act(async () => {
+    await flushEffects();
+    await flushEffects();
+  });
+  return { container, root };
+}
+
+describe('theater from the public game page', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+    localStorage.clear();
+    window.history.pushState(null, '', '/');
+    vi.restoreAllMocks();
+  });
+
+  it('opens the theater (and remix sheet) from Remix without trapping page scroll alone', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/nightshift/sky-dodge');
+    const { container, root } = await renderApp();
+
+    expect(container.querySelector('.game-page h1')?.textContent).toBe('Sky Dodge');
+    expect(document.body.classList.contains('player-open')).toBe(false);
+
+    const remix = container.querySelector<HTMLButtonElement>('.game-page-remix');
+    expect(remix).not.toBeNull();
+    await act(async () => {
+      remix?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    // The failure mode was: player-open with no theater. Both must be present.
+    expect(document.body.classList.contains('player-open')).toBe(true);
+    expect(container.querySelector('.stage.is-playing-full-viewport')).not.toBeNull();
+    expect(container.querySelector('.exit-btn')).not.toBeNull();
+    // initialRemixOpen hands the sheet to the frame once the document loads.
+    await act(async () => {
+      await flushEffects();
+      await flushEffects();
+    });
+    expect(container.querySelector('.remix-panel, .remix-host')).not.toBeNull();
+
+    const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
+    await act(async () => {
+      exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(document.body.classList.contains('player-open')).toBe(false);
+    expect(container.querySelector('.stage.is-playing-full-viewport')).toBeNull();
+    expect(window.location.pathname).toBe('/nightshift/sky-dodge');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('opens the theater from Play on the same route', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/nightshift/sky-dodge');
+    const { container, root } = await renderApp();
+
+    const play = container.querySelector<HTMLButtonElement>('.game-page-actions .primary-btn');
+    expect(play).not.toBeNull();
+    await act(async () => {
+      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(document.body.classList.contains('player-open')).toBe(true);
+    expect(container.querySelector('.exit-btn')).not.toBeNull();
+    expect(window.location.pathname).toBe('/nightshift/sky-dodge');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -769,6 +769,80 @@ export function App() {
     }
   }
 
+  // Full-viewport theater / party overlay. Rendered from every branch that can open
+  // it — including the open-chrome early returns for `/:handle` and `/:handle/:slug`.
+  // Those routes set `stageContent` (and with it `body.player-open` scroll lock) the
+  // same way home and `/play` do; if the overlay only lived in the signed-in main
+  // return, Play/Remix on a game page would lock the page and show nothing.
+  const stageOverlay = (
+    <>
+      {stageContent?.type === 'party' && (
+        <section id="stage" className="panel stage is-playing-full-viewport">
+          <div className="game-theater-bar">
+            <div className="game-theater-meta">
+              <span className="theater-badge">
+                <PixelIcon name="phone" size={13} /> {t('party.badge')}
+              </span>
+              <h2 className="theater-title">{stageContent.game.title}</h2>
+            </div>
+            <div className="game-theater-actions">
+              <button
+                className="secondary-btn exit-btn"
+                onClick={() => setStageContent(null)}
+                aria-label={t('catalog.exitPlayer', { defaultValue: 'Close' })}
+                title={t('catalog.exitPlayer', { defaultValue: 'Close' })}
+              >
+                <PixelIcon name="close" size={14} />
+              </button>
+            </div>
+          </div>
+          <div className="game-viewport-container">
+            <PartyStage
+              key={stageContent.session.code}
+              game={stageContent.game}
+              session={stageContent.session}
+              onExit={() => setStageContent(null)}
+            />
+          </div>
+        </section>
+      )}
+
+      {stageContent?.type === 'catalog' && (
+        <GameTheater
+          key={stageContent.game.slug}
+          title={stageContent.game.title}
+          // AI Act art. 50 needs a disclosure at the point of consumption; keep
+          // it short so the title stays the hero of the bar.
+          badge={{ icon: 'sparkle', label: t('ai.generatedShort') }}
+          source={{ slug: stageContent.game.slug }}
+          onExit={() => setStageContent(null)}
+          orientation={stageContent.game.orientation}
+          reportSlug={stageContent.game.slug}
+          submittedBy={stageContent.game.submittedBy}
+          creatorHandle={stageContent.game.creatorHandle}
+          controls={stageContent.game.controls}
+          touch={stageContent.game.touch}
+          initialRemixOpen={stageContent.initialRemixOpen}
+        />
+      )}
+
+      {stageContent?.type === 'generated' && (
+        <GameTheater
+          key={stageContent.game.html}
+          title={stageContent.game.title}
+          badge={{ icon: 'rocket', label: t('ai.generatedShort') }}
+          source={{ html: stageContent.game.html }}
+          onExit={() => setStageContent(null)}
+          meta={
+            stageContent.prompt ? (
+              <span className="theater-controls">{t('home.generatedFrom', { prompt: stageContent.prompt })}</span>
+            ) : undefined
+          }
+        />
+      )}
+    </>
+  );
+
   // A phone that scanned a lobby QR is anonymous by design: it has no session and
   // never will, so the controller route is checked BEFORE the auth gates. It is
   // useless without a valid room token, which only an allowlisted host can mint.
@@ -848,7 +922,9 @@ export function App() {
             }}
           />
         </main>
-        <SiteFooter />
+        {/* Theater must mount here too: profile Play sets stageContent on this branch. */}
+        {stageOverlay}
+        {!stageContent && <SiteFooter />}
       </div>
     );
   }
@@ -880,7 +956,10 @@ export function App() {
             onGameLoaded={setGameTitle}
           />
         </main>
-        <SiteFooter />
+        {/* Play/Remix on this page set stageContent; without the overlay here the
+            body scroll-locks (`player-open`) and nothing covers the page. */}
+        {stageOverlay}
+        {!stageContent && <SiteFooter />}
       </div>
     );
   }
@@ -1029,70 +1108,7 @@ export function App() {
               </>
             )}
 
-            {stageContent?.type === 'party' && (
-              <section id="stage" className="panel stage is-playing-full-viewport">
-                <div className="game-theater-bar">
-                  <div className="game-theater-meta">
-                    <span className="theater-badge">
-                      <PixelIcon name="phone" size={13} /> {t('party.badge')}
-                    </span>
-                    <h2 className="theater-title">{stageContent.game.title}</h2>
-                  </div>
-                  <div className="game-theater-actions">
-                    <button
-                      className="secondary-btn exit-btn"
-                      onClick={() => setStageContent(null)}
-                      aria-label={t('catalog.exitPlayer', { defaultValue: 'Close' })}
-                      title={t('catalog.exitPlayer', { defaultValue: 'Close' })}
-                    >
-                      <PixelIcon name="close" size={14} />
-                    </button>
-                  </div>
-                </div>
-                <div className="game-viewport-container">
-                  <PartyStage
-                    key={stageContent.session.code}
-                    game={stageContent.game}
-                    session={stageContent.session}
-                    onExit={() => setStageContent(null)}
-                  />
-                </div>
-              </section>
-            )}
-
-            {stageContent?.type === 'catalog' && (
-              <GameTheater
-                key={stageContent.game.slug}
-                title={stageContent.game.title}
-                // AI Act art. 50 needs a disclosure at the point of consumption; keep
-                // it short so the title stays the hero of the bar.
-                badge={{ icon: 'sparkle', label: t('ai.generatedShort') }}
-                source={{ slug: stageContent.game.slug }}
-                onExit={() => setStageContent(null)}
-                orientation={stageContent.game.orientation}
-                reportSlug={stageContent.game.slug}
-                submittedBy={stageContent.game.submittedBy}
-                creatorHandle={stageContent.game.creatorHandle}
-                controls={stageContent.game.controls}
-                touch={stageContent.game.touch}
-                initialRemixOpen={stageContent.initialRemixOpen}
-              />
-            )}
-
-            {stageContent?.type === 'generated' && (
-              <GameTheater
-                key={stageContent.game.html}
-                title={stageContent.game.title}
-                badge={{ icon: 'rocket', label: t('ai.generatedShort') }}
-                source={{ html: stageContent.game.html }}
-                onExit={() => setStageContent(null)}
-                meta={
-                  stageContent.prompt ? (
-                    <span className="theater-controls">{t('home.generatedFrom', { prompt: stageContent.prompt })}</span>
-                  ) : undefined
-                }
-              />
-            )}
+            {stageOverlay}
 
             {partyError && <p className="error party-error">{partyError}</p>}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On a public game page (`/:handle/:slug`, e.g. `/magicgames/nieustanne-skoki`), pressing **Remix** (or **Play**):

1. Did not open the theater / remix UI
2. Locked page scroll (`body.player-open`) with no way to recover without a reload

## Cause

Those routes early-return an open-chrome shell in `App`. The Play/Remix handlers still set `stageContent`, which applies the scroll lock — but `GameTheater` only mounted in the signed-in main return, so the overlay never appeared.

Same gap for **Play** from a creator profile (`/:handle`).

## Fix

Extract the stage overlay into one shared fragment and render it from the game and creator early-return branches (as well as the main shell).

## Test

- `App.gamePageTheater.test.ts` — Remix and Play from `/:handle/:slug` mount the theater, set/clear `player-open`, and leave the URL unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c3bea59-364b-4f86-acff-fb7eb03a1537?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c3bea59-364b-4f86-acff-fb7eb03a1537&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

