### PR TITLE
MR-04: pin the Creator Kit engine for the life of a round

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -144,6 +144,24 @@ It used to mean the latter, and often did: on 2026-08-05 seven kits published in
 one over a commit that added an internal probe script. `apps/api/src/kit-window.ts` is the rule;
 the games repo's `docs/kit-versioning.md` is when to bump.
 
+### One round builds against one engine
+
+`get_kit` is pinned. The first call of a round fixes the `engineRef` on the job, and every
+later call in that round returns the same one even if the registry pointer has moved on.
+`submit_sources` refuses a `kitEngineRef` that is not the pinned one, with
+`reason: "kit_engine_ref_mismatch"`.
+
+That is a response to a real round: two `get_kit` calls 76 seconds apart returned different
+engines because the games repo published in between, and the agent only noticed because it
+happened to re-read. One that had cached the first ref would have submitted against a
+superseded engine, and the disagreement between the engine it read the API from and the
+engine it was validated against would have been silent.
+
+The pin is dropped when the round closes, and replaced in exactly one case: after a
+`kit_outdated` verdict, where a newer engine is the whole fix. That call returns
+`kitEngineChanged: true` — an explicit signal, rather than an idempotent-looking read
+quietly answering differently. Follow the `kit_outdated` recipe above when you see it.
+
 ### Staging is creator-visible (live staged preview)
 
 `apps/api/src/staged-preview.ts` assembles the **staging buffer itself** and stores it as

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -157,10 +157,12 @@ happened to re-read. One that had cached the first ref would have submitted agai
 superseded engine, and the disagreement between the engine it read the API from and the
 engine it was validated against would have been silent.
 
-The pin is dropped when the round closes, and replaced in exactly one case: after a
-`kit_outdated` verdict, where a newer engine is the whole fix. That call returns
-`kitEngineChanged: true` — an explicit signal, rather than an idempotent-looking read
-quietly answering differently. Follow the `kit_outdated` recipe above when you see it.
+The pin is dropped when the round closes, and replaced in two cases: after a `kit_outdated`
+verdict, where a newer engine is the whole fix, and when the pinned kit has fallen out of
+retention, where serving it would wedge the round on a tarball that no longer exists. Either
+way the call returns `kitEngineChanged: true` — an explicit signal, rather than an
+idempotent-looking read quietly answering differently. Treat it as the `kit_outdated` recipe
+above: take the new `engineRef` and submit against that.
 
 ### Staging is creator-visible (live staged preview)
 

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -262,6 +262,34 @@ describe('agent build reads (BY-04)', () => {
     expect(signReadUrl).toHaveBeenCalledWith(`kits/${ENGINE}.tgz`, expect.any(Number));
   });
 
+  it('pins the round to one engine even when the registry pointer advances', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const moved = 'f'.repeat(40);
+    const registry = { current: ENGINE, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' };
+    const objects = new Map<string, Buffer>([
+      ['kits/current.json', Buffer.from(JSON.stringify(registry))],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-09T00:00:00.000Z' }))],
+      [`kits/${ENGINE}.tgz`, Buffer.from('fake-tarball')],
+      [`kits/${moved}.json`, Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-09T00:01:00.000Z' }))],
+      [`kits/${moved}.tgz`, Buffer.from('fake-tarball-2')],
+    ]);
+    app = await createApp(store, {
+      ...mockObjectStore(objects),
+      signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+    });
+
+    const first = await app.inject({ method: 'GET', url: '/api/agent/build/kit', headers: agentHeaders() });
+    expect(first.json().engineRef).toBe(ENGINE);
+
+    objects.set('kits/current.json', Buffer.from(JSON.stringify({ ...registry, current: moved })));
+    const second = await app.inject({ method: 'GET', url: '/api/agent/build/kit', headers: agentHeaders() });
+
+    expect(second.json().engineRef).toBe(ENGINE);
+    expect(second.json().kitEngineChanged).toBeUndefined();
+    expect(second.json().kitUrl).toContain(ENGINE);
+  });
+
   it('lists, searches, and reads kit files from the packed tarball over the channel', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -290,6 +290,32 @@ describe('agent build reads (BY-04)', () => {
     expect(second.json().kitUrl).toContain(ENGINE);
   });
 
+  it('replaces a pin whose kit has aged out, and says the engine moved', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const gone = 'c'.repeat(40);
+    await store.pinRoundKitEngineRef(ISSUE, gone);
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' })),
+      ],
+      [`kits/${ENGINE}.json`, Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-09T00:00:00.000Z' }))],
+      [`kits/${ENGINE}.tgz`, Buffer.from('fake-tarball')],
+    ]);
+    app = await createApp(store, {
+      ...mockObjectStore(objects),
+      objectExists: async (name: string) => objects.has(name),
+      signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/agent/build/kit', headers: agentHeaders() });
+
+    expect(res.json().engineRef).toBe(ENGINE);
+    expect(res.json().kitEngineChanged).toBe(true);
+    expect((await store.getSubmission(ISSUE))?.roundKitEngineRef).toBe(ENGINE);
+  });
+
   it('lists, searches, and reads kit files from the packed tarball over the channel', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1585,6 +1585,17 @@ export async function registerAgentChannelRoutes(
         }
       }
 
+      // One round, one engine: a mismatch means unvalidated sources.
+      const pinnedEngineRef = record.roundKitEngineRef;
+      if (pinnedEngineRef && parsed.data.kitEngineRef && parsed.data.kitEngineRef !== pinnedEngineRef) {
+        return reply.status(400).send({
+          error:
+            `This round is pinned to Creator Kit engine ${pinnedEngineRef}, not ${parsed.data.kitEngineRef}. ` +
+            'Call get_kit and submit with the engineRef it returns.',
+          reason: 'kit_engine_ref_mismatch',
+        });
+      }
+
       // The job's own slug wins whenever it has one. A build that has already been
       // associated with a game cannot deliver into a different one, whatever it sends.
       //
@@ -2094,7 +2105,17 @@ export async function registerAgentChannelRoutes(
           });
         }
         const registry = parseKitRegistry(registryBody.toString('utf8'));
-        const engineRef = registry.current;
+        // The pointer can advance mid-round; the round builds against one engine.
+        const previousPin = resolved.record.roundKitEngineRef;
+        const outdated = (await gateVerdict(resolved.record))?.status === 'kit_outdated';
+        let engineRef =
+          (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, outdated)) ?? registry.current;
+        // Re-pin when the pinned kit has aged out of retention.
+        if (engineRef !== registry.current && !(await options.objectStore.objectExists(`kits/${engineRef}.tgz`))) {
+          engineRef =
+            (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, true)) ?? registry.current;
+        }
+        const kitEngineChanged = Boolean(previousPin) && previousPin !== engineRef;
         const sidecarBody = await options.objectStore.readObject(`kits/${engineRef}.json`);
         if (!sidecarBody) {
           return reply.status(404).send({
@@ -2118,9 +2139,9 @@ export async function registerAgentChannelRoutes(
           sha256: sidecar.sha256,
           unpack: kitUnpackCommand(kitUrl),
           entry: KIT_ENTRY,
-          // Shell-less MCP clients (ChatGPT Apps code_execution often cannot curl
-          // storage.googleapis.com) should browse via the kit file tools instead of
-          // unpacking — keep kitUrl/unpack for agents with a writable checkout.
+          // Only ever true after a kit_outdated verdict: rebuild against this engine.
+          ...(kitEngineChanged ? { kitEngineChanged: true } : {}),
+          // Shell-less clients browse via these tools instead of unpacking.
           browse: {
             list: 'list_kit_files',
             search: 'search_kit_files',

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2139,7 +2139,7 @@ export async function registerAgentChannelRoutes(
           sha256: sidecar.sha256,
           unpack: kitUnpackCommand(kitUrl),
           entry: KIT_ENTRY,
-          // Only ever true after a kit_outdated verdict: rebuild against this engine.
+          // The round's engine moved: rebuild against the one in this reply.
           ...(kitEngineChanged ? { kitEngineChanged: true } : {}),
           // Shell-less clients browse via these tools instead of unpacking.
           browse: {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2448,8 +2448,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Fetch Creator Kit metadata: engineRef (required for submit_sources), sha256, entry, ' +
         'and optional kitUrl/unpack for agents with shell egress. ' +
         'engineRef is pinned for the round: repeat calls return the same engine even if the ' +
-        'registry moves. kitEngineChanged:true means the pin was replaced after a kit_outdated ' +
-        'verdict — rebuild against the engine in this reply. ' +
+        'registry moves. kitEngineChanged:true means the pin was replaced — after a kit_outdated ' +
+        'verdict, or because the pinned kit is no longer retained — so rebuild against the ' +
+        'engine in this reply. ' +
         'browse is present only when this surface advertises kit browse tools; when it is absent, ' +
         'the injected digest is the API reference and there is no browse path — ' +
         'do not pull the whole kit into context. ' +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2430,6 +2430,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           sha256: { type: 'string' },
           unpack: { type: 'string' },
           entry: { type: 'string' },
+          kitEngineChanged: { type: 'boolean' },
           browse: {
             type: 'object',
             properties: {
@@ -2446,6 +2447,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       description:
         'Fetch Creator Kit metadata: engineRef (required for submit_sources), sha256, entry, ' +
         'and optional kitUrl/unpack for agents with shell egress. ' +
+        'engineRef is pinned for the round: repeat calls return the same engine even if the ' +
+        'registry moves. kitEngineChanged:true means the pin was replaced after a kit_outdated ' +
+        'verdict — rebuild against the engine in this reply. ' +
         'browse is present only when this surface advertises kit browse tools; when it is absent, ' +
         'the injected digest is the API reference and there is no browse path — ' +
         'do not pull the whole kit into context. ' +

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -457,6 +457,45 @@ describe('self builder (BY-02)', () => {
     expect(refused.json().error).toMatch(/kitEngineRef/i);
   });
 
+  it('rejects a delivery built against an engine this round is not pinned to', async () => {
+    const { gamesStore } = stubGamesStore();
+    const created = await createApp({ gamesStore });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Pinned Kit', concept: CONCEPT, builder: 'self' },
+    });
+    const slug = submit.json().slug as string;
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+    });
+    const pinned = 'a'.repeat(40);
+    await store.pinRoundKitEngineRef(issueNumber, pinned);
+
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: 'b'.repeat(40) },
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.json()).toMatchObject({ reason: 'kit_engine_ref_mismatch' });
+    expect(refused.json().error).toContain(pinned);
+
+    const accepted = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/sources',
+      headers: agentHeaders(issueNumber),
+      payload: { slug, files: MINIMAL_FILES, kitEngineRef: pinned },
+    });
+    expect(accepted.statusCode).toBe(200);
+  });
+
   it('enforces SELF_BUILD_DELIVERY_CAP with a machine-readable refusal', async () => {
     process.env.SELF_BUILD_DELIVERY_CAP = '2';
     const { gamesStore } = stubGamesStore();

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -165,7 +165,7 @@ export interface SubmissionRecord {
    */
   previewVersion?: string;
   // The kit engine this round builds against, fixed by its first get_kit.
-  // Dropped when the round closes; replaced only on a kit_outdated verdict.
+  // Dropped when the round closes; replaced on kit_outdated or lost retention.
   roundKitEngineRef?: string;
   /**
    * How many times this job has been sent back for finishing without delivering.
@@ -1767,7 +1767,7 @@ export interface Store {
    */
   ensureRoundGeneration(issueNumber: number): Promise<number | null>;
   // Fixes the round's kit engine and returns it; first caller wins.
-  // `replace` overrides the pin, for a kit_outdated recovery.
+  // `replace` overrides the pin: kit_outdated recovery, or a kit gone.
   pinRoundKitEngineRef(issueNumber: number, engineRef: string, replace?: boolean): Promise<string | null>;
   /** Records the agent backend's last reported state, for stall detection. */
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -155,14 +155,8 @@ export interface SubmissionRecord {
    * not a state to design around.
    */
   slug?: string;
-  /**
-   * The most recent candidate version this job delivered to the games store.
-   *
-   * Kept on the record rather than discovered by listing the bucket, because the
-   * preview needs it on every poll and a list-per-poll would be the same mistake the
-   * GitHub-derived status was. It is also what makes the preview possible at all now
-   * that a build has no pull request to read from.
-   */
+  // Latest candidate version delivered to the games store.
+  // Kept here so the preview never lists the bucket per poll.
   deliveredVersion?: string;
   /**
    * Latest Studio-playable delivery (preview or publish). Preview-only rounds update
@@ -170,6 +164,9 @@ export interface SubmissionRecord {
    * reconciliation still wait for a sealed publish delivery.
    */
   previewVersion?: string;
+  // The kit engine this round builds against, fixed by its first get_kit.
+  // Dropped when the round closes; replaced only on a kit_outdated verdict.
+  roundKitEngineRef?: string;
   /**
    * How many times this job has been sent back for finishing without delivering.
    *
@@ -1769,6 +1766,9 @@ export interface Store {
    * validation rejects the brand-new key (`active === undefined`).
    */
   ensureRoundGeneration(issueNumber: number): Promise<number | null>;
+  // Fixes the round's kit engine and returns it; first caller wins.
+  // `replace` overrides the pin, for a kit_outdated recovery.
+  pinRoundKitEngineRef(issueNumber: number, engineRef: string, replace?: boolean): Promise<string | null>;
   /** Records the agent backend's last reported state, for stall detection. */
   setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void>;
   /**
@@ -2974,6 +2974,7 @@ export class InMemoryStore implements Store {
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
+      delete next.roundKitEngineRef;
     }
     this.submissions.set(issueNumber, next);
     return true;
@@ -2989,8 +2990,17 @@ export class InMemoryStore implements Store {
     delete next.lastAgentSignalAt;
     delete next.lastAgentPresence;
     delete next.agentEndedAt;
+    delete next.roundKitEngineRef;
     this.submissions.set(issueNumber, next);
     return roundGeneration;
+  }
+
+  async pinRoundKitEngineRef(issueNumber: number, engineRef: string, replace = false): Promise<string | null> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return null;
+    if (sub.roundKitEngineRef && !replace) return sub.roundKitEngineRef;
+    this.submissions.set(issueNumber, { ...sub, roundKitEngineRef: engineRef });
+    return engineRef;
   }
 
   async requestBuilderHandoff(
@@ -5141,6 +5151,7 @@ export class FirestoreStore implements Store {
         delete next.lastAgentSignalAt;
         delete next.lastAgentPresence;
         delete next.agentEndedAt;
+        delete next.roundKitEngineRef;
         tx.set(ref, next);
       } else {
         tx.set(
@@ -5170,8 +5181,21 @@ export class FirestoreStore implements Store {
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
+      delete next.roundKitEngineRef;
       tx.set(ref, next);
       return roundGeneration;
+    });
+  }
+
+  async pinRoundKitEngineRef(issueNumber: number, engineRef: string, replace = false): Promise<string | null> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return null;
+      const current = snap.data() as SubmissionRecord;
+      if (current.roundKitEngineRef && !replace) return current.roundKitEngineRef;
+      tx.set(ref, { roundKitEngineRef: engineRef }, { merge: true });
+      return engineRef;
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two `get_kit` calls 76 seconds apart in the same round returned different engines, because the games repo published in between and the registry pointer moved. The agent noticed only because it happened to re-read; its message before submitting says "Now submit with the updated kitEngineRef". One that had cached the first ref would have submitted against an engine that was already superseded, and the disagreement between the engine it read the API from and the engine its delivery was validated against would have been silent.

`get_kit` is now idempotent for the round. The first call fixes `roundKitEngineRef` on the job and every later call returns that engine whatever the registry says, so a round builds against exactly one kit. `submit_sources` refuses a `kitEngineRef` that is not the pinned one with `reason: "kit_engine_ref_mismatch"` and a message naming the ref the round is on.

The pin moves in exactly two situations, and both report `kitEngineChanged: true` so the change is never a silent difference in an idempotent-looking read:

- **`kit_outdated`.** The recovery recipe is "re-run `get_kit` for a fresh engineRef, then re-submit", and a pin that could never move would turn that into a loop the round cannot leave.
- **Lost retention.** If the pinned tarball is no longer in the bucket, serving it would wedge the round on a 404.

The pin is round-scoped state, so it is dropped everywhere the other round-scoped fields are — round-closing transitions and `bumpRoundGeneration`, in both the in-memory and Firestore stores.

## Review feedback addressed

Four comments all caught the same real divergence: the retention re-pin also sets `kitEngineChanged`, while the store field comment, the channel comment, the `get_kit` tool description and the skill doc each said the flag meant `kit_outdated` and nothing else. An agent reading the tool description would have mis-handled the signal. Rather than narrow the flag — a kit that vanished from retention is exactly as much a change the agent must rebuild against — all four now describe both cases, and a new test covers the retention path end to end: a pin whose tarball is gone is replaced with the current engine, the reply carries `kitEngineChanged: true`, and the job records the new pin.

## Verification

`npm run type-check && npm run lint && npm run test && npm run build` all green; CI is green on the head commit.

Three tests carry the behaviour. `agent-build-reads.test.ts` moves `kits/current.json` between two `get_kit` calls and asserts the second still returns the first engine, with a `kitUrl` signed for it and no `kitEngineChanged`; a second test covers the retention re-pin above. `self-build.test.ts` pins a round, watches `submit_sources` refuse a different ref with the mismatch reason, and then accepts the pinned one.

The rationale that used to be inline is in `.claude/skills/byoca-mcp/SKILL.md` under "One round builds against one engine", next to the `kit_outdated` recipe it interacts with. Comment budget: the file baselines are ratchet-only, so the new inline notes are offset by tightening two long-form blocks in the same files (`deliveredVersion`, and the shell-less browse note); no reasoning was lost, only re-sited.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

