### PR TITLE
Add owner-only Open in Studio link on game pages

### DIFF
--- a/apps/web/src/GameDetailPage.test.tsx
+++ b/apps/web/src/GameDetailPage.test.tsx
@@ -8,10 +8,15 @@ import i18n from './i18n/index.js';
 
 const { recordRemixStep } = vi.hoisted(() => ({ recordRemixStep: vi.fn() }));
 
+let authUser: { uid: string; handle?: string } | null = null;
+
 vi.mock('./visitTelemetry.js', () => ({ recordRemixStep }));
 vi.mock('./VoteWidget.js', () => ({ VoteWidget: () => <button data-testid="vote">Like 7</button> }));
 vi.mock('./ShareGameButton.js', () => ({
   ShareGameButton: () => <button data-testid="share">Share</button>,
+}));
+vi.mock('./AuthContext.js', () => ({
+  useAuth: () => ({ user: authUser, refreshUser: vi.fn(), logout: vi.fn() }),
 }));
 
 import { GameDetailPage } from './GameDetailPage.js';
@@ -45,6 +50,7 @@ let root: Root | null = null;
 beforeEach(async () => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   await i18n.changeLanguage('en');
+  authUser = null;
   recordRemixStep.mockReset();
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -120,6 +126,19 @@ describe('GameDetailPage', () => {
     });
     expect(recordRemixStep).toHaveBeenCalledWith('opened', { control: 'page' });
     expect(onRemix).toHaveBeenCalledWith(game);
+  });
+
+  it('hides Open in Studio from visitors', () => {
+    render();
+    expect(container.querySelector('a[href="/studio/bridge-builder"]')).toBeNull();
+  });
+
+  it('offers Open in Studio to the owning creator', () => {
+    authUser = { uid: 'u1', handle: 'gtanczyk' };
+    render();
+    const studio = container.querySelector<HTMLAnchorElement>('a[href="/studio/bridge-builder"]');
+    expect(studio).not.toBeNull();
+    expect(studio?.textContent).toContain('Open in Studio');
   });
 
   it('does not autoplay when the only preview asset is a video', () => {

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppLoadingScreen } from './AppLoadingScreen.js';
+import { useAuth } from './AuthContext.js';
 import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
 import { PixelIcon } from './PixelIcon.js';
 import { ShareGameButton } from './ShareGameButton.js';
 import { VoteWidget } from './VoteWidget.js';
-import { creatorPath } from './router.js';
+import { creatorPath, studioPath } from './router.js';
 import { recordRemixStep } from './visitTelemetry.js';
 
 type GameDetailPageProps = {
@@ -30,6 +31,7 @@ function previewScreenshot(game: CatalogEntry) {
  */
 export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDetailPageProps) {
   const { t } = useTranslation();
+  const { user } = useAuth();
   const [selectedScreenshotName, setSelectedScreenshotName] = useState<string | null>(null);
 
   useEffect(() => {
@@ -62,6 +64,9 @@ export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDe
   const screenshot = screenshots.find((candidate) => candidate.name === selectedScreenshotName) ?? primaryScreenshot;
   const authorLabel = isPlatformAuthor(game.submittedBy) ? t('catalog.platformAuthor') : game.submittedBy;
   const authorPath = game.creatorHandle ? creatorPath(game.creatorHandle) : null;
+  const isOwner = Boolean(
+    user?.handle && game.creatorHandle && user.handle.toLowerCase() === game.creatorHandle.toLowerCase(),
+  );
 
   const play = () => onPlay(game);
   const remix = () => {
@@ -83,6 +88,11 @@ export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDe
             <PixelIcon name="play" size={13} /> {t('catalog.play')}
           </button>
           <VoteWidget slug={game.slug} />
+          {isOwner ? (
+            <a className="secondary-btn game-page-studio" href={studioPath(game.slug)}>
+              <PixelIcon name="wrench" size={13} /> {t('gamePage.openStudio')}
+            </a>
+          ) : null}
           <button type="button" className="secondary-btn game-page-remix" onClick={remix}>
             <PixelIcon name="wrench" size={13} /> {t('catalog.remix')}
           </button>

--- a/apps/web/src/GamePage.test.tsx
+++ b/apps/web/src/GamePage.test.tsx
@@ -310,6 +310,27 @@ describe('GamePage', () => {
     expect(container.textContent).toContain('gamedev.pl');
   });
 
+  it('hides Open in Studio from visitors', async () => {
+    await renderPage();
+    expect(container.querySelector('a[href="/studio/neon-courier"]')).toBeNull();
+  });
+
+  it('offers Open in Studio to the owning creator', async () => {
+    authUser = { uid: 'u1', handle: 'nightshift' };
+    await renderPage();
+
+    const studio = container.querySelector<HTMLAnchorElement>('a[href="/studio/neon-courier"]');
+    expect(studio).not.toBeNull();
+    expect(studio?.textContent).toContain('Open in Studio');
+    expect(studio?.classList.contains('secondary-btn')).toBe(true);
+  });
+
+  it('does not treat a different signed-in handle as the owner', async () => {
+    authUser = { uid: 'u2', handle: 'somebody_else' };
+    await renderPage();
+    expect(container.querySelector('a[href="/studio/neon-courier"]')).toBeNull();
+  });
+
   it('reports the loaded title upward for document.title', async () => {
     const onGameLoaded = vi.fn();
     await renderPage({ onGameLoaded });

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -6,7 +6,7 @@ import { catalogMediaUrl, gamePageHandle, type CatalogEntry } from './catalog.js
 import { fetchGamePage, type GamePage as GamePageData } from './gamePageApi.js';
 import { PixelIcon } from './PixelIcon.js';
 import { ShareGameButton } from './ShareGameButton.js';
-import { creatorPath, gamePath, playPath } from './router.js';
+import { creatorPath, gamePath, playPath, studioPath } from './router.js';
 import { recordRemixStep } from './visitTelemetry.js';
 import { VoteWidget } from './VoteWidget.js';
 
@@ -23,9 +23,11 @@ function previewScreenshot(game: CatalogEntry) {
  *
  * This is a landing page, not a player and not an agent workspace. It gives a visitor
  * enough context to decide whether to play, then crosses the explicit Play/Remix
- * boundary into the existing sandboxed theater. Old tab URLs are accepted by the
- * router but intentionally land on this same compact page because those surfaces had
- * no reliable public data behind them.
+ * boundary into the existing sandboxed theater. The owning creator also gets an
+ * "Open in Studio" door into `/studio/<slug>` — same owner-only control as the
+ * creator profile. Old tab URLs are accepted by the router but intentionally land
+ * on this same compact page because those surfaces had no reliable public data
+ * behind them.
  */
 export function GamePage({
   handle,
@@ -181,6 +183,9 @@ export function GamePage({
     ? t('catalog.platformAuthor')
     : creator?.profileName?.trim() || creator?.handle || t('catalog.platformAuthor');
   const shareHandle = creator?.handle ?? gamePageHandle(entry);
+  const ownerHandle = creator?.handle ?? entry.creatorHandle ?? null;
+  const isOwner = Boolean(user?.handle && ownerHandle && user.handle.toLowerCase() === ownerHandle.toLowerCase());
+  const studioHref = studioPath(slug);
 
   const play = () => {
     if (playGated) {
@@ -230,6 +235,15 @@ export function GamePage({
             <PixelIcon name="play" size={13} /> {t('gamePage.play')}
           </button>
           <VoteWidget slug={slug} />
+          {isOwner ? (
+            <a
+              className="secondary-btn game-page-studio"
+              href={studioHref}
+              onClick={intercept(() => onNavigate(studioHref))}
+            >
+              <PixelIcon name="wrench" size={13} /> {t('gamePage.openStudio')}
+            </a>
+          ) : null}
           <button type="button" className="secondary-btn game-page-remix" onClick={openRemixEntry} ref={remixButtonRef}>
             <PixelIcon name="wrench" size={13} /> {t('gamePage.remix')}
           </button>

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -19,15 +19,11 @@ function previewScreenshot(game: CatalogEntry) {
 }
 
 /**
- * The canonical public game page at `/:handle/:slug`.
+ * Canonical public game page at `/:handle/:slug`.
  *
- * This is a landing page, not a player and not an agent workspace. It gives a visitor
- * enough context to decide whether to play, then crosses the explicit Play/Remix
- * boundary into the existing sandboxed theater. The owning creator also gets an
- * "Open in Studio" door into `/studio/<slug>` — same owner-only control as the
- * creator profile. Old tab URLs are accepted by the router but intentionally land
- * on this same compact page because those surfaces had no reliable public data
- * behind them.
+ * Landing page, not a player or agent workspace. Visitors get Play/Remix into
+ * the sandboxed theater; the owning creator also gets Open in Studio.
+ * Old tab URLs land here — those surfaces had no reliable public data.
  */
 export function GamePage({
   handle,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1302,6 +1302,7 @@
     "loadError": "Could not load this game page.",
     "actions": "Game actions",
     "play": "Play",
+    "openStudio": "Open in Studio",
     "playPreview": "Play {{title}} in theater mode",
     "openTheater": "Play in theater",
     "screenshots": "Screenshots",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1306,6 +1306,7 @@
     "loadError": "Nie udało się wczytać strony gry.",
     "actions": "Akcje gry",
     "play": "Zagraj",
+    "openStudio": "Otwórz w Studio",
     "playPreview": "Zagraj w {{title}} w trybie kinowym",
     "openTheater": "Graj w trybie kinowym",
     "screenshots": "Zrzuty ekranu",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13415,6 +13415,19 @@ button.builder-mode-selector:disabled {
   min-height: 44px;
 }
 
+.game-page-studio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 8px;
+  padding: 10px 18px;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+
 .game-page-actions .vote-widget {
   display: contents;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Creators already get **Open in Studio** on their own profile game cards, but the public game landing (`/:handle/:slug`) only offered Play / Like / Remix / Share — so owners had to detour through the global Studio chip and pick the game from the shelf.

## What

- When the signed-in user owns the game (handle match), show **Open in Studio** linking to `/studio/<slug>` on `GamePage` and `GameDetailPage`.
- Same owner check and copy pattern as the creator profile control.
- Unit coverage for owner vs visitor (one render per test).
- Rebased onto latest `master` (includes `/play` auto-open theater changes).

## Test plan

- [ ] As the game owner, open `/:handle/:slug` and confirm **Open in Studio** appears and lands on that game’s Studio thread.
- [ ] As another signed-in user (or signed out), confirm the control is absent.
- [ ] Confirm Play / Remix / Share still work and layout wraps cleanly on a phone width.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af2d38c-577b-4c29-a1f3-df97a338272e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af2d38c-577b-4c29-a1f3-df97a338272e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

