### PR TITLE
fix(player): keep embed canvas hit box aligned with letterbox

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -38,8 +38,7 @@ describe('embedGameHtml', () => {
     const out = embedGameHtml('<html><head></head><body></body></html>');
     expect(out).toContain("CustomEvent('gdpl-pause')");
     expect(out).toContain("CustomEvent('gdpl-resume')");
-    // Bridge freeze is required — GameKit alone keeps draw() running, and older
-    // assembled docs never listen for gdpl-pause.
+    // Bridge freezes rAF; GameKit alone would keep drawing.
     expect(out).toContain('heldRaf');
     expect(out).toContain('flushHeldRaf');
     expect(out).toContain('suspendAudio');
@@ -48,12 +47,12 @@ describe('embedGameHtml', () => {
   it('suppresses the iOS long-press loupe and Copy/Translate callout inside the frame', () => {
     const out = embedGameHtml('<html><head></head><body><canvas id="game"></canvas></body></html>');
 
-    // CSS must land in the opaque-origin document — parent styles cannot reach it.
+    // Opaque-origin frame; parent CSS cannot reach in.
     expect(out).toContain('-webkit-touch-callout:none');
     expect(out).toContain('-webkit-user-select:none');
     expect(out).toContain('user-select:none');
     expect(out).toContain('touch-action:none');
-    // Event backstops for Safari versions that still open the callout under CSS alone.
+    // Event backstops when CSS alone is not enough.
     expect(out).toContain("addEventListener('contextmenu'");
     expect(out).toContain("addEventListener('selectstart'");
   });
@@ -63,10 +62,10 @@ describe('embedGameHtml', () => {
       '<html><head></head><body><div class="wrap"><canvas id="game"></canvas></div></body></html>',
     );
 
-    // Override shell's 1400px wrap inside the opaque frame.
+    // Drop shell's 1400px wrap gutters.
     expect(out).toContain('.wrap{width:100%!important;max-width:none!important');
     expect(out).toContain('padding:0!important');
-    // Contained element box (not 100%×100% + object-fit) so hit-testing matches paint.
+    // Element box matches paint; avoid object-fit letterbox hitbox.
     expect(out).toContain('#game{width:auto!important;height:auto!important');
     expect(out).toContain('max-width:100%!important');
     expect(out).toContain('max-height:100%!important');

--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -66,8 +66,12 @@ describe('embedGameHtml', () => {
     // Override shell's 1400px wrap inside the opaque frame.
     expect(out).toContain('.wrap{width:100%!important;max-width:none!important');
     expect(out).toContain('padding:0!important');
-    expect(out).toContain('#game{width:100%!important;height:100%!important');
-    expect(out).toContain('object-fit:contain');
+    // Contained element box (not 100%×100% + object-fit) so hit-testing matches paint.
+    expect(out).toContain('#game{width:auto!important;height:auto!important');
+    expect(out).toContain('max-width:100%!important');
+    expect(out).toContain('max-height:100%!important');
+    expect(out).not.toContain('#game{width:100%!important;height:100%!important');
+    expect(out).not.toContain('object-fit:contain');
   });
 });
 

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -355,6 +355,10 @@ const BRIDGE = `(function(){
 // Hide in-game chrome; theater owns title/sound instead.
 // Parent CSS cannot reach opaque-origin frame (iOS loupe).
 // Undo shell's 1400px wrap so desktop theater is full-bleed.
+//
+// Size `#game` with max-width/max-height (not 100%×100% + object-fit). A full-box
+// canvas letterboxes its bitmap *inside* the element, so getBoundingClientRect
+// mapping (fixtures, older games) shifts taps. Contained element box = hit box.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
   // Hide buttons-only GameKit chrome on mouse desktops.
@@ -362,21 +366,26 @@ const HIDE_CHROME =
   `.gamekit-touch:not(:has(.gamekit-touch-pad)){display:none!important}` +
   `}` +
   `html,body{width:100%;height:100%;margin:0;background:#000}` +
-  `body{display:block;min-height:100%;overflow:hidden}` +
+  `body{display:flex;align-items:center;justify-content:center;` +
+  `min-height:100%;overflow:hidden}` +
   `.wrap{` +
   `width:100%!important;` +
   `max-width:none!important;` +
   `height:100%!important;` +
   `min-height:100%!important;` +
   `padding:0!important;` +
-  `gap:0!important` +
+  `gap:0!important;` +
+  `display:flex!important;` +
+  `align-items:center!important;` +
+  `justify-content:center!important` +
   `}` +
   `#game{` +
-  `width:100%!important;` +
-  `height:100%!important;` +
+  `width:auto!important;` +
+  `height:auto!important;` +
+  `max-width:100%!important;` +
+  `max-height:100%!important;` +
   `min-height:0!important;` +
-  `box-shadow:none!important;` +
-  `object-fit:contain` +
+  `box-shadow:none!important` +
   `}` +
   `html,body,canvas,img,video{` +
   `-webkit-touch-callout:none;` +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Follow-up to #664. Codex P1 on [`discussion_r3736927655`](https://github.com/gamedevpl/www.gamedev.pl/pull/664#discussion_r3736927655):

`#game { width/height: 100%; object-fit: contain }` makes the **element** fill the iframe while the bitmap letterboxes *inside* that box. Games that map pointers with `getBoundingClientRect()` (fixtures `pixel-dodge`, `odd-one-out`, and any similar code) see shifted taps / unreachable playfield edges.

GameKit’s own `object-fit`-aware mapper was fine; naive rect mapping was not.

## Fix
Contain by sizing the canvas element itself:

- `.wrap` / `body` → flex center, full viewport (no 1400px gutters)
- `#game` → `width/height: auto; max-width/max-height: 100%` (no `object-fit`)

Letterboxing stays in the black margins **outside** the canvas hit box, so rect mapping matches paint.

## Test plan
- [x] `npm test -w @gamedevpl/web -- --run src/gamePlayer.test.ts`
- [ ] Play a non-16:10 viewport game; taps land on the visible playfield
- [ ] Desktop theater still has no 1400px side card
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11e52f09-1b81-4425-82e0-df4327abe3d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11e52f09-1b81-4425-82e0-df4327abe3d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

