### PR TITLE
Fix language toggle: EN|PL with active state

### DIFF
--- a/apps/web/src/LanguageSwitcher.tsx
+++ b/apps/web/src/LanguageSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { SUPPORTED_LANGUAGES } from './i18n/index.js';
 
 const LABELS: Record<string, string> = { en: 'EN', pl: 'PL' };
 
@@ -6,25 +7,25 @@ function resolveLang(language: string | undefined): 'en' | 'pl' {
   return language?.toLowerCase().startsWith('pl') ? 'pl' : 'en';
 }
 
-/**
- * One control that flips between the two shipped languages. Showing the language
- * you would switch *to* makes the action obvious without a two-button segmented
- * control eating header space.
- */
+/** EN | PL with the active locale pressed — a lone code was ambiguous. */
 export function LanguageSwitcher() {
   const { t, i18n } = useTranslation();
   const current = resolveLang(i18n.resolvedLanguage ?? i18n.language);
-  const next = current === 'en' ? 'pl' : 'en';
 
   return (
-    <button
-      type="button"
-      className="language-switcher"
-      aria-label={t('header.languageAria')}
-      title={LABELS[next]}
-      onClick={() => void i18n.changeLanguage(next)}
-    >
-      {LABELS[next]}
-    </button>
+    <div className="language-switcher" role="group" aria-label={t('header.languageAria')}>
+      {SUPPORTED_LANGUAGES.map((lang) => (
+        <button
+          key={lang}
+          type="button"
+          className={lang === current ? 'active' : ''}
+          aria-pressed={lang === current}
+          aria-label={t(lang === 'en' ? 'header.languageEn' : 'header.languagePl')}
+          onClick={() => void i18n.changeLanguage(lang)}
+        >
+          {LABELS[lang]}
+        </button>
+      ))}
+    </div>
   );
 }

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -691,7 +691,7 @@ describe('LanguageSwitcher in header', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders one button that toggles to the other language', async () => {
+  it('renders EN and PL with the active language pressed', async () => {
     await i18n.changeLanguage('en');
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
@@ -727,17 +727,22 @@ describe('LanguageSwitcher in header', () => {
       await Promise.resolve();
     });
 
-    const switcher = container.querySelector<HTMLButtonElement>('button.language-switcher');
+    const switcher = container.querySelector('.language-switcher');
     // Header + (closed) menu: only the header instance is mounted while the menu is closed.
     expect(switcher).not.toBeNull();
-    expect(switcher?.textContent).toBe('PL');
+    const buttons = [...(switcher?.querySelectorAll('button') ?? [])];
+    expect(buttons.map((b) => b.textContent)).toEqual(['EN', 'PL']);
+    expect(buttons[0]?.getAttribute('aria-pressed')).toBe('true');
+    expect(buttons[1]?.getAttribute('aria-pressed')).toBe('false');
 
     await act(async () => {
-      switcher?.click();
+      buttons[1]?.click();
       await Promise.resolve();
     });
     expect(i18n.language).toMatch(/^pl/);
-    expect(container.querySelector('button.language-switcher')?.textContent).toBe('EN');
+    const after = [...(container.querySelectorAll('.language-switcher button') ?? [])];
+    expect(after[0]?.getAttribute('aria-pressed')).toBe('false');
+    expect(after[1]?.getAttribute('aria-pressed')).toBe('true');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -95,6 +95,8 @@
     "logoAlt": "Gamedev.pl",
     "githubAria": "GitHub",
     "languageAria": "Language",
+    "languageEn": "English",
+    "languagePl": "Polish",
     "statusOnline": "Agent Network Online",
     "navPrompt": "Create Game",
     "navArcade": "Arcade",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -95,6 +95,8 @@
     "logoAlt": "Gamedev.pl",
     "githubAria": "GitHub",
     "languageAria": "Język",
+    "languageEn": "Angielski",
+    "languagePl": "Polski",
     "statusOnline": "Sieć Agentów Online",
     "navPrompt": "Stwórz Grę",
     "navArcade": "Arcade",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -226,6 +226,11 @@ a {
 }
 
 .language-switcher {
+  display: flex;
+  gap: 4px;
+}
+
+.language-switcher button {
   background: transparent;
   color: var(--muted);
   border: 1px solid var(--panel-border);
@@ -236,9 +241,15 @@ a {
   cursor: pointer;
 }
 
-.language-switcher:hover {
+.language-switcher button:hover {
   color: var(--text);
   border-color: var(--muted);
+}
+
+.language-switcher button.active {
+  background: var(--turquoise);
+  color: #0b221d;
+  border-color: var(--turquoise);
 }
 
 .user-avatar-btn {
@@ -3158,8 +3169,13 @@ body.player-open {
   }
 
   .menu-extras .language-switcher {
+    gap: 8px;
+    padding: 4px 4px 0;
+  }
+
+  .menu-extras .language-switcher button {
+    flex: 1;
     min-height: 44px;
-    width: 100%;
   }
 
   /* Thumb-sized targets. 44px is the iOS HIG floor; below it, taps miss. */

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -434,7 +434,7 @@
     "apps/web/src/i18n/locales.test.ts": 272,
     "apps/web/src/InstallPrompt.test.tsx": 183,
     "apps/web/src/InstallPrompt.tsx": 201,
-    "apps/web/src/LanguageSwitcher.tsx": 29,
+    "apps/web/src/LanguageSwitcher.tsx": 12,
     "apps/web/src/legal/index.ts": 50,
     "apps/web/src/legal/inline.test.tsx": 33,
     "apps/web/src/legal/inline.tsx": 108,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The header language control was a single button that showed the *other* locale (`PL` on an English UI, `EN` on Polish). That code reads as “current language,” so clicking it felt like a surprise flip.

## Fix

Restore the compact `EN | PL` group with `aria-pressed` / `.active` on the current locale. Same footprint idea as before the one-button collapse, without the ambiguous destination-only label.

## Test plan

- [ ] English UI: `EN` pressed, click `PL` → Polish chrome, `PL` pressed
- [ ] Polish UI: `PL` pressed, click `EN` → English chrome
- [ ] Phone: language control still usable in the hamburger `.menu-extras` (44px targets)
- [ ] `npm run type-check && npm run lint && npm run test && npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d62f64-9530-4bbb-be7d-cd12d7767947?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d62f64-9530-4bbb-be7d-cd12d7767947&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

