### PR TITLE
feat: add one-time closed beta invite links

### DIFF
--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -763,6 +763,42 @@ describe('/api/admin/waitlist', () => {
   });
 });
 
+describe('/api/admin/beta-invites', () => {
+  it('creates a one-time link, lists its state, and revokes it', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    const app = await appWith(store);
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/admin/beta-invites',
+      headers: authHeaders('g:boss'),
+    });
+
+    expect(created.statusCode).toBe(201);
+    const body = created.json() as { invite: { id: string; status: string }; code: string };
+    expect(body.code).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(body.invite).toMatchObject({ status: 'available' });
+    expect(body.invite).not.toHaveProperty('codeHash');
+
+    const listed = await app.inject({
+      method: 'GET',
+      url: '/api/admin/beta-invites',
+      headers: authHeaders('g:boss'),
+    });
+    expect(listed.json()).toEqual({ invites: [expect.objectContaining({ id: body.invite.id, status: 'available' })] });
+
+    const revoked = await app.inject({
+      method: 'POST',
+      url: `/api/admin/beta-invites/${body.invite.id}/revoke`,
+      headers: authHeaders('g:boss'),
+    });
+    expect(revoked.statusCode).toBe(200);
+    expect(revoked.json()).toMatchObject({ id: body.invite.id, status: 'revoked' });
+    await app.close();
+  });
+});
+
 describe('GET /api/admin/costs', () => {
   it('answers 404 to a signed-in non-admin', async () => {
     const store = new InMemoryStore();

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -31,6 +31,8 @@ import {
 import { DEFAULT_CREATION_LIMITS_TTL_MS, resolveDefaultGlobalDailyCap } from './creation-limits.js';
 import {
   BOT_UID_PREFIX,
+  type BetaInvite,
+  type BetaInviteStatus,
   type CreationLimits,
   type PublicPlayConfig,
   type Scorecard,
@@ -239,8 +241,25 @@ export interface WaitlistListResponse {
   entries: WaitlistEntry[];
 }
 
+export interface BetaInviteResponse {
+  id: string;
+  createdAt: string;
+  createdByUid: string;
+  status: BetaInviteStatus;
+  claimedAt?: string;
+  claimedUid?: string;
+  revokedAt?: string;
+  revokedByUid?: string;
+}
+
+export interface CreatedBetaInviteResponse {
+  invite: BetaInviteResponse;
+  code: string;
+}
+
 /** How many waitlist rows one console read may return. Matches the store default. */
 const MAX_WAITLIST_ENTRIES = 200;
+const MAX_BETA_INVITES = 200;
 
 const WaitlistStatusSchema = z.enum(['pending', 'approved', 'rejected']);
 
@@ -256,6 +275,23 @@ const WaitlistPreapproveSchema = z.object({
   email: z.string().trim().email('invalid email').max(254),
   status: WaitlistStatusSchema.default('approved'),
 });
+
+const BetaInviteIdSchema = z.object({
+  id: z.string().uuid('invalid invite id'),
+});
+
+function betaInviteResponse(invite: BetaInvite): BetaInviteResponse {
+  return {
+    id: invite.id,
+    createdAt: invite.createdAt,
+    createdByUid: invite.createdByUid,
+    status: invite.status,
+    ...(invite.claimedAt ? { claimedAt: invite.claimedAt } : {}),
+    ...(invite.claimedUid ? { claimedUid: invite.claimedUid } : {}),
+    ...(invite.revokedAt ? { revokedAt: invite.revokedAt } : {}),
+    ...(invite.revokedByUid ? { revokedByUid: invite.revokedByUid } : {}),
+  };
+}
 
 const WaitlistUidParamsSchema = z.object({
   // Same shape the auth layer mints (`g:` / `a:`) plus the `email:` pre-approve prefix
@@ -452,6 +488,43 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
       'waitlist status set by email by operator',
     );
     return reply.status(200).send(entry);
+  });
+
+  app.get('/api/admin/beta-invites', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const invites = await store.listBetaInvites({ limit: MAX_BETA_INVITES });
+    return reply.status(200).send({ invites: invites.map(betaInviteResponse) });
+  });
+
+  app.post('/api/admin/beta-invites', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const created = await store.createBetaInvite(request.user!.uid);
+    app.log.info({ inviteId: created.invite.id, by: request.user!.uid }, 'beta invite created');
+    const response: CreatedBetaInviteResponse = {
+      invite: betaInviteResponse(created.invite),
+      code: created.code,
+    };
+    return reply.status(201).send(response);
+  });
+
+  app.post<{ Params: { id: string } }>('/api/admin/beta-invites/:id/revoke', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const params = BetaInviteIdSchema.safeParse(request.params ?? {});
+    if (!params.success) {
+      return reply.status(400).send({ error: params.error.issues[0]?.message ?? 'invalid invite id' });
+    }
+    const invite = await store.revokeBetaInvite(params.data.id, request.user!.uid);
+    if (!invite) {
+      return reply.status(409).send({ error: 'invite is unavailable' });
+    }
+    app.log.info({ inviteId: invite.id, by: request.user!.uid }, 'beta invite revoked');
+    return reply.status(200).send(betaInviteResponse(invite));
   });
 
   /**

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -66,6 +66,7 @@ describe('Auth API Routes', () => {
   const setupTestServer = async (
     mockUsers: Record<string, { sub: string; email?: string; name?: string; picture?: string }> = {},
     adminUids?: Set<string>,
+    privateBeta = false,
   ) => {
     const store = new InMemoryStore();
     const verifier = new MockGoogleVerifier(mockUsers);
@@ -76,6 +77,9 @@ describe('Auth API Routes', () => {
       sessionSecret: 'test-secret-key',
       googleAuthVerifier: verifier,
       ...(adminUids ? { adminUids } : {}),
+      ...(privateBeta
+        ? { privateBeta: true, betaAllowedUids: new Set<string>(), betaAllowedEmails: new Set<string>() }
+        : {}),
     });
 
     return { app, store };
@@ -165,6 +169,37 @@ describe('Auth API Routes', () => {
 
     expect(res.statusCode).toBe(401);
     expect(JSON.parse(res.body)).toEqual({ error: 'invalid google authentication' });
+  });
+
+  it('accepts a beta invite once and binds it to the first account', async () => {
+    const { app, store } = await setupTestServer(
+      {
+        'first-token': { sub: '10011', email: 'first@example.com', emailVerified: true },
+        'second-token': { sub: '10012', email: 'second@example.com', emailVerified: true },
+      },
+      undefined,
+      true,
+    );
+    const created = await store.createBetaInvite('g:operator');
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'first-token', inviteCode: created.code },
+    });
+    expect(first.statusCode).toBe(200);
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'second-token', inviteCode: created.code },
+    });
+    expect(second.statusCode).toBe(403);
+    expect(JSON.parse(second.body).error).toBe('beta invite is invalid or already used');
+
+    const invites = await store.listBetaInvites();
+    expect(invites[0]).toMatchObject({ status: 'claimed', claimedUid: 'g:10011' });
+    expect(invites[0]).not.toHaveProperty('code');
   });
 
   it('POST /api/auth/google rejects blocked user', async () => {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -37,6 +37,7 @@ function localeFromRequest(request: FastifyRequest): string | undefined {
 export const SESSION_COOKIE_NAME = 'gamedev_session';
 export const DEFAULT_SESSION_DURATION_SECONDS = 12 * 60 * 60; // 12 hours
 export const HALF_LIFE_SECONDS = 6 * 60 * 60; // 6 hours (sliding renewal threshold)
+export const BETA_INVITE_CODE_PATTERN = /^[A-Za-z0-9_-]{32}$/;
 
 export interface SessionPayload {
   uid: string;
@@ -240,10 +241,12 @@ export interface AuthPluginOptions {
 
 const GoogleAuthSchema = z.object({
   idToken: z.string().trim().min(1, 'idToken is required'),
+  inviteCode: z.string().regex(BETA_INVITE_CODE_PATTERN, 'invalid invite code').optional(),
 });
 
 const AppleAuthSchema = z.object({
   idToken: z.string().trim().min(1, 'idToken is required'),
+  inviteCode: z.string().regex(BETA_INVITE_CODE_PATTERN, 'invalid invite code').optional(),
   /**
    * Apple's ID token carries no name claim, ever. The display name arrives exactly once —
    * in the body of the *first* authorization, alongside the token — and Apple never sends
@@ -262,6 +265,10 @@ const WaitlistSchema = z.object({
   // Which provider minted `idToken`. Defaults to Google because every waitlist entry
   // predating Sign in with Apple came from there.
   provider: z.enum(['google', 'apple']).optional(),
+});
+
+const BetaInviteClaimSchema = z.object({
+  code: z.string().regex(BETA_INVITE_CODE_PATTERN, 'invalid invite code'),
 });
 
 function isRateLimited(
@@ -447,15 +454,27 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         // an unverified email claim must never satisfy an access-control allowlist.
         if (options.privateBeta) {
           const emailLower = googleUser.emailVerified && googleUser.email ? googleUser.email.toLowerCase() : '';
-          const allowed =
+          const existingUser = await store.getUser(uid);
+          if (existingUser?.tier === 'blocked') {
+            return reply.status(403).send({ error: 'account is blocked' });
+          }
+          const allowlisted =
             (options.betaAllowedUids?.has(uid) ?? false) ||
             (emailLower !== '' && (options.betaAllowedEmails?.has(emailLower) ?? false)) ||
             (await store.isWaitlistApproved(uid, emailLower));
+          const inviteClaim =
+            parseResult.data.inviteCode === undefined
+              ? null
+              : await store.claimBetaInvite(parseResult.data.inviteCode, uid);
+          const allowed = allowlisted || inviteClaim?.ok === true;
           if (!allowed) {
             // Look up existing waitlist status so the client can show it
             const waitlistEntry = await store.getWaitlistEntry(uid);
             return reply.status(403).send({
-              error: 'private beta — sign-ups are closed',
+              error:
+                parseResult.data.inviteCode === undefined
+                  ? 'private beta — sign-ups are closed'
+                  : 'beta invite is invalid or already used',
               waitlistStatus: waitlistEntry?.status ?? null,
             });
           }
@@ -540,14 +559,26 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         // arriving through a different button.
         if (options.privateBeta) {
           const emailLower = resolution.email?.toLowerCase() ?? '';
-          const allowed =
+          const existingUser = await store.getUser(uid);
+          if (existingUser?.tier === 'blocked') {
+            return reply.status(403).send({ error: 'account is blocked' });
+          }
+          const allowlisted =
             (options.betaAllowedUids?.has(uid) ?? false) ||
             (emailLower !== '' && (options.betaAllowedEmails?.has(emailLower) ?? false)) ||
             (await store.isWaitlistApproved(uid, emailLower));
+          const inviteClaim =
+            parseResult.data.inviteCode === undefined
+              ? null
+              : await store.claimBetaInvite(parseResult.data.inviteCode, uid);
+          const allowed = allowlisted || inviteClaim?.ok === true;
           if (!allowed) {
             const waitlistEntry = await store.getWaitlistEntry(uid);
             return reply.status(403).send({
-              error: 'private beta — sign-ups are closed',
+              error:
+                parseResult.data.inviteCode === undefined
+                  ? 'private beta — sign-ups are closed'
+                  : 'beta invite is invalid or already used',
               waitlistStatus: waitlistEntry?.status ?? null,
             });
           }
@@ -680,6 +711,26 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         const message = err instanceof Error ? err.message : 'token verification failed';
         return reply.status(401).send({ error: message });
       }
+    },
+  );
+
+  app.post(
+    '/api/beta-invites/claim',
+    { config: { rateLimit: { max: maxAuthRequestsPerWindow, timeWindow: authRateLimitWindowMs } } },
+    async (request, reply) => {
+      if (request.authMethod !== 'session' || !request.user) {
+        return reply.status(401).send({ error: 'authentication required' });
+      }
+      const parsed = BetaInviteClaimSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      const result = await store.claimBetaInvite(parsed.data.code, request.user.uid);
+      if (!result.ok) {
+        return reply.status(409).send({ error: 'beta invite is invalid or already used' });
+      }
+      return { status: 'claimed' };
     },
   );
 

--- a/apps/api/src/creator-profile.ts
+++ b/apps/api/src/creator-profile.ts
@@ -46,6 +46,7 @@ export const RESERVED_HANDLES: ReadonlySet<string> = new Set([
   'gamedevpl',
   'health',
   'help',
+  'invite',
   'join',
   'me',
   'null',

--- a/apps/api/src/spa-paths.test.ts
+++ b/apps/api/src/spa-paths.test.ts
@@ -67,6 +67,7 @@ describe('isKnownSpaShellPath', () => {
     '/admin/assessments',
     '/review',
     '/join/K7M3QP',
+    `/invite/${'Abc123_-'.repeat(4)}`,
     '/nightshift/neon-courier',
     // The platform's namespace is reserved against claiming but is a real address:
     // it is where every game with no creator to name lives.
@@ -97,6 +98,8 @@ describe('isKnownSpaShellPath', () => {
     '/join/lower1',
     '/join/TOOLONG9',
     '/join/K7M3QP/extra',
+    '/invite/too-short',
+    `/invite/${'a'.repeat(33)}`,
     // Game page: reserved first segments, bad slugs, and unknown tabs stay 404.
     '/studio/neon-courier/releases/extra',
     '/play/neon-courier/board',

--- a/apps/api/src/spa-paths.ts
+++ b/apps/api/src/spa-paths.ts
@@ -16,6 +16,7 @@ const PLAY_PREFIX_PATTERN = /^\/(play|ay|ai)\/([^/]+)$/;
 const DRAFT_PATTERN = /^\/draft\/([^/]+)$/;
 const STATUS_PATTERN = /^\/status\/([^/]+)$/;
 const JOIN_PATTERN = /^\/join\/([A-Z0-9]{6})$/;
+const INVITE_PATTERN = /^\/invite\/([A-Za-z0-9_-]{32})$/;
 /** Public creator profile aliases — same grammar as `creatorPath` in apps/web/src/router.ts. */
 const CREATOR_ALIAS_PATTERN = /^\/creators\/([a-z][a-z0-9_]{2,23})$/;
 const ROOT_CREATOR_PATTERN = /^\/([a-z][a-z0-9_]{2,23})$/;
@@ -111,6 +112,7 @@ export function isKnownSpaShellPath(urlOrPath: string): boolean {
 
   // Fragment is not on the request line; `/join/ABC123` alone must still 200.
   if (JOIN_PATTERN.test(pathname)) return true;
+  if (INVITE_PATTERN.test(pathname)) return true;
 
   if (CREATOR_ALIAS_PATTERN.test(pathname)) return true;
   if (ROOT_CREATOR_PATTERN.test(pathname)) return !RESERVED_HANDLES.has(pathname.slice(1));

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -315,6 +315,24 @@ describe('FirestoreStore.upsertWaitlistEntry', () => {
   });
 });
 
+describe('FirestoreStore beta invites', () => {
+  it('stores only a hash and claims the code through a transaction', async () => {
+    const { db, docs, key } = fakeFirestore();
+    const store = new FirestoreStore(db);
+    const created = await store.createBetaInvite('g:operator');
+
+    const stored = docs.get(key('betaInvites', created.invite.id))!;
+    expect(stored.codeHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(stored).not.toHaveProperty('code');
+
+    expect(await store.claimBetaInvite(created.code, 'g:first')).toMatchObject({
+      ok: true,
+      invite: { status: 'claimed', claimedUid: 'g:first' },
+    });
+    expect(await store.claimBetaInvite(created.code, 'g:second')).toEqual({ ok: false, reason: 'claimed' });
+  });
+});
+
 describe('FirestoreStore game saves', () => {
   it('stores a save whose contents Firestore could never hold as fields', async () => {
     const { db } = fakeFirestore();

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -388,6 +388,21 @@ describe('InMemoryStore', () => {
     expect(entry).toMatchObject({ uid: 'g:789', email: 'test@example.com', status: 'pending' });
   });
 
+  it('creates, atomically claims, and revokes one-time beta invites', async () => {
+    const store = new InMemoryStore();
+    const created = await store.createBetaInvite('g:operator');
+
+    expect(created.code).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(created.invite).not.toHaveProperty('code');
+    expect((await store.claimBetaInvite(created.code, 'g:first')).ok).toBe(true);
+    expect(await store.claimBetaInvite(created.code, 'g:first')).toMatchObject({ ok: true });
+    expect(await store.claimBetaInvite(created.code, 'g:second')).toEqual({ ok: false, reason: 'claimed' });
+
+    const other = await store.createBetaInvite('g:operator');
+    expect(await store.revokeBetaInvite(other.invite.id, 'g:operator')).toMatchObject({ status: 'revoked' });
+    expect(await store.claimBetaInvite(other.code, 'g:second')).toEqual({ ok: false, reason: 'revoked' });
+  });
+
   it('isWaitlistApproved returns true when entry status is approved (by uid or email)', async () => {
     const store = new InMemoryStore();
     await store.upsertWaitlistEntry({ uid: 'g:789', email: 'approved@example.com' });

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { FieldValue, Firestore, type DocumentData } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-state.js';
 import type { SeedFiles } from './agent-backend.js';
@@ -20,6 +20,11 @@ import type { BuildEvent, SubmissionStatus } from './submission-status.js';
 export const BOT_UID_PREFIX = 'bot:';
 
 const PUBLIC_PLAY_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const BETA_INVITE_CODE_BYTES = 24;
+
+function hashBetaInviteCode(code: string): string {
+  return createHash('sha256').update(code).digest('hex');
+}
 
 function normalizePublicPlaySlugs(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -755,6 +760,7 @@ export interface VisitEvent {
     | 'how_to_play_opened'
     | 'create_step'
     | 'waitlist_step'
+    | 'invite_step'
     | 'studio_step'
     | 'editor_step'
     | 'assist_step'
@@ -1533,6 +1539,28 @@ export interface WaitlistEntry {
   status: WaitlistStatus;
 }
 
+export type BetaInviteStatus = 'available' | 'claimed' | 'revoked';
+
+export interface BetaInvite {
+  id: string;
+  codeHash: string;
+  createdAt: string;
+  createdByUid: string;
+  status: BetaInviteStatus;
+  claimedAt?: string;
+  claimedUid?: string;
+  revokedAt?: string;
+  revokedByUid?: string;
+}
+
+export interface CreatedBetaInvite {
+  invite: BetaInvite;
+  code: string;
+}
+
+export type ClaimBetaInviteResult =
+  { ok: true; invite: BetaInvite } | { ok: false; reason: 'not_found' | 'claimed' | 'revoked' };
+
 /**
  * A personal access token issued to a user account (docs/agent-access-tokens.md).
  *
@@ -2086,6 +2114,10 @@ export interface Store {
    * creates `waitlist/email:<lower>` with the requested status.
    */
   setWaitlistStatusByEmail(email: string, status: WaitlistStatus): Promise<WaitlistEntry>;
+  createBetaInvite(createdByUid: string): Promise<CreatedBetaInvite>;
+  listBetaInvites(opts?: { limit?: number }): Promise<BetaInvite[]>;
+  claimBetaInvite(code: string, uid: string): Promise<ClaimBetaInviteResult>;
+  revokeBetaInvite(id: string, revokedByUid: string): Promise<BetaInvite | null>;
   /**
    * Idempotent by notification id: a second emit for the same id is a no-op and
    * returns `created: false` (a crashed/re-run sweep can safely re-emit).
@@ -2576,6 +2608,7 @@ export class InMemoryStore implements Store {
   private creationLimits: CreationLimits | null = null;
   private publicPlayConfig: PublicPlayConfig | null = null;
   private waitlist = new Map<string, WaitlistEntry>();
+  private betaInvites = new Map<string, BetaInvite>();
   // yyyymmdd -> events recorded that day
   private telemetry = new Map<string, TelemetryEvent[]>();
   // yyyymmdd -> visit events recorded that day
@@ -2765,6 +2798,9 @@ export class InMemoryStore implements Store {
       for (const [key, entry] of [...this.waitlist]) {
         if (entry.email?.toLowerCase() === email) this.waitlist.delete(key);
       }
+    }
+    for (const [id, invite] of [...this.betaInvites]) {
+      if (invite.createdByUid === uid || invite.claimedUid === uid) this.betaInvites.delete(id);
     }
     this.notifications.delete(uid);
     this.pushSubs.delete(uid);
@@ -3689,6 +3725,59 @@ export class InMemoryStore implements Store {
     };
     this.waitlist.set(created.uid, created);
     return { ...created };
+  }
+
+  async createBetaInvite(createdByUid: string): Promise<CreatedBetaInvite> {
+    const code = randomBytes(BETA_INVITE_CODE_BYTES).toString('base64url');
+    const invite: BetaInvite = {
+      id: randomUUID(),
+      codeHash: hashBetaInviteCode(code),
+      createdAt: new Date().toISOString(),
+      createdByUid,
+      status: 'available',
+    };
+    this.betaInvites.set(invite.id, invite);
+    return { invite: { ...invite }, code };
+  }
+
+  async listBetaInvites(opts?: { limit?: number }): Promise<BetaInvite[]> {
+    const limit = opts?.limit ?? 200;
+    return [...this.betaInvites.values()]
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit)
+      .map((invite) => ({ ...invite }));
+  }
+
+  async claimBetaInvite(code: string, uid: string): Promise<ClaimBetaInviteResult> {
+    const codeHash = hashBetaInviteCode(code);
+    const invite = [...this.betaInvites.values()].find((candidate) => candidate.codeHash === codeHash);
+    if (!invite) return { ok: false, reason: 'not_found' };
+    if (invite.status === 'revoked') return { ok: false, reason: 'revoked' };
+    if (invite.status === 'claimed') {
+      return invite.claimedUid === uid ? { ok: true, invite: { ...invite } } : { ok: false, reason: 'claimed' };
+    }
+
+    const claimed: BetaInvite = {
+      ...invite,
+      status: 'claimed',
+      claimedAt: new Date().toISOString(),
+      claimedUid: uid,
+    };
+    this.betaInvites.set(invite.id, claimed);
+    return { ok: true, invite: { ...claimed } };
+  }
+
+  async revokeBetaInvite(id: string, revokedByUid: string): Promise<BetaInvite | null> {
+    const invite = this.betaInvites.get(id);
+    if (!invite || invite.status !== 'available') return null;
+    const revoked: BetaInvite = {
+      ...invite,
+      status: 'revoked',
+      revokedAt: new Date().toISOString(),
+      revokedByUid,
+    };
+    this.betaInvites.set(id, revoked);
+    return { ...revoked };
   }
 
   async createNotification(
@@ -4774,6 +4863,8 @@ export class FirestoreStore implements Store {
       affinity,
       usageCounters,
       waitlistByEmail,
+      betaInvitesCreated,
+      betaInvitesClaimed,
     ] = await Promise.all([
       this.db.collection('accessTokens').where('uid', '==', uid).get(),
       this.db.collection('gameAgentKeys').where('ownerUid', '==', uid).get(),
@@ -4792,6 +4883,8 @@ export class FirestoreStore implements Store {
       this.db.collection('users').doc(uid).collection('playAffinity').get(),
       this.db.collection('usage').doc(uid).collection('counters').get(),
       email ? this.db.collection('waitlist').where('email', '==', email).get() : Promise.resolve(null),
+      this.db.collection('betaInvites').where('createdByUid', '==', uid).get(),
+      this.db.collection('betaInvites').where('claimedUid', '==', uid).get(),
     ]);
 
     // Refresh-token index rows historically carry only grantId, so ownerUid is absent.
@@ -4827,6 +4920,8 @@ export class FirestoreStore implements Store {
       addDeletes(snap.docs);
     }
     if (waitlistByEmail) addDeletes(waitlistByEmail.docs);
+    addDeletes(betaInvitesCreated.docs);
+    addDeletes(betaInvitesClaimed.docs);
     deleteRefs.set(`waitlist/${uid}`, this.db.collection('waitlist').doc(uid));
     deleteRefs.set(`creatorAgentKeys/${uid}`, this.db.collection('creatorAgentKeys').doc(uid));
     deleteRefs.set(`usage/${uid}`, this.db.collection('usage').doc(uid));
@@ -6089,6 +6184,73 @@ export class FirestoreStore implements Store {
     };
     await this.db.collection('waitlist').doc(created.uid).set(stripUndefined(created));
     return created;
+  }
+
+  async createBetaInvite(createdByUid: string): Promise<CreatedBetaInvite> {
+    const code = randomBytes(BETA_INVITE_CODE_BYTES).toString('base64url');
+    const invite: BetaInvite = {
+      id: randomUUID(),
+      codeHash: hashBetaInviteCode(code),
+      createdAt: new Date().toISOString(),
+      createdByUid,
+      status: 'available',
+    };
+    await this.db.collection('betaInvites').doc(invite.id).set(stripUndefined(invite));
+    return { invite, code };
+  }
+
+  async listBetaInvites(opts?: { limit?: number }): Promise<BetaInvite[]> {
+    const limit = opts?.limit ?? 200;
+    const snap = await this.db.collection('betaInvites').get();
+    return snap.docs
+      .map((doc) => doc.data() as BetaInvite)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit);
+  }
+
+  async claimBetaInvite(code: string, uid: string): Promise<ClaimBetaInviteResult> {
+    const codeHash = hashBetaInviteCode(code);
+    const querySnap = await this.db.collection('betaInvites').where('codeHash', '==', codeHash).limit(1).get();
+    if (querySnap.empty) return { ok: false, reason: 'not_found' };
+
+    const docRef = querySnap.docs[0]!.ref;
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(docRef);
+      if (!snap.exists) return { ok: false, reason: 'not_found' };
+      const invite = snap.data() as BetaInvite;
+      if (invite.status === 'revoked') return { ok: false, reason: 'revoked' };
+      if (invite.status === 'claimed') {
+        return invite.claimedUid === uid ? { ok: true, invite } : { ok: false, reason: 'claimed' };
+      }
+
+      const claimed: BetaInvite = {
+        ...invite,
+        status: 'claimed',
+        claimedAt: new Date().toISOString(),
+        claimedUid: uid,
+      };
+      transaction.set(docRef, stripUndefined(claimed), { merge: true });
+      return { ok: true, invite: claimed };
+    });
+  }
+
+  async revokeBetaInvite(id: string, revokedByUid: string): Promise<BetaInvite | null> {
+    const docRef = this.db.collection('betaInvites').doc(id);
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(docRef);
+      if (!snap.exists) return null;
+      const invite = snap.data() as BetaInvite;
+      if (invite.status !== 'available') return null;
+
+      const revoked: BetaInvite = {
+        ...invite,
+        status: 'revoked',
+        revokedAt: new Date().toISOString(),
+        revokedByUid,
+      };
+      transaction.set(docRef, stripUndefined(revoked), { merge: true });
+      return revoked;
+    });
   }
 
   private notificationRef(uid: string, id: string) {

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -211,6 +211,23 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.waitlist[0]).toEqual({ step: 'cta_clicked', visits: 1 });
   });
 
+  it('reports the invite funnel separately from the waitlist', () => {
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      { visitId: 'a', type: 'invite_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step: 'opened' },
+      { visitId: 'a', type: 'invite_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 1, step: 'accepted' },
+      started('b'),
+      { visitId: 'b', type: 'invite_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step: 'opened' },
+    ]);
+
+    expect(funnel.invites).toEqual([
+      { step: 'opened', visits: 2 },
+      { step: 'accepted', visits: 1 },
+      { step: 'unavailable', visits: 0 },
+    ]);
+    expect(funnel.waitlist[0]).toEqual({ step: 'cta_clicked', visits: 0 });
+  });
+
   it('counts painting visits and splits them by the door that led to the brush', () => {
     const remix = (visitId: string, step: string, via?: string): VisitEvent =>
       ({

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -67,6 +67,7 @@ export interface VisitFunnel {
    * present — including zeroes. Same posture as `creating`.
    */
   waitlist: Array<{ step: WaitlistStep; visits: number }>;
+  invites: Array<{ step: InviteStep; visits: number }>;
   /**
    * EditorKit's revision funnel — opened → saved a draft → played it → published.
    * Same posture as `creating`: every step, in order, zeroes included.
@@ -177,6 +178,10 @@ export const WAITLIST_STEPS = ['cta_clicked', 'joined'] as const;
 
 export type WaitlistStep = (typeof WAITLIST_STEPS)[number];
 
+export const INVITE_STEPS = ['opened', 'accepted', 'unavailable'] as const;
+
+export type InviteStep = (typeof INVITE_STEPS)[number];
+
 export const EDITOR_STEPS = ['opened', 'draft_saved', 'previewed', 'published'] as const;
 
 export type EditorStep = (typeof EDITOR_STEPS)[number];
@@ -258,6 +263,7 @@ interface VisitRollup {
   steps: Set<string>;
   /** Waitlist steps this visit reached. Separate from create so the two funnels cannot collide. */
   waitlistSteps: Set<string>;
+  inviteSteps: Set<string>;
   /** Editor steps this visit reached. Separate again, for the same reason. */
   editorSteps: Set<string>;
   /** The door on this visit's `painted`, first one wins (the client dedupes). */
@@ -307,6 +313,7 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       plays: 0,
       steps: new Set<string>(),
       waitlistSteps: new Set<string>(),
+      inviteSteps: new Set<string>(),
       editorSteps: new Set<string>(),
       assistSteps: new Set<string>(),
       remixSteps: new Set<string>(),
@@ -328,6 +335,8 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       if (event.step) rollup.steps.add(event.step);
     } else if (event.type === 'waitlist_step') {
       if (event.step) rollup.waitlistSteps.add(event.step);
+    } else if (event.type === 'invite_step') {
+      if (event.step) rollup.inviteSteps.add(event.step);
     } else if (event.type === 'editor_step') {
       if (event.step) rollup.editorSteps.add(event.step);
     } else if (event.type === 'assist_step') {
@@ -499,6 +508,10 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     waitlist: WAITLIST_STEPS.map((step) => ({
       step,
       visits: rollups.filter((rollup) => rollup.waitlistSteps.has(step)).length,
+    })),
+    invites: INVITE_STEPS.map((step) => ({
+      step,
+      visits: rollups.filter((rollup) => rollup.inviteSteps.has(step)).length,
     })),
     editing: EDITOR_STEPS.map((step) => ({
       step,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -239,6 +239,26 @@ describe('POST /api/telemetry/visit', () => {
     expect(bad.statusCode).toBe(400);
   });
 
+  it('records invite steps and rejects an unknown invite outcome', async () => {
+    const ok = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'invite_step', step: 'opened', msSinceStart: 0 }],
+    });
+    expect(ok.statusCode).toBe(202);
+    expect((await store.listVisitEvents(today()))[0]).toMatchObject({
+      type: 'invite_step',
+      step: 'opened',
+    });
+
+    const bad = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'invite_step', step: 'claimed_twice', msSinceStart: 0 }],
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
   it('carries which control opened a remix, and refuses a control it does not know', async () => {
     const ok = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -45,6 +45,7 @@ const RouteKindSchema = z.enum([
   'draft',
   'status',
   'join',
+  'invite',
   'legal',
   'health',
   'studio',
@@ -71,6 +72,7 @@ const CreateStepSchema = z.enum([
  * reaches a grouping key on an open endpoint.
  */
 const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
+const InviteStepSchema = z.enum(['opened', 'accepted', 'unavailable']);
 /**
  * Studio / self-build funnel (BY-08). Sibling to create steps — not ordered with them.
  * Reaches a grouping key; closed enum on an open endpoint.
@@ -191,6 +193,7 @@ const EventSchema = z.discriminatedUnion('type', [
     ...offsetField,
   }),
   z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
+  z.object({ type: z.literal('invite_step'), step: InviteStepSchema, ...offsetField }),
   z.object({
     type: z.literal('studio_step'),
     step: StudioStepSchema,
@@ -304,6 +307,8 @@ export async function registerVisitTelemetryRoutes(
             ...(event.builder === undefined ? {} : { builder: event.builder }),
           };
         case 'waitlist_step':
+          return { ...base, type: event.type, step: event.step };
+        case 'invite_step':
           return { ...base, type: event.type, step: event.step };
         case 'studio_step':
           return {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,6 +69,7 @@ import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
 import { recordCreateStep, recordStudioStep } from './visitTelemetry.js';
 import { ClosedBetaSplash } from './ClosedBetaSplash.js';
+import { BetaInvitePage } from './BetaInvitePage.js';
 import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { ControllerView } from './mp/ControllerView.js';
 import { PartyStage } from './mp/PartyStage.js';
@@ -179,6 +180,7 @@ export function App() {
       copy: {
         home: t('pageTitle.home'),
         join: t('pageTitle.join'),
+        invite: t('pageTitle.invite'),
         health: t('pageTitle.health'),
         review: t('pageTitle.review'),
         studio: t('pageTitle.studio'),
@@ -1085,6 +1087,14 @@ export function App() {
 
   if (authLoading) {
     return <AppLoadingScreen />;
+  }
+
+  if (route.view === 'invite') {
+    return user ? (
+      <BetaInvitePage code={route.code} onContinue={() => navigate('/')} />
+    ) : (
+      <ClosedBetaSplash inviteCode={route.code} />
+    );
   }
 
   // Closed beta: no session → branded splash (sign-in + waitlist). The shell still loads so

--- a/apps/web/src/AppleSignInButton.tsx
+++ b/apps/web/src/AppleSignInButton.tsx
@@ -45,12 +45,13 @@ const APPLE_SDK_SRC = 'https://appleid.cdn-apple.com/appleauth/static/jsapi/appl
 
 interface AppleSignInButtonProps {
   onSuccess?: () => void;
+  inviteCode?: string;
   // Mirrors GoogleSignInButton: the token travels with the error so a caller can offer
   // the waitlist without making a rejected user authenticate a second time.
   onError?: (err: string, idToken?: string) => void;
 }
 
-export function AppleSignInButton({ onSuccess, onError }: AppleSignInButtonProps) {
+export function AppleSignInButton({ onSuccess, onError, inviteCode }: AppleSignInButtonProps) {
   const { t } = useTranslation();
   const { signInWithAppleToken, appleSignIn } = useAuth();
   const [ready, setReady] = useState(false);
@@ -115,7 +116,7 @@ export function AppleSignInButton({ onSuccess, onError }: AppleSignInButtonProps
       const name = `${first} ${last}`.trim();
 
       try {
-        await signInWithAppleToken(idToken, name || undefined);
+        await signInWithAppleToken(idToken, name || undefined, inviteCode);
         onSuccess?.();
       } catch (err) {
         onError?.(err instanceof Error ? err.message : 'Sign in failed', idToken);
@@ -130,7 +131,7 @@ export function AppleSignInButton({ onSuccess, onError }: AppleSignInButtonProps
     } finally {
       setBusy(false);
     }
-  }, [busy, onError, onSuccess, signInWithAppleToken]);
+  }, [busy, inviteCode, onError, onSuccess, signInWithAppleToken]);
 
   if (!enabled) return null;
 

--- a/apps/web/src/AuthContext.tsx
+++ b/apps/web/src/AuthContext.tsx
@@ -47,15 +47,16 @@ interface AuthContextType {
    */
   appleSignIn: boolean;
   waitlistStatus: WaitlistStatus;
-  signInWithGoogleToken: (idToken: string) => Promise<void>;
+  signInWithGoogleToken: (idToken: string, inviteCode?: string) => Promise<void>;
   /**
    * `name` is Apple's first-authorization gift: it arrives once, outside the token, and
    * never again. Passing it through on that one sign-in is the only chance to record it.
    */
-  signInWithAppleToken: (idToken: string, name?: string) => Promise<void>;
+  signInWithAppleToken: (idToken: string, name?: string, inviteCode?: string) => Promise<void>;
   // Closed-beta waitlist: works without a session (the caller is by definition
   // not on the allowlist). Re-verifies the same ID token server-side.
   joinWaitlist: (idToken: string, locale?: string, provider?: 'google' | 'apple') => Promise<void>;
+  acceptBetaInvite: (code: string) => Promise<void>;
   logout: () => Promise<void>;
   deleteAccount: () => Promise<{ deleteAfter: string }>;
   refreshUser: () => Promise<void>;
@@ -71,6 +72,7 @@ const AuthContext = createContext<AuthContextType>({
   signInWithGoogleToken: async () => {},
   signInWithAppleToken: async () => {},
   joinWaitlist: async () => {},
+  acceptBetaInvite: async () => {},
   logout: async () => {},
   deleteAccount: async () => ({ deleteAfter: '' }),
   refreshUser: async () => {},
@@ -123,12 +125,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     refreshUser();
   }, []);
 
-  const signInWithGoogleToken = async (idToken: string) => {
+  const signInWithGoogleToken = async (idToken: string, inviteCode?: string) => {
     const res = await fetch('/api/auth/google', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ idToken }),
+      body: JSON.stringify({ idToken, ...(inviteCode ? { inviteCode } : {}) }),
     });
 
     if (!res.ok) {
@@ -143,12 +145,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(data.user);
   };
 
-  const signInWithAppleToken = async (idToken: string, name?: string) => {
+  const signInWithAppleToken = async (idToken: string, name?: string, inviteCode?: string) => {
     const res = await fetch('/api/auth/apple', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ idToken, name }),
+      body: JSON.stringify({ idToken, name, ...(inviteCode ? { inviteCode } : {}) }),
     });
 
     if (!res.ok) {
@@ -180,6 +182,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setWaitlistStatus(data.waitlistStatus as WaitlistStatus);
     } else {
       setWaitlistStatus('pending');
+    }
+  };
+
+  const acceptBetaInvite = async (code: string) => {
+    const res = await fetch('/api/beta-invites/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ code }),
+    });
+    if (!res.ok) {
+      const err = (await res.json().catch(() => null)) as { error?: string } | null;
+      throw new Error(err?.error ?? 'Could not accept beta invite');
     }
   };
 
@@ -218,6 +233,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         signInWithGoogleToken,
         signInWithAppleToken,
         joinWaitlist,
+        acceptBetaInvite,
         logout,
         deleteAccount,
         refreshUser,

--- a/apps/web/src/BetaInvitePage.tsx
+++ b/apps/web/src/BetaInvitePage.tsx
@@ -12,6 +12,7 @@ export function BetaInvitePage({ code, onContinue }: { code: string; onContinue:
 
   useEffect(() => {
     let cancelled = false;
+    recordBetaInviteStep('opened');
     void acceptBetaInvite(code)
       .then(() => {
         if (cancelled) return;

--- a/apps/web/src/BetaInvitePage.tsx
+++ b/apps/web/src/BetaInvitePage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from './AuthContext.js';
+import { recordBetaInviteStep } from './visitTelemetry.js';
+
+type InviteState = 'claiming' | 'accepted' | 'unavailable';
+
+export function BetaInvitePage({ code, onContinue }: { code: string; onContinue: () => void }) {
+  const { t } = useTranslation();
+  const { acceptBetaInvite } = useAuth();
+  const [state, setState] = useState<InviteState>('claiming');
+
+  useEffect(() => {
+    let cancelled = false;
+    void acceptBetaInvite(code)
+      .then(() => {
+        if (cancelled) return;
+        recordBetaInviteStep('accepted');
+        setState('accepted');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        recordBetaInviteStep('unavailable');
+        setState('unavailable');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [acceptBetaInvite, code]);
+
+  return (
+    <div className="beta-invite">
+      <div className="beta-invite__card">
+        <div className="beta-splash__logo">
+          <span className="beta-splash__logo-main">gamedev</span>
+          <span className="beta-splash__logo-tld">.pl</span>
+        </div>
+        {state === 'claiming' && (
+          <>
+            <h1>{t('betaInvite.claiming')}</h1>
+            <p>{t('betaInvite.claimingSub')}</p>
+          </>
+        )}
+        {state === 'accepted' && (
+          <>
+            <h1>{t('betaInvite.accepted')}</h1>
+            <p>{t('betaInvite.acceptedSub')}</p>
+            <button type="button" className="beta-splash__waitlist-btn" onClick={onContinue}>
+              {t('betaInvite.continue')}
+            </button>
+          </>
+        )}
+        {state === 'unavailable' && (
+          <>
+            <h1>{t('betaInvite.unavailable')}</h1>
+            <p>{t('betaInvite.unavailableSub')}</p>
+            <button type="button" className="beta-splash__waitlist-btn" onClick={onContinue}>
+              {t('betaInvite.backHome')}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -79,6 +79,71 @@ describe('ClosedBetaSplash', () => {
     await act(async () => root.unmount());
   });
 
+  it('sends the invite code through sign-in and records acceptance', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    let capturedCallback: ((res: { credential: string }) => void) | null = null;
+    const sent: unknown[] = [];
+    const session = new VisitSession('33333333-3333-4333-8333-333333333333', 0, (body) => sent.push(body));
+    setVisitSessionForTesting(session);
+
+    (globalThis as unknown as { google: unknown }).google = {
+      accounts: {
+        id: {
+          initialize: (config: { callback: (res: { credential: string }) => void }) => {
+            capturedCallback = config.callback;
+          },
+          renderButton: () => {},
+          prompt: () => {},
+        },
+      },
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) return new Response(JSON.stringify({}), { status: 401 });
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', privateBeta: true }));
+      }
+      if (url.endsWith('/api/auth/google')) {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          idToken: 'invite-credential',
+          inviteCode: 'Abc123_-'.repeat(4),
+        });
+        return new Response(JSON.stringify({ user: { uid: 'g:invitee', tier: 'standard' } }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(AuthProvider, null, createElement(ClosedBetaSplash, { inviteCode: 'Abc123_-'.repeat(4) })),
+      );
+      await flushEffects();
+    });
+
+    expect(container.querySelector('#btn-accept-beta-invite')).not.toBeNull();
+    await act(async () => {
+      capturedCallback!({ credential: 'invite-credential' });
+      await flushEffects();
+      await flushEffects();
+    });
+
+    session.flush();
+    const steps = sent.flatMap((body) => (body as { events: Array<{ type: string; step?: string }> }).events);
+    expect(steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'invite_step', step: 'opened' }),
+        expect.objectContaining({ type: 'invite_step', step: 'accepted' }),
+      ]),
+    );
+
+    await act(async () => root.unmount());
+  });
+
   it('Join without a token asks for sign-in and does not POST yet', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const sent: unknown[] = [];
@@ -172,9 +237,9 @@ describe('ClosedBetaSplash', () => {
     });
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('#btn-join-waitlist')?.dispatchEvent(
-        new MouseEvent('click', { bubbles: true }),
-      );
+      container
+        .querySelector<HTMLButtonElement>('#btn-join-waitlist')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
 

--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -1,14 +1,14 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppleSignInButton } from './AppleSignInButton.js';
 import { useAuth } from './AuthContext.js';
 import { GoogleSignInButton } from './GoogleSignInButton.js';
 import { InteractiveMascot } from './Mascot.js';
-import { recordWaitlistStep } from './visitTelemetry.js';
+import { recordBetaInviteStep, recordWaitlistStep } from './visitTelemetry.js';
 
 type WaitlistState = 'idle' | 'joining' | 'joined' | 'error';
 
-export function ClosedBetaSplash() {
+export function ClosedBetaSplash({ inviteCode }: { inviteCode?: string }) {
   const { t, i18n } = useTranslation();
   const { joinWaitlist, waitlistStatus } = useAuth();
   const [error, setError] = useState<string | null>(null);
@@ -18,11 +18,16 @@ export function ClosedBetaSplash() {
   // verifier would reject the very person the waitlist exists to catch.
   const [idTokenProvider, setIdTokenProvider] = useState<'google' | 'apple'>('google');
   const [waitlistState, setWaitlistState] = useState<WaitlistState>('idle');
+  const isInvite = inviteCode !== undefined;
   // Clicked Join before signing in — after a rejected sign-in we auto-join with that token
   // so the visitor is not asked to press Join a second time.
   const [awaitingSignIn, setAwaitingSignIn] = useState(false);
   const joinIntentRef = useRef(false);
   const isBlocked = error != null;
+
+  useEffect(() => {
+    if (isInvite) recordBetaInviteStep('opened');
+  }, [isInvite]);
 
   const doJoin = async (token: string, provider: 'google' | 'apple') => {
     if (waitlistState === 'joining' || waitlistState === 'joined') return;
@@ -40,6 +45,10 @@ export function ClosedBetaSplash() {
 
   const handleJoinWaitlist = () => {
     if (waitlistState === 'joining' || waitlistState === 'joined') return;
+    if (isInvite) {
+      setAwaitingSignIn(true);
+      return;
+    }
     recordWaitlistStep('cta_clicked');
     if (!idToken) {
       // Still requires login: the CTA is visible up front, but the write only happens
@@ -55,14 +64,18 @@ export function ClosedBetaSplash() {
     setError(msg);
     setIdToken(token ?? null);
     setIdTokenProvider(provider);
-    if (token && joinIntentRef.current) {
+    if (!isInvite && token && joinIntentRef.current) {
       void doJoin(token, provider);
     }
   };
 
+  const handleInviteSignIn = () => {
+    recordBetaInviteStep('accepted');
+  };
+
   // Determine if we should show a known waitlist status (from the API 403 or a previous join)
   const hasKnownStatus = waitlistStatus === 'pending' || waitlistStatus === 'approved' || waitlistStatus === 'rejected';
-  const showStatus = waitlistState === 'joined' || (hasKnownStatus && waitlistState !== 'error');
+  const showStatus = !isInvite && (waitlistState === 'joined' || (hasKnownStatus && waitlistState !== 'error'));
 
   return (
     <div className="beta-splash">
@@ -80,8 +93,8 @@ export function ClosedBetaSplash() {
           <span className="beta-splash__logo-tld">.pl</span>
         </div>
 
-        <h1 className="beta-splash__headline">{t('betaSplash.headline')}</h1>
-        <p className="beta-splash__sub">{t('betaSplash.sub')}</p>
+        <h1 className="beta-splash__headline">{isInvite ? t('betaInvite.headline') : t('betaSplash.headline')}</h1>
+        <p className="beta-splash__sub">{isInvite ? t('betaInvite.sub') : t('betaSplash.sub')}</p>
 
         <div className="beta-splash__badge">{t('betaSplash.badge')}</div>
 
@@ -100,32 +113,48 @@ export function ClosedBetaSplash() {
             </div>
           ) : (
             <>
-              {isBlocked && <p className="beta-splash__blocked-msg">{t('betaSplash.blockedMsg')}</p>}
+              {isBlocked && (
+                <p className="beta-splash__blocked-msg">
+                  {isInvite ? t('betaInvite.unavailableSub') : t('betaSplash.blockedMsg')}
+                </p>
+              )}
               <button
-                id="btn-join-waitlist"
+                id={isInvite ? 'btn-accept-beta-invite' : 'btn-join-waitlist'}
                 className="beta-splash__waitlist-btn"
                 onClick={handleJoinWaitlist}
                 disabled={waitlistState === 'joining'}
               >
-                {waitlistState === 'joining' ? t('betaSplash.joiningWaitlist') : t('betaSplash.joinWaitlist')}
+                {isInvite
+                  ? t('betaInvite.accept')
+                  : waitlistState === 'joining'
+                    ? t('betaSplash.joiningWaitlist')
+                    : t('betaSplash.joinWaitlist')}
               </button>
               {awaitingSignIn && !idToken && (
-                <p className="beta-splash__signin-hint">{t('betaSplash.signInToJoin')}</p>
+                <p className="beta-splash__signin-hint">
+                  {isInvite ? t('betaInvite.signInHint') : t('betaSplash.signInToJoin')}
+                </p>
               )}
             </>
           )}
           {waitlistState === 'error' && (
-            <p className="beta-splash__waitlist-error">{t('betaSplash.waitlistError')}</p>
+            <p className="beta-splash__waitlist-error">
+              {isInvite ? t('betaInvite.unavailableSub') : t('betaSplash.waitlistError')}
+            </p>
           )}
         </div>
 
         <div className="beta-splash__signin">
           <GoogleSignInButton
+            inviteCode={inviteCode}
+            onSuccess={isInvite ? handleInviteSignIn : undefined}
             onError={(msg, token) => {
               handleSignInError(msg, token, 'google');
             }}
           />
           <AppleSignInButton
+            inviteCode={inviteCode}
+            onSuccess={isInvite ? handleInviteSignIn : undefined}
             onError={(msg, token) => {
               handleSignInError(msg, token, 'apple');
             }}

--- a/apps/web/src/GoogleSignInButton.tsx
+++ b/apps/web/src/GoogleSignInButton.tsx
@@ -23,6 +23,7 @@ declare global {
 
 interface GoogleSignInButtonProps {
   onSuccess?: () => void;
+  inviteCode?: string;
   // idToken is passed alongside a sign-in error (e.g. private-beta 403) so a
   // caller can offer a follow-up action — like joining the waitlist — that
   // re-verifies the same token server-side without asking the user to sign in twice.
@@ -58,7 +59,7 @@ function GoogleMark() {
   );
 }
 
-export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonProps) {
+export function GoogleSignInButton({ onSuccess, onError, inviteCode }: GoogleSignInButtonProps) {
   const { t, i18n } = useTranslation();
   const { signInWithGoogleToken } = useAuth();
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -73,9 +74,11 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
   const signInRef = useRef(signInWithGoogleToken);
+  const inviteCodeRef = useRef(inviteCode);
   onSuccessRef.current = onSuccess;
   onErrorRef.current = onError;
   signInRef.current = signInWithGoogleToken;
+  inviteCodeRef.current = inviteCode;
 
   useEffect(() => {
     if (window.google?.accounts?.id) {
@@ -107,7 +110,7 @@ export function GoogleSignInButton({ onSuccess, onError }: GoogleSignInButtonPro
       auto_select: true,
       callback: async (response) => {
         try {
-          await signInRef.current(response.credential);
+          await signInRef.current(response.credential, inviteCodeRef.current);
           onSuccessRef.current?.();
         } catch (err) {
           window.google?.accounts?.id?.disableAutoSelect?.();

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -34,6 +34,12 @@ const WAITLIST_LABELS: Record<string, string> = {
   joined: 'joined waitlist',
 };
 
+const INVITE_LABELS: Record<string, string> = {
+  opened: 'opened an invite',
+  accepted: 'accepted an invite',
+  unavailable: 'hit an unavailable invite',
+};
+
 const EDITOR_LABELS: Record<string, string> = {
   opened: 'opened the editor',
   draft_saved: 'saved a draft',
@@ -206,6 +212,36 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                     <td>{WAITLIST_LABELS[row.step] ?? row.step}</td>
                     <td className="num">{row.visits}</td>
                     <td className="num">{percent(row.visits, funnel.waitlist[0]?.visits ?? 0)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="funnel-block">
+          <h3>Invites</h3>
+          {(funnel.invites ?? []).every((row) => row.visits === 0) ? (
+            <p className="health-empty">Nobody opened an invite in this window.</p>
+          ) : (
+            <table className="health-table">
+              <thead>
+                <tr>
+                  <th scope="col">Step</th>
+                  <th scope="col" className="num">
+                    Visits
+                  </th>
+                  <th scope="col" className="num">
+                    Of opens
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {(funnel.invites ?? []).map((row) => (
+                  <tr key={row.step}>
+                    <td>{INVITE_LABELS[row.step] ?? row.step}</td>
+                    <td className="num">{row.visits}</td>
+                    <td className="num">{percent(row.visits, funnel.invites?.[0]?.visits ?? 0)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/WaitlistPanel.test.tsx
+++ b/apps/web/src/WaitlistPanel.test.tsx
@@ -2,12 +2,15 @@
 
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WaitlistPanel } from './WaitlistPanel.js';
 import type { WaitlistEntry } from './adminApi.js';
 
 const mocked = vi.hoisted(() => ({
+  createBetaInvite: vi.fn(),
+  fetchBetaInvites: vi.fn(),
   fetchWaitlist: vi.fn(),
+  revokeBetaInvite: vi.fn(),
   setWaitlistStatus: vi.fn(),
   setWaitlistStatusByEmail: vi.fn(),
 }));
@@ -50,6 +53,10 @@ async function type(input: HTMLInputElement, value: string) {
 afterEach(() => {
   document.body.innerHTML = '';
   vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mocked.fetchBetaInvites.mockResolvedValue([]);
 });
 
 describe('WaitlistPanel', () => {

--- a/apps/web/src/WaitlistPanel.test.tsx
+++ b/apps/web/src/WaitlistPanel.test.tsx
@@ -107,6 +107,50 @@ describe('WaitlistPanel', () => {
     await act(async () => root.unmount());
   });
 
+  it('creates and copies a one-time invite link', async () => {
+    mocked.fetchWaitlist.mockResolvedValue([]);
+    mocked.createBetaInvite.mockResolvedValue({
+      invite: {
+        id: '11111111-1111-4111-8111-111111111111',
+        createdAt: new Date().toISOString(),
+        createdByUid: 'g:boss',
+        status: 'available',
+      },
+      code: 'Abc123_-'.repeat(4),
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { container, root } = await render();
+    const create = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Create invite link',
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      create.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const link = container.querySelector<HTMLInputElement>('input[aria-label="New beta invite link"]');
+    expect(link?.value).toBe(`${window.location.origin}/invite/${'Abc123_-'.repeat(4)}`);
+    expect(mocked.createBetaInvite).toHaveBeenCalledOnce();
+
+    const copy = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Copy link',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      copy.click();
+      await Promise.resolve();
+    });
+    expect(writeText).toHaveBeenCalledWith(link?.value);
+
+    await act(async () => root.unmount());
+  });
+
   it('tells a non-operator nothing', async () => {
     mocked.fetchWaitlist.mockResolvedValue(null);
 

--- a/apps/web/src/WaitlistPanel.tsx
+++ b/apps/web/src/WaitlistPanel.tsx
@@ -84,8 +84,11 @@ export function WaitlistPanel() {
   useEffect(() => {
     setState('loading');
     void load(filter);
+  }, [filter, load]);
+
+  useEffect(() => {
     void loadInvites();
-  }, [filter, load, loadInvites]);
+  }, [loadInvites]);
 
   const changeStatus = useCallback(
     async (uid: string, status: WaitlistStatus) => {

--- a/apps/web/src/WaitlistPanel.tsx
+++ b/apps/web/src/WaitlistPanel.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  createBetaInvite,
+  fetchBetaInvites,
   fetchWaitlist,
+  revokeBetaInvite,
+  type BetaInvite,
   setWaitlistStatus,
   setWaitlistStatusByEmail,
   type WaitlistEntry,
   type WaitlistStatus,
 } from './adminApi.js';
+import { betaInvitePath } from './router.js';
 
 /**
  * Closed-beta waitlist membership — list, approve, reject, pre-approve by email.
@@ -43,6 +48,9 @@ export function WaitlistPanel() {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [email, setEmail] = useState('');
+  const [invites, setInvites] = useState<BetaInvite[] | null>(null);
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [inviteBusy, setInviteBusy] = useState(false);
   // Monotonic id so a slow Pending fetch cannot overwrite an Approved list the
   // operator already switched to (Copilot + Codex both flagged this race).
   const loadGeneration = useRef(0);
@@ -64,10 +72,20 @@ export function WaitlistPanel() {
     }
   }, []);
 
+  const loadInvites = useCallback(async () => {
+    try {
+      const result = await fetchBetaInvites();
+      if (result !== null) setInvites(result);
+    } catch {
+      setInvites([]);
+    }
+  }, []);
+
   useEffect(() => {
     setState('loading');
     void load(filter);
-  }, [filter, load]);
+    void loadInvites();
+  }, [filter, load, loadInvites]);
 
   const changeStatus = useCallback(
     async (uid: string, status: WaitlistStatus) => {
@@ -114,6 +132,56 @@ export function WaitlistPanel() {
     }
   }, [email, filter, load]);
 
+  const makeInvite = useCallback(async () => {
+    setInviteBusy(true);
+    setMessage(null);
+    try {
+      const result = await createBetaInvite();
+      if ('error' in result) {
+        setMessage(result.error);
+        return;
+      }
+      setInviteLink(new URL(betaInvitePath(result.code), window.location.origin).toString());
+      setMessage('Invite link created. It can be used once.');
+      await loadInvites();
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setInviteBusy(false);
+    }
+  }, [loadInvites]);
+
+  const copyInvite = useCallback(async () => {
+    if (!inviteLink || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setMessage('Invite link copied.');
+    } catch {
+      setMessage('Copy failed — select the link manually.');
+    }
+  }, [inviteLink]);
+
+  const revokeInvite = useCallback(
+    async (id: string) => {
+      setInviteBusy(true);
+      setMessage(null);
+      try {
+        const result = await revokeBetaInvite(id);
+        if ('error' in result) {
+          setMessage(result.error);
+          return;
+        }
+        setMessage('Invite link revoked.');
+        await loadInvites();
+      } catch {
+        setMessage('could not reach the API');
+      } finally {
+        setInviteBusy(false);
+      }
+    },
+    [loadInvites],
+  );
+
   // Filters stay mounted during the first load so a slow Pending fetch cannot
   // trap the operator — they can switch to Approved while it is still in flight,
   // which is also the race the generation guard below exists for.
@@ -128,6 +196,60 @@ export function WaitlistPanel() {
         Closed-beta membership. Approving grants sign-in without a redeploy; rejecting or resetting updates the same
         Firestore row the CLI writes.
       </p>
+
+      <section className="admin-beta-invites">
+        <h3>One-time invite links</h3>
+        <p className="health-summary">
+          Create a link for someone whose email you do not know. The first account to accept it gets access; the link
+          cannot be reused.
+        </p>
+        <button type="button" disabled={inviteBusy} onClick={() => void makeInvite()}>
+          Create invite link
+        </button>
+        {inviteLink && (
+          <div className="admin-beta-invite-created">
+            <input
+              aria-label="New beta invite link"
+              readOnly
+              value={inviteLink}
+              onFocus={(event) => event.currentTarget.select()}
+            />
+            <button type="button" disabled={inviteBusy} onClick={() => void copyInvite()}>
+              Copy link
+            </button>
+          </div>
+        )}
+        {invites && invites.length > 0 && (
+          <div className="health-table-scroll">
+            <table className="health-table">
+              <thead>
+                <tr>
+                  <th>Status</th>
+                  <th>Created</th>
+                  <th>Claimed by</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {invites.map((invite) => (
+                  <tr key={invite.id}>
+                    <td>{invite.status}</td>
+                    <td title={invite.createdAt}>{since(invite.createdAt, now)}</td>
+                    <td>{invite.claimedUid ?? '—'}</td>
+                    <td>
+                      {invite.status === 'available' && (
+                        <button type="button" disabled={inviteBusy} onClick={() => void revokeInvite(invite.id)}>
+                          Revoke
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
 
       <div className="admin-waitlist-filters" role="group" aria-label="Filter by status">
         {FILTERS.map((candidate) => (

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -40,6 +40,19 @@ export interface WaitlistEntry {
   status: WaitlistStatus;
 }
 
+export type BetaInviteStatus = 'available' | 'claimed' | 'revoked';
+
+export interface BetaInvite {
+  id: string;
+  createdAt: string;
+  createdByUid: string;
+  status: BetaInviteStatus;
+  claimedAt?: string;
+  claimedUid?: string;
+  revokedAt?: string;
+  revokedByUid?: string;
+}
+
 /**
  * The console's admission test as well as its header.
  *
@@ -363,6 +376,33 @@ export async function setWaitlistStatusByEmail(
     body: JSON.stringify({ email, status }),
   });
   if (res.ok) return (await res.json()) as WaitlistEntry;
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
+}
+
+export async function fetchBetaInvites(): Promise<BetaInvite[] | null> {
+  const res = await fetch(`${API_BASE}/api/admin/beta-invites`, { credentials: 'include' });
+  if (res.status === 404 || res.status === 401) return null;
+  if (!res.ok) throw new Error(`beta invites failed (${res.status})`);
+  return ((await res.json()) as { invites: BetaInvite[] }).invites;
+}
+
+export async function createBetaInvite(): Promise<{ invite: BetaInvite; code: string } | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/beta-invites`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (res.ok) return (await res.json()) as { invite: BetaInvite; code: string };
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return { error: body.error ?? `request failed (${res.status})` };
+}
+
+export async function revokeBetaInvite(id: string): Promise<BetaInvite | { error: string }> {
+  const res = await fetch(`${API_BASE}/api/admin/beta-invites/${encodeURIComponent(id)}/revoke`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (res.ok) return (await res.json()) as BetaInvite;
   const body = (await res.json().catch(() => ({}))) as { error?: string };
   return { error: body.error ?? `request failed (${res.status})` };
 }

--- a/apps/web/src/betaSplashFit.test.ts
+++ b/apps/web/src/betaSplashFit.test.ts
@@ -11,7 +11,7 @@ const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url))
 
 describe('the beta splash fits a small phone', () => {
   it('measures the viewport as the part you can see', () => {
-    const rule = css.slice(css.indexOf('.beta-splash {'), css.indexOf('.beta-splash__card {'));
+    const rule = css.slice(css.indexOf('.beta-splash,\n.beta-invite {'), css.indexOf('.beta-splash__card {'));
     // Both, in this order. iOS resolves 100vh to the large viewport, so dvh has to
     // come second and win; the vh line stays as the fallback for browsers without dvh.
     expect(rule).toMatch(/min-height: 100vh;[\s\S]*min-height: 100dvh;/);
@@ -29,9 +29,8 @@ describe('the beta splash fits a small phone', () => {
   it('centres the card without making an overflowing one unreachable', () => {
     const query = css.slice(css.indexOf('@media (max-height: 720px)'));
     // Comments here explain what NOT to use, so strip them before asserting absence.
-    const splash = query
-      .slice(query.indexOf('.beta-splash {'), query.indexOf('.beta-splash__card {'))
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+    const splashStart = query.indexOf('.beta-splash,\n  .beta-invite {');
+    const splash = query.slice(splashStart, query.indexOf('}', splashStart) + 1).replace(/\/\*[\s\S]*?\*\//g, '');
     // Centring a flex item that overflows puts its top edge where it cannot be
     // scrolled to. `safe center` expresses the intent but older Safari drops it and
     // falls back to plain `center` — the bug it was meant to avoid. Auto margins on
@@ -39,7 +38,7 @@ describe('the beta splash fits a small phone', () => {
     expect(splash).toContain('align-items: flex-start');
     expect(splash).not.toContain('align-items: center');
     expect(splash).not.toContain('safe center');
-    const card = query.slice(query.indexOf('.beta-splash__card {'));
+    const card = query.slice(query.indexOf('.beta-splash__card,\n  .beta-invite__card {'));
     expect(card.slice(0, 200)).toMatch(/margin-top: auto;\s*margin-bottom: auto;/);
   });
 

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -82,6 +82,7 @@ export interface VisitFunnel {
   creating: Array<{ step: string; visits: number }>;
   /** Closed-beta waitlist funnel in step order, every step present even at zero. */
   waitlist: Array<{ step: string; visits: number }>;
+  invites?: Array<{ step: string; visits: number }>;
   /** EditorKit revision funnel in step order, every step present even at zero. */
   editing: Array<{ step: string; visits: number }>;
   /**

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -836,6 +836,20 @@
     "waitlistError": "Couldn't join the waitlist right now. Please try again.",
     "footer": "Access is invite-only during the closed beta."
   },
+  "betaInvite": {
+    "headline": "You've been invited to the closed beta.",
+    "sub": "This link is for one person. Sign in with the account you want to use.",
+    "accept": "Accept invitation",
+    "signInHint": "Sign in with Google or Apple below to accept it.",
+    "unavailableSub": "This invitation was already used, revoked, or is not valid. Ask the sender for a new link.",
+    "claiming": "Checking your invitation…",
+    "claimingSub": "This link will be attached to your account.",
+    "accepted": "Invitation accepted.",
+    "acceptedSub": "Your account now has access to the closed beta.",
+    "continue": "Enter the beta",
+    "unavailable": "This invitation is no longer available.",
+    "backHome": "Back to the home page"
+  },
   "errors": {
     "generic": "Something went wrong",
     "creationPaused": "New games are paused for a moment while we look at something on our side. Your daily allowance hasn't been touched — please try again shortly.",
@@ -980,6 +994,7 @@
     "home": "Gamedev.pl — Describe a game, play it",
     "status": "Your game is in the works",
     "join": "Join the game",
+    "invite": "Beta invitation",
     "health": "Telemetry",
     "review": "Game review",
     "studio": "Creator Studio",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -840,6 +840,20 @@
     "waitlistError": "Nie udało się dołączyć do listy. Spróbuj ponownie.",
     "footer": "W trakcie zamkniętej bety dostęp jest tylko na zaproszenie."
   },
+  "betaInvite": {
+    "headline": "Otrzymujesz zaproszenie do zamkniętej bety.",
+    "sub": "Ten link jest dla jednej osoby. Zaloguj się na konto, którego chcesz używać.",
+    "accept": "Przyjmij zaproszenie",
+    "signInHint": "Zaloguj się przez Google lub Apple poniżej, aby je przyjąć.",
+    "unavailableSub": "To zaproszenie zostało już użyte, anulowane albo jest nieprawidłowe. Poproś nadawcę o nowy link.",
+    "claiming": "Sprawdzanie zaproszenia…",
+    "claimingSub": "Link zostanie przypisany do Twojego konta.",
+    "accepted": "Zaproszenie przyjęte.",
+    "acceptedSub": "Twoje konto ma teraz dostęp do zamkniętej bety.",
+    "continue": "Wejdź do bety",
+    "unavailable": "To zaproszenie nie jest już dostępne.",
+    "backHome": "Wróć na stronę główną"
+  },
   "errors": {
     "generic": "Coś poszło nie tak",
     "creationPaused": "Tworzenie nowych gier jest na chwilę wstrzymane — sprawdzamy coś u nas. Twój dzienny limit pozostaje nietknięty, spróbuj ponownie za moment.",
@@ -984,6 +998,7 @@
     "home": "Gamedev.pl — Opisz grę, zagraj w nią",
     "status": "Twoja gra jest w trakcie tworzenia",
     "join": "Dołącz do gry",
+    "invite": "Zaproszenie do bety",
     "health": "Telemetria",
     "review": "Ocena gier",
     "studio": "Studio Twórcy",

--- a/apps/web/src/pageTitle.test.ts
+++ b/apps/web/src/pageTitle.test.ts
@@ -11,6 +11,7 @@ import {
 const copy: DocumentTitleCopy = {
   home: 'Gamedev.pl — Describe a game, play it',
   join: 'Join the game',
+  invite: 'Beta invitation',
   health: 'Telemetry',
   review: 'Game review',
   studio: 'Creator Studio',
@@ -95,6 +96,9 @@ describe('resolveDocumentTitle', () => {
     );
     expect(resolveDocumentTitle({ view: 'join', code: 'K7M3QP', token: 't' }, { copy })).toBe(
       'Join the game — Gamedev.pl',
+    );
+    expect(resolveDocumentTitle({ view: 'invite', code: 'A'.repeat(32) }, { copy })).toBe(
+      'Beta invitation — Gamedev.pl',
     );
     expect(resolveDocumentTitle({ view: 'admin', section: 'queue' }, { copy })).toBe('Telemetry — Gamedev.pl');
     expect(resolveDocumentTitle({ view: 'legal', doc: 'privacy' }, { copy })).toBe('Privacy Policy — Gamedev.pl');

--- a/apps/web/src/pageTitle.ts
+++ b/apps/web/src/pageTitle.ts
@@ -27,6 +27,7 @@ export type DocumentTitleCopy = {
   /** Full home title, e.g. "Gamedev.pl — Describe a game, play it". */
   home: string;
   join: string;
+  invite: string;
   health: string;
   review: string;
   studio: string;
@@ -71,6 +72,8 @@ export function resolveDocumentTitle(route: AppRoute, ctx: DocumentTitleContext)
       return brandedNamedTitle(ctx.copy.playNamed, ctx.playTitle?.trim() || humanizeSlug(route.slug));
     case 'join':
       return brandedPageTitle(ctx.copy.join);
+    case 'invite':
+      return brandedPageTitle(ctx.copy.invite);
     case 'admin':
       return brandedPageTitle(ctx.copy.health);
     case 'review':

--- a/apps/web/src/router.test.ts
+++ b/apps/web/src/router.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   canonicalPath,
   canonicalPlayPath,
+  betaInvitePath,
   creatorPath,
   gamePath,
   joinPath,
@@ -63,6 +64,13 @@ describe('parsePathRoute', () => {
       code: 'K7M3QP',
       token: 'abc-DEF_123',
     });
+  });
+
+  it('parses one-time beta invite links and rejects malformed codes', () => {
+    const code = 'Abc123_-'.repeat(4);
+    expect(parsePathRoute(betaInvitePath(code))).toEqual({ view: 'invite', code });
+    expect(parsePathRoute('/invite/too-short')).toEqual({ view: 'notFound' });
+    expect(parsePathRoute(`/invite/${'a'.repeat(33)}`)).toEqual({ view: 'notFound' });
   });
 
   it('maps malformed join links to notFound', () => {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -88,6 +88,7 @@ export type AppRoute =
   // to everyone else. `/health` still resolves here (telemetry) — it was the whole
   // surface before there was a console, and links to it are in people's bookmarks.
   | { view: 'admin'; section: AdminSection }
+  | { view: 'invite'; code: string }
   // Reviewer desk; unlisted like /admin.
   | { view: 'review' }
   // Creator control panel: own games, draft build (ex-status), playtest, improve.
@@ -132,6 +133,7 @@ export type AppRoute =
 // Game slugs are lowercase kebab-case (matches the games-repo catalog); keep the
 // route pattern strict so arbitrary path segments can't masquerade as a play route.
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const BETA_INVITE_CODE_PATTERN = /^[A-Za-z0-9_-]{32}$/;
 
 /** Creator handles — keep aligned with apps/api/src/creator-profile.ts HANDLE_PATTERN. */
 const CREATOR_HANDLE_PATTERN = /^[a-z][a-z0-9_]{2,23}$/;
@@ -163,6 +165,7 @@ const RESERVED_HANDLE_SEGMENTS = new Set([
   'gamedevpl',
   'health',
   'help',
+  'invite',
   'join',
   'me',
   'null',
@@ -229,6 +232,15 @@ export function parsePathRoute(pathname: string, hash = ''): AppRoute {
 
   if (normalizedPath === '/contact') {
     return { view: 'contact' };
+  }
+
+  const inviteMatch = normalizedPath.match(/^\/invite\/([^/]+)$/);
+  if (inviteMatch?.[1]) {
+    const code = decodeSegment(inviteMatch[1]);
+    if (code && BETA_INVITE_CODE_PATTERN.test(code)) {
+      return { view: 'invite', code };
+    }
+    return { view: 'notFound' };
   }
 
   const creatorMatch = normalizedPath.match(/^\/creators\/([^/]+)$/);
@@ -491,6 +503,7 @@ export function navUpTarget(route: AppRoute): NavUpTarget | null {
   switch (route.view) {
     case 'home':
     case 'join':
+    case 'invite':
       return null;
     // `/play/:slug` auto-opens; Close replaces onto the canonical game page.
     case 'play':
@@ -537,6 +550,10 @@ export function reviewPath(): string {
 /** QR / share URL path+fragment for a multiplayer lobby guest. */
 export function joinPath(code: string, token: string): string {
   return `/join/${code}#${token}`;
+}
+
+export function betaInvitePath(code: string): string {
+  return `/invite/${encodeURIComponent(code)}`;
 }
 
 /**

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4318,7 +4318,8 @@ a.user-name--profile:focus-visible {
 }
 
 /* CLOSED BETA SPLASH */
-.beta-splash {
+.beta-splash,
+.beta-invite {
   min-height: 100vh;
   /* iOS resolves 100vh to the LARGE viewport — the one you get with the toolbars
      retracted — so a screen centred in it sits partly behind Safari's bottom bar
@@ -4328,6 +4329,10 @@ a.user-name--profile:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.beta-splash,
+.beta-invite {
   padding: 24px;
 }
 
@@ -4343,6 +4348,29 @@ a.user-name--profile:focus-visible {
   /* Pull-ups climb onto the rim — don't clip him. */
   position: relative;
   overflow: visible;
+}
+
+.beta-invite__card {
+  width: 100%;
+  max-width: 460px;
+  padding: 48px 40px;
+  text-align: center;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.beta-invite__card h1 {
+  margin: 0 0 12px;
+  font-size: 1.6rem;
+  line-height: 1.3;
+}
+
+.beta-invite__card p {
+  margin: 0 0 24px;
+  color: var(--muted);
+  line-height: 1.5;
 }
 
 .beta-splash__logo {
@@ -4492,18 +4520,14 @@ a.user-name--profile:focus-visible {
  * catches a phone held in landscape, where a width query would not fire.
  */
 @media (max-height: 720px) {
-  .beta-splash {
-    padding: 12px;
-    /* Centring a flex item that overflows pushes its top edge past the container's,
-       where it cannot be scrolled back to — the head gets cut off as well as the feet.
-       `align-items: safe center` says exactly that, but older Safari drops the whole
-       declaration as invalid and silently falls back to plain `center`, which is the
-       bug. Auto margins do the same job with no support story: they centre while there
-       is free space and collapse to zero when there is not. */
+  .beta-splash,
+  .beta-invite {
     align-items: flex-start;
+    padding: 12px;
   }
 
-  .beta-splash__card {
+  .beta-splash__card,
+  .beta-invite__card {
     margin-top: auto;
     margin-bottom: auto;
     padding: 24px 20px;
@@ -12293,6 +12317,35 @@ button.builder-mode-selector:disabled {
   align-items: center;
 }
 
+.admin-beta-invites {
+  margin: 1.25rem 0 1.5rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-radius: 6px;
+}
+
+.admin-beta-invites h3 {
+  margin: 0 0 0.35rem;
+}
+
+.admin-beta-invites .health-summary {
+  margin-bottom: 0.75rem;
+}
+
+.admin-beta-invite-created {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.admin-beta-invite-created input {
+  min-width: min(100%, 24rem);
+  flex: 1;
+  font: inherit;
+  padding: 0.3rem 0.4rem;
+}
+
 .admin-waitlist-actions {
   margin: 0;
   gap: 0.35rem;
@@ -12301,6 +12354,7 @@ button.builder-mode-selector:disabled {
 .admin-limits-controls button,
 .admin-tokens-form button,
 .admin-tokens button,
+.admin-beta-invites button,
 .admin-waitlist-filters button,
 .admin-waitlist-actions button {
   cursor: pointer;

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -9,6 +9,7 @@ import { parsePathRoute } from './router.js';
 vi.stubGlobal('crypto', webcrypto);
 import {
   readVisitIdentity,
+  recordBetaInviteStep,
   recordCreateStep,
   recordStudioStep,
   recordVisitEvent,
@@ -327,6 +328,25 @@ describe('recordWaitlistStep', () => {
   it('is a silent no-op when tracking was never started', () => {
     setVisitSessionForTesting(null);
     expect(() => recordWaitlistStep('cta_clicked')).not.toThrow();
+  });
+});
+
+describe('recordBetaInviteStep', () => {
+  it('records invite outcomes once per visit', () => {
+    const { batches, send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    setVisitSessionForTesting(session);
+
+    recordBetaInviteStep('opened');
+    recordBetaInviteStep('opened');
+    recordBetaInviteStep('accepted');
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    expect(batches[0].events).toEqual([
+      expect.objectContaining({ type: 'invite_step', step: 'opened' }),
+      expect.objectContaining({ type: 'invite_step', step: 'accepted' }),
+    ]);
   });
 });
 

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -28,7 +28,7 @@ const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 /** Where a visit is, coarsely. Route parameters (tokens, slugs) never travel. */
 export type VisitRouteKind =
   // `draft` is historical only — new visits on `/draft/<slug>` emit `play`.
-  'home' | 'play' | 'draft' | 'status' | 'join' | 'legal' | 'health' | 'studio' | 'game' | 'notFound';
+  'home' | 'play' | 'draft' | 'status' | 'join' | 'invite' | 'legal' | 'health' | 'studio' | 'game' | 'notFound';
 
 export type VisitEvent =
   | {
@@ -62,6 +62,7 @@ export type VisitEvent =
   | { type: 'create_step'; step: CreateStep; builder?: BuilderDimension }
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */
   | { type: 'waitlist_step'; step: WaitlistStep }
+  | { type: 'invite_step'; step: InviteStep }
   /**
    * Studio / self-build funnel facts on the same visit stream as `create_step`.
    * Always carries `builder` so BYOCA reach-to-publish is measurable without a
@@ -114,6 +115,8 @@ export type WaitlistStep =
   | 'cta_clicked'
   /** `POST /api/waitlist` succeeded for this visit. */
   | 'joined';
+
+export type InviteStep = 'opened' | 'accepted' | 'unavailable';
 
 /**
  * Which chrome surface opened the How to play card.
@@ -336,6 +339,7 @@ export function routeKind(view: string): VisitRouteKind {
   switch (view) {
     case 'play':
     case 'join':
+    case 'invite':
     case 'legal':
     case 'studio':
     case 'notFound':
@@ -520,6 +524,14 @@ export function recordWaitlistStep(step: WaitlistStep): void {
   currentSession.record({ type: 'waitlist_step', step });
 }
 
+let recordedBetaInviteSteps = new Set<InviteStep>();
+
+export function recordBetaInviteStep(step: InviteStep): void {
+  if (!currentSession || recordedBetaInviteSteps.has(step)) return;
+  recordedBetaInviteSteps.add(step);
+  currentSession.record({ type: 'invite_step', step });
+}
+
 /**
  * Studio steps already recorded for the live visit.
  *
@@ -599,6 +611,7 @@ export function setVisitSessionForTesting(session: VisitSession | null): void {
   // Otherwise one test's steps would silence the next test's identical steps.
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
+  recordedBetaInviteSteps = new Set();
   recordedStudioSteps = new Set();
   recordedEditorSteps = new Set();
   recordedAssistSteps = new Set();

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -649,6 +649,7 @@ export function startVisitTracking(options: StartVisitTrackingOptions = {}): () 
   // stop deduping across it if these were not cleared with the session that owns them.
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
+  recordedBetaInviteSteps = new Set();
   recordedStudioSteps = new Set();
 
   if (identity.isNew) {

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -95,12 +95,27 @@ their anonymous play telemetry bypass the beta wall without opening the catalog.
 - `POST /api/waitlist` with no body → 400 (proves the route exists and
   validates; no auth header needed for the probe).
 
-## Explicitly not in v1
+## One-time invite links
 
-- Email-form waitlist (unverified input, bots, moderation surface — no).
-- Invite emails from the console (CLI `beta:invite` remains); counts on the splash page.
+Operators can create a one-time invitation from **`/admin/waitlist`**. The panel returns the
+link once, with a copy button, and keeps only its status afterward:
 
-## Later addition
+- The link contains a high-entropy bearer code.
+- The first account to accept it through Google or Apple gets beta access.
+- The code is hashed in Firestore and claimed in a transaction, so concurrent clicks cannot
+  spend it twice.
+- The invitation is bound to the account used during sign-in, not to an email address.
+- Operators can revoke an unused link and create another if it is lost or shared too widely.
+- The invitation page explains that the first account to accept owns the link; forwarding is
+  therefore intentional access delegation, not proof of a particular person's identity.
+
+The link route records only invite funnel steps (`opened`, `accepted`, `unavailable`) in the
+anonymous visit stream. It never records the code or the signed-in account there.
+
+Email-form waitlist remains out of scope: it would accept unverified identity data and create
+a separate moderation surface.
+
+## Existing operator surface
 
 - Admin UI for the waitlist shipped as the operator console **Waitlist** tab
   (`/admin/waitlist`) — list, approve/reject/reset, pre-approve by email.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,6 +198,17 @@ previews the rendered email with no Firestore write and no send. See
 [`.claude/skills/managing-beta-participants`](../.claude/skills/managing-beta-participants) for
 the full access model.
 
+### Sending a one-time invite link
+
+When you do not know the invitee's email, open `/admin/waitlist` and use **One-time invite
+links → Create invite link**. Copy the returned link into the conversation. It is a bearer
+link: the first account to accept it through Google or Apple receives beta access, and the
+same link cannot be used by a second account.
+
+The raw code is returned only when the link is created. Firestore stores its SHA-256 hash,
+and claiming uses a transaction. The panel shows claimed/revoked status and can revoke an
+unused link. If a link is lost or shared accidentally, revoke it and create a replacement.
+
 ## Issuing agent access tokens
 
 Coding agents authenticate to the deployed site with personal access tokens


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add admin-created, one-time beta invite links in the Waitlist console
- bind the first accepting Google/Apple account atomically and hash codes at rest
- add invite acceptance UI, revocation, routing, telemetry, and focused tests
- address review feedback for telemetry-session resets, signed-in invite opens, filter-independent invite refreshes, and operator-flow UI coverage

## UX
The invitation page explains that the first account to accept owns the link. Operators see the link once with a copy action, can review status, and can revoke unused links.

## Screenshots

### Desktop invite page
[Desktop beta invite page](https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6/artifacts?path=%2Ftmp%2Fcomputer-use%2F14a8f.webp)

### Mobile invite page
[Mobile beta invite page](https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6/artifacts?path=%2Ftmp%2Fcomputer-use%2F559fc.webp)

### Invalid invite link
[Invalid beta invite link](https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6/artifacts?path=%2Ftmp%2Fcomputer-use%2F514a8.webp)

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- focused API and web Vitest suites

Instrumentation: invite opens, acceptance, and unavailable links are tracked as anonymous visit-funnel steps without code or account identifiers.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

