### PR TITLE
fix(web): continuous mascot + auto-open theater on /play links

### DIFF
--- a/.claude/skills/browse-live-site/SKILL.md
+++ b/.claude/skills/browse-live-site/SKILL.md
@@ -138,10 +138,10 @@ roughly in order of how often they turn up real issues:
 
 - **Home** (`/`) — scroll to the bottom too; lazy-loaded catalog cards fetch media on scroll.
 - **Play a real game** (`/play/<slug>` for a `single-player` catalog entry from
-  `GET /api/catalog`) — the shareable page is **preview-first** (screenshot + Play;
-  no autoplaying iframe). Click Play (or the preview) to open the sandboxed theater,
-  then click into the game's iframe and send keyboard input; a game that never
-  responds to input is the most user-visible failure mode there is.
+  `GET /api/catalog`) — the play permalink **auto-opens** the sandboxed theater.
+  Canonical `/:handle/:slug` pages stay preview-first (screenshot + Play). Click
+  into the game's iframe and send keyboard input; a game that never responds to
+  input is the most user-visible failure mode there is.
 - **Play alias rewrite** (`/ai/<slug>` or `/ay/<slug>`) — should 30x/rewrite to the canonical
   `/play/<slug>` (see `apps/web/src/router.ts`).
 - **Multiplayer lobby** — click "Play together" on a catalog entry with `multiplayer` set;

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -70,8 +70,9 @@ Two concrete instances of that (observed 2026-07-23):
   waits forever while everything already completed. Always `git rev-parse` to full length.
 - **A green unit suite + "I checked it in a browser" can still fail the deploy browser
   gate when the UX flow changed and e2e was not updated.** Observed (#599, 2026-08-05):
-  published `/play/<slug>` became preview-first (screenshot + Play, no autoplaying
-  iframe). Unit tests and claimed manual browser checks were green; deploy's
+  published `/play/<slug>` briefly became preview-first (screenshot + Play, no
+  autoplaying iframe; later restored to auto-open, with `/:handle/:slug` staying
+  preview-first). Unit tests and claimed manual browser checks were green; deploy's
   `npm run e2e` still waited for `iframe` / `.game-theater-bar` on bare navigation and
   blocked promotion. When a PR changes _when_ a frame mounts (or the copy of an error
   state the gate asserts), update `apps/e2e` in the same PR — the unit suite never

--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -299,21 +299,10 @@ export async function visit(page: Page, path: string, settleMs = 3_000) {
 }
 
 /**
- * Open a published game's sandboxed theater from its shareable preview page.
- *
- * `/play/<slug>` is preview-first (`GameDetailPage`): screenshot/actions only, no
- * iframe. Play is the explicit execution boundary that mounts `GameTheater`. The
- * deploy browser gate must cross that boundary before asserting on frames, canvas
- * liveness, or theater chrome — otherwise every check fails against a page that is
- * working as designed.
+ * Open a published game's theater via `/play/<slug>` (auto-opens once catalog-ready).
+ * Canonical `/:handle/:slug` stays preview-first — use those to test Play clicks.
  */
 export async function openPlayTheater(page: Page, slug: string, settleMs = 4_000): Promise<void> {
   await visit(page, `/play/${encodeURIComponent(slug)}`, settleMs);
-  // Class within the actions row, not `button.primary-btn` — the control is the
-  // primary action by role in the layout; tying the gate to the element type would
-  // fail a deploy over a harmless `<a class="primary-btn">` restyle.
-  const play = page.locator('.game-page-actions .primary-btn');
-  await play.waitFor({ state: 'visible', timeout: 30_000 });
-  await play.click();
   await page.locator('.game-theater-bar').waitFor({ state: 'visible', timeout: 30_000 });
 }

--- a/apps/e2e/src/games-playable.test.ts
+++ b/apps/e2e/src/games-playable.test.ts
@@ -115,7 +115,7 @@ async function sampleCanvas(frame: Frame): Promise<CanvasSample | null> {
 async function inspectGame(page: Page, slug: string): Promise<GameReport> {
   const report: GameReport = { slug, frameAppeared: false, sandbox: null, litPixels: -1, animated: false };
 
-  // Preview page first, then Play — the iframe does not exist until the theater opens.
+  // /play/<slug> auto-opens the theater; the iframe mounts with GameTheater.
   await openPlayTheater(page, slug);
 
   const iframe = page.locator('iframe').first();

--- a/apps/e2e/src/walkthrough.test.ts
+++ b/apps/e2e/src/walkthrough.test.ts
@@ -85,7 +85,7 @@ describe.skipIf(!prereq.ok)('signed-in walkthrough', () => {
 
     let frame: Frame | undefined;
     for (const candidate of candidates) {
-      // Preview page → Play → theater. The iframe is not on the shareable page.
+      // /play/<slug> auto-opens the theater; the iframe mounts with GameTheater.
       await openPlayTheater(page, candidate.slug, 6_000);
       // The theater bar mounts before PublishedGameFrame attaches the iframe, so a
       // bare frames() scan right after openPlayTheater can miss a healthy game.

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -271,7 +271,7 @@ describe('catalog playback', () => {
     });
   });
 
-  it('keeps the full-page mascot on direct play links until the catalog resolves', async () => {
+  it('keeps the full-page mascot on direct play links until the theater opens', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     let resolveCatalog!: (value: Response) => void;
     const catalogPending = new Promise<Response>((resolve) => {
@@ -292,8 +292,14 @@ describe('catalog playback', () => {
       if (url.includes('/api/recommendations')) {
         return new Response(JSON.stringify({ items: [] }));
       }
+      if (url.endsWith('/api/games/airtime')) {
+        return new Response(JSON.stringify({ slug: 'airtime', title: 'Airtime', html: '<canvas>air</canvas>' }));
+      }
       if (url.endsWith('/api/games/airtime/votes')) {
         return new Response(JSON.stringify({ up: 0, down: 0, mine: null }));
+      }
+      if (/\/api\/games\/[^/]+\/played$/.test(new URL(url, 'http://localhost').pathname)) {
+        return new Response(null, { status: 204 });
       }
       throw new Error(`unexpected fetch: ${url}`);
     });
@@ -315,6 +321,7 @@ describe('catalog playback', () => {
     expect(container.querySelector('.app-loading-screen')).not.toBeNull();
     expect(container.querySelector('.app-header')).toBeNull();
     expect(container.querySelector('.game-page')).toBeNull();
+    expect(container.querySelector('.game-theater-bar')).toBeNull();
     expect(container.textContent).not.toMatch(/Loading the game page/i);
 
     await act(async () => {
@@ -336,11 +343,13 @@ describe('catalog playback', () => {
       await flushEffects();
       await flushEffects();
       await flushEffects();
+      await flushEffects();
     });
 
+    // Catalog ready → auto-open theater (GameDetailPage may sit underneath for Close).
     expect(container.querySelector('.app-loading-screen')).toBeNull();
-    expect(container.querySelector('.game-page h1')?.textContent).toBe('Airtime');
-    expect(container.querySelector('.app-header')).not.toBeNull();
+    expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+    expect(container.querySelector('iframe[title="Airtime"]')).not.toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -105,8 +105,8 @@ describe('catalog playback', () => {
     expect(previewButton?.textContent).toContain('Pause preview');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(2);
 
-    // Explicit Play opens theater in place. `/play/:slug` is the shareable preview
-    // page now, so a catalog click must not navigate through it before starting.
+    // Explicit Play opens theater in place. `/play/:slug` is the shareable play
+    // permalink (auto-opens theater); a catalog click must not navigate through it.
     const navigations: string[] = [];
     const onNavigate = (event: Event) => {
       navigations.push((event as CustomEvent<NavigateEventDetail>).detail.path);
@@ -204,7 +204,7 @@ describe('catalog playback', () => {
     });
   });
 
-  it('renders a static game page for direct play paths without loading the game iframe', async () => {
+  it('auto-opens the theater for a direct /play path once the catalog is ready', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const fetched: string[] = [];
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
@@ -261,14 +261,10 @@ describe('catalog playback', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector('iframe')).toBeNull();
-    expect(container.querySelector('.game-page h1')?.textContent).toBe('Football 3D Lite');
-    expect(container.querySelector<HTMLImageElement>('.game-page-preview img')?.src).toContain('match.png?w=1280');
-
-    // The page needs catalog metadata, but game code does not load until a deliberate
-    // Play/preview click crosses into theater.
+    expect(container.querySelector('.game-theater-bar')).not.toBeNull();
+    expect(container.querySelector('iframe[title="Football 3D Lite"]')).not.toBeNull();
     expect(fetched.some((url) => url.includes('/api/catalog'))).toBe(true);
-    expect(fetched.some((url) => url.endsWith('/api/games/football-3d-lite'))).toBe(false);
+    expect(fetched.some((url) => url.endsWith('/api/games/football-3d-lite'))).toBe(true);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -315,8 +315,7 @@ describe('catalog playback', () => {
       await flushEffects();
     });
 
-    // Auth has resolved (catalog fetch is in flight) — still the full-page mascot,
-    // not the header shell with a second "Loading the game page…" stage.
+    // Catalog still pending: mascot only, no header loading stage.
     expect(container.querySelector('.app-loading-screen')).not.toBeNull();
     expect(container.querySelector('.app-header')).toBeNull();
     expect(container.querySelector('.game-page')).toBeNull();

--- a/apps/web/src/App.catalog.test.ts
+++ b/apps/web/src/App.catalog.test.ts
@@ -275,6 +275,83 @@ describe('catalog playback', () => {
     });
   });
 
+  it('keeps the full-page mascot on direct play links until the catalog resolves', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    let resolveCatalog!: (value: Response) => void;
+    const catalogPending = new Promise<Response>((resolve) => {
+      resolveCatalog = resolve;
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: { uid: 'g:test', tier: 'standard' } }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/catalog')) {
+        return catalogPending;
+      }
+      if (url.includes('/api/recommendations')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      if (url.endsWith('/api/games/airtime/votes')) {
+        return new Response(JSON.stringify({ up: 0, down: 0, mine: null }));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/play/airtime');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(App)));
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    // Auth has resolved (catalog fetch is in flight) — still the full-page mascot,
+    // not the header shell with a second "Loading the game page…" stage.
+    expect(container.querySelector('.app-loading-screen')).not.toBeNull();
+    expect(container.querySelector('.app-header')).toBeNull();
+    expect(container.querySelector('.game-page')).toBeNull();
+    expect(container.textContent).not.toMatch(/Loading the game page/i);
+
+    await act(async () => {
+      resolveCatalog(
+        new Response(
+          JSON.stringify([
+            {
+              slug: 'airtime',
+              title: 'Airtime',
+              genre: 'arcade',
+              controls: 'Hold to glide',
+              status: 'published',
+              media: { screenshots: [{ name: 'flight', file: 'flight.png' }], video: null },
+              multiplayer: null,
+            },
+          ]),
+        ),
+      );
+      await flushEffects();
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.app-loading-screen')).toBeNull();
+    expect(container.querySelector('.game-page h1')?.textContent).toBe('Airtime');
+    expect(container.querySelector('.app-header')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('opens the theater from a canonical game page and auto-starts its carried Remix request', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const assistBodies: unknown[] = [];

--- a/apps/web/src/App.overlayExit.test.ts
+++ b/apps/web/src/App.overlayExit.test.ts
@@ -8,12 +8,11 @@ import { AuthProvider } from './AuthContext.js';
 import i18n from './i18n/index.js';
 
 /**
- * Closing a game reveals the page that opened it.
+ * Closing a game reveals the page that opened it — or, for a `/play/<slug>` deep
+ * link, replaces onto the canonical game page so the URL matches the surface.
  *
- * Published play is an in-place theater: catalog/profile buttons open over their
- * current page, while a shared `/play/<slug>` link auto-opens the theater and Close
- * reveals the static game page underneath. Closing must dismiss the theater without
- * mutating browser history in either case.
+ * Catalog/profile Play opens an in-place theater; Close dismisses without history.
+ * A shared `/play/<slug>` auto-opens, and Close goes to `/:handle/:slug`.
  */
 
 async function flushEffects() {
@@ -40,8 +39,35 @@ function mockApi() {
             controls: 'Arrow keys',
             status: 'published',
             media: null,
+            creatorHandle: 'nightshift',
+            submittedBy: 'Night Shift',
           },
         ]),
+      );
+    }
+    if (url.endsWith('/api/games/sky-dodge/page')) {
+      return new Response(
+        JSON.stringify({
+          entry: {
+            slug: 'sky-dodge',
+            title: 'Sky Dodge',
+            genre: 'Arcade',
+            controls: 'Arrow keys',
+            status: 'published',
+            media: null,
+            creatorHandle: 'nightshift',
+            submittedBy: 'Night Shift',
+          },
+          creator: {
+            handle: 'nightshift',
+            profileName: 'Night Shift',
+            bio: '',
+            avatarUrl: null,
+            profileCreatedAt: '2026-07-01T00:00:00.000Z',
+          },
+          platformAuthored: false,
+          description: 'Dodge the sky.',
+        }),
       );
     }
     if (url.includes('/api/games/')) {
@@ -107,7 +133,7 @@ describe('closing a full-viewport game', () => {
     });
   });
 
-  it('reveals the static game page behind a cold deep-link theater', async () => {
+  it('replaces a cold /play deep link onto the canonical game page on Close', async () => {
     mockApi();
     window.history.pushState(null, '', '/play/sky-dodge');
     const { container, root } = await renderApp();
@@ -120,12 +146,13 @@ describe('closing a full-viewport game', () => {
     await act(async () => {
       exit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
+      await flushEffects();
     });
 
     expect(back).not.toHaveBeenCalled();
-    expect(window.location.pathname).toBe('/play/sky-dodge');
-    expect(container.querySelector('.game-page h1')?.textContent).toBe('Sky Dodge');
+    expect(window.location.pathname).toBe('/nightshift/sky-dodge');
     expect(container.querySelector('.exit-btn')).toBeNull();
+    expect(container.querySelector('.game-page h1')?.textContent).toBe('Sky Dodge');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.overlayExit.test.ts
+++ b/apps/web/src/App.overlayExit.test.ts
@@ -10,10 +10,10 @@ import i18n from './i18n/index.js';
 /**
  * Closing a game reveals the page that opened it.
  *
- * Published play is an in-place theater now: catalog/profile buttons open over their
- * current page, while a shared `/play/<slug>` link first renders a static game page.
- * Closing must therefore dismiss the theater without mutating browser history in either
- * case. That keeps catalog position and leaves a shared link shareable after play.
+ * Published play is an in-place theater: catalog/profile buttons open over their
+ * current page, while a shared `/play/<slug>` link auto-opens the theater and Close
+ * reveals the static game page underneath. Closing must dismiss the theater without
+ * mutating browser history in either case.
  */
 
 async function flushEffects() {
@@ -114,13 +114,7 @@ describe('closing a full-viewport game', () => {
 
     const back = vi.spyOn(window.history, 'back').mockImplementation(() => {});
 
-    const play = container.querySelector<HTMLButtonElement>('.game-page-actions .primary-btn');
-    expect(play).not.toBeNull();
-    await act(async () => {
-      play?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await flushEffects();
-    });
-
+    // Deep link auto-opens the theater; no Play click required.
     const exit = container.querySelector<HTMLButtonElement>('.exit-btn');
     expect(exit).not.toBeNull();
     await act(async () => {
@@ -131,6 +125,7 @@ describe('closing a full-viewport game', () => {
     expect(back).not.toHaveBeenCalled();
     expect(window.location.pathname).toBe('/play/sky-dodge');
     expect(container.querySelector('.game-page h1')?.textContent).toBe('Sky Dodge');
+    expect(container.querySelector('.exit-btn')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { generateGame, type GeneratedGame, type GenerateGameApiError } from './api.js';
-import { fetchCatalog, type CatalogEntry } from './catalog.js';
+import { fetchCatalog, gamePageHandle, type CatalogEntry } from './catalog.js';
 import { GameTheater } from './GameTheater.js';
 import { NavHeader } from './NavHeader.js';
 import { HeroPromptSection } from './HeroPromptSection.js';
@@ -18,6 +18,7 @@ import {
   adminPath,
   canonicalPath,
   creatorPath,
+  gamePath,
   NAVIGATE_EVENT,
   navUpTarget,
   parsePathRoute,
@@ -105,8 +106,6 @@ export function App() {
   // Builds actually in flight, from the server — the header badge's source of truth.
   // Paused while a game is on screen because the player covers the header.
   const activeBuildCount = useActiveBuildCount(myGamesRefreshKey, !stageContent);
-  // `/play/<slug>` auto-opens theater; Close keeps the URL and remembers dismiss.
-  const playTheaterDismissedSlugRef = useRef<string | null>(null);
 
   // Greenfield submission state
   // 'refining' is the spec-refiner call that precedes a submission — a few seconds
@@ -237,14 +236,10 @@ export function App() {
     return () => document.body.classList.remove('player-open');
   }, [stageContent]);
 
-  // `/play/<slug>` auto-opens theater once the catalog confirms the game. Close leaves
-  // GameDetailPage on the same URL. Canonical `/:handle/:slug` stays preview-first.
-  // In-place Play from home/profile is not cleared here.
+  // `/play/<slug>` auto-opens theater once the catalog confirms the game.
+  // Close replaces onto the canonical page; in-place Play is untouched.
   useEffect(() => {
-    if (route.view !== 'play') {
-      playTheaterDismissedSlugRef.current = null;
-      return;
-    }
+    if (route.view !== 'play') return;
 
     const entry = catalogEntries.find((game) => game.slug === route.slug);
 
@@ -261,7 +256,6 @@ export function App() {
       return;
     }
 
-    if (playTheaterDismissedSlugRef.current === route.slug) return;
     // Wait so unknown slugs do not flash a 404 theater.
     if (catalogStatus !== 'ready' || !entry) return;
 
@@ -796,8 +790,7 @@ export function App() {
   }, [route, stageContent, unpublishedPlayTheater, t]);
 
   function handlePlayGame(game: CatalogEntry) {
-    // In-place Play; on `/play/<slug>` also re-opens after Close.
-    playTheaterDismissedSlugRef.current = null;
+    // In-place Play from home/profile/game page; `/play/<slug>` auto-opens itself.
     setStageContent({ type: 'catalog', game });
     // Soft refresh so "continue" / genre picks update after the next home visit.
     setRecommendationsRefreshKey((n) => n + 1);
@@ -806,14 +799,16 @@ export function App() {
   function handleRemixGame(game: CatalogEntry, initialRemixRequest?: string) {
     // The game still has to be mounted for Remix to swap and preview its document,
     // but the sheet opens on the first frame — no theater detour and second wrench.
-    playTheaterDismissedSlugRef.current = null;
     setStageContent({ type: 'catalog', game, initialRemixOpen: true, initialRemixRequest });
   }
 
   function handleExitCatalogTheater() {
-    // Keep `/play/<slug>`; mark dismissed so auto-open does not loop.
-    if (route.view === 'play') {
-      playTheaterDismissedSlugRef.current = route.slug;
+    // Deep-linked `/play` → canonical page (replace). Else dismiss overlay only.
+    if (route.view === 'play' && stageContent?.type === 'catalog') {
+      const game = stageContent.game;
+      navigate(gamePath(gamePageHandle(game), game.slug), { replace: true });
+      setStageContent(null);
+      return;
     }
     setStageContent(null);
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1102,6 +1102,17 @@ export function App() {
     return <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />;
   }
 
+  // Bridge catalog-ready → auto-open so GameDetailPage does not flash first.
+  if (
+    route.view === 'play' &&
+    catalogStatus === 'ready' &&
+    playCatalogGame &&
+    !stageContent &&
+    playTheaterDismissedSlugRef.current !== route.slug
+  ) {
+    return <AppLoadingScreen />;
+  }
+
   return (
     <div className="app">
       <NavHeader

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1052,6 +1052,21 @@ export function App() {
     return <ClosedBetaSplash />;
   }
 
+  // Direct `/play/<slug>`: keep the full-page mascot through catalog resolve. Otherwise
+  // auth's AppLoadingScreen hands off to a bare "Loading…" under the header — two stages
+  // for one cold visit. Home still shows its own in-page busy state; only play links
+  // need this continuous cover.
+  if (route.view === 'play' && catalogStatus === 'loading') {
+    return <AppLoadingScreen />;
+  }
+
+  // Unpublished half of `/play/<slug>` owns the viewport (theater or its own loader).
+  // No app chrome underneath — same lifetime permalink before publish; legacy `/draft/`
+  // rewrites here. Catalog errors keep GameDetailPage's retry UI in the main shell.
+  if (unpublishedPlayTheater) {
+    return <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />;
+  }
+
   return (
     <div className="app">
       <NavHeader
@@ -1088,21 +1103,13 @@ export function App() {
         ) : (
           <>
             {route.view === 'play' ? (
-              unpublishedPlayTheater ? (
-                // Same `/play/<slug>` permalink before publish — API serves the draft to
-                // the owner (or anyone once sharing is on). Legacy `/draft/` rewrites here.
-                // Only when catalog is ready and the slug is absent — catalog errors keep
-                // GameDetailPage's retry UI below.
-                <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />
-              ) : (
-                <GameDetailPage
-                  game={playCatalogGame}
-                  state={catalogStatus}
-                  onPlay={handlePlayGame}
-                  onRemix={handleRemixGame}
-                  onRetry={handleRetryCatalog}
-                />
-              )
+              <GameDetailPage
+                game={playCatalogGame}
+                state={catalogStatus}
+                onPlay={handlePlayGame}
+                onRemix={handleRemixGame}
+                onRetry={handleRetryCatalog}
+              />
             ) : (
               <>
                 <div id="hero-prompt">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1052,17 +1052,12 @@ export function App() {
     return <ClosedBetaSplash />;
   }
 
-  // Direct `/play/<slug>`: keep the full-page mascot through catalog resolve. Otherwise
-  // auth's AppLoadingScreen hands off to a bare "Loading…" under the header — two stages
-  // for one cold visit. Home still shows its own in-page busy state; only play links
-  // need this continuous cover.
+  // /play cold visit: hold mascot until catalog answers.
   if (route.view === 'play' && catalogStatus === 'loading') {
     return <AppLoadingScreen />;
   }
 
-  // Unpublished half of `/play/<slug>` owns the viewport (theater or its own loader).
-  // No app chrome underneath — same lifetime permalink before publish; legacy `/draft/`
-  // rewrites here. Catalog errors keep GameDetailPage's retry UI in the main shell.
+  // Unpublished /play: theater owns the viewport; no chrome.
   if (unpublishedPlayTheater) {
     return <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />;
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -105,6 +105,8 @@ export function App() {
   // Builds actually in flight, from the server — the header badge's source of truth.
   // Paused while a game is on screen because the player covers the header.
   const activeBuildCount = useActiveBuildCount(myGamesRefreshKey, !stageContent);
+  // `/play/<slug>` auto-opens theater; Close keeps the URL and remembers dismiss.
+  const playTheaterDismissedSlugRef = useRef<string | null>(null);
 
   // Greenfield submission state
   // 'refining' is the spec-refiner call that precedes a submission — a few seconds
@@ -235,6 +237,37 @@ export function App() {
     return () => document.body.classList.remove('player-open');
   }, [stageContent]);
 
+  // `/play/<slug>` auto-opens theater once the catalog confirms the game. Close leaves
+  // GameDetailPage on the same URL. Canonical `/:handle/:slug` stays preview-first.
+  // In-place Play from home/profile is not cleared here.
+  useEffect(() => {
+    if (route.view !== 'play') {
+      playTheaterDismissedSlugRef.current = null;
+      return;
+    }
+
+    const entry = catalogEntries.find((game) => game.slug === route.slug);
+
+    if (stageContent?.type === 'catalog' && stageContent.game.slug === route.slug) {
+      if (entry && stageContent.game !== entry) {
+        setStageContent((prev) =>
+          prev?.type === 'catalog' && prev.game.slug === route.slug ? { ...prev, game: entry } : prev,
+        );
+      }
+      // Ready + missing → UnpublishedPlayView.
+      if (catalogStatus === 'ready' && !entry) {
+        setStageContent(null);
+      }
+      return;
+    }
+
+    if (playTheaterDismissedSlugRef.current === route.slug) return;
+    // Wait so unknown slugs do not flash a 404 theater.
+    if (catalogStatus !== 'ready' || !entry) return;
+
+    setStageContent({ type: 'catalog', game: entry });
+  }, [route, catalogEntries, catalogStatus, stageContent]);
+
   // Guard against accidental reload/close while a game is open. The browser shows
   // its native "Leave site?" confirmation; games run in a sandboxed iframe with no
   // access to parent storage, so their internal progress can't be persisted here —
@@ -258,8 +291,7 @@ export function App() {
     // would just 401. Don't fetch (and don't render an error) until signed in.
     // Outside private beta, catalog reads stay public (owner decision).
     if (privateBeta && !user) return;
-    // Home renders the gallery; `/play/<slug>` renders one preview-first game page.
-    // Both need catalog metadata, but only Home mounts the grid itself.
+    // Home needs the gallery; `/play/<slug>` needs catalog to auto-open theater.
     if (route.view !== 'home' && route.view !== 'play') return;
 
     let cancelled = false;
@@ -764,9 +796,8 @@ export function App() {
   }, [route, stageContent, unpublishedPlayTheater, t]);
 
   function handlePlayGame(game: CatalogEntry) {
-    // Explicit Play is the execution boundary. Shared `/play/<slug>` links land on a
-    // static preview first; catalog/profile Play buttons open the sandboxed theater
-    // immediately without making the preview page masquerade as a running game.
+    // In-place Play; on `/play/<slug>` also re-opens after Close.
+    playTheaterDismissedSlugRef.current = null;
     setStageContent({ type: 'catalog', game });
     // Soft refresh so "continue" / genre picks update after the next home visit.
     setRecommendationsRefreshKey((n) => n + 1);
@@ -775,7 +806,16 @@ export function App() {
   function handleRemixGame(game: CatalogEntry, initialRemixRequest?: string) {
     // The game still has to be mounted for Remix to swap and preview its document,
     // but the sheet opens on the first frame — no theater detour and second wrench.
+    playTheaterDismissedSlugRef.current = null;
     setStageContent({ type: 'catalog', game, initialRemixOpen: true, initialRemixRequest });
+  }
+
+  function handleExitCatalogTheater() {
+    // Keep `/play/<slug>`; mark dismissed so auto-open does not loop.
+    if (route.view === 'play') {
+      playTheaterDismissedSlugRef.current = route.slug;
+    }
+    setStageContent(null);
   }
 
   async function handlePlayTogether(game: CatalogEntry) {
@@ -841,7 +881,7 @@ export function App() {
           // it short so the title stays the hero of the bar.
           badge={{ icon: 'sparkle', label: t('ai.generatedShort') }}
           source={{ slug: stageContent.game.slug }}
-          onExit={() => setStageContent(null)}
+          onExit={handleExitCatalogTheater}
           orientation={stageContent.game.orientation}
           reportSlug={stageContent.game.slug}
           submittedBy={stageContent.game.submittedBy}

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -23,10 +23,9 @@ function previewScreenshot(game: CatalogEntry) {
 }
 
 /**
- * `/play/<slug>` after Close, and while catalog loads before auto-open.
+ * `/play/<slug>` after Close (permalink stays; theater auto-opens on cold visit).
  *
- * The permalink auto-opens theater; this surface remains after dismiss. It never
- * mounts the iframe — Play re-opens theater. Canonical pages use {@link GamePage}.
+ * Never mounts the iframe — Play re-opens theater. Canonical pages use {@link GamePage}.
  *
  * Not a SPEC.md rendering: agent source, not player copy. Compact controls only.
  */

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -45,8 +45,7 @@ export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDe
   }, [game]);
 
   if (state === 'loading') {
-    // App normally covers `/play` catalog waits with AppLoadingScreen at the root;
-    // keep the same mascot here as a fallback if this surface is mounted mid-fetch.
+    // Fallback mascot if mounted while catalog still loads.
     return <AppLoadingScreen />;
   }
 

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -22,12 +22,10 @@ function previewScreenshot(game: CatalogEntry) {
 }
 
 /**
- * `/play/<slug>` after Close, and while catalog loads before auto-open.
+ * Loading/error shell under `/play/<slug>` before theater auto-opens.
  *
- * The permalink auto-opens theater; this surface remains after dismiss. It never
- * mounts the iframe — Play re-opens theater. Canonical pages use {@link GamePage}.
- *
- * Not a SPEC.md rendering: agent source, not player copy. Compact controls only.
+ * Published play redirects Close onto the canonical game page ({@link GamePage}).
+ * This surface never mounts the iframe.
  */
 export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDetailPageProps) {
   const { t } = useTranslation();

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { catalogMediaUrl, isPlatformAuthor, type CatalogEntry } from './catalog.js';
 import { PixelIcon } from './PixelIcon.js';
 import { ShareGameButton } from './ShareGameButton.js';
@@ -44,7 +45,9 @@ export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDe
   }, [game]);
 
   if (state === 'loading') {
-    return <p className="game-page-state">{t('gamePage.loading')}</p>;
+    // App normally covers `/play` catalog waits with AppLoadingScreen at the root;
+    // keep the same mascot here as a fallback if this surface is mounted mid-fetch.
+    return <AppLoadingScreen />;
   }
 
   if (state === 'error') {

--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -22,17 +22,12 @@ function previewScreenshot(game: CatalogEntry) {
 }
 
 /**
- * A published game's shareable landing page.
+ * `/play/<slug>` after Close, and while catalog loads before auto-open.
  *
- * This surface deliberately never mounts the game iframe. A shared link should let a
- * visitor understand what they are about to open before untrusted game code starts,
- * and it should stay useful on a phone where an autoplaying game consumes the whole
- * viewport. Play is the explicit boundary that opens the sandboxed theater.
+ * The permalink auto-opens theater; this surface remains after dismiss. It never
+ * mounts the iframe — Play re-opens theater. Canonical pages use {@link GamePage}.
  *
- * The page is intentionally not a rendering of SPEC.md. The spec is an agent-facing
- * source of truth, not player copy; the compact controls line is the only part a player
- * needs here. Releases, source, follow and comparison queues do not appear until the
- * product has real data and behaviour behind them.
+ * Not a SPEC.md rendering: agent source, not player copy. Compact controls only.
  */
 export function GameDetailPage({ game, state, onPlay, onRemix, onRetry }: GameDetailPageProps) {
   const { t } = useTranslation();

--- a/apps/web/src/UnpublishedPlayView.tsx
+++ b/apps/web/src/UnpublishedPlayView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { fetchPublishedGame, type GameFetchError } from './catalog.js';
 import { GameTheater } from './GameTheater.js';
 
@@ -89,13 +90,9 @@ export function UnpublishedPlayView({ slug, onExit, onTitle }: UnpublishedPlayVi
   }
 
   if (!game) {
-    return (
-      <section className="panel status-panel">
-        <p className="catalog-state">
-          <span className="status-preview-spinner" aria-hidden="true" /> {t('draft.loading')}
-        </p>
-      </section>
-    );
+    // Same full-page mascot as the catalog wait on `/play/<slug>` — one continuous
+    // loader from cold visit through document fetch, not a spinner under the header.
+    return <AppLoadingScreen />;
   }
 
   return (

--- a/apps/web/src/UnpublishedPlayView.tsx
+++ b/apps/web/src/UnpublishedPlayView.tsx
@@ -17,8 +17,8 @@ type UnpublishedPlayViewProps = {
 /**
  * Unpublished half of `/play/<slug>`.
  *
- * Published games auto-open theater over {@link GameDetailPage}. Missing catalog
- * entries load via `GET /api/games/:slug` here — same lifetime permalink.
+ * Published games auto-open theater; Close replaces onto {@link GamePage}.
+ * Missing catalog entries load via `GET /api/games/:slug` here instead.
  *
  * Legacy `/draft/<slug>` links rewrite to `/play/<slug>` in the router.
  */

--- a/apps/web/src/UnpublishedPlayView.tsx
+++ b/apps/web/src/UnpublishedPlayView.tsx
@@ -17,10 +17,8 @@ type UnpublishedPlayViewProps = {
 /**
  * Unpublished half of `/play/<slug>`.
  *
- * Catalog games render {@link GameDetailPage} on the same URL. When the slug is
- * not in the catalog yet (owner draft, or a draft someone shared), this view
- * loads the playable document via `GET /api/games/:slug` and opens the theater
- * — the lifetime permalink stays `/play/<slug>` before and after publish.
+ * Published games auto-open theater over {@link GameDetailPage}. Missing catalog
+ * entries load via `GET /api/games/:slug` here — same lifetime permalink.
  *
  * Legacy `/draft/<slug>` links rewrite to `/play/<slug>` in the router.
  */

--- a/apps/web/src/UnpublishedPlayView.tsx
+++ b/apps/web/src/UnpublishedPlayView.tsx
@@ -90,8 +90,7 @@ export function UnpublishedPlayView({ slug, onExit, onTitle }: UnpublishedPlayVi
   }
 
   if (!game) {
-    // Same full-page mascot as the catalog wait on `/play/<slug>` — one continuous
-    // loader from cold visit through document fetch, not a spinner under the header.
+    // Match /play catalog wait: full-page mascot, not a spinner.
     return <AppLoadingScreen />;
   }
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -470,7 +470,7 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
     case 'home':
     case 'join':
       return null;
-    // `/play/:slug` auto-opens; Up shows after Close. Drafts own Close themselves.
+    // `/play/:slug` auto-opens; Close replaces onto the canonical game page.
     case 'play':
       return { path: '/', labelKey: 'upHome' };
     case 'studio':

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -255,8 +255,7 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
   }
 
   // Legacy `/draft/<slug>` — same game as `/play/<slug>`. Parsed as play so the
-  // canonical rewrite below puts the bar on the lifetime permalink; the app used
-  // to keep a separate theater-only view here after /play became preview-first.
+  // canonical rewrite below puts the bar on the lifetime permalink.
   const draftMatch = normalizedPath.match(/^\/draft\/([^/]+)$/);
   if (draftMatch?.[1]) {
     const slug = decodeSegment(draftMatch[1]);
@@ -471,8 +470,7 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
     case 'home':
     case 'join':
       return null;
-    // `/play/:slug` is preview-first for catalog games; unpublished drafts open a
-    // theater that owns Close — Up stays for the static preview page.
+    // `/play/:slug` auto-opens; Up shows after Close. Drafts own Close themselves.
     case 'play':
       return { path: '/', labelKey: 'upHome' };
     case 'studio':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cold visits to `/play/<slug>` (e.g. `/play/airtime`) had a broken share-link experience: a two-stage loader (full-page mascot, then “Loading…” under the header), and preview-first instead of playing.

This PR combines continuous mascot loading with [#649](https://github.com/gamedevpl/www.gamedev.pl/pull/649) (auto-open theater + Close → canonical game page):

1. **Continuous full-page mascot** through auth + catalog + auto-open handoff
2. **Auto-open theater** on published `/play/<slug>` once the catalog confirms the game
3. **Close on `/play`** replaces onto `/:handle/:slug` (canonical preview page). In-place Play from home/profile still dismisses without history changes.

## Changes
- `App.tsx`: hold `AppLoadingScreen` while catalog loads and until theater auto-opens; unpublished play without chrome; auto-open + Close→canonical from #649
- `UnpublishedPlayView` / `GameDetailPage`: loading uses the mascot
- e2e helpers/docs updated for auto-open
- Tests: mid-catalog mascot → theater; Close from `/play` → `/:handle/:slug`

## Test plan
- [ ] Open `/play/airtime` cold: only the full-page mascot, then the theater
- [ ] Close theater: lands on `/<handle>/airtime` (canonical page), not stuck on `/play/airtime`
- [ ] Catalog/home Play still opens theater in place; Close stays on home
- [ ] Canonical `/:handle/:slug` stays preview-first
- [ ] Unpublished `/play/<slug>` stays on the mascot until theater or error

## Verification
- #649 tip (including Close→canonical) merged and green locally: `type-check`, `lint`, `test`, `build`

**Note:** After this merges, #649 can be closed as superseded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-649faec6-71c6-4237-939a-bcac8667f997?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-649faec6-71c6-4237-939a-bcac8667f997&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

