### PR TITLE
claude: record which surfaces the plugin is actually verified on

### DIFF
--- a/listings/mcp/claude-plugin/README.md
+++ b/listings/mcp/claude-plugin/README.md
@@ -30,6 +30,18 @@ from you, so Claude puts every MCP server a plugin declares behind the same per-
 approval as a project `.mcp.json`. Without that gate, installing a third-party plugin
 could silently attach a remote server to your assistant. Two steps, on purpose.
 
+### Verified surfaces
+
+| Surface       | Verified   | How far the check went                                                                      |
+| ------------- | ---------- | ------------------------------------------------------------------------------------------- |
+| claude.ai     | 2026-08-06 | Plugin installs, connector approves, tools load, server's own notice arrives with them      |
+| Claude Cowork | 2026-08-06 | The above, plus an authenticated `create_game` round-trip returning a real `jobId` and slug |
+| Claude Code   | —          | Not yet exercised through the plugin path                                                   |
+
+Recorded because "installs cleanly" and "actually exposes the server" turned out to be
+independent: 1.0.1 did the first and not the second, and nothing errored in between. A
+surface is only listed here once a tool call has really run on it.
+
 ## What you can do with it
 
 - **Start a new game** from a description and have Claude build, submit and iterate on it


### PR DESCRIPTION
Docs only. Adds a verified-surfaces table to the plugin README.

| Surface | Verified | How far the check went |
| --- | --- | --- |
| claude.ai | 2026-08-06 | Plugin installs, connector approves, tools load, server's own notice arrives with them |
| Claude Cowork | 2026-08-06 | The above, plus an authenticated `create_game` round-trip returning a real `jobId` and slug |
| Claude Code | — | Not yet exercised through the plugin path |

## Why this table exists

**"Installs cleanly" and "actually exposes the server" turned out to be independent properties.** 1.0.1 did the first and not the second, with nothing erroring anywhere in between — the marketplace resolved, the install succeeded, the Directory rendered the entry correctly, and the plugin contained no server. That is why 1.0.2 exists.

So a surface earns a row here only once a tool call has really run on it. Claude Code is listed as unverified rather than assumed, even though it would very likely work — the plugin is just a remote MCP declaration.

The Cowork check is the strongest evidence the plugin has: an authenticated **write** through the plugin, on a real surface, returning a live `jobId` and slug from production.

Manifest still passes `claude plugin validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_