### PR TITLE
Telemetry charts: hover tooltips and legend toggles

### DIFF
--- a/apps/web/src/TelemetryCharts.test.tsx
+++ b/apps/web/src/TelemetryCharts.test.tsx
@@ -3,7 +3,7 @@
 import { act, createElement, type ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it } from 'vitest';
-import { Gauge, Histogram, OpenGauge } from './TelemetryCharts.js';
+import { Gauge, Histogram, LineChart, OpenGauge } from './TelemetryCharts.js';
 
 /**
  * Chart primitives must not invent confidence: a null rate is a dash, an empty
@@ -98,6 +98,83 @@ describe('Histogram', () => {
     );
     expect(host.textContent).toContain('No visit reached a game.');
     expect(host.querySelector('.telem-histogram-plot')).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+  });
+});
+
+describe('LineChart', () => {
+  const series = [
+    { id: 'visits', label: 'Visits', color: '#00e4ac', values: [10, 20, 30] },
+    { id: 'plays', label: 'Plays', color: '#38bdf8', values: [4, 8, 12] },
+    { id: 'creations', label: 'Creations', color: '#fbbf24', values: [1, 0, 2], axis: 'right' as const },
+  ];
+
+  it('toggles a series off when its legend button is clicked', () => {
+    const { host, root } = render(
+      createElement(LineChart, {
+        title: 'Visits & plays',
+        labels: ['08-01', '08-02', '08-03'],
+        series,
+      }),
+    );
+    expect(host.querySelectorAll('.telem-line-path')).toHaveLength(3);
+    const visitsBtn = Array.from(host.querySelectorAll('button.telem-line-legend-btn')).find((btn) =>
+      btn.textContent?.includes('Visits'),
+    );
+    expect(visitsBtn).toBeTruthy();
+    act(() => {
+      visitsBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(host.querySelectorAll('.telem-line-path')).toHaveLength(2);
+    expect(visitsBtn?.getAttribute('aria-pressed')).toBe('false');
+    expect(visitsBtn?.classList.contains('is-off')).toBe(true);
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('shows a tooltip for the nearest day on hover', () => {
+    const { host, root } = render(
+      createElement(LineChart, {
+        title: 'Visits & plays',
+        labels: ['08-01', '08-02', '08-03'],
+        series,
+      }),
+    );
+    const svg = host.querySelector('svg.telem-line-svg');
+    expect(svg).not.toBeNull();
+    // jsdom lacks layout — stub the SVG box for hover math.
+    Object.defineProperty(svg, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 640,
+        height: 200,
+        right: 640,
+        bottom: 200,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+    act(() => {
+      // hasRight → pad.right 40; plot mid-point maps to the second label.
+      svg?.dispatchEvent(
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: 40 + (640 - 40 - 40) / 2,
+          clientY: 100,
+        }),
+      );
+    });
+    const tooltip = host.querySelector('.telem-line-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toContain('08-02');
+    expect(tooltip?.textContent).toContain('Visits');
+    expect(tooltip?.textContent).toContain('20');
+    expect(host.querySelector('.telem-line-crosshair')).not.toBeNull();
     act(() => {
       root.unmount();
     });

--- a/apps/web/src/TelemetryCharts.test.tsx
+++ b/apps/web/src/TelemetryCharts.test.tsx
@@ -130,6 +130,8 @@ describe('LineChart', () => {
     expect(host.querySelectorAll('.telem-line-path')).toHaveLength(2);
     expect(visitsBtn?.getAttribute('aria-pressed')).toBe('false');
     expect(visitsBtn?.classList.contains('is-off')).toBe(true);
+    const svgAfterToggle = host.querySelector('svg.telem-line-svg');
+    expect(svgAfterToggle?.getAttribute('aria-label')).toBe('Visits & plays: Plays, Creations');
     act(() => {
       root.unmount();
     });
@@ -143,8 +145,8 @@ describe('LineChart', () => {
         series,
       }),
     );
-    const svg = host.querySelector('svg.telem-line-svg');
-    expect(svg).not.toBeNull();
+    const svg = host.querySelector<SVGSVGElement>('svg.telem-line-svg');
+    if (!svg) throw new Error('expected chart svg');
     // jsdom lacks layout — stub the SVG box for hover math.
     Object.defineProperty(svg, 'getBoundingClientRect', {
       value: () => ({
@@ -161,7 +163,7 @@ describe('LineChart', () => {
     });
     act(() => {
       // hasRight → pad.right 40; plot mid-point maps to the second label.
-      svg?.dispatchEvent(
+      svg.dispatchEvent(
         new MouseEvent('mousemove', {
           bubbles: true,
           clientX: 40 + (640 - 40 - 40) / 2,
@@ -171,10 +173,23 @@ describe('LineChart', () => {
     });
     const tooltip = host.querySelector('.telem-line-tooltip');
     expect(tooltip).not.toBeNull();
+    expect(tooltip?.classList.contains('is-flip')).toBe(false);
     expect(tooltip?.textContent).toContain('08-02');
     expect(tooltip?.textContent).toContain('Visits');
     expect(tooltip?.textContent).toContain('20');
     expect(host.querySelector('.telem-line-crosshair')).not.toBeNull();
+
+    act(() => {
+      // Near the right edge → tooltip flips left of the column.
+      svg.dispatchEvent(
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: 40 + (640 - 40 - 40) * 0.95,
+          clientY: 100,
+        }),
+      );
+    });
+    expect(host.querySelector('.telem-line-tooltip')?.classList.contains('is-flip')).toBe(true);
     act(() => {
       root.unmount();
     });

--- a/apps/web/src/TelemetryCharts.tsx
+++ b/apps/web/src/TelemetryCharts.tsx
@@ -267,13 +267,15 @@ export function LineChart({
           })
           .filter((row): row is { id: string; label: string; color: string; text: string } => row !== null);
 
-  // Pin tooltip near the column; flip left near the right edge.
+  // Pin tooltip to the hover column; flip left when that column is in the right ~38%.
+  const tooltipFlip = hover !== null && xAt(hover) > pad.left + innerW * 0.62;
   const tooltipStyle =
     hover === null
       ? undefined
       : {
-          left: `${(Math.min(xAt(hover), pad.left + innerW * 0.62) / width) * 100}%`,
+          left: `${(xAt(hover) / width) * 100}%`,
         };
+  const visibleLabels = visible.map((s) => s.label).join(', ') || 'no series visible';
 
   return (
     <figure className="telem-line">
@@ -287,7 +289,7 @@ export function LineChart({
               className="telem-line-svg"
               viewBox={`0 0 ${width} ${height}`}
               role="img"
-              aria-label={`${title}: ${series.map((s) => s.label).join(', ')}`}
+              aria-label={`${title}: ${visibleLabels}`}
               onMouseMove={(event) => {
                 const index = indexFromClientX(event.currentTarget, event.clientX);
                 setHover(index);
@@ -381,7 +383,11 @@ export function LineChart({
               />
             </svg>
             {hover !== null && hoverLabel !== undefined && tooltipRows.length > 0 && (
-              <div className="telem-line-tooltip" style={tooltipStyle} role="status">
+              <div
+                className={tooltipFlip ? 'telem-line-tooltip is-flip' : 'telem-line-tooltip'}
+                style={tooltipStyle}
+                role="status"
+              >
                 <div className="telem-line-tooltip-label">{hoverLabel}</div>
                 <ul>
                   {tooltipRows.map((row) => (

--- a/apps/web/src/TelemetryCharts.tsx
+++ b/apps/web/src/TelemetryCharts.tsx
@@ -7,6 +7,8 @@
  * panels: null / empty evidence renders as absence, never as a confident zero.
  */
 
+import { useState } from 'react';
+
 export type GaugeTone = 'ok' | 'warn' | 'bad' | 'idle';
 
 /** Semicircle rate gauge. `value` is a 0–1 fraction; null means no evidence. */
@@ -174,16 +176,13 @@ export interface LineSeries {
   values: Array<number | null>;
   /** Dashed stroke — used for rolling averages over the raw series. */
   dashed?: boolean;
-  /** Right axis for low-volume series (creations) that would flatline on the left scale. */
+  /** Right axis for low-volume series (e.g. creations). */
   axis?: 'left' | 'right';
 }
 
 /**
- * Multi-series line chart for trend observation.
- *
- * Null values break the path (a gap), so a day with no retention cohort does not
- * invent a zero that looks like a crash. Y-axis is nice-scaled from the data.
- * Optional right axis keeps low-volume series readable beside high-volume ones.
+ * Multi-series line chart. Nulls gap the path; optional right axis for low-volume
+ * series. Hover shows a day tooltip; legend clicks hide/show a series.
  */
 export function LineChart({
   title,
@@ -200,23 +199,28 @@ export function LineChart({
   formatYRight?: (value: number) => string;
   emptyMessage?: string;
 }) {
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [hover, setHover] = useState<number | null>(null);
+
   const width = 640;
   const height = 200;
-  const hasRight = series.some((s) => (s.axis ?? 'left') === 'right');
+  const visible = series.filter((s) => !hidden.has(s.id));
+  const hasRight = visible.some((s) => (s.axis ?? 'left') === 'right');
   const pad = { top: 16, right: hasRight ? 40 : 12, bottom: 28, left: 40 };
   const innerW = width - pad.left - pad.right;
   const innerH = height - pad.top - pad.bottom;
 
-  const leftValues = series
+  const leftValues = visible
     .filter((s) => (s.axis ?? 'left') === 'left')
     .flatMap((s) => s.values)
     .filter((value): value is number => value !== null);
-  const rightValues = series
+  const rightValues = visible
     .filter((s) => s.axis === 'right')
     .flatMap((s) => s.values)
     .filter((value): value is number => value !== null);
-  const empty = labels.length === 0 || (leftValues.length === 0 && rightValues.length === 0);
-  const yMaxLeft = empty || leftValues.length === 0 ? 1 : niceCeil(Math.max(...leftValues, 0));
+  const empty = labels.length === 0 || series.every((s) => s.values.every((value) => value === null));
+  const noVisible = !empty && visible.length === 0;
+  const yMaxLeft = leftValues.length === 0 ? 1 : niceCeil(Math.max(...leftValues, 0));
   const yMaxRight = rightValues.length === 0 ? 1 : niceCeil(Math.max(...rightValues, 0));
   const yMin = 0;
   const rightFormat = formatYRight ?? formatY;
@@ -230,6 +234,47 @@ export function LineChart({
   const rightTicks = [0, 0.5, 1].map((fraction) => yMin + (yMaxRight - yMin) * fraction);
   const labelStep = Math.max(1, Math.ceil(labels.length / 7));
 
+  function toggleSeries(id: string) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function indexFromClientX(svg: SVGSVGElement, clientX: number): number | null {
+    if (labels.length === 0) return null;
+    const rect = svg.getBoundingClientRect();
+    if (rect.width <= 0) return null;
+    const localX = ((clientX - rect.left) / rect.width) * width;
+    if (localX < pad.left || localX > pad.left + innerW) return null;
+    if (labels.length === 1) return 0;
+    const ratio = (localX - pad.left) / innerW;
+    return Math.max(0, Math.min(labels.length - 1, Math.round(ratio * (labels.length - 1))));
+  }
+
+  const hoverLabel = hover === null ? null : labels[hover];
+  const tooltipRows =
+    hover === null
+      ? []
+      : visible
+          .map((s) => {
+            const value = s.values[hover];
+            if (value === null || value === undefined) return null;
+            const format = s.axis === 'right' ? rightFormat : formatY;
+            return { id: s.id, label: s.label, color: s.color, text: format(value) };
+          })
+          .filter((row): row is { id: string; label: string; color: string; text: string } => row !== null);
+
+  // Pin tooltip near the column; flip left near the right edge.
+  const tooltipStyle =
+    hover === null
+      ? undefined
+      : {
+          left: `${(Math.min(xAt(hover), pad.left + innerW * 0.62) / width) * 100}%`,
+        };
+
   return (
     <figure className="telem-line">
       <figcaption className="telem-line-title">{title}</figcaption>
@@ -237,75 +282,143 @@ export function LineChart({
         <p className="health-empty">{emptyMessage}</p>
       ) : (
         <>
-          <svg
-            className="telem-line-svg"
-            viewBox={`0 0 ${width} ${height}`}
-            role="img"
-            aria-label={`${title}: ${series.map((s) => s.label).join(', ')}`}
-          >
-            {leftTicks.map((tick) => (
-              <g key={`L${tick}`}>
-                <line
-                  className="telem-line-grid"
-                  x1={pad.left}
-                  x2={pad.left + innerW}
-                  y1={yAtLeft(tick)}
-                  y2={yAtLeft(tick)}
-                />
-                <text className="telem-line-axis" x={pad.left - 6} y={yAtLeft(tick) + 3} textAnchor="end">
-                  {formatY(tick)}
-                </text>
-              </g>
-            ))}
-            {hasRight &&
-              rightTicks.map((tick) => (
-                <text
-                  key={`R${tick}`}
-                  className="telem-line-axis telem-line-axis--right"
-                  x={pad.left + innerW + 6}
-                  y={yAtRight(tick) + 3}
-                  textAnchor="start"
-                >
-                  {rightFormat(tick)}
-                </text>
+          <div className="telem-line-plot">
+            <svg
+              className="telem-line-svg"
+              viewBox={`0 0 ${width} ${height}`}
+              role="img"
+              aria-label={`${title}: ${series.map((s) => s.label).join(', ')}`}
+              onMouseMove={(event) => {
+                const index = indexFromClientX(event.currentTarget, event.clientX);
+                setHover(index);
+              }}
+              onMouseLeave={() => setHover(null)}
+            >
+              {leftTicks.map((tick) => (
+                <g key={`L${tick}`}>
+                  <line
+                    className="telem-line-grid"
+                    x1={pad.left}
+                    x2={pad.left + innerW}
+                    y1={yAtLeft(tick)}
+                    y2={yAtLeft(tick)}
+                  />
+                  <text className="telem-line-axis" x={pad.left - 6} y={yAtLeft(tick) + 3} textAnchor="end">
+                    {formatY(tick)}
+                  </text>
+                </g>
               ))}
-            {series.map((s) => {
-              const yAt = s.axis === 'right' ? yAtRight : yAtLeft;
-              return (
-                <path
-                  key={s.id}
-                  className={s.dashed ? 'telem-line-path is-dashed' : 'telem-line-path'}
-                  d={linePath(s.values, xAt, yAt)}
-                  stroke={s.color}
-                  fill="none"
+              {hasRight &&
+                rightTicks.map((tick) => (
+                  <text
+                    key={`R${tick}`}
+                    className="telem-line-axis telem-line-axis--right"
+                    x={pad.left + innerW + 6}
+                    y={yAtRight(tick) + 3}
+                    textAnchor="start"
+                  >
+                    {rightFormat(tick)}
+                  </text>
+                ))}
+              {visible.map((s) => {
+                const yAt = s.axis === 'right' ? yAtRight : yAtLeft;
+                return (
+                  <path
+                    key={s.id}
+                    className={s.dashed ? 'telem-line-path is-dashed' : 'telem-line-path'}
+                    d={linePath(s.values, xAt, yAt)}
+                    stroke={s.color}
+                    fill="none"
+                  />
+                );
+              })}
+              {hover !== null && (
+                <line
+                  className="telem-line-crosshair"
+                  x1={xAt(hover)}
+                  x2={xAt(hover)}
+                  y1={pad.top}
+                  y2={pad.top + innerH}
                 />
+              )}
+              {hover !== null &&
+                visible.map((s) => {
+                  const value = s.values[hover];
+                  if (value === null || value === undefined) return null;
+                  const yAt = s.axis === 'right' ? yAtRight : yAtLeft;
+                  return (
+                    <circle
+                      key={`dot-${s.id}`}
+                      className="telem-line-dot"
+                      cx={xAt(hover)}
+                      cy={yAt(value)}
+                      r={3.5}
+                      fill={s.color}
+                    />
+                  );
+                })}
+              {labels.map((label, index) =>
+                index % labelStep === 0 || index === labels.length - 1 ? (
+                  <text
+                    key={`${label}-${index}`}
+                    className="telem-line-axis"
+                    x={xAt(index)}
+                    y={height - 8}
+                    textAnchor="middle"
+                  >
+                    {label}
+                  </text>
+                ) : null,
+              )}
+              {/* Transparent hit target over the plot area. */}
+              <rect
+                className="telem-line-hit"
+                x={pad.left}
+                y={pad.top}
+                width={innerW}
+                height={innerH}
+                fill="transparent"
+              />
+            </svg>
+            {hover !== null && hoverLabel !== undefined && tooltipRows.length > 0 && (
+              <div className="telem-line-tooltip" style={tooltipStyle} role="status">
+                <div className="telem-line-tooltip-label">{hoverLabel}</div>
+                <ul>
+                  {tooltipRows.map((row) => (
+                    <li key={row.id}>
+                      <span className="telem-line-tooltip-swatch" style={{ background: row.color }} />
+                      <span className="telem-line-tooltip-name">{row.label}</span>
+                      <span className="telem-line-tooltip-value">{row.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {noVisible && (
+              <p className="telem-line-hidden-note">All series hidden — click a legend item to show one.</p>
+            )}
+          </div>
+          <ul className="telem-line-legend">
+            {series.map((s) => {
+              const isHidden = hidden.has(s.id);
+              return (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    className={isHidden ? 'telem-line-legend-btn is-off' : 'telem-line-legend-btn'}
+                    aria-pressed={!isHidden}
+                    onClick={() => toggleSeries(s.id)}
+                  >
+                    <span
+                      className={s.dashed ? 'telem-line-swatch is-dashed' : 'telem-line-swatch'}
+                      style={{ background: s.color, borderColor: s.color }}
+                    />
+                    {s.label}
+                    {s.axis === 'right' ? <span className="telem-line-axis-tag">right</span> : null}
+                  </button>
+                </li>
               );
             })}
-            {labels.map((label, index) =>
-              index % labelStep === 0 || index === labels.length - 1 ? (
-                <text
-                  key={`${label}-${index}`}
-                  className="telem-line-axis"
-                  x={xAt(index)}
-                  y={height - 8}
-                  textAnchor="middle"
-                >
-                  {label}
-                </text>
-              ) : null,
-            )}
-          </svg>
-          <ul className="telem-line-legend">
-            {series.map((s) => (
-              <li key={s.id}>
-                <span
-                  className={s.dashed ? 'telem-line-swatch is-dashed' : 'telem-line-swatch'}
-                  style={{ background: s.color, borderColor: s.color }}
-                />
-                {s.label}
-                {s.axis === 'right' ? <span className="telem-line-axis-tag">right</span> : null}
-              </li>
-            ))}
           </ul>
         </>
       )}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8787,10 +8787,15 @@ button.builder-mode-selector:disabled {
   font-style: normal;
 }
 
+.telem-line-plot {
+  position: relative;
+}
+
 .telem-line-svg {
   width: 100%;
   height: auto;
   display: block;
+  cursor: crosshair;
 }
 
 .telem-line-grid {
@@ -8820,6 +8825,7 @@ button.builder-mode-selector:disabled {
   stroke-width: 2;
   stroke-linejoin: round;
   stroke-linecap: round;
+  pointer-events: none;
 }
 
 .telem-line-path.is-dashed {
@@ -8827,10 +8833,97 @@ button.builder-mode-selector:disabled {
   stroke-width: 2.25;
 }
 
+.telem-line-crosshair {
+  stroke: var(--muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.telem-line-dot {
+  stroke: var(--panel);
+  stroke-width: 1.5;
+  pointer-events: none;
+}
+
+.telem-line-hit {
+  pointer-events: all;
+  cursor: crosshair;
+}
+
+.telem-line-tooltip {
+  position: absolute;
+  top: 0.5rem;
+  z-index: 2;
+  min-width: 8.5rem;
+  max-width: 14rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: rgba(22, 28, 34, 0.96);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+  font-size: 0.75rem;
+  color: var(--text);
+}
+
+.telem-line-tooltip-label {
+  margin-bottom: 0.35rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.telem-line-tooltip ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.telem-line-tooltip li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.telem-line-tooltip-swatch {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 1px;
+}
+
+.telem-line-tooltip-name {
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.telem-line-tooltip-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.telem-line-hidden-note {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  padding: 1rem;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  pointer-events: none;
+}
+
 .telem-line-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1rem;
+  gap: 0.35rem 0.5rem;
   margin: 0.5rem 0 0;
   padding: 0;
   list-style: none;
@@ -8841,7 +8934,34 @@ button.builder-mode-selector:disabled {
 .telem-line-legend li {
   display: inline-flex;
   align-items: center;
+}
+
+.telem-line-legend-btn {
+  display: inline-flex;
+  align-items: center;
   gap: 0.35rem;
+  margin: 0;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.telem-line-legend-btn:hover {
+  border-color: var(--panel-border);
+  color: var(--text);
+}
+
+.telem-line-legend-btn.is-off {
+  opacity: 0.4;
+  text-decoration: line-through;
+}
+
+.telem-line-legend-btn.is-off:hover {
+  opacity: 0.7;
 }
 
 .telem-line-swatch {
@@ -8849,6 +8969,7 @@ button.builder-mode-selector:disabled {
   height: 0.25rem;
   border-radius: 1px;
   display: inline-block;
+  flex: none;
 }
 
 .telem-line-swatch.is-dashed {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8866,6 +8866,11 @@ button.builder-mode-selector:disabled {
   pointer-events: none;
   font-size: 0.75rem;
   color: var(--text);
+  transform: translateX(0.35rem);
+}
+
+.telem-line-tooltip.is-flip {
+  transform: translateX(calc(-100% - 0.35rem));
 }
 
 .telem-line-tooltip-label {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hover tooltips and clickable legend toggles for telemetry trend `LineChart`s on `/admin/telemetry`.

## Review follow-ups

Addressed Copilot feedback on #645:

1. **Tooltip flip** — near the right ~38% of the plot, the tooltip uses `translateX(-100%)` (`.is-flip`) instead of only clamping `left`.
2. **Test typing** — hover test uses `querySelector<SVGSVGElement>` plus a runtime guard before `Object.defineProperty`.
3. **aria-label** — chart `aria-label` lists only visible series after legend toggles.

## Test plan

- [x] `TelemetryCharts.test.tsx` (legend toggle, aria-label, hover + flip)
- [x] `npm run lint` / `npm run type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d2662b-1577-4ca1-8716-c564dfcedce3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d2662b-1577-4ca1-8716-c564dfcedce3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

