### PR TITLE
feat(player): accept adaptive orientation (no rotate nudge)

### DIFF
--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -299,7 +299,7 @@ export interface CatalogGameEntry {
   touch?: CatalogGameTouch;
 }
 
-export type CatalogGameOrientation = 'any' | 'portrait' | 'landscape';
+export type CatalogGameOrientation = 'any' | 'portrait' | 'landscape' | 'adaptive';
 
 export interface CatalogGameMultiplayer {
   mode: 'controllers';
@@ -352,7 +352,7 @@ function parseMultiplayer(frontmatter: Record<string, string>): CatalogGameMulti
   return { mode: 'controllers', minPlayers, maxPlayers };
 }
 
-const GAME_ORIENTATIONS = new Set<CatalogGameOrientation>(['any', 'portrait', 'landscape']);
+const GAME_ORIENTATIONS = new Set<CatalogGameOrientation>(['any', 'portrait', 'landscape', 'adaptive']);
 
 /**
  * Anything unrecognised degrades to 'any' rather than failing the catalog: an

--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -62,7 +62,7 @@ type GameTheaterProps = {
   source: GameTheaterSource;
   onExit: () => void;
   /** The orientation the game was designed for; drives the rotate nudge. */
-  orientation?: 'any' | 'portrait' | 'landscape';
+  orientation?: 'any' | 'portrait' | 'landscape' | 'adaptive';
   /** Extra header content shown when the bridge hasn't reported a description yet
    *  (e.g. the prompt a generated game was made from). */
   meta?: ReactNode;
@@ -109,11 +109,17 @@ export const PLAYER_CHROME_IDLE_MS = 3200;
  * Only handhelds are nudged: a desktop window can be any shape and its owner
  * resizes it rather than turning it over, so telling them to rotate is noise.
  */
-function useOrientationMismatch(desired: 'any' | 'portrait' | 'landscape'): boolean {
+function useOrientationMismatch(desired: 'any' | 'portrait' | 'landscape' | 'adaptive'): boolean {
   const [mismatched, setMismatched] = useState(false);
 
   useEffect(() => {
-    if (desired === 'any' || typeof matchMedia !== 'function' || !matchMedia('(pointer: coarse)').matches) {
+    // adaptive / any: the game follows the device — never nag to rotate.
+    if (
+      desired === 'any' ||
+      desired === 'adaptive' ||
+      typeof matchMedia !== 'function' ||
+      !matchMedia('(pointer: coarse)').matches
+    ) {
       setMismatched(false);
       return;
     }

--- a/apps/web/src/catalog.test.ts
+++ b/apps/web/src/catalog.test.ts
@@ -110,15 +110,16 @@ describe('catalog helpers', () => {
         JSON.stringify([
           { slug: 'a', title: 'A', genre: '', controls: '', status: 'published', orientation: 'landscape' },
           { slug: 'b', title: 'B', genre: '', controls: '', status: 'published', orientation: 'portrait' },
-          { slug: 'c', title: 'C', genre: '', controls: '', status: 'published', orientation: 'sideways' },
+          { slug: 'c', title: 'C', genre: '', controls: '', status: 'published', orientation: 'adaptive' },
+          { slug: 'd', title: 'D', genre: '', controls: '', status: 'published', orientation: 'sideways' },
           // An API older than this field must not make the player nag anyone.
-          { slug: 'd', title: 'D', genre: '', controls: '', status: 'published' },
+          { slug: 'e', title: 'E', genre: '', controls: '', status: 'published' },
         ]),
       ),
     );
 
     const entries = await fetchCatalog();
-    expect(entries.map((entry) => entry.orientation)).toEqual(['landscape', 'portrait', 'any', 'any']);
+    expect(entries.map((entry) => entry.orientation)).toEqual(['landscape', 'portrait', 'adaptive', 'any', 'any']);
   });
 
   it('keeps a known touch class and treats anything else as unknown', async () => {

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -169,7 +169,7 @@ function parseCatalogMultiplayer(value: unknown): CatalogMultiplayer | null {
 
 /** An older API (or a spec typo the API let through) simply means "no preference". */
 function parseCatalogOrientation(value: unknown): CatalogOrientation {
-  return value === 'portrait' || value === 'landscape' ? value : 'any';
+  return value === 'portrait' || value === 'landscape' || value === 'adaptive' ? value : 'any';
 }
 
 const CATALOG_TOUCH_VALUES = new Set<string>(['gamekit', 'native', 'controllers', 'none']);

--- a/apps/web/src/catalog.ts
+++ b/apps/web/src/catalog.ts
@@ -16,7 +16,7 @@ export interface CatalogMultiplayer {
 }
 
 /** The orientation a game was designed for; 'any' unless its spec says otherwise. */
-export type CatalogOrientation = 'any' | 'portrait' | 'landscape';
+export type CatalogOrientation = 'any' | 'portrait' | 'landscape' | 'adaptive';
 
 /**
  * How a game can be driven by a finger. Unlike everything else on an entry this is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Games-repo GameKit now supports `.orientation('adaptive')` — the playfield follows the device. The theater must not show a rotate nudge for those games, and the catalog type must accept `adaptive`.

## Changes
- `CatalogOrientation` / `CatalogGameOrientation` include `adaptive`
- `useOrientationMismatch` treats `adaptive` like `any` (no nudge)

Companion: gamedevpl/www.gamedev.pl-games#603

## Test plan
- [ ] Catalog entry with `orientation: adaptive` plays without rotate nudge on phone
- [ ] Locked `portrait` / `landscape` still nudge when mismatched
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11e52f09-1b81-4425-82e0-df4327abe3d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11e52f09-1b81-4425-82e0-df4327abe3d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

