### PR TITLE
auth: sign in with an access token, in a browser

### DIFF
--- a/apps/api/src/access-token-service.ts
+++ b/apps/api/src/access-token-service.ts
@@ -1,5 +1,11 @@
-import { generateAccessToken, isAccessTokenExpired } from './access-token.js';
-import { BOT_UID_PREFIX, type AccessTokenRecord, type Store } from './store.js';
+import {
+  generateAccessToken,
+  isAccessTokenExpired,
+  looksLikeAccessToken,
+  parseAccessToken,
+  verifyTokenSecret,
+} from './access-token.js';
+import { BOT_UID_PREFIX, type AccessTokenRecord, type Store, type User } from './store.js';
 
 export { isAccessTokenExpired } from './access-token.js';
 
@@ -99,6 +105,55 @@ export async function mintAccessTokenFor(store: Store, params: MintAccessTokenPa
   await store.createAccessToken(record);
 
   return { token, record, accountCreated: !existing };
+}
+
+/**
+ * Resolve a personal access token string to the account it belongs to
+ * (docs/agent-access-tokens.md).
+ *
+ * Shared by the two doors a token can arrive at: the `Authorization: Bearer` header on
+ * the API, and the sign-in form at /oauth/token-login where a human pastes one into a
+ * browser. Both must agree on every check — prefix, expiry, revocation, deleted accounts
+ * — because a token the header path refuses but the form path accepts would be a way in
+ * that no amount of reading either file alone would reveal.
+ *
+ * Returns null — never throws — for every failure. Distinguishing "expired" from
+ * "revoked" from "never existed" would only tell a caller holding a stolen token which
+ * one they hold.
+ */
+export async function resolveAccessTokenUser(store: Store, token: string, nowMs = Date.now()): Promise<User | null> {
+  if (!looksLikeAccessToken(token)) return null;
+
+  let tokenId: string;
+  let secret: string;
+  try {
+    ({ tokenId, secret } = parseAccessToken(token));
+  } catch {
+    return null;
+  }
+
+  const record = await store.getAccessToken(tokenId);
+  if (!record) return null;
+  if (!verifyTokenSecret(secret, record.secretHash)) return null;
+  // Fail closed on corrupt/missing expiresAt (NaN from Date.parse would otherwise read
+  // as "not expired").
+  if (isAccessTokenExpired(record.expiresAt, nowMs)) return null;
+
+  const user = await store.getUser(record.uid);
+  if (!user || user.deletionScheduledFor) return null;
+
+  // Last-use tracking, coarsened to a day so a chatty agent costs one write rather than
+  // one per request — the question it answers ("is anything still using this token?")
+  // does not need finer resolution. Best-effort by design: bookkeeping must never turn a
+  // working request into a failing one.
+  const nowIso = new Date(nowMs).toISOString();
+  if (record.lastUsedAt?.slice(0, 10) !== nowIso.slice(0, 10)) {
+    void store.touchAccessToken(tokenId, nowIso).catch(() => {
+      /* same contract as every other measurement in this file */
+    });
+  }
+
+  return user;
 }
 
 /** The safe projection of a token record — everything except the hash of the secret. */

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -77,6 +77,7 @@ import { registerOAuthProtectedResourceRoutes } from './mcp-oauth-metadata.js';
 import { registerMcpServerDiscoveryRoutes } from './mcp-server-discovery.js';
 import { registerOpenAiAppsChallengeRoute } from './openai-apps-challenge.js';
 import { registerOAuthAuthorizationServerRoutes } from './oauth-as.js';
+import { registerTokenLoginRoutes } from './oauth-token-login.js';
 import { registerCreatorAgentKeyRoutes } from './creator-agent-key-routes.js';
 
 const GenerateRequestSchema = z.object({
@@ -767,6 +768,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     sessionSecret: oauthSessionSecret,
     sessionSecretPrev: oauthSessionSecretPrev,
   });
+
+  // Browser sign-in for accounts that hold a personal access token instead of a Google
+  // or Apple identity. Registered right after the AS because the only reason it exists
+  // is to get such an account to the consent screen above.
+  registerTokenLoginRoutes(app, { store, sessionSecret: oauthSessionSecret });
 
   // Creator-wide MCP opener (BY-27a). Needs the same HMAC secret as per-game keys.
   if (submissionTokenSecret) {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -3,7 +3,7 @@ import cookie from '@fastify/cookie';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
 import { z } from 'zod';
-import { isAccessTokenExpired, looksLikeAccessToken, parseAccessToken, verifyTokenSecret } from './access-token.js';
+import { resolveAccessTokenUser } from './access-token-service.js';
 import { isAdmin, isAdminSession } from './admin.js';
 import { resolveAppleAccount } from './apple-account.js';
 import { createAppleAuthVerifierFromEnv, parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
@@ -332,50 +332,18 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
    * Resolve a personal access token from the Authorization header
    * (docs/agent-access-tokens.md).
    *
-   * Returns null — never throws — for every failure, so a bad token is simply an
-   * unauthenticated request and the route's own 401 explains it. Distinguishing
-   * "expired" from "revoked" from "never existed" in the response would only tell a
-   * caller holding a stolen token which one they hold.
-   *
-   * This API carries other Bearer credentials that are not PATs (the build channel's
-   * per-issue tokens, the scheduler's OIDC tokens). The `gdpl_pat_` prefix check is
-   * what keeps those out of here — they fall through untouched to the handlers that
-   * do understand them.
+   * The checks themselves live in access-token-service.ts, shared with the browser
+   * sign-in form, so the header and the form can never disagree about which tokens are
+   * good. What is specific to this door is the question of which Bearer credentials are
+   * even candidates: this API carries others that are not PATs (the build channel's
+   * per-issue tokens, the scheduler's OIDC tokens), and the `gdpl_pat_` prefix check
+   * inside the resolver is what keeps those out — they fall through untouched to the
+   * handlers that do understand them.
    */
   const getAccessTokenUser = async (request: FastifyRequest): Promise<User | null> => {
     const bearer = readBearerToken(request.headers.authorization);
-    if (!bearer || !looksLikeAccessToken(bearer)) return null;
-
-    let tokenId: string;
-    let secret: string;
-    try {
-      ({ tokenId, secret } = parseAccessToken(bearer));
-    } catch {
-      return null;
-    }
-
-    const record = await store.getAccessToken(tokenId);
-    if (!record) return null;
-    if (!verifyTokenSecret(secret, record.secretHash)) return null;
-    // Fail closed on corrupt/missing expiresAt (NaN from Date.parse would
-    // otherwise read as "not expired").
-    if (isAccessTokenExpired(record.expiresAt, Date.now())) return null;
-
-    const user = await store.getUser(record.uid);
-    if (!user || user.deletionScheduledFor) return null;
-
-    // Last-use tracking, coarsened to a day so a chatty agent costs one write rather
-    // than one per request — the question it answers ("is anything still using this
-    // token?") does not need finer resolution. Best-effort by design: bookkeeping must
-    // never turn a working request into a failing one.
-    const nowIso = new Date().toISOString();
-    if (record.lastUsedAt?.slice(0, 10) !== nowIso.slice(0, 10)) {
-      void store.touchAccessToken(tokenId, nowIso).catch(() => {
-        /* same contract as every other measurement in this file */
-      });
-    }
-
-    return user;
+    if (!bearer) return null;
+    return resolveAccessTokenUser(store, bearer);
   };
 
   app.decorateRequest('user', null);

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import { endOpenAgentSessions } from './agent-session-revocation.js';
 import { InvalidSessionError, readSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { escapeHtml, MASCOT_SVG, OAUTH_PAGE_STYLES } from './oauth-page-chrome.js';
 import { redirectUriAllowed } from './oauth-redirect.js';
 import { verifyPkceS256 } from './oauth-pkce.js';
 import {
@@ -281,7 +282,7 @@ function consentHtml(input: {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(copy.title)}</title>
-  ${CONSENT_STYLES}
+  ${OAUTH_PAGE_STYLES}
 </head>
 <body>
   <main>
@@ -318,72 +319,6 @@ function consentHtml(input: {
   </main>
 </body>
 </html>`;
-}
-
-/**
- * The gamedev.pl mascot, idle pose, as one static path.
- *
- * Traced spans from apps/web/src/mascotSpans.ts, flattened at authoring time because
- * this page is server-rendered plain HTML with no bundler and no React — and because a
- * consent screen must not depend on a network fetch that can fail or leak a referrer.
- *
- * It is here for recognition, which is the only anti-phishing cue a creator actually
- * has: a page that looks like gamedev.pl is one they can judge. Small and beside the
- * wordmark rather than a hero, so the permissions stay above the fold on a phone.
- */
-const MASCOT_SVG = `<svg class="mascot" viewBox="0 0 70 60" width="34" height="29" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M21 1h28v1h-28zM19 2h32v1h-32zM18 3h14v1h-14zM33 3h4v1h-4zM39 3h14v1h-14zM17 4h13v1h-13zM34 4h3v1h-3zM40 4h14v1h-14zM16 5h13v1h-13zM33 5h5v1h-5zM41 5h14v1h-14zM15 6h13v1h-13zM32 6h6v1h-6zM41 6h14v1h-14zM14 7h14v1h-14zM31 7h8v1h-8zM41 7h15v1h-15zM14 8h42v1h-42zM14 9h43v1h-43zM14 10h43v1h-43zM13 11h20v1h-20zM38 11h19v1h-19zM13 12h19v1h-19zM39 12h18v1h-18zM13 13h18v1h-18zM39 13h18v1h-18zM13 14h18v1h-18zM40 14h17v1h-17zM13 15h17v1h-17zM40 15h10v1h-10zM51 15h7v1h-7zM13 16h6v1h-6zM21 16h9v1h-9zM41 16h8v1h-8zM51 16h7v1h-7zM5 17h6v1h-6zM13 17h6v1h-6zM22 17h7v1h-7zM41 17h8v1h-8zM52 17h6v1h-6zM59 17h6v1h-6zM3 18h15v1h-15zM23 18h6v1h-6zM42 18h6v1h-6zM52 18h14v1h-14zM2 19h16v1h-16zM23 19h5v1h-5zM43 19h4v1h-4zM53 19h15v1h-15zM1 20h16v1h-16zM24 20h3v1h-3zM43 20h3v1h-3zM53 20h15v1h-15zM1 21h4v1h-4zM11 21h6v1h-6zM25 21h2v1h-2zM44 21h2v1h-2zM53 21h6v1h-6zM64 21h5v1h-5zM0 22h4v1h-4zM12 22h5v1h-5zM44 22h1v1h-1zM53 22h5v1h-5zM66 22h3v1h-3zM0 23h3v1h-3zM6 23h4v1h-4zM12 23h5v1h-5zM53 23h4v1h-4zM60 23h4v1h-4zM66 23h4v1h-4zM0 24h3v1h-3zM5 24h6v1h-6zM13 24h4v1h-4zM53 24h4v1h-4zM59 24h5v1h-5zM67 24h3v1h-3zM0 25h3v1h-3zM5 25h6v1h-6zM13 25h4v1h-4zM53 25h4v1h-4zM59 25h6v1h-6zM67 25h3v1h-3zM0 26h3v1h-3zM5 26h6v1h-6zM13 26h4v1h-4zM53 26h4v1h-4zM59 26h6v1h-6zM67 26h3v1h-3zM0 27h3v1h-3zM5 27h6v1h-6zM13 27h4v1h-4zM53 27h4v1h-4zM59 27h6v1h-6zM67 27h3v1h-3zM0 28h3v1h-3zM6 28h4v1h-4zM13 28h4v1h-4zM53 28h4v1h-4zM60 28h4v1h-4zM66 28h4v1h-4zM0 29h4v1h-4zM12 29h5v1h-5zM53 29h5v1h-5zM66 29h3v1h-3zM1 30h4v1h-4zM11 30h6v1h-6zM53 30h6v1h-6zM64 30h5v1h-5zM1 31h16v1h-16zM53 31h15v1h-15zM2 32h15v1h-15zM53 32h15v1h-15zM3 33h14v1h-14zM53 33h14v1h-14zM5 34h12v1h-12zM26 34h1v1h-1zM44 34h1v1h-1zM53 34h12v1h-12zM10 35h8v1h-8zM26 35h2v1h-2zM43 35h2v1h-2zM53 35h7v1h-7zM10 36h8v1h-8zM25 36h4v1h-4zM42 36h4v1h-4zM53 36h7v1h-7zM9 37h9v1h-9zM25 37h5v1h-5zM41 37h5v1h-5zM52 37h10v1h-10zM7 38h12v1h-12zM25 38h6v1h-6zM40 38h7v1h-7zM52 38h11v1h-11zM6 39h13v1h-13zM24 39h8v1h-8zM39 39h8v1h-8zM51 39h13v1h-13zM5 40h15v1h-15zM24 40h9v1h-9zM38 40h9v1h-9zM50 40h15v1h-15zM4 41h5v1h-5zM10 41h11v1h-11zM23 41h11v1h-11zM37 41h11v1h-11zM49 41h11v1h-11zM61 41h4v1h-4zM4 42h4v1h-4zM11 42h11v1h-11zM23 42h12v1h-12zM36 42h24v1h-24zM62 42h4v1h-4zM3 43h4v1h-4zM11 43h48v1h-48zM63 43h3v1h-3zM3 44h4v1h-4zM12 44h47v1h-47zM63 44h3v1h-3zM3 45h3v1h-3zM12 45h46v1h-46zM63 45h4v1h-4zM3 46h3v1h-3zM13 46h44v1h-44zM63 46h4v1h-4zM3 47h3v1h-3zM14 47h42v1h-42zM63 47h4v1h-4zM3 48h3v1h-3zM16 48h38v1h-38zM63 48h4v1h-4zM3 49h3v1h-3zM18 49h34v1h-34zM63 49h4v1h-4zM3 50h3v1h-3zM21 50h8v1h-8zM40 50h8v1h-8zM63 50h4v1h-4zM3 51h3v1h-3zM21 51h8v1h-8zM40 51h8v1h-8zM64 51h3v1h-3zM4 52h1v1h-1zM21 52h8v1h-8zM40 52h8v1h-8zM21 53h8v1h-8zM40 53h8v1h-8zM21 54h8v1h-8zM40 54h8v1h-8zM21 55h8v1h-8zM40 55h8v1h-8zM21 56h7v1h-7zM40 56h8v1h-8zM22 57h6v1h-6zM41 57h6v1h-6zM23 58h4v1h-4zM42 58h4v1h-4z"/></svg>`;
-
-/**
- * The site's own tokens, copied from apps/web/src/styles.css.
- *
- * This page is server-rendered and never met the design system, so it shipped on the
- * browser default white while gamedev.pl is dark. That is not only ugly: a consent
- * screen is where someone decides whether a page is really the site it claims to be,
- * and one that looks nothing like the site removes the only cue they have.
- */
-const CONSENT_STYLES = `<style>
-    :root {
-      --bg: #0f1418; --panel: #161c22; --panel-border: #232c35; --panel-card: #1c242c;
-      --text: #f0f4f8; --muted: #94a3b8; --turquoise: #00e4ac; --warn: #e5b76a;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0; padding: 2rem 1rem 4rem; background: var(--bg);
-      background-image: radial-gradient(circle at 50% 0%, #1a232b 0%, #0f1418 70%);
-      background-attachment: fixed; color: var(--text);
-      font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.55;
-    }
-    main { max-width: 34rem; margin: 0 auto; background: var(--panel);
-      border: 1px solid var(--panel-border); border-radius: 14px; padding: 2rem; }
-    .brand { margin: 0 0 1.25rem; font-size: 0.8rem; font-weight: 700; color: var(--turquoise);
-      display: flex; align-items: center; gap: 0.5rem; }
-    .mascot { display: block; flex: none; }
-    h1 { font-size: 1.5rem; line-height: 1.2; margin: 0 0 0.75rem; }
-    h2 { font-size: 0.9rem; margin: 1.5rem 0 0.5rem; }
-    .lead { margin: 0 0 1rem; }
-    .who { margin: 0 0 1rem; padding: 0.75rem 0; color: var(--muted); font-size: 0.9rem;
-      border-top: 1px solid var(--panel-border); border-bottom: 1px solid var(--panel-border); }
-    .who strong { color: var(--text); }
-    ul { margin: 0; padding-left: 1.1rem; }
-    ul.can li { margin: 0.25rem 0; }
-    ul.cannot li { margin: 0.25rem 0; color: var(--muted); font-size: 0.92rem; }
-    .redirect { font-family: ui-monospace, monospace; word-break: break-all;
-      background: var(--panel-card); border: 1px solid var(--panel-border);
-      padding: 0.75rem; border-radius: 0.5rem; margin: 0; }
-    .hint, .duration { color: var(--muted); font-size: 0.85rem; }
-    .duration { background: var(--panel-card); padding: 0.7rem 0.8rem; border-radius: 0.5rem; margin: 1.25rem 0 0; }
-    .waiting { display: inline-block; margin: 0 0 0.75rem; padding: 0.25rem 0.75rem; border-radius: 999px;
-      background: rgba(229,183,106,0.14); color: var(--warn); font-size: 0.8rem; font-weight: 700; }
-    .actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap; }
-    button { font: inherit; font-weight: 700; padding: 0.6rem 1.25rem; border-radius: 0.55rem;
-      border: 1px solid var(--panel-border); background: transparent; color: var(--text); cursor: pointer; }
-    .approve { background: var(--turquoise); color: #0b1017; border-color: var(--turquoise); }
-    .bail { margin: 1.25rem 0 0; padding-top: 1rem; border-top: 1px solid var(--panel-border);
-      color: var(--muted); font-size: 0.85rem; }
-  </style>`;
-
-function escapeHtml(value: string): string {
-  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 function oauthErrorRedirect(redirectUri: string, error: string, state?: string): string {

--- a/apps/api/src/oauth-page-chrome.ts
+++ b/apps/api/src/oauth-page-chrome.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared chrome for the OAuth pages the API server-renders itself.
+ *
+ * Both the consent screen (oauth-as.ts) and the token sign-in page
+ * (oauth-token-login.ts) are plain HTML with no bundler and no React, and both are
+ * pages where someone decides whether what they are looking at is really gamedev.pl.
+ * That judgement is the only anti-phishing cue either page offers, so the two must
+ * not be allowed to drift apart into looking like different sites.
+ */
+
+/**
+ * The gamedev.pl mascot, idle pose, as one static path.
+ *
+ * Traced spans from apps/web/src/mascotSpans.ts, flattened at authoring time because
+ * this page is server-rendered plain HTML with no bundler and no React — and because a
+ * consent screen must not depend on a network fetch that can fail or leak a referrer.
+ *
+ * It is here for recognition, which is the only anti-phishing cue a creator actually
+ * has: a page that looks like gamedev.pl is one they can judge. Small and beside the
+ * wordmark rather than a hero, so the permissions stay above the fold on a phone.
+ */
+export const MASCOT_SVG = `<svg class="mascot" viewBox="0 0 70 60" width="34" height="29" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M21 1h28v1h-28zM19 2h32v1h-32zM18 3h14v1h-14zM33 3h4v1h-4zM39 3h14v1h-14zM17 4h13v1h-13zM34 4h3v1h-3zM40 4h14v1h-14zM16 5h13v1h-13zM33 5h5v1h-5zM41 5h14v1h-14zM15 6h13v1h-13zM32 6h6v1h-6zM41 6h14v1h-14zM14 7h14v1h-14zM31 7h8v1h-8zM41 7h15v1h-15zM14 8h42v1h-42zM14 9h43v1h-43zM14 10h43v1h-43zM13 11h20v1h-20zM38 11h19v1h-19zM13 12h19v1h-19zM39 12h18v1h-18zM13 13h18v1h-18zM39 13h18v1h-18zM13 14h18v1h-18zM40 14h17v1h-17zM13 15h17v1h-17zM40 15h10v1h-10zM51 15h7v1h-7zM13 16h6v1h-6zM21 16h9v1h-9zM41 16h8v1h-8zM51 16h7v1h-7zM5 17h6v1h-6zM13 17h6v1h-6zM22 17h7v1h-7zM41 17h8v1h-8zM52 17h6v1h-6zM59 17h6v1h-6zM3 18h15v1h-15zM23 18h6v1h-6zM42 18h6v1h-6zM52 18h14v1h-14zM2 19h16v1h-16zM23 19h5v1h-5zM43 19h4v1h-4zM53 19h15v1h-15zM1 20h16v1h-16zM24 20h3v1h-3zM43 20h3v1h-3zM53 20h15v1h-15zM1 21h4v1h-4zM11 21h6v1h-6zM25 21h2v1h-2zM44 21h2v1h-2zM53 21h6v1h-6zM64 21h5v1h-5zM0 22h4v1h-4zM12 22h5v1h-5zM44 22h1v1h-1zM53 22h5v1h-5zM66 22h3v1h-3zM0 23h3v1h-3zM6 23h4v1h-4zM12 23h5v1h-5zM53 23h4v1h-4zM60 23h4v1h-4zM66 23h4v1h-4zM0 24h3v1h-3zM5 24h6v1h-6zM13 24h4v1h-4zM53 24h4v1h-4zM59 24h5v1h-5zM67 24h3v1h-3zM0 25h3v1h-3zM5 25h6v1h-6zM13 25h4v1h-4zM53 25h4v1h-4zM59 25h6v1h-6zM67 25h3v1h-3zM0 26h3v1h-3zM5 26h6v1h-6zM13 26h4v1h-4zM53 26h4v1h-4zM59 26h6v1h-6zM67 26h3v1h-3zM0 27h3v1h-3zM5 27h6v1h-6zM13 27h4v1h-4zM53 27h4v1h-4zM59 27h6v1h-6zM67 27h3v1h-3zM0 28h3v1h-3zM6 28h4v1h-4zM13 28h4v1h-4zM53 28h4v1h-4zM60 28h4v1h-4zM66 28h4v1h-4zM0 29h4v1h-4zM12 29h5v1h-5zM53 29h5v1h-5zM66 29h3v1h-3zM1 30h4v1h-4zM11 30h6v1h-6zM53 30h6v1h-6zM64 30h5v1h-5zM1 31h16v1h-16zM53 31h15v1h-15zM2 32h15v1h-15zM53 32h15v1h-15zM3 33h14v1h-14zM53 33h14v1h-14zM5 34h12v1h-12zM26 34h1v1h-1zM44 34h1v1h-1zM53 34h12v1h-12zM10 35h8v1h-8zM26 35h2v1h-2zM43 35h2v1h-2zM53 35h7v1h-7zM10 36h8v1h-8zM25 36h4v1h-4zM42 36h4v1h-4zM53 36h7v1h-7zM9 37h9v1h-9zM25 37h5v1h-5zM41 37h5v1h-5zM52 37h10v1h-10zM7 38h12v1h-12zM25 38h6v1h-6zM40 38h7v1h-7zM52 38h11v1h-11zM6 39h13v1h-13zM24 39h8v1h-8zM39 39h8v1h-8zM51 39h13v1h-13zM5 40h15v1h-15zM24 40h9v1h-9zM38 40h9v1h-9zM50 40h15v1h-15zM4 41h5v1h-5zM10 41h11v1h-11zM23 41h11v1h-11zM37 41h11v1h-11zM49 41h11v1h-11zM61 41h4v1h-4zM4 42h4v1h-4zM11 42h11v1h-11zM23 42h12v1h-12zM36 42h24v1h-24zM62 42h4v1h-4zM3 43h4v1h-4zM11 43h48v1h-48zM63 43h3v1h-3zM3 44h4v1h-4zM12 44h47v1h-47zM63 44h3v1h-3zM3 45h3v1h-3zM12 45h46v1h-46zM63 45h4v1h-4zM3 46h3v1h-3zM13 46h44v1h-44zM63 46h4v1h-4zM3 47h3v1h-3zM14 47h42v1h-42zM63 47h4v1h-4zM3 48h3v1h-3zM16 48h38v1h-38zM63 48h4v1h-4zM3 49h3v1h-3zM18 49h34v1h-34zM63 49h4v1h-4zM3 50h3v1h-3zM21 50h8v1h-8zM40 50h8v1h-8zM63 50h4v1h-4zM3 51h3v1h-3zM21 51h8v1h-8zM40 51h8v1h-8zM64 51h3v1h-3zM4 52h1v1h-1zM21 52h8v1h-8zM40 52h8v1h-8zM21 53h8v1h-8zM40 53h8v1h-8zM21 54h8v1h-8zM40 54h8v1h-8zM21 55h8v1h-8zM40 55h8v1h-8zM21 56h7v1h-7zM40 56h8v1h-8zM22 57h6v1h-6zM41 57h6v1h-6zM23 58h4v1h-4zM42 58h4v1h-4z"/></svg>`;
+
+/**
+ * The site's own tokens, copied from apps/web/src/styles.css.
+ *
+ * This page is server-rendered and never met the design system, so it shipped on the
+ * browser default white while gamedev.pl is dark. That is not only ugly: a consent
+ * screen is where someone decides whether a page is really the site it claims to be,
+ * and one that looks nothing like the site removes the only cue they have.
+ */
+export const OAUTH_PAGE_STYLES = `<style>
+    :root {
+      --bg: #0f1418; --panel: #161c22; --panel-border: #232c35; --panel-card: #1c242c;
+      --text: #f0f4f8; --muted: #94a3b8; --turquoise: #00e4ac; --warn: #e5b76a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; padding: 2rem 1rem 4rem; background: var(--bg);
+      background-image: radial-gradient(circle at 50% 0%, #1a232b 0%, #0f1418 70%);
+      background-attachment: fixed; color: var(--text);
+      font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.55;
+    }
+    main { max-width: 34rem; margin: 0 auto; background: var(--panel);
+      border: 1px solid var(--panel-border); border-radius: 14px; padding: 2rem; }
+    .brand { margin: 0 0 1.25rem; font-size: 0.8rem; font-weight: 700; color: var(--turquoise);
+      display: flex; align-items: center; gap: 0.5rem; }
+    .mascot { display: block; flex: none; }
+    h1 { font-size: 1.5rem; line-height: 1.2; margin: 0 0 0.75rem; }
+    h2 { font-size: 0.9rem; margin: 1.5rem 0 0.5rem; }
+    .lead { margin: 0 0 1rem; }
+    .who { margin: 0 0 1rem; padding: 0.75rem 0; color: var(--muted); font-size: 0.9rem;
+      border-top: 1px solid var(--panel-border); border-bottom: 1px solid var(--panel-border); }
+    .who strong { color: var(--text); }
+    ul { margin: 0; padding-left: 1.1rem; }
+    ul.can li { margin: 0.25rem 0; }
+    ul.cannot li { margin: 0.25rem 0; color: var(--muted); font-size: 0.92rem; }
+    .redirect { font-family: ui-monospace, monospace; word-break: break-all;
+      background: var(--panel-card); border: 1px solid var(--panel-border);
+      padding: 0.75rem; border-radius: 0.5rem; margin: 0; }
+    .hint, .duration { color: var(--muted); font-size: 0.85rem; }
+    .duration { background: var(--panel-card); padding: 0.7rem 0.8rem; border-radius: 0.5rem; margin: 1.25rem 0 0; }
+    .waiting { display: inline-block; margin: 0 0 0.75rem; padding: 0.25rem 0.75rem; border-radius: 999px;
+      background: rgba(229,183,106,0.14); color: var(--warn); font-size: 0.8rem; font-weight: 700; }
+    label { display: block; margin: 1.5rem 0 0.4rem; font-size: 0.9rem; font-weight: 700; }
+    input[type="password"], input[type="text"] {
+      width: 100%; font: inherit; font-family: ui-monospace, monospace; padding: 0.6rem 0.75rem;
+      border-radius: 0.55rem; border: 1px solid var(--panel-border); background: var(--panel-card);
+      color: var(--text); }
+    input[type="password"]:focus, input[type="text"]:focus {
+      outline: 2px solid var(--turquoise); outline-offset: 1px; }
+    .actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap; }
+    button { font: inherit; font-weight: 700; padding: 0.6rem 1.25rem; border-radius: 0.55rem;
+      border: 1px solid var(--panel-border); background: transparent; color: var(--text); cursor: pointer; }
+    .approve { background: var(--turquoise); color: #0b1017; border-color: var(--turquoise); }
+    .bail { margin: 1.25rem 0 0; padding-top: 1rem; border-top: 1px solid var(--panel-border);
+      color: var(--muted); font-size: 0.85rem; }
+  </style>`;
+
+export function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/apps/api/src/oauth-token-login.test.ts
+++ b/apps/api/src/oauth-token-login.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { generateAccessToken } from './access-token.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, readSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { formToken, sanitizeOAuthReturnPath, TOKEN_LOGIN_PATH } from './oauth-token-login.js';
+import { InMemoryStore } from './store.js';
+
+/**
+ * Driven through the fully assembled app for the same reason access-token-routes.test.ts
+ * is: the private-beta wall lives in app.ts, and a sign-in page that unit-tests green
+ * while the wall 401s it in production would be worse than no page at all — it is the
+ * one route whose entire job is to be reachable by someone with no session.
+ */
+
+const sessionSecret = 'dev-session-secret-change-me';
+
+function appWith(store: InMemoryStore, extra: { betaAllowedUids?: string } = {}) {
+  return buildApp({ store, sessionSecret, adminUids: 'g:boss', ...extra });
+}
+
+async function mintToken(app: Awaited<ReturnType<typeof buildApp>>, uid: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/admin/access-tokens',
+    headers: { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:boss', sessionSecret)}` },
+    payload: { uid, name: 'reviewer' },
+  });
+  expect(res.statusCode).toBe(201);
+  return res.json().token as string;
+}
+
+function post(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  fields: Record<string, string>,
+  at = Date.now(),
+): ReturnType<typeof app.inject> {
+  return app.inject({
+    method: 'POST',
+    url: TOKEN_LOGIN_PATH,
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    payload: new URLSearchParams({ form_token: formToken(sessionSecret, at), ...fields }).toString(),
+  });
+}
+
+function sessionFrom(res: { headers: Record<string, unknown> }): string | null {
+  const raw = res.headers['set-cookie'];
+  const all = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  const hit = all.find((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`));
+  return hit ? hit.slice(`${SESSION_COOKIE_NAME}=`.length).split(';')[0] : null;
+}
+
+describe('sanitizeOAuthReturnPath', () => {
+  it('accepts the authorize path with and without a query', () => {
+    expect(sanitizeOAuthReturnPath('/oauth/authorize')).toBe('/oauth/authorize');
+    expect(sanitizeOAuthReturnPath('/oauth/authorize?client_id=x')).toBe('/oauth/authorize?client_id=x');
+  });
+
+  it('refuses anything that could land the browser off-site', () => {
+    // An open redirect here hands a phishing page a browser that has just authenticated.
+    expect(sanitizeOAuthReturnPath('//evil.example/oauth/authorize')).toBeNull();
+    expect(sanitizeOAuthReturnPath('https://evil.example/oauth/authorize')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/authorize\\@evil.example')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/authorizex')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/studio')).toBeNull();
+    expect(sanitizeOAuthReturnPath('/oauth/authorize\r\nSet-Cookie: x=1')).toBeNull();
+  });
+});
+
+describe('GET /oauth/token-login', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+  });
+
+  it('renders the form to a visitor with no session, even in private beta', async () => {
+    // The whole point: this page is the door for someone the wall would otherwise 401.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const res = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.body).toContain(`action="${TOKEN_LOGIN_PATH}"`);
+    expect(res.body).toContain('name="token"');
+  });
+
+  it('keeps itself out of search results', async () => {
+    const app = await appWith(store);
+    const res = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+    expect(res.body).toContain('name="robots" content="noindex, nofollow"');
+  });
+
+  it('carries a valid oauth_return through to the form', async () => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'GET',
+      url: `${TOKEN_LOGIN_PATH}?oauth_return=${encodeURIComponent('/oauth/authorize?client_id=abc')}`,
+    });
+    expect(res.body).toContain('name="oauth_return" value="/oauth/authorize?client_id=abc"');
+  });
+
+  it('drops an off-site oauth_return rather than rendering it', async () => {
+    const app = await appWith(store);
+    const res = await app.inject({
+      method: 'GET',
+      url: `${TOKEN_LOGIN_PATH}?oauth_return=${encodeURIComponent('https://evil.example/')}`,
+    });
+    expect(res.body).not.toContain('evil.example');
+    expect(res.body).not.toContain('name="oauth_return"');
+  });
+});
+
+describe('POST /oauth/token-login', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+  });
+
+  it('signs in the token holder and lands them in the studio', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await post(app, { token });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/studio');
+    const cookie = sessionFrom(res);
+    expect(cookie).toBeTruthy();
+    expect(readSessionToken(cookie!, sessionSecret).uid).toBe('bot:reviewer');
+  });
+
+  it("stamps the cookie src:'token' so it carries the token's authority and no more", async () => {
+    // Without the stamp this page would be an escalation: a leaked PAT for an admin
+    // account could be traded for a cookie that satisfied the session-only surfaces.
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await post(app, { token });
+
+    expect(readSessionToken(sessionFrom(res)!, sessionSecret).src).toBe('token');
+  });
+
+  it('refuses to mint further tokens with the cookie it just handed out', async () => {
+    // The concrete consequence of the stamp above, asserted end to end rather than by
+    // reading a claim: minting is an operator surface and must stay session-only.
+    const app = await appWith(store);
+    await store.upsertUser({ uid: 'g:boss2' });
+    const token = await mintToken(app, 'g:boss');
+
+    const res = await post(app, { token });
+    const cookie = sessionFrom(res)!;
+
+    const mint = await app.inject({
+      method: 'POST',
+      url: '/api/admin/access-tokens',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+      payload: { uid: 'g:boss2', name: 'laundered' },
+    });
+    // 404, not 403: the admin surface does not advertise itself to a caller that
+    // fails isAdminSession. The same call with a real session cookie returns 201
+    // above, so this is the refusal and not a missing route.
+    expect(mint.statusCode).toBe(404);
+  });
+
+  it('returns to the authorize URL when one was carried through', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await post(app, { token, oauth_return: '/oauth/authorize?client_id=abc' });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/oauth/authorize?client_id=abc');
+  });
+
+  it('ignores an off-site oauth_return and lands in the studio instead', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await post(app, { token, oauth_return: 'https://evil.example/steal' });
+
+    expect(res.headers.location).toBe('/studio');
+  });
+
+  it('reaches the consent screen with the cookie it minted', async () => {
+    // The end the page exists for: an account with no Google identity, in private beta,
+    // getting far enough to approve an MCP client.
+    const app = await appWith(store, { betaAllowedUids: 'g:boss' });
+    const token = await mintToken(app, 'bot:reviewer');
+    const cookie = sessionFrom(await post(app, { token }))!;
+
+    const authorize = await app.inject({
+      method: 'GET',
+      url: '/oauth/authorize',
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+
+    // Past the sign-in redirect: a missing session bounces to /studio?oauth_return=…,
+    // and this account never bounces. The 400 is the *next* check complaining about
+    // absent client_id/redirect_uri, which is exactly how far this test means to get.
+    expect(authorize.statusCode).not.toBe(302);
+    expect(authorize.statusCode).toBe(400);
+  });
+
+  it('rejects a POST with no form token', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: TOKEN_LOGIN_PATH,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ token }).toString(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('rejects a form token minted from a different secret', async () => {
+    // Login CSRF: sameSite=lax does not stop a top-level cross-site form POST, and the
+    // next thing this flow does is ask the browser to approve durable write access.
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: TOKEN_LOGIN_PATH,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ token, form_token: formToken('somebody-elses-secret', Date.now()) }).toString(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('rejects a form token from a stale bucket but accepts the previous one', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+    const hourMs = 60 * 60 * 1000;
+
+    const stale = await post(app, { token }, Date.now() - 3 * hourMs);
+    expect(stale.statusCode).toBe(403);
+
+    const recent = await post(app, { token }, Date.now() - hourMs);
+    expect(recent.statusCode).toBe(302);
+  });
+
+  it('refuses an unknown token without saying why', async () => {
+    const app = await appWith(store);
+    const res = await post(app, { token: generateAccessToken().token });
+
+    expect(res.statusCode).toBe(401);
+    expect(sessionFrom(res)).toBeNull();
+    expect(res.body).toContain('not valid');
+    expect(res.body).not.toMatch(/expired|revoked|unknown account/i);
+  });
+
+  it('refuses a credential that is not a personal access token at all', async () => {
+    const app = await appWith(store);
+    const res = await post(app, { token: 'gdpl_oat_something_else' });
+    expect(res.statusCode).toBe(401);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('refuses an empty submission', async () => {
+    const app = await appWith(store);
+    const res = await post(app, { token: '   ' });
+    expect(res.statusCode).toBe(400);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('refuses an expired token', async () => {
+    const app = await appWith(store);
+    const generated = generateAccessToken();
+    await store.upsertUser({ uid: 'bot:stale' });
+    await store.createAccessToken({
+      tokenId: generated.tokenId,
+      uid: 'bot:stale',
+      secretHash: generated.secretHash,
+      name: 'expired',
+      createdAt: new Date(Date.now() - 200 * 24 * 3600 * 1000).toISOString(),
+      createdByUid: 'g:boss',
+      expiresAt: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
+    });
+
+    const res = await post(app, { token: generated.token });
+
+    expect(res.statusCode).toBe(401);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('refuses a blocked account', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+    await store.upsertUser({ uid: 'bot:reviewer', tier: 'blocked' });
+
+    const res = await post(app, { token });
+
+    expect(res.statusCode).toBe(403);
+    expect(sessionFrom(res)).toBeNull();
+  });
+});

--- a/apps/api/src/oauth-token-login.test.ts
+++ b/apps/api/src/oauth-token-login.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { generateAccessToken } from './access-token.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, readSessionToken, SESSION_COOKIE_NAME } from './auth.js';
-import { formToken, sanitizeOAuthReturnPath, TOKEN_LOGIN_PATH } from './oauth-token-login.js';
+import { newCsrfNonce, originAllowed, sanitizeOAuthReturnPath, TOKEN_LOGIN_PATH } from './oauth-token-login.js';
 import { InMemoryStore } from './store.js';
 
 /**
@@ -29,24 +29,49 @@ async function mintToken(app: Awaited<ReturnType<typeof buildApp>>, uid: string)
   return res.json().token as string;
 }
 
+const CSRF_COOKIE = 'gamedev_token_login_csrf';
+
+function cookieFrom(res: { headers: Record<string, unknown> }, name: string): string | null {
+  const raw = res.headers['set-cookie'];
+  const all = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  const hit = all.find((c) => c.startsWith(`${name}=`));
+  if (!hit) return null;
+  const value = hit.slice(`${name}=`.length).split(';')[0];
+  return value === '' ? null : value;
+}
+
+/**
+ * The real browser sequence: load the page, keep the CSRF cookie it set, submit the
+ * nonce it rendered. Tests that skip the GET are testing an attacker, not a visitor.
+ */
+async function visitAndPost(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  fields: Record<string, string>,
+): Promise<Awaited<ReturnType<typeof app.inject>>> {
+  const page = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+  const nonce = cookieFrom(page, CSRF_COOKIE)!;
+  expect(page.body).toContain(`name="form_token" value="${nonce}"`);
+  return post(app, { form_token: nonce, ...fields }, `${CSRF_COOKIE}=${nonce}`);
+}
+
 function post(
   app: Awaited<ReturnType<typeof buildApp>>,
   fields: Record<string, string>,
-  at = Date.now(),
+  cookie?: string,
 ): ReturnType<typeof app.inject> {
   return app.inject({
     method: 'POST',
     url: TOKEN_LOGIN_PATH,
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    payload: new URLSearchParams({ form_token: formToken(sessionSecret, at), ...fields }).toString(),
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      ...(cookie ? { cookie } : {}),
+    },
+    payload: new URLSearchParams(fields).toString(),
   });
 }
 
 function sessionFrom(res: { headers: Record<string, unknown> }): string | null {
-  const raw = res.headers['set-cookie'];
-  const all = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
-  const hit = all.find((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`));
-  return hit ? hit.slice(`${SESSION_COOKIE_NAME}=`.length).split(';')[0] : null;
+  return cookieFrom(res, SESSION_COOKIE_NAME);
 }
 
 describe('sanitizeOAuthReturnPath', () => {
@@ -63,6 +88,28 @@ describe('sanitizeOAuthReturnPath', () => {
     expect(sanitizeOAuthReturnPath('/oauth/authorizex')).toBeNull();
     expect(sanitizeOAuthReturnPath('/studio')).toBeNull();
     expect(sanitizeOAuthReturnPath('/oauth/authorize\r\nSet-Cookie: x=1')).toBeNull();
+  });
+});
+
+describe('originAllowed', () => {
+  const req = (origin?: string) => ({ headers: origin === undefined ? {} : { origin } });
+
+  it('accepts the canonical origin and refuses any other, in production', () => {
+    expect(originAllowed(req('https://www.gamedev.pl'), true)).toBe(true);
+    expect(originAllowed(req('https://evil.example'), true)).toBe(false);
+    expect(originAllowed(req('http://www.gamedev.pl'), true)).toBe(false);
+  });
+
+  it('allows a request that sends no Origin at all', () => {
+    // Not every form POST carries one, and this is the third layer behind
+    // SameSite=Strict and the double-submit nonce — it must not be the one that
+    // decides a legitimate submission is an attack.
+    expect(originAllowed(req(), true)).toBe(true);
+    expect(originAllowed(req(''), true)).toBe(true);
+  });
+
+  it('does not enforce outside production, where the canonical origin is not the dev one', () => {
+    expect(originAllowed(req('http://localhost:5173'), false)).toBe(true);
   });
 });
 
@@ -124,7 +171,7 @@ describe('POST /oauth/token-login', () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await post(app, { token });
+    const res = await visitAndPost(app, { token });
 
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe('/studio');
@@ -139,7 +186,7 @@ describe('POST /oauth/token-login', () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await post(app, { token });
+    const res = await visitAndPost(app, { token });
 
     expect(readSessionToken(sessionFrom(res)!, sessionSecret).src).toBe('token');
   });
@@ -151,7 +198,7 @@ describe('POST /oauth/token-login', () => {
     await store.upsertUser({ uid: 'g:boss2' });
     const token = await mintToken(app, 'g:boss');
 
-    const res = await post(app, { token });
+    const res = await visitAndPost(app, { token });
     const cookie = sessionFrom(res)!;
 
     const mint = await app.inject({
@@ -170,7 +217,7 @@ describe('POST /oauth/token-login', () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await post(app, { token, oauth_return: '/oauth/authorize?client_id=abc' });
+    const res = await visitAndPost(app, { token, oauth_return: '/oauth/authorize?client_id=abc' });
 
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe('/oauth/authorize?client_id=abc');
@@ -180,7 +227,7 @@ describe('POST /oauth/token-login', () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await post(app, { token, oauth_return: 'https://evil.example/steal' });
+    const res = await visitAndPost(app, { token, oauth_return: 'https://evil.example/steal' });
 
     expect(res.headers.location).toBe('/studio');
   });
@@ -190,7 +237,7 @@ describe('POST /oauth/token-login', () => {
     // getting far enough to approve an MCP client.
     const app = await appWith(store, { betaAllowedUids: 'g:boss' });
     const token = await mintToken(app, 'bot:reviewer');
-    const cookie = sessionFrom(await post(app, { token }))!;
+    const cookie = sessionFrom(await visitAndPost(app, { token }))!;
 
     const authorize = await app.inject({
       method: 'GET',
@@ -209,49 +256,106 @@ describe('POST /oauth/token-login', () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await app.inject({
-      method: 'POST',
-      url: TOKEN_LOGIN_PATH,
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: new URLSearchParams({ token }).toString(),
-    });
+    const res = await post(app, { token });
 
     expect(res.statusCode).toBe(403);
     expect(sessionFrom(res)).toBeNull();
   });
 
-  it('rejects a form token minted from a different secret', async () => {
-    // Login CSRF: sameSite=lax does not stop a top-level cross-site form POST, and the
-    // next thing this flow does is ask the browser to approve durable write access.
+  it('rejects a nonce the attacker fetched for themselves', async () => {
+    // The bypass this replaced: the form token used to be an HMAC over a time bucket,
+    // identical for every visitor that hour. Anyone could load the page, read a valid
+    // token, and put it in a cross-site form — the check passed, and the login CSRF it
+    // existed to stop went through. Binding the nonce to a cookie is what closes it,
+    // so the attack has to be the test.
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
 
-    const res = await app.inject({
-      method: 'POST',
-      url: TOKEN_LOGIN_PATH,
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: new URLSearchParams({ token, form_token: formToken('somebody-elses-secret', Date.now()) }).toString(),
-    });
+    // The attacker loads the page and keeps the nonce it rendered...
+    const attackerPage = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+    const attackerNonce = cookieFrom(attackerPage, CSRF_COOKIE)!;
+    expect(attackerPage.body).toContain(`value="${attackerNonce}"`);
+
+    // ...and puts it in a form the victim's browser submits. That browser carries no
+    // CSRF cookie of its own, because SameSite=Strict withholds it cross-site.
+    const res = await post(app, { token, form_token: attackerNonce });
 
     expect(res.statusCode).toBe(403);
     expect(sessionFrom(res)).toBeNull();
   });
 
-  it('rejects a form token from a stale bucket but accepts the previous one', async () => {
+  it("rejects a nonce that is not the one in this browser's cookie", async () => {
     const app = await appWith(store);
     const token = await mintToken(app, 'bot:reviewer');
-    const hourMs = 60 * 60 * 1000;
+    const page = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+    const mine = cookieFrom(page, CSRF_COOKIE)!;
 
-    const stale = await post(app, { token }, Date.now() - 3 * hourMs);
-    expect(stale.statusCode).toBe(403);
+    const res = await post(app, { token, form_token: newCsrfNonce() }, `${CSRF_COOKIE}=${mine}`);
 
-    const recent = await post(app, { token }, Date.now() - hourMs);
-    expect(recent.statusCode).toBe(302);
+    expect(res.statusCode).toBe(403);
+    expect(sessionFrom(res)).toBeNull();
+  });
+
+  it('rejects a malformed nonce without measuring it against anything', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+    const nonce = cookieFrom(await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH }), CSRF_COOKIE)!;
+
+    for (const bad of ['', 'x'.repeat(100_000), `${nonce}!`, nonce.slice(0, 42)]) {
+      const res = await post(app, { token, form_token: bad }, `${CSRF_COOKIE}=${nonce}`);
+      expect(res.statusCode).toBe(403);
+      expect(sessionFrom(res)).toBeNull();
+    }
+  });
+
+  it('hands back a submittable form when it refuses', async () => {
+    // A refusal that renders a dead nonce would strand the visitor in a loop of
+    // "that form expired" with no way out.
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+
+    const refused = await post(app, { token });
+    expect(refused.statusCode).toBe(403);
+
+    const nonce = cookieFrom(refused, CSRF_COOKIE)!;
+    expect(refused.body).toContain(`name="form_token" value="${nonce}"`);
+
+    const retry = await post(app, { token, form_token: nonce }, `${CSRF_COOKIE}=${nonce}`);
+    expect(retry.statusCode).toBe(302);
+  });
+
+  it('reuses the nonce a second tab already holds', async () => {
+    const app = await appWith(store);
+    const first = await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH });
+    const nonce = cookieFrom(first, CSRF_COOKIE)!;
+
+    const second = await app.inject({
+      method: 'GET',
+      url: TOKEN_LOGIN_PATH,
+      headers: { cookie: `${CSRF_COOKIE}=${nonce}` },
+    });
+
+    // No re-issue, and the same value rendered — otherwise opening a second tab would
+    // silently break the form sitting in the first.
+    expect(cookieFrom(second, CSRF_COOKIE)).toBeNull();
+    expect(second.body).toContain(`value="${nonce}"`);
+  });
+
+  it('clears the nonce once it has been spent', async () => {
+    const app = await appWith(store);
+    const token = await mintToken(app, 'bot:reviewer');
+    const nonce = cookieFrom(await app.inject({ method: 'GET', url: TOKEN_LOGIN_PATH }), CSRF_COOKIE)!;
+
+    const res = await post(app, { token, form_token: nonce }, `${CSRF_COOKIE}=${nonce}`);
+
+    expect(res.statusCode).toBe(302);
+    const setCookies = res.headers['set-cookie'] as string[];
+    expect(setCookies.some((c) => c.startsWith(`${CSRF_COOKIE}=;`))).toBe(true);
   });
 
   it('refuses an unknown token without saying why', async () => {
     const app = await appWith(store);
-    const res = await post(app, { token: generateAccessToken().token });
+    const res = await visitAndPost(app, { token: generateAccessToken().token });
 
     expect(res.statusCode).toBe(401);
     expect(sessionFrom(res)).toBeNull();
@@ -261,14 +365,14 @@ describe('POST /oauth/token-login', () => {
 
   it('refuses a credential that is not a personal access token at all', async () => {
     const app = await appWith(store);
-    const res = await post(app, { token: 'gdpl_oat_something_else' });
+    const res = await visitAndPost(app, { token: 'gdpl_oat_something_else' });
     expect(res.statusCode).toBe(401);
     expect(sessionFrom(res)).toBeNull();
   });
 
   it('refuses an empty submission', async () => {
     const app = await appWith(store);
-    const res = await post(app, { token: '   ' });
+    const res = await visitAndPost(app, { token: '   ' });
     expect(res.statusCode).toBe(400);
     expect(sessionFrom(res)).toBeNull();
   });
@@ -287,7 +391,7 @@ describe('POST /oauth/token-login', () => {
       expiresAt: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
     });
 
-    const res = await post(app, { token: generated.token });
+    const res = await visitAndPost(app, { token: generated.token });
 
     expect(res.statusCode).toBe(401);
     expect(sessionFrom(res)).toBeNull();
@@ -298,7 +402,7 @@ describe('POST /oauth/token-login', () => {
     const token = await mintToken(app, 'bot:reviewer');
     await store.upsertUser({ uid: 'bot:reviewer', tier: 'blocked' });
 
-    const res = await post(app, { token });
+    const res = await visitAndPost(app, { token });
 
     expect(res.statusCode).toBe(403);
     expect(sessionFrom(res)).toBeNull();

--- a/apps/api/src/oauth-token-login.ts
+++ b/apps/api/src/oauth-token-login.ts
@@ -1,0 +1,212 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { resolveAccessTokenUser } from './access-token-service.js';
+import { DEFAULT_SESSION_DURATION_SECONDS, mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { escapeHtml, MASCOT_SVG, OAUTH_PAGE_STYLES } from './oauth-page-chrome.js';
+import type { Store } from './store.js';
+
+export const TOKEN_LOGIN_PATH = '/oauth/token-login';
+
+/**
+ * How long a rendered form stays submittable. Stateless: the token is an HMAC over a
+ * time bucket, so accepting the current and previous bucket gives every visitor at
+ * least this long and at most twice it, with nothing to store or expire.
+ */
+const FORM_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+export interface TokenLoginOptions {
+  store: Store;
+  sessionSecret: string;
+  now?: () => number;
+}
+
+/**
+ * True when `path` is a relative authorize URL we may navigate to after sign-in.
+ *
+ * Mirrors sanitizeOAuthReturnPath in apps/web/src/oauthReturn.ts, which does this for
+ * the Google/Apple path. Kept as a separate copy rather than shared because the two live
+ * in different workspaces with no common package, and the alternative — importing across
+ * apps — is the thing the import rule exists to prevent. Any change here belongs there
+ * too: both answer "may we redirect a just-authenticated browser at this?", and an open
+ * redirect at that exact moment is a phishing page wearing our session.
+ */
+export function sanitizeOAuthReturnPath(path: string): string | null {
+  const trimmed = path.trim();
+  if (!trimmed.startsWith('/oauth/authorize')) return null;
+  if (trimmed.startsWith('//') || trimmed.includes('\\') || /[\r\n]/.test(trimmed)) return null;
+  if (trimmed.includes('://')) return null;
+  if (trimmed !== '/oauth/authorize' && !trimmed.startsWith('/oauth/authorize?')) return null;
+  return trimmed;
+}
+
+export function formToken(secret: string, nowMs: number, bucketOffset = 0): string {
+  const bucket = Math.floor(nowMs / FORM_TOKEN_TTL_MS) - bucketOffset;
+  return createHmac('sha256', secret).update(`oauth-token-login-v1:${bucket}`).digest('hex');
+}
+
+function formTokenValid(candidate: string, secret: string, nowMs: number): boolean {
+  // Current and previous bucket, so a form rendered at 10:59 still submits at 11:01.
+  return [0, 1].some((offset) => {
+    const a = Buffer.from(candidate, 'utf8');
+    const b = Buffer.from(formToken(secret, nowMs, offset), 'utf8');
+    return a.length === b.length && timingSafeEqual(a, b);
+  });
+}
+
+/**
+ * English only, unlike the consent screen beside it.
+ *
+ * The consent screen is shown to creators, who arrive in whatever language they use the
+ * site in. This one is shown to whoever was handed a token out of band — an operator or
+ * a marketplace reviewer — and translating a page nobody reaches by accident would be
+ * inventing an audience it does not have.
+ */
+function tokenLoginHtml(input: { oauthReturn: string | null; formToken: string; error?: string }): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Sign in with an access token · gamedev.pl</title>
+  ${OAUTH_PAGE_STYLES}
+</head>
+<body>
+  <main>
+    <p class="brand">${MASCOT_SVG}<span>gamedev.pl</span></p>
+    <h1>Sign in with an access token</h1>
+    <p class="lead">
+      Paste the personal access token you were given. It signs you in as the account the
+      token belongs to, for ${DEFAULT_SESSION_DURATION_SECONDS / 3600} hours.
+    </p>
+    ${input.error ? `<p class="waiting">${escapeHtml(input.error)}</p>` : ''}
+
+    <form method="post" action="${TOKEN_LOGIN_PATH}">
+      <input type="hidden" name="form_token" value="${escapeHtml(input.formToken)}" />
+      ${input.oauthReturn ? `<input type="hidden" name="oauth_return" value="${escapeHtml(input.oauthReturn)}" />` : ''}
+      <label for="token">Access token</label>
+      <input
+        type="password"
+        id="token"
+        name="token"
+        autocomplete="current-password"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        placeholder="gdpl_pat_…"
+        required
+      />
+      <div class="actions">
+        <button type="submit" class="approve">Sign in</button>
+      </div>
+    </form>
+
+    <p class="bail">
+      This page is for accounts that sign in with a token rather than Google or Apple.
+      If you have a gamedev.pl account, use the sign-in button on the site instead.
+    </p>
+  </main>
+</body>
+</html>`;
+}
+
+/**
+ * Sign in with a personal access token, in a browser (docs/agent-access-tokens.md).
+ *
+ * `POST /api/auth/session` already trades a PAT for a session cookie, and that is the
+ * mechanism here — this page adds no authority, and is emphatically not the bypass route
+ * AGENTS.md promises does not exist. What it adds is a way to *perform* that exchange
+ * without a shell: the API route wants an `Authorization` header, and a human sitting in
+ * front of a browser cannot produce one. That gap matters because sign-in on this site
+ * is Google or Apple and nothing else, so anyone who must reach the consent screen
+ * without a Google account — a marketplace reviewer testing the MCP connector, most
+ * immediately — has no door at all.
+ *
+ * Deliberately not linked from anywhere. It is not a second front door for creators;
+ * it is the door for whoever was handed a token, and a token can only exist because an
+ * operator minted one. That is what stands in for registration: there is no signup here
+ * because there is no way to acquire the credential except by being given it.
+ */
+export function registerTokenLoginRoutes(app: FastifyInstance, options: TokenLoginOptions): void {
+  const { store, sessionSecret } = options;
+  const now = options.now ?? (() => Date.now());
+  const isProd = process.env.NODE_ENV === 'production';
+
+  // Same guarded registration as oauth-as.ts: in app.ts that module has already claimed
+  // the parser, but this one has to stand alone when a test mounts only these routes.
+  if (!app.hasContentTypeParser('application/x-www-form-urlencoded')) {
+    app.addContentTypeParser('application/x-www-form-urlencoded', { parseAs: 'string' }, (_request, body, done) => {
+      const params = new URLSearchParams(body as string);
+      const parsed: Record<string, string> = {};
+      for (const [key, value] of params) parsed[key] = value;
+      done(null, parsed);
+    });
+  }
+
+  app.get(TOKEN_LOGIN_PATH, async (request, reply) => {
+    const raw = (request.query as { oauth_return?: string }).oauth_return;
+    return reply
+      .type('text/html')
+      .header('cache-control', 'no-store')
+      .send(
+        tokenLoginHtml({
+          oauthReturn: typeof raw === 'string' ? sanitizeOAuthReturnPath(raw) : null,
+          formToken: formToken(sessionSecret, now()),
+        }),
+      );
+  });
+
+  app.post(
+    TOKEN_LOGIN_PATH,
+    // Per-IP, because the token is the only thing guarding the account behind it and a
+    // form is far easier to grind than a curl loop. The window matches /api/auth/*.
+    { config: { rateLimit: { max: 20, timeWindow: 60 * 60 * 1000 } } },
+    async (request, reply) => {
+      const body = (request.body ?? {}) as { token?: string; oauth_return?: string; form_token?: string };
+      const oauthReturn = typeof body.oauth_return === 'string' ? sanitizeOAuthReturnPath(body.oauth_return) : null;
+      const nowMs = now();
+
+      const fail = (status: number, error: string) =>
+        reply
+          .status(status)
+          .type('text/html')
+          .header('cache-control', 'no-store')
+          .send(tokenLoginHtml({ oauthReturn, formToken: formToken(sessionSecret, nowMs), error }));
+
+      // Login CSRF: `sameSite: 'lax'` does not stop a top-level cross-site form POST, so
+      // without this an attacker could silently sign a visitor's browser into an account
+      // the attacker controls — and the next thing this flow does is ask that browser to
+      // approve durable write access. Proving the POST came from a form we served is
+      // cheap and closes it.
+      if (typeof body.form_token !== 'string' || !formTokenValid(body.form_token, sessionSecret, nowMs)) {
+        return fail(403, 'That form expired. Try again.');
+      }
+
+      const token = typeof body.token === 'string' ? body.token.trim() : '';
+      if (!token) return fail(400, 'Paste an access token.');
+
+      const user = await resolveAccessTokenUser(store, token, nowMs);
+      // One message for every failure — wrong, expired, revoked, unknown. Saying which
+      // would tell someone holding a stolen token what they hold.
+      if (!user) return fail(401, 'That token is not valid.');
+      if (user.tier === 'blocked') return fail(403, 'That account is blocked.');
+
+      // Stamped `src: 'token'` exactly as POST /api/auth/session stamps it, so the
+      // session-only operator surfaces keep refusing this cookie. A cookie minted here
+      // must carry the token's authority and not a grain more.
+      reply.setCookie(
+        SESSION_COOKIE_NAME,
+        mintSessionToken(user.uid, sessionSecret, DEFAULT_SESSION_DURATION_SECONDS, undefined, 'token'),
+        {
+          path: '/',
+          httpOnly: true,
+          secure: isProd,
+          sameSite: 'lax',
+          maxAge: DEFAULT_SESSION_DURATION_SECONDS,
+        },
+      );
+
+      return reply.redirect(oauthReturn ?? '/studio');
+    },
+  );
+}

--- a/apps/api/src/oauth-token-login.ts
+++ b/apps/api/src/oauth-token-login.ts
@@ -1,6 +1,7 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
-import type { FastifyInstance } from 'fastify';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { resolveAccessTokenUser } from './access-token-service.js';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import { DEFAULT_SESSION_DURATION_SECONDS, mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { escapeHtml, MASCOT_SVG, OAUTH_PAGE_STYLES } from './oauth-page-chrome.js';
 import type { Store } from './store.js';
@@ -8,11 +9,23 @@ import type { Store } from './store.js';
 export const TOKEN_LOGIN_PATH = '/oauth/token-login';
 
 /**
- * How long a rendered form stays submittable. Stateless: the token is an HMAC over a
- * time bucket, so accepting the current and previous bucket gives every visitor at
- * least this long and at most twice it, with nothing to store or expire.
+ * Per-browser CSRF nonce, carried in its own cookie and echoed by the form.
+ *
+ * The first version of this was an HMAC over a time bucket, which proved only that a
+ * form had been rendered *recently* — not that it had been rendered for *this* browser.
+ * Anyone could fetch the page, read a currently-valid token, and put it in a cross-site
+ * form; the check passed and the login CSRF it was supposed to stop went through. The
+ * value has to be one the attacker cannot read, which means one the victim's browser
+ * holds.
+ *
+ * Scoped to this path so it rides on nothing else, and `SameSite=Strict` so it is not
+ * even sent on the cross-site POST that would spend it.
  */
-const FORM_TOKEN_TTL_MS = 60 * 60 * 1000;
+const CSRF_COOKIE_NAME = 'gamedev_token_login_csrf';
+const CSRF_COOKIE_MAX_AGE_SECONDS = 60 * 60;
+/** 32 random bytes, base64url. Anchored and fixed-length, so a huge candidate is
+ *  rejected in constant time without ever being copied into a Buffer. */
+const CSRF_NONCE_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 
 export interface TokenLoginOptions {
   store: Store;
@@ -39,18 +52,36 @@ export function sanitizeOAuthReturnPath(path: string): string | null {
   return trimmed;
 }
 
-export function formToken(secret: string, nowMs: number, bucketOffset = 0): string {
-  const bucket = Math.floor(nowMs / FORM_TOKEN_TTL_MS) - bucketOffset;
-  return createHmac('sha256', secret).update(`oauth-token-login-v1:${bucket}`).digest('hex');
+export function newCsrfNonce(): string {
+  return randomBytes(32).toString('base64url');
 }
 
-function formTokenValid(candidate: string, secret: string, nowMs: number): boolean {
-  // Current and previous bucket, so a form rendered at 10:59 still submits at 11:01.
-  return [0, 1].some((offset) => {
-    const a = Buffer.from(candidate, 'utf8');
-    const b = Buffer.from(formToken(secret, nowMs, offset), 'utf8');
-    return a.length === b.length && timingSafeEqual(a, b);
-  });
+/**
+ * Double submit: the nonce in the cookie must equal the nonce in the form body.
+ *
+ * Both sides are format-checked before either becomes a Buffer, so an oversized or
+ * malformed submission costs a regex and nothing else.
+ */
+function csrfValid(cookieNonce: unknown, submitted: unknown): boolean {
+  if (typeof cookieNonce !== 'string' || !CSRF_NONCE_PATTERN.test(cookieNonce)) return false;
+  if (typeof submitted !== 'string' || !CSRF_NONCE_PATTERN.test(submitted)) return false;
+  // Equal lengths guaranteed by the pattern above, so timingSafeEqual cannot throw.
+  return timingSafeEqual(Buffer.from(cookieNonce, 'utf8'), Buffer.from(submitted, 'utf8'));
+}
+
+/**
+ * Third layer, behind SameSite=Strict and the double-submit nonce.
+ *
+ * Enforced in production only: browsers send `Origin` on same-origin POSTs too, and the
+ * canonical origin is `https://www.gamedev.pl` by default — so enforcing it everywhere
+ * would refuse every form submitted against a dev server on localhost. That makes this
+ * the one check here that depends on deployment config, which is exactly why it is not
+ * the one the other two lean on.
+ */
+export function originAllowed(request: Pick<FastifyRequest, 'headers'>, isProd: boolean): boolean {
+  const origin = request.headers.origin;
+  if (!isProd || typeof origin !== 'string' || origin === '') return true;
+  return origin === canonicalAppBaseUrl();
 }
 
 /**
@@ -143,15 +174,32 @@ export function registerTokenLoginRoutes(app: FastifyInstance, options: TokenLog
     });
   }
 
+  const setCsrfCookie = (reply: FastifyReply, nonce: string) => {
+    reply.setCookie(CSRF_COOKIE_NAME, nonce, {
+      path: TOKEN_LOGIN_PATH,
+      httpOnly: true,
+      secure: isProd,
+      sameSite: 'strict',
+      maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+    });
+  };
+
   app.get(TOKEN_LOGIN_PATH, async (request, reply) => {
     const raw = (request.query as { oauth_return?: string }).oauth_return;
+
+    // Reused when the browser already holds one, so a second tab does not invalidate
+    // the form open in the first.
+    const held = request.cookies[CSRF_COOKIE_NAME];
+    const nonce = typeof held === 'string' && CSRF_NONCE_PATTERN.test(held) ? held : newCsrfNonce();
+    if (nonce !== held) setCsrfCookie(reply, nonce);
+
     return reply
       .type('text/html')
       .header('cache-control', 'no-store')
       .send(
         tokenLoginHtml({
           oauthReturn: typeof raw === 'string' ? sanitizeOAuthReturnPath(raw) : null,
-          formToken: formToken(sessionSecret, now()),
+          formToken: nonce,
         }),
       );
   });
@@ -166,21 +214,27 @@ export function registerTokenLoginRoutes(app: FastifyInstance, options: TokenLog
       const oauthReturn = typeof body.oauth_return === 'string' ? sanitizeOAuthReturnPath(body.oauth_return) : null;
       const nowMs = now();
 
-      const fail = (status: number, error: string) =>
-        reply
+      // A refusal has to hand back a form that can actually be submitted, so it carries
+      // the browser's live nonce — minting one if the reason for the refusal was that
+      // the browser had none.
+      const held = request.cookies[CSRF_COOKIE_NAME];
+      const liveNonce = typeof held === 'string' && CSRF_NONCE_PATTERN.test(held) ? held : newCsrfNonce();
+
+      const fail = (status: number, error: string) => {
+        if (liveNonce !== held) setCsrfCookie(reply, liveNonce);
+        return reply
           .status(status)
           .type('text/html')
           .header('cache-control', 'no-store')
-          .send(tokenLoginHtml({ oauthReturn, formToken: formToken(sessionSecret, nowMs), error }));
+          .send(tokenLoginHtml({ oauthReturn, formToken: liveNonce, error }));
+      };
 
-      // Login CSRF: `sameSite: 'lax'` does not stop a top-level cross-site form POST, so
-      // without this an attacker could silently sign a visitor's browser into an account
-      // the attacker controls — and the next thing this flow does is ask that browser to
-      // approve durable write access. Proving the POST came from a form we served is
-      // cheap and closes it.
-      if (typeof body.form_token !== 'string' || !formTokenValid(body.form_token, sessionSecret, nowMs)) {
-        return fail(403, 'That form expired. Try again.');
-      }
+      // Login CSRF. `sameSite: 'lax'` on the session cookie does not stop a top-level
+      // cross-site form POST, and the next thing this flow does is ask the browser to
+      // approve durable write access — so an attacker who can silently sign a visitor
+      // into an account they control gets that approval from someone else's browser.
+      if (!originAllowed(request, isProd)) return fail(403, 'That request did not come from gamedev.pl.');
+      if (!csrfValid(held, body.form_token)) return fail(403, 'That form expired. Reload and try again.');
 
       const token = typeof body.token === 'string' ? body.token.trim() : '';
       if (!token) return fail(400, 'Paste an access token.');
@@ -205,6 +259,10 @@ export function registerTokenLoginRoutes(app: FastifyInstance, options: TokenLog
           maxAge: DEFAULT_SESSION_DURATION_SECONDS,
         },
       );
+
+      // Spent. The next visit mints a fresh one rather than reusing a nonce that has
+      // already been exchanged for a session.
+      reply.clearCookie(CSRF_COOKIE_NAME, { path: TOKEN_LOGIN_PATH });
 
       return reply.redirect(oauthReturn ?? '/studio');
     },

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -197,6 +197,38 @@ Traps, in the order an agent will hit them:
 - **Production cookies carry `Secure`** — they travel over HTTPS only, so the same
   script pointed at a plain-HTTP host will not authenticate.
 
+**Signing in as a human, in a browser** — `/oauth/token-login` is the same exchange
+with a form instead of a header. Paste the token, get the session cookie, land in the
+studio (or back at `/oauth/authorize`, if that is where you came from).
+
+It exists because sign-in on this site is Google or Apple and nothing else. That is fine
+for creators and useless for anyone who has to reach the OAuth consent screen without a
+Google account — a marketplace reviewer testing the MCP connector, most immediately, and
+OpenAI's plugin review explicitly forbids 2FA and account creation on a test credential.
+Handing over a shared Google login would mean disabling 2FA on an account Google will
+challenge anyway the moment it is used from an unfamiliar IP.
+
+The page adds no authority: it is `POST /api/auth/session` with a form on the front, the
+cookie carries the same `src: 'token'` stamp, and the operator surfaces refuse it
+identically. It is **not** the bypass route `AGENTS.md` says does not exist — there is
+still no way in without a token, and a token still only exists because an operator minted
+one. That is what stands in for registration: no signup, because the credential cannot be
+self-served.
+
+Practical notes:
+
+- **Not linked from anywhere**, and `noindex`. Reviewers get the URL out of band.
+- **Give it its own account and its own expiry.** `npm run token:mint -w @gamedevpl/api --
+--uid bot:reviewer --name "openai review" --days 30` scopes the blast radius to one
+  account holding nothing but sample games, and expires it on the review window rather
+  than the 90-day default.
+- **Revoking the token does not revoke OAuth grants approved during that session.** The
+  grant is its own record with its own lifetime. Close a review by revoking the token
+  _and_ removing the grant in Studio → connected apps.
+- The form carries a one-hour CSRF token, so a page left open overnight needs a reload.
+  `sameSite: 'lax'` does not stop a top-level cross-site form POST, and the next thing
+  this flow does is ask the browser to approve durable write access.
+
 ## CI: the authenticated deploy smoke
 
 `deploy.yml` runs two layers of this on every candidate revision, **before traffic
@@ -255,7 +287,8 @@ issuing a credential is an admission decision in itself.
 | File                                   | What it holds                                                       |
 | -------------------------------------- | ------------------------------------------------------------------- |
 | `apps/api/src/access-token.ts`         | Pure format, mint, hash, verify — no I/O                            |
-| `apps/api/src/access-token-service.ts` | The shared issuance rules (namespace, cap, expiry)                  |
+| `apps/api/src/access-token-service.ts` | Shared issuance rules (namespace, cap, expiry) and token resolution |
 | `apps/api/src/access-token-routes.ts`  | Operator HTTP surface                                               |
 | `apps/api/src/auth.ts`                 | Bearer resolution in the `onRequest` hook; `POST /api/auth/session` |
+| `apps/api/src/oauth-token-login.ts`    | `/oauth/token-login` — the same exchange as a browser form          |
 | `apps/api/scripts/access-token.ts`     | The `token:mint` / `token:list` / `token:revoke` CLI                |

--- a/docs/agent-access-tokens.md
+++ b/docs/agent-access-tokens.md
@@ -225,9 +225,11 @@ Practical notes:
 - **Revoking the token does not revoke OAuth grants approved during that session.** The
   grant is its own record with its own lifetime. Close a review by revoking the token
   _and_ removing the grant in Studio → connected apps.
-- The form carries a one-hour CSRF token, so a page left open overnight needs a reload.
-  `sameSite: 'lax'` does not stop a top-level cross-site form POST, and the next thing
-  this flow does is ask the browser to approve durable write access.
+- The form carries a per-browser CSRF nonce in a `SameSite=Strict` cookie, valid an hour,
+  so a page left open overnight needs a reload. It has to be per-browser, not merely
+  per-hour: a nonce anyone could fetch for themselves is one an attacker can put in a
+  cross-site form, and the next thing this flow does is ask the browser to approve
+  durable write access.
 
 ## CI: the authenticated deploy smoke
 


### PR DESCRIPTION
Adds `/oauth/token-login` — a one-field form that trades a personal access token for a session cookie and returns to the OAuth authorize URL it came from.

## Why

Sign-in here is Google or Apple and nothing else (`auth.ts` types the provider as exactly `z.enum(['google', 'apple'])`). That's fine for creators and useless for anyone who has to reach the OAuth consent screen without a Google account.

The immediate case is the OpenAI plugin submission, whose test-credentials step requires credentials that "work immediately with no additional setup" and permits neither account creation nor 2FA. We have no username/password to give. The alternative was a shared Google account with 2FA disabled — which Google challenges anyway the first time it's used from an unfamiliar IP, and that failure would land mid-review and look like our server was broken. The same problem is open for the Anthropic plugin directory reviewer account.

`POST /api/auth/session` already performs this exact exchange. What it can't do is be driven by a human, because it wants an `Authorization` header. This is that route with a form on the front.

## What it is not

Not the bypass route `AGENTS.md` promises doesn't exist. There is still no way in without a token, and a token still only exists because an operator ran `token:mint`. That's what stands in for registration: no signup, because the credential can't be self-served.

Not an escalation. The cookie carries the same `src: 'token'` stamp as the existing exchange, so the session-only operator surfaces refuse it. Asserted end to end rather than claimed — mint a PAT for an *admin* account, trade it here, then try to mint another token with the resulting cookie: 404. Without the stamp that would have been a real hole.

No passwords are stored, hashed, or accepted anywhere. That property is worth keeping and this change doesn't spend it.

## Changes

- `oauth-token-login.ts` (new) — the GET form, the POST exchange, the CSRF nonce, and an API-side copy of the `oauth_return` sanitiser.
- `access-token-service.ts` — token resolution moves here and is now shared with the Bearer path in `auth.ts`. A token the header refuses but the form accepts would be a way in that reading either file alone wouldn't reveal.
- `oauth-page-chrome.ts` (new) — the styles, mascot, and `escapeHtml` shared by both server-rendered OAuth pages. Looking like gamedev.pl is the only anti-phishing cue either page offers; letting them diverge costs that.
- `docs/agent-access-tokens.md` — the page, and the operational caveat below.

## Security notes for review

- **Login CSRF.** The first version of this was wrong, and both review bots caught it independently — the token was an HMAC over a global time bucket, identical for every visitor that hour, so an attacker could load the public page, read a valid token, and put it in a cross-site form. Fixed in a9686b6 with a per-browser nonce: 32 random bytes in a `SameSite=Strict`, `HttpOnly` cookie scoped to this path, echoed by the form and compared on submit. The attacker can't read the victim's cookie, and `Strict` means the browser won't send it on the cross-site POST that would spend it. `Origin` is checked as a third layer, production-only — the canonical origin is `www.gamedev.pl`, so enforcing it everywhere would refuse every form submitted against a dev server, which is exactly why it isn't the layer the others lean on.
- **Open redirect is handled.** `oauth_return` is whitelisted to relative `/oauth/authorize` paths only, mirroring `apps/web/src/oauthReturn.ts`. Tested against scheme-relative, absolute, backslash, and CRLF forms.
- **Failures are indistinguishable.** Wrong, expired, revoked, and never-existed all return the same message. Saying which would tell someone holding a stolen token what they hold.
- **Known gap, unchanged by this PR:** revoking a token does not revoke OAuth grants approved during that session — the grant is its own record with its own lifetime. Closing a review means revoking the token *and* removing the grant in Studio. Documented rather than fixed; the cascade is its own change.
- Rate limited 20/hour/IP, matching `/api/auth/*`. Not linked from anywhere, and `noindex`.

## Testing

27 tests, driven through the fully assembled app rather than the route plugin — the private-beta wall lives in `app.ts`, and a sign-in page whose entire job is being reachable without a session has to be tested against it.

The CSRF bypass is now the regression test: it posts a nonce fetched by a second client carrying no cookie of its own, which is precisely what the old code accepted. Also covered — a nonce that isn't the one in this browser's cookie, malformed nonces (empty, 100k characters, mutated, truncated), that a refusal hands back a *submittable* form rather than stranding the visitor in a loop, that a second tab reuses rather than invalidates the first tab's nonce, and that the nonce is cleared once spent.

Beyond CSRF: redirect sanitising, expired and blocked and unknown tokens, the `src: 'token'` stamp and its consequence, and reaching the consent screen end to end as an account with no Google identity while private beta is on.

Green gate clean: type-check, lint, full suite, build.

Rendered at 1024px and 390px, plus the refusal state, to confirm it picks up the consent screen's theme rather than shipping on browser-default white.

## Follow-up (not in this PR)

Mint the reviewer account once deployed:

```
npm run token:mint -w @gamedevpl/api -- --uid bot:reviewer --name "openai review" --days 30
```

30 days rather than the 90-day default, to scope the credential to the review window.