### PR TITLE
chore(contract): mirror shared path module

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -5,6 +5,7 @@
     "input",
     "collision",
     "world",
+    "path",
     "ai",
     "gameplay",
     "rng",

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -301,6 +301,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     ['football', Date.parse('2026-08-10T00:00:00.000Z')],
     ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
+    ['path', Date.parse('2026-08-15T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const now = options.now?.() ?? Date.now();

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -93,6 +93,7 @@ describe('games-repo-contract (website half)', () => {
       'input',
       'collision',
       'world',
+      'path',
       'ai',
       'gameplay',
       'rng',
@@ -226,7 +227,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
+        'input', 'collision', 'world', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -42,6 +42,7 @@ export const GAME_KIT_MODULES = [
   'input',
   'collision',
   'world',
+  'path',
   'ai',
   'gameplay',
   'rng',


### PR DESCRIPTION
## Summary

- Add `path` to the website-side GameKit module contract and vendored assemble fixture.
- Keep the serve-time module order in lockstep with the KC-03 games-repo change.
- Update the contract tests to cover the new canonical module order and extractor fixture.

## Paired change

- Games repo PR: https://github.com/gamedevpl/www.gamedev.pl-games/pull/647

## CI rollout guard

- Add a short-lived website-ahead expiry for `path` through `2026-08-15T00:00:00.000Z`.
- Remove that entry as soon as the paired games change lands.

## Validation

- `git diff --check`
- The paired games PR's full gate passes on `47c8ff37cf3f78715223377387379cff05a7b2d6`.

Merge this contract PR before the paired games-repo PR so the website recognizes the new module.