### PR TITLE
Use actual iframe bounds for game sizing

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -67,7 +67,7 @@ describe('embedGameHtml', () => {
     expect(out).toContain('padding:0!important');
     // Fit the box to the logical bitmap without object-fit hitbox offsets.
     expect(out).toContain(
-      '#game{--gdpl-canvas-ratio:1.6;flex:0 1 auto!important;width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important;',
+      '#game{--gdpl-canvas-ratio:1.6;--gdpl-embed-width:100%;--gdpl-embed-height:100dvh;flex:0 1 auto!important;width:min(var(--gdpl-embed-width),calc(var(--gdpl-embed-height) * var(--gdpl-canvas-ratio)))!important;',
     );
     expect(out).toContain('aspect-ratio:var(--gdpl-canvas-ratio)!important');
     expect(out).toContain('max-width:100%!important');

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -342,7 +342,11 @@ const BRIDGE = `(function(){
   function fitGameCanvas(){
     var canvas=el('game');
     if(!canvas||!canvas.width||!canvas.height)return;
+    var wrap=canvas.closest('.wrap')||document.body;
+    var bounds=wrap.getBoundingClientRect();
     canvas.style.setProperty('--gdpl-canvas-ratio',String(canvas.width/canvas.height));
+    canvas.style.setProperty('--gdpl-embed-width',String(bounds.width)+'px');
+    canvas.style.setProperty('--gdpl-embed-height',String(bounds.height)+'px');
   }
   function scheduleGameCanvasFit(){
     fitGameCanvas();
@@ -350,7 +354,7 @@ const BRIDGE = `(function(){
   }
   addEventListener('resize',scheduleGameCanvasFit);
   function init(){
-    fitGameCanvas();
+    scheduleGameCanvasFit();
     sendMeta();
     var s=el('sound-toggle');
     if(s&&'MutationObserver'in window){new MutationObserver(sendSound).observe(s,{attributes:true,attributeFilter:['aria-pressed']});}
@@ -390,8 +394,10 @@ const HIDE_CHROME =
   `}` +
   `#game{` +
   `--gdpl-canvas-ratio:1.6;` +
+  `--gdpl-embed-width:100%;` +
+  `--gdpl-embed-height:100dvh;` +
   `flex:0 1 auto!important;` +
-  `width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important;` +
+  `width:min(var(--gdpl-embed-width),calc(var(--gdpl-embed-height) * var(--gdpl-canvas-ratio)))!important;` +
   `height:auto!important;` +
   `aspect-ratio:var(--gdpl-canvas-ratio)!important;` +
   `max-width:100%!important;` +

--- a/apps/web/src/gamePlayerBridge.test.ts
+++ b/apps/web/src/gamePlayerBridge.test.ts
@@ -274,7 +274,9 @@ describe('embedded canvas sizing', () => {
     const html = embedGameHtml('<html><head></head><body><canvas id="game"></canvas></body></html>');
 
     expect(html).toContain('flex:0 1 auto!important');
-    expect(html).toContain('width:min(100%,calc(100dvh * var(--gdpl-canvas-ratio)))!important');
+    expect(html).toContain(
+      'width:min(var(--gdpl-embed-width),calc(var(--gdpl-embed-height) * var(--gdpl-canvas-ratio)))!important',
+    );
     expect(html).toContain('aspect-ratio:var(--gdpl-canvas-ratio)!important');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix embedded canvas sizing when iframe viewport units differ from the iframe element bounds.
- Measure the actual `.wrap` box and use its width/height for aspect-ratio fitting.
- Preserve resize handling for adaptive games.

## Validation
- Reproduced the Settlers case: iframe `1085×986`, canvas was incorrectly `646×525` because `100dvh` resolved to `525px`.
- With wrapper-bound sizing, Settlers renders at approximately `1085×882`, preserving its `640×520` ratio.
- Targeted embed tests pass.
- Public green gate passes: type-check, lint, 1,207 tests, and build.

```gate-attest
sha: 0566f631e32ee0f8849b3c139aef764f3588c07c
command: npm run type-check && npm run lint && npm run test && npm run build
result: pass
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b427ff4-cc51-4bff-bd87-35dfacd51096?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b427ff4-cc51-4bff-bd87-35dfacd51096&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

