### PR TITLE
Add gauges and histograms to operator telemetry

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -160,8 +160,10 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     conflated with clipboard copies. `create_step` may also carry optional `builder` once
     chosen. Same three-place contract (`visitTelemetry.ts`, `visit-telemetry.ts`,
     `VisitEvent` in `store.ts`). Time-to-first agent signal is `msSinceStart` on
-    `agent_signaled`. No admin rollup yet — emission and schema first; a VisitFunnelPanel
-    Studio block is a follow-up.
+    `agent_signaled`. ~~No admin rollup yet~~ — **closed 2026-08-06**: daily MCP adoption
+    series (`selfChosen` / `connected` / `signaled` / `gateVerdicts`) on
+    `GET /api/admin/telemetry/trends`, rendered on the Trends strip of the operator
+    telemetry tab beside visits/plays/creations.
 - ~~How-to-play opens recorded but unreadable~~ — **closed 2026-07-31** for the read
   path that [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) needs:
   `how_to_play_opened` carries `via: 'bar' | 'more'` and optional `reopen: true` (same

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -19,6 +19,14 @@ import {
 } from './operator-alerts.js';
 import { summarizeVisitFunnel, type VisitFunnel } from './visit-funnel.js';
 import { summarizeCreatorMetrics, type CreatorMetrics } from './creator-metrics.js';
+import {
+  summarizeRetentionByEligibilityDay,
+  summarizeVisitDay,
+  trendPartitions,
+  type DailyActivityPoint,
+  type DailyRetentionPoint,
+  type TelemetryTrends,
+} from './telemetry-trends.js';
 import { DEFAULT_CREATION_LIMITS_TTL_MS, resolveDefaultGlobalDailyCap } from './creation-limits.js';
 import {
   BOT_UID_PREFIX,
@@ -51,6 +59,9 @@ import {
 /** Widest window one request may ask for. Each day is a separate Firestore query. */
 const MAX_DAYS = 30;
 const DEFAULT_DAYS = 7;
+/** Trends need a longer window than a funnel glance — still bounded, still per-day. */
+const MAX_TREND_DAYS = 90;
+const DEFAULT_TREND_DAYS = 30;
 /** Per-partition read cap, matching the store's own default. */
 const MAX_EVENTS_PER_DAY = 1000;
 /**
@@ -63,10 +74,19 @@ const MAX_EVENTS_PER_DAY = 1000;
  * degrade by narrowing the window rather than by silently costing thirty times more.
  */
 const MAX_EVENTS_PER_REQUEST = 5_000;
+/** Trends walk every day in the window and discard events after summarizing, so the
+ *  total can be wider than the funnel reads without holding them all in memory. */
+const MAX_TREND_EVENTS_PER_REQUEST = 20_000;
 
 const QuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(MAX_DAYS).optional(),
 });
+
+const TrendsQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(MAX_TREND_DAYS).optional(),
+});
+
+export type TrendsResponse = TelemetryTrends;
 
 export interface AdminRoutesOptions {
   store: Store;
@@ -515,6 +535,64 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
     );
 
     const body: VisitsResponse = { days: scanned, truncated, funnel: summarizeVisitFunnel(events) };
+    return reply.status(200).send(body);
+  });
+
+  /**
+   * Daily activity + D7 retention series for trend charts.
+   *
+   * Separate from the funnel reads: those answer "what happened in this window" as
+   * one aggregate; this answers "is it getting better" as a time series. Each day is
+   * summarized and discarded so a 90-day walk does not hold 90 days of raw events.
+   */
+  app.get('/api/admin/telemetry/trends', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+
+    const parsed = TrendsQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
+    }
+
+    const requested = trendPartitions(parsed.data.days ?? DEFAULT_TREND_DAYS, now());
+    const activity: DailyActivityPoint[] = [];
+    const scanned: string[] = [];
+    let truncated = false;
+    let readTotal = 0;
+
+    for (const dateStr of requested) {
+      const remaining = MAX_TREND_EVENTS_PER_REQUEST - readTotal;
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      const limit = Math.min(MAX_EVENTS_PER_DAY, remaining);
+      const dayEvents = await store.listVisitEvents(dateStr, { limit });
+      const dayTruncated = dayEvents.length >= limit;
+      if (dayTruncated) truncated = true;
+      readTotal += dayEvents.length;
+      activity.push(summarizeVisitDay(dateStr, dayEvents, dayTruncated));
+      scanned.push(dateStr);
+    }
+
+    const submissions = (await store.listRecentlyPublished(MAX_SUBMISSIONS_SAMPLED)).filter(
+      (submission) => !submission.ownerUid.startsWith(BOT_UID_PREFIX),
+    );
+    const usersByUid = new Map<string, User>();
+    for (const uid of new Set(submissions.map((submission) => submission.ownerUid))) {
+      const user = await store.getUser(uid);
+      if (user) usersByUid.set(uid, user);
+    }
+
+    const retention: DailyRetentionPoint[] = summarizeRetentionByEligibilityDay(
+      submissions,
+      usersByUid,
+      scanned,
+      now(),
+    );
+
+    const body: TrendsResponse = { days: scanned, truncated, activity, retention };
     return reply.status(200).send(body);
   });
 

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -24,6 +24,7 @@ import {
   summarizeVisitDay,
   trendPartitions,
   type DailyActivityPoint,
+  type DailyMcpPoint,
   type DailyRetentionPoint,
   type TelemetryTrends,
 } from './telemetry-trends.js';
@@ -557,6 +558,7 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
 
     const requested = trendPartitions(parsed.data.days ?? DEFAULT_TREND_DAYS, now());
     const activity: DailyActivityPoint[] = [];
+    const mcp: DailyMcpPoint[] = [];
     const scanned: string[] = [];
     let truncated = false;
     let readTotal = 0;
@@ -572,7 +574,9 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       const dayTruncated = dayEvents.length >= limit;
       if (dayTruncated) truncated = true;
       readTotal += dayEvents.length;
-      activity.push(summarizeVisitDay(dateStr, dayEvents, dayTruncated));
+      const day = summarizeVisitDay(dateStr, dayEvents, dayTruncated);
+      activity.push(day.activity);
+      mcp.push(day.mcp);
       scanned.push(dateStr);
     }
 
@@ -592,7 +596,7 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       now(),
     );
 
-    const body: TrendsResponse = { days: scanned, truncated, activity, retention };
+    const body: TrendsResponse = { days: scanned, truncated, activity, mcp, retention };
     return reply.status(200).send(body);
   });
 

--- a/apps/api/src/telemetry-trends.route.test.ts
+++ b/apps/api/src/telemetry-trends.route.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { InMemoryStore, type VisitEvent } from './store.js';
+import type { TrendsResponse } from './admin.js';
+
+const sessionSecret = 'dev-session-secret-change-me';
+const today = new Date().toISOString().slice(0, 10);
+
+function authHeaders(uid: string) {
+  return { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` };
+}
+
+function visit(partial: Partial<VisitEvent> & Pick<VisitEvent, 'visitId' | 'type'>): VisitEvent {
+  return {
+    at: `${today}T10:00:00.000Z`,
+    msSinceStart: 0,
+    ...partial,
+  };
+}
+
+describe('GET /api/admin/telemetry/trends', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.upsertUser({ uid: 'g:player' });
+  });
+
+  it('returns a daily activity series for an admin', async () => {
+    await store.appendVisitEvents(today, [
+      visit({ visitId: 'a', type: 'visit_started' }),
+      visit({ visitId: 'b', type: 'visit_started' }),
+      visit({ visitId: 'a', type: 'play_started', msSinceStart: 2_000 }),
+      visit({ visitId: 'a', type: 'create_step', step: 'submission_created', msSinceStart: 9_000 }),
+    ]);
+
+    const app = await buildApp({ store, sessionSecret, adminUids: 'g:boss' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/telemetry/trends?days=1',
+      headers: authHeaders('g:boss'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as TrendsResponse;
+    expect(body.days).toEqual([today]);
+    expect(body.activity).toEqual([{ date: today, visits: 2, plays: 1, creations: 1, truncated: false }]);
+    expect(body.retention).toHaveLength(1);
+    await app.close();
+  });
+
+  it('is invisible to a non-admin', async () => {
+    const app = await buildApp({ store, sessionSecret, adminUids: 'g:boss' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/telemetry/trends',
+      headers: authHeaders('g:player'),
+    });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});

--- a/apps/api/src/telemetry-trends.route.test.ts
+++ b/apps/api/src/telemetry-trends.route.test.ts
@@ -47,6 +47,17 @@ describe('GET /api/admin/telemetry/trends', () => {
     const body = res.json() as TrendsResponse;
     expect(body.days).toEqual([today]);
     expect(body.activity).toEqual([{ date: today, visits: 2, plays: 1, creations: 1, truncated: false }]);
+    expect(body.mcp).toEqual([
+      {
+        date: today,
+        selfChosen: 0,
+        platformChosen: 0,
+        connected: 0,
+        signaled: 0,
+        gateVerdicts: 0,
+        truncated: false,
+      },
+    ]);
     expect(body.retention).toHaveLength(1);
     await app.close();
   });

--- a/apps/api/src/telemetry-trends.test.ts
+++ b/apps/api/src/telemetry-trends.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  periodKey,
+  rollingAverage,
+  rollupTrends,
+  summarizeRetentionByEligibilityDay,
+  summarizeVisitDay,
+  trendPartitions,
+} from './telemetry-trends.js';
+import type { SubmissionRecord, User, VisitEvent } from './store.js';
+
+function visit(partial: Partial<VisitEvent> & Pick<VisitEvent, 'visitId' | 'type'>): VisitEvent {
+  return {
+    at: '2026-08-01T12:00:00.000Z',
+    msSinceStart: 0,
+    ...partial,
+  };
+}
+
+describe('summarizeVisitDay', () => {
+  it('counts distinct visits, every play, and distinct creations', () => {
+    const point = summarizeVisitDay('2026-08-01', [
+      visit({ visitId: 'a', type: 'visit_started' }),
+      visit({ visitId: 'b', type: 'visit_started' }),
+      visit({ visitId: 'a', type: 'play_started', msSinceStart: 1000 }),
+      visit({ visitId: 'a', type: 'play_started', msSinceStart: 5000 }),
+      visit({ visitId: 'a', type: 'create_step', step: 'prompt_started' }),
+      visit({ visitId: 'a', type: 'create_step', step: 'submission_created' }),
+      visit({ visitId: 'a', type: 'create_step', step: 'submission_created' }),
+    ]);
+    expect(point).toEqual({
+      date: '2026-08-01',
+      visits: 2,
+      plays: 2,
+      creations: 1,
+      truncated: false,
+    });
+  });
+
+  it('marks the day truncated when the caller says so', () => {
+    expect(summarizeVisitDay('2026-08-01', [], true).truncated).toBe(true);
+  });
+});
+
+describe('summarizeRetentionByEligibilityDay', () => {
+  const NOW = Date.parse('2026-08-20T12:00:00.000Z');
+
+  function submission(ownerUid: string, publishedAt: string): SubmissionRecord {
+    return {
+      issueNumber: Math.floor(Math.random() * 10_000),
+      ownerUid,
+      title: 't',
+      createdAt: publishedAt,
+      publishedAt,
+      lastStatus: 'published',
+    } as SubmissionRecord;
+  }
+
+  function user(uid: string, activeDays: string[]): User {
+    return { uid, activeDays } as User;
+  }
+
+  it('plots D7 on the eligibility day, not the publish day', () => {
+    // Published Aug 1 → eligible Aug 8. Returned on Aug 5.
+    const points = summarizeRetentionByEligibilityDay(
+      [submission('g:a', '2026-08-01T10:00:00.000Z')],
+      new Map([['g:a', user('g:a', ['2026-08-01', '2026-08-05'])]]),
+      ['2026-08-01', '2026-08-08'],
+      NOW,
+    );
+    expect(points.find((row) => row.date === '2026-08-01')).toEqual({
+      date: '2026-08-01',
+      eligible: 0,
+      returned: 0,
+      rate: null,
+    });
+    expect(points.find((row) => row.date === '2026-08-08')).toEqual({
+      date: '2026-08-08',
+      eligible: 1,
+      returned: 1,
+      rate: 1,
+    });
+  });
+
+  it('excludes bot creators and open windows', () => {
+    const points = summarizeRetentionByEligibilityDay(
+      [
+        submission('bot:e2e', '2026-08-01T10:00:00.000Z'),
+        submission('g:fresh', '2026-08-18T10:00:00.000Z'), // window still open at NOW
+      ],
+      new Map([
+        ['bot:e2e', user('bot:e2e', ['2026-08-02'])],
+        ['g:fresh', user('g:fresh', ['2026-08-19'])],
+      ]),
+      ['2026-08-08', '2026-08-25'],
+      NOW,
+    );
+    expect(points.every((row) => row.eligible === 0)).toBe(true);
+  });
+});
+
+describe('rollupTrends + rollingAverage', () => {
+  it('sums activity into ISO weeks and averages retention', () => {
+    const activity = [
+      {
+        date: '2026-08-03', // Monday
+        visits: 10,
+        plays: 5,
+        creations: 1,
+        truncated: false,
+      },
+      {
+        date: '2026-08-04',
+        visits: 20,
+        plays: 8,
+        creations: 0,
+        truncated: false,
+      },
+    ];
+    const retention = [
+      { date: '2026-08-03', eligible: 2, returned: 1, rate: 0.5 },
+      { date: '2026-08-04', eligible: 2, returned: 2, rate: 1 },
+    ];
+    const weeks = rollupTrends(activity, retention, 'week');
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0]).toMatchObject({
+      key: '2026-08-03',
+      visits: 30,
+      plays: 13,
+      creations: 1,
+      retentionEligible: 4,
+      retentionReturned: 3,
+      retentionRate: 0.75,
+    });
+  });
+
+  it('rolls a trailing mean and keeps nulls when nothing is measured', () => {
+    expect(rollingAverage([1, 2, 3, 4], 2)).toEqual([1, 1.5, 2.5, 3.5]);
+    expect(rollingAverage([null, 1, null, 3], 2)).toEqual([null, 1, 1, 3]);
+  });
+});
+
+describe('periodKey + trendPartitions', () => {
+  it('labels weeks from Monday and months as yyyy-mm', () => {
+    expect(periodKey('2026-08-05', 'week')).toEqual({ key: '2026-08-03', label: 'w 08-03' });
+    expect(periodKey('2026-08-05', 'month')).toEqual({ key: '2026-08', label: '2026-08' });
+  });
+
+  it('returns oldest-first partitions ending today', () => {
+    const now = Date.parse('2026-08-06T12:00:00.000Z');
+    expect(trendPartitions(3, now)).toEqual(['2026-08-04', '2026-08-05', '2026-08-06']);
+  });
+});

--- a/apps/api/src/telemetry-trends.test.ts
+++ b/apps/api/src/telemetry-trends.test.ts
@@ -19,7 +19,7 @@ function visit(partial: Partial<VisitEvent> & Pick<VisitEvent, 'visitId' | 'type
 
 describe('summarizeVisitDay', () => {
   it('counts distinct visits, every play, and distinct creations', () => {
-    const point = summarizeVisitDay('2026-08-01', [
+    const { activity } = summarizeVisitDay('2026-08-01', [
       visit({ visitId: 'a', type: 'visit_started' }),
       visit({ visitId: 'b', type: 'visit_started' }),
       visit({ visitId: 'a', type: 'play_started', msSinceStart: 1000 }),
@@ -28,7 +28,7 @@ describe('summarizeVisitDay', () => {
       visit({ visitId: 'a', type: 'create_step', step: 'submission_created' }),
       visit({ visitId: 'a', type: 'create_step', step: 'submission_created' }),
     ]);
-    expect(point).toEqual({
+    expect(activity).toEqual({
       date: '2026-08-01',
       visits: 2,
       plays: 2,
@@ -37,8 +37,28 @@ describe('summarizeVisitDay', () => {
     });
   });
 
+  it('counts MCP adoption rungs as distinct self visits', () => {
+    const { mcp } = summarizeVisitDay('2026-08-01', [
+      visit({ visitId: 'a', type: 'studio_step', step: 'builder_chosen', builder: 'self' }),
+      visit({ visitId: 'b', type: 'studio_step', step: 'builder_chosen', builder: 'platform' }),
+      visit({ visitId: 'a', type: 'studio_step', step: 'connect_copied', builder: 'self', detail: 'install' }),
+      visit({ visitId: 'a', type: 'studio_step', step: 'connect_deeplink', builder: 'self', detail: 'cursor' }),
+      visit({ visitId: 'a', type: 'studio_step', step: 'agent_signaled', builder: 'self' }),
+      visit({ visitId: 'c', type: 'studio_step', step: 'gate_verdict', builder: 'self', detail: 'green' }),
+    ]);
+    expect(mcp).toEqual({
+      date: '2026-08-01',
+      selfChosen: 1,
+      platformChosen: 1,
+      connected: 1,
+      signaled: 1,
+      gateVerdicts: 1,
+      truncated: false,
+    });
+  });
+
   it('marks the day truncated when the caller says so', () => {
-    expect(summarizeVisitDay('2026-08-01', [], true).truncated).toBe(true);
+    expect(summarizeVisitDay('2026-08-01', [], true).activity.truncated).toBe(true);
   });
 });
 
@@ -117,17 +137,41 @@ describe('rollupTrends + rollingAverage', () => {
         truncated: false,
       },
     ];
+    const mcp = [
+      {
+        date: '2026-08-03',
+        selfChosen: 2,
+        platformChosen: 1,
+        connected: 1,
+        signaled: 1,
+        gateVerdicts: 0,
+        truncated: false,
+      },
+      {
+        date: '2026-08-04',
+        selfChosen: 1,
+        platformChosen: 0,
+        connected: 1,
+        signaled: 0,
+        gateVerdicts: 1,
+        truncated: false,
+      },
+    ];
     const retention = [
       { date: '2026-08-03', eligible: 2, returned: 1, rate: 0.5 },
       { date: '2026-08-04', eligible: 2, returned: 2, rate: 1 },
     ];
-    const weeks = rollupTrends(activity, retention, 'week');
+    const weeks = rollupTrends(activity, mcp, retention, 'week');
     expect(weeks).toHaveLength(1);
     expect(weeks[0]).toMatchObject({
       key: '2026-08-03',
       visits: 30,
       plays: 13,
       creations: 1,
+      selfChosen: 3,
+      connected: 2,
+      signaled: 1,
+      gateVerdicts: 1,
       retentionEligible: 4,
       retentionReturned: 3,
       retentionRate: 0.75,

--- a/apps/api/src/telemetry-trends.ts
+++ b/apps/api/src/telemetry-trends.ts
@@ -1,0 +1,275 @@
+import type { SubmissionRecord, User, VisitEvent } from './store.js';
+import { BOT_UID_PREFIX } from './store.js';
+import { returnedAfterPublish } from './creator-metrics.js';
+
+/**
+ * Time series for the operator telemetry tab — the glance that answers "is this
+ * getting better or worse?" rather than "what happened in this window".
+ *
+ * Daily points are the source of truth. Weekly / monthly grains and rolling
+ * averages are pure rollups over those points (same module, same tests), so the
+ * three timescales cannot drift from each other.
+ *
+ * Visits / plays / creations come from the anonymous visit stream, partitioned
+ * by UTC day. Retention is the Stage 0 D7 return rate, plotted on the day a
+ * creator's 7-day window closes (the first day the outcome is knowable) — not
+ * on the publish day, which would be a prediction.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type TrendGrain = 'day' | 'week' | 'month';
+
+export interface DailyActivityPoint {
+  /** UTC `yyyy-mm-dd` partition the counts were read from. */
+  date: string;
+  /** Distinct visits that recorded `visit_started` that day. */
+  visits: number;
+  /** `play_started` events that day — one sitting can contribute several. */
+  plays: number;
+  /** Distinct visits that reached `submission_created` that day. */
+  creations: number;
+  /** True when this day's read hit its cap, so the counts are a floor. */
+  truncated: boolean;
+}
+
+export interface DailyRetentionPoint {
+  /**
+   * The day the D7 window closed for this cohort (publish day + 7).
+   * Absent cohorts still appear as a zero-eligible row when the activity
+   * series has that day, so the two charts stay aligned.
+   */
+  date: string;
+  eligible: number;
+  returned: number;
+  /** Null when nobody's window closed that day — absence, not a measured 0%. */
+  rate: number | null;
+}
+
+export interface TelemetryTrends {
+  /** Days actually scanned, oldest first — chart order. */
+  days: string[];
+  truncated: boolean;
+  activity: DailyActivityPoint[];
+  retention: DailyRetentionPoint[];
+}
+
+/** One day's activity from its visit-event partition. */
+export function summarizeVisitDay(dateStr: string, events: VisitEvent[], truncated = false): DailyActivityPoint {
+  const started = new Set<string>();
+  const created = new Set<string>();
+  let plays = 0;
+
+  for (const event of events) {
+    if (event.type === 'visit_started') {
+      started.add(event.visitId);
+    } else if (event.type === 'play_started') {
+      plays += 1;
+    } else if (event.type === 'create_step' && event.step === 'submission_created') {
+      created.add(event.visitId);
+    }
+  }
+
+  return {
+    date: dateStr,
+    visits: started.size,
+    plays,
+    creations: created.size,
+    truncated,
+  };
+}
+
+/**
+ * D7 return, one point per eligibility day.
+ *
+ * A creator who published on day P becomes eligible on day P+7. Plotting on P+7
+ * means every point is a resolved outcome, never a half-open window. Creators
+ * whose window has not yet closed are excluded — same honesty rule as
+ * `summarizeCreatorMetrics`.
+ */
+export function summarizeRetentionByEligibilityDay(
+  submissions: SubmissionRecord[],
+  usersByUid: Map<string, User>,
+  dayKeys: string[],
+  now: number = Date.now(),
+): DailyRetentionPoint[] {
+  const daySet = new Set(dayKeys);
+  const cohorts = new Map<string, { eligible: number; returned: number }>();
+
+  // One row per creator (earliest publish), matching summarizeCreatorMetrics.
+  const earliestPublishByOwner = new Map<string, string>();
+  for (const submission of submissions) {
+    if (submission.ownerUid.startsWith(BOT_UID_PREFIX)) continue;
+    const at = submission.publishedAt;
+    if (!at) continue;
+    const current = earliestPublishByOwner.get(submission.ownerUid);
+    if (current === undefined || at < current) earliestPublishByOwner.set(submission.ownerUid, at);
+  }
+
+  earliestPublishByOwner.forEach((publishedAt, uid) => {
+    const published = Date.parse(publishedAt);
+    if (!Number.isFinite(published)) return;
+    const publishDay = new Date(published).toISOString().slice(0, 10);
+    const eligibleAt = Date.parse(`${publishDay}T00:00:00.000Z`) + 7 * DAY_MS;
+    if (!Number.isFinite(eligibleAt) || now < eligibleAt) return;
+    const eligibleDay = new Date(eligibleAt).toISOString().slice(0, 10);
+    if (!daySet.has(eligibleDay)) return;
+
+    const cohort = cohorts.get(eligibleDay) ?? { eligible: 0, returned: 0 };
+    cohort.eligible += 1;
+    if (returnedAfterPublish(usersByUid.get(uid)?.activeDays, publishedAt)) {
+      cohort.returned += 1;
+    }
+    cohorts.set(eligibleDay, cohort);
+  });
+
+  return dayKeys.map((date) => {
+    const cohort = cohorts.get(date);
+    if (!cohort || cohort.eligible === 0) {
+      return { date, eligible: 0, returned: 0, rate: null };
+    }
+    return {
+      date,
+      eligible: cohort.eligible,
+      returned: cohort.returned,
+      rate: cohort.returned / cohort.eligible,
+    };
+  });
+}
+
+export interface RolledPoint {
+  /** Period key: day `yyyy-mm-dd`, week start `yyyy-mm-dd`, or month `yyyy-mm`. */
+  key: string;
+  label: string;
+  visits: number;
+  plays: number;
+  creations: number;
+  /** Retention over the period: null when no cohort closed inside it. */
+  retentionRate: number | null;
+  retentionEligible: number;
+  retentionReturned: number;
+  truncated: boolean;
+}
+
+/** Roll daily activity + retention up to week or month. Day grain is a pass-through. */
+export function rollupTrends(
+  activity: DailyActivityPoint[],
+  retention: DailyRetentionPoint[],
+  grain: TrendGrain,
+): RolledPoint[] {
+  if (grain === 'day') {
+    const byDate = new Map(retention.map((row) => [row.date, row]));
+    return activity.map((row) => {
+      const ret = byDate.get(row.date);
+      return {
+        key: row.date,
+        label: row.date.slice(5), // mm-dd — short axis labels
+        visits: row.visits,
+        plays: row.plays,
+        creations: row.creations,
+        retentionRate: ret?.rate ?? null,
+        retentionEligible: ret?.eligible ?? 0,
+        retentionReturned: ret?.returned ?? 0,
+        truncated: row.truncated,
+      };
+    });
+  }
+
+  const buckets = new Map<
+    string,
+    {
+      label: string;
+      visits: number;
+      plays: number;
+      creations: number;
+      retentionEligible: number;
+      retentionReturned: number;
+      truncated: boolean;
+    }
+  >();
+
+  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
+
+  for (const row of activity) {
+    const { key, label } = periodKey(row.date, grain);
+    const bucket = buckets.get(key) ?? {
+      label,
+      visits: 0,
+      plays: 0,
+      creations: 0,
+      retentionEligible: 0,
+      retentionReturned: 0,
+      truncated: false,
+    };
+    bucket.visits += row.visits;
+    bucket.plays += row.plays;
+    bucket.creations += row.creations;
+    if (row.truncated) bucket.truncated = true;
+    const ret = retentionByDate.get(row.date);
+    if (ret) {
+      bucket.retentionEligible += ret.eligible;
+      bucket.retentionReturned += ret.returned;
+    }
+    buckets.set(key, bucket);
+  }
+
+  return Array.from(buckets, ([key, bucket]) => ({
+    key,
+    label: bucket.label,
+    visits: bucket.visits,
+    plays: bucket.plays,
+    creations: bucket.creations,
+    retentionEligible: bucket.retentionEligible,
+    retentionReturned: bucket.retentionReturned,
+    retentionRate: bucket.retentionEligible === 0 ? null : bucket.retentionReturned / bucket.retentionEligible,
+    truncated: bucket.truncated,
+  }));
+}
+
+/**
+ * Trailing mean over `window` points. Until the window is full the average uses
+ * whatever points exist (so the left edge of a chart is not blank); a stretch of
+ * all-null inputs stays null.
+ */
+export function rollingAverage(values: Array<number | null>, window: number): Array<number | null> {
+  const size = Math.max(1, Math.floor(window));
+  return values.map((_, index) => {
+    const from = Math.max(0, index - size + 1);
+    let sum = 0;
+    let count = 0;
+    for (let i = from; i <= index; i += 1) {
+      const value = values[i];
+      if (value === null) continue;
+      sum += value;
+      count += 1;
+    }
+    return count === 0 ? null : sum / count;
+  });
+}
+
+/** ISO week starts Monday; month is calendar month. Keys sort lexicographically. */
+export function periodKey(dateStr: string, grain: TrendGrain): { key: string; label: string } {
+  if (grain === 'day') return { key: dateStr, label: dateStr.slice(5) };
+  if (grain === 'month') {
+    const key = dateStr.slice(0, 7);
+    return { key, label: key };
+  }
+  const start = weekStart(dateStr);
+  return { key: start, label: `w ${start.slice(5)}` };
+}
+
+function weekStart(dateStr: string): string {
+  const date = new Date(`${dateStr}T00:00:00.000Z`);
+  // getUTCDay: 0 Sun … 6 Sat. Shift so Monday is 0.
+  const day = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - day);
+  return date.toISOString().slice(0, 10);
+}
+
+/** Oldest-first partition list for a chart window ending at `now`. */
+export function trendPartitions(days: number, now: number = Date.now()): string[] {
+  const count = Math.max(1, days);
+  return Array.from({ length: count }, (_, index) =>
+    new Date(now - (count - 1 - index) * DAY_MS).toISOString().slice(0, 10),
+  );
+}

--- a/apps/api/src/telemetry-trends.ts
+++ b/apps/api/src/telemetry-trends.ts
@@ -10,13 +10,17 @@ import { returnedAfterPublish } from './creator-metrics.js';
  * averages are pure rollups over those points (same module, same tests), so the
  * three timescales cannot drift from each other.
  *
- * Visits / plays / creations come from the anonymous visit stream, partitioned
- * by UTC day. Retention is the Stage 0 D7 return rate, plotted on the day a
- * creator's 7-day window closes (the first day the outcome is knowable) — not
- * on the publish day, which would be a prediction.
+ * Visits / plays / creations and MCP (studio_step) adoption come from the
+ * anonymous visit stream, partitioned by UTC day. Retention is the Stage 0 D7
+ * return rate, plotted on the day a creator's 7-day window closes (the first
+ * day the outcome is knowable) — not on the publish day, which would be a
+ * prediction.
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Connect steps that mean "this visit reached an MCP install surface". */
+const MCP_CONNECT_STEPS = new Set(['connect_copied', 'connect_deeplink', 'connect_restored']);
 
 export type TrendGrain = 'day' | 'week' | 'month';
 
@@ -30,6 +34,28 @@ export interface DailyActivityPoint {
   /** Distinct visits that reached `submission_created` that day. */
   creations: number;
   /** True when this day's read hit its cap, so the counts are a floor. */
+  truncated: boolean;
+}
+
+/**
+ * BYOCA / self-build MCP adoption for one day (visit-stream `studio_step`).
+ *
+ * Counts are distinct visits per rung. `signaled` is the usage signal — an agent
+ * actually talked to `/api/mcp`. Connect without signal is install friction;
+ * signal without a gate verdict is still a working connector.
+ */
+export interface DailyMcpPoint {
+  date: string;
+  /** Visits that chose the self (BYOCA) builder. */
+  selfChosen: number;
+  /** Visits that chose the platform builder — the adoption denominator's other half. */
+  platformChosen: number;
+  /** Visits that copied a connect snippet, used a deeplink, or restored a key. */
+  connected: number;
+  /** Visits that got an agent signal over MCP. */
+  signaled: number;
+  /** Visits that reached a gate verdict on a self round. */
+  gateVerdicts: number;
   truncated: boolean;
 }
 
@@ -51,14 +77,25 @@ export interface TelemetryTrends {
   days: string[];
   truncated: boolean;
   activity: DailyActivityPoint[];
+  mcp: DailyMcpPoint[];
   retention: DailyRetentionPoint[];
 }
 
-/** One day's activity from its visit-event partition. */
-export function summarizeVisitDay(dateStr: string, events: VisitEvent[], truncated = false): DailyActivityPoint {
+/** One day's activity + MCP adoption from its visit-event partition. */
+export function summarizeVisitDay(
+  dateStr: string,
+  events: VisitEvent[],
+  truncated = false,
+): { activity: DailyActivityPoint; mcp: DailyMcpPoint } {
   const started = new Set<string>();
   const created = new Set<string>();
   let plays = 0;
+
+  const selfChosen = new Set<string>();
+  const platformChosen = new Set<string>();
+  const connected = new Set<string>();
+  const signaled = new Set<string>();
+  const gateVerdicts = new Set<string>();
 
   for (const event of events) {
     if (event.type === 'visit_started') {
@@ -67,15 +104,37 @@ export function summarizeVisitDay(dateStr: string, events: VisitEvent[], truncat
       plays += 1;
     } else if (event.type === 'create_step' && event.step === 'submission_created') {
       created.add(event.visitId);
+    } else if (event.type === 'studio_step' && event.step) {
+      const builder = event.builder ?? 'self';
+      if (event.step === 'builder_chosen') {
+        if (builder === 'platform') platformChosen.add(event.visitId);
+        else selfChosen.add(event.visitId);
+      } else if (builder === 'self' || builder === undefined) {
+        // Connect / signal / gate are only meaningful for the self (MCP) lane.
+        if (MCP_CONNECT_STEPS.has(event.step)) connected.add(event.visitId);
+        else if (event.step === 'agent_signaled') signaled.add(event.visitId);
+        else if (event.step === 'gate_verdict') gateVerdicts.add(event.visitId);
+      }
     }
   }
 
   return {
-    date: dateStr,
-    visits: started.size,
-    plays,
-    creations: created.size,
-    truncated,
+    activity: {
+      date: dateStr,
+      visits: started.size,
+      plays,
+      creations: created.size,
+      truncated,
+    },
+    mcp: {
+      date: dateStr,
+      selfChosen: selfChosen.size,
+      platformChosen: platformChosen.size,
+      connected: connected.size,
+      signaled: signaled.size,
+      gateVerdicts: gateVerdicts.size,
+      truncated,
+    },
   };
 }
 
@@ -144,6 +203,11 @@ export interface RolledPoint {
   visits: number;
   plays: number;
   creations: number;
+  selfChosen: number;
+  platformChosen: number;
+  connected: number;
+  signaled: number;
+  gateVerdicts: number;
   /** Retention over the period: null when no cohort closed inside it. */
   retentionRate: number | null;
   retentionEligible: number;
@@ -151,26 +215,35 @@ export interface RolledPoint {
   truncated: boolean;
 }
 
-/** Roll daily activity + retention up to week or month. Day grain is a pass-through. */
+/** Roll daily activity + MCP + retention up to week or month. Day grain is a pass-through. */
 export function rollupTrends(
   activity: DailyActivityPoint[],
+  mcp: DailyMcpPoint[],
   retention: DailyRetentionPoint[],
   grain: TrendGrain,
 ): RolledPoint[] {
+  const mcpByDate = new Map(mcp.map((row) => [row.date, row]));
+  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
+
   if (grain === 'day') {
-    const byDate = new Map(retention.map((row) => [row.date, row]));
     return activity.map((row) => {
-      const ret = byDate.get(row.date);
+      const mcpRow = mcpByDate.get(row.date);
+      const ret = retentionByDate.get(row.date);
       return {
         key: row.date,
         label: row.date.slice(5), // mm-dd — short axis labels
         visits: row.visits,
         plays: row.plays,
         creations: row.creations,
+        selfChosen: mcpRow?.selfChosen ?? 0,
+        platformChosen: mcpRow?.platformChosen ?? 0,
+        connected: mcpRow?.connected ?? 0,
+        signaled: mcpRow?.signaled ?? 0,
+        gateVerdicts: mcpRow?.gateVerdicts ?? 0,
         retentionRate: ret?.rate ?? null,
         retentionEligible: ret?.eligible ?? 0,
         retentionReturned: ret?.returned ?? 0,
-        truncated: row.truncated,
+        truncated: row.truncated || mcpRow?.truncated === true,
       };
     });
   }
@@ -182,13 +255,16 @@ export function rollupTrends(
       visits: number;
       plays: number;
       creations: number;
+      selfChosen: number;
+      platformChosen: number;
+      connected: number;
+      signaled: number;
+      gateVerdicts: number;
       retentionEligible: number;
       retentionReturned: number;
       truncated: boolean;
     }
   >();
-
-  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
 
   for (const row of activity) {
     const { key, label } = periodKey(row.date, grain);
@@ -197,6 +273,11 @@ export function rollupTrends(
       visits: 0,
       plays: 0,
       creations: 0,
+      selfChosen: 0,
+      platformChosen: 0,
+      connected: 0,
+      signaled: 0,
+      gateVerdicts: 0,
       retentionEligible: 0,
       retentionReturned: 0,
       truncated: false,
@@ -204,6 +285,15 @@ export function rollupTrends(
     bucket.visits += row.visits;
     bucket.plays += row.plays;
     bucket.creations += row.creations;
+    const mcpRow = mcpByDate.get(row.date);
+    if (mcpRow) {
+      bucket.selfChosen += mcpRow.selfChosen;
+      bucket.platformChosen += mcpRow.platformChosen;
+      bucket.connected += mcpRow.connected;
+      bucket.signaled += mcpRow.signaled;
+      bucket.gateVerdicts += mcpRow.gateVerdicts;
+      if (mcpRow.truncated) bucket.truncated = true;
+    }
     if (row.truncated) bucket.truncated = true;
     const ret = retentionByDate.get(row.date);
     if (ret) {
@@ -219,6 +309,11 @@ export function rollupTrends(
     visits: bucket.visits,
     plays: bucket.plays,
     creations: bucket.creations,
+    selfChosen: bucket.selfChosen,
+    platformChosen: bucket.platformChosen,
+    connected: bucket.connected,
+    signaled: bucket.signaled,
+    gateVerdicts: bucket.gateVerdicts,
     retentionEligible: bucket.retentionEligible,
     retentionReturned: bucket.retentionReturned,
     retentionRate: bucket.retentionEligible === 0 ? null : bucket.retentionReturned / bucket.retentionEligible,

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -107,6 +107,19 @@ function respondWith(body: HealthResponse | null, status = 200, funnel?: VisitsR
   // an unrouted URL would fall through to the health body and render as a scorecard.
   const scorecardsBody: ScorecardsResponse | null =
     body === null ? null : { scorecards: [], newestComputedAt: null, oldestComputedAt: null };
+  const trendsBody =
+    body === null
+      ? null
+      : {
+          days: [...body.days].reverse(),
+          truncated: false,
+          activity: [...body.days]
+            .reverse()
+            .map((date) => ({ date, visits: 0, plays: 0, creations: 0, truncated: false })),
+          retention: [...body.days]
+            .reverse()
+            .map((date) => ({ date, eligible: 0, returned: 0, rate: null as number | null })),
+        };
 
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
     const url = String(input);
@@ -114,9 +127,11 @@ function respondWith(body: HealthResponse | null, status = 200, funnel?: VisitsR
       ? visitsBody
       : url.includes('/telemetry/creators')
         ? creatorsBody
-        : url.includes('/admin/scorecards')
-          ? scorecardsBody
-          : body;
+        : url.includes('/telemetry/trends')
+          ? trendsBody
+          : url.includes('/admin/scorecards')
+            ? scorecardsBody
+            : body;
     return payload === null ? new Response(null, { status }) : new Response(JSON.stringify(payload), { status: 200 });
   }) as MockInstance<typeof globalThis.fetch>;
 }

--- a/apps/web/src/GameHealthView.test.tsx
+++ b/apps/web/src/GameHealthView.test.tsx
@@ -116,6 +116,15 @@ function respondWith(body: HealthResponse | null, status = 200, funnel?: VisitsR
           activity: [...body.days]
             .reverse()
             .map((date) => ({ date, visits: 0, plays: 0, creations: 0, truncated: false })),
+          mcp: [...body.days].reverse().map((date) => ({
+            date,
+            selfChosen: 0,
+            platformChosen: 0,
+            connected: 0,
+            signaled: 0,
+            gateVerdicts: 0,
+            truncated: false,
+          })),
           retention: [...body.days]
             .reverse()
             .map((date) => ({ date, eligible: 0, returned: 0, rate: null as number | null })),

--- a/apps/web/src/GameHealthView.tsx
+++ b/apps/web/src/GameHealthView.tsx
@@ -15,6 +15,7 @@ import { CreatorMetricsPanel } from './CreatorMetricsPanel.js';
 import { GrowthPanel } from './GrowthPanel.js';
 import { ScorecardPanel } from './ScorecardPanel.js';
 import { TelemetryOverview } from './TelemetryOverview.js';
+import { TelemetryTrendsPanel } from './TelemetryTrendsPanel.js';
 
 /**
  * Operator view over play telemetry (docs/improvement-loop-plan.md IL-2).
@@ -157,6 +158,8 @@ export function GameHealthView() {
       {state === 'ready' && data && visits && creators?.metrics && (
         <TelemetryOverview health={data} visits={visits} creators={creators} />
       )}
+
+      {state === 'ready' && <TelemetryTrendsPanel />}
 
       {/* The one business number, above the panels that carry its ingredients. Needs all
           three reads at once — it is their product — so it simply stays absent when any

--- a/apps/web/src/GameHealthView.tsx
+++ b/apps/web/src/GameHealthView.tsx
@@ -14,6 +14,7 @@ import { VisitFunnelPanel } from './VisitFunnelPanel.js';
 import { CreatorMetricsPanel } from './CreatorMetricsPanel.js';
 import { GrowthPanel } from './GrowthPanel.js';
 import { ScorecardPanel } from './ScorecardPanel.js';
+import { TelemetryOverview } from './TelemetryOverview.js';
 
 /**
  * Operator view over play telemetry (docs/improvement-loop-plan.md IL-2).
@@ -151,6 +152,12 @@ export function GameHealthView() {
         Promise.all and one error state, so a creators payload of an unexpected shape
         would otherwise blank the game-health table too.
       */}
+      {/* Overview first: gauges + distribution histograms, then the panels that
+          carry the same numbers in prose. Needs all three reads — same gate as Growth. */}
+      {state === 'ready' && data && visits && creators?.metrics && (
+        <TelemetryOverview health={data} visits={visits} creators={creators} />
+      )}
+
       {/* The one business number, above the panels that carry its ingredients. Needs all
           three reads at once — it is their product — so it simply stays absent when any
           of them failed to load. */}

--- a/apps/web/src/TelemetryCharts.test.tsx
+++ b/apps/web/src/TelemetryCharts.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Gauge, Histogram, OpenGauge } from './TelemetryCharts.js';
+
+/**
+ * Chart primitives must not invent confidence: a null rate is a dash, an empty
+ * distribution is an empty message — never a drawn zero that looks measured.
+ */
+
+function render(node: ReactElement): { host: HTMLElement; root: ReturnType<typeof createRoot> } {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  act(() => {
+    root.render(node);
+  });
+  return { host, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Gauge', () => {
+  it('exposes the formatted value and label to assistive tech', () => {
+    const { host, root } = render(createElement(Gauge, { value: 0.27, display: '27%', label: 'reached a game' }));
+    const svg = host.querySelector('svg[role="img"]');
+    expect(svg?.getAttribute('aria-label')).toBe('reached a game: 27%');
+    expect(host.textContent).toContain('27%');
+    expect(host.textContent).toContain('reached a game');
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('draws no fill and marks itself empty when there is no evidence', () => {
+    const { host, root } = render(createElement(Gauge, { value: null, display: '—', label: 'creator D7 return' }));
+    expect(host.querySelector('.telem-gauge')?.classList.contains('is-empty')).toBe(true);
+    expect(host.querySelector('.telem-gauge-fill')).toBeNull();
+    expect(host.textContent).toContain('—');
+    act(() => {
+      root.unmount();
+    });
+  });
+});
+
+describe('OpenGauge', () => {
+  it('keeps the goal tick even when the reading overshoots the base scale', () => {
+    const { host, root } = render(
+      createElement(OpenGauge, {
+        value: 4.94,
+        display: '4.94',
+        label: 'growth k',
+        max: 5,
+        goal: 1,
+      }),
+    );
+    expect(host.querySelector('.telem-gauge-target')).not.toBeNull();
+    expect(host.textContent).toContain('4.94');
+    act(() => {
+      root.unmount();
+    });
+  });
+});
+
+describe('Histogram', () => {
+  it('renders one column per bucket with the count visible', () => {
+    const { host, root } = render(
+      createElement(Histogram, {
+        title: 'Time to first play',
+        bars: [
+          { label: '≤10s', value: 291 },
+          { label: '≤30s', value: 144 },
+          { label: '≤1m', value: 37 },
+        ],
+      }),
+    );
+    expect(host.textContent).toContain('Time to first play');
+    expect(host.textContent).toContain('291');
+    expect(host.textContent).toContain('≤10s');
+    expect(host.querySelectorAll('.telem-histogram-col')).toHaveLength(3);
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('says so plainly when every bucket is empty', () => {
+    const { host, root } = render(
+      createElement(Histogram, {
+        title: 'Games per visit',
+        bars: [],
+        emptyMessage: 'No visit reached a game.',
+      }),
+    );
+    expect(host.textContent).toContain('No visit reached a game.');
+    expect(host.querySelector('.telem-histogram-plot')).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/src/TelemetryCharts.tsx
+++ b/apps/web/src/TelemetryCharts.tsx
@@ -1,0 +1,168 @@
+/**
+ * Lean chart primitives for the operator telemetry dashboard.
+ *
+ * No chart library: the page already answers with numbers, and these exist only to
+ * make the same aggregates scannable at a glance — arc length for rates, bar height
+ * for bucketed distributions. Both preserve the honesty rules of the surrounding
+ * panels: null / empty evidence renders as absence, never as a confident zero.
+ */
+
+export type GaugeTone = 'ok' | 'warn' | 'bad' | 'idle';
+
+/** Semicircle rate gauge. `value` is a 0–1 fraction; null means no evidence. */
+export function Gauge({
+  value,
+  label,
+  display,
+  tone = 'ok',
+  target,
+}: {
+  value: number | null;
+  /** Visible number in the middle — already formatted by the caller. */
+  display: string;
+  label: string;
+  tone?: GaugeTone;
+  /** Optional goal on the same 0–1 scale (drawn as a tick on the arc). */
+  target?: number;
+}) {
+  const clamped = value === null ? null : Math.max(0, Math.min(1, value));
+  // Polar arc from 180° (left) to 0° (right). A dash for the missing case keeps the
+  // track drawn so the empty slot still reads as a gauge, not a missing widget.
+  const sweep = clamped === null ? 0 : clamped * 180;
+  const targetAngle = target === undefined ? null : 180 - Math.max(0, Math.min(1, target)) * 180;
+
+  return (
+    <figure className={`telem-gauge telem-gauge--${tone}${clamped === null ? ' is-empty' : ''}`}>
+      <svg className="telem-gauge-svg" viewBox="0 0 120 78" role="img" aria-label={`${label}: ${display}`}>
+        <path className="telem-gauge-track" d={arcPath(60, 64, 44, 180, 0)} fill="none" />
+        {sweep > 0 && <path className="telem-gauge-fill" d={arcPath(60, 64, 44, 180, 180 - sweep)} fill="none" />}
+        {targetAngle !== null && (
+          <line
+            className="telem-gauge-target"
+            x1={60 + Math.cos((targetAngle * Math.PI) / 180) * 36}
+            y1={64 - Math.sin((targetAngle * Math.PI) / 180) * 36}
+            x2={60 + Math.cos((targetAngle * Math.PI) / 180) * 52}
+            y2={64 - Math.sin((targetAngle * Math.PI) / 180) * 52}
+          />
+        )}
+        <text className="telem-gauge-value" x="60" y="58" textAnchor="middle">
+          {display}
+        </text>
+      </svg>
+      <figcaption className="telem-gauge-label">{label}</figcaption>
+    </figure>
+  );
+}
+
+/**
+ * Open-scale dial for unbounded coefficients like growth k.
+ *
+ * The track runs 0 → `max`; a goal tick marks the sustainability threshold (1).
+ * Values above `max` pin the needle at the end rather than inventing a new scale
+ * mid-glance — the number in the middle is still the truth.
+ */
+export function OpenGauge({
+  value,
+  label,
+  display,
+  max,
+  goal,
+  tone = 'ok',
+}: {
+  value: number | null;
+  display: string;
+  label: string;
+  max: number;
+  goal?: number;
+  tone?: GaugeTone;
+}) {
+  const ratio = value === null || max <= 0 ? null : Math.max(0, Math.min(1, value / max));
+  const sweep = ratio === null ? 0 : ratio * 180;
+  const goalAngle = goal === undefined || max <= 0 ? null : 180 - Math.max(0, Math.min(1, goal / max)) * 180;
+
+  return (
+    <figure className={`telem-gauge telem-gauge--${tone}${ratio === null ? ' is-empty' : ''}`}>
+      <svg className="telem-gauge-svg" viewBox="0 0 120 78" role="img" aria-label={`${label}: ${display}`}>
+        <path className="telem-gauge-track" d={arcPath(60, 64, 44, 180, 0)} fill="none" />
+        {sweep > 0 && <path className="telem-gauge-fill" d={arcPath(60, 64, 44, 180, 180 - sweep)} fill="none" />}
+        {goalAngle !== null && (
+          <line
+            className="telem-gauge-target"
+            x1={60 + Math.cos((goalAngle * Math.PI) / 180) * 36}
+            y1={64 - Math.sin((goalAngle * Math.PI) / 180) * 36}
+            x2={60 + Math.cos((goalAngle * Math.PI) / 180) * 52}
+            y2={64 - Math.sin((goalAngle * Math.PI) / 180) * 52}
+          />
+        )}
+        <text className="telem-gauge-value" x="60" y="58" textAnchor="middle">
+          {display}
+        </text>
+      </svg>
+      <figcaption className="telem-gauge-label">{label}</figcaption>
+    </figure>
+  );
+}
+
+export interface HistogramBar {
+  label: string;
+  value: number;
+}
+
+/** Vertical bar histogram for a small, fixed set of buckets. */
+export function Histogram({
+  title,
+  bars,
+  emptyMessage = 'No data.',
+  unit = 'visits',
+}: {
+  title: string;
+  bars: HistogramBar[];
+  emptyMessage?: string;
+  unit?: string;
+}) {
+  const max = bars.reduce((peak, bar) => Math.max(peak, bar.value), 0);
+  const total = bars.reduce((sum, bar) => sum + bar.value, 0);
+
+  return (
+    <figure className="telem-histogram">
+      <figcaption className="telem-histogram-title">{title}</figcaption>
+      {total === 0 || bars.length === 0 ? (
+        <p className="health-empty">{emptyMessage}</p>
+      ) : (
+        <div
+          className="telem-histogram-plot"
+          role="img"
+          aria-label={`${title}: ${bars.map((bar) => `${bar.label} ${bar.value} ${unit}`).join(', ')}`}
+        >
+          {bars.map((bar) => {
+            const heightPct = max === 0 ? 0 : (bar.value / max) * 100;
+            return (
+              <div key={bar.label} className="telem-histogram-col">
+                <span className="telem-histogram-count">{bar.value}</span>
+                <div className="telem-histogram-track" aria-hidden="true">
+                  <div className="telem-histogram-bar" style={{ height: `${heightPct}%` }} />
+                </div>
+                <span className="telem-histogram-label">{bar.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </figure>
+  );
+}
+
+/** SVG arc path from `startAngle` to `endAngle` (degrees, 0 = east, CCW). */
+function arcPath(cx: number, cy: number, r: number, startAngle: number, endAngle: number): string {
+  const start = polar(cx, cy, r, startAngle);
+  const end = polar(cx, cy, r, endAngle);
+  const large = Math.abs(endAngle - startAngle) > 180 ? 1 : 0;
+  // Sweep-flag 1 = clockwise in SVG — we walk from left (180°) toward right (0°).
+  const sweep = startAngle > endAngle ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${large} ${sweep} ${end.x} ${end.y}`;
+}
+
+function polar(cx: number, cy: number, r: number, angleDeg: number): { x: number; y: number } {
+  const rad = (angleDeg * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy - r * Math.sin(rad) };
+}

--- a/apps/web/src/TelemetryCharts.tsx
+++ b/apps/web/src/TelemetryCharts.tsx
@@ -174,6 +174,8 @@ export interface LineSeries {
   values: Array<number | null>;
   /** Dashed stroke — used for rolling averages over the raw series. */
   dashed?: boolean;
+  /** Right axis for low-volume series (creations) that would flatline on the left scale. */
+  axis?: 'left' | 'right';
 }
 
 /**
@@ -181,36 +183,51 @@ export interface LineSeries {
  *
  * Null values break the path (a gap), so a day with no retention cohort does not
  * invent a zero that looks like a crash. Y-axis is nice-scaled from the data.
+ * Optional right axis keeps low-volume series readable beside high-volume ones.
  */
 export function LineChart({
   title,
   labels,
   series,
   formatY = (value: number) => String(Math.round(value)),
+  formatYRight,
   emptyMessage = 'No data in this window.',
 }: {
   title: string;
   labels: string[];
   series: LineSeries[];
   formatY?: (value: number) => string;
+  formatYRight?: (value: number) => string;
   emptyMessage?: string;
 }) {
   const width = 640;
   const height = 200;
-  const pad = { top: 16, right: 12, bottom: 28, left: 40 };
+  const hasRight = series.some((s) => (s.axis ?? 'left') === 'right');
+  const pad = { top: 16, right: hasRight ? 40 : 12, bottom: 28, left: 40 };
   const innerW = width - pad.left - pad.right;
   const innerH = height - pad.top - pad.bottom;
 
-  const allValues = series.flatMap((s) => s.values).filter((value): value is number => value !== null);
-  const empty = labels.length === 0 || allValues.length === 0;
-  const yMax = empty ? 1 : niceCeil(Math.max(...allValues, 0));
+  const leftValues = series
+    .filter((s) => (s.axis ?? 'left') === 'left')
+    .flatMap((s) => s.values)
+    .filter((value): value is number => value !== null);
+  const rightValues = series
+    .filter((s) => s.axis === 'right')
+    .flatMap((s) => s.values)
+    .filter((value): value is number => value !== null);
+  const empty = labels.length === 0 || (leftValues.length === 0 && rightValues.length === 0);
+  const yMaxLeft = empty || leftValues.length === 0 ? 1 : niceCeil(Math.max(...leftValues, 0));
+  const yMaxRight = rightValues.length === 0 ? 1 : niceCeil(Math.max(...rightValues, 0));
   const yMin = 0;
+  const rightFormat = formatYRight ?? formatY;
 
   const xAt = (index: number): number =>
     labels.length <= 1 ? pad.left + innerW / 2 : pad.left + (index / (labels.length - 1)) * innerW;
-  const yAt = (value: number): number => pad.top + innerH - ((value - yMin) / (yMax - yMin || 1)) * innerH;
+  const yAtLeft = (value: number): number => pad.top + innerH - ((value - yMin) / (yMaxLeft - yMin || 1)) * innerH;
+  const yAtRight = (value: number): number => pad.top + innerH - ((value - yMin) / (yMaxRight - yMin || 1)) * innerH;
 
-  const ticks = [0, 0.5, 1].map((fraction) => yMin + (yMax - yMin) * fraction);
+  const leftTicks = [0, 0.5, 1].map((fraction) => yMin + (yMaxLeft - yMin) * fraction);
+  const rightTicks = [0, 0.5, 1].map((fraction) => yMin + (yMaxRight - yMin) * fraction);
   const labelStep = Math.max(1, Math.ceil(labels.length / 7));
 
   return (
@@ -226,23 +243,44 @@ export function LineChart({
             role="img"
             aria-label={`${title}: ${series.map((s) => s.label).join(', ')}`}
           >
-            {ticks.map((tick) => (
-              <g key={tick}>
-                <line className="telem-line-grid" x1={pad.left} x2={pad.left + innerW} y1={yAt(tick)} y2={yAt(tick)} />
-                <text className="telem-line-axis" x={pad.left - 6} y={yAt(tick) + 3} textAnchor="end">
+            {leftTicks.map((tick) => (
+              <g key={`L${tick}`}>
+                <line
+                  className="telem-line-grid"
+                  x1={pad.left}
+                  x2={pad.left + innerW}
+                  y1={yAtLeft(tick)}
+                  y2={yAtLeft(tick)}
+                />
+                <text className="telem-line-axis" x={pad.left - 6} y={yAtLeft(tick) + 3} textAnchor="end">
                   {formatY(tick)}
                 </text>
               </g>
             ))}
-            {series.map((s) => (
-              <path
-                key={s.id}
-                className={s.dashed ? 'telem-line-path is-dashed' : 'telem-line-path'}
-                d={linePath(s.values, xAt, yAt)}
-                stroke={s.color}
-                fill="none"
-              />
-            ))}
+            {hasRight &&
+              rightTicks.map((tick) => (
+                <text
+                  key={`R${tick}`}
+                  className="telem-line-axis telem-line-axis--right"
+                  x={pad.left + innerW + 6}
+                  y={yAtRight(tick) + 3}
+                  textAnchor="start"
+                >
+                  {rightFormat(tick)}
+                </text>
+              ))}
+            {series.map((s) => {
+              const yAt = s.axis === 'right' ? yAtRight : yAtLeft;
+              return (
+                <path
+                  key={s.id}
+                  className={s.dashed ? 'telem-line-path is-dashed' : 'telem-line-path'}
+                  d={linePath(s.values, xAt, yAt)}
+                  stroke={s.color}
+                  fill="none"
+                />
+              );
+            })}
             {labels.map((label, index) =>
               index % labelStep === 0 || index === labels.length - 1 ? (
                 <text
@@ -265,6 +303,7 @@ export function LineChart({
                   style={{ background: s.color, borderColor: s.color }}
                 />
                 {s.label}
+                {s.axis === 'right' ? <span className="telem-line-axis-tag">right</span> : null}
               </li>
             ))}
           </ul>

--- a/apps/web/src/TelemetryCharts.tsx
+++ b/apps/web/src/TelemetryCharts.tsx
@@ -166,3 +166,139 @@ function polar(cx: number, cy: number, r: number, angleDeg: number): { x: number
   const rad = (angleDeg * Math.PI) / 180;
   return { x: cx + r * Math.cos(rad), y: cy - r * Math.sin(rad) };
 }
+
+export interface LineSeries {
+  id: string;
+  label: string;
+  color: string;
+  values: Array<number | null>;
+  /** Dashed stroke — used for rolling averages over the raw series. */
+  dashed?: boolean;
+}
+
+/**
+ * Multi-series line chart for trend observation.
+ *
+ * Null values break the path (a gap), so a day with no retention cohort does not
+ * invent a zero that looks like a crash. Y-axis is nice-scaled from the data.
+ */
+export function LineChart({
+  title,
+  labels,
+  series,
+  formatY = (value: number) => String(Math.round(value)),
+  emptyMessage = 'No data in this window.',
+}: {
+  title: string;
+  labels: string[];
+  series: LineSeries[];
+  formatY?: (value: number) => string;
+  emptyMessage?: string;
+}) {
+  const width = 640;
+  const height = 200;
+  const pad = { top: 16, right: 12, bottom: 28, left: 40 };
+  const innerW = width - pad.left - pad.right;
+  const innerH = height - pad.top - pad.bottom;
+
+  const allValues = series.flatMap((s) => s.values).filter((value): value is number => value !== null);
+  const empty = labels.length === 0 || allValues.length === 0;
+  const yMax = empty ? 1 : niceCeil(Math.max(...allValues, 0));
+  const yMin = 0;
+
+  const xAt = (index: number): number =>
+    labels.length <= 1 ? pad.left + innerW / 2 : pad.left + (index / (labels.length - 1)) * innerW;
+  const yAt = (value: number): number => pad.top + innerH - ((value - yMin) / (yMax - yMin || 1)) * innerH;
+
+  const ticks = [0, 0.5, 1].map((fraction) => yMin + (yMax - yMin) * fraction);
+  const labelStep = Math.max(1, Math.ceil(labels.length / 7));
+
+  return (
+    <figure className="telem-line">
+      <figcaption className="telem-line-title">{title}</figcaption>
+      {empty ? (
+        <p className="health-empty">{emptyMessage}</p>
+      ) : (
+        <>
+          <svg
+            className="telem-line-svg"
+            viewBox={`0 0 ${width} ${height}`}
+            role="img"
+            aria-label={`${title}: ${series.map((s) => s.label).join(', ')}`}
+          >
+            {ticks.map((tick) => (
+              <g key={tick}>
+                <line className="telem-line-grid" x1={pad.left} x2={pad.left + innerW} y1={yAt(tick)} y2={yAt(tick)} />
+                <text className="telem-line-axis" x={pad.left - 6} y={yAt(tick) + 3} textAnchor="end">
+                  {formatY(tick)}
+                </text>
+              </g>
+            ))}
+            {series.map((s) => (
+              <path
+                key={s.id}
+                className={s.dashed ? 'telem-line-path is-dashed' : 'telem-line-path'}
+                d={linePath(s.values, xAt, yAt)}
+                stroke={s.color}
+                fill="none"
+              />
+            ))}
+            {labels.map((label, index) =>
+              index % labelStep === 0 || index === labels.length - 1 ? (
+                <text
+                  key={`${label}-${index}`}
+                  className="telem-line-axis"
+                  x={xAt(index)}
+                  y={height - 8}
+                  textAnchor="middle"
+                >
+                  {label}
+                </text>
+              ) : null,
+            )}
+          </svg>
+          <ul className="telem-line-legend">
+            {series.map((s) => (
+              <li key={s.id}>
+                <span
+                  className={s.dashed ? 'telem-line-swatch is-dashed' : 'telem-line-swatch'}
+                  style={{ background: s.color, borderColor: s.color }}
+                />
+                {s.label}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </figure>
+  );
+}
+
+/** Polyline that gaps across nulls instead of dropping to zero. */
+function linePath(
+  values: Array<number | null>,
+  xAt: (index: number) => number,
+  yAt: (value: number) => number,
+): string {
+  let d = '';
+  let drawing = false;
+  values.forEach((value, index) => {
+    if (value === null) {
+      drawing = false;
+      return;
+    }
+    const command = drawing ? 'L' : 'M';
+    d += `${command}${xAt(index)} ${yAt(value)} `;
+    drawing = true;
+  });
+  return d.trim();
+}
+
+function niceCeil(value: number): number {
+  if (value <= 0) return 1;
+  if (value <= 1) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const normalized = value / magnitude;
+  const nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return nice * magnitude;
+}

--- a/apps/web/src/TelemetryOverview.test.tsx
+++ b/apps/web/src/TelemetryOverview.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TelemetryOverview } from './TelemetryOverview.js';
+import type { CreatorsResponse, HealthResponse, VisitsResponse } from './healthApi.js';
+
+/**
+ * The overview is the glance layer: it must show the same rates the panels below
+ * compute, and it must not invent a confident dial when a term is missing.
+ */
+
+function health(sessions = 12): HealthResponse {
+  return {
+    days: ['2026-08-06'],
+    truncated: false,
+    games: [
+      {
+        slug: 'demo',
+        sessions,
+        bounces: 0,
+        closes: 0,
+        medianPlaySeconds: 30,
+        totalPlaySeconds: 300,
+        errors: 0,
+        errorSamples: [],
+        aliveTicks: 0,
+        stalledTicks: 0,
+        stallRate: 0,
+        medianFps: null,
+        resumeTicksIgnored: 0,
+        outcomes: { won: 0, lost: 0, quit: 0 },
+        sessionsWithEnding: 0,
+        finishRate: 0,
+        zoneAdmitted: 0,
+        zoneJoined: 0,
+        zoneJoinRate: null,
+        winRate: null,
+        medianBestScore: null,
+        progressLabels: [],
+        gfxBackends: { canvas2d: 0, webgl: 0, webgl3d: 0 },
+      },
+    ],
+  };
+}
+
+function visits(overrides: Partial<VisitsResponse['funnel']> = {}): VisitsResponse {
+  return {
+    days: ['2026-08-06'],
+    truncated: false,
+    funnel: {
+      visits: 100,
+      bounces: 73,
+      visitsWithPlay: 27,
+      plays: 80,
+      depth: [
+        { plays: 1, visits: 10 },
+        { plays: 2, visits: 8 },
+        { plays: 3, visits: 9 },
+      ],
+      medianPlaysPerPlayingVisit: 3,
+      timeToFirstPlay: [
+        { upToSeconds: 10, visits: 15 },
+        { upToSeconds: 30, visits: 8 },
+        { upToSeconds: 60, visits: 4 },
+      ],
+      medianSecondsToFirstPlay: 8,
+      entries: [],
+      referrers: [],
+      campaigns: [],
+      creating: [
+        { step: 'prompt_started', visits: 10 },
+        { step: 'submission_created', visits: 1 },
+      ],
+      waitlist: [],
+      editing: [],
+      howToPlay: {
+        opens: 0,
+        visits: 0,
+        repeatVisits: 0,
+        via: [
+          { via: 'bar', opens: 0, visits: 0 },
+          { via: 'more', opens: 0, visits: 0 },
+        ],
+        byEntry: [],
+      },
+      ...overrides,
+    },
+  };
+}
+
+function creators(overrides: Partial<CreatorsResponse['metrics']> = {}): CreatorsResponse {
+  return {
+    sampled: 5,
+    metrics: {
+      published: 3,
+      eligibleForReturn: 2,
+      returnedWithin7Days: 2,
+      d7ReturnRate: 1,
+      medianBuildMinutes: 620,
+      p90BuildMinutes: 1965,
+      creators: 3,
+      gamesPerCreator: 4,
+      ...overrides,
+    },
+  };
+}
+
+function render(props: { health: HealthResponse; visits: VisitsResponse; creators: CreatorsResponse }): string {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  act(() => {
+    root.render(createElement(TelemetryOverview, props));
+  });
+  const text = host.textContent ?? '';
+  act(() => {
+    root.unmount();
+  });
+  host.remove();
+  return text;
+}
+
+describe('TelemetryOverview', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('puts the key rates and both distribution histograms on screen', () => {
+    const text = render({ health: health(), visits: visits(), creators: creators() });
+    expect(text).toContain('growth k');
+    expect(text).toContain('reached a game');
+    expect(text).toContain('27%');
+    expect(text).toContain('played → submitted');
+    expect(text).toContain('creator D7 return');
+    expect(text).toContain('Time to first play');
+    expect(text).toContain('Games per visit');
+    expect(text).toContain('≤10s');
+    expect(text).toContain('15');
+  });
+
+  it('dashes the gauges when a term has no evidence, rather than drawing a zero', () => {
+    const text = render({
+      health: health(0),
+      visits: visits({
+        visits: 0,
+        visitsWithPlay: 0,
+        bounces: 0,
+        plays: 0,
+        depth: [],
+        timeToFirstPlay: [],
+        creating: [],
+      }),
+      creators: creators({ d7ReturnRate: null, gamesPerCreator: null, published: 0 }),
+    });
+    expect(text).toContain('—');
+    expect(text).toContain('No visits in this window.');
+  });
+
+  it('labels the time-to-play buckets in human units, including the overflow', () => {
+    const text = render({
+      health: health(),
+      visits: visits({
+        visits: 3,
+        visitsWithPlay: 3,
+        plays: 3,
+        timeToFirstPlay: [
+          { upToSeconds: 30, visits: 1 },
+          { upToSeconds: 180, visits: 1 },
+          { upToSeconds: null, visits: 1 },
+        ],
+      }),
+      creators: creators(),
+    });
+    expect(text).toContain('≤30s');
+    expect(text).toContain('≤3m');
+    expect(text).toContain('slower');
+  });
+});

--- a/apps/web/src/TelemetryOverview.tsx
+++ b/apps/web/src/TelemetryOverview.tsx
@@ -1,0 +1,109 @@
+import type { CreatorsResponse, HealthResponse, VisitsResponse } from './healthApi.js';
+import { computeGrowthReading } from './growthReading.js';
+import { Gauge, Histogram, OpenGauge, type GaugeTone } from './TelemetryCharts.js';
+
+/**
+ * At-a-glance strip for the telemetry tab.
+ *
+ * Dashboard posture: rates as gauges, distributions as histograms, above the
+ * sections that carry the same numbers in prose. The strip does not invent
+ * metrics — every figure is one the panels below already compute.
+ *
+ * Gauges stay on bounded rates (0–1). Growth k is unbounded, so it gets an
+ * open dial with a goal tick at 1 (the sustainability threshold), not a
+ * percentage gauge that would pin past 100% and lie.
+ */
+
+const READABLE_COHORT = 20;
+
+function percentDisplay(value: number | null): string {
+  return value === null ? '—' : `${Math.round(value * 100)}%`;
+}
+
+function reachRate(visits: VisitsResponse): number | null {
+  const { visits: total, visitsWithPlay } = visits.funnel;
+  if (total === 0) return null;
+  return visitsWithPlay / total;
+}
+
+/** Only the documented k≥1 threshold gets a tone; other rates stay neutral. */
+function kTone(k: number | null, smallCohort: boolean): GaugeTone {
+  if (k === null) return 'idle';
+  if (smallCohort) return 'warn';
+  return k >= 1 ? 'ok' : 'warn';
+}
+
+function measuredTone(value: number | null, caution = false): GaugeTone {
+  if (value === null) return 'idle';
+  return caution ? 'warn' : 'ok';
+}
+
+function bucketLabel(upToSeconds: number | null): string {
+  if (upToSeconds === null) return 'slower';
+  if (upToSeconds < 60) return `≤${upToSeconds}s`;
+  return `≤${Math.round(upToSeconds / 60)}m`;
+}
+
+export function TelemetryOverview({
+  health,
+  visits,
+  creators,
+}: {
+  health: HealthResponse;
+  visits: VisitsResponse;
+  creators: CreatorsResponse;
+}) {
+  const reading = computeGrowthReading(health, visits, creators);
+  const reach = reachRate(visits);
+  const d7 = creators.metrics.d7ReturnRate;
+  const smallCohort = creators.metrics.eligibleForReturn < READABLE_COHORT;
+  // Dial max: enough headroom past the goal so a healthy loop still has arc left,
+  // without inventing a scale that changes every refresh. Cap the domain at the
+  // reading itself when it overshoots, so the needle never lies about overflow.
+  const kMax = reading.k === null ? 2 : Math.max(2, Math.ceil(reading.k));
+
+  const timeBars = visits.funnel.timeToFirstPlay.map((row) => ({
+    label: bucketLabel(row.upToSeconds),
+    value: row.visits,
+  }));
+  const depthBars = visits.funnel.depth.map((row) => ({
+    label: String(row.plays),
+    value: row.visits,
+  }));
+
+  return (
+    <section className="telem-overview" aria-label="Telemetry overview">
+      <div className="telem-overview-gauges">
+        <OpenGauge
+          value={reading.k}
+          display={reading.k === null ? '—' : reading.k.toFixed(2)}
+          label="growth k"
+          max={kMax}
+          goal={1}
+          tone={kTone(reading.k, smallCohort)}
+        />
+        <Gauge value={reach} display={percentDisplay(reach)} label="reached a game" tone={measuredTone(reach)} />
+        <Gauge
+          value={reading.playToCreate}
+          display={percentDisplay(reading.playToCreate)}
+          label="played → submitted"
+          tone={measuredTone(reading.playToCreate)}
+        />
+        <Gauge value={d7} display={percentDisplay(d7)} label="creator D7 return" tone={measuredTone(d7, smallCohort)} />
+      </div>
+
+      <div className="telem-overview-charts">
+        <Histogram
+          title="Time to first play"
+          bars={timeBars}
+          emptyMessage={visits.funnel.visits === 0 ? 'No visits in this window.' : 'No visit reached a game.'}
+        />
+        <Histogram
+          title="Games per visit"
+          bars={depthBars}
+          emptyMessage={visits.funnel.visits === 0 ? 'No visits in this window.' : 'No visit reached a game.'}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/TelemetryTrendsPanel.tsx
+++ b/apps/web/src/TelemetryTrendsPanel.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchTelemetryTrends, type TrendsResponse } from './healthApi.js';
+import { LineChart } from './TelemetryCharts.js';
+import {
+  rollingAverage,
+  rollingPeriods,
+  rollupTrends,
+  type RollingWindow,
+  type TrendGrain,
+} from './telemetryTrends.js';
+
+/**
+ * Trend strip for the telemetry tab: visits / plays / creations and D7 return
+ * over time, with grain and rolling-average toggles.
+ *
+ * Fetches its own window (30 / 90 days) rather than sharing the funnel's 1/7/30
+ * selector — a one-day trend chart is not a trend chart.
+ */
+
+const WINDOWS = [30, 90] as const;
+const GRAINS: Array<{ id: TrendGrain; label: string }> = [
+  { id: 'day', label: 'Day' },
+  { id: 'week', label: 'Week' },
+  { id: 'month', label: 'Month' },
+];
+const ROLLING: Array<{ id: RollingWindow; label: string }> = [
+  { id: 0, label: 'Raw' },
+  { id: 7, label: '7d avg' },
+  { id: 28, label: '28d avg' },
+];
+
+const COLOR = {
+  visits: 'var(--turquoise)',
+  plays: 'var(--accent-blue)',
+  creations: '#fbbf24',
+  retention: 'var(--turquoise)',
+};
+
+export function TelemetryTrendsPanel() {
+  const [days, setDays] = useState<(typeof WINDOWS)[number]>(30);
+  const [grain, setGrain] = useState<TrendGrain>('day');
+  const [rolling, setRolling] = useState<RollingWindow>(7);
+  const [data, setData] = useState<TrendsResponse | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'forbidden' | 'error'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    fetchTelemetryTrends(days)
+      .then((response) => {
+        if (cancelled) return;
+        if (!response) {
+          setState('forbidden');
+          return;
+        }
+        setData(response);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const rolled = useMemo(() => {
+    if (!data) return [];
+    return rollupTrends(data.activity, data.retention, grain);
+  }, [data, grain]);
+
+  const periodWindow = rollingPeriods(grain, rolling);
+
+  const activitySeries = useMemo(() => {
+    const visits = rolled.map((row) => row.visits);
+    const plays = rolled.map((row) => row.plays);
+    const creations = rolled.map((row) => row.creations);
+    if (periodWindow === 0) {
+      return [
+        { id: 'visits', label: 'Visits', color: COLOR.visits, values: visits },
+        { id: 'plays', label: 'Plays', color: COLOR.plays, values: plays },
+        { id: 'creations', label: 'Creations', color: COLOR.creations, values: creations },
+      ];
+    }
+    return [
+      {
+        id: 'visits-avg',
+        label: `Visits (${rolling}d avg)`,
+        color: COLOR.visits,
+        values: rollingAverage(visits, periodWindow),
+      },
+      {
+        id: 'plays-avg',
+        label: `Plays (${rolling}d avg)`,
+        color: COLOR.plays,
+        values: rollingAverage(plays, periodWindow),
+      },
+      {
+        id: 'creations-avg',
+        label: `Creations (${rolling}d avg)`,
+        color: COLOR.creations,
+        values: rollingAverage(creations, periodWindow),
+      },
+    ];
+  }, [rolled, periodWindow, rolling]);
+
+  const retentionSeries = useMemo(() => {
+    const rates = rolled.map((row) => row.retentionRate);
+    if (periodWindow === 0) {
+      return [{ id: 'd7', label: 'D7 return', color: COLOR.retention, values: rates }];
+    }
+    return [
+      {
+        id: 'd7-avg',
+        label: `D7 return (${rolling}d avg)`,
+        color: COLOR.retention,
+        values: rollingAverage(rates, periodWindow),
+      },
+    ];
+  }, [rolled, periodWindow, rolling]);
+
+  if (state === 'forbidden') return null;
+
+  return (
+    <section className="telem-trends" aria-label="Telemetry trends">
+      <header className="telem-trends-header">
+        <h2 className="telem-trends-title">Trends</h2>
+        <div className="telem-trends-controls">
+          <div className="health-windows" role="group" aria-label="Trend window">
+            {WINDOWS.map((window) => (
+              <button
+                key={window}
+                type="button"
+                className={window === days ? 'health-window is-active' : 'health-window'}
+                onClick={() => setDays(window)}
+              >
+                {window}d
+              </button>
+            ))}
+          </div>
+          <div className="health-windows" role="group" aria-label="Grain">
+            {GRAINS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={option.id === grain ? 'health-window is-active' : 'health-window'}
+                onClick={() => setGrain(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <div className="health-windows" role="group" aria-label="Rolling average">
+            {ROLLING.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={option.id === rolling ? 'health-window is-active' : 'health-window'}
+                onClick={() => setRolling(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {state === 'loading' && <p className="health-empty">Reading trends…</p>}
+      {state === 'error' && <p className="health-empty">Could not read trends.</p>}
+
+      {state === 'ready' && data && (
+        <>
+          <div className="telem-trends-charts">
+            <LineChart
+              title="Visits, plays, creations"
+              labels={rolled.map((row) => row.label)}
+              series={activitySeries}
+              emptyMessage="No visit activity in this window."
+            />
+            <LineChart
+              title="Creator D7 return"
+              labels={rolled.map((row) => row.label)}
+              series={retentionSeries}
+              formatY={(value) => `${Math.round(value * 100)}%`}
+              emptyMessage="No creator cohort has closed its 7-day window in this range."
+            />
+          </div>
+          <p className="health-note">
+            Activity is UTC day partitions from the visit stream. D7 return is plotted on the day a creator&apos;s
+            window closes (publish + 7), so every point is a resolved outcome
+            {data.days.length > 0 && (
+              <>
+                . Window: {data.days[0]} → {data.days[data.days.length - 1]}
+              </>
+            )}
+            {data.truncated && <>. A day hit the read cap, so some counts are a floor</>}.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/TelemetryTrendsPanel.tsx
+++ b/apps/web/src/TelemetryTrendsPanel.tsx
@@ -10,8 +10,8 @@ import {
 } from './telemetryTrends.js';
 
 /**
- * Trend strip for the telemetry tab: visits / plays / creations and D7 return
- * over time, with grain and rolling-average toggles.
+ * Trend strip for the telemetry tab: visits / plays / creations, MCP adoption,
+ * and D7 return over time, with grain and rolling-average toggles.
  *
  * Fetches its own window (30 / 90 days) rather than sharing the funnel's 1/7/30
  * selector — a one-day trend chart is not a trend chart.
@@ -34,7 +34,23 @@ const COLOR = {
   plays: 'var(--accent-blue)',
   creations: '#fbbf24',
   retention: 'var(--turquoise)',
+  selfChosen: 'var(--accent-blue)',
+  connected: '#fbbf24',
+  signaled: 'var(--turquoise)',
+  gate: '#c084fc',
 };
+
+function maybeRoll(values: number[], periodWindow: number, rolling: RollingWindow, label: string, color: string) {
+  if (periodWindow === 0) {
+    return { id: label.toLowerCase().replace(/\s+/g, '-'), label, color, values };
+  }
+  return {
+    id: `${label.toLowerCase().replace(/\s+/g, '-')}-avg`,
+    label: `${label} (${rolling}d avg)`,
+    color,
+    values: rollingAverage(values, periodWindow),
+  };
+}
 
 export function TelemetryTrendsPanel() {
   const [days, setDays] = useState<(typeof WINDOWS)[number]>(30);
@@ -66,41 +82,70 @@ export function TelemetryTrendsPanel() {
 
   const rolled = useMemo(() => {
     if (!data) return [];
-    return rollupTrends(data.activity, data.retention, grain);
+    return rollupTrends(data.activity, data.mcp ?? [], data.retention, grain);
   }, [data, grain]);
 
   const periodWindow = rollingPeriods(grain, rolling);
+
+  const totals = useMemo(() => {
+    const selfChosen = rolled.reduce((sum, row) => sum + row.selfChosen, 0);
+    const platformChosen = rolled.reduce((sum, row) => sum + row.platformChosen, 0);
+    const connected = rolled.reduce((sum, row) => sum + row.connected, 0);
+    const signaled = rolled.reduce((sum, row) => sum + row.signaled, 0);
+    const chosen = selfChosen + platformChosen;
+    return {
+      selfChosen,
+      platformChosen,
+      connected,
+      signaled,
+      selfShare: chosen === 0 ? null : selfChosen / chosen,
+      connectToSignal: connected === 0 ? null : signaled / connected,
+    };
+  }, [rolled]);
 
   const activitySeries = useMemo(() => {
     const visits = rolled.map((row) => row.visits);
     const plays = rolled.map((row) => row.plays);
     const creations = rolled.map((row) => row.creations);
-    if (periodWindow === 0) {
-      return [
-        { id: 'visits', label: 'Visits', color: COLOR.visits, values: visits },
-        { id: 'plays', label: 'Plays', color: COLOR.plays, values: plays },
-        { id: 'creations', label: 'Creations', color: COLOR.creations, values: creations },
-      ];
-    }
+    const visitsSeries = maybeRoll(visits, periodWindow, rolling, 'Visits', COLOR.visits);
+    const playsSeries = maybeRoll(plays, periodWindow, rolling, 'Plays', COLOR.plays);
+    const creationsSeries = {
+      ...maybeRoll(creations, periodWindow, rolling, 'Creations', COLOR.creations),
+      axis: 'right' as const,
+    };
+    return [visitsSeries, playsSeries, creationsSeries];
+  }, [rolled, periodWindow, rolling]);
+
+  const mcpSeries = useMemo(() => {
     return [
-      {
-        id: 'visits-avg',
-        label: `Visits (${rolling}d avg)`,
-        color: COLOR.visits,
-        values: rollingAverage(visits, periodWindow),
-      },
-      {
-        id: 'plays-avg',
-        label: `Plays (${rolling}d avg)`,
-        color: COLOR.plays,
-        values: rollingAverage(plays, periodWindow),
-      },
-      {
-        id: 'creations-avg',
-        label: `Creations (${rolling}d avg)`,
-        color: COLOR.creations,
-        values: rollingAverage(creations, periodWindow),
-      },
+      maybeRoll(
+        rolled.map((row) => row.selfChosen),
+        periodWindow,
+        rolling,
+        'Self chosen',
+        COLOR.selfChosen,
+      ),
+      maybeRoll(
+        rolled.map((row) => row.connected),
+        periodWindow,
+        rolling,
+        'Connected',
+        COLOR.connected,
+      ),
+      maybeRoll(
+        rolled.map((row) => row.signaled),
+        periodWindow,
+        rolling,
+        'Agent signaled',
+        COLOR.signaled,
+      ),
+      maybeRoll(
+        rolled.map((row) => row.gateVerdicts),
+        periodWindow,
+        rolling,
+        'Gate verdicts',
+        COLOR.gate,
+      ),
     ];
   }, [rolled, periodWindow, rolling]);
 
@@ -170,12 +215,41 @@ export function TelemetryTrendsPanel() {
 
       {state === 'ready' && data && (
         <>
+          <ul className="telem-trends-kpis">
+            <li>
+              <span className="telem-trends-kpi-value">
+                {totals.selfShare === null ? '—' : `${Math.round(totals.selfShare * 100)}%`}
+              </span>
+              <span className="telem-trends-kpi-label">chose self (MCP)</span>
+            </li>
+            <li>
+              <span className="telem-trends-kpi-value">{totals.connected}</span>
+              <span className="telem-trends-kpi-label">connected</span>
+            </li>
+            <li>
+              <span className="telem-trends-kpi-value">{totals.signaled}</span>
+              <span className="telem-trends-kpi-label">agent signaled</span>
+            </li>
+            <li>
+              <span className="telem-trends-kpi-value">
+                {totals.connectToSignal === null ? '—' : `${Math.round(totals.connectToSignal * 100)}%`}
+              </span>
+              <span className="telem-trends-kpi-label">connect → signal</span>
+            </li>
+          </ul>
+
           <div className="telem-trends-charts">
             <LineChart
-              title="Visits, plays, creations"
+              title="Visits & plays (creations on right)"
               labels={rolled.map((row) => row.label)}
               series={activitySeries}
               emptyMessage="No visit activity in this window."
+            />
+            <LineChart
+              title="MCP adoption (self-build)"
+              labels={rolled.map((row) => row.label)}
+              series={mcpSeries}
+              emptyMessage="No studio / MCP steps in this window."
             />
             <LineChart
               title="Creator D7 return"
@@ -186,8 +260,9 @@ export function TelemetryTrendsPanel() {
             />
           </div>
           <p className="health-note">
-            Activity is UTC day partitions from the visit stream. D7 return is plotted on the day a creator&apos;s
-            window closes (publish + 7), so every point is a resolved outcome
+            Activity and MCP rungs are UTC day partitions from the visit stream (`studio_step` for self-build). D7
+            return is plotted on the day a creator&apos;s window closes (publish + 7), so every point is a resolved
+            outcome
             {data.days.length > 0 && (
               <>
                 . Window: {data.days[0]} → {data.days[data.days.length - 1]}

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -110,24 +110,6 @@ describe('VisitFunnelPanel', () => {
     expect(text).toContain('direct');
   });
 
-  it('labels the time-to-play buckets in human units, including the overflow', () => {
-    const text = render(
-      response({
-        visits: 3,
-        visitsWithPlay: 3,
-        plays: 3,
-        timeToFirstPlay: [
-          { upToSeconds: 30, visits: 1 },
-          { upToSeconds: 180, visits: 1 },
-          { upToSeconds: null, visits: 1 },
-        ],
-      }),
-    );
-    expect(text).toContain('≤ 30s');
-    expect(text).toContain('≤ 3m');
-    expect(text).toContain('slower');
-  });
-
   it('shows campaigns only when some visit carried UTM values', () => {
     expect(render(response({ visits: 2 }))).not.toContain('Campaigns');
 
@@ -141,7 +123,7 @@ describe('VisitFunnelPanel', () => {
     expect(withCampaign).toContain('linkedin / beta');
   });
 
-  it('renders the depth table so a multi-game sitting is visible', () => {
+  it('still reports median depth after the distribution charts moved to the overview', () => {
     const text = render(
       response({
         visits: 2,
@@ -154,8 +136,8 @@ describe('VisitFunnelPanel', () => {
         ],
       }),
     );
-    expect(text).toContain('Games per visit');
     expect(text).toContain('median games / playing visit');
+    expect(text).toContain('2');
   });
 
   it('renders the waitlist funnel as a share of clicks, not of all visits', () => {

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -7,6 +7,10 @@ import { type VisitFunnel, type VisitsResponse } from './healthApi.js';
  * before that and which no per-game view can reach: how many arrivals there were, how
  * many reached a game at all, how fast, how deep, and where they came from.
  *
+ * Time-to-first-play and games-per-visit distributions live in TelemetryOverview at
+ * the top of the tab (histograms); this panel keeps the medians in its headline row
+ * and the acquisition / creation / edit funnels below.
+ *
  * Untranslated for the same reason as the rest of this page — a single-operator
  * surface no player can reach.
  */
@@ -78,12 +82,6 @@ const HOW_TO_ENTRY_LABELS: Record<string, string> = {
   home: 'arcade (home)',
 };
 
-function bucketLabel(upToSeconds: number | null): string {
-  if (upToSeconds === null) return 'slower';
-  if (upToSeconds < 60) return `≤ ${upToSeconds}s`;
-  return `≤ ${Math.round(upToSeconds / 60)}m`;
-}
-
 /** A labelled count with its share of visits, for the small ranked tables. */
 function RankedRows({ rows, whole }: { rows: Array<{ label: string; visits: number; plays: number }>; whole: number }) {
   return (
@@ -150,58 +148,6 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
       </ul>
 
       <div className="funnel-grid">
-        <div className="funnel-block">
-          <h3>Time to first play</h3>
-          {funnel.timeToFirstPlay.length === 0 ? (
-            <p className="health-empty">No visit reached a game.</p>
-          ) : (
-            <table className="health-table">
-              <thead>
-                <tr>
-                  <th scope="col">Within</th>
-                  <th scope="col" className="num">
-                    Visits
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {funnel.timeToFirstPlay.map((row) => (
-                  <tr key={String(row.upToSeconds)}>
-                    <td>{bucketLabel(row.upToSeconds)}</td>
-                    <td className="num">{row.visits}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
-
-        <div className="funnel-block">
-          <h3>Games per visit</h3>
-          {funnel.depth.length === 0 ? (
-            <p className="health-empty">No visit reached a game.</p>
-          ) : (
-            <table className="health-table">
-              <thead>
-                <tr>
-                  <th scope="col">Games</th>
-                  <th scope="col" className="num">
-                    Visits
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {funnel.depth.map((row) => (
-                  <tr key={row.plays}>
-                    <td>{row.plays}</td>
-                    <td className="num">{row.visits}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
-
         <div className="funnel-block">
           <h3>Creating</h3>
           {funnel.creating.every((row) => row.visits === 0) ? (

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -162,6 +162,16 @@ export interface DailyActivityPoint {
   truncated: boolean;
 }
 
+export interface DailyMcpPoint {
+  date: string;
+  selfChosen: number;
+  platformChosen: number;
+  connected: number;
+  signaled: number;
+  gateVerdicts: number;
+  truncated: boolean;
+}
+
 export interface DailyRetentionPoint {
   date: string;
   eligible: number;
@@ -173,6 +183,7 @@ export interface TrendsResponse {
   days: string[];
   truncated: boolean;
   activity: DailyActivityPoint[];
+  mcp: DailyMcpPoint[];
   retention: DailyRetentionPoint[];
 }
 

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -154,6 +154,40 @@ export async function fetchCreatorMetrics(): Promise<CreatorsResponse | null> {
   return (await res.json()) as CreatorsResponse;
 }
 
+export interface DailyActivityPoint {
+  date: string;
+  visits: number;
+  plays: number;
+  creations: number;
+  truncated: boolean;
+}
+
+export interface DailyRetentionPoint {
+  date: string;
+  eligible: number;
+  returned: number;
+  rate: number | null;
+}
+
+export interface TrendsResponse {
+  days: string[];
+  truncated: boolean;
+  activity: DailyActivityPoint[];
+  retention: DailyRetentionPoint[];
+}
+
+/** Same 404-means-not-for-you contract as the other operator reads. */
+export async function fetchTelemetryTrends(days: number): Promise<TrendsResponse | null> {
+  const res = await fetch(`${API_BASE}/api/admin/telemetry/trends?days=${days}`, {
+    credentials: 'include',
+  });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) {
+    throw new Error(`Trends request failed (${res.status})`);
+  }
+  return (await res.json()) as TrendsResponse;
+}
+
 /**
  * The stored output of the nightly scorecard sweep, as written for IL-3.
  *

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8389,6 +8389,178 @@ button.builder-mode-selector:disabled {
   margin: 1.5rem 0 2.5rem;
 }
 
+/* ——— Telemetry overview: gauges + distribution histograms ——— */
+.telem-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 0.5rem 0 2rem;
+  padding: 1.25rem 1.25rem 1.5rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.telem-overview-gauges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
+  gap: 0.75rem 1rem;
+  justify-items: center;
+}
+
+.telem-overview-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  gap: 1.5rem;
+}
+
+.telem-gauge {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  min-width: 0;
+  width: 100%;
+  max-width: 8.5rem;
+}
+
+.telem-gauge-svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.telem-gauge-track {
+  stroke: var(--panel-border);
+  stroke-width: 8;
+  stroke-linecap: round;
+}
+
+.telem-gauge-fill {
+  stroke: var(--turquoise);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+.telem-gauge--warn .telem-gauge-fill {
+  stroke: #fbbf24;
+}
+
+.telem-gauge--bad .telem-gauge-fill {
+  stroke: var(--error);
+}
+
+.telem-gauge--idle .telem-gauge-fill,
+.telem-gauge.is-empty .telem-gauge-fill {
+  stroke: var(--muted);
+}
+
+.telem-gauge-target {
+  stroke: var(--text);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  opacity: 0.55;
+}
+
+.telem-gauge-value {
+  fill: var(--turquoise);
+  font-size: 1.15rem;
+  font-weight: 600;
+  font-family: inherit;
+}
+
+.telem-gauge--warn .telem-gauge-value {
+  fill: #fbbf24;
+}
+
+.telem-gauge--bad .telem-gauge-value {
+  fill: var(--error);
+}
+
+.telem-gauge.is-empty .telem-gauge-value,
+.telem-gauge--idle .telem-gauge-value {
+  fill: var(--muted);
+}
+
+.telem-gauge-label {
+  font-size: 0.75rem;
+  line-height: 1.25;
+  color: var(--muted);
+  text-align: center;
+}
+
+.telem-histogram {
+  margin: 0;
+  min-width: 0;
+}
+
+.telem-histogram-title {
+  margin: 0 0 0.65rem;
+  font-size: 0.9375rem;
+  color: var(--text);
+  font-style: normal;
+}
+
+.telem-histogram-plot {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  min-height: 9rem;
+  padding-top: 0.25rem;
+}
+
+.telem-histogram-col {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  height: 9rem;
+}
+
+.telem-histogram-count {
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.telem-histogram-track {
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: 2.25rem;
+  display: flex;
+  align-items: flex-end;
+  border-radius: 4px 4px 0 0;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.telem-histogram-bar {
+  width: 100%;
+  min-height: 2px;
+  border-radius: 4px 4px 0 0;
+  background: var(--turquoise);
+  transition: height 0.35s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .telem-histogram-bar,
+  .telem-gauge-fill {
+    transition: none;
+  }
+}
+
+.telem-histogram-label {
+  font-size: 0.7rem;
+  line-height: 1.2;
+  color: var(--muted);
+  text-align: center;
+  word-break: break-word;
+}
+
 .funnel h2,
 .health-section-title {
   margin: 0 0 0.75rem;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8601,6 +8601,36 @@ button.builder-mode-selector:disabled {
   .telem-trends-charts {
     grid-template-columns: 1fr 1fr;
   }
+
+  .telem-trends-charts > :last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+}
+
+.telem-trends-kpis {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 1.75rem;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  list-style: none;
+}
+
+.telem-trends-kpis li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.telem-trends-kpi-value {
+  font-size: 1.25rem;
+  line-height: 1.1;
+  color: var(--turquoise);
+}
+
+.telem-trends-kpi-label {
+  font-size: 0.75rem;
+  color: var(--muted);
 }
 
 .telem-line {
@@ -8630,6 +8660,18 @@ button.builder-mode-selector:disabled {
   fill: var(--muted);
   font-size: 10px;
   font-family: inherit;
+}
+
+.telem-line-axis--right {
+  fill: #fbbf24;
+}
+
+.telem-line-axis-tag {
+  margin-left: 0.25rem;
+  font-size: 0.65rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .telem-line-path {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8561,6 +8561,118 @@ button.builder-mode-selector:disabled {
   word-break: break-word;
 }
 
+/* ——— Telemetry trends: time series over visits / plays / creations / D7 ——— */
+.telem-trends {
+  margin: 0 0 2rem;
+  padding: 1.25rem 1.25rem 1.5rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.telem-trends-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.telem-trends-title {
+  margin: 0;
+  font-size: 1.125rem;
+  color: var(--text);
+}
+
+.telem-trends-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.telem-trends-charts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .telem-trends-charts {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.telem-line {
+  margin: 0;
+  min-width: 0;
+}
+
+.telem-line-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.9375rem;
+  color: var(--text);
+  font-style: normal;
+}
+
+.telem-line-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.telem-line-grid {
+  stroke: var(--panel-border);
+  stroke-width: 1;
+}
+
+.telem-line-axis {
+  fill: var(--muted);
+  font-size: 10px;
+  font-family: inherit;
+}
+
+.telem-line-path {
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.telem-line-path.is-dashed {
+  stroke-dasharray: 5 4;
+  stroke-width: 2.25;
+}
+
+.telem-line-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.telem-line-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.telem-line-swatch {
+  width: 0.75rem;
+  height: 0.25rem;
+  border-radius: 1px;
+  display: inline-block;
+}
+
+.telem-line-swatch.is-dashed {
+  background: transparent !important;
+  border-top: 2px dashed;
+  height: 0;
+}
+
 .funnel h2,
 .health-section-title {
   margin: 0 0 0.75rem;

--- a/apps/web/src/telemetryTrends.test.ts
+++ b/apps/web/src/telemetryTrends.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { rollingAverage, rollingPeriods, rollupTrends } from './telemetryTrends.js';
+
+describe('telemetryTrends rollups', () => {
+  it('passes daily points through and rolls weeks', () => {
+    const activity = [
+      { date: '2026-08-03', visits: 10, plays: 4, creations: 1, truncated: false },
+      { date: '2026-08-04', visits: 5, plays: 2, creations: 0, truncated: false },
+    ];
+    const retention = [
+      { date: '2026-08-03', eligible: 2, returned: 1, rate: 0.5 },
+      { date: '2026-08-04', eligible: 0, returned: 0, rate: null },
+    ];
+    expect(rollupTrends(activity, retention, 'day')).toHaveLength(2);
+    expect(rollupTrends(activity, retention, 'week')[0]).toMatchObject({
+      visits: 15,
+      plays: 6,
+      creations: 1,
+      retentionEligible: 2,
+      retentionReturned: 1,
+      retentionRate: 0.5,
+    });
+  });
+
+  it('maps calendar rolling windows onto grain periods', () => {
+    expect(rollingPeriods('day', 7)).toBe(7);
+    expect(rollingPeriods('week', 28)).toBe(4);
+    expect(rollingPeriods('month', 28)).toBe(1);
+    expect(rollingAverage([2, 4, 6], 2)).toEqual([2, 3, 5]);
+  });
+});

--- a/apps/web/src/telemetryTrends.test.ts
+++ b/apps/web/src/telemetryTrends.test.ts
@@ -2,20 +2,45 @@ import { describe, expect, it } from 'vitest';
 import { rollingAverage, rollingPeriods, rollupTrends } from './telemetryTrends.js';
 
 describe('telemetryTrends rollups', () => {
-  it('passes daily points through and rolls weeks', () => {
+  it('passes daily points through and rolls weeks including MCP rungs', () => {
     const activity = [
       { date: '2026-08-03', visits: 10, plays: 4, creations: 1, truncated: false },
       { date: '2026-08-04', visits: 5, plays: 2, creations: 0, truncated: false },
+    ];
+    const mcp = [
+      {
+        date: '2026-08-03',
+        selfChosen: 2,
+        platformChosen: 1,
+        connected: 1,
+        signaled: 1,
+        gateVerdicts: 0,
+        truncated: false,
+      },
+      {
+        date: '2026-08-04',
+        selfChosen: 0,
+        platformChosen: 1,
+        connected: 0,
+        signaled: 0,
+        gateVerdicts: 1,
+        truncated: false,
+      },
     ];
     const retention = [
       { date: '2026-08-03', eligible: 2, returned: 1, rate: 0.5 },
       { date: '2026-08-04', eligible: 0, returned: 0, rate: null },
     ];
-    expect(rollupTrends(activity, retention, 'day')).toHaveLength(2);
-    expect(rollupTrends(activity, retention, 'week')[0]).toMatchObject({
+    expect(rollupTrends(activity, mcp, retention, 'day')).toHaveLength(2);
+    expect(rollupTrends(activity, mcp, retention, 'week')[0]).toMatchObject({
       visits: 15,
       plays: 6,
       creations: 1,
+      selfChosen: 2,
+      platformChosen: 2,
+      connected: 1,
+      signaled: 1,
+      gateVerdicts: 1,
       retentionEligible: 2,
       retentionReturned: 1,
       retentionRate: 0.5,

--- a/apps/web/src/telemetryTrends.ts
+++ b/apps/web/src/telemetryTrends.ts
@@ -1,4 +1,4 @@
-import type { DailyActivityPoint, DailyRetentionPoint } from './healthApi.js';
+import type { DailyActivityPoint, DailyMcpPoint, DailyRetentionPoint } from './healthApi.js';
 
 /**
  * Client-side rollups over the daily trends payload.
@@ -19,6 +19,11 @@ export interface RolledTrendPoint {
   visits: number;
   plays: number;
   creations: number;
+  selfChosen: number;
+  platformChosen: number;
+  connected: number;
+  signaled: number;
+  gateVerdicts: number;
   retentionRate: number | null;
   retentionEligible: number;
   retentionReturned: number;
@@ -27,23 +32,32 @@ export interface RolledTrendPoint {
 
 export function rollupTrends(
   activity: DailyActivityPoint[],
+  mcp: DailyMcpPoint[],
   retention: DailyRetentionPoint[],
   grain: TrendGrain,
 ): RolledTrendPoint[] {
+  const mcpByDate = new Map(mcp.map((row) => [row.date, row]));
+  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
+
   if (grain === 'day') {
-    const byDate = new Map(retention.map((row) => [row.date, row]));
     return activity.map((row) => {
-      const ret = byDate.get(row.date);
+      const mcpRow = mcpByDate.get(row.date);
+      const ret = retentionByDate.get(row.date);
       return {
         key: row.date,
         label: row.date.slice(5),
         visits: row.visits,
         plays: row.plays,
         creations: row.creations,
+        selfChosen: mcpRow?.selfChosen ?? 0,
+        platformChosen: mcpRow?.platformChosen ?? 0,
+        connected: mcpRow?.connected ?? 0,
+        signaled: mcpRow?.signaled ?? 0,
+        gateVerdicts: mcpRow?.gateVerdicts ?? 0,
         retentionRate: ret?.rate ?? null,
         retentionEligible: ret?.eligible ?? 0,
         retentionReturned: ret?.returned ?? 0,
-        truncated: row.truncated,
+        truncated: row.truncated || mcpRow?.truncated === true,
       };
     });
   }
@@ -55,12 +69,16 @@ export function rollupTrends(
       visits: number;
       plays: number;
       creations: number;
+      selfChosen: number;
+      platformChosen: number;
+      connected: number;
+      signaled: number;
+      gateVerdicts: number;
       retentionEligible: number;
       retentionReturned: number;
       truncated: boolean;
     }
   >();
-  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
 
   for (const row of activity) {
     const { key, label } = periodKey(row.date, grain);
@@ -69,6 +87,11 @@ export function rollupTrends(
       visits: 0,
       plays: 0,
       creations: 0,
+      selfChosen: 0,
+      platformChosen: 0,
+      connected: 0,
+      signaled: 0,
+      gateVerdicts: 0,
       retentionEligible: 0,
       retentionReturned: 0,
       truncated: false,
@@ -76,6 +99,15 @@ export function rollupTrends(
     bucket.visits += row.visits;
     bucket.plays += row.plays;
     bucket.creations += row.creations;
+    const mcpRow = mcpByDate.get(row.date);
+    if (mcpRow) {
+      bucket.selfChosen += mcpRow.selfChosen;
+      bucket.platformChosen += mcpRow.platformChosen;
+      bucket.connected += mcpRow.connected;
+      bucket.signaled += mcpRow.signaled;
+      bucket.gateVerdicts += mcpRow.gateVerdicts;
+      if (mcpRow.truncated) bucket.truncated = true;
+    }
     if (row.truncated) bucket.truncated = true;
     const ret = retentionByDate.get(row.date);
     if (ret) {
@@ -91,6 +123,11 @@ export function rollupTrends(
     visits: bucket.visits,
     plays: bucket.plays,
     creations: bucket.creations,
+    selfChosen: bucket.selfChosen,
+    platformChosen: bucket.platformChosen,
+    connected: bucket.connected,
+    signaled: bucket.signaled,
+    gateVerdicts: bucket.gateVerdicts,
     retentionEligible: bucket.retentionEligible,
     retentionReturned: bucket.retentionReturned,
     retentionRate: bucket.retentionEligible === 0 ? null : bucket.retentionReturned / bucket.retentionEligible,

--- a/apps/web/src/telemetryTrends.ts
+++ b/apps/web/src/telemetryTrends.ts
@@ -1,0 +1,142 @@
+import type { DailyActivityPoint, DailyRetentionPoint } from './healthApi.js';
+
+/**
+ * Client-side rollups over the daily trends payload.
+ *
+ * The API ships daily points only (one source of truth, one read budget). Grain and
+ * rolling averages are toggles an operator flips while looking — recomputing them
+ * here keeps those clicks free of another Firestore walk.
+ *
+ * Arithmetic mirrors apps/api/src/telemetry-trends.ts; keep the two in step.
+ */
+
+export type TrendGrain = 'day' | 'week' | 'month';
+export type RollingWindow = 0 | 7 | 28;
+
+export interface RolledTrendPoint {
+  key: string;
+  label: string;
+  visits: number;
+  plays: number;
+  creations: number;
+  retentionRate: number | null;
+  retentionEligible: number;
+  retentionReturned: number;
+  truncated: boolean;
+}
+
+export function rollupTrends(
+  activity: DailyActivityPoint[],
+  retention: DailyRetentionPoint[],
+  grain: TrendGrain,
+): RolledTrendPoint[] {
+  if (grain === 'day') {
+    const byDate = new Map(retention.map((row) => [row.date, row]));
+    return activity.map((row) => {
+      const ret = byDate.get(row.date);
+      return {
+        key: row.date,
+        label: row.date.slice(5),
+        visits: row.visits,
+        plays: row.plays,
+        creations: row.creations,
+        retentionRate: ret?.rate ?? null,
+        retentionEligible: ret?.eligible ?? 0,
+        retentionReturned: ret?.returned ?? 0,
+        truncated: row.truncated,
+      };
+    });
+  }
+
+  const buckets = new Map<
+    string,
+    {
+      label: string;
+      visits: number;
+      plays: number;
+      creations: number;
+      retentionEligible: number;
+      retentionReturned: number;
+      truncated: boolean;
+    }
+  >();
+  const retentionByDate = new Map(retention.map((row) => [row.date, row]));
+
+  for (const row of activity) {
+    const { key, label } = periodKey(row.date, grain);
+    const bucket = buckets.get(key) ?? {
+      label,
+      visits: 0,
+      plays: 0,
+      creations: 0,
+      retentionEligible: 0,
+      retentionReturned: 0,
+      truncated: false,
+    };
+    bucket.visits += row.visits;
+    bucket.plays += row.plays;
+    bucket.creations += row.creations;
+    if (row.truncated) bucket.truncated = true;
+    const ret = retentionByDate.get(row.date);
+    if (ret) {
+      bucket.retentionEligible += ret.eligible;
+      bucket.retentionReturned += ret.returned;
+    }
+    buckets.set(key, bucket);
+  }
+
+  return Array.from(buckets, ([key, bucket]) => ({
+    key,
+    label: bucket.label,
+    visits: bucket.visits,
+    plays: bucket.plays,
+    creations: bucket.creations,
+    retentionEligible: bucket.retentionEligible,
+    retentionReturned: bucket.retentionReturned,
+    retentionRate: bucket.retentionEligible === 0 ? null : bucket.retentionReturned / bucket.retentionEligible,
+    truncated: bucket.truncated,
+  }));
+}
+
+export function rollingAverage(values: Array<number | null>, window: number): Array<number | null> {
+  const size = Math.max(1, Math.floor(window));
+  return values.map((_, index) => {
+    const from = Math.max(0, index - size + 1);
+    let sum = 0;
+    let count = 0;
+    for (let i = from; i <= index; i += 1) {
+      const value = values[i];
+      if (value === null) continue;
+      sum += value;
+      count += 1;
+    }
+    return count === 0 ? null : sum / count;
+  });
+}
+
+/**
+ * Map a calendar rolling window (7d / 28d) onto the current grain.
+ * Day grain uses the window as-is; week ≈ window/7 periods; month ≈ window/30.
+ */
+export function rollingPeriods(grain: TrendGrain, windowDays: RollingWindow): number {
+  if (windowDays === 0) return 0;
+  if (grain === 'day') return windowDays;
+  if (grain === 'week') return Math.max(1, Math.round(windowDays / 7));
+  return Math.max(1, Math.round(windowDays / 30));
+}
+
+function periodKey(dateStr: string, grain: TrendGrain): { key: string; label: string } {
+  if (grain === 'month') {
+    const key = dateStr.slice(0, 7);
+    return { key, label: key };
+  }
+  const start = weekStart(dateStr);
+  return { key: start, label: `w ${start.slice(5)}` };
+}
+
+function weekStart(dateStr: string): string {
+  const date = new Date(`${dateStr}T00:00:00.000Z`);
+  const day = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - day);
+  return date.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an at-a-glance overview and **time-series trends** to `/admin/telemetry`.

### Overview
- Gauges + histograms for the headline rates and visit distributions

### Trends
- **Visits & plays** on the left axis; **creations on the right axis** (so low-volume creates stay readable)
- **MCP adoption** from `studio_step`: self chosen → connected → agent signaled → gate verdicts
- Window KPIs: % chose self, connected, signaled, connect→signal
- Day / Week / Month grain, Raw / 7d / 28d rolling averages, 30d / 90d window
- D7 return on its own chart (eligibility day = publish + 7)
- `GET /api/admin/telemetry/trends`

## Screenshots

Trends (dual-axis activity + MCP + D7):

[Telemetry trends](https://cursor.com/agents/bc-a2d2662b-1577-4ca1-8716-c564dfcedce3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftelemetry-trends.png)

Full tab:

[Telemetry full](https://cursor.com/agents/bc-a2d2662b-1577-4ca1-8716-c564dfcedce3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftelemetry-full.png)

## Test plan

- [x] Unit/route tests for MCP daily summarizer and rollups
- [x] Dual-axis line chart + GameHealthView mock updated for `mcp`
- [x] Local screenshots
- [ ] Spot-check on a live operator session after merge


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d2662b-1577-4ca1-8716-c564dfcedce3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d2662b-1577-4ca1-8716-c564dfcedce3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

