### PR TITLE
fix Studio conversation log default scroll (runway pad)

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -228,9 +228,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         let padHeight = 0;
         let scrollerClientHeight = 0;
         let slackWithTurn = 0;
-        // Default stick must park the last turn near the bottom of the pane, not
-        // inside the runway (last turn at the top + empty void). #616 added the
-        // pad; without this check stick-to-scrollHeight ships that void again.
+        // Default stick must not land inside the runway.
         let defaultLastTurnTopRatio = 1;
         let defaultScrollRemaining = 0;
         if (scroller && pad) {
@@ -247,7 +245,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
             pad.before(turn);
           }
           slackWithTurn = scroller.scrollHeight - scroller.clientHeight;
-          // Re-apply the content-end stick the app uses (not absolute bottom).
+          // Content-end stick, not absolute scrollHeight.
           const contentEnd = Math.max(0, scroller.scrollHeight - scroller.clientHeight - padHeight);
           scroller.scrollTop = contentEnd;
           const scrollerRect = scroller.getBoundingClientRect();
@@ -306,8 +304,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       expect(shell.slackWithTurn, 'with a turn above the pad, the transcript must become scrollable').toBeGreaterThan(
         80,
       );
-      // Stick parks the last turn in the lower half — not at the top with the pad filling
-      // the pane (the void from scrolling to absolute bottom into the runway).
+      // Last turn stays low; runway stays below the fold.
       expect(
         shell.defaultLastTurnTopRatio,
         'default stick must keep the last turn in the lower half of the pane',

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -217,6 +217,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       const shell = await page.evaluate(() => {
         const scroller = document.querySelector('.studio-thread-scroll');
         const pad = document.querySelector('.studio-thread-scroll-pad');
+        const body = document.querySelector('.studio-thread-scroll-body');
         const detail = document.querySelector('.studio-detail');
         const layout = document.querySelector('.studio-layout');
         // The fixture thread is empty/short. A pad sized as a fraction of the
@@ -227,6 +228,11 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         let padHeight = 0;
         let scrollerClientHeight = 0;
         let slackWithTurn = 0;
+        // Default stick must park the last turn near the bottom of the pane, not
+        // inside the runway (last turn at the top + empty void). #616 added the
+        // pad; without this check stick-to-scrollHeight ships that void again.
+        let defaultLastTurnTopRatio = 1;
+        let defaultScrollRemaining = 0;
         if (scroller && pad) {
           padHeight = pad.getBoundingClientRect().height;
           scrollerClientHeight = scroller.clientHeight;
@@ -234,17 +240,33 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           turn.dataset.e2eInjected = 'true';
           // Taller than the 4.5rem the pad leaves, so max-scroll is non-trivial.
           turn.style.cssText = 'height:200px;flex:none;';
-          pad.before(turn);
+          const mount = body ?? pad.parentElement;
+          if (mount && body) {
+            body.appendChild(turn);
+          } else {
+            pad.before(turn);
+          }
           slackWithTurn = scroller.scrollHeight - scroller.clientHeight;
+          // Re-apply the content-end stick the app uses (not absolute bottom).
+          const contentEnd = Math.max(0, scroller.scrollHeight - scroller.clientHeight - padHeight);
+          scroller.scrollTop = contentEnd;
+          const scrollerRect = scroller.getBoundingClientRect();
+          const turnRect = turn.getBoundingClientRect();
+          defaultLastTurnTopRatio =
+            scrollerClientHeight > 0 ? (turnRect.top - scrollerRect.top) / scrollerClientHeight : 1;
+          defaultScrollRemaining = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
           turn.remove();
         }
         return {
           pageScroll: document.documentElement.scrollHeight - document.documentElement.clientHeight,
           scrollerOverflowY: scroller ? getComputedStyle(scroller).overflowY : null,
           hasScrollPad: Boolean(pad),
+          hasScrollBody: Boolean(body),
           padHeight,
           scrollerClientHeight,
           slackWithTurn,
+          defaultLastTurnTopRatio,
+          defaultScrollRemaining,
           gameOpen: Boolean(document.querySelector('.studio-layout.is-game-open')),
           compactShelf: Boolean(layout?.classList.contains('is-compact-shelf')),
           shelfOpen: Boolean(layout?.classList.contains('is-shelf-open')),
@@ -275,15 +297,25 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
 
       // Claude/Cursor shape: empty runway under the turns so the last message can rise.
       expect(shell.hasScrollPad, 'transcript needs a bottom pad for last-turn scroll').toBe(true);
+      expect(shell.hasScrollBody, 'transcript body anchors short threads above the composer').toBe(true);
       expect(shell.padHeight, 'bottom pad needs real height (not a zero-height spacer)').toBeGreaterThan(80);
       expect(
         shell.padHeight,
         'bottom pad should be roughly one scrollport so the last turn can rise to the top',
       ).toBeGreaterThan(shell.scrollerClientHeight * 0.5);
+      expect(shell.slackWithTurn, 'with a turn above the pad, the transcript must become scrollable').toBeGreaterThan(
+        80,
+      );
+      // Stick parks the last turn in the lower half — not at the top with the pad filling
+      // the pane (the void from scrolling to absolute bottom into the runway).
       expect(
-        shell.slackWithTurn,
-        'with a turn above the pad, the transcript must become scrollable',
-      ).toBeGreaterThan(80);
+        shell.defaultLastTurnTopRatio,
+        'default stick must keep the last turn in the lower half of the pane',
+      ).toBeGreaterThan(0.4);
+      expect(
+        shell.defaultScrollRemaining,
+        'default stick must leave the runway below the fold (not scrolled into)',
+      ).toBeGreaterThan(shell.padHeight * 0.5);
 
       // Desktop compact rail (~56px) leaves the work surface owning the rest of the window.
       if (viewport.width >= 801) {

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1464,6 +1464,7 @@ describe('SubmissionStatusView', () => {
     expect(container.querySelector('.studio-thread-context')).toBeNull();
     // Empty runway under the turns so the last message can scroll to the top of the pane.
     expect(container.querySelector('.studio-thread-scroll-pad')).not.toBeNull();
+    expect(container.querySelector('.studio-thread-scroll-body')).not.toBeNull();
     // Abandon / checklist / Play stay out of the foot.
     expect(container.querySelector('.studio-context-stop')).toBeNull();
     expect(container.querySelector('.studio-context-progress')).toBeNull();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -29,6 +29,7 @@ import { StudioLivePreview } from './StudioLivePreview.js';
 import { StudioPriorRounds } from './StudioPriorRounds.js';
 import { submitImprovement } from './studioApi.js';
 import { pollDelayMs } from './studioStatusPoll.js';
+import { studioThreadContentScrollTop, studioThreadNearContentEnd } from './studioThreadScroll.js';
 import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
 
 function copyInputFromStatus(status: SubmissionStatus | null | undefined) {
@@ -1603,6 +1604,9 @@ function FeedbackPanel({
  * Scrolls in its own pane so the composer beneath it never moves, and sticks to the
  * bottom as the agent talks — unless the reader has scrolled up, which is them saying
  * they are reading something and would like it to stay put.
+ *
+ * "Bottom" means the end of the transcript body. A Claude/Cursor runway pad sits under
+ * that so the last turn can rise to the top of the pane; stick must not scroll into it.
  */
 type ThreadWorkingState = {
   /** Coarse phase — "Writing code" / "Starting agent". */
@@ -1651,15 +1655,16 @@ function ThreadStream({
   const onScroll = () => {
     const pane = scrollRef.current;
     if (!pane) return;
-    // A small slack, because "at the bottom" is never exact once fonts and images have
-    // settled, and a reader one pixel short of it still means to be following along.
-    stickToBottomRef.current = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 48;
+    // Content end, not the runway pad — see studioThreadScroll.ts.
+    stickToBottomRef.current = studioThreadNearContentEnd(pane);
   };
 
   useEffect(() => {
     const pane = scrollRef.current;
     if (!pane || !stickToBottomRef.current) return;
-    pane.scrollTop = pane.scrollHeight;
+    // Park the last turn at the bottom of the pane. Scrolling to scrollHeight would
+    // land inside the Claude/Cursor runway and leave an empty void under the turn.
+    pane.scrollTop = studioThreadContentScrollTop(pane);
   }, [entries.length, stickNonce, working?.label, working?.thoughtLabel]);
 
   // Presence ages out client-side; one timeout at expiry so the working line falls
@@ -1684,84 +1689,89 @@ function ThreadStream({
 
   return (
     <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
-      {priorSlug && priorRounds && priorRounds.length > 0 ? (
-        <StudioPriorRounds slug={priorSlug} rounds={priorRounds} />
-      ) : null}
-      {entries.length === 0 && !working ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
-      <ol className="studio-thread-turns">
-        {entries.map((entry, index) => {
-          const mine = entry.kind === 'revision';
-          const media = entry.media?.filter((item) => !broken.includes(item.ref)) ?? [];
-          return (
-            <li
-              key={`${entry.kind}-${entry.at}-${index}`}
-              className={`studio-turn${mine ? ' is-mine' : ''}${entry.pending ? ' is-pending' : ''}`}
-            >
-              <div className="studio-turn-body">
-                {/* The step is a closed set, so it is our own translated copy rather than
-                    a machine translation of whatever the agent happened to write. */}
-                {!mine && entry.step ? (
-                  <span className="studio-turn-kicker">{t(`statusView.progress.steps.${entry.step}`)}</span>
-                ) : null}
-                {/* A relayed request wears its provenance. Unlabelled, an agent's own
-                    summary of a chat held elsewhere reads as words the creator typed. */}
-                {mine && entry.relayed ? (
-                  <span className="studio-turn-kicker">{t('statusView.progress.relayedRequest')}</span>
-                ) : null}
-                <p className="studio-turn-text">{entry.text}</p>
-                {media.length > 0 ? (
-                  <span className="studio-turn-shots">
-                    {media.map((item) => (
-                      <button
-                        key={item.ref}
-                        type="button"
-                        className="build-activity-shot"
-                        onClick={() => setZoomed(item)}
-                        title={t('statusView.gallery.expand')}
-                      >
-                        <img
-                          src={buildMediaUrl(token, item)}
-                          alt={item.label || t('statusView.gallery.alt')}
-                          loading="lazy"
-                          onError={() => setBroken((refs) => [...refs, item.ref])}
-                        />
-                      </button>
-                    ))}
-                  </span>
-                ) : null}
-              </div>
-              <time className="studio-turn-time" dateTime={new Date(entry.at).toISOString()}>
-                {entry.pending
-                  ? t('statusView.progress.yourRequestSending')
-                  : formatRelativeTime(entry.at, i18n.language)}
-              </time>
-            </li>
-          );
-        })}
-        {working && workingHeadline ? (
-          <li className={`studio-turn is-working${thoughtFresh ? ' is-thought' : ''}`} aria-live="polite">
-            <div
-              className="studio-turn-working"
-              key={
-                thoughtFresh && working.thoughtKey
-                  ? `thought:${working.thoughtKey}:${working.thoughtAt}`
-                  : `phase:${working.label}`
-              }
-            >
-              <span className="studio-turn-working-pulse" aria-hidden="true" />
-              <span className="studio-turn-working-label">{workingHeadline}</span>
-            </div>
-            {working.heartbeatAt !== null ? (
-              <span className="studio-turn-time">
-                <BuildHeartbeat at={working.heartbeatAt} />
-              </span>
-            ) : null}
-          </li>
+      {/* min-height 100% + flex-end: short threads sit above the composer, not under the
+          lid. The runway pad below is optional slack the reader scrolls into. */}
+      <div className="studio-thread-scroll-body">
+        {priorSlug && priorRounds && priorRounds.length > 0 ? (
+          <StudioPriorRounds slug={priorSlug} rounds={priorRounds} />
         ) : null}
-      </ol>
-      {after}
+        {entries.length === 0 && !working ? <p className="studio-thread-empty">{emptyLabel}</p> : null}
+        <ol className="studio-thread-turns">
+          {entries.map((entry, index) => {
+            const mine = entry.kind === 'revision';
+            const media = entry.media?.filter((item) => !broken.includes(item.ref)) ?? [];
+            return (
+              <li
+                key={`${entry.kind}-${entry.at}-${index}`}
+                className={`studio-turn${mine ? ' is-mine' : ''}${entry.pending ? ' is-pending' : ''}`}
+              >
+                <div className="studio-turn-body">
+                  {/* The step is a closed set, so it is our own translated copy rather than
+                      a machine translation of whatever the agent happened to write. */}
+                  {!mine && entry.step ? (
+                    <span className="studio-turn-kicker">{t(`statusView.progress.steps.${entry.step}`)}</span>
+                  ) : null}
+                  {/* A relayed request wears its provenance. Unlabelled, an agent's own
+                      summary of a chat held elsewhere reads as words the creator typed. */}
+                  {mine && entry.relayed ? (
+                    <span className="studio-turn-kicker">{t('statusView.progress.relayedRequest')}</span>
+                  ) : null}
+                  <p className="studio-turn-text">{entry.text}</p>
+                  {media.length > 0 ? (
+                    <span className="studio-turn-shots">
+                      {media.map((item) => (
+                        <button
+                          key={item.ref}
+                          type="button"
+                          className="build-activity-shot"
+                          onClick={() => setZoomed(item)}
+                          title={t('statusView.gallery.expand')}
+                        >
+                          <img
+                            src={buildMediaUrl(token, item)}
+                            alt={item.label || t('statusView.gallery.alt')}
+                            loading="lazy"
+                            onError={() => setBroken((refs) => [...refs, item.ref])}
+                          />
+                        </button>
+                      ))}
+                    </span>
+                  ) : null}
+                </div>
+                <time className="studio-turn-time" dateTime={new Date(entry.at).toISOString()}>
+                  {entry.pending
+                    ? t('statusView.progress.yourRequestSending')
+                    : formatRelativeTime(entry.at, i18n.language)}
+                </time>
+              </li>
+            );
+          })}
+          {working && workingHeadline ? (
+            <li className={`studio-turn is-working${thoughtFresh ? ' is-thought' : ''}`} aria-live="polite">
+              <div
+                className="studio-turn-working"
+                key={
+                  thoughtFresh && working.thoughtKey
+                    ? `thought:${working.thoughtKey}:${working.thoughtAt}`
+                    : `phase:${working.label}`
+                }
+              >
+                <span className="studio-turn-working-pulse" aria-hidden="true" />
+                <span className="studio-turn-working-label">{workingHeadline}</span>
+              </div>
+              {working.heartbeatAt !== null ? (
+                <span className="studio-turn-time">
+                  <BuildHeartbeat at={working.heartbeatAt} />
+                </span>
+              ) : null}
+            </li>
+          ) : null}
+        </ol>
+        {after}
+      </div>
       {/* Empty runway under the turns — Claude/Cursor shape. Lets the reader scroll
-          until the last message sits at the top of the pane, not stuck on the fold. */}
+          until the last message sits at the top of the pane, not stuck on the fold.
+          Stick-to-bottom targets the body end, not this pad. */}
       <div className="studio-thread-scroll-pad" aria-hidden="true" />
       {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}
     </div>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1604,9 +1604,6 @@ function FeedbackPanel({
  * Scrolls in its own pane so the composer beneath it never moves, and sticks to the
  * bottom as the agent talks — unless the reader has scrolled up, which is them saying
  * they are reading something and would like it to stay put.
- *
- * "Bottom" means the end of the transcript body. A Claude/Cursor runway pad sits under
- * that so the last turn can rise to the top of the pane; stick must not scroll into it.
  */
 type ThreadWorkingState = {
   /** Coarse phase — "Writing code" / "Starting agent". */
@@ -1655,15 +1652,14 @@ function ThreadStream({
   const onScroll = () => {
     const pane = scrollRef.current;
     if (!pane) return;
-    // Content end, not the runway pad — see studioThreadScroll.ts.
+    // Content end, not the runway pad.
     stickToBottomRef.current = studioThreadNearContentEnd(pane);
   };
 
   useEffect(() => {
     const pane = scrollRef.current;
     if (!pane || !stickToBottomRef.current) return;
-    // Park the last turn at the bottom of the pane. Scrolling to scrollHeight would
-    // land inside the Claude/Cursor runway and leave an empty void under the turn.
+    // Do not scroll into the Claude/Cursor runway.
     pane.scrollTop = studioThreadContentScrollTop(pane);
   }, [entries.length, stickNonce, working?.label, working?.thoughtLabel]);
 
@@ -1689,8 +1685,7 @@ function ThreadStream({
 
   return (
     <div className="studio-thread-scroll" ref={scrollRef} onScroll={onScroll}>
-      {/* min-height 100% + flex-end: short threads sit above the composer, not under the
-          lid. The runway pad below is optional slack the reader scrolls into. */}
+      {/* Short threads sit above the composer, not under the lid. */}
       <div className="studio-thread-scroll-body">
         {priorSlug && priorRounds && priorRounds.length > 0 ? (
           <StudioPriorRounds slug={priorSlug} rounds={priorRounds} />
@@ -1769,9 +1764,7 @@ function ThreadStream({
         </ol>
         {after}
       </div>
-      {/* Empty runway under the turns — Claude/Cursor shape. Lets the reader scroll
-          until the last message sits at the top of the pane, not stuck on the fold.
-          Stick-to-bottom targets the body end, not this pad. */}
+      {/* Runway under turns — stick targets body end, not this pad. */}
       <div className="studio-thread-scroll-pad" aria-hidden="true" />
       {zoomed ? <ShotLightbox token={token} item={zoomed} onClose={() => setZoomed(null)} /> : null}
     </div>

--- a/apps/web/src/studioThreadScroll.test.ts
+++ b/apps/web/src/studioThreadScroll.test.ts
@@ -15,11 +15,11 @@ function fakePane(opts: { scrollHeight: number; clientHeight: number; scrollTop?
 
 describe('studioThreadScroll', () => {
   it('sticks to the content end, not the runway pad', () => {
-    // 400px of turns + 350px pad in a 400px pane — absolute bottom is 350; content end is 0.
+    // 400px turns + 350px pad; content end is 0.
     const pane = fakePane({ scrollHeight: 750, clientHeight: 400, padHeight: 350 });
     expect(studioThreadContentScrollTop(pane)).toBe(0);
     expect(studioThreadNearContentEnd({ ...pane, scrollTop: 0 })).toBe(true);
-    // Absolute bottom (into the pad) is still "following" — last turn can rise.
+    // Absolute bottom still counts as following.
     expect(studioThreadNearContentEnd({ ...pane, scrollTop: 350 })).toBe(true);
   });
 
@@ -30,7 +30,6 @@ describe('studioThreadScroll', () => {
       padHeight: 350,
       scrollTop: 200,
     });
-    // Content end scrollTop = 2000 - 400 - 350 = 1250; 200 is far above that.
     expect(studioThreadContentScrollTop(pane)).toBe(1250);
     expect(studioThreadNearContentEnd(pane)).toBe(false);
   });

--- a/apps/web/src/studioThreadScroll.test.ts
+++ b/apps/web/src/studioThreadScroll.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { studioThreadContentScrollTop, studioThreadNearContentEnd } from './studioThreadScroll.js';
+
+function fakePane(opts: { scrollHeight: number; clientHeight: number; scrollTop?: number; padHeight: number }) {
+  return {
+    scrollHeight: opts.scrollHeight,
+    clientHeight: opts.clientHeight,
+    scrollTop: opts.scrollTop ?? 0,
+    querySelector: (selector: string) => {
+      if (selector !== '.studio-thread-scroll-pad') return null;
+      return { offsetHeight: opts.padHeight } as HTMLElement;
+    },
+  };
+}
+
+describe('studioThreadScroll', () => {
+  it('sticks to the content end, not the runway pad', () => {
+    // 400px of turns + 350px pad in a 400px pane — absolute bottom is 350; content end is 0.
+    const pane = fakePane({ scrollHeight: 750, clientHeight: 400, padHeight: 350 });
+    expect(studioThreadContentScrollTop(pane)).toBe(0);
+    expect(studioThreadNearContentEnd({ ...pane, scrollTop: 0 })).toBe(true);
+    // Absolute bottom (into the pad) is still "following" — last turn can rise.
+    expect(studioThreadNearContentEnd({ ...pane, scrollTop: 350 })).toBe(true);
+  });
+
+  it('leaves history readers unstuck when they scroll up', () => {
+    const pane = fakePane({
+      scrollHeight: 2000,
+      clientHeight: 400,
+      padHeight: 350,
+      scrollTop: 200,
+    });
+    // Content end scrollTop = 2000 - 400 - 350 = 1250; 200 is far above that.
+    expect(studioThreadContentScrollTop(pane)).toBe(1250);
+    expect(studioThreadNearContentEnd(pane)).toBe(false);
+  });
+
+  it('treats a missing pad as a normal chat scroller', () => {
+    const pane = {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+      querySelector: () => null,
+    };
+    expect(studioThreadContentScrollTop(pane)).toBe(600);
+    expect(studioThreadNearContentEnd(pane)).toBe(true);
+    expect(studioThreadNearContentEnd({ ...pane, scrollTop: 100 })).toBe(false);
+  });
+});

--- a/apps/web/src/studioThreadScroll.ts
+++ b/apps/web/src/studioThreadScroll.ts
@@ -1,0 +1,38 @@
+/**
+ * Studio transcript stick-to-bottom math.
+ *
+ * The scroller keeps a Claude/Cursor-shaped runway pad under the turns so the last
+ * message can rise to the top of the pane. Stick-to-bottom must target the end of the
+ * *content*, not the end of that pad — otherwise the default view is an empty void with
+ * the last turn parked at the top of the scrollport.
+ */
+
+function padHeightOf(pane: ParentNode): number {
+  const pad = pane.querySelector('.studio-thread-scroll-pad');
+  return pad instanceof HTMLElement ? pad.offsetHeight : 0;
+}
+
+/** ScrollTop that puts the last turn at the bottom of the pane (pad below the fold). */
+export function studioThreadContentScrollTop(pane: {
+  scrollHeight: number;
+  clientHeight: number;
+  querySelector: ParentNode['querySelector'];
+}): number {
+  return Math.max(0, pane.scrollHeight - pane.clientHeight - padHeightOf(pane));
+}
+
+/**
+ * True when the reader is at (or past) the content end — including into the runway pad.
+ * Scrolling up into history clears this; scrolling the last turn toward the top does not.
+ */
+export function studioThreadNearContentEnd(
+  pane: {
+    scrollHeight: number;
+    clientHeight: number;
+    scrollTop: number;
+    querySelector: ParentNode['querySelector'];
+  },
+  slackPx = 48,
+): boolean {
+  return pane.scrollHeight - padHeightOf(pane) - pane.scrollTop - pane.clientHeight < slackPx;
+}

--- a/apps/web/src/studioThreadScroll.ts
+++ b/apps/web/src/studioThreadScroll.ts
@@ -1,38 +1,24 @@
-/**
- * Studio transcript stick-to-bottom math.
- *
- * The scroller keeps a Claude/Cursor-shaped runway pad under the turns so the last
- * message can rise to the top of the pane. Stick-to-bottom must target the end of the
- * *content*, not the end of that pad — otherwise the default view is an empty void with
- * the last turn parked at the top of the scrollport.
- */
-
-function padHeightOf(pane: ParentNode): number {
-  const pad = pane.querySelector('.studio-thread-scroll-pad');
-  return pad instanceof HTMLElement ? pad.offsetHeight : 0;
-}
-
-/** ScrollTop that puts the last turn at the bottom of the pane (pad below the fold). */
-export function studioThreadContentScrollTop(pane: {
+// Stick-to-bottom targets content end, not the runway pad.
+export type StudioThreadScrollPane = {
   scrollHeight: number;
   clientHeight: number;
-  querySelector: ParentNode['querySelector'];
-}): number {
+  scrollTop?: number;
+  querySelector: (selectors: string) => Element | null;
+};
+
+function padHeightOf(pane: StudioThreadScrollPane): number {
+  const pad = pane.querySelector('.studio-thread-scroll-pad');
+  if (!pad || !('offsetHeight' in pad)) return 0;
+  const height = (pad as { offsetHeight: unknown }).offsetHeight;
+  return typeof height === 'number' ? height : 0;
+}
+
+// Last turn at pane bottom; pad stays below the fold.
+export function studioThreadContentScrollTop(pane: StudioThreadScrollPane): number {
   return Math.max(0, pane.scrollHeight - pane.clientHeight - padHeightOf(pane));
 }
 
-/**
- * True when the reader is at (or past) the content end — including into the runway pad.
- * Scrolling up into history clears this; scrolling the last turn toward the top does not.
- */
-export function studioThreadNearContentEnd(
-  pane: {
-    scrollHeight: number;
-    clientHeight: number;
-    scrollTop: number;
-    querySelector: ParentNode['querySelector'];
-  },
-  slackPx = 48,
-): boolean {
-  return pane.scrollHeight - padHeightOf(pane) - pane.scrollTop - pane.clientHeight < slackPx;
+// Near content end (into pad still counts as following).
+export function studioThreadNearContentEnd(pane: StudioThreadScrollPane, slackPx = 48): boolean {
+  return pane.scrollHeight - padHeightOf(pane) - (pane.scrollTop ?? 0) - pane.clientHeight < slackPx;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5325,6 +5325,18 @@ a.user-name--profile:focus-visible {
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 4px 2px 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Short threads sit above the composer (flex-end), not under the lid. Long threads
+   grow past min-height and scroll normally from the top of the conversation. */
+.studio-thread-scroll-body {
+  flex: 1 0 auto;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 /* Claude / Cursor / GPT slack: enough empty runway under the transcript that the
@@ -5333,6 +5345,9 @@ a.user-name--profile:focus-visible {
    gives the thread a height; `min-height` covers the page-scroll phone band where
    the scrollport height is indefinite. vh first, then dvh — same pairing as
    `.beta-splash` / `.qa-wizard`, so browsers without dvh keep the runway.
+
+   Stick-to-bottom must target the body end, not this pad — scrolling to absolute
+   bottom parks the last turn at the top with an empty void under it.
 
    A percentage of the scrollport cannot create overflow on an empty thread
    (H−4.5rem ≤ H), and that is fine: the runway matters once there is a last

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -543,7 +543,7 @@
     "apps/web/src/styles.studioShell.test.ts": 42,
     "apps/web/src/submissionApi.ts": 1262,
     "apps/web/src/SubmissionStatusView.test.ts": 1816,
-    "apps/web/src/SubmissionStatusView.tsx": 4195,
+    "apps/web/src/SubmissionStatusView.tsx": 4157,
     "apps/web/src/SuggestionsPanel.test.tsx": 28,
     "apps/web/src/SuggestionsPanel.tsx": 113,
     "apps/web/src/telemetry.test.ts": 201,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #616 added a Claude/Cursor-shaped bottom runway pad so the last Studio turn can rise to the top of the pane, stick-to-bottom still did `scrollTop = scrollHeight`. That lands **inside** the pad, so the default view is a large empty void with the last turn parked at the top of the scrollport (scrollbar thumb at the bottom) — matching the Studio conversation screenshots.

## Fix

- Stick-to-bottom and “near bottom” detection target the **transcript body end**, not the runway pad (`studioThreadScroll.ts`).
- Wrap turns in `.studio-thread-scroll-body` with `min-height: 100%` + `justify-content: flex-end` so short threads sit above the composer instead of under the lid.
- Keep the pad so readers can still scroll the last turn to the top.
- Unit tests for the scroll math; e2e shell gate asserts default stick keeps the last turn in the lower half and leaves the runway below the fold.

## Verification

- `npm run type-check && npm run lint && npm run test && npm run build` — green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-305868ba-7083-4fd9-ba27-143d80fb11e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-305868ba-7083-4fd9-ba27-143d80fb11e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

