### PR TITLE
Review desk: Try play opens full-screen theater

### DIFF
--- a/apps/web/src/GameTheater.test.tsx
+++ b/apps/web/src/GameTheater.test.tsx
@@ -653,6 +653,24 @@ describe('GameTheater how-to-play visit telemetry', () => {
     expect(container.querySelector('.remix-btn')).toBeNull();
   });
 
+  it('hides remix chrome and telemetry when remixable is false', async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <GameTheater
+          title="Review play"
+          badge={{ icon: 'star', label: 'Try play' }}
+          source={{ slug: 'sky-dodge' }}
+          onExit={() => {}}
+          remixable={false}
+        />,
+      );
+    });
+    session.flush();
+    expect(batches.flatMap((batch) => batch.events).filter((event) => event.type === 'remix_step')).toEqual([]);
+    expect(container.querySelector('.remix-btn')).toBeNull();
+  });
+
   it('does not record how_to_play_opened for a draft theater', async () => {
     // Draft / generated theaters share the card UI but must not enter the open-rate
     // numerator against a denominator that only counts published plays.

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -95,6 +95,8 @@ type GameTheaterProps = {
   initialRemixOpen?: boolean;
   /** A request written before theater entry; RemixPanel starts it once safely ready. */
   initialRemixRequest?: string;
+  trackPlay?: boolean;
+  remixable?: boolean;
 };
 
 // Long enough that the bar never reacts like a hover tooltip, short enough to clear
@@ -146,6 +148,8 @@ export function GameTheater({
   touch = null,
   initialRemixOpen = false,
   initialRemixRequest,
+  trackPlay = true,
+  remixable = true,
 }: GameTheaterProps) {
   const { t } = useTranslation();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
@@ -760,7 +764,8 @@ export function GameTheater({
             title={title}
             frameRef={frameRef}
             embed
-            remixable
+            remixable={remixable}
+            trackPlay={trackPlay}
             remixOpenNonce={remixOpenNonce}
             initialRemixRequest={initialRemixRequest}
             painterNonce={painterNonce}

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -502,7 +502,7 @@ export function GameTheater({
    * again) should be made against a number.
    */
   const remixControl = (className: string, control: 'bar' | 'more') =>
-    'slug' in source ? (
+    remixable && 'slug' in source ? (
       <button
         type="button"
         className={className}
@@ -525,9 +525,9 @@ export function GameTheater({
   // `opened` is read against. Fires on render, since being shown is the most the
   // client can honestly claim to know.
   useEffect(() => {
-    if (!('slug' in source)) return;
+    if (!remixable || !('slug' in source)) return;
     recordRemixStep('offered');
-  }, [source]);
+  }, [remixable, source]);
 
   // The one thing a player needs before the first key press, and the game's own copy of
   // it is hidden inside the frame by HIDE_CHROME. Reuses `theater-menu-item` in the
@@ -702,7 +702,7 @@ export function GameTheater({
                   {micControl('theater-menu-item mic-menu')}
                   {soundControl('theater-menu-item theater-mobile-chrome')}
                   {fullscreenControl('theater-menu-item theater-mobile-chrome')}
-                  {'slug' in source ? (
+                  {remixable && 'slug' in source ? (
                     <>
                       {remixControl('theater-menu-item theater-mobile-chrome', 'more')}
                       {remixHasPainter ? (

--- a/apps/web/src/ReviewDesk.test.tsx
+++ b/apps/web/src/ReviewDesk.test.tsx
@@ -46,7 +46,7 @@ beforeEach(async () => {
         slug: 'sky-dodge',
         title: 'Sky Dodge',
         source: 'catalog',
-        creatorHandle: null,
+        creatorHandle: 'sky-pilot',
         genre: 'arcade',
         issueNumber: null,
         media: {
@@ -184,6 +184,7 @@ describe('ReviewDesk', () => {
   });
 
   it('opens the full-viewport theater when Try play is pressed', async () => {
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
     root = createRoot(container);
     await act(async () => {
       root!.render(<ReviewDesk />);
@@ -205,6 +206,10 @@ describe('ReviewDesk', () => {
     expect(theater?.getAttribute('role')).toBe('dialog');
     expect(container.querySelector('[data-testid="frame"]')?.textContent).toContain('sky-dodge');
     expect(container.querySelector('video.review-preview-video')).toBeTruthy();
+    expect(pauseSpy).toHaveBeenCalled();
+    expect(theater?.querySelector('a.theater-author-link')?.getAttribute('href')).toBe('/sky-pilot');
+    expect(theater?.textContent).toMatch(/sky-pilot/);
+    expect(theater?.querySelector('.remix-btn')).toBeNull();
     expect(document.body.classList.contains('player-open')).toBe(true);
 
     const exitBtn = theater!.querySelector('button.exit-btn') as HTMLButtonElement | null;
@@ -216,6 +221,7 @@ describe('ReviewDesk', () => {
 
     expect(container.querySelector('.stage.is-playing-full-viewport')).toBeNull();
     expect(document.body.classList.contains('player-open')).toBe(false);
+    pauseSpy.mockRestore();
   });
 
   it('sends cut when the Cut control is pressed', async () => {

--- a/apps/web/src/ReviewDesk.test.tsx
+++ b/apps/web/src/ReviewDesk.test.tsx
@@ -183,7 +183,7 @@ describe('ReviewDesk', () => {
     expect(container.textContent).toContain('Neon Courier');
   });
 
-  it('mounts the live frame when Try play is pressed', async () => {
+  it('opens the full-viewport theater when Try play is pressed', async () => {
     root = createRoot(container);
     await act(async () => {
       root!.render(<ReviewDesk />);
@@ -194,18 +194,28 @@ describe('ReviewDesk', () => {
       button.textContent?.includes('Try play'),
     );
     expect(tryPlay).toBeTruthy();
-    // Overlay on the stage — sticky checklist must not bury Try play.
     expect(tryPlay!.className).toContain('is-overlay');
-    expect(container.querySelector('.review-stage-tools')).toBeNull();
     await act(async () => {
       tryPlay!.click();
     });
     await flush();
 
+    const theater = container.querySelector('.stage.is-playing-full-viewport');
+    expect(theater).toBeTruthy();
+    expect(theater?.getAttribute('role')).toBe('dialog');
     expect(container.querySelector('[data-testid="frame"]')?.textContent).toContain('sky-dodge');
-    expect(container.querySelector('video.review-preview-video')).toBeNull();
-    expect(container.textContent).toMatch(/Show preview/);
-    expect(container.querySelector('button.review-play-btn.is-overlay.is-active')).toBeTruthy();
+    expect(container.querySelector('video.review-preview-video')).toBeTruthy();
+    expect(document.body.classList.contains('player-open')).toBe(true);
+
+    const exitBtn = theater!.querySelector('button.exit-btn') as HTMLButtonElement | null;
+    expect(exitBtn).toBeTruthy();
+    await act(async () => {
+      exitBtn!.click();
+    });
+    await flush();
+
+    expect(container.querySelector('.stage.is-playing-full-viewport')).toBeNull();
+    expect(document.body.classList.contains('player-open')).toBe(false);
   });
 
   it('sends cut when the Cut control is pressed', async () => {

--- a/apps/web/src/ReviewDesk.tsx
+++ b/apps/web/src/ReviewDesk.tsx
@@ -185,9 +185,12 @@ export function ReviewDesk() {
   }, [playing]);
 
   useEffect(() => {
-    if (!videoUrl || playing) return;
     const video = videoRef.current;
     if (!video) return;
+    if (playing || !videoUrl) {
+      video.pause();
+      return;
+    }
     void Promise.resolve(video.play()).then(
       () => undefined,
       () => undefined,
@@ -618,6 +621,8 @@ export function ReviewDesk() {
           onExit={() => setPlaying(false)}
           trackPlay={false}
           remixable={false}
+          submittedBy={current.creatorHandle}
+          creatorHandle={current.creatorHandle}
         />
       ) : null}
     </section>

--- a/apps/web/src/ReviewDesk.tsx
+++ b/apps/web/src/ReviewDesk.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } f
 import { useTranslation } from 'react-i18next';
 import { useAuth } from './AuthContext.js';
 import { catalogMediaUrl } from './catalog.js';
-import { PublishedGameFrame } from './PublishedGameFrame.js';
+import { GameTheater } from './GameTheater.js';
 import {
   ASSESSMENT_CHECKLIST_KEYS,
   ASSESSMENT_CHECKLIST_MARKS,
@@ -166,7 +166,7 @@ export function ReviewDesk() {
     };
   }, []);
 
-  // Open play mode when preview media is missing.
+  // Open theater when preview media is missing.
   useEffect(() => {
     if (!current) return;
     setPlaying(!hasPreviewMedia(current));
@@ -177,6 +177,12 @@ export function ReviewDesk() {
     dragYRef.current = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- slug only
   }, [current?.slug]);
+
+  useEffect(() => {
+    if (!playing) return;
+    document.body.classList.add('player-open');
+    return () => document.body.classList.remove('player-open');
+  }, [playing]);
 
   useEffect(() => {
     if (!videoUrl || playing) return;
@@ -385,7 +391,7 @@ export function ReviewDesk() {
   const keepHint = dragX > 40;
   const cutHint = dragX < -40;
   const skipHint = dragY > 40 && Math.abs(dragY) > Math.abs(dragX);
-  const showMedia = Boolean(current && !playing && hasPreviewMedia(current));
+  const showMedia = Boolean(current && hasPreviewMedia(current));
 
   return (
     <section className="review-desk">
@@ -422,13 +428,9 @@ export function ReviewDesk() {
           <div className="review-scroll">
             <div
               className={`review-card${flash ? ` is-${flash}` : ''}`}
-              style={
-                playing
-                  ? undefined
-                  : {
-                      transform: `translate(${dragX}px, ${Math.max(0, dragY) * 0.4}px) rotate(${tilt}deg)`,
-                    }
-              }
+              style={{
+                transform: `translate(${dragX}px, ${Math.max(0, dragY) * 0.4}px) rotate(${tilt}deg)`,
+              }}
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
               onPointerUp={onPointerUp}
@@ -443,16 +445,8 @@ export function ReviewDesk() {
                 </p>
               </div>
 
-              <div className={`review-card-stage${playing ? ' is-playing' : ''}`}>
-                {playing ? (
-                  <PublishedGameFrame
-                    slug={current.slug}
-                    title={current.title}
-                    embed
-                    remixable={false}
-                    trackPlay={false}
-                  />
-                ) : showMedia ? (
+              <div className="review-card-stage">
+                {showMedia ? (
                   <>
                     {videoUrl ? (
                       <video
@@ -480,16 +474,9 @@ export function ReviewDesk() {
                     <p>{t('review.noMedia')}</p>
                   </div>
                 )}
-                {hasPreviewMedia(current) || !showMedia ? (
-                  <button
-                    type="button"
-                    className={playing ? 'review-play-btn is-overlay is-active' : 'review-play-btn is-overlay'}
-                    aria-pressed={playing}
-                    onClick={() => setPlaying((prev) => !prev)}
-                  >
-                    {playing ? t('review.showPreview') : t('review.tryPlay')}
-                  </button>
-                ) : null}
+                <button type="button" className="review-play-btn is-overlay" onClick={() => setPlaying(true)}>
+                  {t('review.tryPlay')}
+                </button>
                 {keepHint ? <div className="review-stamp is-keep">{t('review.keep')}</div> : null}
                 {cutHint ? <div className="review-stamp is-cut">{t('review.cut')}</div> : null}
                 {skipHint ? <div className="review-stamp is-skip">{t('review.skip')}</div> : null}
@@ -620,6 +607,18 @@ export function ReviewDesk() {
         <p className="review-error" role="alert">
           {error}
         </p>
+      ) : null}
+
+      {playing && current ? (
+        <GameTheater
+          key={current.slug}
+          title={current.title}
+          badge={{ icon: 'star', label: t('review.tryPlay') }}
+          source={{ slug: current.slug }}
+          onExit={() => setPlaying(false)}
+          trackPlay={false}
+          remixable={false}
+        />
       ) : null}
     </section>
   );

--- a/docs/game-assessment-plan.md
+++ b/docs/game-assessment-plan.md
@@ -19,7 +19,7 @@ judgment_ from someone who knows what the shelf should feel like.
 | Surface       | Unlisted `/review`. 404 to everyone else (API answers 404, not 403).                                                                 |
 | Queue         | **Catalog** (published) and **Creator** (delivered, shared drafts that are not yet published). Private unshared drafts stay private. |
 | Gesture       | Swipe right = keep, left = cut, down/button = skip. Keyboard: `→` / `←` / `↓`.                                                       |
-| Preview       | Catalog **MP4 + screenshots** first (gate media). Optional **Try play** mounts the sandboxed game without play telemetry.            |
+| Preview       | Catalog **MP4 + screenshots** first (gate media). Optional **Try play** opens full-screen theater (no play telemetry, no remix).     |
 | Mobile dock   | Note + Cut/Skip/Keep sit in a **sticky bottom dock** (thumb zone). Install/update banners lift the dock via `:has(...)`.             |
 | Rationale     | **Required** free text and/or speech-to-text (same Web Speech API as the hero mic). Transcript only — no audio upload.               |
 | Checklist     | Required marks for **graphics / gameplay / fun / sound / controls** — each `ok` · `weak` · `bad`.                                    |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On `/review`, **Try play** now opens the same full-screen `GameTheater` used by the catalog player, instead of embedding the game inline under the media preview.

- Stage stays on catalog MP4 / screenshots while theater is open (preview video pauses).
- Review sessions use `trackPlay={false}` and `remixable={false}` — theater remix chrome and `remix_step` offered telemetry are gated too.
- Creator-queue items pass `creatorHandle` / `submittedBy` so the theater byline matches the card.
- Exit returns to the desk (no navigation away).

## Codex review

Addressed all three P2s from `chatgpt-codex-connector` on `22e0527`:

1. Gate theater remix controls + offered telemetry on `remixable`
2. Pause preview `<video>` while theater is open
3. Pass creator attribution into `GameTheater`

## Test plan

- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] `ReviewDesk` / `GameTheater` unit coverage for theater open, pause, attribution, remixable=false
- [ ] Manual: as a reviewer, open `/review`, press Try play, confirm full-viewport theater and exit back to the dock
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a25ba38-de6c-4be3-ad5f-d43b9b423a6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a25ba38-de6c-4be3-ad5f-d43b9b423a6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

