### PR TITLE
Creator-facing MCP round card (less debug, live pulse + stages)

### DIFF
--- a/apps/api/scripts/screenshot-mcp-card.mjs
+++ b/apps/api/scripts/screenshot-mcp-card.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Renders the real MCP round-status card against fixture payloads and writes
+ * one PNG per state under /opt/cursor/artifacts (or --out).
+ *
+ * Usage: node --import tsx apps/api/scripts/screenshot-mcp-card.mjs
+ */
+import { mkdirSync, writeFileSync, mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { ROUND_STATUS_RESOURCE_URI, readUiResource } from '../src/mcp-ui.ts';
+
+const outDir = process.argv.includes('--out')
+  ? process.argv[process.argv.indexOf('--out') + 1]
+  : '/opt/cursor/artifacts/mcp-card-states';
+
+const FALLBACK_PNG =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const NOW = '2026-08-07T00:20:00.000Z';
+const NOTE_AT = '2026-08-07T00:17:00.000Z';
+
+const chromeBin =
+  process.env.CHROME_PATH ||
+  ['google-chrome', 'chromium', 'chromium-browser'].find((bin) => spawnSync('which', [bin]).status === 0);
+
+if (!chromeBin) {
+  console.error('No chrome/chromium on PATH');
+  process.exit(1);
+}
+
+const resource = readUiResource(ROUND_STATUS_RESOURCE_URI);
+if (!resource?.text) {
+  console.error('Could not read round-status resource');
+  process.exit(1);
+}
+
+mkdirSync(outDir, { recursive: true });
+const work = mkdtempSync(join(tmpdir(), 'mcp-card-'));
+
+function chromeShot(url, outPath, size = '720,1200', scale = '2') {
+  spawnSync(
+    'timeout',
+    [
+      '20s',
+      chromeBin,
+      '--headless=new',
+      '--disable-gpu',
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--hide-scrollbars',
+      `--user-data-dir=${join(work, `ud-${Math.random().toString(36).slice(2)}`)}`,
+      `--force-device-scale-factor=${scale}`,
+      `--window-size=${size}`,
+      `--screenshot=${outPath}`,
+      url,
+    ],
+    { encoding: 'utf8' },
+  );
+  return readFileSync(outPath);
+}
+
+function bakeFrame(name, fill, label) {
+  const htmlPath = join(work, `${name}-frame.html`);
+  const pngPath = join(work, `${name}-frame.png`);
+  writeFileSync(
+    htmlPath,
+    `<!doctype html><html><body style="margin:0;background:${fill};width:320px;height:180px;display:flex;align-items:center;justify-content:center;font:600 18px system-ui;color:#f2f4f5">${label}</body></html>`,
+  );
+  try {
+    return chromeShot(pathToFileURL(htmlPath).href, pngPath, '320,180', '1').toString('base64');
+  } catch {
+    return FALLBACK_PNG;
+  }
+}
+
+const frameA = bakeFrame('a', '#1a2740', 'Score 0');
+const frameB = bakeFrame('b', '#243552', 'Score 1');
+const frameC = bakeFrame('c', '#2e4464', 'Score 5');
+
+const base = {
+  title: 'Simple Arkanoid',
+  slug: 'simple-arkanoid-2',
+  round: 1,
+  deliveriesRemaining: 18,
+  playUrl: 'https://www.gamedev.pl/play/simple-arkanoid-2',
+  studioUrl: 'https://www.gamedev.pl/studio/simple-arkanoid-2',
+  siteUrl: 'https://www.gamedev.pl',
+  retryAfterSeconds: 30,
+  agentEnded: false,
+  stall: null,
+  note: null,
+  presence: null,
+  shot: null,
+  gate: null,
+};
+
+const fixtures = {
+  queued: {
+    ...base,
+    phase: 'queued',
+    status: 'queued',
+    stall: 'no_agent_yet',
+  },
+  building: {
+    ...base,
+    phase: 'building',
+    status: 'building',
+    presence: { key: 'reading_kit', at: NOW },
+    note: {
+      text: 'The pink rival paddle now tracks the ball with a capped reaction speed.',
+      createdAt: NOTE_AT,
+    },
+    shot: {
+      id: 'shot-1',
+      createdAt: NOTE_AT,
+      label: 'Playtest frame',
+      png: frameA,
+    },
+  },
+  gating: {
+    ...base,
+    phase: 'gating',
+    status: 'building',
+    agentEnded: true,
+    stall: 'ended',
+    note: {
+      text: 'Submitted preview delivery for the pink paddle update.',
+      createdAt: NOTE_AT,
+    },
+    gate: {
+      status: 'pending',
+      lane: 'preview',
+      deliveryId: 'v20260806T221748222Z-4a9950',
+      ranAt: null,
+      summary: 'Delivered — waiting on the gate.',
+    },
+  },
+  preview_passed: {
+    ...base,
+    phase: 'building',
+    status: 'building',
+    agentEnded: true,
+    stall: 'ended',
+    note: {
+      text: 'The pink rival paddle now tracks the ball with a capped reaction speed, rebounds it from above, and is called out in the HUD and instructions.',
+      createdAt: NOTE_AT,
+    },
+    gate: {
+      status: 'preview_passed',
+      lane: 'preview',
+      deliveryId: 'v20260806T221748222Z-4a9950',
+      ranAt: NOW,
+      summary:
+        'preview check passed — continue iterating, then submit_sources with mode=publish (TRACE required)',
+      report:
+        'check:game --preview passed against engine 39b773aa2fec9885fd77171b32ee6f42d4c03ec9; 5 artifact(s) stored',
+    },
+    _gallery: [
+      { name: 'frame-0.png', png: frameA },
+      { name: 'frame-1.png', png: frameB },
+      { name: 'frame-2.png', png: frameC },
+    ],
+  },
+  preview_failed: {
+    ...base,
+    phase: 'building',
+    status: 'building',
+    agentEnded: true,
+    stall: 'ended',
+    gate: {
+      status: 'preview_failed',
+      lane: 'preview',
+      deliveryId: 'v20260806T221748222Z-fail',
+      ranAt: NOW,
+      summary: 'preview check refused this delivery',
+      report: 'smoke failed: TypeError: paddle.update is not a function\n  at game/runtime.ts:88',
+    },
+  },
+  published: {
+    ...base,
+    phase: 'published',
+    status: 'published',
+    agentEnded: true,
+    deliveriesRemaining: 17,
+    note: {
+      text: 'Publish sealed. The pink paddle rival ships.',
+      createdAt: NOW,
+    },
+    gate: {
+      status: 'green',
+      lane: 'publish',
+      deliveryId: 'v20260806T230000000Z-pub',
+      ranAt: NOW,
+      summary: 'gate accepted this delivery',
+      report: 'check:game passed; catalog entry published',
+    },
+    _gallery: [{ name: 'frame-0.png', png: frameA }],
+  },
+};
+
+/**
+ * Build a standalone page: the real card document, then a boot script that cannot
+ * be closed early by `</script>` inside the card (card is the document itself).
+ */
+function pageFor(stateName, openDetails) {
+  const fixture = fixtures[stateName];
+  if (!fixture) throw new Error(`unknown state ${stateName}`);
+  const gallery = fixture._gallery ?? null;
+  const payload = { ...fixture };
+  delete payload._gallery;
+
+  // Append boot script before </body> of the real card HTML.
+  const boot = `
+<script>
+(function () {
+  var api = window.__gamedevRoundCard;
+  if (!api) { document.body.textContent = 'Card API missing'; return; }
+  var payload = ${JSON.stringify(payload)};
+  var gallery = ${JSON.stringify(gallery)};
+  api.render(payload);
+  if (gallery) api.renderMedia({ frames: gallery, lane: payload.gate && payload.gate.lane });
+  ${openDetails ? "var d = document.getElementById('details'); if (d) d.open = true;" : ''}
+  document.documentElement.style.background = '#0f1214';
+  document.body.style.background = '#0f1214';
+})();
+</script>`;
+
+  return resource.text.replace('</body>', `${boot}\n  </body>`);
+}
+
+const jobs = [
+  ['queued', false],
+  ['building', false],
+  ['gating', false],
+  ['preview_passed', false],
+  ['preview_passed', true],
+  ['preview_failed', false],
+  ['published', false],
+];
+
+for (const [state, openDetails] of jobs) {
+  const label = openDetails ? `${state}_details` : state;
+  const htmlPath = join(work, `${label}.html`);
+  const out = join(outDir, `mcp-card-${label}.png`);
+  writeFileSync(htmlPath, pageFor(state, openDetails));
+  try {
+    const buf = chromeShot(pathToFileURL(htmlPath).href, out);
+    console.log('wrote', out, `(${buf.length} bytes)`);
+  } catch (err) {
+    console.error('screenshot failed', label, err);
+    process.exitCode = 1;
+  }
+}
+
+rmSync(work, { recursive: true, force: true });
+console.log('done →', outDir);

--- a/apps/api/scripts/screenshot-mcp-card.mjs
+++ b/apps/api/scripts/screenshot-mcp-card.mjs
@@ -12,15 +12,25 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { ROUND_STATUS_RESOURCE_URI, readUiResource } from '../src/mcp-ui.ts';
 
-const outDir = process.argv.includes('--out')
-  ? process.argv[process.argv.indexOf('--out') + 1]
-  : '/opt/cursor/artifacts/mcp-card-states';
+const DEFAULT_OUT = '/opt/cursor/artifacts/mcp-card-states';
+const outFlag = process.argv.indexOf('--out');
+let outDir = DEFAULT_OUT;
+if (outFlag !== -1) {
+  const value = process.argv[outFlag + 1];
+  if (!value || value.startsWith('-')) {
+    console.error('Usage: node --import tsx apps/api/scripts/screenshot-mcp-card.mjs [--out <dir>]');
+    process.exit(1);
+  }
+  outDir = value;
+}
 
 const FALLBACK_PNG =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
 
 const NOW = '2026-08-07T00:20:00.000Z';
 const NOTE_AT = '2026-08-07T00:17:00.000Z';
+/** Chrome often writes the PNG then hangs in sandboxes — kill after this. */
+const CHROME_TIMEOUT_MS = 20_000;
 
 const chromeBin =
   process.env.CHROME_PATH ||
@@ -41,11 +51,9 @@ mkdirSync(outDir, { recursive: true });
 const work = mkdtempSync(join(tmpdir(), 'mcp-card-'));
 
 function chromeShot(url, outPath, size = '720,1200', scale = '2') {
-  spawnSync(
-    'timeout',
+  const result = spawnSync(
+    chromeBin,
     [
-      '20s',
-      chromeBin,
       '--headless=new',
       '--disable-gpu',
       '--no-sandbox',
@@ -57,9 +65,22 @@ function chromeShot(url, outPath, size = '720,1200', scale = '2') {
       `--screenshot=${outPath}`,
       url,
     ],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', timeout: CHROME_TIMEOUT_MS, killSignal: 'SIGKILL' },
   );
-  return readFileSync(outPath);
+  try {
+    return readFileSync(outPath);
+  } catch {
+    const detail =
+      result.error?.message ||
+      (result.stderr && String(result.stderr).trim()) ||
+      `exit ${result.status}`;
+    throw new Error(`chrome screenshot failed: ${detail}`);
+  }
+}
+
+/** Safe for embedding inside a <script> — escapes `<` so `</script>` cannot close early. */
+function embedJson(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 
 function bakeFrame(name, fill, label) {
@@ -218,8 +239,8 @@ function pageFor(stateName, openDetails) {
 (function () {
   var api = window.__gamedevRoundCard;
   if (!api) { document.body.textContent = 'Card API missing'; return; }
-  var payload = ${JSON.stringify(payload)};
-  var gallery = ${JSON.stringify(gallery)};
+  var payload = ${embedJson(payload)};
+  var gallery = ${embedJson(gallery)};
   api.render(payload);
   if (gallery) api.renderMedia({ frames: gallery, lane: payload.gate && payload.gate.lane });
   ${openDetails ? "var d = document.getElementById('details'); if (d) d.open = true;" : ''}

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -161,6 +161,10 @@ const ROUND_STATUS_OUTPUT_SCHEMA: Record<string, unknown> = {
       type: ['object', 'null'],
       properties: { text: { type: 'string' }, createdAt: { type: 'string' } },
     },
+    presence: {
+      type: ['object', 'null'],
+      properties: { key: { type: 'string' }, at: { type: 'string' } },
+    },
     shot: {
       type: ['object', 'null'],
       properties: {
@@ -4045,6 +4049,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           round: record.roundGeneration ?? 1,
           deliveriesRemaining: cap === null ? null : Math.max(0, cap - used),
           note: latestEvent ? { text: noteTextFor(latestEvent, args.locale), createdAt: latestEvent.createdAt } : null,
+          presence: record.lastAgentPresence
+            ? { key: record.lastAgentPresence.key, at: record.lastAgentPresence.at }
+            : null,
           shot,
           gate,
           retryAfterSeconds: ROUND_STATUS_RETRY_AFTER_SECONDS,

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -430,6 +430,7 @@ describe('ui resources', () => {
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
     expect(html).toContain('pill-live');
     expect(html).toContain('gd-pulse-sq');
+    expect(html).toContain('prefers-reduced-motion');
     expect(html).toContain('PREVIEW_GATE_STAGES');
     expect(html).toContain('Technical details');
     expect(html).toContain('setDetailsVisible');

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -419,11 +419,34 @@ describe('ui resources', () => {
   });
 
   it('does not print the gate detail twice, or lead with instructions meant for the agent', () => {
-    // kit_outdated returns the same long agent-facing text as both summary and report,
-    // which the card printed twice — once as its headline.
+    // Settled gates lead with GATE_COPY; agent summaries stay in details.
     const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
-    expect(html).toContain('gateSummary.length <= 180');
-    expect(html).toContain('detail !== summary.textContent');
+    expect(html).toContain('GATE_COPY[gateStatus]');
+    expect(html).toContain('looksAgentFacing');
+    expect(html).toContain("detail && detail === summary.textContent) detail = ''");
+  });
+
+  it('pulses live phases and keeps operator metadata behind Technical details', () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('pill-live');
+    expect(html).toContain('gd-pulse-sq');
+    expect(html).toContain('PREVIEW_GATE_STAGES');
+    expect(html).toContain('Technical details');
+    expect(html).toContain('setDetailsVisible');
+    expect(html).toContain('report-fail');
+    expect(html).toContain('preferFailSurface');
+    expect(html).toContain('Preview check passed — the game runs');
+    expect(html).not.toMatch(/GATE_COPY[\s\S]{0,400}?submit_sources/);
+  });
+
+  it('surfaces presence / progress as a live activity line while building or gating', () => {
+    const html = readUiResource(ROUND_STATUS_RESOURCE_URI)?.text ?? '';
+    expect(html).toContain('PRESENCE_COPY');
+    expect(html).toContain('id="activity"');
+    expect(html).toContain('setActivity');
+    expect(html).toContain('id="stages"');
+    expect(html).toContain("'Typecheck'");
+    expect(html).toContain("'Capture'");
   });
 
   it('keeps polling after a fixable gate refusal so a resumed agent refreshes the card', () => {

--- a/apps/api/src/mcp-ui.test.ts
+++ b/apps/api/src/mcp-ui.test.ts
@@ -436,7 +436,8 @@ describe('ui resources', () => {
     expect(html).toContain('setDetailsVisible');
     expect(html).toContain('report-fail');
     expect(html).toContain('preferFailSurface');
-    expect(html).toContain('Preview check passed — the game runs');
+    expect(html).toContain('Preview check passed. Keep iterating');
+    expect(html).not.toContain('the game runs');
     expect(html).not.toMatch(/GATE_COPY[\s\S]{0,400}?submit_sources/);
   });
 
@@ -447,7 +448,12 @@ describe('ui resources', () => {
     expect(html).toContain('setActivity');
     expect(html).toContain('id="stages"');
     expect(html).toContain("'Typecheck'");
+    // Preview omits Capture (stills are advisory / killable); publish still lists it.
+    expect(html).toContain("var PREVIEW_GATE_STAGES = ['Typecheck', 'Smoke', 'Build']");
     expect(html).toContain("'Capture'");
+    // Quiet/ended stalls must not keep pulsing a stale presence line.
+    expect(html).toContain("status.stall === 'quiet'");
+    expect(html).toContain('agentQuiet');
   });
 
   it('keeps polling after a fixable gate refusal so a resumed agent refreshes the card', () => {

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -781,11 +781,11 @@ const ROUND_STATUS_HTML = `<!doctype html>
           metaList.appendChild(dd);
         }
 
-        function setPill(headline) {
+        function setPill(headline, isLive) {
           var key = String(headline || 'waiting');
           var label = key === 'green' ? 'published' : key;
           pillLabel.textContent = label.replace(/_/g, ' ');
-          pill.className = 'pill pill-' + key + (LIVE_HEADLINES[key] ? ' pill-live' : '');
+          pill.className = 'pill pill-' + key + (isLive ? ' pill-live' : '');
         }
 
         function looksAgentFacing(text) {
@@ -918,7 +918,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
           pending: 'Checks are still running.',
           green: 'Published — this round is complete.',
           red: 'Publish check failed. See what broke below.',
-          preview_passed: 'Preview check passed — the game runs. Keep iterating, then publish when you are happy with it.',
+          preview_passed:
+            'Preview check passed. Keep iterating, then publish when you are happy with it.',
           preview_failed: 'Preview check failed. See what broke below.',
           kit_outdated: 'The Creator Kit changed mid-round, so this delivery has to be rebuilt against the new one.'
         };
@@ -961,7 +962,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
         };
 
         /** Gate check chain — shown while checks run (no fake step progress). */
-        var PREVIEW_GATE_STAGES = ['Typecheck', 'Smoke', 'Build', 'Capture'];
+        // Preview omits Capture: stills are advisory and killable via GATE_PREVIEW_STILLS=0.
+        var PREVIEW_GATE_STAGES = ['Typecheck', 'Smoke', 'Build'];
         var PUBLISH_GATE_STAGES = ['Typecheck', 'Smoke', 'Build', 'Trace', 'Capture', 'Validate'];
 
         var ACTIONS = {
@@ -1178,7 +1180,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
         function renderGateOnly(verdict) {
           var status = typeof verdict.status === 'string' ? verdict.status : 'pending';
-          setPill(status);
+          var gateLive = status === 'pending' && Boolean(verdict.deliveryId);
+          setPill(status, gateLive);
           var gateSummary = typeof verdict.summary === 'string' ? verdict.summary : '';
           summary.textContent =
             (gateSummary && !looksAgentFacing(gateSummary) ? gateSummary : '') ||
@@ -1187,7 +1190,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
             'Gate status: ' + status;
 
           setActivity(null);
-          setStages(verdict.lane, status === 'pending' && verdict.deliveryId);
+          setStages(verdict.lane, gateLive);
 
           metaList.textContent = '';
           addRow('Lane', verdict.lane);
@@ -1233,7 +1236,17 @@ const ROUND_STATUS_HTML = `<!doctype html>
                   ? 'stopped'
                   : status.phase;
 
-          setPill(headline);
+          var showStages =
+            headline === 'gating' ||
+            headline === 'submitted' ||
+            (gateStatus === 'pending' && gate && gate.deliveryId);
+          // Quiet/ended mean the agent is not working — do not pulse a stale presence
+          // line. Gating still pulses: the gate (not the agent) is the live actor.
+          var agentQuiet = status.stall === 'quiet' || status.stall === 'ended';
+          var live =
+            (LIVE_HEADLINES[headline] || showStages) && !(agentQuiet && !showStages);
+
+          setPill(headline, live);
 
           if (status.title) {
             titleEl.textContent = status.slug ? status.title + ' · ' + status.slug : status.title;
@@ -1259,6 +1272,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
             line = 'Delivered — automated checks are running.';
           } else if (status.agentEnded) {
             line = 'The agent has stopped without delivering.';
+          } else if (agentQuiet && STALL_COPY[status.stall]) {
+            // Prefer the stall over "The agent is building…" when the agent went quiet.
+            line = STALL_COPY[status.stall];
           }
           if (!line) line = PHASE_COPY[status.phase];
           if (!line && gateStatus) line = GATE_COPY[gateStatus];
@@ -1269,15 +1285,8 @@ const ROUND_STATUS_HTML = `<!doctype html>
             status.presence && typeof status.presence === 'object' ? status.presence : null;
           var presenceKey = presence && typeof presence.key === 'string' ? presence.key : '';
           var presenceLine = presenceKey && PRESENCE_COPY[presenceKey] ? PRESENCE_COPY[presenceKey] : '';
-          var live =
-            LIVE_HEADLINES[headline] ||
-            (gateStatus === 'pending' && gate && gate.deliveryId);
           var noteText =
             status.note && typeof status.note.text === 'string' ? status.note.text : '';
-          var showStages =
-            headline === 'gating' ||
-            headline === 'submitted' ||
-            (gateStatus === 'pending' && gate && gate.deliveryId);
           if (live && presenceLine && !showStages) {
             setActivity(presenceLine, presence.at);
           } else if (live && noteText && (headline === 'building' || headline === 'dispatched')) {

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -345,6 +345,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
       .linked:hover { text-decoration: underline; }
       .brand .dot { color: var(--gd-accent); }
       .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
         font-size: 12px;
         font-weight: 600;
         text-transform: uppercase;
@@ -355,12 +358,72 @@ const ROUND_STATUS_HTML = `<!doctype html>
         white-space: nowrap;
       }
       .pill-waiting, .pill-pending, .pill-queued, .pill-dispatched, .pill-stopped { color: var(--gd-muted); }
-      .pill-building, .pill-submitted, .pill-gating { color: #6fb3ff; }
+      .pill-building, .pill-submitted, .pill-gating, .pill-publishing { color: #6fb3ff; }
       .pill-green, .pill-preview_passed, .pill-published { color: var(--gd-accent); }
       .pill-red, .pill-preview_failed, .pill-failed { color: #ff6b6b; }
       .pill-kit_outdated, .pill-needs_changes { color: #ffb454; }
+      /* Pulse live pills so a 30s poll does not look frozen. */
+      .pulse-sq {
+        display: none;
+        width: 7px;
+        height: 7px;
+        flex: 0 0 auto;
+        background: currentColor;
+        border-radius: 1px;
+      }
+      .pill-live .pulse-sq {
+        display: inline-block;
+        animation: gd-pulse-sq 1.15s ease-in-out infinite;
+      }
+      @keyframes gd-pulse-sq {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.3; transform: scale(0.82); }
+      }
       .title { margin: 0 0 8px; font-size: 12.5px; color: var(--gd-muted); }
       .summary { margin: 0; font-size: 14px; line-height: 1.5; }
+      .activity {
+        margin: 10px 0 0;
+        font-size: 13px;
+        line-height: 1.45;
+        color: var(--gd-fg);
+      }
+      .activity .pulse-sq {
+        display: inline-block;
+        margin-right: 8px;
+        vertical-align: middle;
+        color: var(--gd-accent);
+        animation: gd-pulse-sq 1.15s ease-in-out infinite;
+      }
+      .activity .when { display: block; margin: 2px 0 0 15px; font-size: 11.5px; color: var(--gd-muted); }
+      .stages {
+        list-style: none;
+        margin: 10px 0 0;
+        padding: 0;
+        display: grid;
+        gap: 5px;
+      }
+      .stages li {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12.5px;
+        color: var(--gd-muted);
+      }
+      .stages li.current { color: var(--gd-fg); }
+      .stages li.done { color: var(--gd-accent); }
+      .stages .mark {
+        width: 7px;
+        height: 7px;
+        border-radius: 1px;
+        background: currentColor;
+        flex: 0 0 auto;
+        opacity: 0.45;
+      }
+      .stages li.current .mark {
+        opacity: 1;
+        animation: gd-pulse-sq 1.15s ease-in-out infinite;
+      }
+      .stages li.done .mark { opacity: 1; }
       .note {
         margin: 10px 0 0;
         padding-left: 10px;
@@ -386,17 +449,50 @@ const ROUND_STATUS_HTML = `<!doctype html>
         color: var(--gd-muted);
         background: rgba(127, 127, 127, 0.08);
       }
+      .details {
+        margin: 12px 0 0;
+        border: 1px solid var(--gd-border);
+        border-radius: 8px;
+        padding: 0 10px;
+        font-size: 12.5px;
+        color: var(--gd-muted);
+      }
+      .details > summary {
+        cursor: pointer;
+        list-style: none;
+        padding: 8px 0;
+        user-select: none;
+      }
+      .details > summary::-webkit-details-marker { display: none; }
+      .details > summary::before {
+        content: '';
+        display: inline-block;
+        width: 0;
+        height: 0;
+        border-top: 4px solid transparent;
+        border-bottom: 4px solid transparent;
+        border-left: 5px solid currentColor;
+        margin-right: 8px;
+        vertical-align: middle;
+      }
+      .details[open] > summary::before {
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid currentColor;
+        border-bottom: 0;
+        margin-right: 7px;
+      }
       .meta {
         display: grid;
         grid-template-columns: auto 1fr;
         gap: 4px 14px;
-        margin: 12px 0 0;
+        margin: 0 0 10px;
         font-size: 12.5px;
       }
       .meta dt { color: var(--gd-muted); }
-      .meta dd { margin: 0; word-break: break-word; }
+      .meta dd { margin: 0; color: var(--gd-fg); word-break: break-word; }
       .report {
-        margin: 12px 0 0;
+        margin: 0 0 10px;
         padding: 10px;
         border-radius: 8px;
         border: 1px solid var(--gd-border);
@@ -407,7 +503,9 @@ const ROUND_STATUS_HTML = `<!doctype html>
         white-space: pre-wrap;
         max-height: 220px;
         overflow: auto;
+        color: var(--gd-fg);
       }
+      .report-fail { margin: 12px 0 0; }
       /* The gate's own frames: a strip, so several fit without pushing the verdict off. */
       .gallery {
         display: grid;
@@ -465,16 +563,22 @@ const ROUND_STATUS_HTML = `<!doctype html>
     <main class="card">
       <div class="head">
         <span id="brand" class="brand">gamedev<span class="dot">.pl</span></span>
-        <span id="pill" class="pill pill-waiting">waiting</span>
+        <span id="pill" class="pill pill-waiting"><span class="pulse-sq" aria-hidden="true"></span><span id="pillLabel">waiting</span></span>
       </div>
       <p id="title" class="title" hidden></p>
       <p id="summary" class="summary">Reading round status…</p>
+      <p id="activity" class="activity" hidden></p>
+      <ul id="stages" class="stages" hidden></ul>
       <blockquote id="note" class="note" hidden></blockquote>
       <figure id="shot" class="shot" hidden><img id="shotImg" alt="Latest frame from the build" /><figcaption id="shotCap"></figcaption></figure>
       <div id="gallery" class="gallery" hidden></div>
       <p id="galleryCap" class="galleryCap" hidden></p>
-      <dl id="meta" class="meta"></dl>
-      <pre id="report" class="report" hidden></pre>
+      <pre id="failReport" class="report report-fail" hidden></pre>
+      <details id="details" class="details" hidden>
+        <summary>Technical details</summary>
+        <dl id="meta" class="meta"></dl>
+        <pre id="report" class="report" hidden></pre>
+      </details>
       <div id="playRow" class="actions" hidden>
         <button id="playBtn" type="button" class="action"></button>
       </div>
@@ -515,8 +619,11 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var timer = null;
 
         var pill = document.getElementById('pill');
+        var pillLabel = document.getElementById('pillLabel');
         var titleEl = document.getElementById('title');
         var summary = document.getElementById('summary');
+        var activityEl = document.getElementById('activity');
+        var stagesEl = document.getElementById('stages');
         var noteEl = document.getElementById('note');
         var shotEl = document.getElementById('shot');
         var shotImg = document.getElementById('shotImg');
@@ -529,8 +636,10 @@ const ROUND_STATUS_HTML = `<!doctype html>
         var actionHint = document.getElementById('actionHint');
         var gallery = document.getElementById('gallery');
         var galleryCap = document.getElementById('galleryCap');
+        var detailsEl = document.getElementById('details');
         var metaList = document.getElementById('meta');
         var report = document.getElementById('report');
+        var failReport = document.getElementById('failReport');
         var foot = document.getElementById('foot');
 
         function post(payload) {
@@ -665,6 +774,81 @@ const ROUND_STATUS_HTML = `<!doctype html>
           metaList.appendChild(dd);
         }
 
+        function setPill(headline) {
+          var key = String(headline || 'waiting');
+          var label = key === 'green' ? 'published' : key;
+          pillLabel.textContent = label.replace(/_/g, ' ');
+          pill.className = 'pill pill-' + key + (LIVE_HEADLINES[key] ? ' pill-live' : '');
+        }
+
+        function looksAgentFacing(text) {
+          return /submit_sources|TRACE|get_kit|mode=publish|kitEngineRef|call_end|get_gate_/i.test(text);
+        }
+
+        function setActivity(text, when) {
+          if (!text) {
+            activityEl.hidden = true;
+            activityEl.textContent = '';
+            return;
+          }
+          activityEl.textContent = '';
+          var mark = document.createElement('span');
+          mark.className = 'pulse-sq';
+          mark.setAttribute('aria-hidden', 'true');
+          activityEl.appendChild(mark);
+          activityEl.appendChild(document.createTextNode(text));
+          if (when) {
+            var stamp = document.createElement('span');
+            stamp.className = 'when';
+            stamp.textContent = formatTime(when);
+            activityEl.appendChild(stamp);
+          }
+          activityEl.hidden = false;
+        }
+
+        function setStages(lane, active) {
+          if (!active) {
+            stagesEl.hidden = true;
+            stagesEl.textContent = '';
+            return;
+          }
+          var labels = lane === 'publish' ? PUBLISH_GATE_STAGES : PREVIEW_GATE_STAGES;
+          stagesEl.textContent = '';
+          for (var i = 0; i < labels.length; i++) {
+            var li = document.createElement('li');
+            // Indeterminate: gate does not stream the active step.
+            li.className = 'current';
+            var mark = document.createElement('span');
+            mark.className = 'mark';
+            mark.setAttribute('aria-hidden', 'true');
+            li.appendChild(mark);
+            li.appendChild(document.createTextNode(labels[i]));
+            stagesEl.appendChild(li);
+          }
+          stagesEl.hidden = false;
+        }
+
+        function setDetailsVisible(hasRows, detailText, preferFailSurface) {
+          var hasDetail = typeof detailText === 'string' && detailText.trim().length > 0;
+          if (preferFailSurface && hasDetail) {
+            failReport.textContent = detailText.trim();
+            failReport.hidden = false;
+            report.hidden = true;
+            report.textContent = '';
+          } else {
+            failReport.hidden = true;
+            failReport.textContent = '';
+            if (hasDetail) {
+              report.textContent = detailText.trim();
+              report.hidden = false;
+            } else {
+              report.hidden = true;
+              report.textContent = '';
+            }
+          }
+          detailsEl.hidden = !(hasRows || (hasDetail && !preferFailSurface));
+        }
+
         /**
          * Hosts differ in how they wrap a tool result, so dig for the payload rather
          * than assuming one shape.
@@ -709,11 +893,11 @@ const ROUND_STATUS_HTML = `<!doctype html>
         }
 
         var PHASE_COPY = {
-          queued: 'Queued. The round is waiting to start.',
+          queued: 'In the queue — waiting to start.',
           dispatched: 'Starting the agent…',
-          building: 'The agent is building.',
-          submitted: 'Sources delivered. The gate is picking them up.',
-          gating: 'The gate is checking this delivery.',
+          building: 'The agent is building your game.',
+          submitted: 'Sources delivered. Automated checks are starting…',
+          gating: 'Running automated checks on this build.',
           ready_for_review: 'Ready for review.',
           publishing: 'Publishing…',
           published: 'Published.',
@@ -724,11 +908,11 @@ const ROUND_STATUS_HTML = `<!doctype html>
         };
 
         var GATE_COPY = {
-          pending: 'Gate status is pending.',
-          green: 'Publish gate green — the round is complete.',
-          red: 'Publish gate red. The report below says what failed.',
-          preview_passed: 'Preview gate passed — the build runs. Publish still needs a green publish gate.',
-          preview_failed: 'Preview gate failed. The report below says what broke.',
+          pending: 'Checks are still running.',
+          green: 'Published — this round is complete.',
+          red: 'Publish check failed. See what broke below.',
+          preview_passed: 'Preview check passed — the game runs. Keep iterating, then publish when you are happy with it.',
+          preview_failed: 'Preview check failed. See what broke below.',
           kit_outdated: 'The Creator Kit changed mid-round, so this delivery has to be rebuilt against the new one.'
         };
 
@@ -740,6 +924,38 @@ const ROUND_STATUS_HTML = `<!doctype html>
           gate_not_started: 'The gate did not start.',
           awaiting_input: 'Waiting on the creator.'
         };
+
+        /** Closed presence keys — same vocabulary as mcp-presence.ts. */
+        var PRESENCE_COPY = {
+          reading_brief: 'Reading the build brief…',
+          loading_seed: 'Loading the seed draft…',
+          fetching_kit: 'Fetching Creator Kit metadata…',
+          browsing_kit: 'Browsing the Creator Kit…',
+          searching_kit: 'Searching the Creator Kit…',
+          reading_kit: 'Reading Creator Kit files…',
+          loading_sources: 'Loading existing game sources…',
+          browsing_examples: 'Browsing example games…',
+          reading_example: 'Reading an example game…',
+          checking_staged: 'Checking staged sources…',
+          checking_inbox: 'Checking creator notes…',
+          waiting_checks: 'Waiting on automated checks…',
+          reviewing_captures: 'Reviewing gate captures…',
+          staging_sources: 'Staging source files…'
+        };
+
+        var LIVE_HEADLINES = {
+          queued: 1,
+          dispatched: 1,
+          building: 1,
+          submitted: 1,
+          gating: 1,
+          pending: 1,
+          publishing: 1
+        };
+
+        /** Gate check chain — shown while checks run (no fake step progress). */
+        var PREVIEW_GATE_STAGES = ['Typecheck', 'Smoke', 'Build', 'Capture'];
+        var PUBLISH_GATE_STAGES = ['Typecheck', 'Smoke', 'Build', 'Trace', 'Capture', 'Validate'];
 
         var ACTIONS = {
           kit_outdated: {
@@ -955,10 +1171,16 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
         function renderGateOnly(verdict) {
           var status = typeof verdict.status === 'string' ? verdict.status : 'pending';
-          pill.textContent = status.replace(/_/g, ' ');
-          pill.className = 'pill pill-' + status;
+          setPill(status);
+          var gateSummary = typeof verdict.summary === 'string' ? verdict.summary : '';
           summary.textContent =
-            (typeof verdict.summary === 'string' && verdict.summary) || GATE_COPY[status] || 'Gate status: ' + status;
+            (gateSummary && !looksAgentFacing(gateSummary) ? gateSummary : '') ||
+            GATE_COPY[status] ||
+            gateSummary ||
+            'Gate status: ' + status;
+
+          setActivity(null);
+          setStages(verdict.lane, status === 'pending' && verdict.deliveryId);
 
           metaList.textContent = '';
           addRow('Lane', verdict.lane);
@@ -967,14 +1189,13 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (status === 'pending') {
             addRow('Next step', verdict.deliveryId ? 'Watch Studio' : 'Continue building');
           }
+          var detail = typeof verdict.report === 'string' ? verdict.report : '';
+          if (!detail && gateSummary && looksAgentFacing(gateSummary)) detail = gateSummary;
+          var failed =
+            status === 'red' || status === 'preview_failed' || status === 'kit_outdated';
+          setDetailsVisible(metaList.childNodes.length > 0, detail, failed);
 
-          if (typeof verdict.report === 'string' && verdict.report.trim()) {
-            report.textContent = verdict.report;
-            report.hidden = false;
-          } else {
-            report.hidden = true;
-          }
-
+          noteEl.hidden = true;
           actionRow.hidden = true;
           playRow.hidden = true;
           gallery.hidden = true;
@@ -1005,8 +1226,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
                   ? 'stopped'
                   : status.phase;
 
-          pill.textContent = String(headline).replace(/_/g, ' ');
-          pill.className = 'pill pill-' + headline;
+          setPill(headline);
 
           if (status.title) {
             titleEl.textContent = status.slug ? status.title + ' · ' + status.slug : status.title;
@@ -1024,11 +1244,12 @@ const ROUND_STATUS_HTML = `<!doctype html>
           // leading with the phase told a creator the agent was working while the note
           // right below it said the agent had stopped.
           var line = null;
+          var gateSummary = gate && typeof gate.summary === 'string' ? gate.summary : '';
           if (gateStatus && gateStatus !== 'pending') {
-            var gateSummary = typeof gate.summary === 'string' ? gate.summary : '';
-            line = (gateSummary.length && gateSummary.length <= 180 ? gateSummary : '') || GATE_COPY[gateStatus] || gateSummary;
+            // Creator-facing GATE_COPY; channel summaries stay in details.
+            line = GATE_COPY[gateStatus] || gateSummary;
           } else if (gate && gate.deliveryId) {
-            line = 'Delivered — the gate is checking it.';
+            line = 'Delivered — automated checks are running.';
           } else if (status.agentEnded) {
             line = 'The agent has stopped without delivering.';
           }
@@ -1036,8 +1257,35 @@ const ROUND_STATUS_HTML = `<!doctype html>
           if (!line && gateStatus) line = GATE_COPY[gateStatus];
           summary.textContent = line || 'Round status: ' + status.phase;
 
-          if (status.note && typeof status.note.text === 'string' && status.note.text) {
-            noteEl.textContent = status.note.text;
+          // Presence or latest note while live; settled cards use the bordered note.
+          var presence =
+            status.presence && typeof status.presence === 'object' ? status.presence : null;
+          var presenceKey = presence && typeof presence.key === 'string' ? presence.key : '';
+          var presenceLine = presenceKey && PRESENCE_COPY[presenceKey] ? PRESENCE_COPY[presenceKey] : '';
+          var live =
+            LIVE_HEADLINES[headline] ||
+            (gateStatus === 'pending' && gate && gate.deliveryId);
+          var noteText =
+            status.note && typeof status.note.text === 'string' ? status.note.text : '';
+          var showStages =
+            headline === 'gating' ||
+            headline === 'submitted' ||
+            (gateStatus === 'pending' && gate && gate.deliveryId);
+          if (live && presenceLine && !showStages) {
+            setActivity(presenceLine, presence.at);
+          } else if (live && noteText && (headline === 'building' || headline === 'dispatched')) {
+            setActivity(noteText, status.note.createdAt);
+          } else if (live && headline === 'queued') {
+            setActivity(STALL_COPY[status.stall] || 'Waiting for an agent to pick this up…', null);
+          } else {
+            setActivity(null);
+          }
+
+          setStages(gate && gate.lane, showStages);
+
+          // Avoid duplicating the note when the activity line already shows it.
+          if (noteText && !(live && (headline === 'building' || headline === 'dispatched'))) {
+            noteEl.textContent = noteText;
             var when = document.createElement('span');
             when.className = 'when';
             when.textContent = formatTime(status.note.createdAt);
@@ -1092,17 +1340,23 @@ const ROUND_STATUS_HTML = `<!doctype html>
           }
 
           var detail = gate && typeof gate.report === 'string' ? gate.report.trim() : '';
-          if (!detail && gate && typeof gate.summary === 'string' && gate.summary.length > 180) {
-            // A long agent-facing summary is the detail, even when the gate sent no
-            // separate report.
-            detail = gate.summary.trim();
+          // Unused channel summary still belongs in Technical details.
+          if (
+            gateSummary &&
+            gateSummary.trim() &&
+            gateSummary.trim() !== summary.textContent &&
+            (looksAgentFacing(gateSummary) || gateSummary.length > 180 || !detail)
+          ) {
+            detail = detail
+              ? gateSummary.trim() + '\\n\\n' + detail
+              : gateSummary.trim();
           }
-          if (detail && detail !== summary.textContent) {
-            report.textContent = detail;
-            report.hidden = false;
-          } else {
-            report.hidden = true;
-          }
+          if (detail && detail === summary.textContent) detail = '';
+          var failed =
+            gateStatus === 'red' ||
+            gateStatus === 'preview_failed' ||
+            gateStatus === 'kit_outdated';
+          setDetailsVisible(metaList.childNodes.length > 0, detail, failed);
 
           renderPlay(status, gateStatus);
           renderAction(status, gateStatus);
@@ -1146,6 +1400,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
           report.textContent =
             report.hidden || !report.textContent ? diagnostic : report.textContent + '\\n\\n' + diagnostic;
           report.hidden = false;
+          detailsEl.hidden = false;
           reportSize();
         }
 
@@ -1492,6 +1747,15 @@ const ROUND_STATUS_HTML = `<!doctype html>
         });
 
         window.addEventListener('resize', reportSize);
+
+        // Standalone harness only — hosts keep parent !== window.
+        if (host === window) {
+          window.__gamedevRoundCard = {
+            render: render,
+            renderGateOnly: renderGateOnly,
+            renderMedia: renderMedia
+          };
+        }
       })();
     </script>
   </body>

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -379,6 +379,13 @@ const ROUND_STATUS_HTML = `<!doctype html>
         0%, 100% { opacity: 1; transform: scale(1); }
         50% { opacity: 0.3; transform: scale(0.82); }
       }
+      @media (prefers-reduced-motion: reduce) {
+        .pill-live .pulse-sq,
+        .activity .pulse-sq,
+        .stages li.current .mark {
+          animation: none;
+        }
+      }
       .title { margin: 0 0 8px; font-size: 12.5px; color: var(--gd-muted); }
       .summary { margin: 0; font-size: 14px; line-height: 1.5; }
       .activity {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The MCP Apps round-status card was reading like an ops console: Round / Lane / Delivery / raw `check:game` reports sat at the same weight as the game, and QUEUED / BUILDING / GATING were a static pill plus one frozen sentence.

### Changes
- **Technical details** accordion for Round, Lane, Delivery, deliveries left, and success-path reports
- Failures keep the gate report on the main surface
- **Pulsing square** on live pills (queued / building / gating / …)
- Live **activity line** from MCP presence (or latest progress note) while building
- **Gate stage list** while checks run (typecheck → smoke → build → capture; publish adds trace/validate) — indeterminate, no fake step progress
- Creator-facing outcome copy; agent instructions (`submit_sources`, TRACE, …) stay in details / model context
- `get_round_status` now includes `presence` so the card can show kit-browsing thoughts
- Harness: `node --import tsx apps/api/scripts/screenshot-mcp-card.mjs`

### State gallery

**Queued**
[MCP card QUEUED](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-queued.png)

**Building** (presence + latest shot)
[MCP card BUILDING](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-building.png)

**Gating**
[MCP card GATING](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-gating.png)

**Preview passed**
[MCP card PREVIEW PASSED](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-preview_passed.png)

**Preview passed — Technical details open**
[MCP card PREVIEW PASSED with details](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-preview_passed_details.png)

**Preview failed**
[MCP card PREVIEW FAILED](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-preview_failed.png)

**Published**
[MCP card PUBLISHED](https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp-card-states%2Fmcp-card-published.png)

### Test plan
- [x] `apps/api/src/mcp-ui.test.ts`
- [x] type-check, lint, test, build
- [x] Fixture screenshots of the seven states above
- [ ] Spot-check a live ChatGPT / Claude Apps round through queued → building → gating → preview_passed

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c3d9f4c-cc39-4ec3-9342-1b9daa8c3210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

