### PR TITLE
feat(mcp): screenshot_upload_url — send screenshots without crossing the model

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -16,10 +16,10 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 `apps/api/src/mcp-server.ts` (returned by `start`, appended to every tool description).
 
 1. `start` → `show_round` (once) → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
-2. Build; `report_progress`; screenshot when something draws — prefer
-   `screenshot_upload_url` then `curl --upload-file <png> "$url"` so the bytes never
-   enter the model; `send_screenshot` (base64) is the no-shell fallback (a max-size PNG
-   cannot fit in model output ceilings)
+2. Build; `report_progress`; screenshot when something draws via
+   `screenshot_upload_url` then `curl --upload-file <png> "$url"`. There is **no**
+   base64 `send_screenshot` — PNG bytes must never enter the model. Without shell
+   egress, skip mid-build screenshots; the gate still captures on delivery
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
@@ -291,8 +291,8 @@ queued.
 
 | Area                         | Path                                                                                                                                                                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` → signed PUT; `send_screenshot` base64 fallback)                                                                    |
-| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `PUT /api/agent/build/shot/upload`                                                                                                 |
+| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` → signed PUT only; no base64 shot tool)                                                                             |
+| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload`                                                                                     |
 | Presence pulses              | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
 | Gate milestones              | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |
 | Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -16,7 +16,10 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 `apps/api/src/mcp-server.ts` (returned by `start`, appended to every tool description).
 
 1. `start` → `show_round` (once) → `get_brief` / `get_seed` / `get_sources` / `get_kit` as needed
-2. Build; `report_progress`; `send_screenshot` when something draws
+2. Build; `report_progress`; screenshot when something draws — prefer
+   `screenshot_upload_url` then `curl --upload-file <png> "$url"` so the bytes never
+   enter the model; `send_screenshot` (base64) is the no-shell fallback (a max-size PNG
+   cannot fit in model output ceilings)
 3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
    `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
@@ -288,7 +291,8 @@ queued.
 
 | Area                         | Path                                                                                                                                                                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP tools                    | `apps/api/src/mcp-server.ts`                                                                                                                                              |
+| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` → signed PUT; `send_screenshot` base64 fallback)                                                                    |
+| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `PUT /api/agent/build/shot/upload`                                                                                                 |
 | Presence pulses              | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
 | Gate milestones              | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |
 | Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -650,18 +650,27 @@ describe('agent build channel', () => {
   // A 1x1 PNG — the smallest payload that still carries a real PNG signature.
   const TINY_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
 
-  it('stores a pushed screenshot, lists it on the status response, and serves the bytes', async () => {
+  it('stores a screenshot via signed PUT, lists it on status, and serves the bytes', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);
     app = await createApp(store);
 
-    const pushed = await app.inject({
+    const minted = await app.inject({
       method: 'POST',
-      url: '/api/agent/build/shot',
+      url: '/api/agent/build/shot/upload-url',
       headers: agentHeaders(),
-      payload: { png: TINY_PNG, label: 'First bridge' },
+      payload: { label: 'First bridge' },
     });
+    expect(minted.statusCode).toBe(200);
+    expect(minted.json().accepted).toBe(true);
+    const url = String(minted.json().url).replace(/^https?:\/\/[^/]+/, '');
 
+    const pushed = await app.inject({
+      method: 'PUT',
+      url,
+      headers: { 'content-type': 'image/png' },
+      payload: Buffer.from(TINY_PNG, 'base64'),
+    });
     expect(pushed.statusCode).toBe(200);
     expect(pushed.json().accepted).toBe(true);
     const shotId = pushed.json().shot.id as string;
@@ -684,16 +693,32 @@ describe('agent build channel', () => {
     expect(image.rawPayload.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
   });
 
-  it('refuses a payload that is not a PNG, whatever it claims to be', async () => {
+  it('retires base64 POST /shot and refuses a non-PNG PUT body', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);
     app = await createApp(store);
 
-    const response = await app.inject({
+    const retired = await app.inject({
       method: 'POST',
       url: '/api/agent/build/shot',
       headers: agentHeaders(),
-      payload: { png: Buffer.from('<svg onload=alert(1)>').toString('base64') },
+      payload: { png: TINY_PNG },
+    });
+    expect(retired.statusCode).toBe(410);
+    expect(retired.json().error).toMatch(/retired|upload-url/i);
+
+    const minted = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/shot/upload-url',
+      headers: agentHeaders(),
+      payload: {},
+    });
+    const url = String(minted.json().url).replace(/^https?:\/\/[^/]+/, '');
+    const response = await app.inject({
+      method: 'PUT',
+      url,
+      headers: { 'content-type': 'application/octet-stream' },
+      payload: Buffer.from('<svg onload=alert(1)>'),
     });
 
     expect(response.statusCode).toBe(400);
@@ -707,11 +732,18 @@ describe('agent build channel', () => {
     await seedSubmission(store, 99);
     app = await createApp(store);
 
-    const pushed = await app.inject({
+    const minted = await app.inject({
       method: 'POST',
-      url: '/api/agent/build/shot',
+      url: '/api/agent/build/shot/upload-url',
       headers: agentHeaders(),
-      payload: { png: TINY_PNG },
+      payload: {},
+    });
+    const url = String(minted.json().url).replace(/^https?:\/\/[^/]+/, '');
+    const pushed = await app.inject({
+      method: 'PUT',
+      url,
+      headers: { 'content-type': 'image/png' },
+      payload: Buffer.from(TINY_PNG, 'base64'),
     });
     const shotId = pushed.json().shot.id as string;
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mintAgentToken, mintLegacyAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import { verifyUploadToken } from './agent-upload-token.js';
 import type { AgentChannelOptions } from './agent-channel.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
@@ -691,6 +692,38 @@ describe('agent build channel', () => {
     expect(image.statusCode).toBe(200);
     expect(image.headers['content-type']).toContain('image/png');
     expect(image.rawPayload.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  });
+
+  it('mints a curl one-liner that sets Content-Type, because no parser claims a missing one', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    app = await createApp(store);
+
+    const minted = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/shot/upload-url',
+      headers: agentHeaders(),
+      payload: {},
+    });
+    expect(minted.statusCode).toBe(200);
+    const { url, upload, expiresAt, expiresInSeconds, maxBytes } = minted.json();
+    expect(upload).toContain("-H 'Content-Type: image/png'");
+    expect(typeof expiresAt).toBe('string');
+    expect(typeof expiresInSeconds).toBe('number');
+    expect(maxBytes).toBe(700 * 1024);
+    // expiresAt must match the signed exp, not a second clock read.
+    const token = new URL(String(url)).searchParams.get('token');
+    const claims = verifyUploadToken(String(token), secret);
+    expect(Math.floor(Date.parse(expiresAt) / 1000)).toBe(claims.exp);
+    expect(expiresInSeconds).toBeGreaterThan(0);
+
+    // Untyped body must not buffer — a '' parser hits everything.
+    const untyped = await app.inject({
+      method: 'PUT',
+      url: String(url).replace(/^https?:\/\/[^/]+/, ''),
+      payload: Buffer.from(TINY_PNG, 'base64'),
+    });
+    expect(untyped.statusCode).not.toBe(200);
   });
 
   it('retires base64 POST /shot and refuses a non-PNG PUT body', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -17,6 +17,12 @@ import {
   verifyAgentToken,
   type AgentTokenAccess,
 } from './agent-token.js';
+import {
+  assertUploadTokenUnexpired,
+  verifyUploadToken,
+  type UploadKind,
+  type UploadTokenClaims,
+} from './agent-upload-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import {
@@ -449,6 +455,36 @@ export async function registerAgentChannelRoutes(
   // Screenshots are far heavier than sentences, so they get their own, tighter caps.
   const maxShotsPerBuild = options.maxShotsPerBuild ?? 24;
   const maxShotsPerWindow = options.maxShotsPerWindow ?? 40;
+
+  // Raw PUT parsers for curl --upload-file (octet-stream / PNG / text).
+  const parseRawBuffer = (
+    _request: FastifyRequest,
+    body: Buffer | string | ArrayBuffer,
+    done: (error: Error | null, result?: Buffer) => void,
+  ): void => {
+    if (Buffer.isBuffer(body)) {
+      done(null, body);
+      return;
+    }
+    if (typeof body === 'string') {
+      done(null, Buffer.from(body));
+      return;
+    }
+    done(null, Buffer.from(body));
+  };
+  for (const type of ['application/octet-stream', 'image/png', 'text/plain', 'text/plain; charset=utf-8'] as const) {
+    try {
+      app.addContentTypeParser(type, { parseAs: 'buffer' }, parseRawBuffer);
+    } catch {
+      // Duplicate parser from a prior register on this app.
+    }
+  }
+  // curl --upload-file may omit Content-Type.
+  try {
+    app.addContentTypeParser('', { parseAs: 'buffer' }, parseRawBuffer);
+  } catch {
+    // already registered
+  }
   // A watcher pushes whatever currently builds, so previews arrive on a cadence rather
   // than on the agent's judgement. Only the newest few are worth keeping — each one
   // obsoletes the last — but the hourly allowance is generous, because a build that
@@ -566,6 +602,67 @@ export async function registerAgentChannelRoutes(
       reply.status(401).send({ error: error.message || 'invalid build token' });
       return null;
     }
+  }
+
+  // Auth via ?token= upload capability (no Authorization header).
+  async function resolveUploadBuild(
+    request: FastifyRequest,
+    reply: FastifyReply,
+    expectedKind: UploadKind,
+  ): Promise<{ issueNumber: number; record: SubmissionRecord; upload: UploadTokenClaims } | null> {
+    if (!store || !agentTokenSecret) {
+      reply.status(503).send({ error: 'the build channel is not configured' });
+      return null;
+    }
+
+    const raw =
+      typeof (request.query as { token?: unknown })?.token === 'string'
+        ? (request.query as { token: string }).token.trim()
+        : '';
+    if (!raw) {
+      reply.status(401).send({ error: 'missing upload token' });
+      return null;
+    }
+
+    let upload: UploadTokenClaims;
+    try {
+      upload = verifyUploadToken(raw, agentTokenSecret);
+      assertUploadTokenUnexpired(upload, now());
+    } catch (error) {
+      if (error instanceof InvalidAgentTokenError) {
+        reply.status(401).send({ error: error.message || 'invalid upload token' });
+        return null;
+      }
+      throw error;
+    }
+
+    if (upload.kind !== expectedKind) {
+      reply.status(403).send({ error: `this upload URL is for ${upload.kind}, not ${expectedKind}` });
+      return null;
+    }
+
+    const issueNumber = upload.jobId;
+    const record = await store.getSubmission(issueNumber);
+    if (!record) {
+      reply.status(404).send({ error: 'unknown build' });
+      return null;
+    }
+
+    try {
+      assertAgentTokenActive(
+        { jobId: upload.jobId, roundGeneration: upload.roundGeneration, exp: upload.exp },
+        record,
+        now(),
+      );
+    } catch (error) {
+      if (error instanceof InvalidAgentTokenError) {
+        reply.status(401).send({ error: error.message || 'invalid upload token' });
+        return null;
+      }
+      throw error;
+    }
+
+    return { issueNumber, record, upload };
   }
 
   function stopReason(record: SubmissionRecord): 'abandoned' | 'published' | 'canceled' | 'builder_handoff' | null {
@@ -914,6 +1011,67 @@ export async function registerAgentChannelRoutes(
         accepted: true,
         shot: { id: stored.id, createdAt: stored.createdAt, ...(label ? { label } : {}) },
         ...(await channelState(issueNumber, record)),
+      });
+    },
+  );
+
+  // Raw PNG PUT for screenshot_upload_url (same caps as POST /shot).
+  app.put(
+    '/api/agent/build/shot/upload',
+    {
+      bodyLimit: maxShotBytes + 1024,
+      config: { rateLimit: { max: 120, timeWindow: '1 hour' } },
+    },
+    async (request, reply) => {
+      const resolved = await resolveUploadBuild(request, reply, 'screenshot');
+      if (!resolved) return reply;
+      const { issueNumber, record, upload } = resolved;
+
+      const reject = async (reason: RejectionReason) =>
+        reply.send({ accepted: false, rejected: reason, ...(await channelState(issueNumber, record)) });
+
+      if (stopReason(record)) {
+        return reject('stopped');
+      }
+      if (isRateLimited(shotsByBuild, issueNumber, now(), maxShotsPerWindow)) {
+        return reject('rate_limited');
+      }
+      if ((await store!.countBuildShots(issueNumber)) >= maxShotsPerBuild) {
+        return reject('too_many_shots');
+      }
+
+      const body = request.body;
+      const bytes = Buffer.isBuffer(body)
+        ? body
+        : typeof body === 'string'
+          ? Buffer.from(body)
+          : body instanceof Uint8Array
+            ? Buffer.from(body)
+            : null;
+      if (!bytes || bytes.length === 0) {
+        return reply.status(400).send({ error: 'png body is required' });
+      }
+      if (bytes.length > maxShotBytes) {
+        return reply.status(413).send({ error: 'screenshot is too large' });
+      }
+      if (!bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+        return reply.status(400).send({ error: 'not a PNG' });
+      }
+
+      const label = upload.label
+        ? sanitizeCreatorText(upload.label, { singleLine: true }).slice(0, MAX_SHOT_LABEL)
+        : '';
+
+      const stored = await store!.appendBuildShot(issueNumber, {
+        data: bytes.toString('base64'),
+        ...(label ? { label } : {}),
+      });
+      options.onEvent?.(issueNumber);
+
+      return reply.send({
+        accepted: true,
+        shot: { id: stored.id, createdAt: stored.createdAt, ...(label ? { label } : {}) },
+        ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
       });
     },
   );

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -19,11 +19,15 @@ import {
 } from './agent-token.js';
 import {
   assertUploadTokenUnexpired,
+  DEFAULT_UPLOAD_URL_TTL_SECONDS,
+  mintUploadToken,
+  uploadCurlCommand,
   verifyUploadToken,
   type UploadKind,
   type UploadTokenClaims,
 } from './agent-upload-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import {
   InvalidUploadError,
@@ -131,36 +135,23 @@ const maxShotBytes = 700 * 1024;
  */
 const MAX_INLINE_FRAMES = 3;
 const MAX_INLINE_FRAME_BYTES = 1_400 * 1024;
-/** Fastify rejects before the handler when the JSON body exceeds this. */
-const shotBodyLimit = Math.ceil((maxShotBytes * 4) / 3) + 4096;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-const BuildShotInputSchema = z.object({
-  // Sized in base64 characters, so an oversized payload is rejected before it is
-  // decoded. 4/3 expansion plus padding slack.
-  png: z
-    .string()
-    .trim()
-    .min(1, 'png is required')
-    .max(Math.ceil((maxShotBytes * 4) / 3) + 1024, 'screenshot is too large')
-    .regex(/^[A-Za-z0-9+/\s]*={0,2}$/, 'png must be base64'),
+const ShotUploadUrlInputSchema = z.object({
   label: z
     .string()
     .trim()
     .max(MAX_SHOT_LABEL * 4)
     .optional(),
-  labelLocalized: z
+  caption: z
     .string()
     .trim()
     .max(MAX_SHOT_LABEL * 4)
     .optional(),
-  locale: z
-    .string()
-    .trim()
-    .max(10)
-    .regex(/^[a-z]{2}(-[A-Za-z0-9]{2,8})?$/, 'invalid locale')
-    .optional(),
 });
+
+const RETIRED_BASE64_SHOT_REASON =
+  'base64 screenshot upload is retired — POST /api/agent/build/shot/upload-url, then curl --upload-file <png> "$url"';
 
 const MAX_PREVIEW_LABEL = 120;
 /**
@@ -941,81 +932,67 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * A picture of the game as it stands, pushed before any commit.
-   *
-   * The agent already renders real frames headlessly (`npm run capture`), but those
-   * only reach the creator once they are committed and pushed, which is late. This
-   * takes the same PNG directly. Bytes are checked rather than trusted: the payload
-   * must actually start with a PNG signature, because everything downstream serves it
-   * back to a browser as an image.
-   */
+  // Retired: base64 PNG in JSON burned model output tokens and was unsafe at real sizes.
   app.post(
     '/api/agent/build/shot',
-    {
-      // Match the decoded PNG ceiling (base64-expanded) so the schema's max is reachable.
-      bodyLimit: shotBodyLimit,
-      config: { rateLimit: { max: 120, timeWindow: '1 hour' } },
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (_request, reply) => {
+      return reply.status(410).send({ error: RETIRED_BASE64_SHOT_REASON });
     },
+  );
+
+  // Mint a short-lived signed PUT URL; agent curls the PNG (no base64 in tool args).
+  app.post(
+    '/api/agent/build/shot/upload-url',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
     async (request, reply) => {
       const resolved = await resolveBuild(request, reply);
       if (!resolved) return reply;
       const { issueNumber, record } = resolved;
+      if (!agentTokenSecret) {
+        return reply.status(503).send({ error: 'the build channel is not configured' });
+      }
 
-      const parsed = BuildShotInputSchema.safeParse(request.body ?? {});
+      const parsed = ShotUploadUrlInputSchema.safeParse(request.body ?? {});
       if (!parsed.success) {
         return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
       }
 
-      const reject = async (reason: RejectionReason) =>
-        reply.send({ accepted: false, rejected: reason, ...(await channelState(issueNumber, record)) });
-
       if (stopReason(record)) {
-        return reject('stopped');
-      }
-      if (isRateLimited(shotsByBuild, issueNumber, now(), maxShotsPerWindow)) {
-        return reject('rate_limited');
-      }
-      if ((await store!.countBuildShots(issueNumber)) >= maxShotsPerBuild) {
-        return reject('too_many_shots');
+        return reply.send({
+          accepted: false,
+          rejected: 'stopped',
+          ...(await channelState(issueNumber, record)),
+        });
       }
 
-      const bytes = Buffer.from(parsed.data.png, 'base64');
-      if (bytes.length > maxShotBytes) {
-        return reply.status(413).send({ error: 'screenshot is too large' });
-      }
-      if (!bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
-        return reply.status(400).send({ error: 'not a PNG' });
-      }
-
-      const label = parsed.data.label
-        ? sanitizeCreatorText(parsed.data.label, { singleLine: true }).slice(0, MAX_SHOT_LABEL)
-        : '';
-      const labelLocalized = parsed.data.labelLocalized
-        ? sanitizeCreatorText(parsed.data.labelLocalized, { singleLine: true }).slice(0, MAX_SHOT_LABEL)
-        : '';
-      // Same rule as a progress sentence: a caption with no language tag cannot be
-      // matched to a reader, so it is dropped rather than shown to the wrong one.
-      const hasLocalized = Boolean(labelLocalized && parsed.data.locale);
-
-      // Re-encoded from the decoded bytes rather than stored as sent: whatever
-      // whitespace or padding variant arrived, what we keep is canonical base64.
-      const stored = await store!.appendBuildShot(issueNumber, {
-        data: bytes.toString('base64'),
+      const labelRaw = parsed.data.label ?? parsed.data.caption;
+      const label = labelRaw ? sanitizeCreatorText(labelRaw, { singleLine: true }).slice(0, MAX_SHOT_LABEL) : '';
+      const generation = record.roundGeneration ?? 1;
+      const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
+      const token = mintUploadToken(agentTokenSecret, {
+        jobId: issueNumber,
+        roundGeneration: generation,
+        kind: 'screenshot',
         ...(label ? { label } : {}),
-        ...(hasLocalized ? { labelLocalized, locale: parsed.data.locale } : {}),
+        now: now(),
+        ttlSeconds,
       });
-      options.onEvent?.(issueNumber);
-
+      const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+      const url = `${canonicalAppBaseUrl()}/api/agent/build/shot/upload?token=${encodeURIComponent(token)}`;
       return reply.send({
         accepted: true,
-        shot: { id: stored.id, createdAt: stored.createdAt, ...(label ? { label } : {}) },
+        url,
+        expiresAt,
+        expiresInSeconds: ttlSeconds,
+        upload: uploadCurlCommand(url, 'shot.png'),
+        maxBytes: maxShotBytes,
         ...(await channelState(issueNumber, record)),
       });
     },
   );
 
-  // Raw PNG PUT for screenshot_upload_url (same caps as POST /shot).
+  // Raw PNG PUT for screenshot_upload_url (no base64).
   app.put(
     '/api/agent/build/shot/upload',
     {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -463,18 +463,13 @@ export async function registerAgentChannelRoutes(
     }
     done(null, Buffer.from(body));
   };
+  // Named types only — a '' parser would buffer every untyped request app-wide.
   for (const type of ['application/octet-stream', 'image/png', 'text/plain', 'text/plain; charset=utf-8'] as const) {
     try {
       app.addContentTypeParser(type, { parseAs: 'buffer' }, parseRawBuffer);
     } catch {
       // Duplicate parser from a prior register on this app.
     }
-  }
-  // curl --upload-file may omit Content-Type.
-  try {
-    app.addContentTypeParser('', { parseAs: 'buffer' }, parseRawBuffer);
-  } catch {
-    // already registered
   }
   // A watcher pushes whatever currently builds, so previews arrive on a cadence rather
   // than on the agent's judgement. Only the newest few are worth keeping — each one
@@ -970,22 +965,24 @@ export async function registerAgentChannelRoutes(
       const label = labelRaw ? sanitizeCreatorText(labelRaw, { singleLine: true }).slice(0, MAX_SHOT_LABEL) : '';
       const generation = record.roundGeneration ?? 1;
       const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
+      // One clock read: advertised expiresAt must match the signed exp.
+      const issuedAt = now();
       const token = mintUploadToken(agentTokenSecret, {
         jobId: issueNumber,
         roundGeneration: generation,
         kind: 'screenshot',
         ...(label ? { label } : {}),
-        now: now(),
+        now: issuedAt,
         ttlSeconds,
       });
-      const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+      const expiresAt = new Date(issuedAt + ttlSeconds * 1000).toISOString();
       const url = `${canonicalAppBaseUrl()}/api/agent/build/shot/upload?token=${encodeURIComponent(token)}`;
       return reply.send({
         accepted: true,
         url,
         expiresAt,
         expiresInSeconds: ttlSeconds,
-        upload: uploadCurlCommand(url, 'shot.png'),
+        upload: uploadCurlCommand(url, 'shot.png', 'image/png'),
         maxBytes: maxShotBytes,
         ...(await channelState(issueNumber, record)),
       });

--- a/apps/api/src/agent-upload-token.test.ts
+++ b/apps/api/src/agent-upload-token.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { InvalidAgentTokenError } from './agent-token.js';
+import {
+  assertUploadTokenUnexpired,
+  mintUploadToken,
+  uploadCurlCommand,
+  verifyUploadToken,
+} from './agent-upload-token.js';
+
+const secret = 'upload-test-secret';
+
+describe('agent-upload-token', () => {
+  it('round-trips a screenshot upload token', () => {
+    const token = mintUploadToken(secret, {
+      jobId: 55,
+      roundGeneration: 1,
+      kind: 'screenshot',
+      label: 'first frame',
+      now: 1_700_000_000_000,
+      ttlSeconds: 900,
+    });
+    const claims = verifyUploadToken(token, secret);
+    expect(claims).toMatchObject({
+      jobId: 55,
+      roundGeneration: 1,
+      kind: 'screenshot',
+      label: 'first frame',
+      exp: 1_700_000_000 + 900,
+    });
+    expect(claims.nonce).toMatch(/^[a-f0-9]+$/);
+    assertUploadTokenUnexpired(claims, 1_700_000_000_000 + 60_000);
+  });
+
+  it('binds stage path into the signature', () => {
+    const token = mintUploadToken(secret, {
+      jobId: 7,
+      roundGeneration: 2,
+      kind: 'stage',
+      path: 'game/render.ts',
+    });
+    const claims = verifyUploadToken(token, secret);
+    expect(claims.path).toBe('game/render.ts');
+    expect(claims.kind).toBe('stage');
+  });
+
+  it('rejects a tampered path', () => {
+    const token = mintUploadToken(secret, {
+      jobId: 7,
+      roundGeneration: 1,
+      kind: 'stage',
+      path: 'game.ts',
+    });
+    const wire = Buffer.from(token, 'base64url').toString('utf8');
+    const parts = wire.split('.');
+    parts[3] = Buffer.from('evil.ts', 'utf8').toString('base64url');
+    const tampered = Buffer.from(parts.join('.'), 'utf8').toString('base64url');
+    expect(() => verifyUploadToken(tampered, secret)).toThrow(InvalidAgentTokenError);
+  });
+
+  it('rejects an expired token', () => {
+    const token = mintUploadToken(secret, {
+      jobId: 1,
+      roundGeneration: 1,
+      kind: 'screenshot',
+      now: 1_000_000,
+      ttlSeconds: 1,
+    });
+    const claims = verifyUploadToken(token, secret);
+    expect(() => assertUploadTokenUnexpired(claims, 1_000_000 + 2_000)).toThrow(/finished/i);
+  });
+
+  it('requires a path for stage uploads', () => {
+    expect(() =>
+      mintUploadToken(secret, {
+        jobId: 1,
+        roundGeneration: 1,
+        kind: 'stage',
+      }),
+    ).toThrow(/path/i);
+  });
+
+  it('builds a curl --upload-file one-liner', () => {
+    expect(uploadCurlCommand("https://example.com/u?token=a'b", 'shot.png')).toBe(
+      "curl --upload-file shot.png 'https://example.com/u?token=a'\\''b'",
+    );
+  });
+});

--- a/apps/api/src/agent-upload-token.test.ts
+++ b/apps/api/src/agent-upload-token.test.ts
@@ -79,9 +79,9 @@ describe('agent-upload-token', () => {
     ).toThrow(/path/i);
   });
 
-  it('builds a curl --upload-file one-liner', () => {
-    expect(uploadCurlCommand("https://example.com/u?token=a'b", 'shot.png')).toBe(
-      "curl --upload-file shot.png 'https://example.com/u?token=a'\\''b'",
+  it('builds a curl --upload-file one-liner carrying an explicit content type', () => {
+    expect(uploadCurlCommand("https://example.com/u?token=a'b", 'shot.png', 'image/png')).toBe(
+      "curl -H 'Content-Type: image/png' --upload-file shot.png 'https://example.com/u?token=a'\\''b'",
     );
   });
 });

--- a/apps/api/src/agent-upload-token.ts
+++ b/apps/api/src/agent-upload-token.ts
@@ -157,8 +157,8 @@ export function assertUploadTokenUnexpired(claims: UploadTokenClaims, nowMs: num
   }
 }
 
-// Copy-paste curl one-liner; URL is already absolute.
-export function uploadCurlCommand(url: string, localPath: string): string {
+// Explicit Content-Type: no parser claims a missing one.
+export function uploadCurlCommand(url: string, localPath: string, contentType: string): string {
   const escaped = url.replace(/'/g, `'\\''`);
-  return `curl --upload-file ${localPath} '${escaped}'`;
+  return `curl -H 'Content-Type: ${contentType}' --upload-file ${localPath} '${escaped}'`;
 }

--- a/apps/api/src/agent-upload-token.ts
+++ b/apps/api/src/agent-upload-token.ts
@@ -1,0 +1,164 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { InvalidAgentTokenError, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import { DEFAULT_SIGNED_URL_TTL_SECONDS } from './gcs-sign.js';
+
+// Short-lived PUT URLs for curl --upload-file.
+
+const SCOPE = 'agent-upload-v1';
+
+// Match kit signed-read TTL (15 min).
+export const DEFAULT_UPLOAD_URL_TTL_SECONDS = DEFAULT_SIGNED_URL_TTL_SECONDS;
+
+export type UploadKind = 'screenshot' | 'stage';
+
+export interface UploadTokenClaims {
+  jobId: number;
+  roundGeneration: number;
+  kind: UploadKind;
+  // Stage path bound into the signature.
+  path?: string;
+  // Optional caption bound into the URL.
+  label?: string;
+  // Unix seconds.
+  exp: number;
+  nonce: string;
+}
+
+export interface MintUploadTokenOptions {
+  jobId: number;
+  roundGeneration: number;
+  kind: UploadKind;
+  path?: string;
+  label?: string;
+  // Epoch ms; defaults to Date.now().
+  now?: number;
+  // Override TTL seconds (tests).
+  ttlSeconds?: number;
+}
+
+function encodeOptional(value: string | undefined): string {
+  return value ? Buffer.from(value, 'utf8').toString('base64url') : '';
+}
+
+function decodeOptional(raw: string): string | undefined {
+  if (!raw) return undefined;
+  return Buffer.from(raw, 'base64url').toString('utf8');
+}
+
+function sign(
+  jobId: number,
+  roundGeneration: number,
+  kind: UploadKind,
+  path: string | undefined,
+  label: string | undefined,
+  exp: number,
+  nonce: string,
+  secret: string,
+): string {
+  return createHmac('sha256', secret)
+    .update(`${SCOPE}:${jobId}:${roundGeneration}:${kind}:${path ?? ''}:${label ?? ''}:${exp}:${nonce}`)
+    .digest('hex');
+}
+
+function safeEqualHex(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+export function mintUploadToken(secret: string, options: MintUploadTokenOptions): string {
+  if (!Number.isSafeInteger(options.jobId) || options.jobId <= 0) {
+    throw new InvalidAgentTokenError('invalid job id');
+  }
+  if (!Number.isSafeInteger(options.roundGeneration) || options.roundGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid round generation');
+  }
+  if (options.kind !== 'screenshot' && options.kind !== 'stage') {
+    throw new InvalidAgentTokenError('invalid upload kind');
+  }
+  if (options.kind === 'stage' && (!options.path || !options.path.trim())) {
+    throw new InvalidAgentTokenError('path is required for stage uploads');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlSeconds = options.ttlSeconds ?? DEFAULT_UPLOAD_URL_TTL_SECONDS;
+  const exp = Math.floor(nowMs / 1000) + Math.max(1, Math.floor(ttlSeconds));
+  const nonce = randomBytes(12).toString('hex');
+  const path = options.path?.trim() || undefined;
+  const label = options.label?.trim() || undefined;
+  const signature = sign(options.jobId, options.roundGeneration, options.kind, path, label, exp, nonce, secret);
+  return Buffer.from(
+    `${options.jobId}.${options.roundGeneration}.${options.kind}.${encodeOptional(path)}.${encodeOptional(label)}.${exp}.${nonce}.${signature}`,
+    'utf8',
+  ).toString('base64url');
+}
+
+export function verifyUploadToken(token: string, secret: string): UploadTokenClaims {
+  try {
+    const parts = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (parts.length !== 8) {
+      throw new InvalidAgentTokenError();
+    }
+    const [jobIdRaw, generationRaw, kindRaw, pathRaw, labelRaw, expRaw, nonce, signature] = parts;
+    if (
+      !jobIdRaw ||
+      !generationRaw ||
+      !kindRaw ||
+      pathRaw === undefined ||
+      labelRaw === undefined ||
+      !expRaw ||
+      !nonce ||
+      !signature ||
+      !/^\d+$/.test(jobIdRaw) ||
+      !/^\d+$/.test(generationRaw) ||
+      (kindRaw !== 'screenshot' && kindRaw !== 'stage') ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]+$/i.test(nonce) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    const jobId = Number.parseInt(jobIdRaw, 10);
+    const roundGeneration = Number.parseInt(generationRaw, 10);
+    const exp = Number.parseInt(expRaw, 10);
+    const kind = kindRaw as UploadKind;
+    const path = decodeOptional(pathRaw);
+    const label = decodeOptional(labelRaw);
+    if (
+      !Number.isSafeInteger(jobId) ||
+      jobId <= 0 ||
+      !Number.isSafeInteger(roundGeneration) ||
+      roundGeneration < 1 ||
+      !Number.isSafeInteger(exp) ||
+      exp <= 0
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    if (!safeEqualHex(signature, sign(jobId, roundGeneration, kind, path, label, exp, nonce, secret))) {
+      throw new InvalidAgentTokenError();
+    }
+    return {
+      jobId,
+      roundGeneration,
+      kind,
+      ...(path ? { path } : {}),
+      ...(label ? { label } : {}),
+      exp,
+      nonce,
+    };
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) throw error;
+    throw new InvalidAgentTokenError();
+  }
+}
+
+export function assertUploadTokenUnexpired(claims: UploadTokenClaims, nowMs: number = Date.now()): void {
+  if (claims.exp * 1000 <= nowMs) {
+    throw new InvalidAgentTokenError(STALE_AGENT_TOKEN_REASON);
+  }
+}
+
+// Copy-paste curl one-liner; URL is already absolute.
+export function uploadCurlCommand(url: string, localPath: string): string {
+  const escaped = url.replace(/'/g, `'\\''`);
+  return `curl --upload-file ${localPath} '${escaped}'`;
+}

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -22,7 +22,6 @@ const NO_PULSE = new Set([
   'open_round',
   'continue_draft',
   'report_progress',
-  'send_screenshot',
   // Mint-only; the signed PUT stores the shot.
   'screenshot_upload_url',
   'submit_sources',

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -23,6 +23,8 @@ const NO_PULSE = new Set([
   'continue_draft',
   'report_progress',
   'send_screenshot',
+  // Mint-only; the signed PUT stores the shot.
+  'screenshot_upload_url',
   'submit_sources',
   // Channel stage/patch already refresh lastAgentSignalAt (+ staging_sources).
   'stage_source_file',

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -363,7 +363,6 @@ describe('POST /api/mcp (BY-05)', () => {
         'list_examples',
         'get_example',
         'report_progress',
-        'send_screenshot',
         'screenshot_upload_url',
         'stage_source_file',
         'patch_source_file',
@@ -376,14 +375,15 @@ describe('POST /api/mcp (BY-05)', () => {
         'ack_inbox',
       ]),
     );
+    expect(names).not.toContain('send_screenshot');
     const tools = listed.json().result.tools as Array<{
       name: string;
       description: string;
       annotations?: { title?: string };
     }>;
     const screenshotUpload = tools.find((t) => t.name === 'screenshot_upload_url');
-    expect(screenshotUpload?.description).toMatch(/curl --upload-file|prefer/i);
-    expect(tools.find((t) => t.name === 'send_screenshot')?.description).toMatch(/screenshot_upload_url|prefer/i);
+    expect(screenshotUpload?.description).toMatch(/curl --upload-file/i);
+    expect(screenshotUpload?.description).toMatch(/no send_screenshot|never enter the model|no base64/i);
     const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
     // start advertises the returned workflow / inbox policy / refusal guidance.
@@ -558,7 +558,8 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
     expect(joined).toMatch(/read_kit_files|list_kit_files|read_kit_file/);
-    expect(joined).toMatch(/send_screenshot/);
+    expect(joined).toMatch(/screenshot_upload_url/);
+    expect(joined).not.toMatch(/send_screenshot/);
     expect(joined).toMatch(/stage_source_file|fromStaged/);
     expect(joined).toMatch(/patch_source_file/);
     expect(joined).toMatch(/module_too_large/);
@@ -967,7 +968,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(warningCodes).toContain('must_deliver');
   });
 
-  it('rejects oversized screenshots at the MCP layer', async () => {
+  it('refuses the retired send_screenshot base64 tool', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
     app = await createApp(store);
@@ -975,29 +976,14 @@ describe('POST /api/mcp (BY-05)', () => {
     const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
     const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
 
-    // Over the Firestore-safe decoded ceiling, under the MCP bodyLimit.
-    const huge = Buffer.alloc(800 * 1024, 1).toString('base64');
-    const res = await callTool(app, 'send_screenshot', { sessionKey, png: huge }, { 'mcp-session-id': sessionId });
-    expect(res.isError).toBe(true);
-    expect(JSON.stringify(res.structured)).toMatch(/too large/i);
-  });
-
-  it('accepts a small screenshot via send_screenshot', async () => {
-    const store = new InMemoryStore();
-    await seedJob(store);
-    app = await createApp(store);
-    const sessionId = await initialize(app);
-    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
-    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
-
-    const res = await callTool(
+    const res = await mcpCall(
       app,
-      'send_screenshot',
-      { sessionKey, png: TINY_PNG, caption: 'first frame' },
+      'tools/call',
+      { name: 'send_screenshot', arguments: { sessionKey, png: TINY_PNG } },
       { 'mcp-session-id': sessionId },
     );
-    expect(res.isError).toBe(false);
-    expect(res.structured).toMatchObject({ ok: true, stop: false });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().error?.message).toMatch(/unknown tool: send_screenshot/);
   });
 
   it('screenshot_upload_url + raw PUT delivers without base64 in a tool argument', async () => {
@@ -1885,7 +1871,7 @@ describe('POST /api/mcp (BY-05)', () => {
       'open_round',
       'continue_draft',
       'report_progress',
-      'send_screenshot',
+      'screenshot_upload_url',
       'stage_source_file',
       'patch_source_file',
       'clear_staged_sources',
@@ -2431,12 +2417,19 @@ describe('MCP Apps views (SEP-1865, Phase 0)', () => {
     const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
 
     await callTool(app, 'report_progress', { sessionKey, text: 'wiring the HUD' }, { 'mcp-session-id': sessionId });
-    await callTool(
+    const minted = await callTool(
       app,
-      'send_screenshot',
-      { sessionKey, png: TINY_PNG, label: 'first draw' },
+      'screenshot_upload_url',
+      { sessionKey, label: 'first draw' },
       { 'mcp-session-id': sessionId },
     );
+    const shotUrl = (minted.structured as { url: string }).url.replace(/^https?:\/\/[^/]+/, '');
+    await app.inject({
+      method: 'PUT',
+      url: shotUrl,
+      headers: { 'content-type': 'image/png' },
+      payload: Buffer.from(TINY_PNG, 'base64'),
+    });
 
     const first = await callTool(app, 'get_round_status', { sessionKey }, { 'mcp-session-id': sessionId });
     const status = first.structured as {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1008,7 +1008,7 @@ describe('POST /api/mcp (BY-05)', () => {
       expiresAt: string;
     };
     expect(maxBytes).toBe(700 * 1024);
-    expect(upload).toMatch(/^curl --upload-file shot\.png '/);
+    expect(upload).toMatch(/^curl -H 'Content-Type: image\/png' --upload-file shot\.png '/);
     expect(url).toMatch(/\/api\/agent\/build\/shot\/upload\?token=/);
 
     const pngBytes = Buffer.from(TINY_PNG, 'base64');

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -364,6 +364,7 @@ describe('POST /api/mcp (BY-05)', () => {
         'get_example',
         'report_progress',
         'send_screenshot',
+        'screenshot_upload_url',
         'stage_source_file',
         'patch_source_file',
         'list_staged_sources',
@@ -380,6 +381,9 @@ describe('POST /api/mcp (BY-05)', () => {
       description: string;
       annotations?: { title?: string };
     }>;
+    const screenshotUpload = tools.find((t) => t.name === 'screenshot_upload_url');
+    expect(screenshotUpload?.description).toMatch(/curl --upload-file|prefer/i);
+    expect(tools.find((t) => t.name === 'send_screenshot')?.description).toMatch(/screenshot_upload_url|prefer/i);
     const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
     // start advertises the returned workflow / inbox policy / refusal guidance.
@@ -994,6 +998,66 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(res.isError).toBe(false);
     expect(res.structured).toMatchObject({ ok: true, stop: false });
+  });
+
+  it('screenshot_upload_url + raw PUT delivers without base64 in a tool argument', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const minted = await callTool(
+      app,
+      'screenshot_upload_url',
+      { sessionKey, caption: 'via curl' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(minted.isError).toBe(false);
+    const { url, upload, maxBytes } = minted.structured as {
+      url: string;
+      upload: string;
+      maxBytes: number;
+      expiresAt: string;
+    };
+    expect(maxBytes).toBe(700 * 1024);
+    expect(upload).toMatch(/^curl --upload-file shot\.png '/);
+    expect(url).toMatch(/\/api\/agent\/build\/shot\/upload\?token=/);
+
+    const pngBytes = Buffer.from(TINY_PNG, 'base64');
+    // ~500 KB of valid PNG prefix + padding would blow the signature check; use a
+    // real-sized buffer that still starts with the PNG magic for the size path, and
+    // the tiny PNG for the happy path.
+    const put = await app.inject({
+      method: 'PUT',
+      url: url.replace(/^https?:\/\/[^/]+/, ''),
+      headers: { 'content-type': 'application/octet-stream' },
+      payload: pngBytes,
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toMatchObject({
+      accepted: true,
+      shot: { label: 'via curl' },
+      control: { stop: false },
+    });
+
+    const shots = await store.listBuildShots(ISSUE);
+    expect(shots).toHaveLength(1);
+    expect(shots[0]?.label).toBe('via curl');
+
+    // Oversized raw body still refused at the same 700 KB ceiling.
+    const huge = Buffer.alloc(800 * 1024, 0x41);
+    huge.set(pngBytes.subarray(0, 8), 0);
+    const minted2 = await callTool(app, 'screenshot_upload_url', { sessionKey }, { 'mcp-session-id': sessionId });
+    const url2 = (minted2.structured as { url: string }).url.replace(/^https?:\/\/[^/]+/, '');
+    const tooBig = await app.inject({
+      method: 'PUT',
+      url: url2,
+      headers: { 'content-type': 'image/png' },
+      payload: huge,
+    });
+    expect(tooBig.statusCode).toBe(413);
   });
 
   it('rate-limits unauthenticated / invalid start attempts', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -39,7 +39,6 @@ import {
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
-import { DEFAULT_UPLOAD_URL_TTL_SECONDS, mintUploadToken, uploadCurlCommand } from './agent-upload-token.js';
 import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
@@ -118,10 +117,10 @@ const SESSION_HEADER = 'mcp-session-id';
 const MAX_INVALID_STARTS_PER_WINDOW = 20;
 const INVALID_START_WINDOW_MS = 60 * 60 * 1000;
 
-/** Hard body ceiling for MCP POSTs (screenshot base64 + JSON-RPC framing). */
+/** Hard body ceiling for MCP POSTs (JSON-RPC framing; screenshots use signed PUT). */
 const MAX_MCP_BODY_BYTES = 2 * 1024 * 1024;
 
-/** Matches channel `maxShotBytes` — Firestore doc limit, not the aspirational 2 MB brief. */
+/** Matches channel `maxShotBytes` — Firestore doc limit on decoded PNG. */
 const MAX_SCREENSHOT_BYTES = 700 * 1024;
 const MAX_SUBMIT_FILES = MAX_UPLOAD_FILES;
 
@@ -530,7 +529,7 @@ const BEHAVIOURAL_CONTRACT = [
   // Agents that skip the pair leave every non-English creator reading commit-speak in a
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
-  'Send a screenshot as soon as the game draws anything playable — prefer screenshot_upload_url + curl --upload-file when you have shell egress; send_screenshot (base64) is the no-shell fallback.',
+  'Send a screenshot as soon as the game draws anything playable via screenshot_upload_url + curl --upload-file. There is no base64 screenshot tool — PNG bytes must never enter the model.',
   'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
@@ -568,7 +567,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them. If warnings.code=module_too_large, split those oversized modules into cohesive game/*.ts pieces BEFORE adding features — do not grow them further.',
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
-  'As soon as the game draws anything playable: prefer screenshot_upload_url then curl --upload-file <png> "$url" (bytes never enter the model). Fall back to send_screenshot with base64 only when you have no shell egress — a real PNG at the 700 KB cap cannot fit in model output.',
+  'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
   'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
@@ -3164,15 +3163,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           expiresInSeconds: { type: 'number' },
           upload: { type: 'string' },
           maxBytes: { type: 'number' },
+          ...REPLY_CONTROL,
         },
         required: ['url', 'expiresAt', 'expiresInSeconds', 'upload', 'maxBytes'],
       },
-      annotations: { title: 'Get a screenshot upload URL', ...READS },
+      annotations: { title: 'Get a screenshot upload URL', ...WRITES },
       description:
-        'Preferred way to send a screenshot when you have curl/shell egress. Returns a short-lived signed PUT URL — ' +
-        'run the returned `upload` one-liner (curl --upload-file <png> "$url"). The PNG body never enters the model; ' +
-        'the PUT still validates ≤700 KB decoded PNG and returns stop/pendingMessages as JSON. ' +
-        'Use send_screenshot (base64) only when you cannot curl. ' +
+        'The only way to send a mid-build screenshot. Returns a short-lived signed PUT URL — run the returned ' +
+        '`upload` one-liner (curl --upload-file <png> "$url"). PNG bytes must never enter the model as base64; ' +
+        'there is no send_screenshot tool. The PUT validates ≤700 KB decoded PNG and returns stop/pendingMessages. ' +
+        'Without shell egress, skip mid-build screenshots — the gate still captures on delivery. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
@@ -3186,96 +3186,36 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
-        if (!agentTokenSecret) return toolErr('the MCP build endpoint is not configured');
         const labelRaw =
           typeof args.caption === 'string' ? args.caption : typeof args.label === 'string' ? args.label : undefined;
         const label = typeof labelRaw === 'string' && labelRaw.trim() ? labelRaw.trim().slice(0, 120) : undefined;
-        const generation = auth.record.roundGeneration ?? auth.claims.roundGeneration ?? 1;
-        const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
-        const token = mintUploadToken(agentTokenSecret, {
-          jobId: auth.issueNumber,
-          roundGeneration: generation,
-          kind: 'screenshot',
-          ...(label ? { label } : {}),
-          now: now(),
-          ttlSeconds,
-        });
-        const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
-        const url = `${canonicalAppBaseUrl()}/api/agent/build/shot/upload?token=${encodeURIComponent(token)}`;
-        return toolOk({
-          url,
-          expiresAt,
-          expiresInSeconds: ttlSeconds,
-          upload: uploadCurlCommand(url, 'shot.png'),
-          maxBytes: MAX_SCREENSHOT_BYTES,
-        });
-      },
-    },
-
-    send_screenshot: {
-      outputSchema: {
-        type: 'object',
-        properties: { ok: { type: 'boolean' }, reason: { type: 'string' }, ...REPLY_CONTROL },
-        required: ['ok'],
-      },
-      annotations: { title: 'Send a screenshot', ...WRITES },
-      description:
-        'Upload a PNG screenshot as base64 (≤700 KB decoded — Firestore-backed). Prefer screenshot_upload_url + ' +
-        'curl --upload-file when you have shell egress — re-emitting a real PNG as base64 burns tens of thousands of ' +
-        'output tokens and often cannot fit in the model ceiling. Reply includes stop and pendingMessages. ' +
-        BEHAVIOURAL_CONTRACT,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          sessionKey: SESSION_KEY_PROP,
-          png: {
-            type: 'string',
-            description: 'Base64-encoded PNG (≤700 KB decoded). Prefer screenshot_upload_url when you have curl.',
-          },
-          pngBase64: { type: 'string', description: 'Alias for png.' },
-          caption: { type: 'string' },
-          label: { type: 'string' },
-        },
-        required: [],
-      },
-      handler: async (args, ctx) => {
-        const auth = await resolveAuth(ctx, args);
-        if (!('channelToken' in auth)) return auth;
-        const pngRaw =
-          typeof args.png === 'string' ? args.png : typeof args.pngBase64 === 'string' ? args.pngBase64 : '';
-        const png = pngRaw.replace(/^data:image\/png;base64,/i, '').replace(/\s+/g, '');
-        if (!png) return toolErr('png is required');
-        let bytes: Buffer;
-        try {
-          bytes = Buffer.from(png, 'base64');
-        } catch {
-          return toolErr('png must be base64');
-        }
-        if (bytes.length > MAX_SCREENSHOT_BYTES) {
-          return toolErr('screenshot is too large (max 700 KB)');
-        }
-        const label =
-          typeof args.caption === 'string' ? args.caption : typeof args.label === 'string' ? args.label : undefined;
-        const res = await injectChannel(ctx.request, 'POST', '/api/agent/build/shot', auth.channelToken, {
-          png,
+        const res = await injectChannel(ctx.request, 'POST', '/api/agent/build/shot/upload-url', auth.channelToken, {
           ...(label ? { label } : {}),
         });
         const body = res.json() as {
           error?: string;
           accepted?: boolean;
           rejected?: string;
+          url?: string;
+          expiresAt?: string;
+          expiresInSeconds?: number;
+          upload?: string;
+          maxBytes?: number;
           control?: { stop?: boolean; reason?: string };
           pending?: Array<{ id: string; text: string; createdAt: string }>;
         };
-        if (res.statusCode === 413) {
-          return toolErr(body.error ?? 'screenshot is too large');
-        }
         if (res.statusCode !== 200) {
-          return toolErr(body.error ?? `screenshot failed (${res.statusCode})`);
+          return toolErr(body.error ?? `screenshot upload URL failed (${res.statusCode})`);
+        }
+        if (!body.url || !body.upload) {
+          return toolErr(body.rejected ?? 'screenshot upload URL was not issued');
         }
         return toolOk({
-          ok: body.accepted !== false,
-          ...(body.rejected ? { rejected: body.rejected } : {}),
+          url: body.url,
+          expiresAt: body.expiresAt ?? '',
+          expiresInSeconds: body.expiresInSeconds ?? 0,
+          upload: body.upload,
+          maxBytes: body.maxBytes ?? MAX_SCREENSHOT_BYTES,
           ...channelControlFields(body),
           pendingMessages: pendingMessagesFromChannel(body),
         });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -39,6 +39,7 @@ import {
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
+import { DEFAULT_UPLOAD_URL_TTL_SECONDS, mintUploadToken, uploadCurlCommand } from './agent-upload-token.js';
 import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
@@ -529,7 +530,7 @@ const BEHAVIOURAL_CONTRACT = [
   // Agents that skip the pair leave every non-English creator reading commit-speak in a
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
-  'Send a screenshot as soon as the game draws anything playable.',
+  'Send a screenshot as soon as the game draws anything playable — prefer screenshot_upload_url + curl --upload-file when you have shell egress; send_screenshot (base64) is the no-shell fallback.',
   'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
@@ -567,7 +568,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them. If warnings.code=module_too_large, split those oversized modules into cohesive game/*.ts pieces BEFORE adding features — do not grow them further.',
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
-  'send_screenshot as soon as the game draws anything playable.',
+  'As soon as the game draws anything playable: prefer screenshot_upload_url then curl --upload-file <png> "$url" (bytes never enter the model). Fall back to send_screenshot with base64 only when you have no shell egress — a real PNG at the 700 KB cap cannot fit in model output.',
   'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
@@ -3154,6 +3155,63 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
     },
 
+    screenshot_upload_url: {
+      outputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string' },
+          expiresAt: { type: 'string' },
+          expiresInSeconds: { type: 'number' },
+          upload: { type: 'string' },
+          maxBytes: { type: 'number' },
+        },
+        required: ['url', 'expiresAt', 'expiresInSeconds', 'upload', 'maxBytes'],
+      },
+      annotations: { title: 'Get a screenshot upload URL', ...READS },
+      description:
+        'Preferred way to send a screenshot when you have curl/shell egress. Returns a short-lived signed PUT URL — ' +
+        'run the returned `upload` one-liner (curl --upload-file <png> "$url"). The PNG body never enters the model; ' +
+        'the PUT still validates ≤700 KB decoded PNG and returns stop/pendingMessages as JSON. ' +
+        'Use send_screenshot (base64) only when you cannot curl. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          caption: { type: 'string' },
+          label: { type: 'string' },
+        },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        if (!agentTokenSecret) return toolErr('the MCP build endpoint is not configured');
+        const labelRaw =
+          typeof args.caption === 'string' ? args.caption : typeof args.label === 'string' ? args.label : undefined;
+        const label = typeof labelRaw === 'string' && labelRaw.trim() ? labelRaw.trim().slice(0, 120) : undefined;
+        const generation = auth.record.roundGeneration ?? auth.claims.roundGeneration ?? 1;
+        const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
+        const token = mintUploadToken(agentTokenSecret, {
+          jobId: auth.issueNumber,
+          roundGeneration: generation,
+          kind: 'screenshot',
+          ...(label ? { label } : {}),
+          now: now(),
+          ttlSeconds,
+        });
+        const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+        const url = `${canonicalAppBaseUrl()}/api/agent/build/shot/upload?token=${encodeURIComponent(token)}`;
+        return toolOk({
+          url,
+          expiresAt,
+          expiresInSeconds: ttlSeconds,
+          upload: uploadCurlCommand(url, 'shot.png'),
+          maxBytes: MAX_SCREENSHOT_BYTES,
+        });
+      },
+    },
+
     send_screenshot: {
       outputSchema: {
         type: 'object',
@@ -3162,13 +3220,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
       annotations: { title: 'Send a screenshot', ...WRITES },
       description:
-        'Upload a PNG screenshot (base64, ≤700 KB decoded — Firestore-backed) as soon as the game draws. Reply includes stop and pendingMessages. ' +
+        'Upload a PNG screenshot as base64 (≤700 KB decoded — Firestore-backed). Prefer screenshot_upload_url + ' +
+        'curl --upload-file when you have shell egress — re-emitting a real PNG as base64 burns tens of thousands of ' +
+        'output tokens and often cannot fit in the model ceiling. Reply includes stop and pendingMessages. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
-          png: { type: 'string', description: 'Base64-encoded PNG (≤700 KB decoded).' },
+          png: {
+            type: 'string',
+            description: 'Base64-encoded PNG (≤700 KB decoded). Prefer screenshot_upload_url when you have curl.',
+          },
           pngBase64: { type: 'string', description: 'Alias for png.' },
           caption: { type: 'string' },
           label: { type: 'string' },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -120,8 +120,6 @@ const INVALID_START_WINDOW_MS = 60 * 60 * 1000;
 /** Hard body ceiling for MCP POSTs (JSON-RPC framing; screenshots use signed PUT). */
 const MAX_MCP_BODY_BYTES = 2 * 1024 * 1024;
 
-/** Matches channel `maxShotBytes` — Firestore doc limit on decoded PNG. */
-const MAX_SCREENSHOT_BYTES = 700 * 1024;
 const MAX_SUBMIT_FILES = MAX_UPLOAD_FILES;
 
 /** How often the round view should re-read status. Matches the gate's own backoff. */
@@ -3207,15 +3205,28 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (res.statusCode !== 200) {
           return toolErr(body.error ?? `screenshot upload URL failed (${res.statusCode})`);
         }
-        if (!body.url || !body.upload) {
-          return toolErr(body.rejected ?? 'screenshot upload URL was not issued');
+        if (body.rejected) {
+          return toolErr(`screenshot upload URL was not issued (${body.rejected})`);
+        }
+        // Never invent an expiry or cap the channel did not state.
+        if (
+          typeof body.url !== 'string' ||
+          !body.url ||
+          typeof body.upload !== 'string' ||
+          !body.upload ||
+          typeof body.expiresAt !== 'string' ||
+          !body.expiresAt ||
+          typeof body.expiresInSeconds !== 'number' ||
+          typeof body.maxBytes !== 'number'
+        ) {
+          return toolErr('screenshot upload URL reply was incomplete — retry');
         }
         return toolOk({
           url: body.url,
-          expiresAt: body.expiresAt ?? '',
-          expiresInSeconds: body.expiresInSeconds ?? 0,
+          expiresAt: body.expiresAt,
+          expiresInSeconds: body.expiresInSeconds,
           upload: body.upload,
-          maxBytes: body.maxBytes ?? MAX_SCREENSHOT_BYTES,
+          maxBytes: body.maxBytes,
           ...channelControlFields(body),
           pendingMessages: pendingMessagesFromChannel(body),
         });

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -32,7 +32,7 @@
     "apps/api/src/agent-build-media.test.ts": 667,
     "apps/api/src/agent-build-reads.test.ts": 14,
     "apps/api/src/agent-channel.test.ts": 1239,
-    "apps/api/src/agent-channel.ts": 5360,
+    "apps/api/src/agent-channel.ts": 5224,
     "apps/api/src/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-creator-key.ts": 257,

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -424,24 +424,24 @@ Calls only the gamedev.pl API on our own domain. It performs no web access, cont
 Append-only: it adds a note. Earlier notes are not edited or removed. Two calls produce two notes, which is why it is not marked idempotent.
 ```
 
-## `send_screenshot`
+## `screenshot_upload_url`
 
 **Read Only: False**
 
 ```
-Attaches a screenshot to the round for the creator to see, which writes state.
+Mints a short-lived signed PUT URL so the agent can curl a PNG into the round. The PUT writes state; there is no base64 screenshot tool.
 ```
 
 **Open World: False**
 
 ```
-Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time.
+Calls only the gamedev.pl API on our own domain. It performs no web access, contacts no third-party service, and accepts no URL or hostname as input, so the set of systems a call can reach is fixed by us at deploy time. The returned URL is same-origin.
 ```
 
 **Destructive: False**
 
 ```
-Additive: it adds an image to the round. No previous screenshot, note or source file is replaced or deleted.
+Minting the URL does not delete anything. The subsequent PUT is additive: it adds an image to the round.
 ```
 
 ## `stage_source_file`

--- a/listings/mcp/claude-plugin/skills/gamedevpl/SKILL.md
+++ b/listings/mcp/claude-plugin/skills/gamedevpl/SKILL.md
@@ -46,8 +46,9 @@ round is, and which mistakes cost a whole build.
 Everything else is in the workflow `start` hands you. These are the ones agents get wrong
 often enough to name up front:
 
-1. **Screenshot as soon as the game draws.** `send_screenshot` early, not at the end. It is
-   the creator's only view of what you are making while you make it.
+1. **Screenshot as soon as the game draws.** `screenshot_upload_url` then
+   `curl --upload-file <png> "$url"` early, not at the end. There is no base64
+   screenshot tool — PNG bytes must never enter the model.
 2. **Stage, don't re-upload.** `stage_source_file` for new or fully rewritten paths;
    `patch_source_file` for edits. Then `submit_sources({ fromStaged: true, … })`, which
    overlays onto the latest delivery — so only changed paths need staging. Never re-emit a

--- a/skills/gamedevpl/SKILL.md
+++ b/skills/gamedevpl/SKILL.md
@@ -46,8 +46,9 @@ round is, and which mistakes cost a whole build.
 Everything else is in the workflow `start` hands you. These are the ones agents get wrong
 often enough to name up front:
 
-1. **Screenshot as soon as the game draws.** `send_screenshot` early, not at the end. It is
-   the creator's only view of what you are making while you make it.
+1. **Screenshot as soon as the game draws.** `screenshot_upload_url` then
+   `curl --upload-file <png> "$url"` early, not at the end. There is no base64
+   screenshot tool — PNG bytes must never enter the model.
 2. **Stage, don't re-upload.** `stage_source_file` for new or fully rewritten paths;
    `patch_source_file` for edits. Then `submit_sources({ fromStaged: true, … })`, which
    overlays onto the latest delivery — so only changed paths need staging. Never re-emit a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`send_screenshot` only accepted base64, capped at 700 KB decoded. That is ~250–300k tokens of base64 — past current model output ceilings. Even a 150 KB PNG is ~40k output tokens. `SESSION_WORKFLOW` told every agent to screenshot as soon as the game draws, so the contract mandated a step its own tool made impractical. Keeping base64 as a “fallback” is still dangerous: agents will try it and stall.

## Fix

- New MCP tool `screenshot_upload_url` → short-lived signed PUT URL + `curl --upload-file` one-liner
- Channel: `POST /api/agent/build/shot/upload-url` (Bearer) + `PUT /api/agent/build/shot/upload?token=…` (raw PNG)
- **Base64 screenshot upload is gone:** `send_screenshot` removed; `POST /api/agent/build/shot` returns `410`
- Same 700 KB decoded cap and PNG signature check on the PUT; reply still carries `stop` / `pendingMessages`
- Without shell egress, skip mid-build screenshots — the gate still captures on delivery

## Acceptance

An agent with shell egress can upload a ~500 KB PNG without the payload appearing in a tool argument. There is no base64 screenshot tool or JSON body path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5cf4877-25ae-4204-bf46-077759748b1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5cf4877-25ae-4204-bf46-077759748b1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

