### PR TITLE
MR-01: do not nudge a managed round that already finished

### DIFF
--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -12,7 +12,7 @@ import { VertexGameSeeder, type GameSeeder } from './game-seed.js';
 import { createGitHubClient } from './github-client.js';
 import { createManagedProvider, type ManagedAgentEffort } from './managed-agent.js';
 import './managed-provider-anthropic.js';
-import { createManagedBackend, type ManagedDeliverySink } from './managed-backend.js';
+import { createManagedBackend, type ManagedDeliverySink, type ManagedRoundSignals } from './managed-backend.js';
 import type { KitDigestLoader } from './kit-digest.js';
 import { createArchiveSeedContextSource } from './seed-context.js';
 import { createSelfBuildBackend, type SelfBuildBackendOptions } from './self-build-backend.js';
@@ -45,6 +45,8 @@ export interface ManagedBackendDeps {
   deliver?: ManagedDeliverySink;
   systemPrompt?: () => Promise<string | undefined>;
   kitDigest?: KitDigestLoader;
+  // Channel-side round state; without it a finished round looks stalled.
+  readSignals?: (issueNumber: number) => Promise<ManagedRoundSignals | null>;
 }
 
 // Vendor is a variable; a delivery sink is required.
@@ -115,6 +117,7 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
 
   return createManagedBackend({
     provider,
+    ...(deps?.readSignals ? { readSignals: deps.readSignals } : {}),
     ...(deps?.deliver ? { deliver: deps.deliver } : {}),
     ...(mcpUrl ? { tools: { mcpEndpoints: [{ url: mcpUrl, name: 'gamedevpl' }] } } : {}),
     ...(deps?.systemPrompt ? { systemPrompt: deps.systemPrompt } : {}),

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -328,6 +328,57 @@ describe('managed backend', () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('does not nudge a round that delivered a preview but has no sealed version yet', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const { provider, setState } = fakeProvider({ sendMessage });
+    const backend = createManagedBackend({
+      provider,
+      tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
+      readSignals: async () => ({ previewVersion: 'v20260809T071502153Z-9fbd2f' }),
+    });
+
+    await backend.dispatch(brief());
+    setState('idle');
+    await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not re-enter a session the agent deliberately ended', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const { provider, setState } = fakeProvider({ sendMessage });
+    const backend = createManagedBackend({
+      provider,
+      tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
+      readSignals: async () => ({ agentEndedAt: '2026-08-09T07:15:08.000Z' }),
+    });
+
+    await backend.dispatch(brief());
+    setState('idle');
+    const observation = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(observation).toMatchObject({ state: 'idle' });
+  });
+
+  it('still nudges a session that went idle without delivering or ending', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const { provider, setState } = fakeProvider({ sendMessage });
+    const backend = createManagedBackend({
+      provider,
+      tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
+      readSignals: async () => ({}),
+    });
+
+    await backend.dispatch(brief());
+    setState('idle');
+    await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+    await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toContain('No delivery is recorded for this round');
+  });
+
   it('releases the lock when delivery fails, so the retry is not locked out', async () => {
     const { provider, setState, setOutputs } = fakeProvider();
     const release = vi.fn(async () => undefined);

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -48,8 +48,19 @@ export interface ManagedDeliveryLock {
   release(claim: ManagedDeliveryClaim): Promise<void>;
 }
 
+// Round state from the build channel, which the vendor session cannot see.
+export interface ManagedRoundSignals {
+  // A sealed publish delivery.
+  deliveredVersion?: string;
+  // A preview delivery: gates without sealing.
+  previewVersion?: string;
+  // The MCP `end` tool; the agent stopped deliberately.
+  agentEndedAt?: string;
+}
+
 export interface ManagedBackendOptions {
   provider: ManagedAgentProvider;
+  readSignals?: (issueNumber: number) => Promise<ManagedRoundSignals | null>;
   // Omit only when an MCP-connected agent submits for itself.
   deliver?: ManagedDeliverySink;
   lock?: ManagedDeliveryLock;
@@ -231,10 +242,20 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         }
       }
 
+      // The provider cannot see a channel submit or end.
+      const signals =
+        options.readSignals && observeOptions.issueNumber !== undefined && session.state === 'idle'
+          ? await options.readSignals(observeOptions.issueNumber)
+          : null;
+      const roundDelivered = Boolean(signals?.deliveredVersion ?? signals?.previewVersion);
+      const agentEnded = Boolean(signals?.agentEndedAt);
+
       let nudged = false;
       if (
         session.state === 'idle' &&
         !hasCandidate &&
+        !roundDelivered &&
+        !agentEnded &&
         options.nudgeIdle !== false &&
         session.stopReason !== 'budget_reached' &&
         options.provider.sendMessage &&
@@ -243,7 +264,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         try {
           await options.provider.sendMessage(
             ref,
-            'Continue this round now. You have not delivered a candidate. Act through the existing tools, submit the playable source tree, and end only after submit_sources succeeds. Do not explain or wait.',
+            'Continue this round now. No delivery is recorded for this round. Act through the existing tools, submit the playable source tree, and end only after submit_sources succeeds. Do not explain or wait.',
           );
           idleNudged.add(ref);
           nudged = true;

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -242,25 +242,24 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         }
       }
 
-      // The provider cannot see a channel submit or end.
+      // Everything a nudge needs except what only the channel knows.
+      const nudgeCandidate =
+        session.state === 'idle' &&
+        !hasCandidate &&
+        options.nudgeIdle !== false &&
+        session.stopReason !== 'budget_reached' &&
+        Boolean(options.provider.sendMessage) &&
+        !idleNudged.has(ref);
+      // Provider cannot see a channel submit or end; read once.
       const signals =
-        options.readSignals && observeOptions.issueNumber !== undefined && session.state === 'idle'
+        nudgeCandidate && options.readSignals && observeOptions.issueNumber !== undefined
           ? await options.readSignals(observeOptions.issueNumber)
           : null;
-      const roundDelivered = Boolean(signals?.deliveredVersion ?? signals?.previewVersion);
+      const roundDelivered = Boolean(signals?.deliveredVersion || signals?.previewVersion);
       const agentEnded = Boolean(signals?.agentEndedAt);
 
       let nudged = false;
-      if (
-        session.state === 'idle' &&
-        !hasCandidate &&
-        !roundDelivered &&
-        !agentEnded &&
-        options.nudgeIdle !== false &&
-        session.stopReason !== 'budget_reached' &&
-        options.provider.sendMessage &&
-        !idleNudged.has(ref)
-      ) {
+      if (nudgeCandidate && !roundDelivered && !agentEnded && options.provider.sendMessage) {
         try {
           await options.provider.sendMessage(
             ref,

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -175,6 +175,27 @@ failed attempt releases the lock so the retry is not locked out. Without a lock 
 the guards are the job's own candidate flag plus a sink that must be idempotent per
 `sessionRef` — which the type says out loud.
 
+### An idle session is not necessarily a stalled one
+
+The backend nudges a session that has gone idle without delivering, because a model that
+stops mid-round otherwise burns the whole wall clock doing nothing. The trap is that the
+provider cannot see the build channel at all. In the MCP shape the agent submits and calls
+`end` through the channel, so by the time the vendor reports `idle` the round may already be
+finished — and a preview submit sets `previewVersion`, not `deliveredVersion`, so the job's
+own `hasCandidate` flag is still false. A nudge at that moment opens a second round on a job
+that is already gating, and the agent has to be interrupted by hand.
+
+So the guard reads the round, not just the session, through an injected `readSignals` — the
+same shape the self backend uses. Two conditions independently suppress the nudge: a
+delivery of either lane exists, or the agent called `end`. The second one is the important
+one. An agent that ended has made a decision, and re-entering it is the damage; a round with
+no delivery at all still must not be restarted behind the agent's back.
+
+The message matters too. It used to assert "You have not delivered a candidate", which was
+simply false in the case above. It now says what the host can actually see — that no
+delivery is recorded — so a nudge that does fire cannot mislead the agent about its own
+round.
+
 ## What is not wired yet
 
 `ManagedDeliverySink` is injected, not implemented here. The channel's `submit_sources`

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -185,11 +185,18 @@ finished — and a preview submit sets `previewVersion`, not `deliveredVersion`,
 own `hasCandidate` flag is still false. A nudge at that moment opens a second round on a job
 that is already gating, and the agent has to be interrupted by hand.
 
-So the guard reads the round, not just the session, through an injected `readSignals` — the
-same shape the self backend uses. Two conditions independently suppress the nudge: a
-delivery of either lane exists, or the agent called `end`. The second one is the important
-one. An agent that ended has made a decision, and re-entering it is the damage; a round with
-no delivery at all still must not be restarted behind the agent's back.
+So the guard reads the round, not just the session, through an injected `readSignals`. That
+is the same seam the self backend takes — a reader handed in by the reconciler rather than a
+store dependency inside the backend — but not the same payload: `ManagedRoundSignals` also
+carries `previewVersion` and `agentEndedAt`, neither of which the self backend consults. Two
+conditions independently suppress the nudge: a delivery of either lane exists, or the agent
+called `end`. The second one is the important one. An agent that ended has made a decision,
+and re-entering it is the damage; a round with no delivery at all still must not be restarted
+behind the agent's back.
+
+The read is taken only when a nudge is otherwise about to fire. Every cheap condition — idle,
+no candidate, nudging enabled, not budget-stopped, not already nudged — is evaluated first,
+so a healthy polling loop does not pay a store round trip per observation.
 
 The message matters too. It used to assert "You have not delivered a candidate", which was
 simply false in the case above. It now says what the host can actually see — that no


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The idle nudge fired at a session that had delivered seventeen seconds earlier and had explicitly called `end`. It told the agent "You have not delivered a candidate", which was false, and the agent believed it: it opened a second round on a job that was already gating, spent about a third of the session's tokens and thirty-five seconds re-reading its own work, and needed two manual interrupts to stop.

The guard missed because nothing in it consulted the round. `hasCandidate` arrives as `Boolean(record.deliveredVersion)`, and a **preview** submit assigns a `deliveryId` and starts a gate without ever setting `deliveredVersion` — so a finished round reads as a stall. The vendor session cannot help here either: an MCP agent submits and ends through the build channel, which the provider has no view of.

So the managed backend now reads the round through an injected `readSignals`. Two conditions independently suppress the nudge:

- a delivery exists in either lane (`previewVersion` or `deliveredVersion`), so a gating preview counts;
- the agent called `end`, recorded as `agentEndedAt`.

The second is the load-bearing one. Even with no delivery at all, an agent that ended has made a decision, and re-entering it is the actual damage.

The message is fixed too: it now says no delivery is *recorded* for the round rather than asserting the agent did not deliver, so a nudge that does fire cannot misstate a fact the host never checked.

## On enforcing it server-side

The brief asks whether a second `start` against a delivered round can be refused outright rather than merely not provoked. I did not add that block, and I think it would be wrong here. `start` after `end` is the supported resume path: an agent whose transport dropped re-acquires a key that way, and a creator-led continuation on an already-previewed draft goes through the same door. A round that delivered a preview is very often a round that must keep working, because a preview gate can come back red and the fix is more work on the same job. Refusing `start` would break both, to prevent a re-entry that only happened because the host invited it. The invitation is what this PR removes.

## Review feedback addressed

- The signals read now happens only when a nudge is otherwise about to fire. Every cheap condition — idle, no candidate, nudging enabled, not budget-stopped, not already nudged — is checked first, so a healthy polling loop does not pay a store round trip per observation.
- `deliveredVersion ?? previewVersion` became `||`, so an empty string cannot mask a real preview delivery.
- The doc no longer says `readSignals` is "the same shape" as the self backend's. It is the same seam; the payload differs, since `ManagedRoundSignals` adds `previewVersion` and `agentEndedAt`.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` all green; the full API suite is 2791 passing, and CI is green on the head commit.

Three tests in `apps/api/src/managed-backend.test.ts`: no nudge when the round has a preview delivery and no sealed version, no nudge after the agent ended, and the genuinely-stalled session still nudged exactly once with the corrected wording.

`readSignals` is threaded through `ManagedBackendDeps`, next to the delivery sink and digest loader. Like those, it has no production call site yet — the managed registry is still not built in `app.ts` — so this is the seam plus its behaviour, and the wiring lands with the rest.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

