### PR TITLE
Play button, show_media, and the card fixes from a live ChatGPT session

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -188,8 +188,14 @@ cache), so a resume cannot keep showing “finished this round” next to live p
   MCP tools refuse an already-issued key with a reconnect instruction. Do not restore a
   per-game compatibility path in UI, API routes, or MCP tool handling.
 - An opener is checked by `start`; later calls use the returned round-scoped `sessionKey`.
-- **`show_round` is the only tool that opens the creator's status card**, and it exists for
-  nothing else. Agents do not call it on their own — ChatGPT never did until the creator
+- **`show_media` is how the creator sees the game.** `get_gate_media` attaches frames as
+  image blocks, which reach the _model_ — it can look at them and describe them, and there is
+  no path back out. Asked to display them, ChatGPT answered "the image attachments apparently
+  didn't render in your view" and the creator saw nothing (2026-08-06). A tool result is input
+  to a model, not output to a person, so a view is the only surface that puts pixels in the
+  conversation. `show_media` carries no bytes: the card fetches them over the app-only
+  `get_round_media`, keeping a megabyte of base64 out of the model's context.
+- **`show_round` opens the creator's status card**, and exists for nothing else. Agents do not call it on their own — ChatGPT never did until the creator
   asked (2026-08-05) — so a view-capable session that has not opened one gets a bounded
   `warnings.code=card_unopened` nudge, the same remedy `call_end` needed. Never sent to a
   client with no views. It used to hang off `start` and `get_gate_verdict`, which made the card a side

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2007,9 +2007,14 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     expect(shower?._meta?.['openai/outputTemplate']).toBe('ui://gamedevpl/round-status');
     // Exactly one tool opens the card. Attaching it to a tool the agent calls for its own
     // reasons made the card count a side effect of agent discretion.
-    expect(tools.filter((tool) => tool._meta?.ui?.resourceUri !== undefined).map((tool) => tool.name)).toEqual([
-      'show_round',
-    ]);
+    // Two intents, one card: watching a round, and being shown its pictures. Both are
+    // deliberate tools rather than side effects of workflow calls.
+    expect(
+      tools
+        .filter((tool) => tool._meta?.ui?.resourceUri !== undefined)
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(['show_media', 'show_round']);
   });
 
   it('reminds a view-capable agent to open the card, then stops asking', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -195,6 +195,24 @@ function playUrlFor(slug: string | null | undefined): string | null {
   return `${canonicalAppBaseUrl()}/play/${encodeURIComponent(slug)}`;
 }
 
+/**
+ * The round's home in Creator Studio — where the creator manages this build.
+ *
+ * The card's title links here rather than to /play, which the Play button already
+ * covers. It is also always valid: Studio shows a round whether or not anything is
+ * playable yet, so it has none of the "not available" risk that keeps the Play button
+ * off a red gate.
+ */
+function studioUrlFor(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return `${canonicalAppBaseUrl()}/studio/${encodeURIComponent(slug)}`;
+}
+
+/** The site itself, for the card's wordmark. */
+function siteUrl(): string {
+  return canonicalAppBaseUrl();
+}
+
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;
 /** A card shows a strip, not a contact sheet; the bytes ride a postMessage. */
 const ROUND_MEDIA_MAX_FRAMES = 3;
@@ -3860,6 +3878,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           title: record.title ?? null,
           slug: record.slug ?? null,
           playUrl: playUrlFor(record.slug),
+          studioUrl: studioUrlFor(record.slug),
+          siteUrl: siteUrl(),
           round: record.roundGeneration ?? 1,
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
           note: latestEvent ? { text: noteTextFor(latestEvent, args.locale), createdAt: latestEvent.createdAt } : null,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { looksLikeCreatorAgentKey } from './agent-creator-key.js';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import {
   resolveCreatorAgentKeyForOpenRound,
   resolveCreatorAgentKeyForStart,
@@ -180,18 +181,18 @@ const ROUND_STATUS_OUTPUT_SCHEMA: Record<string, unknown> = {
  *
  * Built here rather than in the view because the view is served to every environment
  * from one string: an origin baked into it would send a staging card's Play button to
- * production. `WEB_ORIGIN` already pins the deployed site; `APP_BASE_URL` is the
- * fallback the OAuth paths use.
+ * production.
  *
- * Null when neither is configured — the card simply offers no button, which is better
- * than guessing an origin and handing the host a link to nowhere.
+ * `canonicalAppBaseUrl()` rather than `WEB_ORIGIN`, and the distinction is load-bearing.
+ * WEB_ORIGIN is a CORS allowlist — in production it begins with the Cloud Run service
+ * URL — so taking its first entry produced a link to an origin that is not in the view's
+ * `redirect_domains`, which ChatGPT would refuse. The button would have been dead in
+ * production and fine everywhere we tested it (Codex, #617). The card's link allowlist
+ * is derived from this same function so the two cannot drift apart again.
  */
 function playUrlFor(slug: string | null | undefined): string | null {
   if (!slug) return null;
-  const configured = (process.env.WEB_ORIGIN ?? '').split(',')[0]?.trim() || process.env.APP_BASE_URL?.trim() || '';
-  const origin = configured.replace(/\/+$/, '');
-  if (!/^https?:\/\//.test(origin)) return null;
-  return `${origin}/play/${encodeURIComponent(slug)}`;
+  return `${canonicalAppBaseUrl()}/play/${encodeURIComponent(slug)}`;
 }
 
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -175,6 +175,25 @@ const ROUND_STATUS_OUTPUT_SCHEMA: Record<string, unknown> = {
   required: ['phase', 'status', 'retryAfterSeconds'],
 };
 
+/**
+ * Where the creator plays what the agent just built.
+ *
+ * Built here rather than in the view because the view is served to every environment
+ * from one string: an origin baked into it would send a staging card's Play button to
+ * production. `WEB_ORIGIN` already pins the deployed site; `APP_BASE_URL` is the
+ * fallback the OAuth paths use.
+ *
+ * Null when neither is configured — the card simply offers no button, which is better
+ * than guessing an origin and handing the host a link to nowhere.
+ */
+function playUrlFor(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  const configured = (process.env.WEB_ORIGIN ?? '').split(',')[0]?.trim() || process.env.APP_BASE_URL?.trim() || '';
+  const origin = configured.replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(origin)) return null;
+  return `${origin}/play/${encodeURIComponent(slug)}`;
+}
+
 const ROUND_STATUS_RETRY_AFTER_SECONDS = 30;
 /** A card shows a strip, not a contact sheet; the bytes ride a postMessage. */
 const ROUND_MEDIA_MAX_FRAMES = 3;
@@ -3783,6 +3802,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           agentEnded: Boolean(record.agentEndedAt),
           title: record.title ?? null,
           slug: record.slug ?? null,
+          playUrl: playUrlFor(record.slug),
           round: record.roundGeneration ?? 1,
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
           note: latestEvent ? { text: noteTextFor(latestEvent, args.locale), createdAt: latestEvent.createdAt } : null,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -434,6 +434,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   // corrected.
   'Hold the sessionKey start gave you for the whole round and pass it on every call. Do not re-run start to refresh it — it is valid until expiresAt. Re-run start only if a call is refused as unauthenticated.',
   "show_round — once, right after start. In a client that renders MCP Apps views this puts a live status card in the creator's chat that follows the build and the gate on its own, so they can watch without you polling. Calling it again renders a second card.",
+  'show_media — whenever the creator asks to see the game. get_gate_media attaches frames for YOU to look at; those attachments do not reach the creator, so describing them is all you can do with it. show_media is what actually puts the pictures in front of them.',
   'get_brief — read the brief; if seedAvailable or seedStatus=available, get_seed and continue that draft. If seedStatus=pending, browse the kit lightly then recheck get_seed before scaffolding.',
   // An improvement round has no seed (seeds are a new-game facility) and its brief is
   // the change request alone, so nothing above this told the agent a game already
@@ -3707,6 +3708,61 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (status.isError || typeof args.sessionKey !== 'string') return status;
         const data = { ...(status.structuredContent as Record<string, unknown>), sessionKey: args.sessionKey };
         return toolOk(data);
+      },
+    },
+
+    /**
+     * Show the creator the gate's pictures — the only way to actually show them.
+     *
+     * `get_gate_media` attaches frames as image blocks, which reach the *model*: it can
+     * look at them and describe them. There is no path back out. Asked to display them,
+     * ChatGPT answered "the image attachments apparently didn't render in your view"
+     * and the creator saw nothing (owner, 2026-08-06). A tool result is input to a
+     * model, not output to a person.
+     *
+     * A view is the only surface that puts pixels in the conversation without going
+     * through the model, so this is not a nicer way to show a picture — it is the way.
+     *
+     * Deliberately carries no bytes. The card fetches them over the app-only
+     * `get_round_media`, so a megabyte of base64 never enters the model's context — the
+     * same reason that tool exists at all.
+     */
+    show_media: {
+      annotations: { title: "Show the creator the gate's screenshots", ...READS },
+      description:
+        "Render the gate's screenshots for a delivery in the creator's chat, at a size they can actually look at, " +
+        'with the gameplay recording and a link to play. ' +
+        'Use this when the creator asks to see the game — get_gate_media lets *you* look at the frames, but its ' +
+        'attachments are input to you rather than something the creator sees. ' +
+        'Defaults to the latest delivery. Only clients that render MCP Apps views show anything. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          deliveryId: { type: 'string', description: "Delivery to show; default is the round's latest." },
+        },
+        required: [],
+      },
+      outputSchema: ROUND_STATUS_OUTPUT_SCHEMA,
+      handler: async (args, ctx) => {
+        const status = await tools.get_round_status.handler(args, ctx);
+        if (status.isError) return status;
+        const auth = await resolveAuth(ctx, args, { allowTerminalReceipt: true });
+        const record = 'record' in auth ? auth.record : null;
+        const wanted =
+          (typeof args.deliveryId === 'string' && args.deliveryId.trim()) ||
+          record?.previewVersion ||
+          record?.deliveredVersion ||
+          null;
+        return toolOk({
+          ...(status.structuredContent as Record<string, unknown>),
+          // Names the delivery the card should fetch frames for. It need not belong to
+          // this round: "show me the screenshot" opens a round that has delivered
+          // nothing, and the frames the creator means are the previous one's.
+          mediaDeliveryId: wanted,
+          ...(typeof args.sessionKey === 'string' ? { sessionKey: args.sessionKey } : {}),
+        });
       },
     },
 

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -258,7 +258,13 @@ describe('ui resources', () => {
     // re-ran `start` before each operation left one card per call (ChatGPT, 2026-08-05),
     // and it was not doing anything wrong enough to forbid. Showing the creator
     // something is now a deliberate act with a deliberate tool.
-    expect(MCP_UI_TOOL_RESOURCES).toEqual({ show_round: ROUND_STATUS_RESOURCE_URI });
+    expect(MCP_UI_TOOL_RESOURCES).toEqual({
+      show_round: ROUND_STATUS_RESOURCE_URI,
+      // Second intent, same card. get_gate_media puts frames in front of the *model*,
+      // which can look at them and cannot show them — a view is the only surface that
+      // reaches the creator, so "show me the screenshots" needs one too.
+      show_media: ROUND_STATUS_RESOURCE_URI,
+    });
 
     // The host renders one card per call carrying _meta.ui, so every tool added here
     // hands the card count back to whatever the agent happens to do.
@@ -403,6 +409,20 @@ describe('ui resources', () => {
     expect(html).toContain("addRow('Round', status.round)");
   });
 
+  it('shows our message, not the exception wrapper a host puts around it', () => {
+    // A refused call surfaced as: Error code: INVALID_ARGUMENT; Error: RuntimeException:
+    // Error calling MCP tool: [TextContent(type='text', text='{"error":"OAuth access
+    // proves your identity only — call start()… — printed verbatim and cut off
+    // mid-sentence. The only actionable part is the JSON inside it.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('function ourError(raw)');
+    // No closing quote required: the host truncates its own wrapper, so the message
+    // that actually arrives has no terminator. Demanding one matched nothing.
+    expect(html).toContain('/"error"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)/');
+    // And a blob with no JSON of ours in it is trimmed rather than dumped whole.
+    expect(html).toContain('text.slice(0, 160)');
+  });
+
   it('says which way a status read failed, so a screenshot is enough to diagnose it', () => {
     // Observed in ChatGPT: one card read status fine (screenshot, note and gate all
     // live) while a later one in the same session did not. "Could not read round status
@@ -424,6 +444,21 @@ describe('ui resources', () => {
     expect(html).not.toContain('JSON.stringify(error)');
   });
 
+  it('loads frames for a named delivery, not only the round it is watching', () => {
+    // The gallery hung off the current round's gate, so a creator asking "show me the
+    // screenshot" got nothing: that request opens a round which has delivered nothing,
+    // and the frames they meant belong to the previous one.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('status.mediaDeliveryId');
+    // Still falls back to the round's own settled gate when no delivery is named.
+    expect(html).toMatch(/gate && gate\.deliveryId && gate\.status !== 'pending'/);
+    // And the named delivery is what gets fetched.
+    expect(html).toContain('var args = { deliveryId: wanted };');
+    // Loaded from the opening result — show_media names the delivery up front, so the
+    // card must not wait for a gate that will never settle in this round.
+    expect(html).toMatch(/render\(opening\);[\s\S]{0,220}?loadMedia\(opening\);/);
+  });
+
   it("shows the gate's own frames, which the agent has no browser to capture", () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("name: 'get_round_media'");
@@ -432,7 +467,7 @@ describe('ui resources', () => {
     expect(html).toContain("'data:image/png;base64,'");
     // Fetched once per delivery, not once per poll: the strip does not change between
     // polls and each frame is hundreds of kilobytes through the host.
-    expect(html).toContain('mediaKey === gate.deliveryId');
+    expect(html).toContain('mediaKey === wanted');
     expect(html).toContain("gate.status === 'pending'");
     // A frame written a moment after the verdict loses the first read; one retry, then
     // stop, so a card cannot re-ask forever.

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -309,16 +309,24 @@ describe('ui resources', () => {
     // string is served to every environment, so an origin here would send a staging
     // card's Play button to production. The self-contained test above enforces it.
     expect(html).toContain('status.playUrl');
+    // The link and the allowlist that permits it come from one function, so they cannot
+    // disagree — they did once, and every production link was non-allowlisted.
+    expect(html).not.toContain('https://www.gamedev.pl/play/');
     // Uses the same host hand-off the gate recording does — the mechanism whose
     // permission (`redirect_domains`) was missing until the CSP work.
     expect(html).toMatch(/playBtn\.onclick[\s\S]{0,120}?request\('ui\/open-link'/);
 
     // Not offered when a round has delivered nothing: the link would open a page saying
     // the game is not available, which is a worse answer than no button.
-    for (const phase of ['ready_for_review', 'published', 'needs_changes']) {
+    for (const phase of ['ready_for_review', 'published']) {
       expect(html).toContain(`status.phase === '${phase}'`);
     }
     expect(html).toContain("gateStatus === 'preview_passed'");
+    // needs_changes is deliberately absent: a publish run that fails before assembly
+    // lands there with neither a bundle nor a preview, so the button would have sent
+    // the creator to the "not available yet" page it exists to avoid. A red gate is
+    // exactly when there may be nothing to play.
+    expect(html).not.toContain("status.phase === 'needs_changes' ||");
     expect(html).toContain('playRow.hidden = true;');
   });
 

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -293,6 +293,29 @@ describe('ui resources', () => {
     expect(html).toMatch(/if \(speculative\) \{[\s\S]{0,400}?if \(sessionKey\) \{[\s\S]{0,80}?poll\(\);/);
   });
 
+  it('invites the creator to play, once there is something to play', () => {
+    // The step the whole flow exists for: the card shows what the agent built, the
+    // theater is where it gets played. A link rather than an embedded game on purpose —
+    // gamedev.pl's theater does fullscreen, pointer lock and touch; a chat card cannot.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('renderPlay');
+    // The URL comes from the server (playUrlFor), never baked into the view — one
+    // string is served to every environment, so an origin here would send a staging
+    // card's Play button to production. The self-contained test above enforces it.
+    expect(html).toContain('status.playUrl');
+    // Uses the same host hand-off the gate recording does — the mechanism whose
+    // permission (`redirect_domains`) was missing until the CSP work.
+    expect(html).toMatch(/playBtn\.onclick[\s\S]{0,120}?request\('ui\/open-link'/);
+
+    // Not offered when a round has delivered nothing: the link would open a page saying
+    // the game is not available, which is a worse answer than no button.
+    for (const phase of ['ready_for_review', 'published', 'needs_changes']) {
+      expect(html).toContain(`status.phase === '${phase}'`);
+    }
+    expect(html).toContain("gateStatus === 'preview_passed'");
+    expect(html).toContain('playRow.hidden = true;');
+  });
+
   it('offers the creator the next move, in the exact ui/message shape the spec defines', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("method: 'ui/message'");

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -299,6 +299,32 @@ describe('ui resources', () => {
     expect(html).toMatch(/if \(speculative\) \{[\s\S]{0,400}?if \(sessionKey\) \{[\s\S]{0,80}?poll\(\);/);
   });
 
+  it('asks for the height its content needs, not the height of the frame it was given', () => {
+    // documentElement.scrollHeight was the content height until applyContainerDimensions
+    // began setting html{height:100%} to fill a host-declared frame. After that the card
+    // filled 400px, reported 400px, and the host never shrank it — a slab of empty space
+    // under the content. Measuring the card breaks the loop. Mutation-checked in the
+    // browser: reverting to scrollHeight reports 520 where this reports 287.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("var card = document.querySelector('.card');");
+    expect(html).toContain('card.getBoundingClientRect().height');
+  });
+
+  it('opens the wordmark and the game name through the host', () => {
+    // Anchors are inert here: the view is sandboxed without allow-top-navigation, so
+    // ui/open-link is the only way out. Both origins come from canonicalAppBaseUrl, the
+    // same function the redirect allowlist is built from, so they cannot fall outside it.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('function linkify(element, url, label)');
+    expect(html).toContain("linkify(brandEl, status.siteUrl, 'Open gamedev.pl')");
+    expect(html).toContain('linkify(titleEl, status.studioUrl,');
+    // The title goes to Studio rather than /play: the Play button already covers play,
+    // and Studio is valid whether or not anything is playable yet.
+    expect(html).not.toContain('linkify(titleEl, status.playUrl');
+    // A missing URL removes the affordance rather than leaving a dead click target.
+    expect(html).toContain("element.className.replace(/ ?linked/, '')");
+  });
+
   it('invites the creator to play, once there is something to play', () => {
     // The step the whole flow exists for: the card shows what the agent built, the
     // theater is where it gets played. A link rather than an embedded game on purpose —

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -358,6 +358,26 @@ describe('ui resources', () => {
     expect(html).toMatch(/navigator\.clipboard[\s\S]{0,400}?function \(\) \{\}/);
   });
 
+  it('does not put a pill on the card that contradicts the sentence under it', () => {
+    // Observed: DISPATCHED above "The agent has stopped without delivering." The phase
+    // lags reality, which the summary already accounts for by ranking it last — the
+    // pill was left on the old rule and disagreed with the text beside it.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toMatch(/headline =[\s\S]{0,320}?status\.agentEnded[\s\S]{0,40}?'stopped'/);
+    // A delivery in flight reads as gating rather than whatever the job record still says.
+    expect(html).toMatch(/gate && gate\.deliveryId[\s\S]{0,40}?'gating'/);
+    // The new state needs a colour, or it falls through to an unstyled pill.
+    expect(html).toContain('.pill-stopped');
+  });
+
+  it('states a stall once, not once per shape', () => {
+    // "The agent has stopped." sat in the Note row under a summary reading "The agent
+    // has stopped without delivering." — same fact twice. Whole-string comparison could
+    // not see that one contains the other.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("summary.textContent.indexOf(stallLine.replace(/\\.$/, '')) === -1");
+  });
+
   it('does not print the gate detail twice, or lead with instructions meant for the agent', () => {
     // kit_outdated returns the same long agent-facing text as both summary and report,
     // which the card printed twice — once as its headline.

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -332,7 +332,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         border: 1px solid currentColor;
         white-space: nowrap;
       }
-      .pill-waiting, .pill-pending, .pill-queued, .pill-dispatched { color: var(--gd-muted); }
+      .pill-waiting, .pill-pending, .pill-queued, .pill-dispatched, .pill-stopped { color: var(--gd-muted); }
       .pill-building, .pill-submitted, .pill-gating { color: #6fb3ff; }
       .pill-green, .pill-preview_passed, .pill-published { color: var(--gd-accent); }
       .pill-red, .pill-preview_failed, .pill-failed { color: #ff6b6b; }
@@ -900,7 +900,19 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function render(status) {
           var gate = status.gate && typeof status.gate === 'object' ? status.gate : null;
           var gateStatus = gate && typeof gate.status === 'string' ? gate.status : null;
-          var headline = gateStatus && gateStatus !== 'pending' ? gateStatus : status.phase;
+          // The pill has to agree with the sentence under it. The phase lags reality —
+          // an agent that has stopped still reads as 'dispatched' for a while — so a
+          // card showed DISPATCHED above "The agent has stopped without delivering."
+          // (owner, 2026-08-06). The summary below already ranks the phase last; the
+          // pill was left on the old rule and contradicted it.
+          var headline =
+            gateStatus && gateStatus !== 'pending'
+              ? gateStatus
+              : gate && gate.deliveryId
+                ? 'gating'
+                : status.agentEnded
+                  ? 'stopped'
+                  : status.phase;
 
           pill.textContent = String(headline).replace(/_/g, ' ');
           pill.className = 'pill pill-' + headline;
@@ -974,8 +986,14 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (typeof status.deliveriesRemaining === 'number') {
             addRow('Deliveries left', status.deliveriesRemaining);
           }
-          if (status.stall && STALL_COPY[status.stall] && STALL_COPY[status.stall] !== summary.textContent) {
-            addRow('Note', STALL_COPY[status.stall]);
+          // Say it once. The stall row used to compare whole strings, so "The agent has
+          // stopped." sat under a summary reading "The agent has stopped without
+          // delivering." — the same fact twice, in two shapes.
+          var stallLine = status.stall ? STALL_COPY[status.stall] : '';
+          // Escape doubled: this file is a TS template literal, so a single backslash
+          // here emits /.$/ — "strip any last character" rather than "strip a period".
+          if (stallLine && summary.textContent.indexOf(stallLine.replace(/\\.$/, '')) === -1) {
+            addRow('Note', stallLine);
           }
 
           var detail = gate && typeof gate.report === 'string' ? gate.report.trim() : '';

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
 
 /**
  * MCP Apps (SEP-1865, extension `io.modelcontextprotocol/ui`).
@@ -248,11 +249,20 @@ export type UiResourceContents = Pick<UiResource, 'uri' | 'mimeType' | 'text'> &
 /**
  * Where the card is allowed to send the reader.
  *
- * Only our own site: every link the card offers is a gamedev.pl page (the gate
- * recording today, the game theater in V3). A wider list would let a future card hand
- * the host somewhere we did not intend.
+ * Only our own site: every link the card offers is a gamedev.pl page — the gate
+ * recording, and the game theater the Play button opens. A wider list would let a
+ * future card hand the host somewhere we did not intend.
+ *
+ * Derived from `canonicalAppBaseUrl()` rather than written out, because the server
+ * builds the Play URL from the same function. Hardcoding this list once meant the two
+ * could disagree, and they did: the link was built from `WEB_ORIGIN`, whose first entry
+ * in production is the Cloud Run service URL, so every production link pointed at an
+ * origin this list did not allow (Codex, #617). A view whose allowlist and whose links
+ * come from one source cannot have that bug.
  */
-const LINK_DOMAINS: readonly string[] = Object.freeze(['https://www.gamedev.pl']);
+function linkDomains(): readonly string[] {
+  return Object.freeze([canonicalAppBaseUrl()]);
+}
 
 /**
  * The origin ChatGPT associates with this hosted component.
@@ -748,11 +758,15 @@ const ROUND_STATUS_HTML = `<!doctype html>
           // every environment, so an origin baked in here would send a staging card's
           // Play button to production.
           var url = typeof status.playUrl === 'string' ? status.playUrl : '';
+          // Every state here implies assembly succeeded. needs_changes was in this list
+          // and should not have been: a publish run that fails before assembly lands
+          // there with neither a bundle nor a preview stored, so the button would have
+          // sent the creator to the exact "not available yet" page it exists to avoid
+          // (Codex, #617). A red gate is precisely when there may be nothing to play.
           var playable =
             url &&
             (status.phase === 'ready_for_review' ||
               status.phase === 'published' ||
-              status.phase === 'needs_changes' ||
               gateStatus === 'green' ||
               gateStatus === 'preview_passed');
           if (!playable) {
@@ -1445,7 +1459,7 @@ function uiResourceMeta(): UiResourceMeta {
       // has no permission to follow, and the Play button V3 is built around would be
       // the same. An empty CSP is right for what the card *fetches* — it fetches
       // nothing — but link targets are a different question and were never answered.
-      redirect_domains: LINK_DOMAINS,
+      redirect_domains: linkDomains(),
     },
   };
 }

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -453,6 +453,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
       <p id="galleryCap" class="galleryCap" hidden></p>
       <dl id="meta" class="meta"></dl>
       <pre id="report" class="report" hidden></pre>
+      <div id="playRow" class="actions" hidden>
+        <button id="playBtn" type="button" class="action"></button>
+      </div>
       <div id="actionRow" class="actions" hidden>
         <button id="actionBtn" type="button" class="action"></button>
         <p id="actionHint" class="hint" hidden></p>
@@ -496,6 +499,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var shotEl = document.getElementById('shot');
         var shotImg = document.getElementById('shotImg');
         var shotCap = document.getElementById('shotCap');
+        var playRow = document.getElementById('playRow');
+        var playBtn = document.getElementById('playBtn');
         var actionRow = document.getElementById('actionRow');
         var actionBtn = document.getElementById('actionBtn');
         var actionHint = document.getElementById('actionHint');
@@ -718,6 +723,41 @@ const ROUND_STATUS_HTML = `<!doctype html>
           }
         };
 
+        /**
+         * The invitation to play — the step the whole flow exists for.
+         *
+         * The card shows what the agent built; the theater is where it is played. This
+         * is the hand-off between them, and it is a link rather than an embedded game on
+         * purpose: gamedev.pl's theater already does fullscreen, pointer lock and touch,
+         * and a chat card cannot.
+         *
+         * Only offered when there is genuinely something to play. A round that has not
+         * delivered yet would open a page saying so, which is a worse answer than no
+         * button at all.
+         */
+        function renderPlay(status, gateStatus) {
+          // The URL is built server-side (playUrlFor): this view is one string served to
+          // every environment, so an origin baked in here would send a staging card's
+          // Play button to production.
+          var url = typeof status.playUrl === 'string' ? status.playUrl : '';
+          var playable =
+            url &&
+            (status.phase === 'ready_for_review' ||
+              status.phase === 'published' ||
+              status.phase === 'needs_changes' ||
+              gateStatus === 'green' ||
+              gateStatus === 'preview_passed');
+          if (!playable) {
+            playRow.hidden = true;
+            return;
+          }
+          playBtn.textContent = status.phase === 'published' ? 'Play it' : 'Play the latest build';
+          playBtn.onclick = function () {
+            request('ui/open-link', { url: url });
+          };
+          playRow.hidden = false;
+        }
+
         function renderAction(status, gateStatus) {
           // Only once the agent has stopped: while it is still working it will act on a
           // red gate itself, and a second instruction would just talk over it.
@@ -845,6 +885,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           }
 
           actionRow.hidden = true;
+          playRow.hidden = true;
           gallery.hidden = true;
           galleryCap.hidden = true;
           foot.textContent =
@@ -950,6 +991,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             report.hidden = true;
           }
 
+          renderPlay(status, gateStatus);
           renderAction(status, gateStatus);
 
           if (isFinished(status)) {

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -58,6 +58,14 @@ export const ROUND_STATUS_RESOURCE_URI = 'ui://gamedevpl/round-status';
  */
 export const MCP_UI_TOOL_RESOURCES: Readonly<Record<string, string>> = Object.freeze({
   show_round: ROUND_STATUS_RESOURCE_URI,
+  // Same card, second intent. "Show me the screenshots" is not "watch this round" — it
+  // names a delivery that may belong to an earlier round — but it wants the same
+  // furniture around the pictures, so it opens the same view rather than a second one.
+  //
+  // This is the exception the note above allows for, and it is worth stating why it
+  // qualifies: `get_gate_media` puts frames in front of the *model*, which can look at
+  // them and cannot show them. A view is the only surface that reaches the creator.
+  show_media: ROUND_STATUS_RESOURCE_URI,
 });
 
 /**
@@ -1098,14 +1106,25 @@ const ROUND_STATUS_HTML = `<!doctype html>
          * captures on both lanes; the card is already here when the verdict lands.
          */
         function loadMedia(status) {
+          // Two ways in. Watching a round, the frames arrive when that round's gate
+          // settles. Asked to *show* media, the delivery is named up front and may
+          // belong to an earlier round entirely — which is the case the gallery could
+          // not serve: a creator asking "show me the screenshot" opens a round that has
+          // delivered nothing, so there is no gate here to hang the frames off.
           var gate = status.gate;
-          if (!gate || !gate.deliveryId || gate.status === 'pending') return;
-          if (mediaKey === gate.deliveryId) return;
-          if (mediaTriesFor !== gate.deliveryId) {
-            mediaTriesFor = gate.deliveryId;
+          var wanted =
+            typeof status.mediaDeliveryId === 'string' && status.mediaDeliveryId
+              ? status.mediaDeliveryId
+              : gate && gate.deliveryId && gate.status !== 'pending'
+                ? gate.deliveryId
+                : null;
+          if (!wanted) return;
+          if (mediaKey === wanted) return;
+          if (mediaTriesFor !== wanted) {
+            mediaTriesFor = wanted;
             mediaTries = 0;
           }
-          mediaKey = gate.deliveryId;
+          mediaKey = wanted;
           var id = nextId++;
           pendingCalls[id] = function (result, error) {
             if (error) {
@@ -1124,7 +1143,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             if (!media) return;
             renderMedia(media);
           };
-          var args = { deliveryId: gate.deliveryId };
+          var args = { deliveryId: wanted };
           if (sessionKey) args.sessionKey = sessionKey;
           post({ jsonrpc: '2.0', id: id, method: 'tools/call', params: { name: 'get_round_media', arguments: args } });
         }
@@ -1211,9 +1230,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
               // carries cycles, and a throw here is inside the message handler, which
               // would take the card's whole update path down with it. A plain coercion
               // says less and cannot fail.
-              var reason = error
-                ? 'call refused: ' + String(error.message || error.code || error).slice(0, 200)
-                : 'the reply was not round status';
+              var reason = error ? 'call refused: ' + ourError(error.message || error.code || error) : 'the reply was not round status';
               lastFailure = (sessionKey ? 'with a round key, ' : 'without a round key, ') + reason;
               log('warning', 'round status unavailable: ' + lastFailure);
               if (speculative) {
@@ -1257,6 +1274,34 @@ const ROUND_STATUS_HTML = `<!doctype html>
             method: 'tools/call',
             params: { name: 'get_round_status', arguments: args }
           });
+        }
+
+        /**
+         * Our message, dug out of the host's wrapper.
+         *
+         * A refused call came back as "Error code: INVALID_ARGUMENT; Error:
+         * RuntimeException: Error calling MCP tool: [TextContent(type='text',
+         * text='{"error":"OAuth access proves your identity only — call start()..."
+         * and the card printed that verbatim, truncated mid-sentence (owner,
+         * 2026-08-06). The only part a creator can act on is the JSON inside it.
+         *
+         * The closing quote is optional on purpose: the host truncates its own wrapper,
+         * so the case that actually shows up is a message cut off mid-sentence with no
+         * terminator. Requiring one matched nothing and printed the whole blob.
+         *
+         * Escapes are doubled throughout: this whole view is a TS template literal.
+         */
+        function ourError(raw) {
+          var text = String(raw === null || raw === undefined ? '' : raw);
+          var match = /"error"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)/.exec(text);
+          if (match) {
+            try {
+              return JSON.parse('"' + match[1] + '"');
+            } catch (e) {
+              return match[1];
+            }
+          }
+          return text.length > 160 ? text.slice(0, 160) + '…' : text;
         }
 
         function noteSessionKey(value) {
@@ -1319,6 +1364,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
             if (opening && !live) {
               painted = true;
               render(opening);
+              // show_media names a delivery that need not belong to this round, so the
+              // frames load from the opening result rather than waiting for a gate.
+              loadMedia(opening);
               schedule(opening.retryAfterSeconds);
             }
             var verdict = opening ? null : unwrap(message.params, looksLikeVerdict);

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -339,6 +339,10 @@ const ROUND_STATUS_HTML = `<!doctype html>
         margin-bottom: 4px;
       }
       .brand { font-weight: 600; letter-spacing: -0.01em; }
+      /* Links the host opens for us, so they are spans rather than anchors — an <a> in
+         a sandboxed frame with no navigation permission does nothing when clicked. */
+      .linked { cursor: pointer; }
+      .linked:hover { text-decoration: underline; }
       .brand .dot { color: var(--gd-accent); }
       .pill {
         font-size: 12px;
@@ -460,7 +464,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
   <body>
     <main class="card">
       <div class="head">
-        <span class="brand">gamedev<span class="dot">.pl</span></span>
+        <span id="brand" class="brand">gamedev<span class="dot">.pl</span></span>
         <span id="pill" class="pill pill-waiting">waiting</span>
       </div>
       <p id="title" class="title" hidden></p>
@@ -519,6 +523,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var shotCap = document.getElementById('shotCap');
         var playRow = document.getElementById('playRow');
         var playBtn = document.getElementById('playBtn');
+        var brandEl = document.getElementById('brand');
         var actionRow = document.getElementById('actionRow');
         var actionBtn = document.getElementById('actionBtn');
         var actionHint = document.getElementById('actionHint');
@@ -548,12 +553,31 @@ const ROUND_STATUS_HTML = `<!doctype html>
           notify('notifications/message', { level: level, logger: 'gamedevpl-round-status', data: text });
         }
 
+        /**
+         * Report what the content needs, never what the frame currently is.
+         *
+         * This used to send documentElement.scrollHeight, which was the content height
+         * until applyContainerDimensions started setting html{height:100%} to fill a
+         * host-declared frame. After that the two became the same number: the card
+         * filled 400px, reported 400px, and the host had no reason to ever shrink —
+         * leaving a slab of empty space under the content (owner, 2026-08-06).
+         *
+         * Measuring the card instead breaks the loop. Filling the frame stays a
+         * cosmetic choice; the size we ask for stays honest either way.
+         */
         function reportSize() {
+          var card = document.querySelector('.card');
+          var height = card
+            ? Math.ceil(card.getBoundingClientRect().height) + BODY_PADDING * 2
+            : document.documentElement.scrollHeight;
           notify('ui/notifications/size-changed', {
-            height: document.documentElement.scrollHeight,
-            width: document.documentElement.scrollWidth
+            height: height,
+            width: card ? Math.ceil(card.getBoundingClientRect().width) + BODY_PADDING * 2 : document.documentElement.scrollWidth
           });
         }
+
+        /** Keep in step with body{padding} in the stylesheet above. */
+        var BODY_PADDING = 12;
 
         var hostLocale = undefined;
         var hostTimeZone = undefined;
@@ -753,6 +777,34 @@ const ROUND_STATUS_HTML = `<!doctype html>
          * delivered yet would open a page saying so, which is a worse answer than no
          * button at all.
          */
+        /**
+         * Make an element open a URL through the host.
+         *
+         * Not an anchor: the view is sandboxed without allow-top-navigation, so a real
+         * href is inert. ui/open-link is the only way out, and the origin is on the
+         * card's redirect allowlist by construction (both come from canonicalAppBaseUrl).
+         *
+         * No backticks anywhere in this file below the template literal opener — one
+         * ends the literal. That has cost four iterations in this workstream.
+         */
+        function linkify(element, url, label) {
+          if (!element || typeof url !== 'string' || !url) {
+            if (element) {
+              element.className = element.className.replace(/ ?linked/, '');
+              element.onclick = null;
+              element.removeAttribute('role');
+              element.removeAttribute('title');
+            }
+            return;
+          }
+          if (element.className.indexOf('linked') === -1) element.className += ' linked';
+          element.setAttribute('role', 'link');
+          if (label) element.setAttribute('title', label);
+          element.onclick = function () {
+            request('ui/open-link', { url: url });
+          };
+        }
+
         function renderPlay(status, gateStatus) {
           // The URL is built server-side (playUrlFor): this view is one string served to
           // every environment, so an origin baked in here would send a staging card's
@@ -945,6 +997,10 @@ const ROUND_STATUS_HTML = `<!doctype html>
           } else {
             titleEl.hidden = true;
           }
+          // The wordmark goes to the site; the game name goes to its round in Studio,
+          // which is valid whether or not anything is playable yet.
+          linkify(brandEl, status.siteUrl, 'Open gamedev.pl');
+          linkify(titleEl, status.studioUrl, 'Open this round in Creator Studio');
 
           // Order matters, and the job's own phase comes last: it lags reality. An agent
           // that has delivered and called end still reads as 'building' for a while, so


### PR DESCRIPTION
Five commits, all driven by the owner testing the card in ChatGPT.

## 1. Play button

The step the flow exists for — the card shows what the agent built, the theater is where it gets played. **A link, not an embedded game**: the theater does fullscreen, pointer lock and touch; a chat card cannot. That is the reasoning that cut in-chat play from Phase 2, and this replaced a six-question spike with a link.

Only offered when something is genuinely playable.

## 2. `show_media` — because the agent cannot show what it can see

The owner's diagnosis, and the sharpest finding in this batch: **a tool result is input to a model, not output to a person.**

`get_gate_media` attaches frames as image blocks. Those reach the *model* — it looks at them, describes them, reasons about them — and there is no path back out. Asked to display them, ChatGPT answered *"the image attachments apparently didn't render in your view"* and the creator saw nothing.

A view is the only surface that puts pixels in the conversation without going through the model. `show_media` opens the card and names which delivery's frames to fetch — the part the existing gallery could not do, since it hung off the *current* round's gate and "show me the screenshot" opens a round that has delivered nothing.

It carries **no bytes**: the card fetches them over the app-only `get_round_media`, keeping a megabyte of base64 out of the model's context.

## 3. The card contradicted itself

The pill read `DISPATCHED` above *"The agent has stopped without delivering."*, and *"The agent has stopped."* repeated as a Note row. The call ledger confirms the card was factually right — both defects were presentational, and both were half-fixed already: the summary ranks the phase last (it lags reality) and the pill was left on the old rule.

The stall dedup needed **the escape doubled** — `/\.$/` written once in this template literal emits `/.$/`, *"strip any last character"*. It happened to look correct only because every stall line ends in a period.

## 4. Codex's two findings — the first would have shipped a dead button

**P1:** `playUrlFor` took the first entry of `WEB_ORIGIN`. That is a **CORS allowlist**, and production starts it with the Cloud Run service URL — so every production Play link pointed at an origin `redirect_domains` does not permit, and ChatGPT would refuse it. **Dead in production, fine everywhere we tested.** Now `canonicalAppBaseUrl()`, with the view's allowlist derived from the same function so they cannot drift again.

**P2:** `needs_changes` was treated as playable. A publish run that fails before assembly lands there with neither bundle nor preview, sending the creator to the exact "not available yet" page the button exists to avoid. Removed — a red gate is precisely when there may be nothing to play.

## 5. Sizing, and it was my own earlier fix

DevTools showed ChatGPT's wrapper pinned at `height: 400px` around ~250px of content.

`reportSize` sent `documentElement.scrollHeight`, which *was* the content height until `applyContainerDimensions` (#606) started setting `html{height:100%}` to fill a host-declared frame. After that the two became the same number: the card filled 400px, reported 400px, and the host had no reason to shrink.

Measuring the card breaks the loop. **Mutation-checked in the browser** against a fixed 400px frame: the old code reports `520`, this reports `287`.

Also as requested: **the wordmark opens gamedev.pl and the game name opens that round in Creator Studio.** Studio rather than `/play` because the Play button already covers playing, and Studio is valid whether or not anything is playable — none of the "not available" risk from P2. Both are click handlers rather than anchors, since the view is sandboxed without `allow-top-navigation` and an `href` is inert.

## Verification

Full API suite green (**2563** tests, 162 files), lint clean.

Browser harness: all three links post `ui/open-link` with the right URLs; the card reports content height inside a fixed frame; the Play button renders only on a playable round.

**Still unproven in a real host:** that ChatGPT opens these links on click. The `CSP off` badge clearing is strong evidence `redirect_domains` is in force, but a click is the proof.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_