### PR TITLE
fix: keep canonical game pages behind beta

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -320,6 +320,13 @@ describe('private beta gate', () => {
     await app.close();
   });
 
+  it('the public game landing page remains walled during private beta', async () => {
+    const app = await buildApp({ betaAllowedUids: ownerUid, publicPlaySlugs: 'promo-game' });
+    const res = await app.inject({ method: 'GET', url: '/api/games/promo-game/page' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
   it('uses the operator-managed promotional list without a redeploy', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: ownerUid });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -828,9 +828,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     getRepoPublishedCatalogEntry: submissionSeams.getRepoPublishedCatalogEntry,
   });
 
-  // The public game page at `/:handle/:slug` — one aggregate read per game. Same
-  // open posture as the creator profile above (exempted from the beta wall below):
-  // the page is a landing page; playing is what stays gated during closed beta.
+  // The game page at `/:handle/:slug` — one aggregate read per game.
   await registerGamePageRoutes(app, {
     store,
     gamesStore,
@@ -942,10 +940,8 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     // Public creator profiles — same posture as contact/legal. Availability checks
     // stay authed (they are under /api/creators/:handle/availability and need a session).
     if (/^\/api\/creators\/[^/]+\/?(\?|$)/.test(request.url)) return;
-    // The public landing page and its declared preview media must load without a
-    // session. Follow counts remain public; changing the subscription still requires
-    // a session in that handler. The playable document and other game routes stay walled.
-    if (/^\/api\/games\/[^/]+\/(page|follow|media)(\/[^?]*)?(\?|$)/.test(request.url)) return;
+    // Preview media and follow counts remain public; game pages stay behind beta access.
+    if (/^\/api\/games\/[^/]+\/(follow|media)(\/[^?]*)?(\?|$)/.test(request.url)) return;
     // Internal endpoints (the Cloud Scheduler notification sweep) authenticate via
     // an OIDC token in the handler, not a session — the wall would 401 them first.
     if (request.url.startsWith('/api/internal/')) return;

--- a/apps/api/src/game-page-routes.test.ts
+++ b/apps/api/src/game-page-routes.test.ts
@@ -158,13 +158,13 @@ describe('game page routes', () => {
     expect((await app.inject({ method: 'GET', url: '/api/games/Not%20A%20Slug/page' })).statusCode).toBe(400);
   });
 
-  it('stays reachable through the private-beta wall while play stays behind it', async () => {
+  it('keeps both the game page and play behind the private-beta wall', async () => {
     const store = new InMemoryStore();
     await publishStoreGame(store);
     const app = await appWith(store, storeGamesStore(), { betaAllowedUids: 'g:creator' });
 
     const page = await app.inject({ method: 'GET', url: '/api/games/neon-courier/page' });
-    expect(page.statusCode).toBe(200);
+    expect(page.statusCode).toBe(401);
 
     const play = await app.inject({ method: 'GET', url: '/api/games/neon-courier' });
     expect(play.statusCode).toBe(401);

--- a/apps/web/src/App.anonymousPlay.test.ts
+++ b/apps/web/src/App.anonymousPlay.test.ts
@@ -95,6 +95,18 @@ describe('anonymous visitors during closed beta', () => {
     expect(calls.some((url) => url.endsWith('/api/catalog'))).toBe(false);
   });
 
+  it('keeps the canonical game page behind the beta wall', async () => {
+    mockApi();
+    window.history.pushState(null, '', '/gtanczyk/airtime');
+
+    const container = await renderApp();
+
+    expect(container.querySelector('.beta-splash')).not.toBeNull();
+    expect(
+      vi.mocked(globalThis.fetch).mock.calls.some((call) => String(call[0]).endsWith('/api/games/airtime/page')),
+    ).toBe(false);
+  });
+
   it('opens an allowlisted promotional game without a session', async () => {
     mockApi(['airtime']);
     window.history.pushState(null, '', '/play/airtime');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1002,10 +1002,8 @@ export function App() {
     );
   }
 
-  // Public game page — the "repo page" nested under the creator profile. Same
-  // open-chrome posture as the profile: the page renders for anonymous visitors,
-  // and the frame pane inside it is what stays gated during closed beta.
-  if (route.view === 'game') {
+  // Game pages require beta access; the play permalink is the promotional exception.
+  if (route.view === 'game' && !authLoading && (!privateBeta || user)) {
     return (
       <div className="app app--game">
         <NavHeader

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -122,8 +122,8 @@ export type AppRoute =
   // an alias for links minted before profiles moved to the root namespace. Handle shape
   // matches the API (`^[a-z][a-z0-9_]{2,23}$`).
   | { view: 'creator'; handle: string }
-  // Public game landing page nested under the creator profile (`/:handle/:slug`).
-  // Reachable without a session; only playing is gated during closed beta.
+  // Game landing page nested under the creator profile (`/:handle/:slug`).
+  // The route is beta-gated; `/play/:slug` is the anonymous promotional permalink.
   | { view: 'game'; handle: string; slug: string }
   // Unknown / invalid path. Kept as its own view so a typo or stale bookmark shows a
   // real 404 instead of silently dumping the visitor on the home catalog.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep `/:handle/:slug` game landing pages behind the closed-beta wall
- preserve the allowlisted `/play/<slug>` route as the anonymous promotional entry point
- protect the game-page API endpoint while retaining public media and follow counts

## Verification
- Local API and web regression tests pass.
- Local `npm run test && npm run build` passes after updating the existing page-gating expectation.
- CI run `31262592780` is green: lint/test/build, games-repo contract, production image, secret scanning, and CodeQL.
- Anonymous coverage confirms `/gtanczyk/airtime` shows the beta splash and does not request page data; `/play/airtime` remains the public route.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f6cc11c-3c58-440e-9810-621b5320cf64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f6cc11c-3c58-440e-9810-621b5320cf64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

