### PR TITLE
Studio: distinct panel icon for Details (not shelf expand)

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -431,6 +431,8 @@ describe('CreatorStudioView', () => {
     expect(play?.classList.contains('is-play')).toBe(true);
     expect(details?.classList.contains('is-primary')).toBe(false);
     expect(details?.classList.contains('is-icon-only')).toBe(true);
+    // Details opens a side rail — panel glyph, not the shelf's expand corners.
+    expect(details?.querySelector('svg')?.getAttribute('data-icon')).toBe('panel');
     expect(container.querySelector('.studio-head-transport')).toBeNull();
     expect(container.querySelector('.studio-preview-rail')).toBeNull();
 

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -431,7 +431,7 @@ describe('CreatorStudioView', () => {
     expect(play?.classList.contains('is-play')).toBe(true);
     expect(details?.classList.contains('is-primary')).toBe(false);
     expect(details?.classList.contains('is-icon-only')).toBe(true);
-    // Details opens a side rail — panel glyph, not the shelf's expand corners.
+    // Details opens a side rail — panel glyph, not shelf expand.
     expect(details?.querySelector('svg')?.getAttribute('data-icon')).toBe('panel');
     expect(container.querySelector('.studio-head-transport')).toBeNull();
     expect(container.querySelector('.studio-preview-rail')).toBeNull();

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -780,7 +780,7 @@ export function CreatorStudioView({
                           openTab('details');
                         }}
                       >
-                        <PixelIcon name="expand" size={12} />{' '}
+                        <PixelIcon name="panel" size={12} />{' '}
                         <span className="studio-head-action-label">{t('studioPanel.tabs.details')}</span>
                       </button>
                     </div>

--- a/apps/web/src/PixelIcon.tsx
+++ b/apps/web/src/PixelIcon.tsx
@@ -654,8 +654,7 @@ const ICONS: Record<PixelIconName, string[]> = {
     '...............',
     '...............',
   ],
-  // Right-rail panel: outer frame + solid strip on the right. Used for Studio Details
-  // so it does not share the expand corners with the shelf toggle.
+  // Right-rail panel: frame + solid strip. Details head action — not shelf expand.
   panel: [
     '...............',
     '...............',

--- a/apps/web/src/PixelIcon.tsx
+++ b/apps/web/src/PixelIcon.tsx
@@ -48,6 +48,7 @@ export type PixelIconName =
   | 'mute'
   | 'expand'
   | 'collapse'
+  | 'panel'
   | 'flag'
   | 'thumbUp'
   | 'thumbDown'
@@ -653,6 +654,25 @@ const ICONS: Record<PixelIconName, string[]> = {
     '...............',
     '...............',
   ],
+  // Right-rail panel: outer frame + solid strip on the right. Used for Studio Details
+  // so it does not share the expand corners with the shelf toggle.
+  panel: [
+    '...............',
+    '...............',
+    '..###########..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..#.......###..',
+    '..###########..',
+    '...............',
+    '...............',
+    '...............',
+  ],
   flag: [
     '...............',
     '...##########..',
@@ -788,6 +808,7 @@ export function PixelIcon({ name, size = 16, className, title }: PixelIconProps)
       role={title ? 'img' : 'presentation'}
       aria-hidden={title ? undefined : true}
       aria-label={title}
+      data-icon={name}
       focusable="false"
       style={{ display: 'inline-block', verticalAlign: '-0.15em', flex: 'none' }}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the Studio game view, the collapsed left shelf toggle and the top-right Details control both used the same four-corner `expand` glyph. Two different actions looked identical.

## Change

- Add a `panel` pixel icon (window frame with a right rail strip).
- Use `panel` for the Details head action; keep `expand` / `collapse` for the shelf rail.
- Expose `data-icon` on `PixelIcon` so tests can assert the glyph.

## Test plan

- [x] `CreatorStudioView` unit tests (41) — Details asserts `data-icon="panel"`
- [x] `type-check` + `lint` (comment-prose clean)
- [ ] Visual: Studio with a long shelf collapsed — left expand corners, right panel glyph

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-616faa8e-e01e-4500-9954-8237e3acffb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-616faa8e-e01e-4500-9954-8237e3acffb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

