### PR TITLE
Scale embedded games to fill the theater

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -65,10 +65,14 @@ describe('embedGameHtml', () => {
     // Drop shell's 1400px wrap gutters.
     expect(out).toContain('.wrap{width:100%!important;max-width:none!important');
     expect(out).toContain('padding:0!important');
-    // Element box matches paint; avoid object-fit letterbox hitbox.
-    expect(out).toContain('#game{width:auto!important;height:auto!important');
+    // Fit the box to the logical bitmap without object-fit hitbox offsets.
+    expect(out).toContain(
+      '#game{--gdpl-canvas-ratio:1.6;flex:0 1 auto!important;width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important;',
+    );
+    expect(out).toContain('aspect-ratio:var(--gdpl-canvas-ratio)!important');
     expect(out).toContain('max-width:100%!important');
     expect(out).toContain('max-height:100%!important');
+    expect(out).not.toContain('#game{width:auto!important;height:auto!important');
     expect(out).not.toContain('#game{width:100%!important;height:100%!important');
     expect(out).not.toContain('object-fit:contain');
   });

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -339,7 +339,14 @@ const BRIDGE = `(function(){
   // remaining native handlers. Games have no selectable document chrome in the player.
   addEventListener('contextmenu',function(e){e.preventDefault();});
   addEventListener('selectstart',function(e){e.preventDefault();});
+  function fitGameCanvas(){
+    var canvas=el('game');
+    if(!canvas||!canvas.width||!canvas.height)return;
+    canvas.style.setProperty('--gdpl-canvas-ratio',String(canvas.width/canvas.height));
+  }
+  addEventListener('resize',fitGameCanvas);
   function init(){
+    fitGameCanvas();
     sendMeta();
     var s=el('sound-toggle');
     if(s&&'MutationObserver'in window){new MutationObserver(sendSound).observe(s,{attributes:true,attributeFilter:['aria-pressed']});}
@@ -352,13 +359,11 @@ const BRIDGE = `(function(){
   if(document.readyState==='loading')addEventListener('DOMContentLoaded',init);else init();
 })();`;
 
-// Hide in-game chrome; theater owns title/sound instead.
-// Parent CSS cannot reach opaque-origin frame (iOS loupe).
-// Undo shell's 1400px wrap so desktop theater is full-bleed.
+// Hide in-game chrome; theater owns title and sound.
+// Opaque-origin frames keep this CSS inside the game.
+// Fill desktop theater while keeping canvas bounds proportional.
 //
-// Size `#game` with max-width/max-height (not 100%×100% + object-fit). A full-box
-// canvas letterboxes its bitmap *inside* the element, so getBoundingClientRect
-// mapping (fixtures, older games) shifts taps. Contained element box = hit box.
+// Fit the logical canvas to the iframe without distorting pointer coordinates.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
   // Hide buttons-only GameKit chrome on mouse desktops.
@@ -380,8 +385,11 @@ const HIDE_CHROME =
   `justify-content:center!important` +
   `}` +
   `#game{` +
-  `width:auto!important;` +
+  `--gdpl-canvas-ratio:1.6;` +
+  `flex:0 1 auto!important;` +
+  `width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important;` +
   `height:auto!important;` +
+  `aspect-ratio:var(--gdpl-canvas-ratio)!important;` +
   `max-width:100%!important;` +
   `max-height:100%!important;` +
   `min-height:0!important;` +

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -344,7 +344,11 @@ const BRIDGE = `(function(){
     if(!canvas||!canvas.width||!canvas.height)return;
     canvas.style.setProperty('--gdpl-canvas-ratio',String(canvas.width/canvas.height));
   }
-  addEventListener('resize',fitGameCanvas);
+  function scheduleGameCanvasFit(){
+    fitGameCanvas();
+    setTimeout(fitGameCanvas,0);
+  }
+  addEventListener('resize',scheduleGameCanvasFit);
   function init(){
     fitGameCanvas();
     sendMeta();

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -268,3 +268,13 @@ describe('the bridge pad fallback', () => {
     expect(controlsFrom(await runBridge('<canvas id="game"></canvas>'))?.kit).toEqual([]);
   });
 });
+
+describe('embedded canvas sizing', () => {
+  it('fits the logical canvas to the iframe without stretching its hit box', () => {
+    const html = embedGameHtml('<html><head></head><body><canvas id="game"></canvas></body></html>');
+
+    expect(html).toContain('flex:0 1 auto!important');
+    expect(html).toContain('width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important');
+    expect(html).toContain('aspect-ratio:var(--gdpl-canvas-ratio)!important');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix the player bridge override that forced embedded canvases back to intrinsic width.
- Scale each game to the available iframe while preserving its logical canvas aspect ratio.
- Recompute the ratio after resize events so adaptive games remain correct when a phone rotates.
- Add bridge sizing regression coverage.

## Validation
- Root cause confirmed from the deployed DevTools view: `HIDE_CHROME` injected `#game { width: auto !important; }`.
- Geometry matrix passes for desktop, portrait mobile, and landscape mobile across landscape, portrait, and adaptive game shapes.
- Tiny Lives scales to approximately `1301×813` in a `1640×813` iframe while preserving 16:10.
- Public green gate passes: type-check, lint, 1,207 tests, and build.

```gate-attest
sha: 7186649e74dd83590c6bb0bd4a902d9a47affdd9
command: npm run type-check && npm run lint && npm run test && npm run build
result: pass
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b427ff4-cc51-4bff-bd87-35dfacd51096?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b427ff4-cc51-4bff-bd87-35dfacd51096&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

