### PR TITLE
Slim the header chrome: one language button, leaner menu

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1116,7 +1116,6 @@ export function App() {
                 onRetryCatalog={handleRetryCatalog}
                 recommendationsRefreshKey={recommendationsRefreshKey}
                 creatorGamesRefreshKey={myGamesRefreshKey}
-                onOpenStudio={() => navigate(studioPath())}
               />
             )}
           </>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,6 @@ import { PixelIcon } from './PixelIcon.js';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
 import { deriveTitleFromConcept } from './gameTitle.js';
 import {
-  adminPath,
   canonicalPath,
   creatorPath,
   NAVIGATE_EVENT,
@@ -863,7 +862,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -884,7 +882,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -905,7 +902,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -941,7 +937,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -976,7 +971,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -998,7 +992,6 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
-          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -1027,7 +1020,6 @@ export function App() {
         onNavigate={handleNavigateSection}
         onHome={() => navigate('/')}
         onStudio={() => navigate(studioPath())}
-        onAdmin={() => navigate(adminPath())}
         upTarget={headerUp}
         onUp={navigate}
       />

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -569,7 +569,7 @@ describe('ArcadeCatalog soft-refresh failure', () => {
   });
 });
 
-describe('ArcadeCatalog Studio chip', () => {
+describe('ArcadeCatalog in-progress builds', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();
     mockSignedOutAuth();
@@ -588,7 +588,7 @@ describe('ArcadeCatalog Studio chip', () => {
     vi.restoreAllMocks();
   });
 
-  it('keeps in-progress builds out of the grid and surfaces them on the Studio chip', async () => {
+  it('keeps in-progress builds out of the grid (Studio chip lives in the header)', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
       user: { uid: 'test-user', tier: 'standard' },
@@ -610,7 +610,6 @@ describe('ArcadeCatalog Studio chip', () => {
       });
     });
 
-    const onOpenStudio = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -624,13 +623,12 @@ describe('ArcadeCatalog Studio chip', () => {
           onPlayGame: vi.fn(),
           onPlayTogether: vi.fn(),
           onRetryCatalog: vi.fn(),
-          onOpenStudio,
         }),
       );
       await flushEffects();
     });
 
-    // Signed-in paint waits for the shelf so Yours pins + Studio chip land with the grid.
+    // Signed-in paint waits for the shelf so Yours pins land with the grid.
     expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
     expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
 
@@ -663,15 +661,7 @@ describe('ArcadeCatalog Studio chip', () => {
 
     expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
     expect(container.querySelectorAll('.catalog-build-card')).toHaveLength(0);
-    const chip = container.querySelector<HTMLButtonElement>('.catalog-studio-chip');
-    expect(chip?.classList.contains('is-live')).toBe(true);
-    expect(chip?.textContent).toMatch(/2 in progress/i);
-    expect(chip?.textContent).toMatch(/Studio/i);
-
-    await act(async () => {
-      chip?.click();
-    });
-    expect(onOpenStudio).toHaveBeenCalledOnce();
+    expect(container.querySelector('.studio-chip, .catalog-studio-chip')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -17,12 +17,7 @@ import {
   type CatalogSortMode,
   type CatalogSortSignals,
 } from './catalogSort.js';
-import {
-  CREATOR_LIVE_STATUSES,
-  loadCreatorGames,
-  publishedCreatorSlugs,
-  type CreatorGameItem,
-} from './creatorGames.js';
+import { loadCreatorGames, publishedCreatorSlugs, type CreatorGameItem } from './creatorGames.js';
 import { MascotMoment } from './Mascot.js';
 import { PixelIcon } from './PixelIcon.js';
 import { getRecentPlays } from './recentPlays.js';
@@ -44,9 +39,8 @@ type ArcadeCatalogProps = {
   onRetryCatalog: () => void;
   /** Bump after a play so the grid can re-sort from fresh affinity. */
   recommendationsRefreshKey?: number;
-  /** Bump after a new submission so the Studio chip refreshes. */
+  /** Bump after a new submission so Yours pins refresh. */
   creatorGamesRefreshKey?: number;
-  onOpenStudio?: () => void;
 };
 
 function humanizeMoment(name: string): string {
@@ -395,75 +389,75 @@ function CatalogCard({
         <div className="catalog-overlay">
           <div className="card-copy">
             <h3 className="card-title">
-            {entry.title}
-            {entry.multiplayer && (
-              <span className="card-party-badge">
-                <PixelIcon name="phone" size={12} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
-              </span>
-            )}
-            {/* Says what the game will do, not what this visitor will get: a signed-out
+              {entry.title}
+              {entry.multiplayer && (
+                <span className="card-party-badge">
+                  <PixelIcon name="phone" size={12} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
+                </span>
+              )}
+              {/* Says what the game will do, not what this visitor will get: a signed-out
                 player sees the badge and no save, which is the honest ordering — the
                 promise belongs to the game, and signing in is what claims it. */}
-            {entry.saves === 'player' && (
-              <span className="card-saves-badge">
-                <PixelIcon name="clock" size={12} /> {t('catalog.savesBadge')}
-              </span>
-            )}
-            {/* The one badge that is about other people rather than about the game.
+              {entry.saves === 'player' && (
+                <span className="card-saves-badge">
+                  <PixelIcon name="clock" size={12} /> {t('catalog.savesBadge')}
+                </span>
+              )}
+              {/* The one badge that is about other people rather than about the game.
                 Worth its own colour: "somebody else has been here" is a different kind
                 of reason to click than "this remembers you". */}
-            {entry.world === 'shared' && (
-              <span className="card-world-badge">
-                <PixelIcon name="star" size={12} /> {t('catalog.worldBadge')}
-              </span>
-            )}
-            {/* Advisory, like saves: says the game answers tilt where the device offers
+              {entry.world === 'shared' && (
+                <span className="card-world-badge">
+                  <PixelIcon name="star" size={12} /> {t('catalog.worldBadge')}
+                </span>
+              )}
+              {/* Advisory, like saves: says the game answers tilt where the device offers
                 it, while the keyboard stays the whole game everywhere else. Reuses the
                 party pill style — it is the same "how you can drive this" family. */}
-            {entry.sensing === 'tilt' && (
-              <span className="card-party-badge" title={t('catalog.tiltTooltip')}>
-                <PixelIcon name="phone" size={12} /> {t('catalog.tiltBadge')}
-              </span>
-            )}
-            {entry.sensing === 'backdrop' && (
-              <span className="card-party-badge" title={t('catalog.cameraTooltip')}>
-                <PixelIcon name="phone" size={12} /> {t('catalog.cameraBadge')}
-              </span>
-            )}
-          </h3>
-          <p className="card-author">
-            {entry.creatorHandle && !isPlatformAuthor(entry.submittedBy) ? (
-              <>
-                {t('player.byAuthorPrefix')}
-                <a className="card-author-link" href={creatorPath(entry.creatorHandle)}>
-                  {entry.submittedBy}
-                </a>
-              </>
-            ) : (
-              t('player.byAuthor', {
-                author: isPlatformAuthor(entry.submittedBy) ? t('catalog.platformAuthor') : entry.submittedBy,
-              })
-            )}
-          </p>
-          {/*
-           * Contributor credit — the growth loop, and the reason proposing is worth doing.
-           * Its own line rather than appended to the byline: the owner is who made the
-           * game, and a contributor sharing that sentence would blur authorship the
-           * ownership rules are careful to keep clear.
-           */}
-          {entry.contributorHandles && entry.contributorHandles.length > 0 ? (
-            <p className="card-contributors">
-              {t('catalog.withContributions')}{' '}
-              {entry.contributorHandles.map((handle, index) => (
-                <span key={handle}>
-                  {index > 0 ? ', ' : null}
-                  <a className="card-author-link" href={creatorPath(handle)}>
-                    @{handle}
-                  </a>
+              {entry.sensing === 'tilt' && (
+                <span className="card-party-badge" title={t('catalog.tiltTooltip')}>
+                  <PixelIcon name="phone" size={12} /> {t('catalog.tiltBadge')}
                 </span>
-              ))}
+              )}
+              {entry.sensing === 'backdrop' && (
+                <span className="card-party-badge" title={t('catalog.cameraTooltip')}>
+                  <PixelIcon name="phone" size={12} /> {t('catalog.cameraBadge')}
+                </span>
+              )}
+            </h3>
+            <p className="card-author">
+              {entry.creatorHandle && !isPlatformAuthor(entry.submittedBy) ? (
+                <>
+                  {t('player.byAuthorPrefix')}
+                  <a className="card-author-link" href={creatorPath(entry.creatorHandle)}>
+                    {entry.submittedBy}
+                  </a>
+                </>
+              ) : (
+                t('player.byAuthor', {
+                  author: isPlatformAuthor(entry.submittedBy) ? t('catalog.platformAuthor') : entry.submittedBy,
+                })
+              )}
             </p>
-          ) : null}
+            {/*
+             * Contributor credit — the growth loop, and the reason proposing is worth doing.
+             * Its own line rather than appended to the byline: the owner is who made the
+             * game, and a contributor sharing that sentence would blur authorship the
+             * ownership rules are careful to keep clear.
+             */}
+            {entry.contributorHandles && entry.contributorHandles.length > 0 ? (
+              <p className="card-contributors">
+                {t('catalog.withContributions')}{' '}
+                {entry.contributorHandles.map((handle, index) => (
+                  <span key={handle}>
+                    {index > 0 ? ', ' : null}
+                    <a className="card-author-link" href={creatorPath(handle)}>
+                      @{handle}
+                    </a>
+                  </span>
+                ))}
+              </p>
+            ) : null}
           </div>
           <div className="card-actions">
             <button className="primary-btn" onClick={() => onPlayGame(entry)}>
@@ -526,7 +520,6 @@ export function ArcadeCatalog({
   onRetryCatalog,
   recommendationsRefreshKey = 0,
   creatorGamesRefreshKey = 0,
-  onOpenStudio,
 }: ArcadeCatalogProps) {
   const { t, i18n } = useTranslation();
   const { user, loading: authLoading } = useAuth();
@@ -644,12 +637,6 @@ export function ArcadeCatalog({
   }, [sortMenuOpen]);
 
   const mySlugs = useMemo(() => publishedCreatorSlugs(creatorItems), [creatorItems]);
-  const hasInProgress = useMemo(() => creatorItems.some((item) => item.status !== 'published'), [creatorItems]);
-  const liveCount = useMemo(
-    () => creatorItems.filter((item) => item.status !== null && CREATOR_LIVE_STATUSES.has(item.status)).length,
-    [creatorItems],
-  );
-  const showStudioChip = Boolean(onOpenStudio) && (hasInProgress || mySlugs.size > 0);
 
   const hasCatalog = catalogStatus === 'ready' && catalogEntries.length > 0;
   // My games only makes sense when signed in and you have a published game of yours.
@@ -725,33 +712,11 @@ export function ArcadeCatalog({
           : t('catalog.empty');
   const showEmpty = layoutReady && displayedEntries.length === 0;
 
-  const studioChipLabel =
-    liveCount > 0
-      ? `${t('myGames.liveCount', { count: liveCount })} — ${t('myGames.openStudio')}`
-      : t('myGames.openStudio');
-
   return (
     <section id="arcade" className="arcade-section">
       <div className="arcade-header">
         <div className="arcade-title-row">
           <h2 className="arcade-title">{t('catalog.title')}</h2>
-          {showStudioChip ? (
-            <button
-              type="button"
-              className={`catalog-studio-chip${liveCount > 0 ? ' is-live' : ''}`}
-              onClick={onOpenStudio}
-              aria-label={studioChipLabel}
-            >
-              {liveCount > 0 ? (
-                <>
-                  <span className="live-dot" aria-hidden="true" />
-                  <span className="catalog-studio-chip-count">{t('myGames.liveCount', { count: liveCount })}</span>
-                </>
-              ) : null}
-              <PixelIcon name="wrench" size={12} />
-              <span className="catalog-studio-chip-label">{t('myGames.openStudio')}</span>
-            </button>
-          ) : null}
         </div>
         {showControls ? (
           <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>

--- a/apps/web/src/LanguageSwitcher.tsx
+++ b/apps/web/src/LanguageSwitcher.tsx
@@ -1,25 +1,30 @@
 import { useTranslation } from 'react-i18next';
-import { SUPPORTED_LANGUAGES } from './i18n/index.js';
 
 const LABELS: Record<string, string> = { en: 'EN', pl: 'PL' };
 
+function resolveLang(language: string | undefined): 'en' | 'pl' {
+  return language?.toLowerCase().startsWith('pl') ? 'pl' : 'en';
+}
+
+/**
+ * One control that flips between the two shipped languages. Showing the language
+ * you would switch *to* makes the action obvious without a two-button segmented
+ * control eating header space.
+ */
 export function LanguageSwitcher() {
   const { t, i18n } = useTranslation();
-  const current = i18n.resolvedLanguage ?? i18n.language;
+  const current = resolveLang(i18n.resolvedLanguage ?? i18n.language);
+  const next = current === 'en' ? 'pl' : 'en';
 
   return (
-    <div className="language-switcher" role="group" aria-label={t('header.languageAria')}>
-      {SUPPORTED_LANGUAGES.map((lang) => (
-        <button
-          key={lang}
-          type="button"
-          className={lang === current ? 'active' : ''}
-          aria-pressed={lang === current}
-          onClick={() => void i18n.changeLanguage(lang)}
-        >
-          {LABELS[lang]}
-        </button>
-      ))}
-    </div>
+    <button
+      type="button"
+      className="language-switcher"
+      aria-label={t('header.languageAria')}
+      title={LABELS[next]}
+      onClick={() => void i18n.changeLanguage(next)}
+    >
+      {LABELS[next]}
+    </button>
   );
 }

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -323,13 +323,13 @@ describe('LanguageSwitcher in header', () => {
       await Promise.resolve();
     });
 
-    const switchers = container.querySelectorAll('button.language-switcher');
+    const switcher = container.querySelector<HTMLButtonElement>('button.language-switcher');
     // Header + (closed) menu: only the header instance is mounted while the menu is closed.
-    expect(switchers).toHaveLength(1);
-    expect(switchers[0]?.textContent).toBe('PL');
+    expect(switcher).not.toBeNull();
+    expect(switcher?.textContent).toBe('PL');
 
     await act(async () => {
-      switchers[0]?.click();
+      switcher?.click();
       await Promise.resolve();
     });
     expect(i18n.language).toMatch(/^pl/);

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -224,11 +224,18 @@ describe('NavHeader Studio chip', () => {
     expect(chip?.classList.contains('is-live')).toBe(true);
     expect(chip?.textContent).toMatch(/9 in progress/i);
     expect(chip?.textContent).toMatch(/Studio/i);
-    expect(chip?.querySelector('.studio-chip-badge')?.textContent).toBe('9');
-    expect(chip?.getAttribute('aria-label')).toMatch(/9 in progress/i);
 
     await act(async () => chip?.click());
     expect(onStudio).toHaveBeenCalledOnce();
+
+    // Menu carries the same count for phones (where the chip is CSS-hidden).
+    const hamburger = container.querySelector<HTMLButtonElement>('.hamburger-btn');
+    expect(hamburger?.querySelector('.hamburger-live-badge')?.textContent).toBe('9');
+    await act(async () => hamburger?.click());
+    const studioLink = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((el) =>
+      /Studio/i.test(el.textContent ?? ''),
+    );
+    expect(studioLink?.querySelector('.specs-count-badge')?.textContent).toBe('9');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -177,6 +177,61 @@ describe('NavHeader menu', () => {
   });
 });
 
+describe('NavHeader Studio chip', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('shows the rich live chip in the header and opens Studio', async () => {
+    await i18n.changeLanguage('en');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:ada', tier: 'standard', name: 'Ada' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onStudio = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 9,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio,
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const chip = container.querySelector<HTMLButtonElement>('button.studio-chip');
+    expect(chip).not.toBeNull();
+    expect(chip?.classList.contains('is-live')).toBe(true);
+    expect(chip?.textContent).toMatch(/9 in progress/i);
+    expect(chip?.textContent).toMatch(/Studio/i);
+
+    await act(async () => chip?.click());
+    expect(onStudio).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+  });
+});
+
 describe('NavHeader profile link', () => {
   afterEach(() => {
     document.body.innerHTML = '';

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -224,6 +224,8 @@ describe('NavHeader Studio chip', () => {
     expect(chip?.classList.contains('is-live')).toBe(true);
     expect(chip?.textContent).toMatch(/9 in progress/i);
     expect(chip?.textContent).toMatch(/Studio/i);
+    expect(chip?.querySelector('.studio-chip-badge')?.textContent).toBe('9');
+    expect(chip?.getAttribute('aria-label')).toMatch(/9 in progress/i);
 
     await act(async () => chip?.click());
     expect(onStudio).toHaveBeenCalledOnce();

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -44,7 +44,6 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
-            onAdmin: vi.fn(),
             upTarget: { path: '/studio', ariaLabel: 'Back to Studio' },
             onUp,
           }),
@@ -82,7 +81,6 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
-            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -97,42 +95,33 @@ describe('NavHeader Up chevron', () => {
   });
 });
 
-// The console has been reachable only by typing its URL, which is why the one operator
-// surface with something to do on it was also the one nothing linked to.
-describe('NavHeader operator link', () => {
+describe('NavHeader menu', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en');
-    // The badge polls; the tests that care about that advance the clock themselves.
-    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
     document.body.innerHTML = '';
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  async function renderWith(summary: { status: number; body: unknown }, admin = true) {
+  async function renderSignedIn(admin = false) {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
       if (url.endsWith('/api/auth/me')) {
-        // The session says whether this account is an operator; the nav never asks an
-        // operator endpoint to find out.
         return new Response(
-          JSON.stringify({ user: { uid: 'g:boss', tier: 'free', ...(admin ? { admin: true } : {}) } }),
+          JSON.stringify({
+            user: { uid: 'g:boss', tier: 'free', name: 'Boss', ...(admin ? { admin: true } : {}) },
+          }),
         );
       }
       if (url.endsWith('/api/health')) {
         return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
       }
-      if (url.endsWith('/api/admin/summary')) {
-        return new Response(JSON.stringify(summary.body), { status: summary.status });
-      }
       return new Response('{}', { status: 404 });
     });
 
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    const onAdmin = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -142,11 +131,10 @@ describe('NavHeader operator link', () => {
           AuthProvider,
           null,
           createElement(NavHeader, {
-            activeBuildCount: 0,
+            activeBuildCount: 2,
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
-            onAdmin,
             upTarget: null,
           }),
         ),
@@ -155,75 +143,36 @@ describe('NavHeader operator link', () => {
       await Promise.resolve();
     });
 
-    // The menu holds the link; open it the way a reader would.
     const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
     await act(async () => {
       hamburger.click();
       await Promise.resolve();
     });
-    return { container, root, onAdmin };
+    return { container, root };
   }
 
-  it('offers the console, with what is waiting, to an operator', async () => {
-    const { container, root, onAdmin } = await renderWith({
-      status: 200,
-      body: {
-        alerts: [
-          {
-            id: 'op-1-review_ready',
-            kind: 'review_ready',
-            issueNumber: 1,
-            title: 'X',
-            ownerUid: 'g:1',
-            since: '2026-07-30T11:00:00Z',
-          },
-        ],
-        queue: { active: 1, stalled: 0, byState: {} },
-        limits: { paused: false, globalDailySubmissionCap: 50, todaySubmissions: 0 },
-      },
-    });
+  it('keeps Create Game and Studio, and drops Arcade / Operator / Account settings', async () => {
+    const { container, root } = await renderSignedIn(true);
+    const labels = Array.from(container.querySelectorAll('.nav-link')).map((el) => el.textContent ?? '');
 
-    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
-      element.textContent?.includes('Operator'),
-    ) as HTMLButtonElement;
-    expect(link).toBeTruthy();
-    expect(link.querySelector('.specs-count-badge')?.textContent).toBe('1');
-
-    await act(async () => link.click());
-    expect(onAdmin).toHaveBeenCalled();
+    expect(labels.some((text) => /Create Game/i.test(text))).toBe(true);
+    expect(labels.some((text) => /Studio/i.test(text))).toBe(true);
+    expect(labels.some((text) => /Arcade/i.test(text))).toBe(false);
+    expect(labels.some((text) => /Operator/i.test(text))).toBe(false);
+    expect(labels.some((text) => /Account settings/i.test(text))).toBe(false);
+    // GitHub left the header; the footer carries the repo link instead.
+    expect(container.querySelector('a.github')).toBeNull();
+    expect(labels.some((text) => /GitHub/i.test(text))).toBe(false);
 
     await act(async () => root.unmount());
   });
 
-  it('never asks an operator endpoint on behalf of someone who is not one', async () => {
-    // The 404 probe this replaced put an error in every non-operator's console on every
-    // page load — which is most people, on most page loads, and is what failed the
-    // deploy gate. A non-operator now makes no operator request at all.
-    const { root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
+  it('never probes an operator endpoint from the chrome', async () => {
+    const { root } = await renderSignedIn(true);
     const summaryCalls = () =>
       vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith('/api/admin/summary')).length;
 
     expect(summaryCalls()).toBe(0);
-    await act(async () => {
-      vi.advanceTimersByTime(10 * 60_000);
-      await Promise.resolve();
-    });
-
-    expect(summaryCalls()).toBe(0);
-
-    await act(async () => root.unmount());
-  });
-
-  it('shows nobody else that there is a console at all', async () => {
-    // A session with no `admin` flag is the API's answer for a signed-in non-admin, and
-    // the nav treats it as the whole answer: no link, no badge, nothing to notice.
-    const { container, root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
-
-    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
-      element.textContent?.includes('Operator'),
-    );
-    expect(link).toBeUndefined();
-
     await act(async () => root.unmount());
   });
 });
@@ -271,7 +220,6 @@ describe('NavHeader profile link', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
-            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -288,7 +236,7 @@ describe('NavHeader profile link', () => {
     await act(async () => root.unmount());
   });
 
-  it('does not link the account name when no handle is claimed', async () => {
+  it('opens account settings from the avatar when no handle is claimed', async () => {
     await i18n.changeLanguage('en');
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
@@ -315,7 +263,6 @@ describe('NavHeader profile link', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
-            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -327,14 +274,66 @@ describe('NavHeader profile link', () => {
     expect(container.querySelector('a.user-name--profile')).toBeNull();
     expect(container.querySelector('.user-name')?.textContent).toBe('Ada Lovelace');
 
-    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
-    await act(async () => hamburger.click());
-    const accountSettings = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((element) =>
-      element.textContent?.includes('Account settings'),
-    );
-    expect(accountSettings).toBeTruthy();
-    await act(async () => accountSettings?.click());
+    const avatar = container.querySelector<HTMLButtonElement>('button.user-avatar-btn');
+    expect(avatar).not.toBeNull();
+    await act(async () => avatar?.click());
     expect(document.body.querySelector('.account-settings-modal-card')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});
+
+describe('LanguageSwitcher in header', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders one button that toggles to the other language', async () => {
+    await i18n.changeLanguage('en');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: null }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+    });
+
+    const switchers = container.querySelectorAll('button.language-switcher');
+    // Header + (closed) menu: only the header instance is mounted while the menu is closed.
+    expect(switchers).toHaveLength(1);
+    expect(switchers[0]?.textContent).toBe('PL');
+
+    await act(async () => {
+      switchers[0]?.click();
+      await Promise.resolve();
+    });
+    expect(i18n.language).toMatch(/^pl/);
+    expect(container.querySelector('button.language-switcher')?.textContent).toBe('EN');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -121,9 +121,8 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
           </button>
         )}
 
-        {/* Rich Studio chip on desktop; on a phone it collapses into an icon that
-            visually joins the avatar/bell pill (still its own ≥44px control — blending
-            the hit targets would make three actions fight one fingertip). */}
+        {/* Rich Studio chip on desktop; on a phone it collapses to a solid icon
+            button matching the hamburger — own 44px target, count as a corner badge. */}
         <button
           type="button"
           className={`studio-chip${activeBuildCount > 0 ? ' is-live' : ''}`}
@@ -142,11 +141,13 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
           ) : null}
           <span className="studio-chip-icon" aria-hidden="true">
             <PixelIcon name="wrench" size={14} />
-            {activeBuildCount > 0 ? (
-              <span className="studio-chip-badge">{activeBuildCount > 99 ? '99+' : activeBuildCount}</span>
-            ) : null}
           </span>
           <span className="studio-chip-label">{t('myGames.openStudio')}</span>
+          {activeBuildCount > 0 ? (
+            <span className="studio-chip-badge" aria-hidden="true">
+              {activeBuildCount > 99 ? '99+' : activeBuildCount}
+            </span>
+          ) : null}
         </button>
 
         <LanguageSwitcher />

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type MouseEvent } from 'react';
+import { useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AccountSettingsModal } from './AccountSettingsModal.js';
@@ -7,10 +7,8 @@ import { LanguageSwitcher } from './LanguageSwitcher.js';
 import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
-import { fetchAdminSummary } from './adminApi.js';
 import { creatorPath } from './router.js';
 import { usePageScrolling } from './usePageScrolling.js';
-import githubIcon from './assets/github-mark-white.svg';
 
 type NavHeaderProps = {
   /** Builds currently in flight for the signed-in creator. Server-derived, not a local tally. */
@@ -20,8 +18,6 @@ type NavHeaderProps = {
   onHome: () => void;
   /** Opens the creator control panel. */
   onStudio: () => void;
-  /** Opens the operator console. Only ever called from a link only operators are shown. */
-  onAdmin: () => void;
   /**
    * Android-style Up target for non-home surfaces. Null on home, join, play, and
    * while an immersive theater owns escape. Never history.back() — deep links
@@ -31,15 +27,7 @@ type NavHeaderProps = {
   onUp?: (path: string) => void;
 };
 
-export function NavHeader({
-  activeBuildCount,
-  onNavigate,
-  onHome,
-  onStudio,
-  onAdmin,
-  upTarget = null,
-  onUp,
-}: NavHeaderProps) {
+export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTarget = null, onUp }: NavHeaderProps) {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -47,42 +35,6 @@ export function NavHeader({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Header mark mimes the visitor: pull a phone and scroll a tiny feed while the page moves.
   const pageScrolling = usePageScrolling();
-  /**
-   * How many jobs are waiting on this person. Only ever read for an operator.
-   *
-   * Whether someone *is* one comes from the session (`user.admin`) rather than from
-   * probing an operator endpoint and reading its 404 as "no". That probe was the
-   * obvious implementation and the wrong one: it asked a settled question on every page
-   * load, and for everybody who is not an operator — which is everybody — it answered
-   * with an error in the browser console. The deploy gate that fails on console errors
-   * caught it, correctly.
-   */
-  const [alertCount, setAlertCount] = useState<number | null>(null);
-  const isOperator = user?.admin === true;
-
-  useEffect(() => {
-    if (!isOperator) {
-      setAlertCount(null);
-      return;
-    }
-    let cancelled = false;
-    const read = () =>
-      fetchAdminSummary()
-        .then((summary) => {
-          if (!cancelled) setAlertCount(summary ? summary.alerts.length : 0);
-        })
-        .catch(() => {
-          // A failed read is not evidence of anything; leave the badge as it was.
-        });
-    void read();
-    // Slower than the console's own poll: this is a badge somebody glances at, not a
-    // queue they are working, and it rides along on every page of the site.
-    const timer = setInterval(read, 120_000);
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [isOperator]);
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -95,6 +47,11 @@ export function NavHeader({
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
     event.preventDefault();
     onHome();
+  };
+
+  const openAccountSettings = () => {
+    setIsMenuOpen(false);
+    setIsAccountSettingsOpen(true);
   };
 
   return (
@@ -126,19 +83,32 @@ export function NavHeader({
       <div className="header-actions">
         {user ? (
           <div className="user-profile-badge">
-            {user.picture ? (
-              <img src={user.picture} alt="" className="user-avatar" width="24" height="24" />
-            ) : (
-              <span className="user-avatar-placeholder">
-                <PixelIcon name="user" size={16} />
-              </span>
-            )}
+            {/* Avatar opens account settings so deletion stays reachable after the
+                menu item was removed — especially for creators who have not claimed
+                a handle yet (Edit Profile is not available to them). */}
+            <button
+              type="button"
+              className="user-avatar-btn"
+              onClick={openAccountSettings}
+              aria-label={t('creatorProfile.accountSettings')}
+              title={t('creatorProfile.accountSettings')}
+            >
+              {user.picture ? (
+                <img src={user.picture} alt="" className="user-avatar" width="24" height="24" />
+              ) : (
+                <span className="user-avatar-placeholder">
+                  <PixelIcon name="user" size={16} />
+                </span>
+              )}
+            </button>
             {user.handle ? (
               <a className="user-name user-name--profile" href={creatorPath(user.handle)}>
                 {user.profileName || `@${user.handle}`}
               </a>
             ) : (
-              <span className="user-name">{user.name || user.email || 'User'}</span>
+              <button type="button" className="user-name user-name--settings" onClick={openAccountSettings}>
+                {user.name || user.email || 'User'}
+              </button>
             )}
             <NotificationBell />
             <button className="logout-btn" onClick={logout} title={t('header.signOut')}>
@@ -152,16 +122,6 @@ export function NavHeader({
         )}
 
         <LanguageSwitcher />
-
-        <a
-          className="github"
-          href="https://github.com/gamedevpl/www.gamedev.pl"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={t('header.githubAria')}
-        >
-          <img src={githubIcon} alt="" width="20" height="20" />
-        </a>
 
         <div className="hamburger-container">
           <button
@@ -179,13 +139,13 @@ export function NavHeader({
               <button className="nav-link" onClick={() => handleNavClick('hero-prompt')}>
                 <PixelIcon name="sparkle" size={14} /> {t('header.navPrompt')}
               </button>
-              <button className="nav-link" onClick={() => handleNavClick('arcade')}>
-                <PixelIcon name="gamepad" size={14} /> {t('header.navArcade')}
-              </button>
               {/* Studio is the creator home. The home page only keeps a short
                   "your games" gist; the full shelf + build/playtest/improve loop
                   lives here. Always offered — unsigned visitors get the sign-in
-                  prompt inside Studio rather than a dead "My Games" scroll target. */}
+                  prompt inside Studio rather than a dead "My Games" scroll target.
+                  Arcade / Operator / Account settings were dropped from this menu:
+                  the catalog is already on the home page, operators reach the
+                  console by URL, and account settings open from the avatar. */}
               <button
                 className="nav-link"
                 onClick={() => {
@@ -205,37 +165,6 @@ export function NavHeader({
                 )}
               </button>
 
-              {/* Operators only — everyone else never learns this exists, which is the
-                  same posture the API takes when asked. */}
-              {isOperator && (
-                <button
-                  className="nav-link"
-                  onClick={() => {
-                    setIsMenuOpen(false);
-                    onAdmin();
-                  }}
-                >
-                  <PixelIcon name="wrench" size={14} /> Operator
-                  {alertCount !== null && alertCount > 0 && (
-                    <span className="specs-count-badge" aria-label={`${alertCount} waiting on you`}>
-                      {alertCount}
-                    </span>
-                  )}
-                </button>
-              )}
-
-              {user && (
-                <button
-                  className="nav-link"
-                  onClick={() => {
-                    setIsMenuOpen(false);
-                    setIsAccountSettingsOpen(true);
-                  }}
-                >
-                  <PixelIcon name="user" size={14} /> {t('creatorProfile.accountSettings')}
-                </button>
-              )}
-
               {/* Controls that live in the header bar on a desktop but cannot fit
                   beside it on a phone. Hidden above the mobile breakpoint, where
                   the header itself still shows them. */}
@@ -251,16 +180,6 @@ export function NavHeader({
                     <PixelIcon name="user" size={14} /> {t('header.signOut')}
                   </button>
                 )}
-
-                <a
-                  className="nav-link"
-                  href="https://github.com/gamedevpl/www.gamedev.pl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  <img src={githubIcon} alt="" width="14" height="14" /> GitHub
-                </a>
 
                 <LanguageSwitcher />
               </div>

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -153,7 +153,7 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
             aria-expanded={isMenuOpen}
             aria-label={
               activeBuildCount > 0
-                ? `${t('header.navStudio')}: ${t('header.activeBuilds', { count: activeBuildCount })}`
+                ? `Menu — ${t('header.activeBuilds', { count: activeBuildCount })}`
                 : 'Toggle Navigation Menu'
             }
             onClick={() => setIsMenuOpen((prev) => !prev)}

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -121,6 +121,28 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
           </button>
         )}
 
+        {/* Rich Studio chip — relocated from the Games header so in-progress work
+            stays visible in chrome without owning a catalog grid cell. */}
+        <button
+          type="button"
+          className={`studio-chip${activeBuildCount > 0 ? ' is-live' : ''}`}
+          onClick={onStudio}
+          aria-label={
+            activeBuildCount > 0
+              ? `${t('myGames.liveCount', { count: activeBuildCount })} — ${t('myGames.openStudio')}`
+              : t('myGames.openStudio')
+          }
+        >
+          {activeBuildCount > 0 ? (
+            <>
+              <span className="live-dot" aria-hidden="true" />
+              <span className="studio-chip-count">{t('myGames.liveCount', { count: activeBuildCount })}</span>
+            </>
+          ) : null}
+          <PixelIcon name="wrench" size={12} />
+          <span className="studio-chip-label">{t('myGames.openStudio')}</span>
+        </button>
+
         <LanguageSwitcher />
 
         <div className="hamburger-container">
@@ -139,13 +161,9 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
               <button className="nav-link" onClick={() => handleNavClick('hero-prompt')}>
                 <PixelIcon name="sparkle" size={14} /> {t('header.navPrompt')}
               </button>
-              {/* Studio is the creator home. The home page only keeps a short
-                  "your games" gist; the full shelf + build/playtest/improve loop
-                  lives here. Always offered — unsigned visitors get the sign-in
-                  prompt inside Studio rather than a dead "My Games" scroll target.
-                  Arcade / Operator / Account settings were dropped from this menu:
-                  the catalog is already on the home page, operators reach the
-                  console by URL, and account settings open from the avatar. */}
+              {/* Studio also lives as the rich chip in the header bar; keep a plain
+                  menu entry for the same destination so phone users who open the
+                  hamburger still find it next to Create Game. */}
               <button
                 className="nav-link"
                 onClick={() => {
@@ -154,15 +172,6 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
                 }}
               >
                 <PixelIcon name="wrench" size={14} /> {t('header.navStudio')}
-                {activeBuildCount > 0 && (
-                  // The bare number reads as "Studio 2" to a screen reader; say what it counts.
-                  <span
-                    className="specs-count-badge"
-                    aria-label={t('header.activeBuilds', { count: activeBuildCount })}
-                  >
-                    {activeBuildCount}
-                  </span>
-                )}
               </button>
 
               {/* Controls that live in the header bar on a desktop but cannot fit

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -121,8 +121,9 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
           </button>
         )}
 
-        {/* Rich Studio chip on desktop; on a phone it collapses to a solid icon
-            button matching the hamburger — own 44px target, count as a corner badge. */}
+        {/* Rich Studio chip — desktop only. On a phone the hamburger already lists
+            Studio next to Create Game; the live count rides on that menu row (and a
+            small badge on the menu button) so the header stays logo · session · menu. */}
         <button
           type="button"
           className={`studio-chip${activeBuildCount > 0 ? ' is-live' : ''}`}
@@ -139,15 +140,8 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
               <span className="studio-chip-count">{t('myGames.liveCount', { count: activeBuildCount })}</span>
             </>
           ) : null}
-          <span className="studio-chip-icon" aria-hidden="true">
-            <PixelIcon name="wrench" size={14} />
-          </span>
+          <PixelIcon name="wrench" size={12} />
           <span className="studio-chip-label">{t('myGames.openStudio')}</span>
-          {activeBuildCount > 0 ? (
-            <span className="studio-chip-badge" aria-hidden="true">
-              {activeBuildCount > 99 ? '99+' : activeBuildCount}
-            </span>
-          ) : null}
         </button>
 
         <LanguageSwitcher />
@@ -157,10 +151,19 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
             type="button"
             className="hamburger-btn"
             aria-expanded={isMenuOpen}
-            aria-label="Toggle Navigation Menu"
+            aria-label={
+              activeBuildCount > 0
+                ? `${t('header.navStudio')}: ${t('header.activeBuilds', { count: activeBuildCount })}`
+                : 'Toggle Navigation Menu'
+            }
             onClick={() => setIsMenuOpen((prev) => !prev)}
           >
             {isMenuOpen ? <PixelIcon name="close" size={16} /> : <PixelIcon name="menu" size={16} />}
+            {activeBuildCount > 0 && !isMenuOpen ? (
+              <span className="hamburger-live-badge" aria-hidden="true">
+                {activeBuildCount > 99 ? '99+' : activeBuildCount}
+              </span>
+            ) : null}
           </button>
 
           {isMenuOpen && (
@@ -168,9 +171,6 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
               <button className="nav-link" onClick={() => handleNavClick('hero-prompt')}>
                 <PixelIcon name="sparkle" size={14} /> {t('header.navPrompt')}
               </button>
-              {/* Studio also lives as the rich chip in the header bar; keep a plain
-                  menu entry for the same destination so phone users who open the
-                  hamburger still find it next to Create Game. */}
               <button
                 className="nav-link"
                 onClick={() => {
@@ -179,6 +179,14 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
                 }}
               >
                 <PixelIcon name="wrench" size={14} /> {t('header.navStudio')}
+                {activeBuildCount > 0 ? (
+                  <span
+                    className="specs-count-badge"
+                    aria-label={t('header.activeBuilds', { count: activeBuildCount })}
+                  >
+                    {activeBuildCount}
+                  </span>
+                ) : null}
               </button>
 
               {/* Controls that live in the header bar on a desktop but cannot fit

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -121,8 +121,9 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
           </button>
         )}
 
-        {/* Rich Studio chip — relocated from the Games header so in-progress work
-            stays visible in chrome without owning a catalog grid cell. */}
+        {/* Rich Studio chip on desktop; on a phone it collapses into an icon that
+            visually joins the avatar/bell pill (still its own ≥44px control — blending
+            the hit targets would make three actions fight one fingertip). */}
         <button
           type="button"
           className={`studio-chip${activeBuildCount > 0 ? ' is-live' : ''}`}
@@ -139,7 +140,12 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
               <span className="studio-chip-count">{t('myGames.liveCount', { count: activeBuildCount })}</span>
             </>
           ) : null}
-          <PixelIcon name="wrench" size={12} />
+          <span className="studio-chip-icon" aria-hidden="true">
+            <PixelIcon name="wrench" size={14} />
+            {activeBuildCount > 0 ? (
+              <span className="studio-chip-badge">{activeBuildCount > 99 ? '99+' : activeBuildCount}</span>
+            ) : null}
+          </span>
           <span className="studio-chip-label">{t('myGames.openStudio')}</span>
         </button>
 

--- a/apps/web/src/SiteFooter.test.tsx
+++ b/apps/web/src/SiteFooter.test.tsx
@@ -56,6 +56,9 @@ describe('SiteFooter project links', () => {
     expect(repoLink).toBeDefined();
     // Leaving the site: opened in a new tab, and without handing over the referrer opener.
     expect(repoLink?.rel).toContain('noopener');
+    // Repo mark lives in the footer now — not the header chrome.
+    expect(repoLink?.classList.contains('site-footer__github')).toBe(true);
+    expect(repoLink?.querySelector('img')).not.toBeNull();
   });
 
   it('sends Contact to the in-app form, not GitHub issues or a bare mailto', () => {

--- a/apps/web/src/SiteFooter.tsx
+++ b/apps/web/src/SiteFooter.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import githubIcon from './assets/github-mark-white.svg';
 import { bugReportUrl, REPO_URL } from './github.js';
 import { OPERATOR_LEGAL_NAME } from './legal/operator.js';
 import { contactPath, legalPath } from './router.js';
@@ -45,7 +46,8 @@ export function SiteFooter() {
       {/* The project half of the footer. Read at render time rather than in an effect so
           the link always carries the id of the visit the reporter is actually in. */}
       <nav className="site-footer__links site-footer__project" aria-label={t('footer.projectNav')}>
-        <a href={REPO_URL} target="_blank" rel="noreferrer noopener">
+        <a href={REPO_URL} target="_blank" rel="noreferrer noopener" className="site-footer__github">
+          <img src={githubIcon} alt="" width="14" height="14" />
           {t('footer.openSource')}
         </a>
         <a

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -226,11 +226,6 @@ a {
 }
 
 .language-switcher {
-  display: flex;
-  gap: 4px;
-}
-
-.language-switcher button {
   background: transparent;
   color: var(--muted);
   border: 1px solid var(--panel-border);
@@ -238,23 +233,43 @@ a {
   padding: 4px 10px;
   font-size: 13px;
   font-weight: 600;
+  cursor: pointer;
 }
 
-.language-switcher button.active {
-  background: var(--turquoise);
-  color: #0b221d;
-  border-color: var(--turquoise);
+.language-switcher:hover {
+  color: var(--text);
+  border-color: var(--muted);
 }
 
-.app-header .github img {
-  width: 24px;
-  height: 24px;
-  opacity: 0.8;
-  transition: opacity 0.2s;
+.user-avatar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 50%;
 }
 
-.app-header .github img:hover {
-  opacity: 1;
+.user-avatar-btn:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+}
+
+.user-name--settings {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.user-name--settings:hover {
+  text-decoration: underline;
 }
 
 /* HAMBURGER MENU */
@@ -2979,7 +2994,6 @@ body.player-open {
   /* Relocated into .menu-extras inside the dropdown. Signing out in
      particular should not sit one thumb-width from the menu button. */
   .header-actions > .language-switcher,
-  .header-actions > .github,
   .user-profile-badge .user-name,
   .user-profile-badge .logout-btn {
     display: none;
@@ -2995,13 +3009,8 @@ body.player-open {
   }
 
   .menu-extras .language-switcher {
-    gap: 8px;
-    padding: 4px 4px 0;
-  }
-
-  .menu-extras .language-switcher button {
-    flex: 1;
     min-height: 44px;
+    width: 100%;
   }
 
   /* Thumb-sized targets. 44px is the iOS HIG floor; below it, taps miss. */
@@ -7905,6 +7914,21 @@ button.builder-mode-selector:disabled {
 .site-footer__project {
   max-width: 68rem;
   margin: 1.25rem auto 0;
+}
+
+.site-footer__github {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.site-footer__github img {
+  opacity: 0.7;
+}
+
+.site-footer__github:hover img,
+.site-footer__github:focus-visible img {
+  opacity: 1;
 }
 
 .site-footer a {
@@ -13571,9 +13595,7 @@ body.remix-entry-open {
     padding-left: max(1rem, env(safe-area-inset-left));
     border: 0;
     border-radius: 0;
-    background:
-      radial-gradient(circle at 100% 0, rgba(0, 229, 183, 0.1), transparent 36%),
-      var(--panel);
+    background: radial-gradient(circle at 100% 0, rgba(0, 229, 183, 0.1), transparent 36%), var(--panel);
     box-shadow: none;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1053,19 +1053,36 @@ button:disabled {
   display: none;
 }
 
-/* Phone only — not `(pointer: coarse)` alone. A wide touch laptop still has room
-   for the rich chip; collapsing there would hide the count behind an icon for no
-   chrome gain. The avatar/bell merge also only works once name/sign-out are hidden. */
+/* Phone: drop the rich pill for a solid icon button that matches the hamburger.
+   No visual merge with the avatar/bell chip — that read as a broken D-shape. */
 @media (max-width: 768px) {
   .studio-chip {
     min-width: 44px;
     min-height: 44px;
     justify-content: center;
-    padding: 0 10px;
+    padding: 6px;
     gap: 0;
+    border-radius: 8px;
+    background: var(--panel-card);
+    border: 1px solid var(--panel-border);
+    color: var(--text);
   }
 
-  /* Icon-only: the full phrase stays in aria-label; the badge carries the glance count. */
+  .studio-chip.is-live {
+    /* Keep the solid chrome; the badge carries the live signal. */
+    border-color: var(--panel-border);
+    background: var(--panel-card);
+    color: var(--text);
+  }
+
+  .studio-chip:hover,
+  .studio-chip:focus-visible,
+  .studio-chip.is-live:hover,
+  .studio-chip.is-live:focus-visible {
+    border-color: var(--turquoise);
+    color: var(--turquoise);
+  }
+
   .studio-chip .live-dot,
   .studio-chip-count,
   .studio-chip-label {
@@ -1075,8 +1092,8 @@ button:disabled {
   .studio-chip-badge {
     display: block;
     position: absolute;
-    top: -7px;
-    right: -9px;
+    top: 2px;
+    right: 2px;
     min-width: 16px;
     height: 16px;
     padding: 0 4px;
@@ -1087,39 +1104,6 @@ button:disabled {
     font-weight: 700;
     line-height: 16px;
     text-align: center;
-  }
-
-  /* Signed-in: join the avatar/bell pill so chrome reads as one chip, but keep
-     three separate buttons — a shared hit target would fail the 44px floor and
-     make Studio/account/notifications compete for the same thumb. */
-  .user-profile-badge {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    border-right-color: transparent;
-  }
-
-  .user-profile-badge + .studio-chip {
-    /* Cancel the header-actions gap so the two pills share one outline. */
-    margin-left: -9px;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  .user-profile-badge + .studio-chip:not(.is-live) {
-    background: var(--panel-card);
-    border-color: var(--panel-border);
-    color: var(--text);
-  }
-
-  .user-avatar-btn {
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  /* Match the Studio icon floor so the blended pill is three equal thumb targets. */
-  .user-profile-badge .notif-trigger {
-    width: 44px;
-    height: 44px;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -999,6 +999,7 @@ button:disabled {
 /* Compact Studio entry in the top nav — live count + wrench in one control so
    in-progress work stays in chrome rather than owning a catalog grid cell. */
 .studio-chip {
+  position: relative;
   display: inline-flex;
   flex: none;
   align-items: center;
@@ -1040,15 +1041,85 @@ button:disabled {
   background: var(--accent-blue);
 }
 
-@media (pointer: coarse), (max-width: 768px) {
+.studio-chip-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Desktop keeps the written count; the numeric badge is the phone-compact form. */
+.studio-chip-badge {
+  display: none;
+}
+
+/* Phone only — not `(pointer: coarse)` alone. A wide touch laptop still has room
+   for the rich chip; collapsing there would hide the count behind an icon for no
+   chrome gain. The avatar/bell merge also only works once name/sign-out are hidden. */
+@media (max-width: 768px) {
   .studio-chip {
+    min-width: 44px;
+    min-height: 44px;
+    justify-content: center;
+    padding: 0 10px;
+    gap: 0;
+  }
+
+  /* Icon-only: the full phrase stays in aria-label; the badge carries the glance count. */
+  .studio-chip .live-dot,
+  .studio-chip-count,
+  .studio-chip-label {
+    display: none;
+  }
+
+  .studio-chip-badge {
+    display: block;
+    position: absolute;
+    top: -7px;
+    right: -9px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background: var(--accent-blue, #38bdf8);
+    color: #0b221d;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+  }
+
+  /* Signed-in: join the avatar/bell pill so chrome reads as one chip, but keep
+     three separate buttons — a shared hit target would fail the 44px floor and
+     make Studio/account/notifications compete for the same thumb. */
+  .user-profile-badge {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-color: transparent;
+  }
+
+  .user-profile-badge + .studio-chip {
+    /* Cancel the header-actions gap so the two pills share one outline. */
+    margin-left: -9px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .user-profile-badge + .studio-chip:not(.is-live) {
+    background: var(--panel-card);
+    border-color: var(--panel-border);
+    color: var(--text);
+  }
+
+  .user-avatar-btn {
+    min-width: 44px;
     min-height: 44px;
   }
 
-  /* Phone chrome is tight: keep the live signal, drop the "Studio" word —
-     the wrench still names the destination, and the hamburger still lists it. */
-  .studio-chip.is-live .studio-chip-label {
-    display: none;
+  /* Match the Studio icon floor so the blended pill is three equal thumb targets. */
+  .user-profile-badge .notif-trigger {
+    width: 44px;
+    height: 44px;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -996,9 +996,9 @@ button:disabled {
   min-width: 0;
 }
 
-/* Compact Studio entry next to Games — live count + wrench in one control so
-   in-progress work never owns a catalog grid cell (or shoves published cards). */
-.catalog-studio-chip {
+/* Compact Studio entry in the top nav — live count + wrench in one control so
+   in-progress work stays in chrome rather than owning a catalog grid cell. */
+.studio-chip {
   display: inline-flex;
   flex: none;
   align-items: center;
@@ -1014,35 +1014,41 @@ button:disabled {
   cursor: pointer;
 }
 
-.catalog-studio-chip:hover,
-.catalog-studio-chip:focus-visible {
+.studio-chip:hover,
+.studio-chip:focus-visible {
   border-color: var(--turquoise);
   color: var(--turquoise);
 }
 
-.catalog-studio-chip.is-live {
+.studio-chip.is-live {
   border-color: rgba(56, 189, 248, 0.35);
   background: rgba(56, 189, 248, 0.1);
   color: var(--accent-blue);
 }
 
-.catalog-studio-chip.is-live:hover,
-.catalog-studio-chip.is-live:focus-visible {
+.studio-chip.is-live:hover,
+.studio-chip.is-live:focus-visible {
   border-color: var(--turquoise);
   color: var(--turquoise);
 }
 
-.catalog-studio-chip-count {
+.studio-chip-count {
   font-weight: 700;
 }
 
-.catalog-studio-chip .live-dot {
+.studio-chip .live-dot {
   background: var(--accent-blue);
 }
 
 @media (pointer: coarse), (max-width: 768px) {
-  .catalog-studio-chip {
+  .studio-chip {
     min-height: 44px;
+  }
+
+  /* Phone chrome is tight: keep the live signal, drop the "Studio" word —
+     the wrench still names the destination, and the hamburger still lists it. */
+  .studio-chip.is-live .studio-chip-label {
+    display: none;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -278,6 +278,7 @@ a {
 }
 
 .hamburger-btn {
+  position: relative;
   background: var(--panel-card);
   border: 1px solid var(--panel-border);
   color: var(--text);
@@ -997,7 +998,8 @@ button:disabled {
 }
 
 /* Compact Studio entry in the top nav — live count + wrench in one control so
-   in-progress work stays in chrome rather than owning a catalog grid cell. */
+   in-progress work stays in chrome rather than owning a catalog grid cell.
+   Phones hide this chip: Studio + the count live in the hamburger instead. */
 .studio-chip {
   position: relative;
   display: inline-flex;
@@ -1041,55 +1043,17 @@ button:disabled {
   background: var(--accent-blue);
 }
 
-.studio-chip-icon {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* Desktop keeps the written count; the numeric badge is the phone-compact form. */
-.studio-chip-badge {
+.hamburger-live-badge {
   display: none;
 }
 
-/* Phone: drop the rich pill for a solid icon button that matches the hamburger.
-   No visual merge with the avatar/bell chip — that read as a broken D-shape. */
 @media (max-width: 768px) {
   .studio-chip {
-    min-width: 44px;
-    min-height: 44px;
-    justify-content: center;
-    padding: 6px;
-    gap: 0;
-    border-radius: 8px;
-    background: var(--panel-card);
-    border: 1px solid var(--panel-border);
-    color: var(--text);
-  }
-
-  .studio-chip.is-live {
-    /* Keep the solid chrome; the badge carries the live signal. */
-    border-color: var(--panel-border);
-    background: var(--panel-card);
-    color: var(--text);
-  }
-
-  .studio-chip:hover,
-  .studio-chip:focus-visible,
-  .studio-chip.is-live:hover,
-  .studio-chip.is-live:focus-visible {
-    border-color: var(--turquoise);
-    color: var(--turquoise);
-  }
-
-  .studio-chip .live-dot,
-  .studio-chip-count,
-  .studio-chip-label {
     display: none;
   }
 
-  .studio-chip-badge {
+  /* Glance count while the menu is closed — the Studio row repeats it once open. */
+  .hamburger-live-badge {
     display: block;
     position: absolute;
     top: 2px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3104,6 +3104,16 @@ body.player-open {
     padding: 4px;
   }
 
+  .user-avatar-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .user-profile-badge .notif-trigger {
+    width: 44px;
+    height: 44px;
+  }
+
   /* The mic / upload / sketch row sat at 30x26 — under half a fingertip. */
   .prompt-icon-btn {
     min-width: 44px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small chrome redesign matching the annotated home-page screenshot:

- **Language:** EN/PL → one toggle button
- **GitHub mark:** footer only
- **Hamburger:** Create Game + Studio only
- **Account settings:** avatar (and name when no handle)
- **Studio chip (desktop):** rich “N in progress · Studio” pill in the top nav
- **Mobile:** Studio chip hidden. Chrome is logo · avatar/bell · hamburger. Live count badges the menu button and the Studio row inside it.

## Screenshots

### Desktop
[Desktop rich chip](https://cursor.com/agents/bc-108f2d63-ae4c-431c-be44-09c41e198bea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnav-blend-desktop.png)

### Mobile — slim
[Mobile header](https://cursor.com/agents/bc-108f2d63-ae4c-431c-be44-09c41e198bea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnav-mobile-slim.png)
[Mobile full](https://cursor.com/agents/bc-108f2d63-ae4c-431c-be44-09c41e198bea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnav-mobile-slim-full.png)

## Test plan

- [x] NavHeader unit tests (chip + menu count + hamburger badge)
- [x] Mobile CSS hides `.studio-chip`; hamburger/menu carry the count


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-108f2d63-ae4c-431c-be44-09c41e198bea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-108f2d63-ae4c-431c-be44-09c41e198bea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

