### PR TITLE
Studio connect step: switch back to the Gamedev.pl agent, live updates, and an exit when the round ends

### DIFF
--- a/apps/web/src/StudioConnectWizard.test.tsx
+++ b/apps/web/src/StudioConnectWizard.test.tsx
@@ -14,6 +14,7 @@ vi.mock('./submissionApi.js', async () => {
     ...actual,
     getSubmissionStatus: vi.fn(),
     listMySubmissions: vi.fn(),
+    handoffToPlatform: vi.fn(),
   };
 });
 
@@ -28,6 +29,7 @@ vi.mock('./connectApi.js', async () => {
 const getStatus = vi.mocked(submissionApi.getSubmissionStatus);
 const listMine = vi.mocked(submissionApi.listMySubmissions);
 const getConnect = vi.mocked(connectApi.getConnectPayload);
+const handoff = vi.mocked(submissionApi.handoffToPlatform);
 
 describe('StudioConnectWizard', () => {
   let container: HTMLDivElement;
@@ -69,7 +71,9 @@ describe('StudioConnectWizard', () => {
         cli: 'cli',
       },
       installLinks: { cursor: 'cursor://add', vscode: 'vscode://add' },
+      canSwitchToPlatform: true,
     });
+    handoff.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -126,6 +130,108 @@ describe('StudioConnectWizard', () => {
       cta.click();
     });
     expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+  });
+
+  it('hands the round to the Gamedev.pl agent and opens Studio', async () => {
+    const onOpenStudio = vi.fn();
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const control = document.querySelector('[data-testid="connect-switch-builder"]');
+    expect(control).toBeTruthy();
+    const start = control?.querySelector('button') as HTMLButtonElement;
+    expect(start.textContent).toMatch(/Gamedev\.pl agent/i);
+    await act(async () => {
+      start.click();
+    });
+
+    const confirm = control?.querySelector('button') as HTMLButtonElement;
+    await act(async () => {
+      confirm.click();
+      await Promise.resolve();
+    });
+
+    expect(handoff).toHaveBeenCalledWith('tok-connect');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+  });
+
+  it('stays on connect while a handoff waits for the agent to acknowledge', async () => {
+    const onOpenStudio = vi.fn();
+    handoff.mockResolvedValue({ pending: true });
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const control = document.querySelector('[data-testid="connect-switch-builder"]');
+    await act(async () => {
+      (control?.querySelector('button') as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      (control?.querySelector('button') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    expect(onOpenStudio).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="connect-switch-builder"]')?.textContent).toMatch(/acknowledge/i);
+  });
+
+  it('shows the latest agent updates once it checks in', async () => {
+    getStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      slug: 'bastion-wave',
+      lastAgentSignalAt: '2026-08-07T00:01:00Z',
+      events: [
+        {
+          id: 'ev-2',
+          kind: 'step',
+          step: 'art',
+          text: 'Drew the pumpkin sprite sheet',
+          progress: { done: 2, total: 5 },
+          createdAt: '2026-08-07T00:02:00Z',
+        },
+        { id: 'ev-1', kind: 'milestone', text: 'Read the kit', createdAt: '2026-08-07T00:01:00Z' },
+      ],
+    });
+
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio: vi.fn() }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const feed = document.querySelector('[data-testid="connect-wizard-feed"]');
+    expect(feed?.textContent).toContain('Drew the pumpkin sprite sheet');
+    expect(feed?.textContent).toContain('Read the kit');
+    expect(feed?.textContent).toContain('Drawing');
+    expect(document.querySelector('.studio-welcome-progress')?.textContent).toContain('2 of 5 done');
+  });
+
+  it('says it is waiting when a connected agent has posted nothing yet', async () => {
+    getStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      slug: 'bastion-wave',
+      lastAgentSignalAt: '2026-08-07T00:01:00Z',
+    });
+
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio: vi.fn() }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('[data-testid="connect-wizard-feed"]')).toBeNull();
+    expect(document.querySelector('.studio-connect-wizard-feed-empty')?.textContent).toMatch(/Waiting for the first/i);
   });
 
   it('uses resume connect mode when a quiet agent resurfaces the card', async () => {

--- a/apps/web/src/StudioConnectWizard.test.tsx
+++ b/apps/web/src/StudioConnectWizard.test.tsx
@@ -234,6 +234,41 @@ describe('StudioConnectWizard', () => {
     expect(document.querySelector('.studio-connect-wizard-feed-empty')?.textContent).toMatch(/Waiting for the first/i);
   });
 
+  it('leaves the connect step for Studio once the agent has ended the round', async () => {
+    const onOpenStudio = vi.fn();
+    getStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      slug: 'bastion-wave',
+      phase: 'submitted',
+      lastAgentSignalAt: '2026-08-07T00:01:00Z',
+      agentEndedAt: '2026-08-07T00:09:00Z',
+    });
+
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+  });
+
+  it('leaves the connect step when the round has published', async () => {
+    const onOpenStudio = vi.fn();
+    getStatus.mockResolvedValue({ status: 'published', builder: 'self', slug: 'bastion-wave' });
+
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+  });
+
   it('uses resume connect mode when a quiet agent resurfaces the card', async () => {
     getStatus.mockResolvedValue({
       status: 'building',

--- a/apps/web/src/StudioConnectWizard.test.tsx
+++ b/apps/web/src/StudioConnectWizard.test.tsx
@@ -255,6 +255,26 @@ describe('StudioConnectWizard', () => {
     expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
   });
 
+  it('leaves the connect step on an ended stall with no agentEndedAt', async () => {
+    const onOpenStudio = vi.fn();
+    getStatus.mockResolvedValue({
+      status: 'building',
+      builder: 'self',
+      slug: 'bastion-wave',
+      stall: 'ended',
+      lastAgentSignalAt: '2026-08-07T00:01:00Z',
+    });
+
+    await act(async () => {
+      createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+  });
+
   it('leaves the connect step when the round has published', async () => {
     const onOpenStudio = vi.fn();
     getStatus.mockResolvedValue({ status: 'published', builder: 'self', slug: 'bastion-wave' });

--- a/apps/web/src/StudioConnectWizard.test.tsx
+++ b/apps/web/src/StudioConnectWizard.test.tsx
@@ -252,7 +252,7 @@ describe('StudioConnectWizard', () => {
       await Promise.resolve();
     });
 
-    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff', { replace: true });
   });
 
   it('leaves the connect step on an ended stall with no agentEndedAt', async () => {
@@ -272,7 +272,7 @@ describe('StudioConnectWizard', () => {
       await Promise.resolve();
     });
 
-    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff', { replace: true });
   });
 
   it('leaves the connect step when the round has published', async () => {
@@ -286,7 +286,7 @@ describe('StudioConnectWizard', () => {
       await Promise.resolve();
     });
 
-    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff', { replace: true });
   });
 
   it('uses resume connect mode when a quiet agent resurfaces the card', async () => {

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -25,7 +25,7 @@ const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabi
 type StudioConnectWizardProps = {
   // Slug or capability token from the URL.
   game: string;
-  onOpenStudio: (path: string) => void;
+  onOpenStudio: (path: string, options?: { replace?: boolean }) => void;
 };
 
 function copyInputFromStatus(status: SubmissionStatus | null): SelfBuildCopyInput {
@@ -86,7 +86,7 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
   const chapterOver = connectChapterOver(status);
   const roundBuilder = status?.builder ?? 'self';
   const agentConnected = Boolean(status && !awaiting && !chapterOver);
-  const goStudioRef = useRef<(deferred: boolean, builder?: 'self' | 'platform') => void>(() => {});
+  const goStudioRef = useRef<(deferred: boolean, builder?: 'self' | 'platform', replace?: boolean) => void>(() => {});
 
   useEffect(() => {
     recordCreateStep('handoff_shown', 'self');
@@ -187,7 +187,7 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     }
   };
 
-  const goStudio = (deferred: boolean, builder: 'self' | 'platform' = 'self') => {
+  const goStudio = (deferred: boolean, builder: 'self' | 'platform' = 'self', replace = false) => {
     markStudioOnboarded();
     // Deferred still enters Studio; record both funnel steps.
     if (deferred) {
@@ -195,7 +195,12 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     }
     recordCreateStep('handoff_enter_studio', builder);
     const address = status?.slug ?? game;
-    onOpenStudio(`${studioPath(address)}?from=handoff`);
+    const path = `${studioPath(address)}?from=handoff`;
+    if (replace) {
+      onOpenStudio(path, { replace: true });
+    } else {
+      onOpenStudio(path);
+    }
   };
 
   useEffect(() => {
@@ -203,9 +208,10 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
   });
 
   // Delivered or finished rounds belong in Studio, not on a connect step.
+  // Replace, not push: Back would land on connect and bounce here again.
   useEffect(() => {
     if (!chapterOver) return;
-    goStudioRef.current(false, roundBuilder);
+    goStudioRef.current(false, roundBuilder, true);
   }, [chapterOver, roundBuilder]);
 
   // Change of mind: hand the round to the Gamedev.pl agent.

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -63,7 +63,7 @@ function connectChapterOver(status: SubmissionStatus | null): boolean {
   if (!status) return false;
   if (status.phase && PAST_CONNECT_PHASES.has(status.phase)) return true;
   if (PAST_CONNECT_STATUSES.has(status.status)) return true;
-  return Boolean(status.agentEndedAt);
+  return status.stall === 'ended' || Boolean(status.agentEndedAt);
 }
 
 function stillNeedsConnect(status: SubmissionStatus | null): boolean {

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -7,8 +7,17 @@ import { connectCardMode, shouldShowConnectCard, type SelfBuildCopyInput } from 
 import { StudioConnectCard } from './StudioConnectCard.js';
 import { markStudioOnboarded, resolveWelcomeToken } from './studioWelcome.js';
 import { pollDelayMs } from './studioStatusPoll.js';
-import { getSubmissionStatus, type SubmissionStatus } from './submissionApi.js';
+import {
+  buildMediaUrl,
+  getSubmissionStatus,
+  handoffToPlatform,
+  type BuildEvent,
+  type SubmissionStatus,
+} from './submissionApi.js';
 import { recordCreateStep, recordStudioStep } from './visitTelemetry.js';
+
+// Studio owns the full transcript; this step shows only the newest few.
+const FEED_LIMIT = 4;
 
 // Focusable controls in the connect dialog.
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -147,18 +156,30 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     }
   };
 
-  const goStudio = (deferred: boolean) => {
+  const goStudio = (deferred: boolean, builder: 'self' | 'platform' = 'self') => {
     markStudioOnboarded();
     // Deferred still enters Studio; record both funnel steps.
     if (deferred) {
       recordStudioStep('connect_dismissed', 'self');
     }
-    recordCreateStep('handoff_enter_studio', 'self');
+    recordCreateStep('handoff_enter_studio', builder);
     const address = status?.slug ?? game;
     onOpenStudio(`${studioPath(address)}?from=handoff`);
   };
 
+  // Change of mind: hand the round to the Gamedev.pl agent.
+  const switchToPlatform = async () => {
+    if (!token) return;
+    const result = await handoffToPlatform(token);
+    if (result.pending) return result;
+    goStudio(false, 'platform');
+    return result;
+  };
+
   const cardMode = connectCardMode(copyInputFromStatus(status)) ?? 'setup';
+  const feed: BuildEvent[] = (status?.events ?? []).slice(0, FEED_LIMIT);
+  const reportedProgress = (status?.events ?? []).find((event) => event.progress)?.progress;
+  const latestShot = status?.media?.[0];
 
   return createPortal(
     <div
@@ -198,10 +219,50 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
                 <PixelIcon name="sparkle" size={13} /> {t('connectWizard.connectedLabel')}
               </p>
               <p className="studio-welcome-progress-message">{t('connectWizard.connectedBody')}</p>
+              {reportedProgress && reportedProgress.total > 0 ? (
+                <p className="studio-connect-wizard-count">
+                  {t('statusView.progress.checklistCount', {
+                    done: reportedProgress.done,
+                    total: reportedProgress.total,
+                  })}
+                </p>
+              ) : null}
+              {feed.length > 0 ? (
+                <ul className="studio-connect-wizard-feed" data-testid="connect-wizard-feed">
+                  {feed.map((event) => (
+                    <li key={event.id}>
+                      <span className="studio-connect-wizard-feed-step">
+                        {event.step ? t(`statusView.progress.steps.${event.step}`) : t('statusView.progress.agentSays')}
+                      </span>{' '}
+                      <span className="studio-connect-wizard-feed-text">{event.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="studio-connect-wizard-feed-empty">
+                  <span className="studio-connect-pulse" aria-hidden="true" />
+                  {t('connectWizard.awaitingUpdates')}
+                </p>
+              )}
+              {latestShot && token ? (
+                <img
+                  className="studio-connect-wizard-shot"
+                  src={buildMediaUrl(token, latestShot)}
+                  alt={latestShot.label ?? t('connectWizard.shotAlt')}
+                  loading="lazy"
+                />
+              ) : null}
             </div>
           ) : token ? (
             <div className="studio-connect-wizard-card">
-              <StudioConnectCard token={token} collapsible={false} agentConnected={false} mode={cardMode} />
+              <StudioConnectCard
+                token={token}
+                collapsible={false}
+                agentConnected={false}
+                mode={cardMode}
+                onSwitchToPlatform={switchToPlatform}
+                builderHandoffPending={status?.builderHandoff?.target === 'platform'}
+              />
             </div>
           ) : (
             <p className="studio-welcome-primer-one">{t('connectWizard.preparing')}</p>

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -207,8 +207,7 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     goStudioRef.current = goStudio;
   });
 
-  // Delivered or finished rounds belong in Studio, not on a connect step.
-  // Replace, not push: Back would land on connect and bounce here again.
+  // Replace: Back would land on this finished round and bounce forward.
   useEffect(() => {
     if (!chapterOver) return;
     goStudioRef.current(false, roundBuilder, true);

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -38,6 +38,34 @@ function copyInputFromStatus(status: SubmissionStatus | null): SelfBuildCopyInpu
   };
 }
 
+// The round left the agent's hands: delivered, gating, or finished.
+const PAST_CONNECT_PHASES: ReadonlySet<string> = new Set([
+  'submitted',
+  'gating',
+  'ready_for_review',
+  'publishing',
+  'published',
+  'needs_changes',
+  'failed',
+  'canceled',
+  'abandoned',
+]);
+
+const PAST_CONNECT_STATUSES: ReadonlySet<SubmissionStatus['status']> = new Set([
+  'in_review',
+  'publishing',
+  'published',
+  'needs_changes',
+  'abandoned',
+]);
+
+function connectChapterOver(status: SubmissionStatus | null): boolean {
+  if (!status) return false;
+  if (status.phase && PAST_CONNECT_PHASES.has(status.phase)) return true;
+  if (PAST_CONNECT_STATUSES.has(status.status)) return true;
+  return Boolean(status.agentEndedAt);
+}
+
 function stillNeedsConnect(status: SubmissionStatus | null): boolean {
   if (!status) return true;
   return shouldShowConnectCard(copyInputFromStatus(status));
@@ -55,7 +83,10 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const awaiting = stillNeedsConnect(status);
-  const agentConnected = Boolean(status && !awaiting);
+  const chapterOver = connectChapterOver(status);
+  const roundBuilder = status?.builder ?? 'self';
+  const agentConnected = Boolean(status && !awaiting && !chapterOver);
+  const goStudioRef = useRef<(deferred: boolean, builder?: 'self' | 'platform') => void>(() => {});
 
   useEffect(() => {
     recordCreateStep('handoff_shown', 'self');
@@ -166,6 +197,16 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     const address = status?.slug ?? game;
     onOpenStudio(`${studioPath(address)}?from=handoff`);
   };
+
+  useEffect(() => {
+    goStudioRef.current = goStudio;
+  });
+
+  // Delivered or finished rounds belong in Studio, not on a connect step.
+  useEffect(() => {
+    if (!chapterOver) return;
+    goStudioRef.current(false, roundBuilder);
+  }, [chapterOver, roundBuilder]);
 
   // Change of mind: hand the round to the Gamedev.pl agent.
   const switchToPlatform = async () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -578,6 +578,8 @@
     "loadError": "We couldn't refresh status just now. Retrying…",
     "connectedLabel": "Agent connected",
     "connectedBody": "The build is underway. Studio is where you watch it and say what to change.",
+    "awaitingUpdates": "Waiting for the first update from your agent…",
+    "shotAlt": "Latest picture of the build",
     "later": "I'll connect later",
     "openStudio": "Open Studio",
     "openStudioAnyway": "Open Studio anyway"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -582,6 +582,8 @@
     "loadError": "Nie udało się odświeżyć statusu. Próbuję ponownie…",
     "connectedLabel": "Agent połączony",
     "connectedBody": "Budowa trwa. W Studio śledzisz postęp i mówisz, co zmienić.",
+    "awaitingUpdates": "Czekamy na pierwszą wiadomość od Twojego agenta…",
+    "shotAlt": "Najnowszy obraz budowanej gry",
     "later": "Podłączę później",
     "openStudio": "Otwórz Studio",
     "openStudioAnyway": "Otwórz Studio mimo to"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7246,7 +7246,13 @@ button.builder-mode-selector:disabled {
   font-weight: 600;
 }
 
-.qa-next {
+/* The wizard's primary action. `.btn`/`.btn-primary` carry no rules anywhere in this
+   stylesheet (see the .qa-back note above), so a footer button that only had those
+   rendered as a default UA slab — grey, next to a turquoise-branded screen. Every
+   wizard primary is `.qa-primary`, so the look lives on that class and `.qa-next`
+   (CreatorQA's, which carries both) keeps it. */
+.qa-next,
+.qa-primary {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -7263,6 +7269,17 @@ button.builder-mode-selector:disabled {
   cursor: pointer;
 }
 
+.qa-next:hover:not(:disabled),
+.qa-primary:hover:not(:disabled) {
+  box-shadow: 0 6px 20px rgba(0, 228, 172, 0.45);
+}
+
+.qa-next:disabled,
+.qa-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* An unanswered question is a legitimate outcome, not a failure to proceed: the
    button still moves you on, but it stops competing with the options for the eye. */
 .qa-next--skip {
@@ -7276,6 +7293,8 @@ button.builder-mode-selector:disabled {
 .qa-next--skip:hover:not(:disabled) {
   color: var(--text, #e2e8f0);
   border-color: var(--muted, #94a3b8);
+  /* The quiet variant must not pick up the branded glow from the shared hover above. */
+  box-shadow: none;
 }
 
 /* A text link, not a third button: it must be findable without competing with the
@@ -7558,6 +7577,73 @@ button.builder-mode-selector:disabled {
 .studio-welcome-more p {
   margin: 8px 0 0;
   line-height: 1.45;
+}
+
+/* Live agent updates on the connect step, so a connected build shows movement
+   rather than one paragraph that never changes. Newest first, capped in the
+   component — the full transcript is Studio's job. */
+.studio-connect-wizard-count {
+  margin: 10px 0 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--turquoise, #00e4ac);
+  font-variant-numeric: tabular-nums;
+}
+
+.studio-connect-wizard-feed {
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.studio-connect-wizard-feed li {
+  padding-top: 8px;
+  border-top: 1px solid var(--panel-border, #33383d);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.studio-connect-wizard-feed li:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.studio-connect-wizard-feed-step {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted, #94a3b8);
+}
+
+.studio-connect-wizard-feed-text {
+  color: var(--text, #e2e8f0);
+  overflow-wrap: anywhere;
+}
+
+.studio-connect-wizard-feed-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted, #94a3b8);
+}
+
+/* The agent's newest capture. Bounded so a tall portrait shot cannot push the
+   footer actions off a phone screen. */
+.studio-connect-wizard-shot {
+  display: block;
+  width: 100%;
+  max-height: 220px;
+  margin-top: 12px;
+  object-fit: contain;
+  border: 1px solid var(--panel-border, #33383d);
+  border-radius: 10px;
+  background: var(--bg, #0a0e12);
 }
 
 .studio-connect-wizard-card {


### PR DESCRIPTION
Four things about the BYOCA connect step that follows Create Now (`/studio/<game>/connect`).

## Switch back to the Gamedev.pl agent from the connect step

The self→platform handoff control already exists (`SwitchToPlatformControl`, gated on the connect payload's `canSwitchToPlatform`) — the wizard simply never passed a handler, so changing your mind meant walking into Studio to find the same button. It now passes one.

A round nobody has connected to stalls as `no_agent_yet`, which is exactly what `allowsSelfToPlatformHandoff` unlocks on, so the switch starts a platform build immediately and we go straight to Studio. A `pending` response — an agent did check in and must acknowledge the stop — stays on the step and lets the control show its waiting line. Copy reuses the existing `connect.switchBuilder.*` strings (EN + PL already written).

## Leave the step once the round is out of the agent's hands

The step only knew two states: `awaiting` from `shouldShowConnectCard`, and "connected" as its inverse. That predicate deliberately returns false after MCP `end` and after a green gate (the connect endpoint returns `inactive_round` there), and the wizard was reading that false as "still building" — so a delivered round sat on "The build is underway" indefinitely.

It now recognises a round that has moved on — a past-connect `phase` (`submitted`, `gating`, `ready_for_review`, `publishing`, `published`, `needs_changes`, `failed`, `canceled`, `abandoned`), a past-connect public status (`in_review`, `publishing`, `published`, `needs_changes`, `abandoned`), or `agentEndedAt` — and enters Studio, where the gate verdict, the transcript and publish live. Same `?from=handoff` path and `markStudioOnboarded()` as pressing the footer button.

Note this is an automatic navigation, not a new button: opening the connect URL for a finished round now lands in Studio rather than showing the step. Happy to make it a "delivered — open Studio" state that waits for a click instead.

## Show what the agent is doing

The connected state was one static paragraph, so a build that was visibly working looked identical to one that had stopped. The poll already carried `events`, `progress` and `media` — nothing rendered them. The step now shows the newest agent updates (step label + text, capped at four so this does not become a second transcript), the reported done/total, the latest capture, and a pulsing "waiting for the first update" line before anything arrives.

## The footer primary rendered as a raw UA button

`.btn` and `.btn-primary` carry no rules anywhere in the stylesheet — the file already notes this about `.btn-secondary` — so the connect footer's Open Studio came out a grey slab on a turquoise-branded screen. The branded primary look moves from `.qa-next` onto `.qa-primary` (CreatorQA's button carries both classes and is unchanged), with hover/disabled states, plus `box-shadow: none` on `.qa-next--skip:hover` so the quiet variant does not inherit the new glow.

## Testing

`npm run type-check && npm run lint && npm run test && npm run build` — all green. Six new cases in `StudioConnectWizard.test.tsx` cover the handoff (immediate and pending), the update feed and its empty state, and the two exit paths (agent ended, published).

---
_Generated by [Claude Code](https://claude.ai/code/session_017KkS7eWBrBJypGfX2X28Ne)_