### PR TITLE
Focus the prompt when Create Game is clicked in the menu

### DIFF
--- a/apps/web/src/App.createGameFocus.test.ts
+++ b/apps/web/src/App.createGameFocus.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('Create Game menu focus', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    window.history.pushState(null, '', '/');
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('focuses the hero prompt when Create Game is chosen from the hamburger', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:test', tier: 'standard', name: 'Tester' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/catalog')) {
+        return new Response(JSON.stringify([]));
+      }
+      if (url.includes('/api/recommendations')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      if (url.endsWith('/api/quota')) {
+        return new Response(JSON.stringify({ submissions: { used: 0, limit: 10 } }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    // Page-load autofocus is desktop-only; force the narrow path so focus comes
+    // only from the menu click under test.
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({
+        matches: true,
+        media: '(max-width: 768px)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    );
+
+    Element.prototype.scrollIntoView = vi.fn();
+
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(App)));
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const prompt = container.querySelector<HTMLTextAreaElement>('.big-prompt-input');
+    expect(prompt).not.toBeNull();
+    expect(document.activeElement).not.toBe(prompt);
+
+    const hamburger = container.querySelector<HTMLButtonElement>('.hamburger-btn');
+    expect(hamburger).not.toBeNull();
+    await act(async () => {
+      hamburger?.click();
+      await flushEffects();
+    });
+
+    const createGame = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((btn) =>
+      /Create Game/i.test(btn.textContent ?? ''),
+    );
+    expect(createGame).toBeDefined();
+
+    await act(async () => {
+      createGame?.click();
+      await flushEffects();
+    });
+
+    expect(document.activeElement).toBe(prompt);
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -411,10 +411,19 @@ export function App() {
   // Menu navigation is scroll-to-section, but the sections only exist on the home
   // route — from a status page we have to go home first and scroll once the target
   // has mounted (the Games gallery may still be loading).
+  // Create Game also focuses the prompt so the visitor can type immediately — that
+  // is intentional on phones too (unlike page-load autofocus, which would pop the
+  // keyboard before they asked for it).
+  const focusHeroPromptInput = () => {
+    const input = document.querySelector<HTMLTextAreaElement>('#hero-prompt .big-prompt-input');
+    input?.focus({ preventScroll: true });
+  };
+
   const handleNavigateSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
     if (element) {
       element.scrollIntoView?.({ behavior: 'smooth' });
+      if (sectionId === 'hero-prompt') focusHeroPromptInput();
       return;
     }
     setPendingScrollTarget(sectionId);
@@ -429,6 +438,7 @@ export function App() {
       const element = document.getElementById(pendingScrollTarget);
       if (element) {
         element.scrollIntoView?.({ behavior: 'smooth' });
+        if (pendingScrollTarget === 'hero-prompt') focusHeroPromptInput();
       }
       // Give a still-loading section a moment to appear, then stop either way.
       if (element || (attempts += 1) > 20) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -415,7 +415,9 @@ export function App() {
   // has mounted (the Games gallery may still be loading).
   // Create Game also focuses the prompt so the visitor can type immediately — that
   // is intentional on phones too (unlike page-load autofocus, which would pop the
-  // keyboard before they asked for it).
+  // keyboard before they asked for it). Focus must happen inside the click (or a
+  // flushSync mount still in that gesture); a later timer will not open the
+  // keyboard on iOS Safari.
   const focusHeroPromptInput = () => {
     const input = document.querySelector<HTMLTextAreaElement>('#hero-prompt .big-prompt-input');
     input?.focus({ preventScroll: true });
@@ -432,16 +434,15 @@ export function App() {
   const handleNavigateSection = (sectionId: string) => {
     if (scrollAndFocusSection(sectionId)) return;
 
-    // Flush home so #hero-prompt can mount inside this click. Focusing from the
-    // pending-scroll interval alone is often ignored on iOS Safari (no user gesture).
+    // Mount home inside this click so focus still counts as a user gesture.
     flushSync(() => {
-      setPendingScrollTarget(sectionId);
       navigate('/');
     });
-    if (scrollAndFocusSection(sectionId)) {
-      setPendingScrollTarget(null);
-      return;
-    }
+    if (scrollAndFocusSection(sectionId)) return;
+
+    // Node still missing (unusual for hero-prompt) — scroll when it appears.
+    // Do not focus from the timer: that is outside the gesture window.
+    setPendingScrollTarget(sectionId);
   };
 
   useEffect(() => {
@@ -452,7 +453,6 @@ export function App() {
       const element = document.getElementById(pendingScrollTarget);
       if (element) {
         element.scrollIntoView?.({ behavior: 'smooth' });
-        if (pendingScrollTarget === 'hero-prompt') focusHeroPromptInput();
       }
       // Give a still-loading section a moment to appear, then stop either way.
       if (element || (attempts += 1) > 20) {

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -171,6 +171,62 @@ describe('NavHeader menu', () => {
     await act(async () => root.unmount());
   });
 
+  it('asks to navigate to the hero prompt when Create Game is clicked', async () => {
+    const onNavigate = vi.fn();
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: null }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate,
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+    await act(async () => {
+      hamburger.click();
+      await Promise.resolve();
+    });
+
+    const createGame = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((btn) =>
+      /Create Game/i.test(btn.textContent ?? ''),
+    );
+    expect(createGame).toBeDefined();
+    await act(async () => {
+      createGame?.click();
+      await Promise.resolve();
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('hero-prompt');
+    expect(container.querySelector('.dropdown-menu')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it('signs out from the menu foot and closes the menu', async () => {
     const logoutSpy = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicking **Create Game** in the hamburger already scrolled to `#hero-prompt`. It now also focuses the big prompt textarea so you can start typing right away.

This is intentional on phones too: page-load autofocus is still skipped (to avoid popping the keyboard unprompted), but an explicit menu click focuses the field.

Off-home (e.g. from Studio) mounts home with `flushSync` before focusing, so the focus still counts as a user gesture on iOS Safari. The pending-scroll interval may still scroll if the node is late, but it does not call `focus()`.

## Test plan

- [x] Unit: Create Game from hamburger focuses `.big-prompt-input`
- [x] Unit: Create Game from Studio navigates home and focuses the prompt
- [x] Unit: Create Game calls `onNavigate('hero-prompt')` and closes the menu
- [ ] Manual: on home, open hamburger → Create Game → caret is in the prompt
- [ ] Manual: from Studio, Create Game → lands on home with prompt focused (keyboard on iOS)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e0c0b1f-3f5d-44f2-b131-72628635c309?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e0c0b1f-3f5d-44f2-b131-72628635c309&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

