### PR TITLE
fix(review): show Try play overlay + Review badge when sweep active

### DIFF
--- a/apps/api/src/review.test.ts
+++ b/apps/api/src/review.test.ts
@@ -156,6 +156,50 @@ describe('reviewer assessment desk', () => {
     );
   });
 
+  it('exposes remaining count for the Review nav badge', async () => {
+    const { app } = await makeApp({ seedSweep: false });
+    const reviewer = await sessionCookie(app, 'reviewer');
+    const stranger = await sessionCookie(app, 'stranger');
+
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: stranger } })).statusCode,
+    ).toBe(404);
+
+    const idle = await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: reviewer } });
+    expect(idle.statusCode).toBe(200);
+    expect(JSON.parse(idle.body)).toEqual({ remaining: 0, sweep: null });
+
+    const boss = await sessionCookie(app, 'boss');
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-sweeps',
+      headers: { cookie: boss },
+      payload: { source: 'catalog', maxGames: 2, releasePerDay: null, notify: false },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const open = await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: reviewer } });
+    expect(open.statusCode).toBe(200);
+    expect(JSON.parse(open.body).remaining).toBe(2);
+    expect(JSON.parse(open.body).sweep.status).toBe('active');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/review/assessments',
+      headers: { cookie: reviewer },
+      payload: {
+        slug: 'sky-dodge',
+        source: 'catalog',
+        verdict: 'keep',
+        note: 'One down.',
+        checklist: sampleChecklist,
+      },
+    });
+
+    const after = await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: reviewer } });
+    expect(JSON.parse(after.body).remaining).toBe(1);
+  });
+
   it('lets admins review without being listed in REVIEWER_UIDS', async () => {
     const { app } = await makeApp({ reviewerUids: '', adminUids: 'dev:boss' });
     const boss = await sessionCookie(app, 'boss');

--- a/apps/api/src/review.ts
+++ b/apps/api/src/review.ts
@@ -303,6 +303,40 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     };
   });
 
+  // Lightweight badge feed for the hamburger Review link.
+  app.get('/api/review/status', async (request, reply) => {
+    const refused = refuseUnlessReviewer(request, reply);
+    if (refused) return refused;
+    const uid = request.user!.uid;
+    const open = await store.getOpenReviewSweep();
+    if (!open || open.status !== 'active') {
+      return {
+        remaining: 0,
+        sweep: open
+          ? {
+              id: open.id,
+              status: open.status,
+              total: open.slugs.length,
+              released: effectiveReleasedCount(open, now()),
+            }
+          : null,
+      };
+    }
+    const mine = await store.listGameAssessmentsByReviewer(uid);
+    const done = new Set(mine.map((row) => row.slug));
+    const unlocked = releasedSlugs(open, now());
+    const remaining = unlocked.reduce((count, slug) => count + (done.has(slug) ? 0 : 1), 0);
+    return {
+      remaining,
+      sweep: {
+        id: open.id,
+        status: open.status,
+        total: open.slugs.length,
+        released: unlocked.length,
+      },
+    };
+  });
+
   app.get('/api/review/assessments/mine', async (request, reply) => {
     const refused = refuseUnlessReviewer(request, reply);
     if (refused) return refused;

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -306,6 +306,71 @@ describe('NavHeader menu', () => {
     await act(async () => root.unmount());
   });
 
+  it('badges Review with remaining games when a sweep is active', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(
+          JSON.stringify({
+            user: { uid: 'g:reviewer', tier: 'free', name: 'Reviewer', reviewer: true },
+          }),
+        );
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/review/status')) {
+        return new Response(
+          JSON.stringify({
+            remaining: 5,
+            sweep: { id: 'swp-1', status: 'active', total: 5, released: 5 },
+          }),
+        );
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onNavigate: vi.fn(),
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin: vi.fn(),
+            onReview: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+    await act(async () => {
+      hamburger.click();
+      await Promise.resolve();
+    });
+
+    const review = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((btn) =>
+      (btn.textContent ?? '').includes('Review'),
+    );
+    expect(review).toBeDefined();
+    expect(review!.querySelector('.specs-count-badge')?.textContent).toBe('5');
+    expect(review!.querySelector('.specs-count-badge')?.getAttribute('aria-label')).toBe('5 games to review');
+
+    await act(async () => root.unmount());
+  });
+
   it('signs out from the menu foot and closes the menu', async () => {
     const logoutSpy = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -8,6 +8,7 @@ import { Mascot } from './Mascot.js';
 import { NotificationBell } from './NotificationBell.js';
 import { PixelIcon } from './PixelIcon.js';
 import { fetchAdminSummary } from './adminApi.js';
+import { fetchReviewStatus } from './reviewApi.js';
 import { creatorPath } from './router.js';
 import { usePageScrolling } from './usePageScrolling.js';
 
@@ -59,6 +60,7 @@ export function NavHeader({
    * caught it, correctly.
    */
   const [alertCount, setAlertCount] = useState<number | null>(null);
+  const [reviewRemaining, setReviewRemaining] = useState<number | null>(null);
   const isOperator = user?.admin === true;
   const isReviewer = user?.reviewer === true || isOperator;
 
@@ -85,6 +87,28 @@ export function NavHeader({
       clearInterval(timer);
     };
   }, [isOperator]);
+
+  useEffect(() => {
+    if (!isReviewer) {
+      setReviewRemaining(null);
+      return;
+    }
+    let cancelled = false;
+    const read = () =>
+      fetchReviewStatus()
+        .then((status) => {
+          if (!cancelled) setReviewRemaining(status ? status.remaining : 0);
+        })
+        .catch(() => {
+          // Leave the last known badge; a transient miss is not "zero left".
+        });
+    void read();
+    const timer = setInterval(read, 120_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [isReviewer]);
 
   const handleNavClick = (sectionId: string) => {
     onNavigate(sectionId);
@@ -264,6 +288,11 @@ export function NavHeader({
                   }}
                 >
                   <PixelIcon name="star" size={14} /> Review
+                  {reviewRemaining !== null && reviewRemaining > 0 ? (
+                    <span className="specs-count-badge" aria-label={`${reviewRemaining} games to review`}>
+                      {reviewRemaining}
+                    </span>
+                  ) : null}
                 </button>
               ) : null}
 

--- a/apps/web/src/ReviewDesk.test.tsx
+++ b/apps/web/src/ReviewDesk.test.tsx
@@ -194,6 +194,9 @@ describe('ReviewDesk', () => {
       button.textContent?.includes('Try play'),
     );
     expect(tryPlay).toBeTruthy();
+    // Overlay on the stage — sticky checklist must not bury Try play.
+    expect(tryPlay!.className).toContain('is-overlay');
+    expect(container.querySelector('.review-stage-tools')).toBeNull();
     await act(async () => {
       tryPlay!.click();
     });
@@ -202,6 +205,7 @@ describe('ReviewDesk', () => {
     expect(container.querySelector('[data-testid="frame"]')?.textContent).toContain('sky-dodge');
     expect(container.querySelector('video.review-preview-video')).toBeNull();
     expect(container.textContent).toMatch(/Show preview/);
+    expect(container.querySelector('button.review-play-btn.is-overlay.is-active')).toBeTruthy();
   });
 
   it('sends cut when the Cut control is pressed', async () => {

--- a/apps/web/src/ReviewDesk.tsx
+++ b/apps/web/src/ReviewDesk.tsx
@@ -478,11 +478,18 @@ export function ReviewDesk() {
                 ) : (
                   <div className="review-preview-empty">
                     <p>{t('review.noMedia')}</p>
-                    <button type="button" className="review-play-btn" onClick={() => setPlaying(true)}>
-                      {t('review.tryPlay')}
-                    </button>
                   </div>
                 )}
+                {hasPreviewMedia(current) || !showMedia ? (
+                  <button
+                    type="button"
+                    className={playing ? 'review-play-btn is-overlay is-active' : 'review-play-btn is-overlay'}
+                    aria-pressed={playing}
+                    onClick={() => setPlaying((prev) => !prev)}
+                  >
+                    {playing ? t('review.showPreview') : t('review.tryPlay')}
+                  </button>
+                ) : null}
                 {keepHint ? <div className="review-stamp is-keep">{t('review.keep')}</div> : null}
                 {cutHint ? <div className="review-stamp is-cut">{t('review.cut')}</div> : null}
                 {skipHint ? <div className="review-stamp is-skip">{t('review.skip')}</div> : null}
@@ -505,19 +512,6 @@ export function ReviewDesk() {
                   ))}
                 </div>
               ) : null}
-
-              <div className="review-stage-tools">
-                {hasPreviewMedia(current) ? (
-                  <button
-                    type="button"
-                    className={playing ? 'review-play-btn is-active' : 'review-play-btn'}
-                    aria-pressed={playing}
-                    onClick={() => setPlaying((prev) => !prev)}
-                  >
-                    {playing ? t('review.showPreview') : t('review.tryPlay')}
-                  </button>
-                ) : null}
-              </div>
             </div>
           </div>
 

--- a/apps/web/src/reviewApi.ts
+++ b/apps/web/src/reviewApi.ts
@@ -111,6 +111,18 @@ export async function fetchReviewQueue(source: 'catalog' | 'creator' | 'all' = '
   return readJson(res);
 }
 
+export interface ReviewStatusResponse {
+  remaining: number;
+  sweep: ReviewQueueSweepHint | null;
+}
+
+export async function fetchReviewStatus(): Promise<ReviewStatusResponse | null> {
+  const res = await fetch(`${API_BASE}/api/review/status`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new ReviewApiError(res.status, `review status failed (${res.status})`);
+  return (await res.json()) as ReviewStatusResponse;
+}
+
 export async function submitAssessment(input: SubmitAssessmentInput): Promise<GameAssessment> {
   const res = await fetch(`${API_BASE}/api/review/assessments`, {
     method: 'POST',

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14847,12 +14847,6 @@ body.remix-entry-open {
   display: block;
 }
 
-.review-stage-tools {
-  display: flex;
-  justify-content: flex-end;
-  padding: 0.45rem 0.75rem 0.7rem;
-}
-
 .review-play-btn {
   border: 1px solid var(--panel-border);
   border-radius: 999px;
@@ -14863,6 +14857,17 @@ body.remix-entry-open {
   font-weight: 600;
   padding: 0.4rem 0.85rem;
   cursor: pointer;
+}
+
+/* Sit on the media so the sticky checklist dock cannot bury Try play. */
+.review-play-btn.is-overlay {
+  position: absolute;
+  right: 0.55rem;
+  bottom: 0.55rem;
+  z-index: 3;
+  background: color-mix(in srgb, var(--panel-card, #1b2229) 88%, transparent);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
 }
 
 .review-play-btn.is-active {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. **Try play** on `/review` sat below the media stage and was buried by the sticky checklist dock — reviewers couldn't see or reach it.
2. The hamburger **Review** link had no count badge while Studio/Operator did, so an active sweep was easy to miss.

## Fix

- Move **Try play** onto the media stage as an absolute overlay (`review-play-btn.is-overlay`) so the dock cannot cover it.
- Add lightweight `GET /api/review/status` (remaining unlocked games for the signed-in reviewer on an active sweep).
- Poll that endpoint from `NavHeader` for reviewers and show a `specs-count-badge` when `remaining > 0`.

## Tests

- API: status 404 for non-reviewers; remaining tracks assessments.
- NavHeader: Review badge when sweep has remaining games.
- ReviewDesk: Try play uses `is-overlay` and toggles the live frame.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a25ba38-de6c-4be3-ad5f-d43b9b423a6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a25ba38-de6c-4be3-ad5f-d43b9b423a6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

