### PR TITLE
Stop naming MCP tools the surface does not advertise

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -62,6 +62,17 @@ progress, staging/submission, gate media, and inbox. Proposal, example, and kit
 browse/read tools remain callable for compatibility but are not advertised to models.
 The digest and `get_kit` replace routine kit browsing.
 
+**Trimming the surface is only half the job — the prose has to follow.** The channel names
+the kit browse tools in every `get_kit` reply, because a REST agent can call them by URL.
+A model can only call what `tools/list` carried, so an unadvertised name that survives in a
+description, in the workflow list, or in the `browse` block of a reply is an invitation the
+host answers with a permission denial. A managed round on 2026-08-09 spent three round trips
+that way and then shipped a game with the audio module stripped out, because the sound-id
+lookup it had been pointed at did not exist for it. The MCP layer now filters `browse` down
+to advertised tools and drops it when none remain; `apps/api/src/mcp-server.test.ts` fails if
+an unadvertised name reappears in the descriptions, the workflow, or a `get_kit` reply. When
+you remove a tool from `MCP_VISIBLE_TOOLS`, grep the prose for its name in the same change.
+
 ### `get_gate_media` must stay reachable from the loop
 
 The step originally read "once a publish verdict lands", immediately after three steps

--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -160,6 +160,8 @@ const backend = createManagedBackend({
   ...(manifest?.agent?.system ? { systemPrompt: async () => manifest.agent!.system } : {}),
   ...(digestPath ? { kitDigest: createFileKitDigestLoader(digestPath) } : {}),
   ...(wait ? { maxDurationSeconds: waitSeconds } : {}),
+  // The probe cannot see MCP deliveries, so nudging would mislead.
+  ...(mcpOnly && !flag('nudge') ? { nudgeIdle: false } : {}),
 });
 
 rule(`probe — backend ${backend.name}${mcpOnly ? ' (MCP shape)' : ' (pull shape)'}`);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -415,7 +415,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
     expect(getKit?.description).toMatch(/entry=gamedevpl-creator-kit\/SKILL\.md/);
     expect(getKit?.description).toMatch(/do not assume a `cd` persists/i);
-    expect(getKit?.description).toMatch(/read_kit_files|list_kit_files|read_kit_file/);
+    expect(getKit?.description).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
     expect(tools.find((t) => t.name === 'list_kit_files')).toBeUndefined();
     expect(tools.find((t) => t.name === 'search_kit_files')).toBeUndefined();
     expect(tools.find((t) => t.name === 'read_kit_file')).toBeUndefined();
@@ -456,6 +456,32 @@ describe('POST /api/mcp (BY-05)', () => {
       ]),
     );
     expect(names).not.toEqual(expect.arrayContaining(['search_kit_files', 'submit_proposal']));
+  });
+
+  it('get_kit does not name kit browse tools this surface never advertised', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const engine = 'c21f5132cedb5133aa87f75654549391f4a5c633';
+    const objectStore: GcsObjectStore = {
+      readObject: async (name: string) =>
+        name === 'kits/current.json'
+          ? Buffer.from(JSON.stringify({ current: engine, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' }))
+          : name === `kits/${engine}.json`
+            ? Buffer.from(JSON.stringify({ sha256: 'a'.repeat(64), packedAt: '2026-08-09T00:00:00.000Z' }))
+            : null,
+      objectExists: async () => true,
+      signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+    };
+    app = await createApp(store, undefined, objectStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const kit = await callTool(app, 'get_kit', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(kit.isError).toBe(false);
+    const structured = kit.structured as { engineRef?: string; browse?: Record<string, string> };
+    expect(structured.engineRef).toBe(engine);
+    expect(JSON.stringify(structured)).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
   });
 
   it('start issues a sessionKey; subsequent tools work with it', async () => {
@@ -597,7 +623,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/available:true/);
     expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
-    expect(joined).toMatch(/read_kit_files|list_kit_files|read_kit_file/);
+    expect(joined).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
     expect(joined).toMatch(/screenshot_upload_url/);
     expect(joined).not.toMatch(/send_screenshot/);
     expect(joined).toMatch(/stage_source_file|fromStaged/);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -142,6 +142,14 @@ const MCP_VISIBLE_TOOLS = new Set([
   'ack_inbox',
 ]);
 
+// A model can only call advertised tools; naming others invites denials.
+function withAdvertisedBrowseTools<T extends { browse?: Record<string, string> }>(body: T): T {
+  if (!body.browse) return body;
+  const advertised = Object.entries(body.browse).filter(([, tool]) => MCP_VISIBLE_TOOLS.has(tool));
+  const { browse: _browse, ...rest } = body;
+  return (advertised.length ? { ...rest, browse: Object.fromEntries(advertised) } : rest) as T;
+}
+
 /** Aggressive ceiling on unauthenticated / invalid `start` attempts per IP. */
 const MAX_INVALID_STARTS_PER_WINDOW = 20;
 const INVALID_START_WINDOW_MS = 60 * 60 * 1000;
@@ -592,7 +600,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   // one. get_sources is cheap and answers available:false on a new game, so it is
   // unconditional rather than gated on a round type the agent cannot see.
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them. If warnings.code=module_too_large, split those oversized modules into cohesive game/*.ts pieces BEFORE adding features — do not grow them further.',
-  'get_kit — keep engineRef for submit_sources; prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / read_kit_file / read_kit_file_fragment) when shell unpack is unavailable; otherwise unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context.',
+  'get_kit — keep engineRef for submit_sources; the reply names any kit browse tools this surface offers, and offers none when the digest already covers the API. With shell egress, unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context, and never call a tool this session did not advertise.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
   'While iterating: run only npm run typecheck -- <slug> locally, then prefer stage_upload_url({ path }) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
@@ -2431,16 +2439,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               readMany: { type: 'string' },
               fragment: { type: 'string' },
             },
-            required: ['list', 'search', 'read', 'readMany', 'fragment'],
           },
         },
-        required: ['engineRef', 'kitUrl', 'sha256', 'unpack', 'entry', 'browse'],
+        required: ['engineRef', 'kitUrl', 'sha256', 'unpack', 'entry'],
       },
       description:
         'Fetch Creator Kit metadata: engineRef (required for submit_sources), sha256, entry, ' +
-        'optional kitUrl/unpack for agents with shell egress, and browse tool names. ' +
-        'Prefer read_kit_files for several known small paths (else list_kit_files / search_kit_files / ' +
-        'read_kit_file / read_kit_file_fragment) over downloading the tarball when curl/unpack is unavailable — ' +
+        'and optional kitUrl/unpack for agents with shell egress. ' +
+        'browse is present only when this surface advertises kit browse tools; when it is absent, ' +
+        'the injected digest is the API reference and there is no browse path — ' +
         'do not pull the whole kit into context. ' +
         'entry=gamedevpl-creator-kit/SKILL.md (tarball roots at gamedevpl-creator-kit/; ' +
         'do not assume a `cd` persists across tool calls). ' +
@@ -2454,11 +2461,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const res = await injectChannel(ctx.request, 'GET', '/api/agent/build/kit', auth.channelToken);
-        const body = res.json() as { error?: string; message?: string };
+        const body = res.json() as { error?: string; message?: string; browse?: Record<string, string> };
         if (res.statusCode !== 200) {
           return toolErr(body.message ?? body.error ?? `kit failed (${res.statusCode})`, body);
         }
-        return toolOk(body);
+        return toolOk(withAdvertisedBrowseTools(body));
       },
     },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Trimming the MCP tool list was only half applied. The prose still pointed at the tools that were removed, and a model can only call what `tools/list` carried — so the host denied every one of those calls.

In the managed round on 2026-08-09 the agent hit the audio preflight, went looking for valid sound ids the way `get_kit` told it to, and burned three round trips on `search_kit_files`, `list_kit_files` and `read_kit_file`, all denied. It then shipped the game with the audio module removed, because the lookup it had been pointed at did not exist for it.

Three places leaked the names: the `get_kit` tool description, the `get_kit` step in the session workflow, and the `browse` block inside every `get_kit` reply. The REST channel still needs that block — a channel agent can call those endpoints by URL — so the filtering happens in the MCP layer: `browse` is narrowed to advertised tools and dropped when none remain, and `browse` is no longer required by the output schema.

Also in here: the probe no longer nudges an idle MCP round. In that shape the platform learns about a delivery from the job, which the probe does not have, so `hasCandidate` is always false and a finished session reads as a failed one — the last run told an agent that had already submitted and called `end` to start over, and it spent the rest of its budget re-reading its own work. `--nudge` still forces the old behaviour when the nudge itself is what you want to exercise.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` all green.

A new test in `apps/api/src/mcp-server.test.ts` drives a real `get_kit` through MCP and fails if any unadvertised tool name appears in the reply; the two existing surface assertions were inverted to guard the descriptions and the workflow the same way. `apps/api/src/agent-build-reads.test.ts` still asserts the full `browse` block on the REST channel, which is the behaviour that must not change.

Not verified end to end: this needs a deploy before the next probe can confirm the agent stops trying those calls.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

