### PR TITLE
EK-02: render all editor collections

### DIFF
--- a/apps/web/src/EditorCollections.test.tsx
+++ b/apps/web/src/EditorCollections.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import type {
   EditorCollectionSpec,
+  EditorConstraint,
   EditorDefinition,
   EditorItemContent,
   GameEditorState,
@@ -28,7 +29,13 @@ import { RemixPainter } from './RemixPainter.js';
 const mapItem: EditorItemContent = { properties: { name: 'Map 1' }, rows: ['..', '..'] };
 const routeItem: EditorItemContent = { properties: { name: 'Route 1' }, rows: ['##', '##'] };
 
-function collection(label: string, itemLabel: string, tileChar: string, item: EditorItemContent): EditorCollectionSpec {
+function collection(
+  label: string,
+  itemLabel: string,
+  tileChar: string,
+  item: EditorItemContent,
+  constraints: EditorConstraint[] = [],
+): EditorCollectionSpec {
   return {
     widget: 'collection',
     label: { en: label, pl: `${label} PL` },
@@ -43,7 +50,7 @@ function collection(label: string, itemLabel: string, tileChar: string, item: Ed
         { key: 'wall', char: tileChar === '.' ? '#' : '.', label: { en: 'Wall', pl: 'Ściana' } },
       ],
       properties: { name: { type: 'text', max: 40 } },
-      constraints: [],
+      constraints,
     },
     defaults: [item],
   };
@@ -53,7 +60,7 @@ const definition: EditorDefinition = {
   version: 1,
   content: {
     maps: collection('Maps', 'Map', '.', mapItem),
-    routes: collection('Routes', 'Route', '#', routeItem),
+    routes: collection('Routes', 'Route', '#', routeItem, [{ tile: 'floor', min: 5 }]),
   },
 };
 
@@ -113,6 +120,7 @@ describe('multi-collection editor surfaces', () => {
     expect(selector).not.toBeNull();
     expect(selector.value).toBe('maps');
     expect(container.querySelector('.editor-item-list')?.textContent).toContain('Map 1');
+    expect(container.querySelector<HTMLButtonElement>('.studio-head-action.is-primary')?.disabled).toBe(true);
 
     changeSelect(selector, 'routes');
 

--- a/apps/web/src/EditorCollections.test.tsx
+++ b/apps/web/src/EditorCollections.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import type {
+  EditorCollectionSpec,
+  EditorDefinition,
+  EditorItemContent,
+  GameEditorState,
+  StudioGame,
+} from './studioApi.js';
+
+const fetchGameEditor = vi.hoisted(() => vi.fn());
+const putEditorDraft = vi.hoisted(() => vi.fn());
+
+vi.mock('./studioApi.js', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi.js')>('./studioApi.js');
+  return { ...actual, fetchGameEditor, putEditorDraft };
+});
+
+vi.mock('./visitTelemetry.js', () => ({ recordAssistStep: vi.fn(), recordEditorStep: vi.fn() }));
+
+import { EditorPanel } from './EditorPanel.js';
+import { RemixPainter } from './RemixPainter.js';
+
+const mapItem: EditorItemContent = { properties: { name: 'Map 1' }, rows: ['..', '..'] };
+const routeItem: EditorItemContent = { properties: { name: 'Route 1' }, rows: ['##', '##'] };
+
+function collection(label: string, itemLabel: string, tileChar: string, item: EditorItemContent): EditorCollectionSpec {
+  return {
+    widget: 'collection',
+    label: { en: label, pl: `${label} PL` },
+    itemLabel: { en: itemLabel, pl: `${itemLabel} PL` },
+    min: 1,
+    max: 2,
+    item: {
+      widget: 'tilemap',
+      grid: { minCols: 2, maxCols: 2, minRows: 2, maxRows: 2 },
+      tiles: [
+        { key: 'floor', char: tileChar, label: { en: 'Floor', pl: 'Podłoga' } },
+        { key: 'wall', char: tileChar === '.' ? '#' : '.', label: { en: 'Wall', pl: 'Ściana' } },
+      ],
+      properties: { name: { type: 'text', max: 40 } },
+      constraints: [],
+    },
+    defaults: [item],
+  };
+}
+
+const definition: EditorDefinition = {
+  version: 1,
+  content: {
+    maps: collection('Maps', 'Map', '.', mapItem),
+    routes: collection('Routes', 'Route', '#', routeItem),
+  },
+};
+
+const content = { maps: [mapItem], routes: [routeItem] };
+
+const game: StudioGame = {
+  token: 'game-token',
+  title: 'Fixture game',
+  createdAt: '2026-08-07T00:00:00.000Z',
+  lastKnownStatus: 'published',
+  slug: 'fixture-game',
+};
+
+function editorState(overrides: Partial<GameEditorState> = {}): GameEditorState {
+  return { version: 'v1', definition, content, draft: null, ...overrides };
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  fetchGameEditor.mockResolvedValue(editorState());
+  putEditorDraft.mockResolvedValue({ revision: 1, updatedAt: '2026-08-07T00:00:01.000Z' });
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  container.remove();
+  vi.clearAllMocks();
+});
+
+async function renderEditor() {
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<EditorPanel game={game} onOpenPlaytest={vi.fn()} onBack={vi.fn()} />);
+    await Promise.resolve();
+  });
+}
+
+function changeSelect(select: HTMLSelectElement, value: string) {
+  act(() => {
+    select.value = value;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+describe('multi-collection editor surfaces', () => {
+  it('switches the studio item list and painter without changing draft state', async () => {
+    await renderEditor();
+
+    const selector = container.querySelector('.editor-collection-selector select') as HTMLSelectElement;
+    expect(selector).not.toBeNull();
+    expect(selector.value).toBe('maps');
+    expect(container.querySelector('.editor-item-list')?.textContent).toContain('Map 1');
+
+    changeSelect(selector, 'routes');
+
+    expect(selector.value).toBe('routes');
+    expect(container.querySelector('.editor-item-list')?.textContent).toContain('Route 1');
+    expect(container.querySelector('.editor-item-list')?.textContent).not.toContain('Map 1');
+    expect(putEditorDraft).not.toHaveBeenCalled();
+  });
+
+  it('switches the remix painter collection and leaves the document untouched', async () => {
+    const onChange = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<RemixPainter content={definition.content} doc={content} onChange={onChange} />);
+    });
+
+    const selector = container.querySelector('.editor-collection-selector select') as HTMLSelectElement;
+    expect(selector.value).toBe('maps');
+    expect(container.querySelector('.remix-painter-items')?.textContent).toContain('Map 1');
+
+    changeSelect(selector, 'routes');
+
+    expect(selector.value).toBe('routes');
+    expect(container.querySelector('.remix-painter-items')?.textContent).toContain('Route 1');
+    expect(container.querySelector('.remix-painter-items')?.textContent).not.toContain('Map 1');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the single-collection surfaces free of selector chrome', async () => {
+    const single = { maps: definition.content.maps };
+    fetchGameEditor.mockResolvedValue(
+      editorState({ definition: { version: 1, content: single }, content: { maps: [mapItem] } }),
+    );
+    await renderEditor();
+    expect(container.querySelector('.editor-collection-selector')).toBeNull();
+
+    act(() => {
+      root!.render(<RemixPainter content={single} doc={{ maps: [mapItem] }} onChange={vi.fn()} />);
+    });
+    expect(container.querySelector('.editor-collection-selector')).toBeNull();
+  });
+});

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -361,10 +361,13 @@ export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => voi
   }
 
   const problems = item && spec ? itemProblems(spec.item, item, name) : [];
-  const allProblems = spec
-    ? items.flatMap((entry, index) => {
-        const found = itemProblems(spec.item, entry, name);
-        return found.length > 0 ? [`${name(spec.itemLabel)} ${index + 1}`] : [];
+  const allProblems = editor
+    ? collectionKeys.flatMap((key) => {
+        const collection = editor.definition.content[key];
+        return itemsOf(content, key).flatMap((entry, index) => {
+          const found = itemProblems(collection.item, entry, name);
+          return found.length > 0 ? [`${name(collection.itemLabel)} ${index + 1}`] : [];
+        });
       })
     : [];
   const width = item ? (item.rows[0]?.length ?? 0) : 0;

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
-import { blankItem, itemProblems, setCell } from './editorContentTools.js';
+import { blankItem, defaultCollectionKey, itemProblems, setCell } from './editorContentTools.js';
 import { recordAssistStep, recordEditorStep } from './visitTelemetry.js';
 import {
   deleteEditorDraft,
@@ -97,13 +97,15 @@ export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => voi
   const [saveState, setSaveState] = useState<SaveState>('clean');
   const [saveProblems, setSaveProblems] = useState<string[]>([]);
   const [publish, setPublish] = useState<PublishState>({ kind: 'idle' });
+  const [selectedCollectionKey, setSelectedCollectionKey] = useState<string | null>(null);
   const [itemIndex, setItemIndex] = useState(0);
   const [tileKey, setTileKey] = useState<string | null>(null);
   const [utterance, setUtterance] = useState('');
   const [assist, setAssist] = useState<AssistState>({ kind: 'idle' });
 
-  // One collection is the pilot vocabulary's reality; the first is the surface.
-  const collectionKey = editor ? (Object.keys(editor.definition.content)[0] ?? null) : null;
+  const collectionKeys = editor ? Object.keys(editor.definition.content) : [];
+  const collectionKey =
+    editor && selectedCollectionKey && editor.definition.content[selectedCollectionKey] ? selectedCollectionKey : null;
   const spec = collectionKey ? editor!.definition.content[collectionKey] : null;
   const items = collectionKey ? ((content[collectionKey] ?? []) as EditorItemContent[]) : [];
   const item = items[itemIndex] ?? null;
@@ -122,8 +124,14 @@ export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => voi
         setContent(mergeDraft(loaded));
         setRevision(loaded.draft?.revision ?? 0);
         setSaveState('clean');
-        const firstCollection = Object.keys(loaded.definition.content)[0];
-        setTileKey(loaded.definition.content[firstCollection]?.item.tiles[0]?.key ?? null);
+        const defaultKey = defaultCollectionKey(loaded.definition.content);
+        setSelectedCollectionKey(defaultKey);
+        setItemIndex(0);
+        setTileKey(
+          defaultKey
+            ? (loaded.definition.content[defaultKey]?.item.tiles.find((tile) => tile.key.length > 0)?.key ?? null)
+            : null,
+        );
         setState('ready');
       })
       .catch(() => {
@@ -274,11 +282,26 @@ export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => voi
       setEditor(loaded);
       setContent(mergeDraft(loaded));
       setRevision(loaded.draft?.revision ?? 0);
+      const defaultKey = defaultCollectionKey(loaded.definition.content);
+      setSelectedCollectionKey(defaultKey);
       setItemIndex(0);
+      setTileKey(
+        defaultKey
+          ? (loaded.definition.content[defaultKey]?.item.tiles.find((tile) => tile.key.length > 0)?.key ?? null)
+          : null,
+      );
       setSaveState('clean');
     } catch {
       setSaveState('error');
     }
+  }
+
+  function selectCollection(nextKey: string) {
+    const nextSpec = editor?.definition.content[nextKey];
+    if (!nextSpec) return;
+    setSelectedCollectionKey(nextKey);
+    setItemIndex(0);
+    setTileKey(nextSpec.item.tiles.find((tile) => tile.key.length > 0)?.key ?? null);
   }
 
   async function discardDraft() {
@@ -602,6 +625,22 @@ export function EditorPanel(props: { game: StudioGame; onOpenPlaytest: () => voi
 
           {spec && collectionKey ? (
             <div className="editor-side-group">
+              {collectionKeys.length > 1 ? (
+                <label className="editor-collection-selector">
+                  <span>{t('studioPanel.editor.collection')}</span>
+                  <select
+                    value={collectionKey}
+                    aria-label={t('studioPanel.editor.collection')}
+                    onChange={(event) => selectCollection(event.target.value)}
+                  >
+                    {collectionKeys.map((key) => (
+                      <option key={key} value={key}>
+                        {name(editor.definition.content[key].label)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
               <h4>
                 {name(spec.label)}{' '}
                 <span className="editor-count">

--- a/apps/web/src/RemixPainter.tsx
+++ b/apps/web/src/RemixPainter.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { blankItem, itemProblems, setCell } from './editorContentTools.js';
+import { blankItem, defaultCollectionKey, itemProblems, setCell } from './editorContentTools.js';
 import type { EditorCollectionSpec, EditorContentDoc, EditorItemContent, EditorLabel } from './studioApi.js';
 
 /**
@@ -19,25 +19,50 @@ export function RemixPainter(props: {
   content: Record<string, EditorCollectionSpec>;
   doc: EditorContentDoc;
   onChange: (next: EditorContentDoc) => void;
+  selectedCollectionKey?: string | null;
+  onCollectionChange?: (key: string) => void;
 }) {
   const { t, i18n } = useTranslation();
   const name = (label: EditorLabel) => (i18n.language?.startsWith('pl') ? label.pl : label.en);
 
-  // One collection is the vocabulary's reality today; the first is the surface.
-  const collectionKey = Object.keys(props.content)[0] ?? null;
+  const collectionKeys = Object.keys(props.content);
+  const [internalCollectionKey, setInternalCollectionKey] = useState<string | null>(null);
+  const requestedCollectionKey =
+    props.selectedCollectionKey !== undefined ? props.selectedCollectionKey : internalCollectionKey;
+  const collectionKey =
+    requestedCollectionKey && props.content[requestedCollectionKey]
+      ? requestedCollectionKey
+      : defaultCollectionKey(props.content);
   const spec = collectionKey ? props.content[collectionKey] : null;
   const items = collectionKey
     ? (((props.doc[collectionKey] as EditorItemContent[] | undefined) ?? []) as EditorItemContent[])
     : [];
   const [itemIndex, setItemIndex] = useState(0);
-  const [tileKey, setTileKey] = useState<string | null>(spec?.item.tiles[0]?.key ?? null);
+  const [tileKey, setTileKey] = useState<string | null>(
+    spec?.item.tiles.find((tile) => tile.key.length > 0)?.key ?? null,
+  );
+
+  useEffect(() => {
+    setItemIndex(0);
+    setTileKey(spec?.item.tiles.find((tile) => tile.key.length > 0)?.key ?? null);
+  }, [collectionKey, spec]);
+
   const item = items[Math.min(itemIndex, Math.max(0, items.length - 1))] ?? null;
   const activeIndex = Math.min(itemIndex, Math.max(0, items.length - 1));
 
   if (!spec || !collectionKey) return null;
+  const activeCollectionKey = collectionKey;
+
+  function selectCollection(nextKey: string) {
+    if (!props.content[nextKey]) return;
+    if (props.selectedCollectionKey === undefined) setInternalCollectionKey(nextKey);
+    props.onCollectionChange?.(nextKey);
+    setItemIndex(0);
+    setTileKey(props.content[nextKey].item.tiles.find((tile) => tile.key.length > 0)?.key ?? null);
+  }
 
   function updateItems(list: EditorItemContent[]) {
-    props.onChange({ ...props.doc, [collectionKey as string]: list });
+    props.onChange({ ...props.doc, [activeCollectionKey]: list });
   }
 
   function updateItem(next: EditorItemContent) {
@@ -51,6 +76,22 @@ export function RemixPainter(props: {
 
   return (
     <div className="remix-painter">
+      {collectionKeys.length > 1 ? (
+        <label className="editor-collection-selector remix-painter-collection-selector">
+          <span>{t('studioPanel.editor.collection')}</span>
+          <select
+            value={collectionKey}
+            aria-label={t('studioPanel.editor.collection')}
+            onChange={(event) => selectCollection(event.target.value)}
+          >
+            {collectionKeys.map((key) => (
+              <option key={key} value={key}>
+                {name(props.content[key].label)}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
       <div className="remix-painter-items" role="tablist" aria-label={name(spec.label)}>
         {items.map((entry, index) => (
           <button

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -26,6 +26,7 @@ import {
   type RemixSuggestion,
 } from './remixApi.js';
 import { RemixPainter } from './RemixPainter.js';
+import { defaultCollectionKey } from './editorContentTools.js';
 import { ProposeComposer } from './ProposeComposer.js';
 import { checkContributions } from './proposalsApi.js';
 import type {
@@ -327,6 +328,7 @@ export function RemixPanel(props: {
   const [contentDoc, setContentDoc] = useState<EditorContentDoc>({});
   const contentDocRef = useRef(contentDoc);
   contentDocRef.current = contentDoc;
+  const [selectedCollectionKey, setSelectedCollectionKey] = useState<string | null>(null);
   const [painterOpen, setPainterOpen] = useState(false);
   /** After the stage has opened once, Done leaves a door back on the sheet. */
   const [painterSeen, setPainterSeen] = useState(false);
@@ -506,6 +508,7 @@ export function RemixPanel(props: {
           : {};
         contentDocRef.current = contentDefaults;
         setContentDoc(contentDefaults);
+        setSelectedCollectionKey(started.content ? defaultCollectionKey(started.content) : null);
         onCapabilities?.({ painter: Boolean(started.content) });
         // A shared link's values are live the moment the game is listening.
         if (props.initialParams) window.setTimeout(() => pushToGame(merged), 300);
@@ -530,6 +533,12 @@ export function RemixPanel(props: {
   }, []);
 
   const painterStageActive = Boolean(painterOpen && session?.content && lane !== 'building');
+  const activeCollectionKey =
+    session?.content && selectedCollectionKey && session.content[selectedCollectionKey]
+      ? selectedCollectionKey
+      : session?.content
+        ? defaultCollectionKey(session.content)
+        : null;
 
   // Latest callback in a ref — parents may pass a fresh arrow each render; the
   // stage/focus effects must not re-bind (or flash) when only the identity changes.
@@ -1298,7 +1307,7 @@ export function RemixPanel(props: {
    * moves focus; the painter tree and the game iframe both stay mounted.
    */
   if (painterStageActive && session?.content) {
-    const collectionKey = Object.keys(session.content)[0];
+    const collectionKey = activeCollectionKey;
     const items = collectionKey ? ((contentDoc[collectionKey] as EditorItemContent[] | undefined) ?? []) : [];
     const levelName =
       typeof items[0]?.properties.name === 'string' && items[0].properties.name ? items[0].properties.name : null;
@@ -1365,7 +1374,13 @@ export function RemixPanel(props: {
                 {t('remix.editorPipMap')}
               </span>
             ) : null}
-            <RemixPainter content={session.content} doc={contentDoc} onChange={paintContent} />
+            <RemixPainter
+              content={session.content}
+              doc={contentDoc}
+              onChange={paintContent}
+              selectedCollectionKey={activeCollectionKey}
+              onCollectionChange={setSelectedCollectionKey}
+            />
             {editorFocus === 'play' ? <span className="remix-editor-pip-cta">{t('remix.editorFocusEdit')}</span> : null}
           </div>
 

--- a/apps/web/src/editorContentTools.ts
+++ b/apps/web/src/editorContentTools.ts
@@ -1,5 +1,9 @@
 import type { EditorCollectionSpec, EditorItemContent, EditorLabel } from './studioApi.js';
 
+export function defaultCollectionKey(collections: Record<string, unknown>): string | null {
+  return Object.keys(collections).find((key) => key.length > 0) ?? null;
+}
+
 /**
  * The pure half of the content painter, shared by its two surfaces: the
  * Studio's EditorPanel (creator drafts) and the RemixPanel's painter (player

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -324,6 +324,7 @@
       "conflictReload": "Load newest",
       "conflictOverwrite": "Keep mine",
       "boardAria": "{{name}} tile painter",
+      "collection": "Collection",
       "tiles": "Tiles",
       "properties": "Properties",
       "checks": "Checks",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -326,6 +326,7 @@
       "conflictReload": "Wczytaj najnowszy",
       "conflictOverwrite": "Zachowaj mój",
       "boardAria": "Malowanie kafelków: {{name}}",
+      "collection": "Kolekcja",
       "tiles": "Kafelki",
       "properties": "Właściwości",
       "checks": "Kontrole",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12077,6 +12077,27 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
+.editor-collection-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.editor-collection-selector select {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: var(--panel-card);
+  color: var(--text);
+  padding: 6px 8px;
+  font: inherit;
+}
+
 .editor-count {
   font-family: ui-monospace, monospace;
   font-size: 0.68rem;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13291,6 +13291,7 @@ button.builder-mode-selector:disabled {
 
 .remix-editor-stage.is-focus-play .remix-painter-items,
 .remix-editor-stage.is-focus-play .editor-palette,
+.remix-editor-stage.is-focus-play .remix-painter-collection-selector,
 .remix-editor-stage.is-focus-play .remix-painter-checks {
   display: none;
 }


### PR DESCRIPTION
## Summary

- Added an EN/PL, keyboard-accessible collection selector to the Studio editor and Remix painter when a definition has multiple collections.
- Collection selection now switches the item list, tile palette, board, property sheet, checks, and Remix stage title together.
- Kept selection as view state only: changing collections does not mutate the content document, autosave state, or draft revision.
- Removed first-collection assumptions from `EditorPanel.tsx`, `RemixPainter.tsx`, and the Remix stage helper path.
- Single-collection games keep their existing UI with no selector chrome.
- Added two-collection fixtures covering both surfaces and the no-selector single-collection path.

## Scope

No editor contract, widget, games-repo, or API changes are included.

## Validation

Passed the full website gate:

```
npm run type-check && npm run lint && npm run test && npm run build
```

Results: 2,666 API/workspace tests, 1,146 web tests, 36 rules tests, and the production build all passed. The first sandboxed test attempt hit localhost listener permissions; the same gate passed with the repository's required localhost access.
