### PR TITLE
Let the last Studio turn scroll to the top of the pane

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -216,11 +216,15 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
 
       const shell = await page.evaluate(() => {
         const scroller = document.querySelector('.studio-thread-scroll');
+        const pad = document.querySelector('.studio-thread-scroll-pad');
         const detail = document.querySelector('.studio-detail');
         const layout = document.querySelector('.studio-layout');
         return {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
+          hasScrollPad: Boolean(pad),
+          // Pad must add real slack: last turn can scroll toward the top of the pane.
+          scrollerSlack: scroller && pad ? scroller.scrollHeight - scroller.clientHeight : 0,
           gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
           compactShelf: Boolean(layout?.classList.contains('is-compact-shelf')),
           shelfOpen: Boolean(layout?.classList.contains('is-shelf-open')),
@@ -248,6 +252,10 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       expect(shell.scrollerOverflowY, 'the transcript needs its own scroller once the page has none').toMatch(
         /^(auto|scroll)$/,
       );
+
+      // Claude/Cursor shape: empty runway under the turns so the last message can rise.
+      expect(shell.hasScrollPad, 'transcript needs a bottom pad for last-turn scroll').toBe(true);
+      expect(shell.scrollerSlack, 'bottom pad must create scrollable slack in the transcript').toBeGreaterThan(80);
 
       // Desktop compact rail (~56px) leaves the work surface owning the rest of the window.
       if (viewport.width >= 801) {

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1462,6 +1462,8 @@ describe('SubmissionStatusView', () => {
     expect(working?.textContent).toContain('Writing code');
     expect(container.querySelector('.studio-turn-working-pulse')).not.toBeNull();
     expect(container.querySelector('.studio-thread-context')).toBeNull();
+    // Empty runway under the turns so the last message can scroll to the top of the pane.
+    expect(container.querySelector('.studio-thread-scroll-pad')).not.toBeNull();
     // Abandon / checklist / Play stay out of the foot.
     expect(container.querySelector('.studio-context-stop')).toBeNull();
     expect(container.querySelector('.studio-context-progress')).toBeNull();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1760,6 +1760,9 @@ function ThreadStream({
         ) : null}
       </ol>
       {after}
+      {/* Empty runway under the turns — Claude/Cursor shape. Lets the reader scroll
+          until the last message sits at the top of the pane, not stuck on the fold. */}
+      <div className="studio-thread-scroll-pad" aria-hidden="true" />
       {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}
     </div>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5148,6 +5148,18 @@ a.user-name--profile:focus-visible {
   padding: 4px 2px 8px;
 }
 
+/* Claude / Cursor / GPT slack: enough empty runway under the transcript that the
+   last turn can scroll up to the top of the pane. Without this the scroller ends
+   on the last line and you cannot lift it. `100%` is the scrollport when the shell
+   gives the thread a height; `min-height` covers the page-scroll phone band where
+   the scrollport height is indefinite. */
+.studio-thread-scroll-pad {
+  flex: none;
+  height: calc(100% - 4.5rem);
+  min-height: min(42dvh, 22rem);
+  pointer-events: none;
+}
+
 .studio-thread-empty {
   color: var(--muted);
   margin: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5152,10 +5152,12 @@ a.user-name--profile:focus-visible {
    last turn can scroll up to the top of the pane. Without this the scroller ends
    on the last line and you cannot lift it. `100%` is the scrollport when the shell
    gives the thread a height; `min-height` covers the page-scroll phone band where
-   the scrollport height is indefinite. */
+   the scrollport height is indefinite. vh first, then dvh — same pairing as
+   `.beta-splash` / `.qa-wizard`, so browsers without dvh keep the runway. */
 .studio-thread-scroll-pad {
   flex: none;
   height: calc(100% - 4.5rem);
+  min-height: min(42vh, 22rem);
   min-height: min(42dvh, 22rem);
   pointer-events: none;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Studio’s transcript scroller ended on the last line, so you couldn’t lift the latest turn (e.g. “Writing code” / “Powstaje kod”) to the top of the pane the way Claude, Cursor, and GPT do.

Adds a scrollport-sized bottom pad under the turns (and connect card) so there is empty runway to scroll into. CSS is written once outside media queries; the game-open shell already owns the scroller on every width.

## Test plan

- [x] Unit: pad is present on the embedded thread
- [x] E2E studio-shell: pad exists and creates scroll slack
- [x] Green gate (`type-check`, `lint`, `test`, `build`)
- [x] Screenshot: last turn scrolled to top of pane with empty space below
- [ ] Manual: long self-build thread on phone + desktop — scroll until last turn sits under the header
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e47ff7f-aa74-4961-a06a-2841f6b3a7a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e47ff7f-aa74-4961-a06a-2841f6b3a7a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

