### PR TITLE
Stop moderation reading our own identifiers as phone numbers

### DIFF
--- a/apps/api/src/moderation-terms.ts
+++ b/apps/api/src/moderation-terms.ts
@@ -104,7 +104,14 @@ export const PII_PATTERNS: RegExp[] = [
   // was refused as PII (owner, 2026-08-06), and engine SHAs like
   // 648092d7e36bc302d981e58c842829b6b4b8029f matched the same way. A phone number is
   // not glued to letters; a version id always is.
-  /(?<![A-Za-z0-9])(\+?\d{1,3}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}(?![A-Za-z0-9])/,
+  //
+  // The extension suffix is matched rather than merely tolerated. A bare trailing
+  // boundary rejected 555-123-4567x89 outright — the compact form people actually
+  // write — so an x/ext tail is now part of the number. That keeps the boundary
+  // meaningful: the only letters allowed to follow are the ones that mean "extension",
+  // which is what separates a phone from an identifier rather than "any letter at all"
+  // (Codex, #626).
+  /(?<![A-Za-z0-9])(\+?\d{1,3}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}(?:\s?(?:x|ext\.?)\s?\d{1,5})?(?![A-Za-z0-9])/i,
   /\b\d{1,5}\s+[a-ząćęłńóśźż]+\s+(street|st\.|avenue|ave\.|road|rd\.|ulica|ul\.)\b/i, // street address
 ];
 

--- a/apps/api/src/moderation-terms.ts
+++ b/apps/api/src/moderation-terms.ts
@@ -97,7 +97,14 @@ export const CATEGORY_TERMS: CategoryTerms[] = [
 // PII patterns don't need en/pl split — email/phone/address shapes are language-agnostic.
 export const PII_PATTERNS: RegExp[] = [
   /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i, // email
-  /(\+?\d{1,3}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}/, // phone-ish digit run
+  // Phone-ish digit run, anchored so it cannot fire inside a longer alphanumeric token.
+  //
+  // Without the boundaries this matched the digits buried in our own identifiers: a
+  // creator asking to "show the screenshot from delivery v20260806T005029733Z-38da4c"
+  // was refused as PII (owner, 2026-08-06), and engine SHAs like
+  // 648092d7e36bc302d981e58c842829b6b4b8029f matched the same way. A phone number is
+  // not glued to letters; a version id always is.
+  /(?<![A-Za-z0-9])(\+?\d{1,3}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}(?![A-Za-z0-9])/,
   /\b\d{1,5}\s+[a-ząćęłńóśźż]+\s+(street|st\.|avenue|ave\.|road|rd\.|ulica|ul\.)\b/i, // street address
 ];
 

--- a/apps/api/src/moderation.test.ts
+++ b/apps/api/src/moderation.test.ts
@@ -61,6 +61,11 @@ describe('moderateText', () => {
     expect(moderateText('call 555-123-4567')).toMatchObject({ allowed: false, category: 'pii' });
     expect(moderateText('(555) 123 4567')).toMatchObject({ allowed: false, category: 'pii' });
     expect(moderateText('reach me on 5551234567')).toMatchObject({ allowed: false, category: 'pii' });
+    // Extensions, including the compact form. Anchoring the pattern against trailing
+    // letters rejected this outright until the x/ext tail became part of the number.
+    for (const withExtension of ['555-123-4567x89', '555-123-4567 x89', '555-123-4567 ext. 89']) {
+      expect(moderateText(withExtension)).toMatchObject({ allowed: false, category: 'pii' });
+    }
   });
 
   it('does not read our own identifiers as a phone number', () => {

--- a/apps/api/src/moderation.test.ts
+++ b/apps/api/src/moderation.test.ts
@@ -57,15 +57,31 @@ describe('moderateText', () => {
       category: 'pii',
     });
     expect(moderateText('call me at +48 512 345 678')).toMatchObject({ allowed: false, category: 'pii' });
+    // Still caught in the shapes people actually write them in.
+    expect(moderateText('call 555-123-4567')).toMatchObject({ allowed: false, category: 'pii' });
+    expect(moderateText('(555) 123 4567')).toMatchObject({ allowed: false, category: 'pii' });
+    expect(moderateText('reach me on 5551234567')).toMatchObject({ allowed: false, category: 'pii' });
+  });
+
+  it('does not read our own identifiers as a phone number', () => {
+    // Observed 2026-08-06: a creator asking to "show the screenshot from delivery
+    // v20260806T005029733Z-38da4c" was refused as PII. The phone pattern had no
+    // boundaries, so it fired on the digits buried inside a version id — and on engine
+    // SHAs the same way. Every one of these is a string our own tools hand the agent.
+    for (const text of [
+      'Show the latest preview screenshot from delivery v20260806T005029733Z-38da4c.',
+      'delivery v20260806T011419323Z-669ea1',
+      'built against engine 648092d7e36bc302d981e58c842829b6b4b8029f',
+      'kitEngineRef=bab4c2a46edb5f143779da6820cb2a6810bb8f9f',
+      'buildId a257d859-a09d-4bab-8a16-00ee973bf14b',
+    ]) {
+      expect(moderateText(text)).toEqual({ allowed: true });
+    }
   });
 
   it('can allow PII when a contact body is expected to name a person', () => {
-    expect(
-      moderateText('Please call me back at +48 512 345 678', { allowPii: true }),
-    ).toEqual({ allowed: true });
-    expect(
-      moderateText('Also email other@example.com if needed', { allowPii: true }),
-    ).toEqual({ allowed: true });
+    expect(moderateText('Please call me back at +48 512 345 678', { allowPii: true })).toEqual({ allowed: true });
+    expect(moderateText('Also email other@example.com if needed', { allowPii: true })).toEqual({ allowed: true });
   });
 
   it('rejects specs with too many outbound links', () => {


### PR DESCRIPTION
From the owner's call ledger. A creator asking to *"show the latest preview screenshot from delivery `v20260806T005029733Z-38da4c`"* was refused with `content_rejected`, `category: pii` — and the agent spent two calls working out why.

## The cause

The phone pattern had **no boundaries**:

```js
/(\+?\d{1,3}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}/
```

So it fired on digit runs buried inside longer alphanumeric tokens — `20260806` out of a version id, `648092` out of an engine SHA:

| input | matched as "phone" |
|---|---|
| `v20260806T005029733Z-38da4c` | `20260806` |
| `648092d7e36bc302d981e58c842829b6b4b8029f` | `648092` |

**Those are strings our own tools hand the agent.** `get_kit` returns the engineRef, `submit_sources` returns the deliveryId — so quoting one back to us was enough to be refused.

## The fix

Anchored on both sides against alphanumerics. A phone number is not glued to letters; a version id always is.

Deliberately the smallest change that holds. The pattern still catches every shape a person actually writes a number in — `+48 512 345 678`, `555-123-4567`, `(555) 123 4567`, and a bare `5551234567` — all now covered by tests alongside the five identifier shapes that were wrongly rejected.

## Known remaining looseness, not addressed here

A bare date like `2026-08-06` in prose still reads as phone-ish. That is a different false positive with a different fix, and nobody has hit it. Flagging rather than fixing so it is a decision rather than an oversight.

## Verification

Full API suite green (**2564** tests, 162 files), lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmKqqxSCF6xdNwD1Ke487B)_