### PR TITLE
Make draft abandon honestly say it removes the game from Studio

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -7,6 +7,7 @@ import { CreatorStudioView } from './CreatorStudioView.js';
 import i18n from './i18n/index.js';
 import type { StudioGame, StudioGamesResponse, StudioScorecard } from './studioApi.js';
 
+const abandonSubmission = vi.fn();
 const fetchStudioGames = vi.fn();
 const fetchStudioHealth = vi.fn();
 const fetchStudioScorecards = vi.fn();
@@ -27,7 +28,7 @@ vi.mock('./submissionApi', async () => {
   return {
     ...actual,
     getSubmissionStatus: vi.fn(async () => ({ media: [] })),
-    abandonSubmission: vi.fn(),
+    abandonSubmission: (...args: unknown[]) => abandonSubmission(...args),
   };
 });
 
@@ -98,6 +99,8 @@ async function renderStudio(props: Partial<Parameters<typeof CreatorStudioView>[
 describe('CreatorStudioView', () => {
   beforeEach(() => {
     authUser = null;
+    abandonSubmission.mockReset();
+    abandonSubmission.mockResolvedValue(undefined);
     fetchStudioGames.mockReset();
     fetchStudioHealth.mockReset();
     fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
@@ -1300,6 +1303,136 @@ describe('CreatorStudioView — what players think', () => {
 
     expect(container.textContent).toContain('What players think');
     expect(container.textContent).toContain('No votes or written notes yet.');
+
+    root.unmount();
+  });
+});
+
+describe('CreatorStudioView abandon', () => {
+  beforeEach(() => {
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    abandonSubmission.mockReset();
+    abandonSubmission.mockResolvedValue(undefined);
+    fetchStudioGames.mockReset();
+    fetchStudioHealth.mockReset();
+    fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset();
+    fetchStudioScorecards.mockResolvedValue([]);
+    fetchStudioSuggestions.mockReset();
+    fetchStudioSuggestions.mockResolvedValue([]);
+    fetchGameAutonomy.mockReset();
+    fetchGameAutonomy.mockRejectedValue(new Error('not owned'));
+    setDraftShared.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('warns that abandoning a draft removes the game from Studio', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: 'Neon Draft',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'neon-draft',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: 'neon-draft', selectedTab: 'details' });
+    const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
+    expect(abandon?.textContent).toContain('Abandon this build');
+
+    await act(async () => {
+      abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.status-abandon')?.textContent).toContain(
+      'Yes, abandon — remove this game from Studio',
+    );
+
+    root.unmount();
+  });
+
+  it('warns that abandoning an improve round keeps the live game', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-improve',
+          title: 'TV Tycoon',
+          createdAt: '2026-08-01T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+          livePublishedAt: '2026-07-31T09:00:00.000Z',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
+    const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
+
+    await act(async () => {
+      abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.status-abandon')?.textContent).toContain(
+      'Yes, abandon — discard this round (live game stays)',
+    );
+
+    root.unmount();
+  });
+
+  it('refetches the shelf after abandon so a published sibling can reappear', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const improveTip = {
+      token: 'token-improve',
+      title: 'TV Tycoon',
+      createdAt: '2026-08-01T09:00:00.000Z',
+      lastKnownStatus: 'building' as const,
+      slug: 'tv-tycoon',
+      livePublishedAt: '2026-07-31T09:00:00.000Z',
+    };
+    const publishedSibling = {
+      token: 'token-live',
+      title: 'TV Tycoon',
+      createdAt: '2026-07-30T09:00:00.000Z',
+      lastKnownStatus: 'published' as const,
+      slug: 'tv-tycoon',
+      publishedAt: '2026-07-31T09:00:00.000Z',
+    };
+
+    fetchStudioGames.mockResolvedValueOnce(studioShelf([improveTip]));
+    fetchStudioGames.mockResolvedValueOnce(studioShelf([publishedSibling]));
+
+    const { container, root, onNavigate } = await renderStudio({
+      selectedGame: 'tv-tycoon',
+      selectedTab: 'details',
+    });
+
+    const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
+    await act(async () => {
+      abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-abandon.is-danger')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(abandonSubmission).toHaveBeenCalledWith('token-improve');
+    expect(fetchStudioGames).toHaveBeenCalledTimes(2);
+    expect(onNavigate).toHaveBeenCalled();
+    expect(container.textContent).toContain('TV Tycoon');
+    // Live published row no longer offers abandon.
+    expect(container.querySelector('.status-abandon')).toBeNull();
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -1346,14 +1346,15 @@ describe('CreatorStudioView abandon', () => {
 
     const { container, root } = await renderStudio({ selectedGame: 'neon-draft', selectedTab: 'details' });
     const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
-    expect(abandon?.textContent).toContain('Abandon this build');
+    expect(abandon?.textContent).toContain('Remove this game from Studio');
 
     await act(async () => {
       abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    expect(container.querySelector('.studio-abandon-hint')?.textContent).toContain('This draft was never published');
     expect(container.querySelector('.status-abandon')?.textContent).toContain(
-      'Yes, abandon — remove this game from Studio',
+      'Yes, remove it — the game leaves Studio',
     );
 
     root.unmount();
@@ -1377,11 +1378,13 @@ describe('CreatorStudioView abandon', () => {
 
     const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
     const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
+    expect(abandon?.textContent).toContain('Abandon this build');
 
     await act(async () => {
       abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    expect(container.querySelector('.studio-abandon-hint')).toBeNull();
     expect(container.querySelector('.status-abandon')?.textContent).toContain(
       'Yes, abandon — discard this round (live game stays)',
     );

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -1432,10 +1432,48 @@ describe('CreatorStudioView abandon', () => {
 
     expect(abandonSubmission).toHaveBeenCalledWith('token-improve');
     expect(fetchStudioGames).toHaveBeenCalledTimes(2);
-    expect(onNavigate).toHaveBeenCalled();
+    expect(fetchStudioGames).toHaveBeenLastCalledWith('tv-tycoon');
+    expect(onNavigate).toHaveBeenCalledWith('/studio/tv-tycoon');
     expect(container.textContent).toContain('TV Tycoon');
     // Live published row no longer offers abandon.
     expect(container.querySelector('.status-abandon')).toBeNull();
+
+    root.unmount();
+  });
+
+  it('returns to bare Studio when abandoning the only draft', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValueOnce(
+      studioShelf([
+        {
+          token: 'token-draft',
+          title: 'Neon Draft',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'neon-draft',
+        },
+      ]),
+    );
+    fetchStudioGames.mockResolvedValueOnce(studioShelf([]));
+
+    const { container, root, onNavigate } = await renderStudio({
+      selectedGame: 'neon-draft',
+      selectedTab: 'details',
+    });
+
+    const abandon = container.querySelector<HTMLButtonElement>('.status-abandon');
+    await act(async () => {
+      abandon!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-abandon.is-danger')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(abandonSubmission).toHaveBeenCalledWith('token-draft');
+    expect(onNavigate).toHaveBeenCalledWith('/studio');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -217,8 +217,7 @@ export function CreatorStudioView({
     requestedGameRef.current = selectedGame;
   }, [selectedGame]);
 
-  // One row per game for picking and counting. The API already collapses to the tip;
-  // after abandon we refetch so a published sibling (or older draft) can reappear.
+  // One row per game. Refetch after abandon can reveal a sibling.
   const shelfGames = useMemo(() => collapseStudioGames(games), [games]);
 
   // Resolve the URL's game segment against the shelf — by slug, or by capability token
@@ -897,8 +896,7 @@ export function CreatorStudioView({
                           onRemoved={async (token) => {
                             setSelected((current) => (current === token ? null : current));
                             onNavigate(studioPath());
-                            // Optimistic hide, then refetch: the tip may have been covering a
-                            // published (or older) sibling that should stay on the shelf.
+                            // Hide tip first; refetch may restore a sibling.
                             setGames((prev) => prev.filter((game) => game.token !== token));
                             try {
                               const shelfPage = await fetchStudioGames();
@@ -906,7 +904,7 @@ export function CreatorStudioView({
                               setShelfTruncated(shelfPage.truncated);
                               setTotalGames(shelfPage.totalGames);
                             } catch {
-                              // Keep the optimistic remove — the job is abandoned either way.
+                              // Optimistic remove stands if refetch fails.
                             }
                           }}
                         />

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -1116,7 +1116,7 @@ function DetailsPanel({
     setAbandoning(true);
     try {
       await abandonSubmission(game.token);
-      onRemoved(game.token);
+      await onRemoved(game.token);
     } catch {
       setAbandoning(false);
       setAbandonArmed(false);

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -1181,20 +1181,25 @@ function DetailsPanel({
                   <PixelIcon name="play" size={12} /> {t('studioPanel.overview.playtest')}
                 </button>
                 {!publishedJob && game.lastKnownStatus !== 'abandoned' ? (
-                  <button
-                    type="button"
-                    className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
-                    onClick={() => void handleAbandon()}
-                    disabled={abandoning}
-                  >
-                    {abandonArmed
-                      ? t(
-                          catalogLive
-                            ? 'studioPanel.overview.abandonConfirmKeepLive'
-                            : 'studioPanel.overview.abandonConfirmRemove',
-                        )
-                      : t('studioPanel.overview.abandon')}
-                  </button>
+                  <div className="studio-abandon-block">
+                    {abandonArmed && !catalogLive ? (
+                      <p className="studio-abandon-hint">{t('studioPanel.overview.abandonHintRemove')}</p>
+                    ) : null}
+                    <button
+                      type="button"
+                      className={`status-abandon${abandonArmed ? ' is-danger' : ''}`}
+                      onClick={() => void handleAbandon()}
+                      disabled={abandoning}
+                    >
+                      {abandonArmed
+                        ? t(
+                            catalogLive
+                              ? 'studioPanel.overview.abandonConfirmKeepLive'
+                              : 'studioPanel.overview.abandonConfirmRemove',
+                          )
+                        : t(catalogLive ? 'studioPanel.overview.abandon' : 'studioPanel.overview.abandonRemove')}
+                    </button>
+                  </div>
                 ) : null}
               </div>
             </section>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -217,8 +217,8 @@ export function CreatorStudioView({
     requestedGameRef.current = selectedGame;
   }, [selectedGame]);
 
-  // One row per game for picking and counting. Raw `games` still holds every job so
-  // abandoning an improve tip can reveal the published sibling again without a refetch.
+  // One row per game for picking and counting. The API already collapses to the tip;
+  // after abandon we refetch so a published sibling (or older draft) can reappear.
   const shelfGames = useMemo(() => collapseStudioGames(games), [games]);
 
   // Resolve the URL's game segment against the shelf — by slug, or by capability token
@@ -894,10 +894,20 @@ export function CreatorStudioView({
                               ),
                             );
                           }}
-                          onRemoved={(token) => {
-                            setGames((prev) => prev.filter((game) => game.token !== token));
+                          onRemoved={async (token) => {
                             setSelected((current) => (current === token ? null : current));
                             onNavigate(studioPath());
+                            // Optimistic hide, then refetch: the tip may have been covering a
+                            // published (or older) sibling that should stay on the shelf.
+                            setGames((prev) => prev.filter((game) => game.token !== token));
+                            try {
+                              const shelfPage = await fetchStudioGames();
+                              setGames(shelfPage.games);
+                              setShelfTruncated(shelfPage.truncated);
+                              setTotalGames(shelfPage.totalGames);
+                            } catch {
+                              // Keep the optimistic remove — the job is abandoned either way.
+                            }
                           }}
                         />
                       </aside>
@@ -1081,7 +1091,7 @@ function DetailsPanel({
   onOpenPlaytest: () => void;
   onPlay: () => void;
   onDraftSharedChange: (shared: boolean) => void;
-  onRemoved: (token: string) => void;
+  onRemoved: (token: string) => void | Promise<void>;
 }) {
   const { t, i18n } = useTranslation();
   // This *job* is published — composer/playtest routing. Distinct from catalog-live below.
@@ -1179,7 +1189,13 @@ function DetailsPanel({
                     onClick={() => void handleAbandon()}
                     disabled={abandoning}
                   >
-                    {abandonArmed ? t('studioPanel.overview.abandonConfirm') : t('studioPanel.overview.abandon')}
+                    {abandonArmed
+                      ? t(
+                          catalogLive
+                            ? 'studioPanel.overview.abandonConfirmKeepLive'
+                            : 'studioPanel.overview.abandonConfirmRemove',
+                        )
+                      : t('studioPanel.overview.abandon')}
                   </button>
                 ) : null}
               </div>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -894,17 +894,25 @@ export function CreatorStudioView({
                             );
                           }}
                           onRemoved={async (token) => {
+                            const abandonedSlug = activeGame.slug;
                             setSelected((current) => (current === token ? null : current));
-                            onNavigate(studioPath());
-                            // Hide tip first; refetch may restore a sibling.
+                            // Hide tip first; refetch may restore a published sibling.
                             setGames((prev) => prev.filter((game) => game.token !== token));
                             try {
-                              const shelfPage = await fetchStudioGames();
+                              // Pass the slug so a live sibling below the shelf ceiling
+                              // is still returned (same deep-link path as Open in Studio).
+                              const shelfPage = await fetchStudioGames(abandonedSlug);
                               setGames(shelfPage.games);
                               setShelfTruncated(shelfPage.truncated);
                               setTotalGames(shelfPage.totalGames);
+                              const sibling =
+                                abandonedSlug &&
+                                shelfPage.games.find((game) => game.slug === abandonedSlug && game.token !== token);
+                              onNavigate(sibling && abandonedSlug ? studioPath(abandonedSlug) : studioPath());
+                              if (sibling) setSelected(sibling.token);
                             } catch {
                               // Optimistic remove stands if refetch fails.
+                              onNavigate(studioPath());
                             }
                           }}
                         />

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -357,7 +357,9 @@
       "openBuild": "Open build",
       "playtest": "Play & note",
       "abandon": "Abandon this build",
-      "abandonConfirm": "Yes, abandon — discard this round"
+      "abandonConfirm": "Yes, abandon — discard this round",
+      "abandonConfirmKeepLive": "Yes, abandon — discard this round (live game stays)",
+      "abandonConfirmRemove": "Yes, abandon — remove this game from Studio"
     },
     "rail": {
       "connect": "Connect your agent",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -357,9 +357,11 @@
       "openBuild": "Open build",
       "playtest": "Play & note",
       "abandon": "Abandon this build",
+      "abandonRemove": "Remove this game from Studio",
       "abandonConfirm": "Yes, abandon — discard this round",
       "abandonConfirmKeepLive": "Yes, abandon — discard this round (live game stays)",
-      "abandonConfirmRemove": "Yes, abandon — remove this game from Studio"
+      "abandonConfirmRemove": "Yes, remove it — the game leaves Studio",
+      "abandonHintRemove": "This draft was never published. Removing it stops the build and takes the game off your Studio shelf."
     },
     "rail": {
       "connect": "Connect your agent",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -359,9 +359,11 @@
       "openBuild": "Otwórz build",
       "playtest": "Zagraj i notatka",
       "abandon": "Porzuć ten build",
+      "abandonRemove": "Usuń tę grę ze Studio",
       "abandonConfirm": "Tak, porzuć — odrzuć tę rundę",
       "abandonConfirmKeepLive": "Tak, porzuć — odrzuć tę rundę (gra na żywo zostaje)",
-      "abandonConfirmRemove": "Tak, porzuć — usuń tę grę ze Studio"
+      "abandonConfirmRemove": "Tak, usuń — gra zniknie ze Studio",
+      "abandonHintRemove": "Ten szkic nigdy nie był opublikowany. Usunięcie zatrzyma build i zdejmie grę z półki Studio."
     },
     "rail": {
       "connect": "Podłącz agenta",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -359,7 +359,9 @@
       "openBuild": "Otwórz build",
       "playtest": "Zagraj i notatka",
       "abandon": "Porzuć ten build",
-      "abandonConfirm": "Tak, porzuć — odrzuć tę rundę"
+      "abandonConfirm": "Tak, porzuć — odrzuć tę rundę",
+      "abandonConfirmKeepLive": "Tak, porzuć — odrzuć tę rundę (gra na żywo zostaje)",
+      "abandonConfirmRemove": "Tak, porzuć — usuń tę grę ze Studio"
     },
     "rail": {
       "connect": "Podłącz agenta",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7906,6 +7906,22 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
+.studio-abandon-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  width: 100%;
+}
+
+.studio-abandon-hint {
+  margin: 0;
+  max-width: 28rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
 /* Today's allowance, under the composer. */
 .quota-note {
   display: block;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Abandoning felt like a bug: for an unpublished draft, one confirm made the game vanish from Studio — while the UI said “discard this round.”

That behavior is intentional when the draft was never published (the round *is* the game). The copy lied about it.

## Changes

- **Unpublished draft:** first click is now “Remove this game from Studio”; armed state shows a short hint that the game leaves the shelf, then “Yes, remove it — the game leaves Studio.”
- **Improve round on a live game:** still “Abandon this build” → “discard this round (live game stays).” After abandon, Studio refetches and lands on `/studio/<slug>` for the remaining live game (same door as #647’s **Open in Studio**).
- EN + PL; tests for both paths, refetch, and post-abandon navigation.

## Product rule (unchanged)

| Situation | What abandon does | How to get back |
| --- | --- | --- |
| Never published | Game disappears from Studio (soft-removed) | Start a new build with the same idea — no restore of that round |
| Live + improve round | Live game stays; only the round is discarded | Stay on `/studio/<slug>`, or use **Open in Studio** on the game page (#647) |

Rebased onto `master` (includes #647).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e22d0cc-2cae-4be9-873c-cacbb30dd887?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e22d0cc-2cae-4be9-873c-cacbb30dd887&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

