### PR TITLE
Collapse Studio shelf rail to folder icon with count badge

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -327,7 +327,7 @@ describe('CreatorStudioView', () => {
     authUser = null;
   });
 
-  it('collapses a long shelf to a rail after a game is selected', async () => {
+  it('collapses a long shelf to a folder+badge rail after a game is selected', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
@@ -339,6 +339,16 @@ describe('CreatorStudioView', () => {
     expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(false);
     expect(container.querySelector('.studio-shelf')).toBeTruthy();
     expect(container.querySelector('.studio-game-switcher')).toBeNull();
+
+    const summary = container.querySelector('.studio-shelf-summary');
+    expect(summary).toBeTruthy();
+    expect(summary?.querySelector('.studio-shelf-summary-badge')?.textContent).toBe('10');
+
+    await act(async () => {
+      summary!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
+    expect(container.querySelectorAll('.studio-shelf-item').length).toBe(10);
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -353,6 +353,22 @@ describe('CreatorStudioView', () => {
     root.unmount();
   });
 
+  it('badges the collapsed shelf with totalGames when the page is truncated', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockResolvedValue(studioShelf(manyGames(10), true, 63));
+
+    const { container, root } = await renderStudio();
+
+    const summary = container.querySelector('.studio-shelf-summary');
+    expect(summary?.querySelector('.studio-shelf-summary-badge')?.textContent).toBe('63');
+    expect(summary?.getAttribute('title')).toContain('10');
+    expect(summary?.getAttribute('title')).toContain('63');
+
+    root.unmount();
+  });
+
   it('locks body scroll while the phone shelf drawer is open', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -360,6 +360,7 @@ export function CreatorStudioView({
     [shelfGames, shelfFilter, shelfQuery],
   );
   const showShelfTools = shelfGames.length >= STUDIO_SHELF_TOOLS_AT;
+  const shelfSummaryCount = shelfTruncated ? totalGames : shelfGames.length;
   // The URL named a game and the shelf does not have it: a typo, a game since abandoned,
   // or somebody else's slug. Said plainly, because an unexplained shelf looks like the
   // link worked and the game vanished.
@@ -648,7 +649,6 @@ export function CreatorStudioView({
                   </button>
                 ) : null}
               </div>
-              {/* Collapsed desktop rail: one folder+count instead of tiny title-letter chips. */}
               {activeGame && showShelfTools ? (
                 <button
                   type="button"
@@ -656,11 +656,15 @@ export function CreatorStudioView({
                   onClick={() => setShelfOpen(true)}
                   aria-expanded={shelfOpen}
                   aria-label={t('studioPanel.shelf.expandShelf')}
-                  title={t('studioPanel.shelf.count', { count: shelfGames.length })}
+                  title={
+                    shelfTruncated
+                      ? t('studioPanel.shelf.countTruncated', { shown: shelfGames.length, total: totalGames })
+                      : t('studioPanel.shelf.count', { count: shelfGames.length })
+                  }
                 >
                   <PixelIcon name="folder" size={16} />
                   <span className="studio-shelf-summary-badge" aria-hidden="true">
-                    {shelfGames.length > 99 ? '99+' : shelfGames.length}
+                    {shelfSummaryCount > 99 ? '99+' : shelfSummaryCount}
                   </span>
                 </button>
               ) : null}
@@ -1030,7 +1034,6 @@ function StudioShelfList({
               aria-current={active ? 'true' : undefined}
               title={game.title}
             >
-              {/* Row avatar: first letters of the first two title words. Status colour. */}
               <span
                 className={`studio-shelf-mark${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
                 aria-hidden="true"

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -595,7 +595,7 @@ export function CreatorStudioView({
             className={[
               'studio-layout',
               activeGame ? 'is-game-open' : '',
-              // Long shelf on a desktop: collapse to a left-edge rail of dots after pick.
+              // Long shelf on a desktop: collapse to a left-edge summary after pick.
               // Phones ignore this — they always use the drawer once a game is open.
               activeGame && showShelfTools ? 'is-compact-shelf' : '',
               shelfOpen ? 'is-shelf-open' : '',
@@ -648,6 +648,22 @@ export function CreatorStudioView({
                   </button>
                 ) : null}
               </div>
+              {/* Collapsed desktop rail: one folder+count instead of tiny title-letter chips. */}
+              {activeGame && showShelfTools ? (
+                <button
+                  type="button"
+                  className="studio-shelf-summary"
+                  onClick={() => setShelfOpen(true)}
+                  aria-expanded={shelfOpen}
+                  aria-label={t('studioPanel.shelf.expandShelf')}
+                  title={t('studioPanel.shelf.count', { count: shelfGames.length })}
+                >
+                  <PixelIcon name="folder" size={16} />
+                  <span className="studio-shelf-summary-badge" aria-hidden="true">
+                    {shelfGames.length > 99 ? '99+' : shelfGames.length}
+                  </span>
+                </button>
+              ) : null}
               <button type="button" className="studio-shelf-new" onClick={() => onNavigate('/')}>
                 <PixelIcon name="sparkle" size={12} />{' '}
                 <span className="studio-shelf-new-label">{t('studioPanel.shelf.newGame')}</span>
@@ -1014,8 +1030,7 @@ function StudioShelfList({
               aria-current={active ? 'true' : undefined}
               title={game.title}
             >
-              {/* Collapsed rail shows letters, not anonymous bulbs — first letters of the
-                  first two title words. Status still rides on the mark's colour. */}
+              {/* Row avatar: first letters of the first two title words. Status colour. */}
               <span
                 className={`studio-shelf-mark${building ? ' is-live' : ''}${live ? ' is-published' : ''}`}
                 aria-hidden="true"

--- a/apps/web/src/studioShelf.ts
+++ b/apps/web/src/studioShelf.ts
@@ -107,7 +107,7 @@ export function filterStudioGames(
 }
 
 /**
- * Two-letter mark for the collapsed shelf — first letter of the first two words.
+ * Two-letter mark for shelf rows — first letter of the first two words.
  * One-word titles take the first two letters. Skips empty tokens; prefers letters/digits.
  */
 export function studioGameInitials(title: string): string {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5294,7 +5294,7 @@ a.user-name--profile:focus-visible {
   box-shadow: 0 0 16px var(--turquoise-glow);
 }
 
-/* Shelf mark: two title letters. Colour carries live/published; letters carry identity. */
+/* Shelf mark: two title letters beside each row. Colour carries live/published. */
 .studio-shelf-mark {
   flex: none;
   display: inline-flex;
@@ -10148,7 +10148,47 @@ button.builder-mode-selector:disabled {
   z-index: 1100;
 }
 
-/* 5+ games on a desktop: collapse to a left-edge rail of title marks after selection.
+/* Collapsed-rail summary (folder + count). Hidden until compact desktop rail is closed. */
+.studio-shelf-summary {
+  display: none;
+  position: relative;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.studio-shelf-summary:hover {
+  border-color: rgba(0, 228, 172, 0.45);
+  color: var(--turquoise);
+}
+
+.studio-shelf-summary-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--turquoise);
+  color: #0b221d;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  box-shadow: 0 0 0 2px var(--panel);
+}
+
+/* 5+ games on a desktop: collapse to a left-edge folder+badge after selection.
    Width matches the header mascot column, so the rail and the logo share one vertical
    band instead of a skinny strip floating left of the face. */
 @media (min-width: 801px) {
@@ -10163,7 +10203,7 @@ button.builder-mode-selector:disabled {
 
   /* Full-bleed studio content starts at x=0 while the header kept 28px — the mascot
      sat indented past the rail. Pull the header in; the wordmark still runs into the
-     main column, and the face sits over the same band as the game marks. */
+     main column, and the face sits over the same band as the summary control. */
   .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) .app-header {
     padding-left: 0;
   }
@@ -10198,7 +10238,7 @@ button.builder-mode-selector:disabled {
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-count,
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-tools,
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-new-label,
-  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-title {
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-truncated {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -10210,32 +10250,24 @@ button.builder-mode-selector:disabled {
     border: 0;
   }
 
+  /* Letter chips stay out of the tab order until the list is expanded. */
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-list,
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-empty {
+    display: none;
+  }
+
+  /* Folder+badge is the expand control; edge chevron only when the list is open. */
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-edge-toggle {
+    display: none;
+  }
+
+  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-summary {
     display: inline-flex;
-    margin-left: 0;
   }
 
   .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-new {
     justify-content: center;
     padding: 8px;
-  }
-
-  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item {
-    justify-content: center;
-    padding: 8px;
-  }
-
-  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-mark {
-    width: 36px;
-    height: 36px;
-    border-radius: 11px;
-    font-size: 0.72rem;
-  }
-
-  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item.is-active,
-  .studio-layout.is-compact-shelf:not(.is-shelf-open) .studio-shelf-item.is-active:hover {
-    /* No left inset bar in the icon rail — the active mark is enough. */
-    box-shadow: 0 0 14px rgba(0, 228, 172, 0.12);
   }
 
   .studio-layout.is-compact-shelf.is-shelf-open .studio-shelf-edge-toggle {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

On a long Studio shelf (5+ games), the desktop compact rail was a stack of two-letter title chips. Those chips are too small to read or tap reliably.

## Change

When the compact shelf is collapsed, hide the letter-chip list and show one **folder** control with a **game-count badge**. Clicking it expands the full labeled list (marks stay as row avatars there). New-game sparkle stays available on the rail.

Phone drawer behaviour is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77c8f35c-7d28-4c0f-b816-e8bf13756510?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77c8f35c-7d28-4c0f-b816-e8bf13756510&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

