### PR TITLE
fix(player): make embedded games full-bleed on desktop

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -57,6 +57,18 @@ describe('embedGameHtml', () => {
     expect(out).toContain("addEventListener('contextmenu'");
     expect(out).toContain("addEventListener('selectstart'");
   });
+
+  it('makes the shell wrap full-bleed so desktop theater has no 1400px gutters', () => {
+    const out = embedGameHtml(
+      '<html><head></head><body><div class="wrap"><canvas id="game"></canvas></div></body></html>',
+    );
+
+    // Override shell's 1400px wrap inside the opaque frame.
+    expect(out).toContain('.wrap{width:100%!important;max-width:none!important');
+    expect(out).toContain('padding:0!important');
+    expect(out).toContain('#game{width:100%!important;height:100%!important');
+    expect(out).toContain('object-fit:contain');
+  });
 });
 
 describe('withGameLocale', () => {

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -352,17 +352,31 @@ const BRIDGE = `(function(){
   if(document.readyState==='loading')addEventListener('DOMContentLoaded',init);else init();
 })();`;
 
-// Hide the game's own chrome (the app theater shows title/desc/sound instead), and
-// strip iOS long-press chrome inside the opaque-origin frame — parent CSS cannot
-// reach in here. Without this, a hold on iPhone SE pops the selection loupe and
-// the Copy / Translate / Look Up callout over the playfield.
+// Hide in-game chrome; theater owns title/sound instead.
+// Parent CSS cannot reach opaque-origin frame (iOS loupe).
+// Undo shell's 1400px wrap so desktop theater is full-bleed.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
-  // Mouse-primary desktops: a buttons-only GameKit cluster (no pad) sits on top of
-  // pointer-native UIs and steals the corner. Phones keep it via any-pointer:coarse;
-  // games that still mount a pad on desktop keep their action cluster too.
+  // Hide buttons-only GameKit chrome on mouse desktops.
   `@media not all and (any-pointer:coarse){` +
   `.gamekit-touch:not(:has(.gamekit-touch-pad)){display:none!important}` +
+  `}` +
+  `html,body{width:100%;height:100%;margin:0;background:#000}` +
+  `body{display:block;min-height:100%;overflow:hidden}` +
+  `.wrap{` +
+  `width:100%!important;` +
+  `max-width:none!important;` +
+  `height:100%!important;` +
+  `min-height:100%!important;` +
+  `padding:0!important;` +
+  `gap:0!important` +
+  `}` +
+  `#game{` +
+  `width:100%!important;` +
+  `height:100%!important;` +
+  `min-height:0!important;` +
+  `box-shadow:none!important;` +
+  `object-fit:contain` +
   `}` +
   `html,body,canvas,img,video{` +
   `-webkit-touch-callout:none;` +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Games looked full-bleed on mobile but showed side gutters on desktop.

The theater host was already `position: fixed; inset: 0`. The bands came from inside the iframe: `game-shell.css` caps `.wrap` at `min(100%, 1400px)` with padding. Phones never hit 1400px, so they looked edge-to-edge; wide desktops centered a 1400px card.

## Fix
Extend `HIDE_CHROME` in `embedGameHtml` so the opaque-origin frame overrides the standalone shell layout:

- `.wrap` → 100% width/height, no max-width, no padding
- `#game` → fill the wrap, drop the card shadow, keep `object-fit: contain` (cover would crop and break GameKit pointer mapping)

Standalone game pages keep the padded 1400px shell; only theater/studio embeds change.

## Test plan
- [x] `npm test -w @gamedevpl/web -- --run src/gamePlayer.test.ts`
- [ ] Play a landscape game on a wide desktop theater — no side bands
- [ ] Confirm portrait games still letterbox correctly (contain)
- [ ] Mobile play still looks full-bleed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11e52f09-1b81-4425-82e0-df4327abe3d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11e52f09-1b81-4425-82e0-df4327abe3d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

