### PR TITLE
claude: say that the connector needs approving after the plugin installs

### DIFF
--- a/listings/mcp/claude-plugin/README.md
+++ b/listings/mcp/claude-plugin/README.md
@@ -12,6 +12,18 @@ root. Install it with:
 or from claude.ai: **Settings → Plugins → Add → Add marketplace**, then
 `gamedevpl/www.gamedev.pl`.
 
+### Installing the plugin does not connect the server — that is deliberate
+
+There is one more step after install: the `gamedevpl` MCP server has to be enabled as a
+connector. It is not automatic and should not be. A plugin comes from a repository rather
+than from you, so Claude puts every MCP server a plugin declares behind **the same
+per-server approval as a project `.mcp.json`** — otherwise installing a third-party plugin
+could silently attach a remote server to your assistant.
+
+So the honest instruction is two steps, not one: **install the plugin, then approve the
+`gamedevpl` connector.** Verified working 2026-08-06 — once approved, the tools load and
+the server's closed-beta notice comes through with them.
+
 ## Why this lives in its own directory
 
 The plugin's `source` deliberately points here rather than at the repository root. Claude


### PR DESCRIPTION
Docs only. The plugin works; the install instructions were a step short.

## What was missing

Installing the plugin does **not** connect the MCP server — the `gamedevpl` connector has to be approved separately. Our README implied one step.

That extra step is deliberate on Claude's side, not a gap in our manifest. Per the [plugins reference](https://code.claude.com/docs/en/plugins-reference), a plugin's content comes from a repository rather than from the user, so **MCP servers it declares go through the same per-server approval as a project `.mcp.json`**. Without that gate, installing a third-party plugin could silently attach a remote server to someone's assistant — so the friction is the feature.

Recorded as two steps: install the plugin, then approve the connector.

## End-to-end verification

This also records the first confirmation of the whole chain through a **real client** rather than curl. With the connector approved, the tools load and the server's own instructions arrive with them, beginning:

> NOTE: gamedev.pl is in closed beta. These tools need a creator account; if you do not have one, join the waitlist at https://www.gamedev.pl/ — listing tools here does not mean you can use them yet.

That is the beta messaging shipped in #508 reaching an actual assistant, which is what it was written for. Until now every check had been an HTTP probe against the endpoint.

## Channel status after this

The Claude plugin channel is complete and working: catalog live on the default branch, plugin `1.0.2`, `.mcp.json` in the plugin root, install path documented accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_