### PR TITLE
fix Build My Game button icon (face-like rocket → send arrow)

### DIFF
--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -563,7 +563,7 @@ export function CreatorQA({
             onClick={handleSubmit}
             disabled={submitting || !titleReady}
           >
-            <PixelIcon name="rocket" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
+            <PixelIcon name="send" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
           </button>
         ) : (
           <button

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -447,7 +447,7 @@ export function HeroPromptSection({
                 (!promptText.trim() && attachments.length === 0)
               }
             >
-              <PixelIcon name="rocket" size={16} />
+              <PixelIcon name="send" size={16} />
               {/* Three states, not two: the refiner runs for a few seconds before
                   anything is submitted, and saying "Submitting…" through it was the
                   creator's first impression of a feature that had just started

--- a/apps/web/src/PixelIcon.tsx
+++ b/apps/web/src/PixelIcon.tsx
@@ -18,6 +18,7 @@ export type PixelIconName =
   | 'close'
   | 'phone'
   | 'rocket'
+  | 'send'
   | 'mic'
   | 'image'
   | 'palette'
@@ -125,21 +126,42 @@ const ICONS: Record<PixelIconName, string[]> = {
     '...............',
     '...............',
   ],
+  // Solid body + bottom fins/exhaust. Avoid `#.#.#` "portholes" — at 16px those
+  // read as eyes and the glyph looks like a little character, not a rocket.
   rocket: [
     '.......#.......',
     '......###......',
     '......###......',
     '.....#####.....',
-    '.....#.#.#.....',
+    '.....#####.....',
     '.....#####.....',
     '.....#####.....',
     '....#######....',
-    '...##.###.##...',
     '...#..###..#...',
+    '..#...###...#..',
     '......###......',
     '.......#.......',
     '......#.#......',
     '.......#.......',
+    '...............',
+  ],
+  // Composer "send" — unambiguous up-arrow. Prefer this over `rocket` on circular
+  // submit buttons; at 16px a rocket silhouette still reads as a creature.
+  send: [
+    '.......#.......',
+    '......###......',
+    '.....#####.....',
+    '....#######....',
+    '...#########...',
+    '......###......',
+    '......###......',
+    '......###......',
+    '......###......',
+    '......###......',
+    '......###......',
+    '......###......',
+    '...............',
+    '...............',
     '...............',
   ],
   mic: [

--- a/apps/web/src/PixelIcon.tsx
+++ b/apps/web/src/PixelIcon.tsx
@@ -126,8 +126,6 @@ const ICONS: Record<PixelIconName, string[]> = {
     '...............',
     '...............',
   ],
-  // Solid body + bottom fins/exhaust. Avoid `#.#.#` "portholes" — at 16px those
-  // read as eyes and the glyph looks like a little character, not a rocket.
   rocket: [
     '.......#.......',
     '......###......',
@@ -145,8 +143,6 @@ const ICONS: Record<PixelIconName, string[]> = {
     '.......#.......',
     '...............',
   ],
-  // Composer "send" — unambiguous up-arrow. Prefer this over `rocket` on circular
-  // submit buttons; at 16px a rocket silhouette still reads as a creature.
   send: [
     '.......#.......',
     '......###......',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The circular **Build My Game** control used the pixel `rocket` glyph. At 16px its `#.#.#` porthole row read as eyes, so the button looked like a little character instead of a launch/send affordance.

### Changes
- Add a `send` up-arrow pixel icon and use it on the hero Build button and QA create submit.
- Redraw `rocket` without the eye portholes (still used on AI badges).

[Before/after Build button icon](https://cursor.com/agents/bc-3d7b89cb-ef7f-4f25-85ca-0befe18e4a3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild-btn-icon-before-after.png)

Green gate: `type-check`, `lint`, `test`, `build` all pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d7b89cb-ef7f-4f25-85ca-0befe18e4a3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d7b89cb-ef7f-4f25-85ca-0befe18e4a3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

