### PR TITLE
claude: declare the MCP server where the plugin loader actually looks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,11 @@
       "name": "gamedev-pl",
       "source": "./listings/mcp/claude-plugin",
       "description": "Build browser games on gamedev.pl from your coding agent.",
-      "version": "1.0.1",
-      "author": { "name": "gamedev.pl", "url": "https://www.gamedev.pl" },
+      "version": "1.0.2",
+      "author": {
+        "name": "gamedev.pl",
+        "url": "https://www.gamedev.pl"
+      },
       "homepage": "https://www.gamedev.pl",
       "license": "GPL-3.0-only",
       "keywords": ["games", "game-development", "browser-games", "mcp", "gamedev"],

--- a/apps/api/src/plugin-manifests.test.ts
+++ b/apps/api/src/plugin-manifests.test.ts
@@ -58,8 +58,17 @@ describe('.claude-plugin marketplace', () => {
     mcpServers?: Record<string, { url?: string; type?: string }>;
   }
 
+  // Both declarations point at the same endpoint, so neither can be updated alone.
+  it('keeps the marketplace entry and the plugin .mcp.json in agreement', () => {
+    const inline = entry.mcpServers as Record<string, { url?: string }>;
+    const file = pluginMcp.mcpServers as Record<string, { url?: string }>;
+    expect(Object.keys(inline)).toEqual(Object.keys(file));
+    expect(inline.gamedevpl.url).toBe(file.gamedevpl.url);
+  });
+
   const entries = marketplace.plugins as MarketplacePlugin[];
   const entry = entries[0];
+  const pluginMcp = readJson('listings/mcp/claude-plugin/.mcp.json');
 
   it('lists exactly the one plugin we intend to publish', () => {
     expect(entries).toHaveLength(1);
@@ -71,15 +80,35 @@ describe('.claude-plugin marketplace', () => {
     expect(plugin.description).toBe(registry.description);
   });
 
+  /**
+   * The first cut declared mcpServers only in the marketplace entry, and the plugin
+   * installed with no tools: the documented locations are `.mcp.json` in the plugin root
+   * or inline in the plugin's own manifest, and the plugin directory had neither. Assert
+   * the file exists and is wired, because "installs cleanly" and "actually exposes the
+   * server" turned out to be different things.
+   */
+  it('ships an .mcp.json in the plugin root, which is where the loader looks', () => {
+    const servers = pluginMcp.mcpServers as Record<string, { url?: string; type?: string }>;
+    const remotes = registry.remotes as Array<{ url: string }>;
+    expect(servers.gamedevpl.url).toBe(remotes[0]?.url);
+    expect(servers.gamedevpl.type).toBe('http');
+    expect(plugin.mcpServers).toBe('./.mcp.json');
+  });
+
   it('advertises the endpoint the registry publishes', () => {
     const remotes = registry.remotes as Array<{ url: string }>;
     expect(entry.mcpServers?.gamedevpl?.url).toBe(remotes[0]?.url);
   });
 
-  it('never ships a credential in the install config', () => {
-    const serialized = JSON.stringify(entry.mcpServers ?? {}).toLowerCase();
-    for (const marker of ['authorization', 'bearer', 'token', 'apikey', 'api_key', 'secret', 'key']) {
-      expect(serialized, `marketplace.json must not carry ${marker}`).not.toContain(marker);
+  it('never ships a credential in either install config', () => {
+    for (const [label, config] of [
+      ['marketplace.json', entry.mcpServers ?? {}],
+      ['.mcp.json', pluginMcp.mcpServers ?? {}],
+    ] as const) {
+      const serialized = JSON.stringify(config).toLowerCase();
+      for (const marker of ['authorization', 'bearer', 'token', 'apikey', 'api_key', 'secret', 'key']) {
+        expect(serialized, `${label} must not carry ${marker}`).not.toContain(marker);
+      }
     }
   });
 

--- a/apps/api/src/plugin-manifests.test.ts
+++ b/apps/api/src/plugin-manifests.test.ts
@@ -54,16 +54,21 @@ describe('.claude-plugin marketplace', () => {
     name: string;
     source: string;
     description: string;
+    version?: string;
     license?: string;
     mcpServers?: Record<string, { url?: string; type?: string }>;
   }
 
   // Both declarations point at the same endpoint, so neither can be updated alone.
+  // Compare whole entries rather than one field, and sort keys so the assertion does not
+  // depend on JSON insertion order or on there only ever being one server.
   it('keeps the marketplace entry and the plugin .mcp.json in agreement', () => {
-    const inline = entry.mcpServers as Record<string, { url?: string }>;
-    const file = pluginMcp.mcpServers as Record<string, { url?: string }>;
-    expect(Object.keys(inline)).toEqual(Object.keys(file));
-    expect(inline.gamedevpl.url).toBe(file.gamedevpl.url);
+    const inline = entry.mcpServers as Record<string, unknown>;
+    const file = pluginMcp.mcpServers as Record<string, unknown>;
+    expect(Object.keys(inline).sort()).toEqual(Object.keys(file).sort());
+    for (const key of Object.keys(file)) {
+      expect(inline[key], `server "${key}" differs between the two declarations`).toEqual(file[key]);
+    }
   });
 
   const entries = marketplace.plugins as MarketplacePlugin[];
@@ -124,9 +129,27 @@ describe('.claude-plugin marketplace', () => {
     expect(entry.source).not.toBe('.');
   });
 
-  it('agrees with the Cursor manifest on licence and version', () => {
+  /**
+   * Three version lines coincided at 1.0.1 and an earlier revision of this test asserted
+   * they must stay equal — which would have blocked the fix that required bumping one of
+   * them. They are independent artifacts:
+   *
+   *   - the registry `server.json` versions the MCP *server*, and is immutable once
+   *     published, so it moves only when the server itself changes;
+   *   - `.cursor-plugin/plugin.json` versions the Cursor plugin;
+   *   - the Claude plugin versions the Claude plugin, and had to ship 1.0.2 because
+   *     Claude uses that number to detect an update, and 1.0.1 was broken.
+   *
+   * Licence is a genuinely shared fact, so that one still has to agree.
+   */
+  it('agrees with the Cursor manifest on licence, but versions independently', () => {
     const cursor = readJson('.cursor-plugin/plugin.json');
     expect(plugin.license).toBe(cursor.license);
-    expect(plugin.version).toBe(cursor.version);
+  });
+
+  // These two declare the *same* artifact, so a bump in one without the other ships a
+  // plugin whose advertised version disagrees with itself.
+  it('versions the plugin identically in its manifest and its marketplace entry', () => {
+    expect(plugin.version).toBe(entry.version);
   });
 });

--- a/listings/mcp/claude-plugin/.claude-plugin/plugin.json
+++ b/listings/mcp/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gamedev-pl",
   "description": "Build browser games on gamedev.pl from your coding agent.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "gamedev.pl",
     "url": "https://www.gamedev.pl"

--- a/listings/mcp/claude-plugin/.claude-plugin/plugin.json
+++ b/listings/mcp/claude-plugin/.claude-plugin/plugin.json
@@ -2,8 +2,12 @@
   "name": "gamedev-pl",
   "description": "Build browser games on gamedev.pl from your coding agent.",
   "version": "1.0.1",
-  "author": { "name": "gamedev.pl", "url": "https://www.gamedev.pl" },
+  "author": {
+    "name": "gamedev.pl",
+    "url": "https://www.gamedev.pl"
+  },
   "homepage": "https://www.gamedev.pl",
   "license": "GPL-3.0-only",
-  "keywords": ["games", "game-development", "browser-games", "mcp", "gamedev"]
+  "keywords": ["games", "game-development", "browser-games", "mcp", "gamedev"],
+  "mcpServers": "./.mcp.json"
 }

--- a/listings/mcp/claude-plugin/.mcp.json
+++ b/listings/mcp/claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gamedevpl": {
+      "type": "http",
+      "url": "https://www.gamedev.pl/api/mcp"
+    }
+  }
+}

--- a/listings/mcp/claude-plugin/README.md
+++ b/listings/mcp/claude-plugin/README.md
@@ -42,3 +42,15 @@ exchange messages — from Claude instead of the web editor.
 
 Creating games is in closed beta. The server says so on connect and in its 401 response;
 anyone can install it and list its tools, but writes need an approved creator account.
+
+## Versioning
+
+This plugin versions independently of the Cursor plugin and of the MCP server's registry
+entry, even though all three started at 1.0.1. Claude uses the plugin version to detect
+updates, so a fix that changes what the plugin exposes **must** ship a bump — an installed
+copy will otherwise keep serving the cached, broken version on refresh. 1.0.2 is exactly
+that case: it added the `.mcp.json` that 1.0.1 was missing.
+
+The registry entry versions the _server_ and is immutable once published, so it moves only
+when the server itself changes. `plugin-manifests.test.ts` asserts the plugin's own two
+declarations agree, and deliberately does not tie them to the other two lines.

--- a/listings/mcp/claude-plugin/README.md
+++ b/listings/mcp/claude-plugin/README.md
@@ -21,9 +21,18 @@ of any published plugin — including a skill describing the private ops repo. R
 plugin at a directory that contains only its own manifest means component discovery can
 only ever find what we put here on purpose.
 
-The MCP server itself is declared inline in the marketplace entry, so there is exactly one
-place the endpoint URL appears for this ecosystem, and `cursor-plugin-manifest.test.ts`
-asserts it matches the registry entry.
+## Where the MCP server is declared, and why in two places
+
+[`.mcp.json`](./.mcp.json) in this directory is the one that matters: the documented
+locations for a plugin's MCP config are **`.mcp.json` in the plugin root, or inline in the
+plugin's own `plugin.json`** — _not_ the marketplace entry. The first cut declared it only
+in the marketplace entry, and the plugin installed cleanly while exposing no tools at all,
+which is a confusing failure because nothing errors.
+
+`plugin.json` points at that file explicitly (`"mcpServers": "./.mcp.json"`), and the
+marketplace entry keeps its inline copy so a loader reading either finds the same server.
+`plugin-manifests.test.ts` asserts all of them agree with the published registry entry and
+with each other, so none can be updated alone.
 
 ## What it does
 


### PR DESCRIPTION
Fixes the Claude plugin shipped in #625: it installed cleanly in claude.ai and exposed **no tools**.

## The bug

`mcpServers` was declared only in the **marketplace entry**. A plugin's MCP config is read from **`.mcp.json` in the plugin root, or inline in the plugin's own `plugin.json`** ([plugins reference](https://code.claude.com/docs/en/plugins-reference)) — and `listings/mcp/claude-plugin/` had neither, only a `plugin.json` and a README.

The failure shape is what made it confusing: **nothing errors.** The marketplace resolves, the install succeeds, the plugin renders correctly in the Directory with its description and author — and the server is simply absent. There is no message anywhere saying a component was not found.

## The fix

- **`listings/mcp/claude-plugin/.mcp.json`** — the documented plugin-root location, `type: http` pointing at `https://www.gamedev.pl/api/mcp`.
- **`plugin.json`** now points at it explicitly with `"mcpServers": "./.mcp.json"`.
- The marketplace entry keeps its inline copy, so a loader reading *either* location finds the same server. Both are asserted to agree.

Checked before adding: `.mcp.json` is not gitignored, so it actually ships.

## Guard

`plugin-manifests.test.ts` grows to 12 assertions. The new ones pin the thing that broke: the file exists, `plugin.json` is wired to it, its endpoint matches the published registry entry, it agrees with the inline copy, and neither declaration carries a credential.

The point is that "installs cleanly" and "actually exposes the server" turned out to be independent, and only the first was covered.

## After merge

The installed copy is cached from the broken version, so a reinstall or marketplace refresh is needed. Then verify the `gamedevpl` tools appear, and that a write attempt returns the closed-beta message rather than a bare auth error — that exercises the whole beta-messaging chain through a real client for the first time.

## Not changed here

The plugin renders as **"Gamedev pl"**, derived from the plugin `name`. Cursor's manifest has a `displayName` for this; I found no equivalent optional field in Claude's plugin schema, so it may not be settable. Worth revisiting once tools are confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_