### PR TITLE
Keep hamburger icon when nav menu is open

### DIFF
--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -178,6 +178,20 @@ describe('NavHeader menu', () => {
     await act(async () => root.unmount());
   });
 
+  it('keeps the hamburger icon when open and highlights it instead of turning into an X', async () => {
+    const { container, root } = await renderSignedIn();
+    const hamburger = container.querySelector('.hamburger-btn') as HTMLButtonElement;
+
+    expect(hamburger.getAttribute('aria-expanded')).toBe('true');
+    expect(hamburger.getAttribute('aria-haspopup')).toBe('menu');
+    expect(container.querySelector('.hamburger-container.is-open')).not.toBeNull();
+    expect(container.querySelector('.dropdown-menu')).not.toBeNull();
+    // Menu glyph = three 11×2 bars → 66 rects. Close/X is 35 — so this pins the icon.
+    expect(hamburger.querySelectorAll('svg rect').length).toBe(66);
+
+    await act(async () => root.unmount());
+  });
+
   it('asks to navigate to the hero prompt when Create Game is clicked', async () => {
     const onNavigate = vi.fn();
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -186,7 +186,7 @@ describe('NavHeader menu', () => {
     expect(hamburger.getAttribute('aria-haspopup')).toBe('menu');
     expect(container.querySelector('.hamburger-container.is-open')).not.toBeNull();
     expect(container.querySelector('.dropdown-menu')).not.toBeNull();
-    // Menu glyph = three 11×2 bars → 66 rects. Close/X is 35 — so this pins the icon.
+    // Menu glyph = 66 rects; close/X is 35.
     expect(hamburger.querySelectorAll('svg rect').length).toBe(66);
 
     await act(async () => root.unmount());

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -193,11 +193,12 @@ export function NavHeader({
 
         <LanguageSwitcher />
 
-        <div className="hamburger-container">
+        <div className={`hamburger-container${isMenuOpen ? ' is-open' : ''}`}>
           <button
             type="button"
             className="hamburger-btn"
             aria-expanded={isMenuOpen}
+            aria-haspopup="menu"
             aria-label={
               activeBuildCount > 0
                 ? `Menu — ${t('header.activeBuilds', { count: activeBuildCount })}`
@@ -205,7 +206,9 @@ export function NavHeader({
             }
             onClick={() => setIsMenuOpen((prev) => !prev)}
           >
-            {isMenuOpen ? <PixelIcon name="close" size={16} /> : <PixelIcon name="menu" size={16} />}
+            {/* Stay a hamburger when open — an X reads as "close the page", not
+                "this menu is open". Highlight communicates open state. */}
+            <PixelIcon name="menu" size={16} />
             {activeBuildCount > 0 && !isMenuOpen ? (
               <span className="hamburger-live-badge" aria-hidden="true">
                 {activeBuildCount > 99 ? '99+' : activeBuildCount}

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -206,8 +206,6 @@ export function NavHeader({
             }
             onClick={() => setIsMenuOpen((prev) => !prev)}
           >
-            {/* Stay a hamburger when open — an X reads as "close the page", not
-                "this menu is open". Highlight communicates open state. */}
             <PixelIcon name="menu" size={16} />
             {activeBuildCount > 0 && !isMenuOpen ? (
               <span className="hamburger-live-badge" aria-hidden="true">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -305,6 +305,13 @@ a {
   color: var(--turquoise);
 }
 
+/* Open state stays a hamburger — highlight instead of morphing into an X. */
+.hamburger-container.is-open .hamburger-btn {
+  color: var(--turquoise);
+  border-color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.12);
+}
+
 .dropdown-menu {
   position: absolute;
   top: calc(100% + 12px);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The header hamburger was morphing into an X when the overflow menu opened. That reads as “close” rather than “menu is open,” especially next to other chrome.

This matches the theater More-menu pattern already in the codebase: keep the hamburger glyph and highlight the trigger (turquoise border/tint) while `aria-expanded` stays authoritative.

## Test plan
- [x] Unit test asserts open state keeps the menu glyph (66 rects) and `is-open` highlight class
- [x] `npm run type-check`, lint, NavHeader tests, and build all green
- [ ] Open the header menu on desktop and phone — trigger stays three lines, highlighted
- [ ] Toggle closed again — highlight clears, menu dismisses as before
- [ ] With active builds, badge still hides once the menu is open (Studio row shows the count)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f400a73-35a8-406c-8c10-48fafd0e46d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f400a73-35a8-406c-8c10-48fafd0e46d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

