### PR TITLE
Move Sign out into the nav menu

### DIFF
--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -163,6 +163,68 @@ describe('NavHeader menu', () => {
     // GitHub left the header; the footer carries the repo link instead.
     expect(container.querySelector('a.github')).toBeNull();
     expect(labels.some((text) => /GitHub/i.test(text))).toBe(false);
+    // Sign out sits at the foot of the menu, not beside the avatar.
+    expect(container.querySelector('.logout-btn')).toBeNull();
+    expect(labels.some((text) => /Sign out/i.test(text))).toBe(true);
+    expect(container.querySelector('.nav-link--sign-out')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('signs out from the menu foot and closes the menu', async () => {
+    const logoutSpy = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:boss', tier: 'free', name: 'Boss' } }));
+      }
+      if (url.endsWith('/api/auth/logout') && init && typeof init === 'object' && init.method === 'POST') {
+        logoutSpy();
+        return new Response(JSON.stringify({ ok: true }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+    await act(async () => {
+      hamburger.click();
+      await Promise.resolve();
+    });
+
+    const signOut = container.querySelector<HTMLButtonElement>('.nav-link--sign-out');
+    expect(signOut).not.toBeNull();
+    await act(async () => {
+      signOut?.click();
+      await Promise.resolve();
+    });
+
+    expect(logoutSpy).toHaveBeenCalledOnce();
+    expect(container.querySelector('.dropdown-menu')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -111,9 +111,6 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
               </button>
             )}
             <NotificationBell />
-            <button className="logout-btn" onClick={logout} title={t('header.signOut')}>
-              {t('header.signOut')}
-            </button>
           </div>
         ) : (
           <button className="sign-in-btn" onClick={() => setIsAuthModalOpen(true)}>
@@ -189,22 +186,23 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
                 ) : null}
               </button>
 
-              {/* Controls that live in the header bar on a desktop but cannot fit
-                  beside it on a phone. Hidden above the mobile breakpoint, where
-                  the header itself still shows them. */}
-              <div className="menu-extras">
-                {user && (
-                  <button
-                    className="nav-link"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      logout();
-                    }}
-                  >
-                    <PixelIcon name="user" size={14} /> {t('header.signOut')}
-                  </button>
-                )}
+              {/* Sign out lives at the foot of the menu on every width — not beside
+                  the avatar, where it competed with the bell and the menu button. */}
+              {user ? (
+                <button
+                  className="nav-link nav-link--sign-out"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    logout();
+                  }}
+                >
+                  <PixelIcon name="user" size={14} /> {t('header.signOut')}
+                </button>
+              ) : null}
 
+              {/* Language lives in the header bar on a desktop. On a phone it
+                  cannot fit beside the avatar, so this group reveals it instead. */}
+              <div className="menu-extras">
                 <LanguageSwitcher />
               </div>
             </nav>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -328,8 +328,16 @@ a {
   color: var(--turquoise);
 }
 
-/* Language, GitHub and sign-out live in the header bar on a desktop. The
-   mobile breakpoint hides them there and reveals this group instead. */
+/* Foot of the menu — separated from Create Game / Studio on every width. */
+.dropdown-menu .nav-link--sign-out {
+  margin-top: 6px;
+  padding-top: 16px;
+  border-top: 1px solid var(--panel-border);
+  border-radius: 0;
+}
+
+/* Language lives in the header bar on a desktop. The mobile breakpoint
+   hides it there and reveals this group instead. */
 .menu-extras {
   display: none;
 }
@@ -3016,11 +3024,9 @@ body.player-open {
     gap: 8px;
   }
 
-  /* Relocated into .menu-extras inside the dropdown. Signing out in
-     particular should not sit one thumb-width from the menu button. */
+  /* Relocated into .menu-extras inside the dropdown. */
   .header-actions > .language-switcher,
-  .user-profile-badge .user-name,
-  .user-profile-badge .logout-btn {
+  .user-profile-badge .user-name {
     display: none;
   }
 
@@ -3031,6 +3037,13 @@ body.player-open {
     margin-top: 6px;
     padding-top: 10px;
     border-top: 1px solid var(--panel-border);
+  }
+
+  /* Sign out already drew the divider; don't stack a second rule above language. */
+  .dropdown-menu .nav-link--sign-out + .menu-extras {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
   }
 
   .menu-extras .language-switcher {
@@ -3748,24 +3761,6 @@ a.user-name--profile:focus-visible {
   color: var(--turquoise, #3dd6c6);
   text-decoration: underline;
   text-underline-offset: 2px;
-}
-
-.logout-btn {
-  background: none;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 0.9rem;
-  opacity: 0.7;
-  padding: 2px 4px;
-  transition:
-    opacity 0.2s ease,
-    color 0.2s ease;
-}
-
-.logout-btn:hover {
-  color: var(--text);
-  opacity: 1;
 }
 
 /* How-to-play and Mic shed to the More menu earlier than sound and fullscreen do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove **Sign out** from the header avatar/bell pill.
- Place it at the foot of the hamburger menu (below Studio) on every viewport, with a divider matching the existing mobile extras treatment.
- Phone language switcher stays in `.menu-extras`; when Sign out is above it, the duplicate top border is suppressed.

## Screenshots

Desktop (menu open — Sign out at the foot, not in the header pill):

[Desktop nav menu with Sign out](https://cursor.com/agents/bc-afda2dce-c699-4350-96cb-8775596780cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsign-out-menu-desktop.png)

Mobile (menu open — Sign out above the language toggle):

[Mobile nav menu with Sign out](https://cursor.com/agents/bc-afda2dce-c699-4350-96cb-8775596780cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsign-out-menu-mobile.png)

## Test plan
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] NavHeader unit tests cover menu placement and logout from the menu foot
- [x] Visual check: desktop + mobile with the menu open

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afda2dce-c699-4350-96cb-8775596780cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afda2dce-c699-4350-96cb-8775596780cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

