### PR TITLE
feat(mcp): stage_upload_url — stage sources without retyping through the model

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -20,8 +20,10 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    `screenshot_upload_url` then `curl --upload-file <png> "$url"`. There is **no**
    base64 `send_screenshot` — PNG bytes must never enter the model. Without shell
    egress, skip mid-build screenshots; the gate still captures on delivery
-3. Prefer `stage_source_file` (new/full rewrite) or `patch_source_file` (unified diff) then
-   `submit_sources({ fromStaged: true, mode, kitEngineRef })`
+3. Prefer staging then `submit_sources({ fromStaged: true, mode, kitEngineRef })`
+   - **New/full rewrite with shell:** `stage_upload_url({ path })` then
+     `curl --upload-file <file> "$url"` — bytes never re-enter the model
+   - **New/full rewrite without shell:** `stage_source_file({ path, content })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
      replace — no diff format). Or `patch_source_file({ path, patch })` with a unified
      diff (`---` / `+++` + `@@` hunks; bare `@@` ok). Do not re-emit whole `render.ts` /
@@ -291,8 +293,8 @@ queued.
 
 | Area                         | Path                                                                                                                                                                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` → signed PUT only; no base64 shot tool)                                                                             |
-| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload`                                                                                     |
+| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` / `stage_upload_url` → signed PUT; no base64 shot tool)                                                             |
+| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload` + `PUT …/sources/stage/upload`                                                      |
 | Presence pulses              | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
 | Gate milestones              | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |
 | Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1215,6 +1215,95 @@ export async function registerAgentChannelRoutes(
     },
   );
 
+  // Raw-body stage PUT for stage_upload_url (same validation as JSON stage).
+  app.put(
+    '/api/agent/build/sources/stage/upload',
+    {
+      config: { rateLimit: { max: 300, timeWindow: '1 hour' } },
+      bodyLimit: 1_000_000 + 1024,
+    },
+    async (request, reply) => {
+      const resolved = await resolveUploadBuild(request, reply, 'stage');
+      if (!resolved) return reply;
+      const { issueNumber, record, upload } = resolved;
+
+      if (!options.gamesStore) {
+        return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+      }
+      if (stopReason(record)) {
+        return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
+      }
+
+      const path = upload.path?.trim() ?? '';
+      if (!path) {
+        return reply.status(400).send({ error: 'path is required' });
+      }
+
+      const body = request.body;
+      const bytes = Buffer.isBuffer(body)
+        ? body
+        : typeof body === 'string'
+          ? Buffer.from(body)
+          : body instanceof Uint8Array
+            ? Buffer.from(body)
+            : null;
+      if (!bytes) {
+        return reply.status(400).send({ error: 'file body is required' });
+      }
+      if (bytes.length > 1_000_000) {
+        return reply
+          .status(413)
+          .send({ error: `file too large: ${path} is ${bytes.length} bytes (max 1000000 per file)` });
+      }
+      const content = bytes.toString('utf8');
+
+      const slug = record.slug;
+      if (!slug) {
+        return reply.status(400).send({
+          error: 'slug is required before staging — send the slug from get_brief / start',
+        });
+      }
+
+      const roundGeneration = store
+        ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+        : (record.roundGeneration ?? 1);
+
+      try {
+        const staged = await options.gamesStore.putStagedSourceFile({
+          slug,
+          issueNumber,
+          roundGeneration,
+          path,
+          content,
+        });
+        await markBuildingFromChannel(issueNumber, record);
+        await store?.touchLastAgentSignalAt(issueNumber, undefined, { key: 'staging_sources' });
+        options.onEvent?.(issueNumber);
+        options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
+        const hint = largeSourceFileHint(staged.path, staged.bytes, content);
+        return reply.send({
+          accepted: true,
+          path: staged.path,
+          bytes: staged.bytes,
+          staged: {
+            files: staged.files,
+            totalBytes: staged.totalBytes,
+            maxBytes: staged.maxBytes,
+            maxFiles: staged.maxFiles,
+            updatedAt: staged.updatedAt,
+          },
+          ...(hint ? { hint } : {}),
+          ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
+        });
+      } catch (error) {
+        if (error instanceof InvalidUploadError) {
+          return reply.status(400).send({ error: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
   /**
    * Unified-diff patch into the staging buffer.
    *

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -22,8 +22,9 @@ const NO_PULSE = new Set([
   'open_round',
   'continue_draft',
   'report_progress',
-  // Mint-only; the signed PUT stores the shot.
+  // Mint-only; the signed PUT stores the shot / staged file.
   'screenshot_upload_url',
+  'stage_upload_url',
   'submit_sources',
   // Channel stage/patch already refresh lastAgentSignalAt (+ staging_sources).
   'stage_source_file',

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1307,7 +1307,7 @@ describe('POST /api/mcp (BY-05)', () => {
     };
     expect(path).toBe('game/extra.ts');
     expect(maxBytes).toBe(1_000_000);
-    expect(upload).toMatch(/^curl --upload-file extra\.ts '/);
+    expect(upload).toMatch(/^curl -H 'Content-Type: text\/plain; charset=utf-8' --upload-file extra\.ts '/);
 
     const content = 'export const stagedViaCurl = true;\n';
     const put = await app.inject({
@@ -1340,6 +1340,16 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(bad.isError).toBe(true);
     expect(JSON.stringify(bad.structured)).toMatch(/illegal path/i);
+
+    // Minting is not idempotent, so it must not be hinted read-only.
+    const listedTools = await mcpCall(app, 'tools/list', undefined, { 'mcp-session-id': sessionId });
+    const stageTool = (
+      listedTools.json().result as {
+        tools: Array<{ name: string; annotations?: { readOnlyHint?: boolean; idempotentHint?: boolean } }>;
+      }
+    ).tools.find((tool) => tool.name === 'stage_upload_url');
+    expect(stageTool?.annotations?.readOnlyHint).toBe(false);
+    expect(stageTool?.annotations?.idempotentHint).toBe(false);
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {
@@ -1934,6 +1944,7 @@ describe('POST /api/mcp (BY-05)', () => {
       'continue_draft',
       'report_progress',
       'screenshot_upload_url',
+      'stage_upload_url',
       'stage_source_file',
       'patch_source_file',
       'clear_staged_sources',

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -364,6 +364,7 @@ describe('POST /api/mcp (BY-05)', () => {
         'get_example',
         'report_progress',
         'screenshot_upload_url',
+        'stage_upload_url',
         'stage_source_file',
         'patch_source_file',
         'list_staged_sources',
@@ -384,6 +385,8 @@ describe('POST /api/mcp (BY-05)', () => {
     const screenshotUpload = tools.find((t) => t.name === 'screenshot_upload_url');
     expect(screenshotUpload?.description).toMatch(/curl --upload-file/i);
     expect(screenshotUpload?.description).toMatch(/no send_screenshot|never enter the model|no base64/i);
+    expect(tools.find((t) => t.name === 'stage_upload_url')?.description).toMatch(/curl --upload-file|prefer/i);
+    expect(tools.find((t) => t.name === 'stage_source_file')?.description).toMatch(/stage_upload_url|prefer/i);
     const start = tools.find((t) => t.name === 'start');
     expect(start?.description).toMatch(/screenshot|Honour stop|sessionKey/i);
     // start advertises the returned workflow / inbox policy / refusal guidance.
@@ -1278,6 +1281,65 @@ describe('POST /api/mcp (BY-05)', () => {
     const secondWarnings = (second.structured as { warnings?: Array<{ code: string }> }).warnings ?? [];
     expect(secondWarnings.some((w) => w.code === 'gate_poll_backoff')).toBe(true);
     expect(secondWarnings.some((w) => w.code === 'call_end')).toBe(true);
+  });
+
+  it('stage_upload_url + raw PUT stages without content in a tool argument', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const minted = await callTool(
+      app,
+      'stage_upload_url',
+      { sessionKey, path: 'game/extra.ts' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(minted.isError).toBe(false);
+    const { url, path, maxBytes, upload } = minted.structured as {
+      url: string;
+      path: string;
+      maxBytes: number;
+      upload: string;
+    };
+    expect(path).toBe('game/extra.ts');
+    expect(maxBytes).toBe(1_000_000);
+    expect(upload).toMatch(/^curl --upload-file extra\.ts '/);
+
+    const content = 'export const stagedViaCurl = true;\n';
+    const put = await app.inject({
+      method: 'PUT',
+      url: url.replace(/^https?:\/\/[^/]+/, ''),
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      payload: Buffer.from(content, 'utf8'),
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toMatchObject({
+      accepted: true,
+      path: 'game/extra.ts',
+      bytes: Buffer.byteLength(content, 'utf8'),
+      control: { stop: false },
+    });
+
+    const listed = await callTool(app, 'list_staged_sources', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(listed.isError).toBe(false);
+    const files = (listed.structured as { files: Array<{ path: string; bytes: number }> }).files;
+    expect(files).toEqual(
+      expect.arrayContaining([{ path: 'game/extra.ts', bytes: Buffer.byteLength(content, 'utf8') }]),
+    );
+
+    // Path allowlisting still applies at mint time.
+    const bad = await callTool(
+      app,
+      'stage_upload_url',
+      { sessionKey, path: '../evil.ts' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(bad.isError).toBe(true);
+    expect(JSON.stringify(bad.structured)).toMatch(/illegal path/i);
   });
 
   it('rejects malformed base64 on stage_source_file instead of silently corrupting', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -39,11 +39,7 @@ import {
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
-import {
-  DEFAULT_UPLOAD_URL_TTL_SECONDS,
-  mintUploadToken,
-  uploadCurlCommand,
-} from './agent-upload-token.js';
+import { DEFAULT_UPLOAD_URL_TTL_SECONDS, mintUploadToken, uploadCurlCommand } from './agent-upload-token.js';
 import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
@@ -3251,7 +3247,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         },
         required: ['url', 'expiresAt', 'expiresInSeconds', 'path', 'upload', 'maxBytes'],
       },
-      annotations: { title: 'Get a stage upload URL', ...READS },
+      // Not READS: each call mints a fresh nonce, so it is neither read-only nor idempotent.
+      annotations: { title: 'Get a stage upload URL', ...WRITES },
       description:
         'Preferred way to stage a new or fully rewritten source file when you have curl/shell egress. ' +
         'Returns a short-lived signed PUT URL bound to `path` — run the returned `upload` one-liner ' +
@@ -3295,15 +3292,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         }
         const generation = auth.record.roundGeneration ?? auth.claims.roundGeneration ?? 1;
         const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
+        // One clock read: advertised expiresAt must match the signed exp.
+        const issuedAt = now();
         const token = mintUploadToken(agentTokenSecret, {
           jobId: auth.issueNumber,
           roundGeneration: generation,
           kind: 'stage',
           path,
-          now: now(),
+          now: issuedAt,
           ttlSeconds,
         });
-        const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+        const expiresAt = new Date(issuedAt + ttlSeconds * 1000).toISOString();
         const url = `${canonicalAppBaseUrl()}/api/agent/build/sources/stage/upload?token=${encodeURIComponent(token)}`;
         const localHint = path.includes('/') ? path.split('/').pop()! : path;
         return toolOk({
@@ -3311,7 +3310,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           expiresAt,
           expiresInSeconds: ttlSeconds,
           path,
-          upload: uploadCurlCommand(url, localHint),
+          upload: uploadCurlCommand(url, localHint, 'text/plain; charset=utf-8'),
           maxBytes: 1_000_000,
         });
       },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -39,10 +39,15 @@ import {
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
+import {
+  DEFAULT_UPLOAD_URL_TTL_SECONDS,
+  mintUploadToken,
+  uploadCurlCommand,
+} from './agent-upload-token.js';
 import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
-import { MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
+import { assertDeliverableSourcePath, InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import { detectStall, resolveJobState, toSubmissionStatus } from './job-state.js';
 import { largeSourceFileHint, moduleSizeWarnings } from './module-size.js';
 import type { GcsObjectStore } from './gcs-sign.js';
@@ -528,7 +533,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable via screenshot_upload_url + curl --upload-file. There is no base64 screenshot tool — PNG bytes must never enter the model.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_source_file for new/rewritten paths and patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_upload_url + curl --upload-file for new/rewritten paths when you have shell; stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'Run kit checks green (at least check:static) before submit_sources when you have a local kit checkout; otherwise submit and let the gate run checks.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end. If you are fixing a refused gate, ignore call_end until after the next submit_sources.',
@@ -566,7 +571,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
-  'While iterating: stage_source_file({ path, content }) for new or fully rewritten paths; for edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
+  'While iterating: prefer stage_upload_url({ path }) then curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed. TRACE/PLAYTEST not required; Studio gets a playable draft after typecheck→smoke→build. Inline files[] still works for tiny trees.',
   'Staging is already visible: once index.html, game.ts, style.css and GAME.json are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   'If a reply has control.reason=builder_handoff, stop work and call end once. That acknowledges the creator’s handoff request; do not retry other build calls afterward.',
@@ -3233,6 +3238,85 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
     },
 
+    stage_upload_url: {
+      outputSchema: {
+        type: 'object',
+        properties: {
+          url: { type: 'string' },
+          expiresAt: { type: 'string' },
+          expiresInSeconds: { type: 'number' },
+          path: { type: 'string' },
+          upload: { type: 'string' },
+          maxBytes: { type: 'number' },
+        },
+        required: ['url', 'expiresAt', 'expiresInSeconds', 'path', 'upload', 'maxBytes'],
+      },
+      annotations: { title: 'Get a stage upload URL', ...READS },
+      description:
+        'Preferred way to stage a new or fully rewritten source file when you have curl/shell egress. ' +
+        'Returns a short-lived signed PUT URL bound to `path` — run the returned `upload` one-liner ' +
+        '(curl --upload-file <file> "$url"). The file bytes never enter the model; the PUT applies the same ' +
+        'validation as stage_source_file (path allowlist, size caps, module_too_large hint) and returns the ' +
+        'staging receipt with stop/pendingMessages. Then submit_sources({ fromStaged: true, … }). ' +
+        'Use stage_source_file / patch_source_file when you have no shell. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionKey: SESSION_KEY_PROP,
+          path: {
+            type: 'string',
+            description: 'Game-relative path (e.g. game.ts, game/render.ts). Bound into the URL.',
+          },
+          slug: { type: 'string' },
+        },
+        required: ['path'],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        if (!agentTokenSecret) return toolErr('the MCP build endpoint is not configured');
+        const pathRaw = typeof args.path === 'string' ? args.path.trim() : '';
+        if (!pathRaw) return toolErr('path is required');
+        let path: string;
+        try {
+          path = assertDeliverableSourcePath(pathRaw);
+        } catch (error) {
+          if (error instanceof InvalidUploadError) return toolErr(error.message);
+          throw error;
+        }
+        const slug =
+          typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
+        if (!slug && !auth.record.slug) {
+          return toolErr('slug is required before staging — send the slug from get_brief / start');
+        }
+        if (auth.record.slug && slug && auth.record.slug !== slug) {
+          return toolErr(`this build delivers to ${auth.record.slug}, not ${slug}`);
+        }
+        const generation = auth.record.roundGeneration ?? auth.claims.roundGeneration ?? 1;
+        const ttlSeconds = DEFAULT_UPLOAD_URL_TTL_SECONDS;
+        const token = mintUploadToken(agentTokenSecret, {
+          jobId: auth.issueNumber,
+          roundGeneration: generation,
+          kind: 'stage',
+          path,
+          now: now(),
+          ttlSeconds,
+        });
+        const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+        const url = `${canonicalAppBaseUrl()}/api/agent/build/sources/stage/upload?token=${encodeURIComponent(token)}`;
+        const localHint = path.includes('/') ? path.split('/').pop()! : path;
+        return toolOk({
+          url,
+          expiresAt,
+          expiresInSeconds: ttlSeconds,
+          path,
+          upload: uploadCurlCommand(url, localHint),
+          maxBytes: 1_000_000,
+        });
+      },
+    },
+
     stage_source_file: {
       // Overwrites the same path if staged again, so it is not additive.
       annotations: { title: 'Stage one source file', ...CONSUMES },
@@ -3265,7 +3349,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['ok', 'path', 'bytes', 'staged', 'stop', 'pendingMessages'],
       },
       description:
-        'Upload ONE game source file into this round’s staging buffer (full rewrite). Prefer this for new files; ' +
+        'Upload ONE game source file into this round’s staging buffer (full rewrite) via inline content. ' +
+        'Prefer stage_upload_url + curl --upload-file when you have shell egress — re-emitting file contents ' +
+        'as a tool argument burns output tokens. Prefer this for new files without shell; ' +
         'for edits to an existing path prefer patch_source_file so you do not re-emit a whole large file. ' +
         'Prefer over a giant submit_sources files[] when the tree is large (Claude Chat often truncates huge tool JSON). ' +
         'Call once per path, then submit_sources({ fromStaged: true, mode, kitEngineRef }). Overwrites the same path if staged again. ' +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`stage_source_file` only accepts file contents as a tool argument. Agents read a file from disk, then re-emit the whole content through the model — measured at minutes and ~10k output tokens per run on files already in the sandbox.

## Fix

- New MCP tool `stage_upload_url({ path })` → short-lived signed PUT URL bound to that path + `curl --upload-file` one-liner
- New channel route `PUT /api/agent/build/sources/stage/upload?token=…` accepts raw utf8 bytes
- Identical validation to `stage_source_file` (path allowlist, per-file/total size caps, `module_too_large` hint)
- `submit_sources({ fromStaged: true })` cannot tell the difference
- `stage_source_file` / `patch_source_file` remain the no-shell fallback for text sources

## Review feedback addressed

- `stage_upload_url` is annotated `WRITES`, not `READS` — each call mints a fresh nonce, so it is neither read-only nor idempotent and clients must not auto-run it. Covered by a test asserting both hints.
- One clock read, so the advertised `expiresAt` matches the `exp` signed into the token.
- The curl one-liner sets an explicit `Content-Type` (the app-wide `''` body parser was removed in #674).

## Base

Rebased onto `master` now that #674 has merged; the diff is only the staging work.

## Acceptance

An agent with shell egress can stage a source file without the payload appearing in a tool argument. Inline `stage_source_file` unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5cf4877-25ae-4204-bf46-077759748b1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5cf4877-25ae-4204-bf46-077759748b1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

