### PR TITLE
Enable remix proposals for catalog games

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -628,6 +628,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     assistant: options.editorAssistant ?? new VertexEditorAssistant(),
     codeLane: new VertexCodeLane(),
     contentChecker,
+    // Same resolver MCP proposal tools and the review diff use — catalog remix propose
+    // reads one game's archive at the live snapshot commit through this seam.
+    resolveProposalBase: resolveBaseForProposal,
     // Same gate the delivery path uses: a proposal is checked by exactly the machinery a
     // creator's own upload is, or the reviewer would be judging something unverified.
     onSourcesDelivered: gateTrigger,

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -1154,6 +1154,53 @@ describe('remix propose', () => {
     });
   });
 
+  it('keeps the snapshot-pinned base when session.sources drift from publishedRef', async () => {
+    // Repo-lane sessions load EDITOR.json from publishedRef at start; the proposal base
+    // is pinned to the snapshot commit. If those disagree, the candidate must still
+    // start from the snapshot — otherwise `base` and the files disagree.
+    const snapshotEditor = JSON.stringify({
+      version: 1,
+      params: {
+        dogScale: { type: 'number', min: 0.5, max: 3, default: 1, label: { en: 'Dog size' } },
+        tagline: { type: 'text', max: 40, default: 'snapshot!', label: { en: 'Tagline' } },
+      },
+    });
+    const puts: Array<{ slug: string; files: Array<{ path: string; content: string }> }> = [];
+    const built = await buildTestApp({
+      gamesStore: stubGamesStore({ puts }),
+      resolveProposalBase: async (slug) => {
+        if (slug !== 'catalog-dash') return null;
+        return {
+          base: { kind: 'repo', snapshotId: 'snap-1', sha: 'snapsha' },
+          files: Object.entries({ ...SOURCES, 'EDITOR.json': snapshotEditor }).map(([path, content]) => ({
+            path,
+            content,
+          })),
+        };
+      },
+    });
+    app = built.app;
+    const { remixId } = (
+      await app.inject({ method: 'POST', url: '/api/games/catalog-dash/remix', headers: alice })
+    ).json();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: {
+        title: 'keep the pin',
+        description: 'Candidate must start from the snapshot commit, not publishedRef.',
+        params: { dogScale: 2, tagline: 'snapshot!' },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    const editor = puts[0]?.files.find((file) => file.path === 'EDITOR.json')?.content ?? '';
+    // Snapshot's default tagline survived; publishedRef's "go!" did not leak in.
+    expect(editor).toContain('snapshot!');
+    expect(editor).not.toContain('"go!"');
+    expect(editor).toMatch(/"default"\s*:\s*2/);
+  });
+
   it('still refuses a catalog remix when the archive base is unavailable', async () => {
     const built = await buildTestApp({
       resolveProposalBase: async () => null,

--- a/apps/api/src/remix.test.ts
+++ b/apps/api/src/remix.test.ts
@@ -137,6 +137,11 @@ async function buildTestApp(
     now?: () => number;
     gamesStore?: GamesStore;
     submissionTokenSecret?: string;
+    resolveProposalBase?: (slug: string) => Promise<{
+      base: { kind: 'store'; version: string } | { kind: 'repo'; snapshotId: string; sha: string };
+      files: Array<{ path: string; content: string }>;
+    } | null>;
+    onSourcesDelivered?: (input: { issueNumber: number; slug: string; version: string }) => void;
   } = {},
 ) {
   const store = new InMemoryStore();
@@ -169,6 +174,8 @@ async function buildTestApp(
     ...(overrides.codeLane ? { codeLane: overrides.codeLane as never } : {}),
     ...(overrides.isAbandoned ? { isAbandoned: overrides.isAbandoned } : {}),
     ...(overrides.now ? { now: overrides.now } : {}),
+    ...(overrides.resolveProposalBase ? { resolveProposalBase: overrides.resolveProposalBase } : {}),
+    ...(overrides.onSourcesDelivered ? { onSourcesDelivered: overrides.onSourcesDelivered } : {}),
   });
   await app.ready();
   return { app, seen, store };
@@ -662,6 +669,11 @@ describe('remix across the two catalog eras', () => {
       codeLane?: unknown;
       gamesStore?: GamesStore;
       store?: InMemoryStore;
+      resolveProposalBase?: (slug: string) => Promise<{
+        base: { kind: 'store'; version: string } | { kind: 'repo'; snapshotId: string; sha: string };
+        files: Array<{ path: string; content: string }>;
+      } | null>;
+      onSourcesDelivered?: (input: { issueNumber: number; slug: string; version: string }) => void;
     } = {},
   ) {
     const store = overrides.store ?? new InMemoryStore();
@@ -681,6 +693,8 @@ describe('remix across the two catalog eras', () => {
       submissionTokenSecret: 'test-submission-secret',
       assistant: { assist: async () => ({ lane: 'params' }) } as EditorAssistant,
       codeLane: (overrides.codeLane ?? { run: async () => ({ ok: true }) }) as never,
+      ...(overrides.resolveProposalBase ? { resolveProposalBase: overrides.resolveProposalBase } : {}),
+      ...(overrides.onSourcesDelivered ? { onSourcesDelivered: overrides.onSourcesDelivered } : {}),
     });
     await instance.ready();
     return { app: instance, store };
@@ -1028,6 +1042,152 @@ describe('remix save as yours', () => {
     });
     expect(response.statusCode).toBe(409);
     expect(response.json().reason).toBe('no_changes');
+  });
+});
+
+describe('remix propose', () => {
+  let app: FastifyInstance | null = null;
+
+  beforeEach(() => {
+    process.env.EDITOR_ASSIST = 'true';
+    process.env.CODE_LANE = 'true';
+  });
+
+  afterEach(async () => {
+    delete process.env.EDITOR_ASSIST;
+    delete process.env.CODE_LANE;
+    if (app) await app.close();
+    app = null;
+  });
+
+  const PROPOSE_BODY = {
+    title: 'makes game harder',
+    description: 'Reduced the race time limit so rounds feel tighter and more tense.',
+    params: { dogScale: 2, tagline: 'go!' },
+  };
+
+  it('proposes a params-only change on a store-lane game', async () => {
+    const puts: Array<{ slug: string; files: Array<{ path: string; content: string }>; manifest: unknown }> = [];
+    const gated: Array<{ issueNumber: number; slug: string; version: string }> = [];
+    const built = await buildTestApp({
+      gamesStore: stubGamesStore({ puts }),
+      onSourcesDelivered: (input) => {
+        gated.push(input);
+      },
+    });
+    app = built.app;
+
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: PROPOSE_BODY,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ proposal: { state: 'checking' } });
+    expect(puts).toHaveLength(1);
+    expect(puts[0].slug).toBe('dog-dash');
+    expect((puts[0].manifest as { deliveryMode?: string }).deliveryMode).toBe('proposal');
+    const editor = puts[0].files.find((file) => file.path === 'EDITOR.json')?.content ?? '';
+    expect(editor).toMatch(/"default"\s*:\s*2/);
+    expect(gated).toHaveLength(1);
+    expect(gated[0].slug).toBe('dog-dash');
+
+    const proposals = await built.store.listProposals({ proposerUid: 'g:alice' });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      targetSlug: 'dog-dash',
+      base: { kind: 'store', version: 'v1' },
+      state: 'submitted',
+    });
+  });
+
+  it('proposes a catalog (repo-lane) remix once the archive-backed base is wired', async () => {
+    const puts: Array<{ slug: string; files: Array<{ path: string; content: string }>; manifest: unknown }> = [];
+    const built = await buildTestApp({
+      gamesStore: stubGamesStore({ puts }),
+      resolveProposalBase: async (slug) => {
+        if (slug !== 'catalog-dash') return null;
+        return {
+          base: { kind: 'repo', snapshotId: 'snap-1', sha: 'abc123def' },
+          files: Object.entries(SOURCES).map(([path, content]) => ({ path, content })),
+        };
+      },
+    });
+    // No publication for catalog-dash — repo-era start path.
+    app = built.app;
+    // buildTestApp publishes dog-dash; catalog-dash is reached through the same github stub.
+    const { remixId } = (
+      await app.inject({ method: 'POST', url: '/api/games/catalog-dash/remix', headers: alice })
+    ).json();
+
+    const refused = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: { title: 'x', description: 'short' },
+    });
+    // Sanity: without a resolver on a *different* harness this used to 409 not_proposable.
+    // Here the resolver is wired; a short description is just validation.
+    expect(refused.statusCode).toBe(400);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: PROPOSE_BODY,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(puts).toHaveLength(1);
+    expect(puts[0].slug).toBe('catalog-dash');
+    expect(puts[0].files.some((file) => file.path === 'game.ts')).toBe(true);
+    expect(puts[0].files.some((file) => file.path === 'SPEC.md')).toBe(true);
+
+    const proposals = await built.store.listProposals({ proposerUid: 'g:alice' });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      targetSlug: 'catalog-dash',
+      targetOwnerUid: null,
+      base: { kind: 'repo', snapshotId: 'snap-1', sha: 'abc123def' },
+      state: 'submitted',
+    });
+  });
+
+  it('still refuses a catalog remix when the archive base is unavailable', async () => {
+    const built = await buildTestApp({
+      resolveProposalBase: async () => null,
+    });
+    app = built.app;
+    const { remixId } = (
+      await app.inject({ method: 'POST', url: '/api/games/catalog-dash/remix', headers: alice })
+    ).json();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: PROPOSE_BODY,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toBe('not_proposable');
+  });
+
+  it('refuses propose with nothing changed', async () => {
+    const built = await buildTestApp();
+    app = built.app;
+    const { remixId } = (await app.inject({ method: 'POST', url: '/api/games/dog-dash/remix', headers: alice })).json();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/remixes/${remixId}/propose`,
+      headers: alice,
+      payload: {
+        title: 'no real change',
+        description: 'Trying to propose the defaults should not open a review.',
+        params: { dogScale: 1, tagline: 'go!' },
+      },
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toBe('no_changes');
   });
 });
 

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -974,9 +974,12 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         return reply.status(409).send({ error: 'not_proposable' });
       }
 
-      // Session declaration / any prior code-lane load wins over a fresh base read for
-      // the same path — then overrides win on top. Same merge save uses for repo-era.
-      const merged = { ...baseSources, ...session.sources, ...session.overrides };
+      // Overrides only on top of the pinned base. Repo-lane `session.sources` starts as
+      // EDITOR.json (and may later hold a code-lane map) read from `publishedRef`, which
+      // can drift from the snapshot commit the base is pinned to — spreading it here would
+      // replace snapshot files and make the candidate disagree with `base`. Code edits
+      // land in `overrides`; params/content are baked below.
+      const merged = { ...baseSources, ...session.overrides };
       const files = Object.entries(merged).map(([path, fileContent]) => ({ path, content: fileContent }));
       bakeRemixEditorDefaults(files, session.definition, params, content);
 

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -15,7 +15,13 @@ import { logModerationRejection } from './moderation-metrics.js';
 import { assembleGameHtml } from './assemble.js';
 import type { GitHubClient } from './github-client.js';
 import { type EditingGate, type CreationGate } from './creation-limits.js';
-import { bakeRemixEditorDefaults, remixHasSavableChange, saveRemixAsStudioDraft } from './remix-save.js';
+import {
+  bakeRemixEditorDefaults,
+  remixHasSavableChange,
+  saveRemixAsStudioDraft,
+  type RemixSaveContent,
+  type RemixSaveParams,
+} from './remix-save.js';
 import {
   openProposal,
   PROPOSAL_NO_JOB,
@@ -24,6 +30,8 @@ import {
   MIN_PROPOSAL_DESCRIPTION_LENGTH,
   type ProposalDeps,
 } from './proposals.js';
+import type { ProposalBase } from './store.js';
+import type { SourceFile } from './games-store.js';
 
 /**
  * Remix: a player bends a published game while playing it.
@@ -46,8 +54,8 @@ import {
  *  - **Params never touch this server.** A slider moves the running game over
  *    the existing `editor:content` bridge, client-side, in under a frame. Only
  *    natural language and code need a round trip, which is why those are the
- *    only edit routes here. Save receives params/content only to bake them into
- *    the draft's EDITOR.json defaults.
+ *    only edit routes here. Save and propose receive params/content only to bake
+ *    them into EDITOR.json defaults (draft or proposal candidate).
  *  - **The player never supplies code.** The session holds the accumulated
  *    source overrides server-side and the client holds only an id, so nothing a
  *    browser sends is ever compiled. What comes back is a whole document for the
@@ -158,6 +166,13 @@ const ProposeSchema = z.object({
     .trim()
     .min(MIN_PROPOSAL_DESCRIPTION_LENGTH, 'say a little more about what you changed')
     .max(MAX_PROPOSAL_DESCRIPTION_LENGTH),
+  /**
+   * Client-held param / paint values. Same shape save accepts: the session never stores
+   * them (params ride the bridge; paint is client-only until a durable exit), so the
+   * propose exit has to bring them in to bake into the candidate's EDITOR.json.
+   */
+  params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+  content: z.record(z.string(), z.unknown()).optional(),
 });
 const ShareSchema = z.object({
   params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
@@ -224,6 +239,15 @@ export interface RemixRoutesOptions {
    * proposal is checked by exactly the machinery a creator's own upload is.
    */
   onSourcesDelivered?: (input: { issueNumber: number; slug: string; version: string }) => void | Promise<unknown>;
+  /**
+   * Published sources + base pin for a proposal, both lanes.
+   *
+   * Same resolver the MCP proposal tools and the review diff use — one answer to
+   * "what is this game right now", so a remix propose cannot disagree with either.
+   * Absent means catalog (repo-lane) propose stays closed; store-lane still works
+   * from the session's own sources.
+   */
+  resolveProposalBase?: (slug: string) => Promise<{ base: ProposalBase; files: SourceFile[] } | null>;
   store?: Store;
   gamesStore?: GamesStore;
   githubClient?: GitHubClient;
@@ -864,14 +888,13 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
    * Remix keeps its two existing exits (save as yours, share) and its founding rule: the
    * session itself still never publishes, and nothing here writes to the game being
    * remixed. What it produces is a *proposal* — an immutable candidate version the game's
-   * owner is asked about and may refuse. The boundary that moved is "a remix may not ask",
-   * not "a remix may publish".
+   * owner (or the platform, for catalog games) is asked about and may refuse. The
+   * boundary that moved is "a remix may not ask", not "a remix may publish".
    *
-   * Store-lane only, and the 409 says so plainly. A repo-era game's code lives on the ref
-   * and this session holds only its declaration (see `loadSources`), so there is no file
-   * set here to propose. Declared-content proposals on repo games arrive when the
-   * archive-backed base lands; until then, offering the button and failing at submit would
-   * be worse than not offering it.
+   * Both catalog eras. Store-lane sessions already hold the published sources; repo-lane
+   * sessions hold only the declaration (see `loadSources`), so the complete file set and
+   * the base pin come from `resolveProposalBase` — the same archive-backed read the MCP
+   * proposal tools use. Accept on a repo-lane proposal still lands via the apply-bot PR.
    */
   app.post(
     '/api/remixes/:id/propose',
@@ -886,26 +909,76 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       if (!body.success) {
         return reply.status(400).send({ error: body.error.issues[0]?.message ?? 'invalid request' });
       }
-      if (!session.fromStore) {
-        return reply.status(409).send({ error: 'not_proposable' });
-      }
-      if (Object.keys(session.overrides).length === 0) {
+
+      const params = body.data.params as RemixSaveParams | undefined;
+      const content = body.data.content as RemixSaveContent | undefined;
+      if (
+        !remixHasSavableChange({
+          overrides: session.overrides,
+          definition: session.definition,
+          params,
+          content,
+        })
+      ) {
         return reply.status(409).send({ error: 'no_changes' });
       }
 
-      const publication = await options.store.getPublication(session.slug);
-      if (publication?.state !== 'published' || !publication.currentVersion) {
-        return reply.status(409).send({ error: 'not_published' });
+      // Free-form text baked into EDITOR.json gets the same bar save uses — title and
+      // description are moderated inside openProposal, but param strings would otherwise
+      // skip the checker and land in a candidate the gate never re-reads as prose.
+      const textFields: string[] = [];
+      const specs = session.definition?.params;
+      if (specs && params) {
+        for (const [name, spec] of Object.entries(specs)) {
+          if (spec.type === 'text' && typeof params[name] === 'string') {
+            const text = (params[name] as string).trim();
+            if (text) textFields.push(text);
+          }
+        }
+      }
+      if (textFields.length > 0 && options.contentChecker) {
+        const verdict = await options.contentChecker.checkFields(textFields);
+        if (!verdict.allowed) {
+          logModerationRejection(request.log, {
+            surface: 'proposal',
+            uid: request.user?.uid,
+            category: verdict.category,
+          });
+          return reply.status(422).send({ error: 'content_rejected', category: verdict.category ?? 'other' });
+        }
       }
 
-      // The proposed game is the base with the session's edits applied. Sent whole rather
-      // than as a patch because a version is a complete source set — the gate builds it,
-      // and "the files it ran" and "the files the reviewer reads" have to be the same
-      // thing.
-      const files = Object.entries({ ...session.sources, ...session.overrides }).map(([path, content]) => ({
-        path,
-        content,
-      }));
+      let base: ProposalBase;
+      let baseSources: Record<string, string>;
+
+      if (options.resolveProposalBase) {
+        const resolved = await options.resolveProposalBase(session.slug);
+        if (!resolved) {
+          // Resolver already collapsed every unavailable reason to null (see app.ts).
+          // Catalog games without an archive pin, and store games without a live
+          // publication, look the same from here: the contribute-back door is shut.
+          return reply.status(409).send({ error: 'not_proposable' });
+        }
+        base = resolved.base;
+        baseSources = Object.fromEntries(resolved.files.map((file) => [file.path, file.content]));
+      } else if (session.fromStore) {
+        // Test / degraded deployments that never wired the shared resolver: the session
+        // already holds the store-lane sources, so propose can still work for those.
+        const publication = await options.store.getPublication(session.slug);
+        if (publication?.state !== 'published' || !publication.currentVersion) {
+          return reply.status(409).send({ error: 'not_published' });
+        }
+        base = { kind: 'store', version: publication.currentVersion };
+        baseSources = session.sources;
+      } else {
+        return reply.status(409).send({ error: 'not_proposable' });
+      }
+
+      // Session declaration / any prior code-lane load wins over a fresh base read for
+      // the same path — then overrides win on top. Same merge save uses for repo-era.
+      const merged = { ...baseSources, ...session.sources, ...session.overrides };
+      const files = Object.entries(merged).map(([path, fileContent]) => ({ path, content: fileContent }));
+      bakeRemixEditorDefaults(files, session.definition, params, content);
 
       const result = await openProposal(
         {
@@ -921,7 +994,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
           proposerUid: request.user!.uid,
           title: body.data.title,
           description: body.data.description,
-          base: { kind: 'store', version: publication.currentVersion },
+          base,
           files,
         },
       );

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -241,6 +241,11 @@ export const REMIX_STEPS = [
   'refused',
   'shared',
   'keep_clicked',
+  // The contribute-back exit: this visit successfully sent a proposal. Beside
+  // `shared` / `keep_clicked` rather than below them — a visit may propose without
+  // sharing a link or keeping a draft, and without this rung "opened the composer"
+  // and "sent a reviewable change" are the same number.
+  'proposed',
 ] as const;
 
 export type RemixStep = (typeof REMIX_STEPS)[number];

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -128,6 +128,7 @@ const RemixStepSchema = z.enum([
   'refused',
   'shared',
   'keep_clicked',
+  'proposed',
 ]);
 /** Which door led to the painter — recorded on `painted`, closed like every grouping key. */
 const RemixViaSchema = z.enum(['redirect', 'menu', 'panel']);

--- a/apps/web/src/ProposeComposer.tsx
+++ b/apps/web/src/ProposeComposer.tsx
@@ -23,6 +23,10 @@ export function ProposeComposer(props: {
   /** How many proposals this person already has open against this game, if known. */
   openCount?: number;
   maxOpen?: number;
+  /** Current remix param values — baked into the candidate the way save bakes them. */
+  params?: Record<string, string | number | boolean>;
+  /** Painted collections, when the player edited them. */
+  content?: Record<string, unknown>;
   onSent: () => void;
   onCancel: () => void;
 }) {
@@ -39,7 +43,12 @@ export function ProposeComposer(props: {
     setSending(true);
     setError(null);
     try {
-      await proposeFromRemix(props.remixId, { title: title.trim(), description: description.trim() });
+      await proposeFromRemix(props.remixId, {
+        title: title.trim(),
+        description: description.trim(),
+        ...(props.params ? { params: props.params } : {}),
+        ...(props.content ? { content: props.content } : {}),
+      });
       props.onSent();
     } catch (caught) {
       // Every refusal the API can give has its own sentence, because "something went

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -1534,6 +1534,7 @@ export function RemixPanel(props: {
           params={valuesRef.current}
           {...(contentEditedRef.current ? { content: contentDocRef.current } : {})}
           onSent={() => {
+            recordRemixStep('proposed');
             setProposing(false);
             setProposed(true);
           }}

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -275,10 +275,11 @@ export function RemixPanel(props: {
   /**
    * Whether this game takes proposals from this player.
    *
-   * Asked once per session rather than assumed: contributions are off by default, and a
-   * button that appears for every game and fails on most of them would teach players to
-   * ignore it. `null` means we have not asked yet, which renders as no button at all —
-   * the honest state, since we do not know.
+   * Asked once per session rather than assumed: creator games are off until they opt in,
+   * and a button that appears for every game and fails on most of them would teach players
+   * to ignore it. Catalog (platform-owned) games are open by default. `null` means we have
+   * not asked yet, which renders as no button at all — the honest state, since we do not
+   * know.
    */
   const [canPropose, setCanPropose] = useState<boolean | null>(null);
   const [proposing, setProposing] = useState(false);
@@ -1530,6 +1531,8 @@ export function RemixPanel(props: {
       {proposing && session ? (
         <ProposeComposer
           remixId={session.remixId}
+          params={valuesRef.current}
+          {...(contentEditedRef.current ? { content: contentDocRef.current } : {})}
           onSent={() => {
             setProposing(false);
             setProposed(true);

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -50,6 +50,7 @@ const REMIX_LABELS: Record<string, string> = {
   refused: 'was refused',
   shared: 'shared their version',
   keep_clicked: 'clicked "make it mine"',
+  proposed: 'sent a proposal',
 };
 
 const REMIX_VIA_LABELS: Record<string, string> = {

--- a/apps/web/src/proposalsApi.ts
+++ b/apps/web/src/proposalsApi.ts
@@ -135,12 +135,18 @@ export function checkContributions(slug: string): Promise<ContributionEligibilit
 /**
  * Turn the current remix session into a proposal.
  *
- * The session's edits become a complete candidate source set server-side; nothing the
- * browser holds is sent as code.
+ * Code overrides stay on the session; params and painted content live only in the
+ * browser (same as save), so they travel with this request for the server to bake into
+ * the candidate. Nothing the browser holds is compiled as game code.
  */
 export function proposeFromRemix(
   remixId: string,
-  input: { title: string; description: string },
+  input: {
+    title: string;
+    description: string;
+    params?: Record<string, string | number | boolean>;
+    content?: Record<string, unknown>;
+  },
 ): Promise<{ proposal: { id: string; state: ProposalState } }> {
   return post(`/api/remixes/${encodeURIComponent(remixId)}/propose`, input);
 }

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -187,8 +187,8 @@ export type AssistStep = 'asked' | 'applied' | 'handoff' | 'rejected';
  * A real funnel this time, and the first two rungs are the whole thesis: of the
  * people who open a remix, how many touch anything at all. `tuned` is that
  * number — the one metric the plan says validates or falsifies the bet for free.
- * The tail (`shared`, `keep_clicked`) is where retention turns into either a
- * visitor or a creator.
+ * The tail (`shared`, `keep_clicked`, `proposed`) is where retention turns into
+ * either a visitor, a creator, or a contributor.
  */
 export type RemixStep =
   // The denominator for every rung below it: this visit was *shown* the way in.
@@ -212,7 +212,8 @@ export type RemixStep =
   | 'handoff'
   | 'refused'
   | 'shared'
-  | 'keep_clicked';
+  | 'keep_clicked'
+  | 'proposed'; // sent a change back for review — the contribute-back exit
 
 /**
  * Which door led to the painter: the router proposing it after a content-shaped


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Remixing a catalog (repo-lane) game let you change it locally, but **Send proposal** failed with “This game can't take proposals yet.”

Two gaps stacked:

1. `/api/remixes/:id/propose` only accepted store-lane sessions (`fromStore`), even though the archive-backed proposal base resolver and apply-bot PR path already existed for catalog games.
2. Params-only remixes never write `session.overrides` (values live on the client), so propose also treated them as `no_changes` — which is exactly the “make it harder” flow in the screenshot.

## Change

- Wire remix propose through the same `resolveProposalBase` seam MCP / review already use.
- Accept `params` / `content` on propose and bake them into `EDITOR.json` the way save does.
- Client sends the current remix values with the proposal.
- Cover store-lane params-only, repo-lane success, unavailable base, and no-change refusals.

## Review follow-ups

- **Base pin:** candidate sources are `baseSources + overrides` only — do not spread `session.sources` (publishedRef / code-lane map) over a snapshot-pinned base.
- **Telemetry:** remix funnel gains `proposed` (browser `recordRemixStep`, API schema, `REMIX_STEPS` rollup, admin label) on successful send.

## How it works for catalog games

1. Player remixes → propose opens a candidate version pinned to the live snapshot commit.
2. Gate runs as usual; platform ops review in Admin → Proposals.
3. Accept still uses the apply-bot to open a games-repo PR; merge + bake republishes.

Creator-owned games are unchanged: still gated by contributions settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9ab85d8-749a-4fec-9285-04553ce86def?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9ab85d8-749a-4fec-9285-04553ce86def&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

