### PR TITLE
mcp: nudge agents to resubmit after a refused preview gate

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -35,6 +35,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    - Each stage may also publish a **live preview** of the buffer — see below
 4. **Prefer `end` after the last successful `submit_sources`** if you will not deliver
    more — Studio shows the gate; do not sit in a `get_gate_verdict` loop
+   - **`preview_failed` / `red`:** do **not** stop at `stage_source_file` / `show_round`.
+     Honour `warnings.code=must_fix_gate`, fix, then `submit_sources` again on the same
+     key. Staging alone leaves the creator card on the refused delivery.
 5. Only call `get_gate_verdict` once when an already-available verdict would change
    what you deliver — and when that check _does_ return a publish verdict, call
    `get_gate_media` once before `end`
@@ -219,14 +222,16 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code                | Meaning                                                                          |
-| ------------------- | -------------------------------------------------------------------------------- |
-| `call_end`          | Call `end` when finished iterating this round                                    |
-| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                       |
-| `gate_poll_backoff` | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true` |
-| `progress_stale`    | Call `report_progress`                                                           |
-| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                               |
-| `seed_unread`       | Call `get_seed` before scaffolding from the kit                                  |
+| Code                | Meaning                                                                                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `call_end`          | Call `end` when finished iterating this round                                                                                                                              |
+| `must_fix_gate`     | Last delivery refused (`preview_failed` / `red` / `kit_outdated`) — fix and **`submit_sources` again**; staging alone does not re-run the gate or refresh the creator card |
+| `must_deliver`      | Nothing delivered yet — submit before finishing                                                                                                                            |
+| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                                                                                                                 |
+| `gate_poll_backoff` | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true`                                                                                           |
+| `progress_stale`    | Call `report_progress`                                                                                                                                                     |
+| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                                                                                                                         |
+| `seed_unread`       | Call `get_seed` before scaffolding from the kit                                                                                                                            |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -46,8 +46,15 @@ function stubGitHub(): GitHubClient {
   };
 }
 
-function stubGamesStore(gate?: { green: boolean; ranAt?: string; report?: string; status?: string }) {
+function stubGamesStore(gate?: {
+  green: boolean;
+  ranAt?: string;
+  report?: string;
+  status?: string;
+  lane?: 'preview' | 'publish';
+}) {
   const stored: Array<{ slug: string; files: unknown[]; kitEngineRef?: string }> = [];
+  const staged = new Map<string, { path: string; content: string; bytes: number }>();
   const gamesStore = {
     putCandidateSources: async (input: {
       slug: string;
@@ -60,22 +67,60 @@ function stubGamesStore(gate?: { green: boolean; ranAt?: string; report?: string
       stored.push(input);
       return { version: 'v1', manifest: {} as never };
     },
-    getManifest: async () =>
-      gate
-        ? {
-            gate: {
-              green: gate.green,
-              ranAt: gate.ranAt ?? '2026-08-01T12:00:00.000Z',
-              ...(gate.report ? { report: gate.report } : {}),
-              ...(gate.status ? { status: gate.status } : {}),
-            },
-          }
-        : null,
+    getManifest: async () => {
+      if (!gate) return null;
+      const ranAt = gate.ranAt ?? '2026-08-01T12:00:00.000Z';
+      if (gate.lane === 'preview' || gate.status === 'preview_failed' || gate.status === 'preview_passed') {
+        return {
+          previewGate: {
+            green: gate.green,
+            ranAt,
+            ...(gate.report ? { report: gate.report } : {}),
+            ...(gate.status === 'kit_outdated' ? { status: 'kit_outdated' } : {}),
+          },
+        };
+      }
+      return {
+        gate: {
+          green: gate.green,
+          ranAt,
+          ...(gate.report ? { report: gate.report } : {}),
+          ...(gate.status ? { status: gate.status } : {}),
+        },
+      };
+    },
     getSourceFile: async () => null,
     putGateResult: async () => {},
     putDerivedArtifact: async () => {},
     getDerivedArtifact: async () => null,
     getKitRegistry: async () => null,
+    putStagedSourceFile: async (input: { path: string; content: string }) => {
+      const bytes = Buffer.byteLength(input.content, 'utf8');
+      staged.set(input.path, { path: input.path, content: input.content, bytes });
+      const files = [...staged.values()].map((f) => ({ path: f.path, bytes: f.bytes }));
+      return {
+        path: input.path,
+        bytes,
+        files,
+        totalBytes: files.reduce((sum, f) => sum + f.bytes, 0),
+        maxBytes: 1_500_000,
+        maxFiles: 64,
+        updatedAt: new Date().toISOString(),
+      };
+    },
+    getStagedSourceFiles: async () => [...staged.values()].map((f) => ({ path: f.path, content: f.content })),
+    getStagedSourceFile: async (input: { path: string }) => staged.get(input.path)?.content ?? null,
+    listStagedSources: async () => ({
+      files: [...staged.values()].map((f) => ({ path: f.path, bytes: f.bytes })),
+      totalBytes: [...staged.values()].reduce((sum, f) => sum + f.bytes, 0),
+      maxBytes: 1_500_000,
+      maxFiles: 64,
+    }),
+    clearStagedSources: async () => {
+      const cleared = staged.size;
+      staged.clear();
+      return { cleared };
+    },
   } as unknown as GamesStore;
   return { gamesStore, stored };
 }
@@ -487,7 +532,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/Do not report_progress, read_inbox, or ack after green/i);
     expect(joined).toMatch(/terminal receipt/i);
     // Both failure branches are covered.
-    expect(joined).toMatch(/red \/ preview_failed:.*resubmit on the SAME key/i);
+    expect(joined).toMatch(/red \/ preview_failed:.*submit_sources again on the SAME key/i);
     expect(joined).toMatch(/kit_outdated:.*fromLatestDelivery/i);
     expect(joined).toMatch(/do NOT get_sources \+ re-stage/i);
 
@@ -1163,6 +1208,44 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(bad.isError).toBe(true);
     expect(JSON.stringify(bad.structured)).toMatch(/invalid base64/i);
+  });
+
+  it('forwards must_fix_gate on stage after preview_failed so Claude submits again', async () => {
+    // Observed 2026-08-06: channel already said mustFixGate; MCP dropped it, Claude kept
+    // staging + show_round, and the creator card stayed on PREVIEW FAILED.
+    const store = new InMemoryStore();
+    await seedJob(store);
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    await store.incrementRoundDeliveryCount(ISSUE);
+    const { gamesStore } = stubGamesStore({
+      green: false,
+      lane: 'preview',
+      status: 'preview_failed',
+      report: 'typecheck failed: missing export',
+      ranAt: '2026-08-06T11:22:00.000Z',
+    });
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const staged = await callTool(
+      app,
+      'stage_source_file',
+      { sessionKey, path: 'game.ts', content: 'export const fixed = true;\n' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(staged.isError).toBe(false);
+    const warnings = (staged.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? [];
+    expect(warnings.some((w) => w.code === 'must_fix_gate')).toBe(true);
+    expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).toMatch(/submit_sources/i);
+    expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).toMatch(/Staging alone/i);
+
+    const shown = await callTool(app, 'show_round', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(shown.isError).toBe(false);
+    const showWarnings = (shown.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
+    expect(showWarnings.some((w) => w.code === 'must_fix_gate')).toBe(true);
+    expect((shown.structured as { gate?: { status?: string } }).gate?.status).toBe('preview_failed');
   });
 
   describe('terminal receipt (generation one behind) on all three transports', () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -910,12 +910,17 @@ describe('POST /api/mcp (BY-05)', () => {
     const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
 
     // list_examples is a hot read — should carry inbox piggyback without a separate read_inbox.
+    // Also forwards channel must_deliver when nothing has been submitted yet (review, #627).
     const examples = await callTool(app, 'list_examples', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(examples.isError).toBe(false);
     expect(examples.structured).toMatchObject({
       pendingMessages: [expect.objectContaining({ text: 'Add a power-up' })],
-      warnings: [expect.objectContaining({ code: 'inbox_pending' })],
     });
+    const warningCodes = ((examples.structured as { warnings?: Array<{ code: string }> }).warnings ?? []).map(
+      (w) => w.code,
+    );
+    expect(warningCodes).toContain('inbox_pending');
+    expect(warningCodes).toContain('must_deliver');
   });
 
   it('rejects oversized screenshots at the MCP layer', async () => {
@@ -1238,8 +1243,12 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(staged.isError).toBe(false);
     const warnings = (staged.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? [];
     expect(warnings.some((w) => w.code === 'must_fix_gate')).toBe(true);
-    expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).toMatch(/submit_sources/i);
+    expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).toMatch(/submit_sources again/i);
     expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).toMatch(/Staging alone/i);
+    // Must not hard-code mode=preview — that contradicts publish red / kit_outdated.
+    expect(warnings.find((w) => w.code === 'must_fix_gate')?.message).not.toMatch(/mode:\s*"preview"/);
+    // call_end is suppressed on this reply while must_fix_gate is present.
+    expect(warnings.some((w) => w.code === 'call_end')).toBe(false);
 
     const shown = await callTool(app, 'show_round', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(shown.isError).toBe(false);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -441,12 +441,16 @@ function warningsFromChannel(body: ChannelControlBody): Array<{ code: string; me
   const warnings: Array<{ code: string; message: string }> = [];
   const fix = typeof body.control?.mustFixGate === 'string' ? body.control.mustFixGate.trim() : '';
   if (fix) {
+    // Do not append a hard-coded mode=preview example — the channel message already
+    // names preview / publish / kit_outdated remedies, and a preview-only suffix
+    // contradicted publish red and kit_outdated (review, #627).
     warnings.push({
       code: 'must_fix_gate',
       message:
         fix +
         ' Staging alone does not re-run the gate or update the creator card — when the fix is ready, ' +
-        'call submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) on this same key.',
+        'call submit_sources again on this same key (same mode as the refused delivery; for kit_outdated use ' +
+        'fromLatestDelivery with a fresh kitEngineRef).',
     });
   }
   const deliver = typeof body.control?.mustDeliver === 'string' ? body.control.mustDeliver.trim() : '';
@@ -1012,11 +1016,25 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       const auth = await resolveAuth(ctx, args);
       if ('channelToken' in auth) {
         const piggy = await writePiggyback(ctx.request, auth.channelToken);
+        const priorWarnings = Array.isArray(data.warnings)
+          ? (data.warnings as NudgeWarning[]).filter(
+              (w) => w && typeof w === 'object' && typeof w.code === 'string' && typeof w.message === 'string',
+            )
+          : [];
+        const piggyWarnings = Array.isArray(piggy.warnings)
+          ? piggy.warnings.filter(
+              (w) => w && typeof w === 'object' && typeof w.code === 'string' && typeof w.message === 'string',
+            )
+          : [];
         data = {
           ...data,
           pendingMessages: piggy.pendingMessages,
           stop: piggy.stop,
           ...(piggy.reason ? { reason: piggy.reason } : {}),
+          // must_fix_gate / must_deliver ride the inbox piggyback on kit/browse reads —
+          // without this, recovery paths discarded the new warning and re-emitted call_end
+          // instead (review, #627).
+          ...(piggyWarnings.length > 0 ? { warnings: [...priorWarnings, ...piggyWarnings] } : {}),
         };
         piggybacked = true;
       }
@@ -1055,16 +1073,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     if (toolName === 'submit_sources' && data.ok === true) {
       nudgeTracker.noteSubmitSuccess(jobId, nowMs);
     }
-    // Resuming after submit (fix a refused gate, or keep iterating) — call_end would
-    // tell Claude to end instead of submit_sources again (owner, 2026-08-06).
-    if (
-      toolName === 'stage_source_file' ||
-      toolName === 'patch_source_file' ||
-      toolName === 'report_progress' ||
-      toolName === 'send_screenshot'
-    ) {
-      nudgeTracker.noteEnded(jobId, nowMs);
-    }
+    // Do not clear awaitingEnd on stage/progress/screenshot. A normal post-submit
+    // progress note must keep call_end armed; suppress call_end only while
+    // must_fix_gate is present on this reply (review, #627).
     if (toolName === 'show_round') nudgeTracker.noteCardOpened(jobId, nowMs);
 
     // show_round nests the verdict under `gate`; get_gate_verdict puts status/deliveryId

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -412,12 +412,98 @@ function pendingMessagesFromChannel(body: {
   return body.pendingMessages ?? body.pending ?? [];
 }
 
-function stopFromChannel(body: { control?: { stop?: boolean; reason?: string } }): {
+type ChannelControlBody = {
+  control?: {
+    stop?: boolean;
+    reason?: string;
+    mustFixGate?: string;
+    mustDeliver?: string;
+  };
+};
+
+function stopFromChannel(body: ChannelControlBody): {
   stop: boolean;
   reason?: string;
 } {
   const stop = Boolean(body.control?.stop);
   return stop ? { stop: true, ...(body.control?.reason ? { reason: body.control.reason } : {}) } : { stop: false };
+}
+
+/**
+ * Soft warnings the channel already computed — MCP used to drop them.
+ *
+ * Observed 2026-08-06: after preview_failed Claude kept staging and calling show_round
+ * while the creator's card sat on the refused delivery. The channel had been saying
+ * `mustFixGate` on every write; stopFromChannel only forwarded stop/reason, so the
+ * model never saw the one instruction that mattered: submit again.
+ */
+function warningsFromChannel(body: ChannelControlBody): Array<{ code: string; message: string }> {
+  const warnings: Array<{ code: string; message: string }> = [];
+  const fix = typeof body.control?.mustFixGate === 'string' ? body.control.mustFixGate.trim() : '';
+  if (fix) {
+    warnings.push({
+      code: 'must_fix_gate',
+      message:
+        fix +
+        ' Staging alone does not re-run the gate or update the creator card — when the fix is ready, ' +
+        'call submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) on this same key.',
+    });
+  }
+  const deliver = typeof body.control?.mustDeliver === 'string' ? body.control.mustDeliver.trim() : '';
+  if (deliver) {
+    warnings.push({ code: 'must_deliver', message: deliver });
+  }
+  return warnings;
+}
+
+/** stop + soft warnings derived from a channel write body. */
+function channelControlFields(
+  body: ChannelControlBody,
+  extraWarnings: Array<{ code: string; message: string }> = [],
+): {
+  stop: boolean;
+  reason?: string;
+  warnings?: Array<{ code: string; message: string }>;
+} {
+  const warnings = [...extraWarnings, ...warningsFromChannel(body)];
+  return {
+    ...stopFromChannel(body),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+/** Gate statuses that mean "fix and deliver again" — not a finished round. */
+function gateNeedsResubmit(status: unknown): boolean {
+  return status === 'preview_failed' || status === 'red' || status === 'kit_outdated';
+}
+
+function mustFixGateWarningForStatus(status: string, deliveryId?: string | null): NudgeWarning {
+  const delivery = deliveryId ? ` (${deliveryId})` : '';
+  if (status === 'kit_outdated') {
+    return {
+      code: 'must_fix_gate',
+      message:
+        `The gate refused the last delivery${delivery} as kit_outdated. Re-run get_kit for a fresh engineRef, then ` +
+        'submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do not only stage; staging alone ' +
+        'does not re-run the gate.',
+    };
+  }
+  if (status === 'preview_failed') {
+    return {
+      code: 'must_fix_gate',
+      message:
+        `The preview check refused the last delivery${delivery}. Fix typecheck/smoke/build, then ` +
+        'submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) on this same key. ' +
+        'Staging alone does not re-run the gate or refresh the creator card.',
+    };
+  }
+  return {
+    code: 'must_fix_gate',
+    message:
+      `The publish gate refused the last delivery${delivery}. Read the gate report, fix, then ` +
+      'submit_sources({ fromStaged: true, mode: "publish", kitEngineRef }) on this same key. ' +
+      'Staging alone does not re-run the gate.',
+  };
 }
 
 const BEHAVIOURAL_CONTRACT = [
@@ -428,8 +514,9 @@ const BEHAVIOURAL_CONTRACT = [
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable.',
   'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
-  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end.',
+  'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end. If you are fixing a refused gate, ignore call_end until after the next submit_sources.',
   'Honour stop immediately — do not continue after stop:true.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
   'Treat get_gate_verdict as a one-shot check, never a polling loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null means you checked before delivering: stop is false, so continue building and call submit_sources instead of checking again. A later creator-led run may check a delivered gate again. Honour warnings.code=gate_poll_backoff on repeated checks.',
@@ -477,7 +564,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   // as advice, did. It is now tied to a verdict already in hand, which is a moment the
   // loop actually reaches, and it still forbids waiting for one.
   "get_gate_media — whenever you already hold a publish verdict (green or red), call it once before you end. It attaches the gate's own frames as images: the only evidence of whether the game truly draws, and the thing to show the creator. On red especially, a frame often names what the report cannot describe. Never wait for a verdict in order to call it — if the gate is pending, end and let Studio show the result. Both lanes carry frames: a preview verdict has stills too, so you can see whether your game draws while you are still iterating. The reply says which lane took them (gate.lane) — a green preview means it typechecks, smokes and assembles, never that it is publish-ready.",
-  'red / preview_failed: read the report, fix, and resubmit on the SAME key (preview while iterating; publish when sealing).',
+  'red / preview_failed: read the report, fix, and submit_sources again on the SAME key (preview while iterating; publish when sealing). Honour warnings.code=must_fix_gate — staging/patching alone does NOT re-run the gate or update the creator card; the card stays on the refused delivery until you submit.',
   'kit_outdated: re-run get_kit for a fresh engineRef, then submit_sources({ fromLatestDelivery: true, mode, kitEngineRef }) — do NOT get_sources + re-stage the whole tree (burns tokens). Only pass files[] for paths you actually changed.',
   // Green closes the round before the next tool call; writes and non-receipt reads then
   // reject the retired key (terminal-receipt tests). Any final progress/inbox work must
@@ -846,17 +933,21 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   async function writePiggyback(
     request: FastifyRequest,
     channelToken: string,
-  ): Promise<{ stop: boolean; reason?: string; pendingMessages: unknown[] }> {
+  ): Promise<{
+    stop: boolean;
+    reason?: string;
+    pendingMessages: unknown[];
+    warnings?: Array<{ code: string; message: string }>;
+  }> {
     const inbox = await injectChannel(request, 'GET', '/api/agent/build/inbox', channelToken);
     if (inbox.statusCode !== 200) {
       return { stop: false, pendingMessages: [] };
     }
-    const body = inbox.json() as {
+    const body = inbox.json() as ChannelControlBody & {
       pending?: Array<{ id: string; text: string; createdAt: string }>;
-      control?: { stop?: boolean; reason?: string };
     };
     return {
-      ...stopFromChannel(body),
+      ...channelControlFields(body),
       pendingMessages: pendingMessagesFromChannel(body),
     };
   }
@@ -964,17 +1055,63 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     if (toolName === 'submit_sources' && data.ok === true) {
       nudgeTracker.noteSubmitSuccess(jobId, nowMs);
     }
+    // Resuming after submit (fix a refused gate, or keep iterating) — call_end would
+    // tell Claude to end instead of submit_sources again (owner, 2026-08-06).
+    if (
+      toolName === 'stage_source_file' ||
+      toolName === 'patch_source_file' ||
+      toolName === 'report_progress' ||
+      toolName === 'send_screenshot'
+    ) {
+      nudgeTracker.noteEnded(jobId, nowMs);
+    }
     if (toolName === 'show_round') nudgeTracker.noteCardOpened(jobId, nowMs);
-    const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs, {
-      // Only nudge toward a card in a client that can render one.
-      uiCapable: sessionWantsUi((ctx.request.headers['mcp-session-id'] as string | undefined) ?? null),
-    });
-    const prior = Array.isArray(data.warnings)
+
+    // show_round nests the verdict under `gate`; get_gate_verdict puts status/deliveryId
+    // on the root. Surface must_fix_gate either way — even when the agent never hits a
+    // write (Claude opened a card and staged nothing yet, or only polled the verdict).
+    const gateObj =
+      data.gate && typeof data.gate === 'object' && !Array.isArray(data.gate)
+        ? (data.gate as { status?: unknown; deliveryId?: unknown })
+        : null;
+    const gateStatus =
+      gateObj && typeof gateObj.status === 'string'
+        ? gateObj.status
+        : toolName === 'get_gate_verdict' && typeof data.status === 'string'
+          ? data.status
+          : null;
+    const gateDelivery =
+      gateObj && typeof gateObj.deliveryId === 'string'
+        ? gateObj.deliveryId
+        : typeof data.deliveryId === 'string'
+          ? data.deliveryId
+          : null;
+    const prior: NudgeWarning[] = Array.isArray(data.warnings)
       ? (data.warnings as NudgeWarning[]).filter(
           (w) => w && typeof w === 'object' && typeof w.code === 'string' && typeof w.message === 'string',
         )
       : [];
-    const warnings = [...prior, ...nudgeWarnings];
+    const hasMustFix = prior.some((w) => w.code === 'must_fix_gate');
+    if (
+      !hasMustFix &&
+      gateStatus &&
+      gateNeedsResubmit(gateStatus) &&
+      (toolName === 'show_round' || toolName === 'get_gate_verdict' || toolName === 'report_progress')
+    ) {
+      prior.push(mustFixGateWarningForStatus(gateStatus, gateDelivery));
+    }
+
+    const nudgeWarnings: NudgeWarning[] = nudgeTracker.warningsFor(jobId, toolName, nowMs, {
+      // Only nudge toward a card in a client that can render one.
+      uiCapable: sessionWantsUi((ctx.request.headers['mcp-session-id'] as string | undefined) ?? null),
+    });
+    // When a refused gate still needs a fix, call_end is the wrong next step — drop it
+    // so must_fix_gate is the loud instruction.
+    const filteredNudges =
+      prior.some((w) => w.code === 'must_fix_gate') || nudgeWarnings.some((w) => w.code === 'must_fix_gate')
+        ? nudgeWarnings.filter((w) => w.code !== 'call_end')
+        : nudgeWarnings;
+    const warnings = [...prior, ...filteredNudges];
     if (warnings.length === 0 && !piggybacked) {
       return result;
     }
@@ -1038,7 +1175,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, card_unopened). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. card_unopened means the creator has no status card yet — call show_round once.',
+        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, card_unopened, must_fix_gate, must_deliver). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. card_unopened means the creator has no status card yet — call show_round once. must_fix_gate means the last delivery was refused — fix and submit_sources again; staging alone does not re-run the gate.',
       items: {
         type: 'object',
         properties: {
@@ -1053,6 +1190,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'gate_poll_backoff',
               'module_too_large',
               'card_unopened',
+              'must_fix_gate',
+              'must_deliver',
             ],
           },
           message: { type: 'string' },
@@ -2969,7 +3108,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return toolOk({
           ok: body.accepted !== false,
           ...(body.rejected ? { rejected: body.rejected } : {}),
-          ...stopFromChannel(body),
+          ...channelControlFields(body),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3034,7 +3173,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return toolOk({
           ok: body.accepted !== false,
           ...(body.rejected ? { rejected: body.rejected } : {}),
-          ...stopFromChannel(body),
+          ...channelControlFields(body),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3075,6 +3214,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'for edits to an existing path prefer patch_source_file so you do not re-emit a whole large file. ' +
         'Prefer over a giant submit_sources files[] when the tree is large (Claude Chat often truncates huge tool JSON). ' +
         'Call once per path, then submit_sources({ fromStaged: true, mode, kitEngineRef }). Overwrites the same path if staged again. ' +
+        'After preview_failed / red (warnings.code=must_fix_gate), staging alone does not re-run the gate — you must submit_sources again. ' +
         'Keep modules modest — if hint warns the file is large, split into cohesive game/*.ts modules. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -3139,9 +3279,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...(body.rejected ? { rejected: body.rejected } : {}),
           path: body.path ?? path,
           bytes: body.bytes ?? 0,
-          ...(hint ? { hint, warnings: [{ code: 'module_too_large' as const, message: hint }] } : {}),
+          ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
-          ...stopFromChannel(body),
+          ...channelControlFields(body, hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3274,9 +3414,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes: body.bytes ?? 0,
           replacements: body.replacements ?? 0,
           baseFrom: body.baseFrom ?? 'staged',
-          ...(hint ? { hint, warnings: [{ code: 'module_too_large' as const, message: hint }] } : {}),
+          ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
-          ...stopFromChannel(body),
+          ...channelControlFields(body, hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3389,7 +3529,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return toolOk({
           ok: body.accepted !== false,
           cleared: body.cleared ?? 0,
-          ...stopFromChannel(body),
+          ...channelControlFields(body),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3623,9 +3763,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           gateStarted,
           ...(typeof body.buildId === 'string' && body.buildId ? { buildId: body.buildId } : {}),
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
-          ...stopFromChannel(body),
+          ...channelControlFields(body, warnings),
           pendingMessages: pendingMessagesFromChannel(body),
-          ...(warnings.length > 0 ? { warnings } : {}),
         });
       },
     },
@@ -3707,6 +3846,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'screenshot, gate verdict, deliveries left. It refreshes itself and stops when the round settles, so ' +
         'the creator can watch without you polling. ' +
         'Call it ONCE per round, after start — a second call renders a second card. ' +
+        'A preview_failed / red card is not finished: honour warnings.code=must_fix_gate, fix, and ' +
+        'submit_sources again — show_round alone does not re-run the gate. ' +
         'Only clients that render MCP Apps views see anything; elsewhere it is a plain status read. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -4238,7 +4379,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         return toolOk({
           messages: pendingMessagesFromChannel(body),
           pendingMessages: pendingMessagesFromChannel(body),
-          ...stopFromChannel(body),
+          ...channelControlFields(body),
           ...(body.gate ? { gate: body.gate } : {}),
         });
       },
@@ -4284,7 +4425,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         }
         // Ack is a write — always piggyback stop/pending (fresh read if channel omitted).
         const piggy = body.pending
-          ? { ...stopFromChannel(body), pendingMessages: pendingMessagesFromChannel(body) }
+          ? { ...channelControlFields(body), pendingMessages: pendingMessagesFromChannel(body) }
           : await writePiggyback(ctx.request, auth.channelToken);
         return toolOk({
           ok: body.ok !== false,

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -83,15 +83,17 @@ describe('mcp-session-nudges', () => {
     ).not.toContain('call_end');
   });
 
-  it('clears awaitingEnd when the agent resumes after submit (noteEnded)', () => {
+  it('keeps call_end armed after noteToolSuccess on progress (end is what clears it)', () => {
+    // applySessionNudges must not clear awaitingEnd on report_progress / stage —
+    // only must_fix_gate on the reply suppresses call_end (review, #627).
     const nudges = createMcpNudgeTracker();
     const t0 = 1_000_000;
     nudges.noteSubmitSuccess(1, t0);
-    expect(nudges.warningsFor(1, 'get_brief', t0).map((w) => w.code)).toContain('call_end');
-    // applySessionNudges calls noteEnded on stage/patch/progress so call_end does not
-    // fight must_fix_gate while Claude is fixing a refused gate.
-    nudges.noteEnded(1, t0 + 1);
-    expect(nudges.warningsFor(1, 'get_brief', t0 + 2).map((w) => w.code)).not.toContain('call_end');
+    nudges.noteToolSuccess(1, 'report_progress', t0 + 1);
+    nudges.noteToolSuccess(1, 'stage_source_file', t0 + 2);
+    expect(nudges.warningsFor(1, 'get_brief', t0 + 3).map((w) => w.code)).toContain('call_end');
+    nudges.noteEnded(1, t0 + 4);
+    expect(nudges.warningsFor(1, 'get_brief', t0 + 5).map((w) => w.code)).not.toContain('call_end');
   });
 
   it('soft-warns gate_poll_backoff on tight get_gate_verdict loops', () => {

--- a/apps/api/src/mcp-session-nudges.test.ts
+++ b/apps/api/src/mcp-session-nudges.test.ts
@@ -83,6 +83,17 @@ describe('mcp-session-nudges', () => {
     ).not.toContain('call_end');
   });
 
+  it('clears awaitingEnd when the agent resumes after submit (noteEnded)', () => {
+    const nudges = createMcpNudgeTracker();
+    const t0 = 1_000_000;
+    nudges.noteSubmitSuccess(1, t0);
+    expect(nudges.warningsFor(1, 'get_brief', t0).map((w) => w.code)).toContain('call_end');
+    // applySessionNudges calls noteEnded on stage/patch/progress so call_end does not
+    // fight must_fix_gate while Claude is fixing a refused gate.
+    nudges.noteEnded(1, t0 + 1);
+    expect(nudges.warningsFor(1, 'get_brief', t0 + 2).map((w) => w.code)).not.toContain('call_end');
+  });
+
   it('soft-warns gate_poll_backoff on tight get_gate_verdict loops', () => {
     const nudges = createMcpNudgeTracker();
     const t0 = 1_000_000;

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -14,7 +14,9 @@ export type NudgeCode =
   | 'call_end'
   | 'gate_not_started'
   | 'gate_poll_backoff'
-  | 'card_unopened';
+  | 'card_unopened'
+  | 'must_fix_gate'
+  | 'must_deliver';
 
 export interface NudgeWarning {
   code: NudgeCode;

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -428,11 +428,16 @@ describe('ui resources', () => {
 
   it('keeps polling after a fixable gate refusal so a resumed agent refreshes the card', () => {
     // Observed 2026-08-06: PREVIEW FAILED + agentEnded froze the card while Claude
-    // staged fixes above it. Fixable verdicts must stay live.
+    // staged fixes above it. Fixable verdicts must stay live — but only after terminal
+    // phases are checked, or a canceled round with a leftover preview_failed would poll
+    // forever (review, #627).
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("gate.status === 'preview_failed'");
     expect(html).toContain("gate.status === 'kit_outdated'");
-    expect(html).toContain('return false;');
+    const canceledAt = html.indexOf("status.phase === 'canceled'");
+    const previewFailedAt = html.indexOf("gate.status === 'preview_failed'");
+    expect(canceledAt).toBeGreaterThan(-1);
+    expect(previewFailedAt).toBeGreaterThan(canceledAt);
     // Still stop once a publish gate is green (or the round is truly terminal).
     expect(html).toContain("gate.status === 'green') return true");
   });

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -426,9 +426,20 @@ describe('ui resources', () => {
     expect(html).toContain('detail !== summary.textContent');
   });
 
+  it('keeps polling after a fixable gate refusal so a resumed agent refreshes the card', () => {
+    // Observed 2026-08-06: PREVIEW FAILED + agentEnded froze the card while Claude
+    // staged fixes above it. Fixable verdicts must stay live.
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain("gate.status === 'preview_failed'");
+    expect(html).toContain("gate.status === 'kit_outdated'");
+    expect(html).toContain('return false;');
+    // Still stop once a publish gate is green (or the round is truly terminal).
+    expect(html).toContain("gate.status === 'green') return true");
+  });
+
   it('stops polling once the agent has stopped and the gate has settled', () => {
     // Nothing further can arrive, so an open tab must not cost a request every 30s
-    // for as long as it stays open.
+    // for as long as it stays open — except fixable refusals (see above).
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain("status.agentEnded && gate && gate.status && gate.status !== 'pending'");
   });

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -925,8 +925,19 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function isFinished(status) {
           var gate = status.gate;
           if (gate && gate.status === 'green') return true;
-          // Agent gone and a verdict already in: nothing further will arrive until
-          // somebody acts, and that act opens a fresh card.
+          // Fixable refusals are not terminal. Freezing here left creators staring at
+          // PREVIEW FAILED while the agent staged fixes above the card (2026-08-06) —
+          // and a resumed agent clears agentEndedAt, but a stopped poll never notices.
+          if (
+            gate &&
+            (gate.status === 'preview_failed' ||
+              gate.status === 'red' ||
+              gate.status === 'kit_outdated')
+          ) {
+            return false;
+          }
+          // Agent gone and a non-fixable verdict already in: nothing further will arrive
+          // until somebody acts, and that act opens a fresh card.
           if (status.agentEnded && gate && gate.status && gate.status !== 'pending') return true;
           return (
             status.phase === 'published' ||

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -925,6 +925,17 @@ const ROUND_STATUS_HTML = `<!doctype html>
         function isFinished(status) {
           var gate = status.gate;
           if (gate && gate.status === 'green') return true;
+          // Terminal phases win over a leftover fixable gate status — otherwise a
+          // canceled/abandoned/failed round whose last gate was preview_failed would
+          // poll forever (review, #627).
+          if (
+            status.phase === 'published' ||
+            status.phase === 'canceled' ||
+            status.phase === 'abandoned' ||
+            status.phase === 'failed'
+          ) {
+            return true;
+          }
           // Fixable refusals are not terminal. Freezing here left creators staring at
           // PREVIEW FAILED while the agent staged fixes above the card (2026-08-06) —
           // and a resumed agent clears agentEndedAt, but a stopped poll never notices.
@@ -939,12 +950,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           // Agent gone and a non-fixable verdict already in: nothing further will arrive
           // until somebody acts, and that act opens a fresh card.
           if (status.agentEnded && gate && gate.status && gate.status !== 'pending') return true;
-          return (
-            status.phase === 'published' ||
-            status.phase === 'canceled' ||
-            status.phase === 'abandoned' ||
-            status.phase === 'failed'
-          );
+          return false;
         }
 
         function renderGateOnly(verdict) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a preview gate fails, Claude often keeps calling `stage_source_file` / `show_round` and never `submit_sources` again. The creator card stays on **PREVIEW FAILED** and looks “stale,” even though the agent is still working.

Root cause: the agent channel already computed `control.mustFixGate` on every write, but MCP only forwarded `stop`/`reason` — so the model never saw the instruction that matters. Post-submit `call_end` also steered toward `end` instead of a fix+resubmit. The round card stopped polling once `agentEnded` + a non-pending verdict landed, so a resumed agent could not refresh it.

## Fix

- Forward channel `mustFixGate` / `mustDeliver` as soft warnings (`must_fix_gate`, `must_deliver`) on stage/patch/progress/inbox/etc.
- Emit `must_fix_gate` from `show_round` / `get_gate_verdict` when the latest gate is `preview_failed` / `red` / `kit_outdated`.
- Suppress `call_end` only while `must_fix_gate` is present on the reply (do not clear `awaitingEnd` on progress/stage).
- Keep the MCP Apps round card polling through fixable gate refusals, after checking terminal phases.
- Merge piggyback `must_fix_gate` / `must_deliver` onto kit/browse reads.
- Mode-neutral resubmit copy (no hard-coded `mode: "preview"` suffix).
- Tighten workflow / stage / show_round copy and the BYOCA skill.

## Review follow-ups (#627)

Addressed Copilot + Codex comments: mode-neutral `warningsFromChannel`, terminal-phase-first `isFinished`, no `noteEnded` overload on resume writes, piggyback warnings merged into tool results.

## Test plan

- [x] `mcp-server` integration: stage after `preview_failed` returns `must_fix_gate`; `show_round` does too
- [x] `mcp-ui`: card keeps polling on fixable refusals; terminal phases still stop
- [x] Piggyback reads include `must_deliver` / `must_fix_gate` when channel says so
- [x] `npm run type-check && npm run lint` + MCP-focused vitest suite green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf2570e3-fe5e-4537-b031-14ec73dcd624?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf2570e3-fe5e-4537-b031-14ec73dcd624&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

