### PR TITLE
fix(e2e): studio scroll-pad gate no longer fails on empty fixture

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -219,12 +219,32 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         const pad = document.querySelector('.studio-thread-scroll-pad');
         const detail = document.querySelector('.studio-detail');
         const layout = document.querySelector('.studio-layout');
+        // The fixture thread is empty/short. A pad sized as a fraction of the
+        // scrollport cannot create overflow by itself (percentage of H is ≤ H),
+        // so "scrollHeight - clientHeight" is the wrong signal here — it would
+        // stay ~0 even with a correct Claude/Cursor runway. Measure the pad
+        // against the scrollport instead, and prove slack with a stand-in turn.
+        let padHeight = 0;
+        let scrollerClientHeight = 0;
+        let slackWithTurn = 0;
+        if (scroller && pad) {
+          padHeight = pad.getBoundingClientRect().height;
+          scrollerClientHeight = scroller.clientHeight;
+          const turn = document.createElement('div');
+          turn.dataset.e2eInjected = 'true';
+          // Taller than the 4.5rem the pad leaves, so max-scroll is non-trivial.
+          turn.style.cssText = 'height:200px;flex:none;';
+          pad.before(turn);
+          slackWithTurn = scroller.scrollHeight - scroller.clientHeight;
+          turn.remove();
+        }
         return {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
           hasScrollPad: Boolean(pad),
-          // Pad must add real slack: last turn can scroll toward the top of the pane.
-          scrollerSlack: scroller && pad ? scroller.scrollHeight - scroller.clientHeight : 0,
+          padHeight,
+          scrollerClientHeight,
+          slackWithTurn,
           gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
           compactShelf: Boolean(layout?.classList.contains('is-compact-shelf')),
           shelfOpen: Boolean(layout?.classList.contains('is-shelf-open')),
@@ -255,7 +275,15 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
 
       // Claude/Cursor shape: empty runway under the turns so the last message can rise.
       expect(shell.hasScrollPad, 'transcript needs a bottom pad for last-turn scroll').toBe(true);
-      expect(shell.scrollerSlack, 'bottom pad must create scrollable slack in the transcript').toBeGreaterThan(80);
+      expect(shell.padHeight, 'bottom pad needs real height (not a zero-height spacer)').toBeGreaterThan(80);
+      expect(
+        shell.padHeight,
+        'bottom pad should be roughly one scrollport so the last turn can rise to the top',
+      ).toBeGreaterThan(shell.scrollerClientHeight * 0.5);
+      expect(
+        shell.slackWithTurn,
+        'with a turn above the pad, the transcript must become scrollable',
+      ).toBeGreaterThan(80);
 
       // Desktop compact rail (~56px) leaves the work surface owning the rest of the window.
       if (viewport.width >= 801) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5153,7 +5153,12 @@ a.user-name--profile:focus-visible {
    on the last line and you cannot lift it. `100%` is the scrollport when the shell
    gives the thread a height; `min-height` covers the page-scroll phone band where
    the scrollport height is indefinite. vh first, then dvh — same pairing as
-   `.beta-splash` / `.qa-wizard`, so browsers without dvh keep the runway. */
+   `.beta-splash` / `.qa-wizard`, so browsers without dvh keep the runway.
+
+   A percentage of the scrollport cannot create overflow on an empty thread
+   (H−4.5rem ≤ H), and that is fine: the runway matters once there is a last
+   turn to lift. The browser gate checks pad height and slack-with-a-stand-in
+   turn, not scrollHeight on the empty fixture. */
 .studio-thread-scroll-pad {
   flex: none;
   height: calc(100% - 4.5rem);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy browser gate (`studio-shell.test.ts`) has been failing on every deploy since #616 with:

`bottom pad must create scrollable slack in the transcript: expected 0 to be greater than 80`

The pad CSS is fine. The assertion was wrong for this fixture: a pad sized as `calc(100% - 4.5rem)` of the scrollport cannot create overflow on an empty/short thread (a percentage of `H` is always ≤ `H`). Slack only appears once there is content above the pad — which is exactly when the Claude/Cursor runway matters.

## Fix

- Assert the pad has real height and is roughly one scrollport tall.
- Inject a stand-in turn above the pad and assert that *then* the transcript becomes scrollable.
- Document the empty-thread measurement trap next to the CSS so it is not “fixed” again by requiring slack on an empty fixture.

## Verification

- Green gate: `type-check`, `lint`, `test` (1104+), `build` — pass
- `studio-shell.test.ts` against the still-live candidate revision (`E2E_BASE_URL=https://candidate---gamedev-app-ll6xk4myya-ew.a.run.app`) — **8/8 pass** (was 4 fail / 4 pass with the old assertion)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee49abf-66b2-42cd-a560-28b3fe76f0ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee49abf-66b2-42cd-a560-28b3fe76f0ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

