### PR TITLE
[AB-05] Make seed availability explicit

### DIFF
--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -179,7 +179,7 @@ describe('agent build reads (BY-04)', () => {
     expect(empty.json()).toEqual({
       available: false,
       status: 'unavailable',
-      notice: null,
+      notice: expect.stringMatching(/no seed draft is available/i),
       files: [],
       references: [],
       notes: null,

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2060,7 +2060,7 @@ export async function registerAgentChannelRoutes(
       return reply.status(404).send({
         available: false,
         status: 'unavailable',
-        notice: null,
+        notice: seed.seedNotice,
         files: [],
         references: [],
         notes: null,

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -553,6 +553,8 @@ describe('POST /api/mcp (BY-05)', () => {
     const joined = workflow.join('\n');
     expect(joined).toMatch(/get_brief/);
     expect(joined).toMatch(/get_seed/);
+    expect(joined).toMatch(/revise that seed as the opening move/i);
+    expect(joined).toMatch(/seedStatus=unavailable.*no seed exists/i);
     // CP-2: an improvement round has no seed and a brief that is only the change
     // request, so without this step the loop reads as "scaffold from the kit" and an
     // agent following it overwrites the published game it was asked to improve.

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -536,7 +536,7 @@ const BEHAVIOURAL_CONTRACT = [
   'Honour stop immediately — do not continue after stop:true. For reason builder_handoff, call end once to acknowledge the stop request, then exit.',
   'gateStarted true means Cloud Build accepted the gate create; gateStarted false after ok submit means no preview is assembling — honour warnings.code=gate_not_started.',
   'Treat get_gate_verdict as a one-shot check, never a polling loop. Pending with a deliveryId returns stop:true: stop immediately and let Studio show the eventual result. Pending with deliveryId:null means you checked before delivering: stop is false, so continue building and call submit_sources instead of checking again. A later creator-led run may check a delivered gate again. Honour warnings.code=gate_poll_backoff on repeated checks.',
-  'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and continue that draft — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding.',
+  'When seedAvailable/seedStatus=available (or warnings.code=seed_unread), call get_seed and revise that seed as the opening move — do not scaffold from scratch. When seedStatus=pending, recheck get_seed before scaffolding. When seedStatus=unavailable, get_seed has confirmed that no seed exists for this round; scaffold from the kit.',
   'Every write reply carries pendingMessages — when that array is non-empty, read_inbox and apply before continuing.',
   'Do not schedule background or recurring inbox polls; drain pendingMessages from write replies (and kit/browse replies that piggyback them) as you go. Honour warnings.code=inbox_pending.',
   'A green *publish* gate verdict ends the round — END immediately; preview_passed does not end the round. The key retires on green and new work arrives as a fresh kickoff.',
@@ -557,7 +557,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Hold the sessionKey start gave you for the whole round and pass it on every call. Do not re-run start to refresh it — it is valid until expiresAt. Re-run start only if a call is refused as unauthenticated.',
   "show_round — once, right after start. In a client that renders MCP Apps views this puts a live status card in the creator's chat that follows the build and the gate on its own, so they can watch without you polling. Calling it again renders a second card.",
   'show_media — whenever the creator asks to see the game. get_gate_media attaches frames for YOU to look at; those attachments do not reach the creator, so describing them is all you can do with it. show_media is what actually puts the pictures in front of them.',
-  'get_brief — read the brief; if seedAvailable or seedStatus=available, get_seed and continue that draft. If seedStatus=pending, browse the kit lightly then recheck get_seed before scaffolding.',
+  'get_brief — read the brief; if seedAvailable or seedStatus=available, call get_seed and revise that seed as the opening move. If seedStatus=pending, browse the kit lightly then recheck get_seed before scaffolding. If seedStatus=unavailable, the response says no seed exists for this round; scaffold from the kit.',
   // An improvement round has no seed (seeds are a new-game facility) and its brief is
   // the change request alone, so nothing above this told the agent a game already
   // existed. Following the loop literally, it scaffolded a fresh game over a published
@@ -2350,8 +2350,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       },
       description:
         'Fetch the platform-generated compiling seed draft for this round when present. ' +
-        'Continue the seed when available/status=available. When status=pending, wait and call again before scaffolding. ' +
-        'Only scaffold from a kit template when status=unavailable. ' +
+        'When available/status=available, revise this seed as the opening move. When status=pending, wait and call again before scaffolding. ' +
+        'Only scaffold from a kit template when status=unavailable; that response explicitly says no seed exists for this round. ' +
         'Honour warnings.code=module_too_large by splitting oversized modules before growing them. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {

--- a/apps/api/src/seed-status.test.ts
+++ b/apps/api/src/seed-status.test.ts
@@ -13,7 +13,7 @@ describe('seed-status', () => {
   it('returns actionable notices only when the agent should act', () => {
     expect(seedNoticeFor('available')).toMatch(/get_seed/);
     expect(seedNoticeFor('pending')).toMatch(/get_seed again|still generating/i);
-    expect(seedNoticeFor('unavailable')).toBeNull();
+    expect(seedNoticeFor('unavailable')).toMatch(/no seed draft is available/i);
     expect(seedPayload({ seedStatus: 'pending' })).toMatchObject({
       seedAvailable: false,
       seedStatus: 'pending',

--- a/apps/api/src/seed-status.ts
+++ b/apps/api/src/seed-status.ts
@@ -18,7 +18,7 @@ export function resolveSeedStatus(record: Pick<SubmissionRecord, 'seed' | 'seedS
   return 'unavailable';
 }
 
-/** Imperative next-step copy for start / brief / get_seed — null when nothing to do. */
+/** Imperative status copy for start / brief / get_seed. */
 export function seedNoticeFor(status: SeedStatus): string | null {
   switch (status) {
     case 'available':
@@ -26,7 +26,7 @@ export function seedNoticeFor(status: SeedStatus): string | null {
     case 'pending':
       return 'Seed draft is still generating. Browse the kit if needed, then call get_seed again before scaffolding from a template.';
     default:
-      return null;
+      return 'No seed draft is available for this round; scaffold from the kit.';
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the unavailable seed response explicitly say that no seed exists for the round
- preserve the available and pending response paths
- tell agents to revise an available seed as the opening move, with workflow and test coverage

## Investigation
- the reported rounds were genuinely seedless: production telemetry showed seed context loading failed because the catalog was absent from the archive
- stored seeds already return `available: true` with their files, so this change does not alter the available path

## Validation
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] Targeted API tests: 87 passed

## Scope
AB-05 only. No seed-generation behavior or fallback path was changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

