### PR TITLE
fix(oauth): accept ChatGPT CIMD clients that support none

### DIFF
--- a/apps/api/src/oauth-as.test.ts
+++ b/apps/api/src/oauth-as.test.ts
@@ -1,10 +1,10 @@
 import type { FastifyInstance } from 'fastify';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildApp } from './app.js';
 import { mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
 import { mintGameAgentKey } from './agent-game-key.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
-import { consentToken, OAUTH_AS_METADATA_PATH } from './oauth-as.js';
+import { cimdSupportsPublicClientAuth, consentToken, OAUTH_AS_METADATA_PATH } from './oauth-as.js';
 import { pkceChallengeS256 } from './oauth-pkce.js';
 import { AS_ACCESS_TOKEN_TTL_MS, generateAsAccessToken, generateAsRefreshToken } from './oauth-tokens.js';
 import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
@@ -404,6 +404,83 @@ describe('OAuth authorization server (BY-18b)', () => {
       headers: { cookie: sessionCookie('g:creator') },
     });
     expect((again.json() as unknown[]).length).toBe(0);
+  });
+
+  it('accepts ChatGPT-shaped CIMD that prefers private_key_jwt but also supports none', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    app = await buildOAuthApp(store);
+
+    const clientIdUrl = 'https://chatgpt.com/oauth/test-client/client.json';
+    const redirectUri = 'https://chatgpt.com/connector/oauth/test-client';
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(clientIdUrl);
+      return new Response(
+        JSON.stringify({
+          client_id: clientIdUrl,
+          client_name: 'ChatGPT',
+          redirect_uris: [redirectUri],
+          token_endpoint_auth_method: 'private_key_jwt',
+          token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+          jwks_uri: 'https://chatgpt.com/oauth/jwks.json',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+      const tokens = await authorizeAndExchange(app, clientIdUrl, redirectUri, verifier);
+      expect(tokens.access_token).toMatch(/^gdpl_oat_/);
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('still rejects CIMD clients that cannot use none', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    app = await buildOAuthApp(store);
+
+    const clientIdUrl = 'https://example.com/oauth/secret-only/client.json';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              client_id: clientIdUrl,
+              redirect_uris: ['https://example.com/callback'],
+              token_endpoint_auth_method: 'private_key_jwt',
+              token_endpoint_auth_methods_supported: ['private_key_jwt'],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    try {
+      const challenge = pkceChallengeS256('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+      const res = await app.inject({
+        method: 'GET',
+        url: '/oauth/authorize',
+        headers: { cookie: sessionCookie('g:creator') },
+        query: {
+          response_type: 'code',
+          client_id: clientIdUrl,
+          redirect_uri: 'https://example.com/callback',
+          scope: 'mcp',
+          code_challenge: challenge,
+          code_challenge_method: 'S256',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'invalid_client' });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 
@@ -846,5 +923,31 @@ describe('oauth token helpers', () => {
     });
     expect(refused.statusCode).toBe(403);
     await app.close();
+  });
+});
+
+describe('cimdSupportsPublicClientAuth', () => {
+  it('accepts ChatGPT RP Metadata Choices listing none alongside private_key_jwt', () => {
+    expect(
+      cimdSupportsPublicClientAuth({
+        token_endpoint_auth_method: 'private_key_jwt',
+        token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts legacy none-only documents (claude.ai shape)', () => {
+    expect(cimdSupportsPublicClientAuth({ token_endpoint_auth_method: 'none' })).toBe(true);
+    expect(cimdSupportsPublicClientAuth({})).toBe(true);
+  });
+
+  it('rejects clients that only speak private_key_jwt', () => {
+    expect(
+      cimdSupportsPublicClientAuth({
+        token_endpoint_auth_method: 'private_key_jwt',
+        token_endpoint_auth_methods_supported: ['private_key_jwt'],
+      }),
+    ).toBe(false);
+    expect(cimdSupportsPublicClientAuth({ token_endpoint_auth_method: 'private_key_jwt' })).toBe(false);
   });
 });

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -105,19 +105,11 @@ interface CimdDocument {
   client_name?: string;
   redirect_uris: string[];
   token_endpoint_auth_method?: string;
-  /** OpenID Connect RP Metadata Choices — methods the client can use. */
+  // RP Metadata Choices: methods ChatGPT can actually use.
   token_endpoint_auth_methods_supported?: string[];
 }
 
-/**
- * Whether a CIMD document can authenticate against an AS that only speaks `none`.
- *
- * ChatGPT prefers `private_key_jwt` in `token_endpoint_auth_method` but also lists
- * `none` in `token_endpoint_auth_methods_supported`. Rejecting on the preferred field
- * alone made every ChatGPT connector install fail with `invalid_client` after sign-in.
- * ChatGPT intersects that list with our AS metadata and uses `none` when we do not
- * advertise `private_key_jwt` (https://developers.openai.com/apps-sdk/build/auth).
- */
+// Prefer Choices list; ChatGPT prefers private_key_jwt but also supports none.
 export function cimdSupportsPublicClientAuth(body: {
   token_endpoint_auth_method?: string;
   token_endpoint_auth_methods_supported?: string[];

--- a/apps/api/src/oauth-as.ts
+++ b/apps/api/src/oauth-as.ts
@@ -105,6 +105,29 @@ interface CimdDocument {
   client_name?: string;
   redirect_uris: string[];
   token_endpoint_auth_method?: string;
+  /** OpenID Connect RP Metadata Choices — methods the client can use. */
+  token_endpoint_auth_methods_supported?: string[];
+}
+
+/**
+ * Whether a CIMD document can authenticate against an AS that only speaks `none`.
+ *
+ * ChatGPT prefers `private_key_jwt` in `token_endpoint_auth_method` but also lists
+ * `none` in `token_endpoint_auth_methods_supported`. Rejecting on the preferred field
+ * alone made every ChatGPT connector install fail with `invalid_client` after sign-in.
+ * ChatGPT intersects that list with our AS metadata and uses `none` when we do not
+ * advertise `private_key_jwt` (https://developers.openai.com/apps-sdk/build/auth).
+ */
+export function cimdSupportsPublicClientAuth(body: {
+  token_endpoint_auth_method?: string;
+  token_endpoint_auth_methods_supported?: string[];
+}): boolean {
+  const supported = body.token_endpoint_auth_methods_supported;
+  if (Array.isArray(supported) && supported.length > 0) {
+    return supported.includes('none');
+  }
+  const method = body.token_endpoint_auth_method;
+  return method === undefined || method === 'none';
 }
 
 async function fetchCimdClient(clientIdUrl: string, nowMs: number): Promise<OAuthClientRecord | null> {
@@ -132,7 +155,7 @@ async function fetchCimdClient(clientIdUrl: string, nowMs: number): Promise<OAut
 
   if (body.client_id !== clientIdUrl) return null;
   if (!Array.isArray(body.redirect_uris) || body.redirect_uris.length === 0) return null;
-  if (body.token_endpoint_auth_method && body.token_endpoint_auth_method !== 'none') return null;
+  if (!cimdSupportsPublicClientAuth(body)) return null;
 
   const client: OAuthClientRecord = {
     clientId: clientIdUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Installing the gamedev.pl MCP connector in ChatGPT failed after sign-in with `{"error":"invalid_client"}`.

ChatGPT identifies itself via CIMD (`client_id` = `https://chatgpt.com/oauth/…/client.json`). That document prefers `token_endpoint_auth_method: "private_key_jwt"` but also advertises `token_endpoint_auth_methods_supported: ["none", "private_key_jwt"]`. Our AS only speaks `none` (+ PKCE) and advertises that in metadata — ChatGPT is documented to fall back to `none` when we do not advertise `private_key_jwt`.

We were rejecting the CIMD document whenever the *preferred* method was not `none`, so authorize always returned `invalid_client` for ChatGPT.

## Fix

Honor OpenID Connect RP Metadata Choices: accept a CIMD client when `token_endpoint_auth_methods_supported` includes `none` (or when the legacy single-method field is absent/`none`). Still reject clients that cannot use `none`. Token exchange stays PKCE/`none` — we do not advertise `private_key_jwt`.

## Test plan

- [x] Unit coverage for ChatGPT-shaped CIMD accept / private_key_jwt-only reject
- [x] Full auth-code + PKCE round trip with mocked ChatGPT CIMD document
- [x] Green gate: type-check, lint, test, build
- [ ] After deploy: re-run ChatGPT “Add Gamedev.pl” OAuth → consent screen instead of `invalid_client`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5995a577-de02-4676-aabc-224d31897029?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5995a577-de02-4676-aabc-224d31897029&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

