### PR TITLE
chore(contract): remove path rollout expiry

### DIFF
--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -301,7 +301,6 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     ['football', Date.parse('2026-08-10T00:00:00.000Z')],
     ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
-    ['path', Date.parse('2026-08-15T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const now = options.now?.() ?? Date.now();


### PR DESCRIPTION
## Summary

- Remove the temporary `path` website-ahead expiry now that games PR #647 is merged.
- Keep the contract check fail-closed for genuinely undeclared website modules.

## References

- Games PR: https://github.com/gamedevpl/www.gamedev.pl-games/pull/647
- Website contract PR: https://github.com/gamedevpl/www.gamedev.pl/pull/684

## Validation

- `npm --workspace apps/api run test -- src/games-repo-contract.test.ts` — 28 tests passed.
- `git diff --check` — passed.
- The live contract command was invoked; this clone has no `GAMES_REPO_TOKEN`, so it skipped the cross-repo fetch.
- Repository-wide type-check is blocked by the clone’s pre-existing missing `genaicode` dependency.