### PR TITLE
KC-01: mirror shared RNG contract

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -7,6 +7,7 @@
     "world",
     "ai",
     "gameplay",
+    "rng",
     "vehicles",
     "urban",
     "drawing",

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -95,6 +95,7 @@ describe('games-repo-contract (website half)', () => {
       'world',
       'ai',
       'gameplay',
+      'rng',
       'vehicles',
       'urban',
       'drawing',
@@ -225,7 +226,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'ai', 'gameplay', 'vehicles', 'urban',
+        'input', 'collision', 'world', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -44,6 +44,7 @@ export const GAME_KIT_MODULES = [
   'world',
   'ai',
   'gameplay',
+  'rng',
   // Top-down arcade vehicle paint/lights — pairs with gameplay.driveArcadeVehicle.
   'vehicles',
   // Genre vertical: deterministic street topology and routing for 2D urban games.


### PR DESCRIPTION
## Summary

- mirror the shared `rng` module in the website's canonical GameKit contract
- update the fixture and extractor expectation so games-repo contract checks stay aligned
- keep the paired games-repository KC-01 change reviewable

## Checks

- `npm run test -w @gamedevpl/api -- src/games-repo-contract.test.ts` — 28 passing
- `npm run build:packages` — passing
- `npm run type-check -w @gamedevpl/api` — passing
- `npm run contract:games-repo` — passing; live GitHub comparison skipped because `GAMES_REPO_TOKEN` is unset

Paired games PR: https://github.com/gamedevpl/www.gamedev.pl-games/pull/607