### PR TITLE
Restore Operator link in the nav menu

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import { PixelIcon } from './PixelIcon.js';
 import { CreatorQA, type QAQuestion } from './CreatorQA.js';
 import { deriveTitleFromConcept } from './gameTitle.js';
 import {
+  adminPath,
   canonicalPath,
   creatorPath,
   NAVIGATE_EVENT,
@@ -862,6 +863,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -882,6 +884,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -902,6 +905,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -937,6 +941,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -971,6 +976,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -992,6 +998,7 @@ export function App() {
           onNavigate={handleNavigateSection}
           onHome={() => navigate('/')}
           onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
           upTarget={headerUp}
           onUp={navigate}
         />
@@ -1020,6 +1027,7 @@ export function App() {
         onNavigate={handleNavigateSection}
         onHome={() => navigate('/')}
         onStudio={() => navigate(studioPath())}
+        onAdmin={() => navigate(adminPath())}
         upTarget={headerUp}
         onUp={navigate}
       />

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -44,6 +44,7 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: { path: '/studio', ariaLabel: 'Back to Studio' },
             onUp,
           }),
@@ -81,6 +82,7 @@ describe('NavHeader Up chevron', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -135,6 +137,7 @@ describe('NavHeader menu', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -151,14 +154,14 @@ describe('NavHeader menu', () => {
     return { container, root };
   }
 
-  it('keeps Create Game and Studio, and drops Arcade / Operator / Account settings', async () => {
+  it('keeps Create Game and Studio, restores Operator for admins, drops Arcade / Account settings', async () => {
     const { container, root } = await renderSignedIn(true);
     const labels = Array.from(container.querySelectorAll('.nav-link')).map((el) => el.textContent ?? '');
 
     expect(labels.some((text) => /Create Game/i.test(text))).toBe(true);
     expect(labels.some((text) => /Studio/i.test(text))).toBe(true);
+    expect(labels.some((text) => /Operator/i.test(text))).toBe(true);
     expect(labels.some((text) => /Arcade/i.test(text))).toBe(false);
-    expect(labels.some((text) => /Operator/i.test(text))).toBe(false);
     expect(labels.some((text) => /Account settings/i.test(text))).toBe(false);
     // GitHub left the header; the footer carries the repo link instead.
     expect(container.querySelector('a.github')).toBeNull();
@@ -168,6 +171,13 @@ describe('NavHeader menu', () => {
     expect(labels.some((text) => /Sign out/i.test(text))).toBe(true);
     expect(container.querySelector('.nav-link--sign-out')).not.toBeNull();
 
+    await act(async () => root.unmount());
+  });
+
+  it('hides Operator from non-operators', async () => {
+    const { container, root } = await renderSignedIn(false);
+    const labels = Array.from(container.querySelectorAll('.nav-link')).map((el) => el.textContent ?? '');
+    expect(labels.some((text) => /Operator/i.test(text))).toBe(false);
     await act(async () => root.unmount());
   });
 
@@ -202,6 +212,7 @@ describe('NavHeader menu', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -229,12 +240,143 @@ describe('NavHeader menu', () => {
     await act(async () => root.unmount());
   });
 
-  it('never probes an operator endpoint from the chrome', async () => {
-    const { root } = await renderSignedIn(true);
+  it('never probes an operator endpoint from the chrome for non-operators', async () => {
+    const { root } = await renderSignedIn(false);
     const summaryCalls = () =>
       vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith('/api/admin/summary')).length;
 
     expect(summaryCalls()).toBe(0);
+    await act(async () => root.unmount());
+  });
+});
+
+// The console has been reachable only by typing its URL, which is why the one operator
+// surface with something to do on it was also the one nothing linked to.
+describe('NavHeader operator link', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    // The badge polls; the tests that care about that advance the clock themselves.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function renderWith(summary: { status: number; body: unknown }, admin = true) {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        // The session says whether this account is an operator; the nav never asks an
+        // operator endpoint to find out.
+        return new Response(
+          JSON.stringify({ user: { uid: 'g:boss', tier: 'free', ...(admin ? { admin: true } : {}) } }),
+        );
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/admin/summary')) {
+        return new Response(JSON.stringify(summary.body), { status: summary.status });
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const onAdmin = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin,
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The menu holds the link; open it the way a reader would.
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+    await act(async () => {
+      hamburger.click();
+      await Promise.resolve();
+    });
+    return { container, root, onAdmin };
+  }
+
+  it('offers the console, with what is waiting, to an operator', async () => {
+    const { container, root, onAdmin } = await renderWith({
+      status: 200,
+      body: {
+        alerts: [
+          {
+            id: 'op-1-review_ready',
+            kind: 'review_ready',
+            issueNumber: 1,
+            title: 'X',
+            ownerUid: 'g:1',
+            since: '2026-07-30T11:00:00Z',
+          },
+        ],
+        queue: { active: 1, stalled: 0, byState: {} },
+        limits: { paused: false, globalDailySubmissionCap: 50, todaySubmissions: 0 },
+      },
+    });
+
+    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
+      element.textContent?.includes('Operator'),
+    ) as HTMLButtonElement;
+    expect(link).toBeTruthy();
+    expect(link.querySelector('.specs-count-badge')?.textContent).toBe('1');
+
+    await act(async () => link.click());
+    expect(onAdmin).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('never asks an operator endpoint on behalf of someone who is not one', async () => {
+    // The 404 probe this replaced put an error in every non-operator's console on every
+    // page load — which is most people, on most page loads, and is what failed the
+    // deploy gate. A non-operator now makes no operator request at all.
+    const { root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
+    const summaryCalls = () =>
+      vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith('/api/admin/summary')).length;
+
+    expect(summaryCalls()).toBe(0);
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60_000);
+      await Promise.resolve();
+    });
+
+    expect(summaryCalls()).toBe(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows nobody else that there is a console at all', async () => {
+    // A session with no `admin` flag is the API's answer for a signed-in non-admin, and
+    // the nav treats it as the whole answer: no link, no badge, nothing to notice.
+    const { container, root } = await renderWith({ status: 404, body: { error: 'not found' } }, false);
+
+    const link = Array.from(container.querySelectorAll('.nav-link')).find((element) =>
+      element.textContent?.includes('Operator'),
+    );
+    expect(link).toBeUndefined();
+
     await act(async () => root.unmount());
   });
 });
@@ -273,6 +415,7 @@ describe('NavHeader Studio chip', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio,
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -346,6 +489,7 @@ describe('NavHeader profile link', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -389,6 +533,7 @@ describe('NavHeader profile link', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),
@@ -442,6 +587,7 @@ describe('LanguageSwitcher in header', () => {
             onNavigate: vi.fn(),
             onHome: vi.fn(),
             onStudio: vi.fn(),
+            onAdmin: vi.fn(),
             upTarget: null,
           }),
         ),

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { AccountSettingsModal } from './AccountSettingsModal.js';
@@ -7,6 +7,7 @@ import { LanguageSwitcher } from './LanguageSwitcher.js';
 import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
+import { fetchAdminSummary } from './adminApi.js';
 import { creatorPath } from './router.js';
 import { usePageScrolling } from './usePageScrolling.js';
 
@@ -18,6 +19,8 @@ type NavHeaderProps = {
   onHome: () => void;
   /** Opens the creator control panel. */
   onStudio: () => void;
+  /** Opens the operator console. Only ever called from a link only operators are shown. */
+  onAdmin: () => void;
   /**
    * Android-style Up target for non-home surfaces. Null on home, join, play, and
    * while an immersive theater owns escape. Never history.back() — deep links
@@ -27,7 +30,15 @@ type NavHeaderProps = {
   onUp?: (path: string) => void;
 };
 
-export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTarget = null, onUp }: NavHeaderProps) {
+export function NavHeader({
+  activeBuildCount,
+  onNavigate,
+  onHome,
+  onStudio,
+  onAdmin,
+  upTarget = null,
+  onUp,
+}: NavHeaderProps) {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -35,6 +46,42 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Header mark mimes the visitor: pull a phone and scroll a tiny feed while the page moves.
   const pageScrolling = usePageScrolling();
+  /**
+   * How many jobs are waiting on this person. Only ever read for an operator.
+   *
+   * Whether someone *is* one comes from the session (`user.admin`) rather than from
+   * probing an operator endpoint and reading its 404 as "no". That probe was the
+   * obvious implementation and the wrong one: it asked a settled question on every page
+   * load, and for everybody who is not an operator — which is everybody — it answered
+   * with an error in the browser console. The deploy gate that fails on console errors
+   * caught it, correctly.
+   */
+  const [alertCount, setAlertCount] = useState<number | null>(null);
+  const isOperator = user?.admin === true;
+
+  useEffect(() => {
+    if (!isOperator) {
+      setAlertCount(null);
+      return;
+    }
+    let cancelled = false;
+    const read = () =>
+      fetchAdminSummary()
+        .then((summary) => {
+          if (!cancelled) setAlertCount(summary ? summary.alerts.length : 0);
+        })
+        .catch(() => {
+          // A failed read is not evidence of anything; leave the badge as it was.
+        });
+    void read();
+    // Slower than the console's own poll: this is a badge somebody glances at, not a
+    // queue they are working, and it rides along on every page of the site.
+    const timer = setInterval(read, 120_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [isOperator]);
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -185,6 +232,25 @@ export function NavHeader({ activeBuildCount, onNavigate, onHome, onStudio, upTa
                   </span>
                 ) : null}
               </button>
+
+              {/* Operators only — everyone else never learns this exists, which is the
+                  same posture the API takes when asked. */}
+              {isOperator ? (
+                <button
+                  className="nav-link"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    onAdmin();
+                  }}
+                >
+                  <PixelIcon name="wrench" size={14} /> Operator
+                  {alertCount !== null && alertCount > 0 ? (
+                    <span className="specs-count-badge" aria-label={`${alertCount} waiting on you`}>
+                      {alertCount}
+                    </span>
+                  ) : null}
+                </button>
+              ) : null}
 
               {/* Sign out lives at the foot of the menu on every width — not beside
                   the avatar, where it competed with the bell and the menu button. */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore the **Operator** menu item for sessions with `user.admin` (dropped as “URL-only” in the header-slim change).
- Bring back the waiting-alert badge via `/api/admin/summary`, still only for operators — non-operators never probe that endpoint.
- Sign out stays at the menu foot.

## Screenshot

[Operator restored in nav menu](https://cursor.com/agents/bc-afda2dce-c699-4350-96cb-8775596780cb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Foperator-menu-restored.png)

## Test plan
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] NavHeader tests: Operator shown for admins, hidden otherwise, badge + click, no summary probe for non-ops
- [x] Visual check with an operator session

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afda2dce-c699-4350-96cb-8775596780cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afda2dce-c699-4350-96cb-8775596780cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

