### PR TITLE
Show Studio that the agent joined as soon as MCP start runs

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -32,6 +32,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    - `mode=preview` while iterating; `mode=publish` to seal (TRACE + PLAYTEST required)
    - Each successful stage/patch refreshes Studio’s heartbeat (so a long staging loop is not
      mistaken for quiet / offline)
+   - **`start` also pulses Studio** (`joining_round`) — clears `agentEndedAt` on resume and
+     shows the creator the agent has joined before `get_sources` / `report_progress`. Without
+     that, Final check / “agent stopped” lingered while ChatGPT was already working.
    - Each stage may also publish a **live preview** of the buffer — see below
 4. **Prefer `end` after the last successful `submit_sources`** if you will not deliver
    more — Studio shows the gate; do not sit in a `get_gate_verdict` loop
@@ -274,12 +277,14 @@ queued.
 | Area                         | Path                                                                                                                                                                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | MCP tools                    | `apps/api/src/mcp-server.ts`                                                                                                                                              |
+| Presence pulses              | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
 | Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |
 | Channel (`POST …/end`, …)    | `apps/api/src/agent-channel.ts`                                                                                                                                           |
 | Stall / `ended`              | `apps/api/src/job-state.ts` (`detectStall`)                                                                                                                               |
 | Handoff gate                 | `apps/api/src/builder.ts` (`allowsSelfToPlatformHandoff`)                                                                                                                 |
 | Live staged preview          | `apps/api/src/staged-preview.ts`                                                                                                                                          |
 | Studio live-preview frame    | `apps/web/src/StudioLivePreview.tsx`                                                                                                                                      |
+| Studio status poll cadence   | `apps/web/src/studioStatusPoll.ts` (tight poll on `ended` / `quiet` / `no_agent_yet` / `dispatched`)                                                                      |
 | Feedback / resume            | `apps/api/src/submissions.ts`                                                                                                                                             |
 | Studio copy / builder choice | `apps/web/src/selfBuildCopy.ts`, `BuilderModeBadge.tsx`, `SubmissionStatusView.tsx` (sticky badge + Change modal at round boundaries; full two-up stays in create wizard) |
 

--- a/apps/api/src/mcp-presence.test.ts
+++ b/apps/api/src/mcp-presence.test.ts
@@ -47,23 +47,35 @@ describe('mcp presence pulses', () => {
     expect(isMcpPresenceEventText('Browsing the Creator Kit…')).toBe(true);
     expect(isMcpPresenceEventText('Reading Creator Kit files…')).toBe(true);
     expect(isMcpPresenceEventText('Checking staged sources…')).toBe(true);
+    expect(isMcpPresenceEventText('Joining the build round…')).toBe(true);
     expect(isMcpPresenceEventText('Getting the squad moving.')).toBe(false);
   });
 
-  it('rate-limits pulses per job', () => {
+  it('rate-limits same-key pulses per job but allows a new thought key immediately', () => {
     const t0 = 1_000_000;
     expect(shouldEmitMcpPresencePulse(undefined, t0)).toBe(true);
-    expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS - 1)).toBe(false);
-    expect(shouldEmitMcpPresencePulse(t0, t0 + MCP_PRESENCE_MIN_GAP_MS)).toBe(true);
+    expect(shouldEmitMcpPresencePulse({ atMs: t0, key: 'browsing_kit' }, t0 + MCP_PRESENCE_MIN_GAP_MS - 1)).toBe(false);
+    expect(
+      shouldEmitMcpPresencePulse(
+        { atMs: t0, key: 'browsing_kit' },
+        t0 + MCP_PRESENCE_MIN_GAP_MS - 1,
+        MCP_PRESENCE_MIN_GAP_MS,
+        'browsing_kit',
+      ),
+    ).toBe(false);
+    expect(
+      shouldEmitMcpPresencePulse({ atMs: t0, key: 'joining_round' }, t0 + 1, MCP_PRESENCE_MIN_GAP_MS, 'reading_brief'),
+    ).toBe(true);
+    expect(shouldEmitMcpPresencePulse({ atMs: t0, key: 'browsing_kit' }, t0 + MCP_PRESENCE_MIN_GAP_MS)).toBe(true);
   });
 
   it('caps the per-job pulse map by dropping the oldest entries', () => {
-    const pulses = new Map<number, number>();
-    noteMcpPresencePulse(pulses, 1, 100, 2);
-    noteMcpPresencePulse(pulses, 2, 200, 2);
-    noteMcpPresencePulse(pulses, 3, 300, 2);
+    const pulses = new Map<number, { atMs: number; key: string }>();
+    noteMcpPresencePulse(pulses, 1, 100, 'a', 2);
+    noteMcpPresencePulse(pulses, 2, 200, 'b', 2);
+    noteMcpPresencePulse(pulses, 3, 300, 'c', 2);
     expect([...pulses.keys()]).toEqual([2, 3]);
-    noteMcpPresencePulse(pulses, 2, 400, 2);
+    noteMcpPresencePulse(pulses, 2, 400, 'b', 2);
     expect([...pulses.keys()]).toEqual([3, 2]);
   });
 });

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -29,7 +29,7 @@ const NO_PULSE = new Set([
   'patch_source_file',
   'clear_staged_sources',
   'ack_inbox',
-  // Creator card polls — not agent work; must not hold off quiet / handoff.
+  // Creator card polls — not agent work; skip.
   'get_round_status',
   'get_round_media',
 ]);

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -11,7 +11,13 @@
 /** Minimum gap between synthetic presence heartbeats for one job. */
 export const MCP_PRESENCE_MIN_GAP_MS = 60_000;
 
-/** Tools that already write real progress / open rounds — never synthesize for these. */
+/**
+ * Tools that already write real progress / open rounds — never synthesize for these.
+ *
+ * `start` is handled separately in the MCP dispatcher: creator-key / OAuth openers have
+ * no round Bearer to resolve a job id from, and a resume after `agentEndedAt` must clear
+ * ended even when a recent gate-poll pulse would rate-limit a normal tool.
+ */
 const NO_PULSE = new Set([
   'start',
   'create_game',
@@ -35,7 +41,16 @@ const NO_PULSE = new Set([
  * Closed vocabulary for Studio thought headlines. Client translates via
  * `statusView.presence.<key>`; English `text` matches historical chat rows so
  * leftover durable steps can still be filtered from the transcript.
+ *
+ * `joining_round` is emitted from MCP `start` (not listed here — start stays in
+ * {@link NO_PULSE} so the generic pulse path does not try to resolve a job id from a
+ * creator-key Bearer).
  */
+export const JOINING_ROUND_PRESENCE = {
+  key: 'joining_round',
+  text: 'Joining the build round…',
+} as const;
+
 const PRESENCE_BY_TOOL: Record<string, { key: string; text: string }> = {
   get_brief: { key: 'reading_brief', text: 'Reading the build brief…' },
   get_seed: { key: 'loading_seed', text: 'Loading the seed draft…' },
@@ -65,7 +80,10 @@ export function presencePreservesEnded(toolName: string): boolean {
   return PRESENCE_PRESERVE_ENDED.has(toolName);
 }
 
-const PRESENCE_EVENT_TEXTS = new Set(Object.values(PRESENCE_BY_TOOL).map((entry) => entry.text));
+const PRESENCE_EVENT_TEXTS = new Set([
+  ...Object.values(PRESENCE_BY_TOOL).map((entry) => entry.text),
+  JOINING_ROUND_PRESENCE.text,
+]);
 
 export function shouldPulseMcpPresence(toolName: string): boolean {
   if (NO_PULSE.has(toolName)) return false;
@@ -91,18 +109,21 @@ export function isMcpPresenceEventText(text: string): boolean {
 /** Cap for the in-process last-pulse map — oldest entries drop first (insertion order). */
 export const MAX_PRESENCE_PULSE_JOBS = 2_000;
 
+export type McpPresencePulse = { atMs: number; key: string };
+
 /**
- * Record a pulse timestamp with a simple LRU cap so long-lived instances cannot grow
- * the map without bound. Pure aside from mutating `pulses`.
+ * Record a pulse timestamp + thought key with a simple LRU cap so long-lived instances
+ * cannot grow the map without bound. Pure aside from mutating `pulses`.
  */
 export function noteMcpPresencePulse(
-  pulses: Map<number, number>,
+  pulses: Map<number, McpPresencePulse>,
   jobId: number,
   atMs: number,
+  key: string,
   maxJobs: number = MAX_PRESENCE_PULSE_JOBS,
 ): void {
   pulses.delete(jobId);
-  pulses.set(jobId, atMs);
+  pulses.set(jobId, { atMs, key });
   while (pulses.size > maxJobs) {
     const oldest = pulses.keys().next().value;
     if (oldest === undefined) break;
@@ -111,14 +132,21 @@ export function noteMcpPresencePulse(
 }
 
 /**
- * Whether enough time has passed since the last pulse for this job.
+ * Whether this job may emit another presence pulse.
+ *
+ * Same thought key is rate-limited (kit-browse spam). A *different* key always
+ * updates — creators should see Joining → Reading brief without waiting a minute.
  * Pure so tests can drive the clock; callers own the last-pulse map.
  */
 export function shouldEmitMcpPresencePulse(
-  lastPulseAtMs: number | undefined,
+  last: McpPresencePulse | number | undefined,
   nowMs: number,
   minGapMs: number = MCP_PRESENCE_MIN_GAP_MS,
+  nextKey?: string,
 ): boolean {
-  if (lastPulseAtMs === undefined) return true;
-  return nowMs - lastPulseAtMs >= minGapMs;
+  if (last === undefined) return true;
+  const lastAt = typeof last === 'number' ? last : last.atMs;
+  const lastKey = typeof last === 'number' ? undefined : last.key;
+  if (nextKey && lastKey && nextKey !== lastKey) return true;
+  return nowMs - lastAt >= minGapMs;
 }

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -1,22 +1,20 @@
 /**
  * Coarse Studio presence pulses from MCP tool activity.
  *
- * ChatGPT Apps (and similar) often browse the kit for many turns with few
- * `report_progress` writes. Studio then looks idle even though the agent is busy.
- * Pulses refresh `lastAgentSignalAt` (stall / heartbeat) and a short-lived
- * `lastAgentPresence` thought key for the thread bar — they must NOT append durable
- * build-event chat rows. Rate-limited so a read-heavy loop cannot hammer Firestore.
+ * Kit-browse loops rarely call `report_progress`, so Studio looked idle while the
+ * agent was busy. Pulses refresh `lastAgentSignalAt` and a short-lived
+ * `lastAgentPresence` key — never durable chat rows. Same-key pulses are
+ * rate-limited so a read-heavy loop cannot hammer Firestore.
  */
 
-/** Minimum gap between synthetic presence heartbeats for one job. */
+/** Minimum gap between same-key synthetic presence heartbeats for one job. */
 export const MCP_PRESENCE_MIN_GAP_MS = 60_000;
 
 /**
- * Tools that already write real progress / open rounds — never synthesize for these.
+ * Tools that already write real progress / open rounds — never synthesize.
  *
- * `start` is handled separately in the MCP dispatcher: creator-key / OAuth openers have
- * no round Bearer to resolve a job id from, and a resume after `agentEndedAt` must clear
- * ended even when a recent gate-poll pulse would rate-limit a normal tool.
+ * `start` pulses in the MCP dispatcher (creator-key openers have no round Bearer;
+ * resume must clear `agentEndedAt` even after a recent gate-poll pulse).
  */
 const NO_PULSE = new Set([
   'start',
@@ -26,25 +24,21 @@ const NO_PULSE = new Set([
   'report_progress',
   'send_screenshot',
   'submit_sources',
-  // Channel PUT …/sources/stage (and POST …/stage/patch) refresh lastAgentSignalAt (+ staging_sources presence).
+  // Channel stage/patch already refresh lastAgentSignalAt (+ staging_sources).
   'stage_source_file',
   'patch_source_file',
   'clear_staged_sources',
   'ack_inbox',
-  // The round view polls this while a creator watches. A human with a chat window open
-  // is not an agent working: pulsing here would refresh the heartbeat, hold off the
-  // quiet stall, and keep self→platform handoff locked for as long as the tab is open.
+  // Creator card polls — not agent work; must not hold off quiet / handoff.
   'get_round_status',
   'get_round_media',
 ]);
+
 /**
- * Closed vocabulary for Studio thought headlines. Client translates via
- * `statusView.presence.<key>`; English `text` matches historical chat rows so
- * leftover durable steps can still be filtered from the transcript.
+ * Closed vocabulary for Studio thought headlines (`statusView.presence.<key>`).
+ * English `text` matches historic chat rows filtered from the transcript.
  *
- * `joining_round` is emitted from MCP `start` (not listed here — start stays in
- * {@link NO_PULSE} so the generic pulse path does not try to resolve a job id from a
- * creator-key Bearer).
+ * `joining_round` comes from MCP `start` (see dispatcher), not this map.
  */
 export const JOINING_ROUND_PRESENCE = {
   key: 'joining_round',
@@ -70,9 +64,8 @@ const PRESENCE_BY_TOOL: Record<string, { key: string; text: string }> = {
 };
 
 /**
- * Gate-poll presence must refresh the heartbeat without clearing `agentEndedAt`.
- * Submit auto-ends for handoff; agents are told to poll next — clearing ended on
- * those pulses would relock self→platform until quiet timeout.
+ * Gate-poll presence refreshes the heartbeat without clearing `agentEndedAt`.
+ * Submit auto-ends for handoff; clearing ended on those pulses would relock it.
  */
 export const PRESENCE_PRESERVE_ENDED = new Set(['get_gate_verdict', 'get_gate_media']);
 
@@ -101,20 +94,17 @@ export function mcpPresenceText(toolName: string): string | null {
   return Object.hasOwn(PRESENCE_BY_TOOL, toolName) ? PRESENCE_BY_TOOL[toolName]!.text : null;
 }
 
-/** True when a durable step text is a leftover synthetic presence row (filter from chat). */
+/** True when a durable step text is a leftover synthetic presence row. */
 export function isMcpPresenceEventText(text: string): boolean {
   return PRESENCE_EVENT_TEXTS.has(text);
 }
 
-/** Cap for the in-process last-pulse map — oldest entries drop first (insertion order). */
+/** Cap for the in-process last-pulse map — oldest entries drop first. */
 export const MAX_PRESENCE_PULSE_JOBS = 2_000;
 
 export type McpPresencePulse = { atMs: number; key: string };
 
-/**
- * Record a pulse timestamp + thought key with a simple LRU cap so long-lived instances
- * cannot grow the map without bound. Pure aside from mutating `pulses`.
- */
+/** Record pulse at+key with LRU cap. Pure aside from mutating `pulses`. */
 export function noteMcpPresencePulse(
   pulses: Map<number, McpPresencePulse>,
   jobId: number,
@@ -133,10 +123,7 @@ export function noteMcpPresencePulse(
 
 /**
  * Whether this job may emit another presence pulse.
- *
- * Same thought key is rate-limited (kit-browse spam). A *different* key always
- * updates — creators should see Joining → Reading brief without waiting a minute.
- * Pure so tests can drive the clock; callers own the last-pulse map.
+ * Same key is rate-limited; a different key always updates (Joining → brief).
  */
 export function shouldEmitMcpPresencePulse(
   last: McpPresencePulse | number | undefined,

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -480,7 +480,7 @@ describe('POST /api/mcp (BY-05)', () => {
     const store = new InMemoryStore();
     await seedActiveSelfJob(store);
     await store.markAgentEnded(ISSUE, '2026-08-07T08:00:00.000Z');
-    // Prior gate-poll presence must not block a resume pulse (rate-limit bypass when ended).
+    // Gate-poll presence must not block resume (ended bypasses same-key gap).
     await store.touchLastAgentSignalAt(
       ISSUE,
       '2026-08-07T08:00:30.000Z',
@@ -498,7 +498,6 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(record?.agentEndedAt).toBeUndefined();
     expect(record?.lastAgentPresence).toMatchObject({ key: 'joining_round' });
     expect(record?.lastAgentSignalAt).toBeTruthy();
-    // Still not a chat row.
     expect((await store.listBuildEvents(ISSUE)).some((e) => e.text.includes('Joining'))).toBe(false);
   });
 

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -476,6 +476,32 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(before);
   });
 
+  it('start pulses joining_round presence and clears agentEndedAt on resume', async () => {
+    const store = new InMemoryStore();
+    await seedActiveSelfJob(store);
+    await store.markAgentEnded(ISSUE, '2026-08-07T08:00:00.000Z');
+    // Prior gate-poll presence must not block a resume pulse (rate-limit bypass when ended).
+    await store.touchLastAgentSignalAt(
+      ISSUE,
+      '2026-08-07T08:00:30.000Z',
+      { key: 'waiting_checks' },
+      { preserveEnded: true },
+    );
+    expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
+
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+
+    const record = await store.getSubmission(ISSUE);
+    expect(record?.agentEndedAt).toBeUndefined();
+    expect(record?.lastAgentPresence).toMatchObject({ key: 'joining_round' });
+    expect(record?.lastAgentSignalAt).toBeTruthy();
+    // Still not a chat row.
+    expect((await store.listBuildEvents(ISSUE)).some((e) => e.text.includes('Joining'))).toBe(false);
+  });
+
   it('start returns the session workflow in both structuredContent and the text body', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -4729,10 +4729,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'mcp session started',
             );
           }
-          // Studio used to stay on Final check / ended until get_sources (or similar):
-          // start never pulsed, and creator-key openers have no round Bearer for the
-          // generic presence path. Pulse here so the creator sees the agent join as
-          // soon as the session binds — especially on resume after submit/end.
+          // Pulse joining_round on start (jobId from result; clears agentEndedAt on resume).
           if (store && typeof started.jobId === 'number') {
             const jobId = started.jobId;
             const at = now();

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -21,11 +21,13 @@ import {
 } from './agent-game-key.js';
 import { creatorOwnsSlug, findActiveRoundForSlug, findDraftJobForSlug } from './agent-game-key-resolve.js';
 import {
+  JOINING_ROUND_PRESENCE,
   mcpPresenceKey,
   noteMcpPresencePulse,
   presencePreservesEnded,
   shouldEmitMcpPresencePulse,
   shouldPulseMcpPresence,
+  type McpPresencePulse,
 } from './mcp-presence.js';
 import {
   classifyAgentTokenAccess,
@@ -729,7 +731,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
   const terminatedTransportSessions = new Map<string, number>();
   const invalidStartsByIp = new Map<string, number[]>();
   /** Last synthetic Studio presence pulse per job — coarse MCP activity, not 1:1 tools. */
-  const presencePulseByJob = new Map<number, number>();
+  const presencePulseByJob = new Map<number, McpPresencePulse>();
   const nudgeTracker = createMcpNudgeTracker();
 
   function pruneTransportSessions(currentTime: number): void {
@@ -4727,6 +4729,30 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'mcp session started',
             );
           }
+          // Studio used to stay on Final check / ended until get_sources (or similar):
+          // start never pulsed, and creator-key openers have no round Bearer for the
+          // generic presence path. Pulse here so the creator sees the agent join as
+          // soon as the session binds — especially on resume after submit/end.
+          if (store && typeof started.jobId === 'number') {
+            const jobId = started.jobId;
+            const at = now();
+            const presenceKey = JOINING_ROUND_PRESENCE.key;
+            try {
+              const record = await store.getSubmission(jobId);
+              const needsSignal = !record?.lastAgentSignalAt || Boolean(record.agentEndedAt);
+              if (
+                needsSignal ||
+                shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at, undefined, presenceKey)
+              ) {
+                noteMcpPresencePulse(presencePulseByJob, jobId, at, presenceKey);
+                await store.touchLastAgentSignalAt(jobId, new Date(at).toISOString(), {
+                  key: presenceKey,
+                });
+              }
+            } catch (pulseError) {
+              request.log.warn({ err: pulseError, jobId, tool: name }, 'mcp start presence pulse failed');
+            }
+          }
         } else if (store && agentTokenSecret && shouldPulseMcpPresence(name)) {
           // Heartbeat + short-lived thought key — never a durable chat row. Kit-browse
           // loops used to spam "Czytanie plików Creator Kit…" between real report_progress.
@@ -4734,8 +4760,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           const presenceKey = mcpPresenceKey(name);
           if (jobId !== null && presenceKey) {
             const at = now();
-            if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at)) {
-              noteMcpPresencePulse(presencePulseByJob, jobId, at);
+            if (shouldEmitMcpPresencePulse(presencePulseByJob.get(jobId), at, undefined, presenceKey)) {
+              noteMcpPresencePulse(presencePulseByJob, jobId, at, presenceKey);
               try {
                 await store.touchLastAgentSignalAt(
                   jobId,

--- a/apps/api/src/mcp-ui.ts
+++ b/apps/api/src/mcp-ui.ts
@@ -935,6 +935,7 @@ const ROUND_STATUS_HTML = `<!doctype html>
 
         /** Closed presence keys — same vocabulary as mcp-presence.ts. */
         var PRESENCE_COPY = {
+          joining_round: 'Joining the build round…',
           reading_brief: 'Reading the build brief…',
           loading_seed: 'Loading the seed draft…',
           fetching_kit: 'Fetching Creator Kit metadata…',

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -63,6 +63,14 @@ describe('pollDelayMs', () => {
   it('polls gently once gate-green is waiting on a human', () => {
     expect(pollDelayMs('in_review')).toBeGreaterThan(ACTIVE_POLL_MS);
   });
+
+  it('polls tightly while a self agent is ended or quiet so resume shows quickly', () => {
+    // Final check / post-submit with agentEndedAt used idle 10s polling; ChatGPT had
+    // already called start before Studio left "agent stopped".
+    expect(pollDelayMs('in_review', 'ended')).toBe(ACTIVE_POLL_MS);
+    expect(pollDelayMs('building', 'quiet')).toBe(ACTIVE_POLL_MS);
+    expect(pollDelayMs('queued', 'no_agent_yet')).toBe(ACTIVE_POLL_MS);
+  });
 });
 
 describe('SubmissionStatusView', () => {

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -65,8 +65,7 @@ describe('pollDelayMs', () => {
   });
 
   it('polls tightly while a self agent is ended or quiet so resume shows quickly', () => {
-    // Final check / post-submit with agentEndedAt used idle 10s polling; ChatGPT had
-    // already called start before Studio left "agent stopped".
+    // Ended/quiet used idle 10s; start already ran before Studio left "stopped".
     expect(pollDelayMs('in_review', 'ended')).toBe(ACTIVE_POLL_MS);
     expect(pollDelayMs('building', 'quiet')).toBe(ACTIVE_POLL_MS);
     expect(pollDelayMs('queued', 'no_agent_yet')).toBe(ACTIVE_POLL_MS);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -702,6 +702,7 @@
     },
     "updatedAgo": "updated {{time}}",
     "presence": {
+      "joining_round": "Joining the build round…",
       "reading_brief": "Reading the build brief…",
       "loading_seed": "Loading the seed draft…",
       "fetching_kit": "Fetching Creator Kit metadata…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -706,6 +706,7 @@
     },
     "updatedAgo": "aktualizacja {{time}}",
     "presence": {
+      "joining_round": "Dołączanie do rundy…",
       "reading_brief": "Czytanie briefu…",
       "loading_seed": "Ładowanie szkicu startowego…",
       "fetching_kit": "Pobieranie metadanych Creator Kit…",

--- a/apps/web/src/studioStatusPoll.ts
+++ b/apps/web/src/studioStatusPoll.ts
@@ -28,6 +28,9 @@ export function pollDelayMs(
   if (status === 'needs_changes') return IDLE_POLL_MS;
   // Flip the connect card to live progress as soon as the agent signals.
   if (stall === 'no_agent_yet') return ACTIVE_POLL_MS;
+  // Self agent resumed or about to: idle 10s polling left Studio on Final check /
+  // "agent stopped" for a long beat after MCP `start` while ChatGPT was already working.
+  if (stall === 'ended' || stall === 'quiet') return ACTIVE_POLL_MS;
   // Copilot session boot: job is `dispatched` (public status still `queued`) until
   // GitHub reports `in_progress`. Poll tightly on that real phase — not a timer guess.
   if (phase === 'dispatched') return ACTIVE_POLL_MS;

--- a/apps/web/src/studioStatusPoll.ts
+++ b/apps/web/src/studioStatusPoll.ts
@@ -7,11 +7,11 @@ import type { SubmissionStatus } from './submissionApi.js';
  * (react-refresh) while tests can still assert the real intervals.
  */
 
-// `in_review` is out on purpose: gate-green waits on a human, not the agent.
+// `in_review` omitted: gate-green waits on a human, not the agent.
 // Tight polling + foot spinner made "Final check" look eternally in progress.
 const ACTIVE_BUILD_STATUSES = new Set<SubmissionStatus['status']>(['building']);
 
-/** Exported so tests advance timers by the real cadence instead of a magic number. */
+/** Exported so tests advance timers by the real cadence. */
 export const ACTIVE_POLL_MS = 3000;
 const IDLE_POLL_MS = 10000;
 
@@ -28,8 +28,7 @@ export function pollDelayMs(
   if (status === 'needs_changes') return IDLE_POLL_MS;
   // Flip the connect card to live progress as soon as the agent signals.
   if (stall === 'no_agent_yet') return ACTIVE_POLL_MS;
-  // Self agent resumed or about to: idle 10s polling left Studio on Final check /
-  // "agent stopped" for a long beat after MCP `start` while ChatGPT was already working.
+  // Resume after end/quiet: pick up MCP start in ~3s, not 10s.
   if (stall === 'ended' || stall === 'quiet') return ACTIVE_POLL_MS;
   // Copilot session boot: job is `dispatched` (public status still `queued`) until
   // GitHub reports `in_progress`. Poll tightly on that real phase — not a timer guess.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When ChatGPT resumed work on a self-build round (e.g. after Final check), Studio could sit on the previous “Final check / agent stopped” state for a long beat even though the agent had already called MCP `start` and was listing/planning. Presence only appeared later (e.g. “Loading existing game sources…” on `get_sources`).

## Fix

- Pulse `joining_round` on successful MCP `start`, using the returned `jobId` (creator-key / OAuth openers have no round Bearer for the generic presence path). Always pulse on first signal or when clearing `agentEndedAt` resume; otherwise rate-limit spammy re-starts.
- Allow a **new** presence thought key immediately (Joining → Reading brief) while still rate-limiting same-key kit-browse spam.
- Poll Studio status tightly while stall is `ended` or `quiet` (same 3s cadence as `no_agent_yet` / `dispatched`) so resume shows within a few seconds.

## Test plan

- [x] Unit: start clears `agentEndedAt` and sets `joining_round`
- [x] Unit: presence key-change vs same-key rate limit
- [x] Unit: `pollDelayMs` for `ended` / `quiet`
- [x] Green gate: type-check, lint, test, build

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dac5c769-7acf-4106-88d3-81f0bd6683d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dac5c769-7acf-4106-88d3-81f0bd6683d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

