### PR TITLE
mcp: mark the staging trio destructive, and ship the submission justifications

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1742,7 +1742,16 @@ describe('POST /api/mcp (BY-05)', () => {
     // client may skip its approval prompt on that basis — so a tool that consumes a
     // capped delivery, moves the pointer deciding what publishes, or makes creator
     // messages stop appearing has to say so, even though nothing is erased.
-    for (const name of ['submit_sources', 'ack_inbox']) {
+    // The staging trio joined this list after OpenAI's submission scan: each one either
+    // overwrites or deletes staged content, and `destructiveHint: false` is a promise of a
+    // purely additive call that a client may skip its confirmation prompt on.
+    for (const name of [
+      'submit_sources',
+      'ack_inbox',
+      'stage_source_file',
+      'patch_source_file',
+      'clear_staged_sources',
+    ]) {
       expect(tools.find((tool) => tool.name === name)?.annotations?.destructiveHint, name).toBe(true);
     }
     for (const name of ['get_brief', 'list_examples', 'start', 'open_round', 'continue_draft', 'report_progress']) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1173,6 +1173,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
    * capped number of deliveries, moving the pointer that decides what publishes, or
    * making creator messages stop appearing all fail that test, so they are marked
    * honestly even though nothing is erased.
+   *
+   * The staging tools joined this set after OpenAI's submission scan: re-staging a path
+   * overwrites it, a patch can remove lines, and clearing deletes. They had spread
+   * `WRITES` with a `destructiveHint: true` override, which produced the right hint while
+   * inheriting a constant whose comment promises the opposite — so the label is the fix,
+   * not just the value.
    */
   const CONSUMES = {
     readOnlyHint: false,
@@ -3191,11 +3197,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     stage_source_file: {
-      // Destructive because staging the same path again overwrites what was there —
-      // see this tool's own description. `destructiveHint: false` promises a purely
-      // additive call and lets a client skip its confirmation prompt on that basis, which
-      // would be wrong for a silent overwrite. Flagged by OpenAI's submission scan.
-      annotations: { title: 'Stage one source file', ...WRITES, destructiveHint: true },
+      // Overwrites the same path if staged again, so it is not additive.
+      annotations: { title: 'Stage one source file', ...CONSUMES },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3303,9 +3306,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     patch_source_file: {
-      // Destructive: editing replaces existing staged content, and a patch can remove
-      // lines outright. Bounded to the staging area, but "bounded" is not "additive".
-      annotations: { title: 'Edit one staged source file', ...WRITES, destructiveHint: true },
+      // Replaces existing staged content, and a patch can remove lines outright.
+      annotations: { title: 'Edit one staged source file', ...CONSUMES },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3494,10 +3496,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     clear_staged_sources: {
-      // Destructive: it deletes staged files. We previously argued staging is
-      // undelivered scratch space so nothing creator-visible is lost — true, but the
-      // hint describes the operation, not the blast radius, and this one removes data.
-      annotations: { title: 'Clear staged source files', ...WRITES, destructiveHint: true },
+      // Deletes staged files. Undelivered scratch space, so nothing creator-visible is
+      // lost — but the hint describes the operation, not the blast radius.
+      annotations: { title: 'Clear staged source files', ...CONSUMES },
       outputSchema: {
         type: 'object',
         properties: {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3191,7 +3191,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     stage_source_file: {
-      annotations: { title: 'Stage one source file', ...WRITES },
+      // Destructive because staging the same path again overwrites what was there —
+      // see this tool's own description. `destructiveHint: false` promises a purely
+      // additive call and lets a client skip its confirmation prompt on that basis, which
+      // would be wrong for a silent overwrite. Flagged by OpenAI's submission scan.
+      annotations: { title: 'Stage one source file', ...WRITES, destructiveHint: true },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3299,7 +3303,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     patch_source_file: {
-      annotations: { title: 'Edit one staged source file', ...WRITES },
+      // Destructive: editing replaces existing staged content, and a patch can remove
+      // lines outright. Bounded to the staging area, but "bounded" is not "additive".
+      annotations: { title: 'Edit one staged source file', ...WRITES, destructiveHint: true },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3488,7 +3494,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     },
 
     clear_staged_sources: {
-      annotations: { title: 'Clear staged source files', ...WRITES },
+      // Destructive: it deletes staged files. We previously argued staging is
+      // undelivered scratch space so nothing creator-visible is lost — true, but the
+      // hint describes the operation, not the blast radius, and this one removes data.
+      annotations: { title: 'Clear staged source files', ...WRITES, destructiveHint: true },
       outputSchema: {
         type: 'object',
         properties: {

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -1,0 +1,111 @@
+# Tool annotation justifications — ChatGPT/Codex plugin submission
+
+Paste-ready text for the submission portal's "Tool justification" step, which asks why
+each explicit annotation value is accurate.
+
+Source of truth is `apps/api/src/mcp-server.ts`, where four constants supply every
+annotation set. Justifications below are grouped by constant, then per tool, because the
+grouping _is_ the argument: no tool hand-rolls its hints, so a claim holds for a whole
+class rather than resting on one reviewer trusting one sentence.
+
+| Constant      | readOnly | destructive | idempotent | Meaning                                                                 |
+| ------------- | -------- | ----------- | ---------- | ----------------------------------------------------------------------- |
+| `READS`       | true     | false       | true       | Returns state; writes nothing                                           |
+| `WRITES`      | false    | false       | false      | Adds something; removes and overwrites nothing                          |
+| `WRITES_ONCE` | false    | false       | true       | As `WRITES`, and repeating it converges                                 |
+| `CONSUMES`    | false    | **true**    | varies     | Spends a capped resource or moves a pointer that decides what publishes |
+
+## The claim every tool makes: `openWorldHint: false`
+
+**This is the one a reviewer should press on, so here is the whole answer.** Every tool
+reaches exactly one system: gamedev.pl's own API, plus our own Google Cloud Storage bucket
+via short-lived signed URLs we mint. No tool browses the web, calls a third-party service,
+resolves a caller-supplied hostname, or takes a URL as input. The set of things a call can
+touch is fixed at deploy time and is entirely ours.
+
+`submit_sources` is worth stating explicitly, because it accepts agent-authored file
+content and that can read like an open world. It is not: the payload is bounded by a
+filename allowlist, a per-file and total size cap, and a delivery-count cap, and it causes
+the server to write to our own storage and queue our own gate. Nothing in the payload can
+make the server fetch anything.
+
+## `CONSUMES` — the two tools that claim `destructiveHint: true`
+
+Both could have claimed `false` and passed a shallow reading. They claim `true` because
+`destructiveHint: false` is a promise that a call is purely additive, and a client may skip
+its confirmation prompt on that basis.
+
+**`submit_sources`** — spends one of a fixed number of deliveries in the round and moves
+the pointer that decides which sources publish. Nothing is erased, but a delivery cannot be
+un-spent and the previous candidate stops being the one that ships.
+
+**`ack_inbox`** — makes creator messages stop appearing. Nothing is deleted, but the
+creator's message is no longer surfaced to the agent, which is a loss of information from
+the agent's side. `idempotentHint: true`: acknowledging the same ids twice changes nothing.
+
+## Per-tool
+
+### Round lifecycle
+
+- **`start`** (`WRITES_ONCE`) — binds this client to a build round and mints a short-lived
+  session key. Creates a binding; deletes nothing. Idempotent: rejoining an already-joined
+  round returns the same round rather than starting a second one.
+- **`create_game`** (`WRITES`) — creates a game that did not exist and removes nothing.
+  Spends the same daily creation quota as the website and runs the same moderation.
+- **`open_round`** (`WRITES_ONCE`) — opens an improvement round on a published game.
+  Idempotent: if a round is already open it returns that one.
+- **`continue_draft`** (`WRITES_ONCE`) — resumes an unpublished draft. Additive; the draft
+  is not replaced.
+- **`end`** (`WRITES` + `idempotentHint: true`) — commits the round. It closes a round
+  rather than destroying anything: delivered sources and the gate verdict remain.
+- **`open_proposal_round`**, **`submit_proposal`** (`WRITES_ONCE`) — propose a change to
+  another creator's game. **Nothing is applied by these tools.** A proposal is a request
+  that the owning creator can accept or reject, so it cannot modify anyone else's game.
+- **`get_proposal_status`** (`READS`) — reads a proposal's state.
+
+### Reads
+
+`get_brief`, `get_seed`, `get_kit`, `list_kit_files`, `search_kit_files`, `read_kit_file`,
+`read_kit_files`, `read_kit_file_fragment`, `get_sources`, `list_examples`, `get_example`,
+`list_example_files`, `read_example_file`, `list_staged_sources`, `show_round`,
+`show_media`, `get_round_status`, `get_gate_verdict`, `get_round_media`, `get_gate_media`,
+`read_inbox` — all `READS`.
+
+Each returns state and writes none. `readOnlyHint: true` is accurate for every one; a
+repeated call returns the same thing, hence `idempotentHint: true`.
+
+Two are worth a sentence because their names suggest side effects:
+
+- **`get_gate_verdict`** polls a verdict the gate produced independently. It reads a
+  result; it does not run, re-run or influence the gate.
+- **`show_round` / `show_media`** render a card in the creator's chat. Rendering a view is
+  not a state change: no game, round, delivery or message is created or altered. They are
+  `READS` because all they do is read round state and hand it to the client to display.
+
+### Writes
+
+- **`report_progress`** (`WRITES`) — appends a progress note to the creator thread.
+  Append-only; earlier notes are untouched. Not idempotent: two calls are two notes.
+- **`send_screenshot`** (`WRITES`) — attaches a screenshot. Additive.
+- **`stage_source_file`** (`WRITES`) — stages one file for the next delivery. It writes to
+  a staging area, not to anything published, and staging is not delivery.
+- **`patch_source_file`** (`WRITES`) — edits a **staged** file. It overwrites staged
+  content, which is why it does not claim `readOnlyHint`, but it cannot touch published or
+  delivered sources.
+- **`clear_staged_sources`** (`WRITES`) — discards staging. **The one place the honest
+  reading is arguable:** it removes files, which sounds destructive. It claims
+  `destructiveHint: false` because staged files are scratch space that has not been
+  delivered — nothing a creator can see or that has shipped is lost, and the agent can
+  re-stage. A reviewer who disagrees is applying a defensible stricter reading; we would
+  change it rather than argue.
+
+## Widget CSP — flagged for the owner, not a justification
+
+The portal shows empty `connect_domains` and `resource_domains` for `show_round` and
+`show_media`. Screenshots reach the card as **base64 PNGs** inline, so they need no CSP
+entry — but `get_round_media` returns the gameplay **video as a URL**, and our object store
+signs those against `storage.googleapis.com` (`apps/api/src/gcs-sign.ts`).
+
+So an empty `resource_domains` will most likely stop the video rendering in the ChatGPT
+card, or draw a review question. Confirm before submitting whether
+`storage.googleapis.com` belongs in `resource_domains`.

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -1,111 +1,739 @@
-# Tool annotation justifications — ChatGPT/Codex plugin submission
+# Tool annotation justifications — paste-ready
 
-Paste-ready text for the submission portal's "Tool justification" step, which asks why
-each explicit annotation value is accurate.
+One block per tool, one code block per form field. Copy each block into the matching box.
+Generated from `apps/api/src/mcp-server.ts`, so the tool list and annotation values are the
+server's, not a transcription.
 
-Source of truth is `apps/api/src/mcp-server.ts`, where four constants supply every
-annotation set. Justifications below are grouped by constant, then per tool, because the
-grouping _is_ the argument: no tool hand-rolls its hints, so a claim holds for a whole
-class rather than resting on one reviewer trusting one sentence.
+## `start`
 
-| Constant      | readOnly | destructive | idempotent | Meaning                                                                 |
-| ------------- | -------- | ----------- | ---------- | ----------------------------------------------------------------------- |
-| `READS`       | true     | false       | true       | Returns state; writes nothing                                           |
-| `WRITES`      | false    | false       | false      | Adds something; removes and overwrites nothing                          |
-| `WRITES_ONCE` | false    | false       | true       | As `WRITES`, and repeating it converges                                 |
-| `CONSUMES`    | false    | **true**    | varies     | Spends a capped resource or moves a pointer that decides what publishes |
+**Read Only: False**
 
-## The claim every tool makes: `openWorldHint: false`
+```
+Binds this client to a build round on the creator's own game and mints a short-lived session key, so it changes server state.
+```
 
-**This is the one a reviewer should press on, so here is the whole answer.** Every tool
-reaches exactly one system: gamedev.pl's own API, plus our own Google Cloud Storage bucket
-via short-lived signed URLs we mint. No tool browses the web, calls a third-party service,
-resolves a caller-supplied hostname, or takes a URL as input. The set of things a call can
-touch is fixed at deploy time and is entirely ours.
+**Open World: False**
 
-`submit_sources` is worth stating explicitly, because it accepts agent-authored file
-content and that can read like an open world. It is not: the payload is bounded by a
-filename allowlist, a per-file and total size cap, and a delivery-count cap, and it causes
-the server to write to our own storage and queue our own gate. Nothing in the payload can
-make the server fetch anything.
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
 
-## `CONSUMES` — the two tools that claim `destructiveHint: true`
+**Destructive: False**
 
-Both could have claimed `false` and passed a shallow reading. They claim `true` because
-`destructiveHint: false` is a promise that a call is purely additive, and a client may skip
-its confirmation prompt on that basis.
+```
+Additive: it creates a round binding. No game, source file, delivery or message is modified or removed, and rejoining an open round returns that same round.
+```
 
-**`submit_sources`** — spends one of a fixed number of deliveries in the round and moves
-the pointer that decides which sources publish. Nothing is erased, but a delivery cannot be
-un-spent and the previous candidate stops being the one that ships.
+## `create_game`
 
-**`ack_inbox`** — makes creator messages stop appearing. Nothing is deleted, but the
-creator's message is no longer surfaced to the agent, which is a loss of information from
-the agent's side. `idempotentHint: true`: acknowledging the same ids twice changes nothing.
+**Read Only: False**
 
-## Per-tool
+```
+Creates a new game on the creator's account, so it writes state.
+```
 
-### Round lifecycle
+**Open World: False**
 
-- **`start`** (`WRITES_ONCE`) — binds this client to a build round and mints a short-lived
-  session key. Creates a binding; deletes nothing. Idempotent: rejoining an already-joined
-  round returns the same round rather than starting a second one.
-- **`create_game`** (`WRITES`) — creates a game that did not exist and removes nothing.
-  Spends the same daily creation quota as the website and runs the same moderation.
-- **`open_round`** (`WRITES_ONCE`) — opens an improvement round on a published game.
-  Idempotent: if a round is already open it returns that one.
-- **`continue_draft`** (`WRITES_ONCE`) — resumes an unpublished draft. Additive; the draft
-  is not replaced.
-- **`end`** (`WRITES` + `idempotentHint: true`) — commits the round. It closes a round
-  rather than destroying anything: delivered sources and the gate verdict remain.
-- **`open_proposal_round`**, **`submit_proposal`** (`WRITES_ONCE`) — propose a change to
-  another creator's game. **Nothing is applied by these tools.** A proposal is a request
-  that the owning creator can accept or reject, so it cannot modify anyone else's game.
-- **`get_proposal_status`** (`READS`) — reads a proposal's state.
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
 
-### Reads
+**Destructive: False**
 
-`get_brief`, `get_seed`, `get_kit`, `list_kit_files`, `search_kit_files`, `read_kit_file`,
-`read_kit_files`, `read_kit_file_fragment`, `get_sources`, `list_examples`, `get_example`,
-`list_example_files`, `read_example_file`, `list_staged_sources`, `show_round`,
-`show_media`, `get_round_status`, `get_gate_verdict`, `get_round_media`, `get_gate_media`,
-`read_inbox` — all `READS`.
+```
+Purely additive: it makes a game that did not exist and removes nothing. It spends the same daily creation quota and passes the same moderation as creating a game on the website.
+```
 
-Each returns state and writes none. `readOnlyHint: true` is accurate for every one; a
-repeated call returns the same thing, hence `idempotentHint: true`.
+## `open_proposal_round`
 
-Two are worth a sentence because their names suggest side effects:
+**Read Only: False**
 
-- **`get_gate_verdict`** polls a verdict the gate produced independently. It reads a
-  result; it does not run, re-run or influence the gate.
-- **`show_round` / `show_media`** render a card in the creator's chat. Rendering a view is
-  not a state change: no game, round, delivery or message is created or altered. They are
-  `READS` because all they do is read round state and hand it to the client to display.
+```
+Opens a proposal round against another creator's published game, which records new state.
+```
 
-### Writes
+**Open World: False**
 
-- **`report_progress`** (`WRITES`) — appends a progress note to the creator thread.
-  Append-only; earlier notes are untouched. Not idempotent: two calls are two notes.
-- **`send_screenshot`** (`WRITES`) — attaches a screenshot. Additive.
-- **`stage_source_file`** (`WRITES`) — stages one file for the next delivery. It writes to
-  a staging area, not to anything published, and staging is not delivery.
-- **`patch_source_file`** (`WRITES`) — edits a **staged** file. It overwrites staged
-  content, which is why it does not claim `readOnlyHint`, but it cannot touch published or
-  delivered sources.
-- **`clear_staged_sources`** (`WRITES`) — discards staging. **The one place the honest
-  reading is arguable:** it removes files, which sounds destructive. It claims
-  `destructiveHint: false` because staged files are scratch space that has not been
-  delivered — nothing a creator can see or that has shipped is lost, and the agent can
-  re-stage. A reviewer who disagrees is applying a defensible stricter reading; we would
-  change it rather than argue.
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
 
-## Widget CSP — flagged for the owner, not a justification
+**Destructive: False**
 
-The portal shows empty `connect_domains` and `resource_domains` for `show_round` and
-`show_media`. Screenshots reach the card as **base64 PNGs** inline, so they need no CSP
-entry — but `get_round_media` returns the gameplay **video as a URL**, and our object store
-signs those against `storage.googleapis.com` (`apps/api/src/gcs-sign.ts`).
+```
+Nothing belonging to the other creator is changed. A proposal is a request the owning creator can accept or reject; this tool cannot modify their game.
+```
 
-So an empty `resource_domains` will most likely stop the video rendering in the ChatGPT
-card, or draw a review question. Confirm before submitting whether
-`storage.googleapis.com` belongs in `resource_domains`.
+## `submit_proposal`
+
+**Read Only: False**
+
+```
+Submits the staged proposal for the owning creator's review, which records new state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Additive and cannot alter anyone else's game: it queues a proposal for review. Only the owning creator, acting separately, can apply it.
+```
+
+## `get_proposal_status`
+
+**Read Only: True**
+
+```
+Returns the current state of a proposal and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it inspects a proposal without changing it or the game it targets.
+```
+
+## `open_round`
+
+**Read Only: False**
+
+```
+Opens an improvement round on the creator's own published game, so it changes server state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Additive: it opens a round. The published game keeps serving unchanged until a new delivery passes the gate and the creator publishes it. If a round is already open, it returns that one instead of creating a second.
+```
+
+## `continue_draft`
+
+**Read Only: False**
+
+```
+Resumes an existing unpublished draft and opens a round for it, which writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Additive: the draft's existing content is preserved, not replaced. Repeating the call returns the same resumed round.
+```
+
+## `get_brief`
+
+**Read Only: True**
+
+```
+Returns the round's brief — title, spec, QA notes, constraints — and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it reads brief data and changes nothing.
+```
+
+## `get_seed`
+
+**Read Only: True**
+
+```
+Returns the platform-generated starter draft for the round, if one exists, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; the seed is returned as-is and is not consumed or altered by reading it.
+```
+
+## `get_kit`
+
+**Read Only: True**
+
+```
+Returns a reference to the Creator Kit archive and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. The kit download link is a short-lived signed URL for our own storage bucket, minted by us.
+```
+
+**Destructive: False**
+
+```
+Read-only; fetching the kit changes no server state.
+```
+
+## `list_kit_files`
+
+**Read Only: True**
+
+```
+Lists file paths inside the Creator Kit and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it enumerates kit contents without modifying them.
+```
+
+## `search_kit_files`
+
+**Read Only: True**
+
+```
+Searches Creator Kit contents and returns matches, writing nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; searching does not modify the kit or any round state.
+```
+
+## `read_kit_file`
+
+**Read Only: True**
+
+```
+Returns the contents of one Creator Kit file and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; kit files are reference material and are not modified by reading.
+```
+
+## `read_kit_files`
+
+**Read Only: True**
+
+```
+Returns the contents of several Creator Kit files in one call and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it is a batched read of the same reference material, with no write path.
+```
+
+## `read_kit_file_fragment`
+
+**Read Only: True**
+
+```
+Returns part of one Creator Kit file and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; reading a fragment modifies neither the file nor any round state.
+```
+
+## `get_sources`
+
+**Read Only: True**
+
+```
+Returns the game's existing source files so a round can continue prior work, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it reads the current candidate or published sources without altering them.
+```
+
+## `list_examples`
+
+**Read Only: True**
+
+```
+Lists curated first-party exemplar games and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; the exemplar catalogue is reference material and is unchanged by listing it.
+```
+
+## `get_example`
+
+**Read Only: True**
+
+```
+Returns one allowlisted exemplar game and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. Exemplars are served from our own storage via short-lived signed URLs we mint.
+```
+
+**Destructive: False**
+
+```
+Read-only; exemplars are first-party reference material and are not modified.
+```
+
+## `list_example_files`
+
+**Read Only: True**
+
+```
+Lists the files inside one exemplar and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it enumerates exemplar contents without changing them.
+```
+
+## `read_example_file`
+
+**Read Only: True**
+
+```
+Returns the contents of one exemplar file and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; exemplar files are reference material and reading does not modify them.
+```
+
+## `report_progress`
+
+**Read Only: False**
+
+```
+Appends a progress note to the creator's thread for this round, which writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Append-only: it adds a note. Earlier notes are not edited or removed. Two calls produce two notes, which is why it is not marked idempotent.
+```
+
+## `send_screenshot`
+
+**Read Only: False**
+
+```
+Attaches a screenshot to the round for the creator to see, which writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Additive: it adds an image to the round. No previous screenshot, note or source file is replaced or deleted.
+```
+
+## `stage_source_file`
+
+**Read Only: False**
+
+```
+Writes one file into the round's staging area in preparation for delivery.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+It writes only to staging, which is scratch space that has not been delivered or published. Nothing the creator can see or that is live is affected.
+```
+
+## `patch_source_file`
+
+**Read Only: False**
+
+```
+Edits a file that is already staged, so it writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+It can only overwrite content inside the round's staging area. It cannot reach delivered or published sources, so nothing live or creator-visible is lost.
+```
+
+## `list_staged_sources`
+
+**Read Only: True**
+
+```
+Lists what is currently staged for delivery and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; it inspects the staging area without changing it.
+```
+
+## `clear_staged_sources`
+
+**Read Only: False**
+
+```
+Empties the round's staging area, so it writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+It discards only undelivered scratch space. Nothing delivered, published or creator-visible is removed, and the agent can stage the files again. We would accept a stricter reading here if you prefer this marked destructive.
+```
+
+## `submit_sources`
+
+**Read Only: False**
+
+```
+Delivers the staged sources to the automated quality gate, which writes state and queues a gate run.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. Source content is agent-authored but purely inbound: it is bounded by a filename allowlist and size caps, and nothing in it can cause the server to fetch anything.
+```
+
+**Destructive: True**
+
+```
+Marked destructive deliberately. Nothing is erased, but the call spends one of a fixed number of deliveries for the round — which cannot be un-spent — and moves the pointer deciding which sources publish, so the previous candidate stops being the one that would ship. We would rather a client prompt for confirmation than skip it.
+```
+
+## `end`
+
+**Read Only: False**
+
+```
+Commits and closes the round, which writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+It closes a round rather than destroying its contents: delivered sources, screenshots, progress notes and the gate verdict all remain. Calling it again on a closed round changes nothing.
+```
+
+## `show_round`
+
+**Read Only: True**
+
+```
+Renders a live status card in the creator's chat and writes no server state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. The card refreshes by calling this same server; it loads nothing from a third party.
+```
+
+**Destructive: False**
+
+```
+Read-only; displaying a view creates or alters no game, round, delivery or message.
+```
+
+## `show_media`
+
+**Read Only: True**
+
+```
+Renders the gate's screenshots and recording in the creator's chat and writes no server state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. Frames are supplied by this server; the gameplay recording is a short-lived signed URL for our own storage bucket.
+```
+
+**Destructive: False**
+
+```
+Read-only; showing media to the creator changes nothing on the server.
+```
+
+## `get_round_status`
+
+**Read Only: True**
+
+```
+Returns the round's current phase and progress for the round view, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only; polling status does not advance, alter or end the round.
+```
+
+## `get_gate_verdict`
+
+**Read Only: True**
+
+```
+Returns the verdict the automated gate has already produced, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only. It reads a result; it does not run, re-run, or influence the gate, and it cannot change whether a delivery passed.
+```
+
+## `get_round_media`
+
+**Read Only: True**
+
+```
+Returns the gate's frames for the round view and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. Frames are returned as inline data by this server; the gameplay recording is a short-lived signed URL for our own storage bucket.
+```
+
+**Destructive: False**
+
+```
+Read-only; retrieving media does not alter the delivery it belongs to.
+```
+
+## `get_gate_media`
+
+**Read Only: True**
+
+```
+Returns the gate's screenshots and gameplay recording for inspection, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. Media is served from our own storage via short-lived signed URLs we mint.
+```
+
+**Destructive: False**
+
+```
+Read-only; it fetches artefacts the gate already produced and changes nothing.
+```
+
+## `read_inbox`
+
+**Read Only: True**
+
+```
+Returns pending messages the creator has sent for this round, and writes nothing.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: False**
+
+```
+Read-only. Reading does not acknowledge, consume or clear messages — that requires a separate explicit call.
+```
+
+## `ack_inbox`
+
+**Read Only: False**
+
+```
+Acknowledges creator messages by id, which writes state.
+```
+
+**Open World: False**
+
+```
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+```
+
+**Destructive: True**
+
+```
+Marked destructive deliberately. Nothing is deleted, but acknowledged messages stop being surfaced to the agent, so information is lost from the agent's view and the creator's message will not be seen again by it. Acknowledging the same ids twice changes nothing further.
+```
+
+---
+
+## Widget CSP — check before submitting
+
+Not a justification; a finding the portal surfaced. `show_round` and `show_media` show
+empty `connect_domains` and `resource_domains`.
+
+Screenshots reach the card as inline data and need no CSP entry. But `get_round_media`
+returns the gameplay **video as a URL**, and our object store signs those against
+`storage.googleapis.com` (`apps/api/src/gcs-sign.ts`). An empty `resource_domains` will
+most likely stop that video rendering, or draw a review question.
+
+Confirm whether `storage.googleapis.com` belongs in `resource_domains` before submitting.

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -458,10 +458,10 @@ Writes one file into the round's staging area in preparation for delivery.
 Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-It writes only to staging, which is scratch space that has not been delivered or published. Nothing the creator can see or that is live is affected.
+Marked destructive because staging the same path again overwrites what was previously staged there. Nothing delivered or published is touched — staging is scratch space for the next delivery — but the call is not purely additive, so a client should be free to confirm it rather than assume it is safe to repeat.
 ```
 
 ## `patch_source_file`
@@ -478,10 +478,10 @@ Edits a file that is already staged, so it writes state.
 Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-It can only overwrite content inside the round's staging area. It cannot reach delivered or published sources, so nothing live or creator-visible is lost.
+Marked destructive because editing replaces existing staged content, and a patch can remove lines outright. It is bounded to the round's staging area and cannot reach delivered or published sources, but bounded is not the same as additive.
 ```
 
 ## `list_staged_sources`
@@ -518,10 +518,10 @@ Empties the round's staging area, so it writes state.
 Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-It discards only undelivered scratch space. Nothing delivered, published or creator-visible is removed, and the agent can stage the files again. We would accept a stricter reading here if you prefer this marked destructive.
+Marked destructive because it deletes staged files. They are undelivered scratch space, so nothing creator-visible or live is lost and the agent can stage them again — but the hint describes what the operation does, and this one removes data.
 ```
 
 ## `submit_sources`


### PR DESCRIPTION
OpenAI's plugin submission scan blocked us on three annotation mismatches. It is right about all three, and this fixes them.

## The finding

`stage_source_file`, `patch_source_file` and `clear_staged_sources` all declared `destructiveHint: false`. Each one either overwrites or deletes staged content — `stage_source_file` convicts itself in its own description: *"Overwrites the same path if staged again."*

`destructiveHint: false` is a promise that a call is purely additive, and a client may skip its confirmation prompt on that basis. That is wrong for a silent overwrite and wrong for a delete.

## Why our counter-argument didn't survive

We had been arguing that staging is undelivered scratch space, so nothing creator-visible or live is lost. **That is true and stays true — it is just not what the hint means.** The hint describes the operation, not the blast radius.

`clear_staged_sources` was already recorded in the submission justifications as the one arguable case we would concede rather than defend. Conceding it is the position we published; the scan simply found the two others that failed the same test.

## Also in here

- **`listings/mcp/chatgpt-apps-connector/tool-annotations.md`** — paste-ready justifications for the portal's per-field boxes: 36 tools × 3 fields, one fenced block per box, generated from `mcp-server.ts` so no tool can be missed or misnamed. Updated to match the new hints.
- A **CSP finding** recorded in that file: `show_round` and `show_media` have empty `resource_domains`, but `get_round_media` returns the gameplay video as a signed `storage.googleapis.com` URL. Screenshots are inline and need nothing; the video probably needs that host. Worth confirming before submitting.

## Sequencing — this must land before the JSON is generated

Production currently reports all three as `false`. I verified against the live server. If `chatgpt-app-submission.json` is generated before this deploys, it captures the old hints and fails the same scan again.

**Merge → deploy → re-check → then generate.**

```bash
# after deploy, all three should read true
curl -s -X POST https://www.gamedev.pl/api/mcp -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' -H "mcp-session-id: $SID" \
  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
```

## Verification

Full API suite passed before the rebase (2605 tests); the annotation regression test now pins all five destructive tools, so this cannot drift back silently.

## Not fixed here, and not a defect

The scan also flagged the legacy credential fields `start.key`, `open_round.key` and `continue_draft.key` for manual review. Those are the durable per-game and legacy keys from the BY-27 design, where the secret lives in client config rather than in a prompt. Expected; nothing to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_