### PR TITLE
feat: add first-login beta welcome splash

### DIFF
--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -117,6 +117,26 @@ describe('Auth API Routes', () => {
     expect(stored?.name).toBe('Alice');
   });
 
+  it('marks only a newly created account for the beta welcome', async () => {
+    const { app } = await setupTestServer({
+      'new-user-token': { sub: '10006', email: 'new@example.com' },
+    });
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'new-user-token' },
+    });
+    expect(JSON.parse(first.body).betaWelcome).toBe(true);
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/auth/google',
+      payload: { idToken: 'new-user-token' },
+    });
+    expect(JSON.parse(second.body).betaWelcome).toBeUndefined();
+  });
+
   it('records the browser language on sign-in, so agent-created games can inherit it', async () => {
     // The only place this preference survives leaving the browser. A game created over
     // MCP has no accept-language — Claude chat is not a browser — so without this
@@ -602,9 +622,13 @@ describe('Local development sign-in', () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).user.uid).toBe('dev:local');
+    expect(JSON.parse(res.body).betaWelcome).toBe(true);
     expect(res.headers['set-cookie']).toBeDefined();
     // The uid namespace keeps a local account from ever colliding with a Google identity.
     expect(await store.getUser('dev:local')).not.toBeNull();
+
+    const second = await app.inject({ method: 'POST', url: '/api/auth/dev', payload: {} });
+    expect(JSON.parse(second.body).betaWelcome).toBeUndefined();
 
     await app.close();
   });

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -447,6 +447,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
       try {
         const googleUser = await verifier.verifyIdToken(parseResult.data.idToken);
         const uid = `g:${googleUser.sub}`;
+        const existingUser = await store.getUser(uid);
 
         // Private-beta allowlist check — before creating/upserting the user doc so
         // rejected sign-ins leave no trace in Firestore. Allow if uid OR verified email matches.
@@ -454,7 +455,6 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         // an unverified email claim must never satisfy an access-control allowlist.
         if (options.privateBeta) {
           const emailLower = googleUser.emailVerified && googleUser.email ? googleUser.email.toLowerCase() : '';
-          const existingUser = await store.getUser(uid);
           if (existingUser?.tier === 'blocked') {
             return reply.status(403).send({ error: 'account is blocked' });
           }
@@ -507,6 +507,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         return sessionPayload(user, {
           admin: isAdmin(user.uid, adminUids),
           reviewer: isReviewer(user.uid, reviewerUids, adminUids),
+          betaWelcome: existingUser === null,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'google token verification failed';
@@ -553,13 +554,13 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         // the allowlist below has had its say.
         const resolution = await resolveAppleAccount(store, applePayload);
         const uid = resolution.uid;
+        const existingUser = await store.getUser(uid);
 
         // Identical rule to the Google path, run against the *resolved* uid: a creator
         // already on the allowlist by their Google uid must not be turned away for
         // arriving through a different button.
         if (options.privateBeta) {
           const emailLower = resolution.email?.toLowerCase() ?? '';
-          const existingUser = await store.getUser(uid);
           if (existingUser?.tier === 'blocked') {
             return reply.status(403).send({ error: 'account is blocked' });
           }
@@ -620,6 +621,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         return sessionPayload(user, {
           admin: isAdmin(user.uid, adminUids),
           reviewer: isReviewer(user.uid, reviewerUids, adminUids),
+          betaWelcome: existingUser === null,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'apple token verification failed';
@@ -832,6 +834,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     const uid = `dev:${handle}`;
 
     await store.cancelAccountDeletion(uid);
+    const existingUser = await store.getUser(uid);
     const user = await store.upsertUser({
       uid,
       email: `${handle}@localhost`,
@@ -853,6 +856,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     return sessionPayload(user, {
       admin: isAdmin(user.uid, adminUids),
       reviewer: isReviewer(user.uid, reviewerUids, adminUids),
+      betaWelcome: existingUser === null,
     });
   });
 
@@ -886,12 +890,12 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
  */
 function sessionPayload(
   user: User,
-  flags: { admin?: boolean; reviewer?: boolean },
-): { user: User & { admin?: true; reviewer?: true } } {
+  flags: { admin?: boolean; reviewer?: boolean; betaWelcome?: boolean },
+): { user: User & { admin?: true; reviewer?: true }; betaWelcome?: true } {
   const next: User & { admin?: true; reviewer?: true } = { ...user };
   if (flags.admin) next.admin = true;
   if (flags.reviewer) next.reviewer = true;
-  return { user: next };
+  return { user: next, ...(flags.betaWelcome ? { betaWelcome: true as const } : {}) };
 }
 
 export function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -761,6 +761,7 @@ export interface VisitEvent {
     | 'create_step'
     | 'waitlist_step'
     | 'invite_step'
+    | 'beta_welcome_step'
     | 'studio_step'
     | 'editor_step'
     | 'assist_step'

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -228,6 +228,28 @@ describe('summarizeVisitFunnel', () => {
     expect(funnel.waitlist[0]).toEqual({ step: 'cta_clicked', visits: 0 });
   });
 
+  it('reports the beta welcome funnel separately from invite steps', () => {
+    const funnel = summarizeVisitFunnel([
+      started('a'),
+      { visitId: 'a', type: 'beta_welcome_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step: 'shown' },
+      {
+        visitId: 'a',
+        type: 'beta_welcome_step',
+        at: '2026-07-26T10:00:00.000Z',
+        msSinceStart: 1,
+        step: 'continued',
+      },
+      started('b'),
+      { visitId: 'b', type: 'beta_welcome_step', at: '2026-07-26T10:00:00.000Z', msSinceStart: 0, step: 'shown' },
+    ]);
+
+    expect(funnel.betaWelcome).toEqual([
+      { step: 'shown', visits: 2 },
+      { step: 'continued', visits: 1 },
+      { step: 'dismissed', visits: 0 },
+    ]);
+  });
+
   it('counts painting visits and splits them by the door that led to the brush', () => {
     const remix = (visitId: string, step: string, via?: string): VisitEvent =>
       ({

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -68,6 +68,7 @@ export interface VisitFunnel {
    */
   waitlist: Array<{ step: WaitlistStep; visits: number }>;
   invites: Array<{ step: InviteStep; visits: number }>;
+  betaWelcome: Array<{ step: BetaWelcomeStep; visits: number }>;
   /**
    * EditorKit's revision funnel — opened → saved a draft → played it → published.
    * Same posture as `creating`: every step, in order, zeroes included.
@@ -182,6 +183,10 @@ export const INVITE_STEPS = ['opened', 'accepted', 'unavailable'] as const;
 
 export type InviteStep = (typeof INVITE_STEPS)[number];
 
+export const BETA_WELCOME_STEPS = ['shown', 'continued', 'dismissed'] as const;
+
+export type BetaWelcomeStep = (typeof BETA_WELCOME_STEPS)[number];
+
 export const EDITOR_STEPS = ['opened', 'draft_saved', 'previewed', 'published'] as const;
 
 export type EditorStep = (typeof EDITOR_STEPS)[number];
@@ -264,6 +269,7 @@ interface VisitRollup {
   /** Waitlist steps this visit reached. Separate from create so the two funnels cannot collide. */
   waitlistSteps: Set<string>;
   inviteSteps: Set<string>;
+  betaWelcomeSteps: Set<string>;
   /** Editor steps this visit reached. Separate again, for the same reason. */
   editorSteps: Set<string>;
   /** The door on this visit's `painted`, first one wins (the client dedupes). */
@@ -314,6 +320,7 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       steps: new Set<string>(),
       waitlistSteps: new Set<string>(),
       inviteSteps: new Set<string>(),
+      betaWelcomeSteps: new Set<string>(),
       editorSteps: new Set<string>(),
       assistSteps: new Set<string>(),
       remixSteps: new Set<string>(),
@@ -337,6 +344,8 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       if (event.step) rollup.waitlistSteps.add(event.step);
     } else if (event.type === 'invite_step') {
       if (event.step) rollup.inviteSteps.add(event.step);
+    } else if (event.type === 'beta_welcome_step') {
+      if (event.step) rollup.betaWelcomeSteps.add(event.step);
     } else if (event.type === 'editor_step') {
       if (event.step) rollup.editorSteps.add(event.step);
     } else if (event.type === 'assist_step') {
@@ -512,6 +521,10 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
     invites: INVITE_STEPS.map((step) => ({
       step,
       visits: rollups.filter((rollup) => rollup.inviteSteps.has(step)).length,
+    })),
+    betaWelcome: BETA_WELCOME_STEPS.map((step) => ({
+      step,
+      visits: rollups.filter((rollup) => rollup.betaWelcomeSteps.has(step)).length,
     })),
     editing: EDITOR_STEPS.map((step) => ({
       step,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -259,6 +259,26 @@ describe('POST /api/telemetry/visit', () => {
     expect(bad.statusCode).toBe(400);
   });
 
+  it('records beta welcome steps and rejects an unknown outcome', async () => {
+    const ok = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'beta_welcome_step', step: 'shown', msSinceStart: 0 }],
+    });
+    expect(ok.statusCode).toBe(202);
+    expect((await store.listVisitEvents(today()))[0]).toMatchObject({
+      type: 'beta_welcome_step',
+      step: 'shown',
+    });
+
+    const bad = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'beta_welcome_step', step: 'opened', msSinceStart: 0 }],
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
   it('carries which control opened a remix, and refuses a control it does not know', async () => {
     const ok = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -73,6 +73,7 @@ const CreateStepSchema = z.enum([
  */
 const WaitlistStepSchema = z.enum(['cta_clicked', 'joined']);
 const InviteStepSchema = z.enum(['opened', 'accepted', 'unavailable']);
+const BetaWelcomeStepSchema = z.enum(['shown', 'continued', 'dismissed']);
 /**
  * Studio / self-build funnel (BY-08). Sibling to create steps — not ordered with them.
  * Reaches a grouping key; closed enum on an open endpoint.
@@ -194,6 +195,7 @@ const EventSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('waitlist_step'), step: WaitlistStepSchema, ...offsetField }),
   z.object({ type: z.literal('invite_step'), step: InviteStepSchema, ...offsetField }),
+  z.object({ type: z.literal('beta_welcome_step'), step: BetaWelcomeStepSchema, ...offsetField }),
   z.object({
     type: z.literal('studio_step'),
     step: StudioStepSchema,
@@ -309,6 +311,8 @@ export async function registerVisitTelemetryRoutes(
         case 'waitlist_step':
           return { ...base, type: event.type, step: event.step };
         case 'invite_step':
+          return { ...base, type: event.type, step: event.step };
+        case 'beta_welcome_step':
           return { ...base, type: event.type, step: event.step };
         case 'studio_step':
           return {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,6 +70,7 @@ import { AuthModal } from './AuthModal.js';
 import { recordCreateStep, recordStudioStep } from './visitTelemetry.js';
 import { ClosedBetaSplash } from './ClosedBetaSplash.js';
 import { BetaInvitePage } from './BetaInvitePage.js';
+import { BetaWelcomeSplash } from './BetaWelcomeSplash.js';
 import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { ControllerView } from './mp/ControllerView.js';
 import { PartyStage } from './mp/PartyStage.js';
@@ -83,7 +84,7 @@ type StageContent =
 
 export function App() {
   const { t, i18n } = useTranslation();
-  const { user, loading: authLoading, privateBeta, publicPlaySlugs } = useAuth();
+  const { user, loading: authLoading, privateBeta, publicPlaySlugs, showBetaWelcome, dismissBetaWelcome } = useAuth();
   const [route, setRoute] = useState(() => readLocationRoute());
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const publicPlayAllowed = route.view === 'play' && publicPlaySlugs.includes(route.slug);
@@ -912,6 +913,7 @@ export function App() {
           }
         />
       )}
+      {showBetaWelcome && user && <BetaWelcomeSplash onContinue={dismissBetaWelcome} />}
     </>
   );
 

--- a/apps/web/src/AuthContext.tsx
+++ b/apps/web/src/AuthContext.tsx
@@ -47,6 +47,7 @@ interface AuthContextType {
    */
   appleSignIn: boolean;
   waitlistStatus: WaitlistStatus;
+  showBetaWelcome: boolean;
   signInWithGoogleToken: (idToken: string, inviteCode?: string) => Promise<void>;
   /**
    * `name` is Apple's first-authorization gift: it arrives once, outside the token, and
@@ -57,6 +58,7 @@ interface AuthContextType {
   // not on the allowlist). Re-verifies the same ID token server-side.
   joinWaitlist: (idToken: string, locale?: string, provider?: 'google' | 'apple') => Promise<void>;
   acceptBetaInvite: (code: string) => Promise<void>;
+  dismissBetaWelcome: () => void;
   logout: () => Promise<void>;
   deleteAccount: () => Promise<{ deleteAfter: string }>;
   refreshUser: () => Promise<void>;
@@ -69,10 +71,12 @@ const AuthContext = createContext<AuthContextType>({
   publicPlaySlugs: [],
   appleSignIn: false,
   waitlistStatus: 'unknown',
+  showBetaWelcome: false,
   signInWithGoogleToken: async () => {},
   signInWithAppleToken: async () => {},
   joinWaitlist: async () => {},
   acceptBetaInvite: async () => {},
+  dismissBetaWelcome: () => {},
   logout: async () => {},
   deleteAccount: async () => ({ deleteAfter: '' }),
   refreshUser: async () => {},
@@ -85,6 +89,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [appleSignIn, setAppleSignIn] = useState(false);
   const [loading, setLoading] = useState(true);
   const [waitlistStatus, setWaitlistStatus] = useState<WaitlistStatus>('unknown');
+  const [showBetaWelcome, setShowBetaWelcome] = useState(false);
 
   const refreshUser = async () => {
     try {
@@ -141,8 +146,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       throw new Error(err?.error ?? 'Sign in failed');
     }
 
-    const data = await res.json();
+    const data = (await res.json()) as { user: User; betaWelcome?: boolean };
     setUser(data.user);
+    setShowBetaWelcome(data.betaWelcome === true);
   };
 
   const signInWithAppleToken = async (idToken: string, name?: string, inviteCode?: string) => {
@@ -161,8 +167,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       throw new Error(err?.error ?? 'Sign in failed');
     }
 
-    const data = await res.json();
+    const data = (await res.json()) as { user: User; betaWelcome?: boolean };
     setUser(data.user);
+    setShowBetaWelcome(data.betaWelcome === true);
   };
 
   const joinWaitlist = async (idToken: string, locale?: string, provider?: 'google' | 'apple') => {
@@ -198,10 +205,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
+  const dismissBetaWelcome = () => {
+    setShowBetaWelcome(false);
+  };
+
   const logout = async () => {
     await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
     clearCachedCatalogSortPayload();
     setUser(null);
+    setShowBetaWelcome(false);
   };
 
   const deleteAccount = async () => {
@@ -218,6 +230,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const result = (await res.json()) as { deleteAfter: string };
     clearCachedCatalogSortPayload();
     setUser(null);
+    setShowBetaWelcome(false);
     return result;
   };
 
@@ -230,10 +243,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         publicPlaySlugs,
         appleSignIn,
         waitlistStatus,
+        showBetaWelcome,
         signInWithGoogleToken,
         signInWithAppleToken,
         joinWaitlist,
         acceptBetaInvite,
+        dismissBetaWelcome,
         logout,
         deleteAccount,
         refreshUser,

--- a/apps/web/src/BetaWelcomeSplash.test.tsx
+++ b/apps/web/src/BetaWelcomeSplash.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { BetaWelcomeSplash } from './BetaWelcomeSplash.js';
+import { setVisitSessionForTesting, VisitSession } from './visitTelemetry.js';
+
+describe('BetaWelcomeSplash', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    setVisitSessionForTesting(null);
+    vi.restoreAllMocks();
+  });
+
+  it('welcomes a first-time tester and records the continue action', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const sent: unknown[] = [];
+    const session = new VisitSession('44444444-4444-4444-8444-444444444444', 0, (body) => sent.push(body));
+    setVisitSessionForTesting(session);
+    await i18n.changeLanguage('en');
+
+    const onContinue = vi.fn();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(createElement(BetaWelcomeSplash, { onContinue }));
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('[role="dialog"] h1')?.textContent).toContain('Welcome');
+    expect(document.querySelectorAll('.beta-welcome-path article')).toHaveLength(3);
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>('.beta-welcome-cta')?.click();
+      await Promise.resolve();
+    });
+    session.flush();
+
+    expect(onContinue).toHaveBeenCalledOnce();
+    expect(sent[0]).toMatchObject({
+      events: [
+        { type: 'beta_welcome_step', step: 'shown' },
+        { type: 'beta_welcome_step', step: 'continued' },
+      ],
+    });
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/BetaWelcomeSplash.test.tsx
+++ b/apps/web/src/BetaWelcomeSplash.test.tsx
@@ -32,7 +32,9 @@ describe('BetaWelcomeSplash', () => {
     });
 
     expect(document.querySelector('[role="dialog"] h1')?.textContent).toContain('Welcome');
+    expect(document.querySelector('.beta-welcome-mascot .mascot')).not.toBeNull();
     expect(document.querySelectorAll('.beta-welcome-path article')).toHaveLength(3);
+    expect(document.querySelector('.beta-welcome-path a[href="/contact"]')?.textContent).toBe('Contact us');
 
     await act(async () => {
       document.querySelector<HTMLButtonElement>('.beta-welcome-cta')?.click();

--- a/apps/web/src/BetaWelcomeSplash.tsx
+++ b/apps/web/src/BetaWelcomeSplash.tsx
@@ -1,23 +1,55 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Mascot } from './Mascot.js';
 import { PixelIcon } from './PixelIcon.js';
 import { recordBetaWelcomeStep } from './visitTelemetry.js';
 
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export function BetaWelcomeSplash({ onContinue }: { onContinue: () => void }) {
   const { t } = useTranslation();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const onContinueRef = useRef(onContinue);
+  onContinueRef.current = onContinue;
 
   useEffect(() => {
     recordBetaWelcomeStep('shown');
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      recordBetaWelcomeStep('dismissed');
-      onContinue();
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        recordBetaWelcomeStep('dismissed');
+        onContinueRef.current();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = cardRef.current;
+      if (!root) return;
+      const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (element) => !element.hasAttribute('disabled') && element.getClientRects().length > 0,
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey) {
+        if (document.activeElement === first || !root.contains(document.activeElement)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last || !root.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
     };
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [onContinue]);
+    cardRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, []);
 
   const continueToBeta = () => {
     recordBetaWelcomeStep('continued');
@@ -28,6 +60,7 @@ export function BetaWelcomeSplash({ onContinue }: { onContinue: () => void }) {
     <div className="beta-welcome-backdrop" role="presentation">
       <div
         className="beta-welcome-card"
+        ref={cardRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="beta-welcome-title"

--- a/apps/web/src/BetaWelcomeSplash.tsx
+++ b/apps/web/src/BetaWelcomeSplash.tsx
@@ -46,7 +46,7 @@ export function BetaWelcomeSplash({ onContinue }: { onContinue: () => void }) {
         </button>
 
         <div className="beta-welcome-mascot" aria-hidden="true">
-          <Mascot emotion="proud" size={82} />
+          <Mascot className="beta-welcome-mascot__mark" emotion="proud" size={82} staticPose />
         </div>
         <div className="beta-welcome-kicker">{t('betaWelcome.kicker')}</div>
         <h1 id="beta-welcome-title">{t('betaWelcome.title')}</h1>
@@ -69,6 +69,15 @@ export function BetaWelcomeSplash({ onContinue }: { onContinue: () => void }) {
             <PixelIcon name="send" size={18} />
             <h2>{t('betaWelcome.feedbackTitle')}</h2>
             <p>{t('betaWelcome.feedbackBody')}</p>
+            <a
+              href="/contact"
+              onClick={() => {
+                recordBetaWelcomeStep('continued');
+                onContinue();
+              }}
+            >
+              {t('betaWelcome.feedbackCta')}
+            </a>
           </article>
         </div>
 

--- a/apps/web/src/BetaWelcomeSplash.tsx
+++ b/apps/web/src/BetaWelcomeSplash.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Mascot } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
+import { recordBetaWelcomeStep } from './visitTelemetry.js';
+
+export function BetaWelcomeSplash({ onContinue }: { onContinue: () => void }) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    recordBetaWelcomeStep('shown');
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      recordBetaWelcomeStep('dismissed');
+      onContinue();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onContinue]);
+
+  const continueToBeta = () => {
+    recordBetaWelcomeStep('continued');
+    onContinue();
+  };
+
+  return createPortal(
+    <div className="beta-welcome-backdrop" role="presentation">
+      <div
+        className="beta-welcome-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="beta-welcome-title"
+        aria-describedby="beta-welcome-subtitle"
+      >
+        <button
+          type="button"
+          className="beta-welcome-close"
+          aria-label={t('betaWelcome.dismiss')}
+          onClick={() => {
+            recordBetaWelcomeStep('dismissed');
+            onContinue();
+          }}
+        >
+          <PixelIcon name="close" size={13} />
+        </button>
+
+        <div className="beta-welcome-mascot" aria-hidden="true">
+          <Mascot emotion="proud" size={82} />
+        </div>
+        <div className="beta-welcome-kicker">{t('betaWelcome.kicker')}</div>
+        <h1 id="beta-welcome-title">{t('betaWelcome.title')}</h1>
+        <p id="beta-welcome-subtitle" className="beta-welcome-subtitle">
+          {t('betaWelcome.subtitle')}
+        </p>
+
+        <div className="beta-welcome-path">
+          <article>
+            <PixelIcon name="play" size={18} />
+            <h2>{t('betaWelcome.playTitle')}</h2>
+            <p>{t('betaWelcome.playBody')}</p>
+          </article>
+          <article>
+            <PixelIcon name="sparkle" size={18} />
+            <h2>{t('betaWelcome.buildTitle')}</h2>
+            <p>{t('betaWelcome.buildBody')}</p>
+          </article>
+          <article>
+            <PixelIcon name="send" size={18} />
+            <h2>{t('betaWelcome.feedbackTitle')}</h2>
+            <p>{t('betaWelcome.feedbackBody')}</p>
+          </article>
+        </div>
+
+        <p className="beta-welcome-note">{t('betaWelcome.note')}</p>
+        <button type="button" className="beta-welcome-cta" onClick={continueToBeta}>
+          <PixelIcon name="arrowRight" size={14} />
+          {t('betaWelcome.cta')}
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -40,6 +40,12 @@ const INVITE_LABELS: Record<string, string> = {
   unavailable: 'hit an unavailable invite',
 };
 
+const BETA_WELCOME_LABELS: Record<string, string> = {
+  shown: 'saw the welcome',
+  continued: 'entered the beta',
+  dismissed: 'dismissed the welcome',
+};
+
 const EDITOR_LABELS: Record<string, string> = {
   opened: 'opened the editor',
   draft_saved: 'saved a draft',
@@ -242,6 +248,36 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
                     <td>{INVITE_LABELS[row.step] ?? row.step}</td>
                     <td className="num">{row.visits}</td>
                     <td className="num">{percent(row.visits, funnel.invites?.[0]?.visits ?? 0)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="funnel-block">
+          <h3>Beta welcome</h3>
+          {(funnel.betaWelcome ?? []).every((row) => row.visits === 0) ? (
+            <p className="health-empty">No first-login welcomes in this window.</p>
+          ) : (
+            <table className="health-table">
+              <thead>
+                <tr>
+                  <th scope="col">Step</th>
+                  <th scope="col" className="num">
+                    Visits
+                  </th>
+                  <th scope="col" className="num">
+                    Of welcomes
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {(funnel.betaWelcome ?? []).map((row) => (
+                  <tr key={row.step}>
+                    <td>{BETA_WELCOME_LABELS[row.step] ?? row.step}</td>
+                    <td className="num">{row.visits}</td>
+                    <td className="num">{percent(row.visits, funnel.betaWelcome?.[0]?.visits ?? 0)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -83,6 +83,7 @@ export interface VisitFunnel {
   /** Closed-beta waitlist funnel in step order, every step present even at zero. */
   waitlist: Array<{ step: string; visits: number }>;
   invites?: Array<{ step: string; visits: number }>;
+  betaWelcome?: Array<{ step: string; visits: number }>;
   /** EditorKit revision funnel in step order, every step present even at zero. */
   editing: Array<{ step: string; visits: number }>;
   /**

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -863,6 +863,20 @@
     "unavailable": "This invitation is no longer available.",
     "backHome": "Back to the home page"
   },
+  "betaWelcome": {
+    "kicker": "Closed beta",
+    "title": "Welcome to gamedev.pl!",
+    "subtitle": "You’re in. Explore the arcade, build something, and help shape what comes next.",
+    "playTitle": "Play first",
+    "playBody": "Try a few games and find one worth sharing.",
+    "buildTitle": "Make your own",
+    "buildBody": "Describe an idea and let an agent turn it into a game.",
+    "feedbackTitle": "Tell us what breaks",
+    "feedbackBody": "Your rough edges and surprises are exactly what this beta needs.",
+    "note": "This is a real beta. Things may change, and your feedback helps decide how.",
+    "cta": "Start exploring",
+    "dismiss": "Skip welcome"
+  },
   "errors": {
     "generic": "Something went wrong",
     "creationPaused": "New games are paused for a moment while we look at something on our side. Your daily allowance hasn't been touched — please try again shortly.",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -873,6 +873,7 @@
     "buildBody": "Describe an idea and let an agent turn it into a game.",
     "feedbackTitle": "Tell us what breaks",
     "feedbackBody": "Your rough edges and surprises are exactly what this beta needs.",
+    "feedbackCta": "Contact us",
     "note": "This is a real beta. Things may change, and your feedback helps decide how.",
     "cta": "Start exploring",
     "dismiss": "Skip welcome"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -877,6 +877,7 @@
     "buildBody": "Opisz pomysł i pozwól agentowi zamienić go w grę.",
     "feedbackTitle": "Powiedz, co nie działa",
     "feedbackBody": "Niedoróbki i zaskoczenia są dokładnie tym, czego potrzebuje ta beta.",
+    "feedbackCta": "Skontaktuj się z nami",
     "note": "To prawdziwa beta. Rzeczy mogą się zmieniać, a Twoje uwagi pomagają o tym decydować.",
     "cta": "Zacznij odkrywać",
     "dismiss": "Pomiń powitanie"

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -867,6 +867,20 @@
     "unavailable": "To zaproszenie nie jest już dostępne.",
     "backHome": "Wróć na stronę główną"
   },
+  "betaWelcome": {
+    "kicker": "Zamknięta beta",
+    "title": "Witaj na gamedev.pl!",
+    "subtitle": "Jesteś w środku. Zagraj, coś stwórz i pomóż zdecydować, co będzie dalej.",
+    "playTitle": "Najpierw zagraj",
+    "playBody": "Wypróbuj kilka gier i znajdź taką, którą warto się podzielić.",
+    "buildTitle": "Stwórz własną",
+    "buildBody": "Opisz pomysł i pozwól agentowi zamienić go w grę.",
+    "feedbackTitle": "Powiedz, co nie działa",
+    "feedbackBody": "Niedoróbki i zaskoczenia są dokładnie tym, czego potrzebuje ta beta.",
+    "note": "To prawdziwa beta. Rzeczy mogą się zmieniać, a Twoje uwagi pomagają o tym decydować.",
+    "cta": "Zacznij odkrywać",
+    "dismiss": "Pomiń powitanie"
+  },
   "errors": {
     "generic": "Coś poszło nie tak",
     "creationPaused": "Tworzenie nowych gier jest na chwilę wstrzymane — sprawdzamy coś u nas. Twój dzienny limit pozostaje nietknięty, spróbuj ponownie za moment.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4452,7 +4452,14 @@ a.user-name--profile:focus-visible {
   z-index: 1;
   width: fit-content;
   margin: 0 auto 8px;
+  color: var(--turquoise);
   filter: drop-shadow(0 0 18px var(--turquoise-glow));
+}
+
+.beta-welcome-mascot__mark {
+  display: block;
+  width: 82px;
+  height: auto;
 }
 
 .beta-welcome-kicker {
@@ -4504,15 +4511,32 @@ a.user-name--profile:focus-visible {
 }
 
 .beta-welcome-path h2 {
+  min-width: 0;
   margin: 10px 0 5px;
   font-size: 0.95rem;
 }
 
 .beta-welcome-path p {
+  min-width: 0;
   margin: 0;
   color: var(--muted);
   font-size: 0.82rem;
   line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.beta-welcome-path a {
+  display: inline-block;
+  margin-top: 9px;
+  color: var(--turquoise);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.beta-welcome-path a:hover,
+.beta-welcome-path a:focus-visible {
+  text-decoration: underline;
 }
 
 .beta-welcome-note {
@@ -4569,17 +4593,30 @@ a.user-name--profile:focus-visible {
   .beta-welcome-path article {
     display: grid;
     grid-template-columns: 24px 1fr;
+    grid-template-areas:
+      'icon title'
+      'icon body'
+      'icon link';
     column-gap: 8px;
     padding: 12px;
   }
 
   .beta-welcome-path article > svg {
-    grid-row: span 2;
+    grid-area: icon;
     margin-top: 2px;
   }
 
   .beta-welcome-path h2 {
+    grid-area: title;
     margin: 0 0 3px;
+  }
+
+  .beta-welcome-path p {
+    grid-area: body;
+  }
+
+  .beta-welcome-path a {
+    grid-area: link;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4373,6 +4373,216 @@ a.user-name--profile:focus-visible {
   line-height: 1.5;
 }
 
+.beta-welcome-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 950;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: 24px;
+  background: rgba(7, 11, 15, 0.84);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+.beta-welcome-card {
+  position: relative;
+  width: min(680px, 100%);
+  overflow: hidden;
+  padding: 42px clamp(20px, 5vw, 52px) 34px;
+  text-align: center;
+  background: radial-gradient(circle at 50% -15%, rgba(0, 228, 172, 0.2), transparent 42%), var(--panel);
+  border: 1px solid rgba(0, 228, 172, 0.38);
+  border-radius: 22px;
+  box-shadow:
+    0 30px 90px rgba(0, 0, 0, 0.58),
+    0 0 48px rgba(0, 228, 172, 0.12);
+}
+
+.beta-welcome-card::before,
+.beta-welcome-card::after {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  content: '';
+  background: var(--turquoise);
+  box-shadow:
+    56px 24px 0 var(--accent-blue),
+    -44px 88px 0 rgba(0, 228, 172, 0.45),
+    90px 116px 0 rgba(56, 189, 248, 0.45);
+  opacity: 0.7;
+}
+
+.beta-welcome-card::before {
+  top: 50px;
+  left: 8%;
+}
+
+.beta-welcome-card::after {
+  right: 8%;
+  bottom: 90px;
+  transform: rotate(45deg);
+}
+
+.beta-welcome-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.beta-welcome-close:hover,
+.beta-welcome-close:focus-visible {
+  color: var(--text);
+  border-color: var(--panel-border);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.beta-welcome-mascot {
+  position: relative;
+  z-index: 1;
+  width: fit-content;
+  margin: 0 auto 8px;
+  filter: drop-shadow(0 0 18px var(--turquoise-glow));
+}
+
+.beta-welcome-kicker {
+  position: relative;
+  z-index: 1;
+  color: var(--turquoise);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.beta-welcome-card h1 {
+  position: relative;
+  z-index: 1;
+  margin: 8px 0 10px;
+  font-size: clamp(1.65rem, 5vw, 2.35rem);
+  line-height: 1.1;
+}
+
+.beta-welcome-subtitle {
+  position: relative;
+  z-index: 1;
+  max-width: 48ch;
+  margin: 0 auto 26px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.beta-welcome-path {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  text-align: left;
+}
+
+.beta-welcome-path article {
+  min-width: 0;
+  padding: 16px 14px;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}
+
+.beta-welcome-path article > svg {
+  color: var(--turquoise);
+}
+
+.beta-welcome-path h2 {
+  margin: 10px 0 5px;
+  font-size: 0.95rem;
+}
+
+.beta-welcome-path p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.beta-welcome-note {
+  position: relative;
+  z-index: 1;
+  max-width: 52ch;
+  margin: 22px auto;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.beta-welcome-cta {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 10px 22px;
+  color: #08241d;
+  font: inherit;
+  font-weight: 700;
+  background: var(--turquoise);
+  border: 0;
+  border-radius: 8px;
+  box-shadow: 0 0 22px rgba(0, 228, 172, 0.22);
+  cursor: pointer;
+}
+
+.beta-welcome-cta:hover,
+.beta-welcome-cta:focus-visible {
+  filter: brightness(1.08);
+  box-shadow: 0 0 30px rgba(0, 228, 172, 0.38);
+}
+
+@media (max-width: 640px) {
+  .beta-welcome-backdrop {
+    align-items: start;
+    padding: 12px;
+  }
+
+  .beta-welcome-card {
+    margin: auto 0;
+    padding: 34px 18px 24px;
+    border-radius: 16px;
+  }
+
+  .beta-welcome-path {
+    grid-template-columns: 1fr;
+  }
+
+  .beta-welcome-path article {
+    display: grid;
+    grid-template-columns: 24px 1fr;
+    column-gap: 8px;
+    padding: 12px;
+  }
+
+  .beta-welcome-path article > svg {
+    grid-row: span 2;
+    margin-top: 2px;
+  }
+
+  .beta-welcome-path h2 {
+    margin: 0 0 3px;
+  }
+}
+
 .beta-splash__logo {
   font-weight: 700;
   font-size: 1.6rem;

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('crypto', webcrypto);
 import {
   readVisitIdentity,
   recordBetaInviteStep,
+  recordBetaWelcomeStep,
   recordCreateStep,
   recordStudioStep,
   recordVisitEvent,
@@ -346,6 +347,25 @@ describe('recordBetaInviteStep', () => {
     expect(batches[0].events).toEqual([
       expect.objectContaining({ type: 'invite_step', step: 'opened' }),
       expect.objectContaining({ type: 'invite_step', step: 'accepted' }),
+    ]);
+  });
+});
+
+describe('recordBetaWelcomeStep', () => {
+  it('records first-login welcome steps once per visit', () => {
+    const { batches, send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    setVisitSessionForTesting(session);
+
+    recordBetaWelcomeStep('shown');
+    recordBetaWelcomeStep('shown');
+    recordBetaWelcomeStep('continued');
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    expect(batches[0].events).toEqual([
+      expect.objectContaining({ type: 'beta_welcome_step', step: 'shown' }),
+      expect.objectContaining({ type: 'beta_welcome_step', step: 'continued' }),
     ]);
   });
 });

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -63,6 +63,7 @@ export type VisitEvent =
   /** A step of the closed-beta waitlist funnel. Carries no identity, ever. */
   | { type: 'waitlist_step'; step: WaitlistStep }
   | { type: 'invite_step'; step: InviteStep }
+  | { type: 'beta_welcome_step'; step: BetaWelcomeStep }
   /**
    * Studio / self-build funnel facts on the same visit stream as `create_step`.
    * Always carries `builder` so BYOCA reach-to-publish is measurable without a
@@ -117,6 +118,8 @@ export type WaitlistStep =
   | 'joined';
 
 export type InviteStep = 'opened' | 'accepted' | 'unavailable';
+
+export type BetaWelcomeStep = 'shown' | 'continued' | 'dismissed';
 
 /**
  * Which chrome surface opened the How to play card.
@@ -532,6 +535,14 @@ export function recordBetaInviteStep(step: InviteStep): void {
   currentSession.record({ type: 'invite_step', step });
 }
 
+let recordedBetaWelcomeSteps = new Set<BetaWelcomeStep>();
+
+export function recordBetaWelcomeStep(step: BetaWelcomeStep): void {
+  if (!currentSession || recordedBetaWelcomeSteps.has(step)) return;
+  recordedBetaWelcomeSteps.add(step);
+  currentSession.record({ type: 'beta_welcome_step', step });
+}
+
 /**
  * Studio steps already recorded for the live visit.
  *
@@ -612,6 +623,7 @@ export function setVisitSessionForTesting(session: VisitSession | null): void {
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
   recordedBetaInviteSteps = new Set();
+  recordedBetaWelcomeSteps = new Set();
   recordedStudioSteps = new Set();
   recordedEditorSteps = new Set();
   recordedAssistSteps = new Set();
@@ -650,6 +662,7 @@ export function startVisitTracking(options: StartVisitTrackingOptions = {}): () 
   recordedSteps = new Set();
   recordedWaitlistSteps = new Set();
   recordedBetaInviteSteps = new Set();
+  recordedBetaWelcomeSteps = new Set();
   recordedStudioSteps = new Set();
 
   if (identity.isNew) {

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -115,6 +115,20 @@ anonymous visit stream. It never records the code or the signed-in account there
 Email-form waitlist remains out of scope: it would accept unverified identity data and create
 a separate moderation surface.
 
+## First-login welcome
+
+The first successful sign-in for a new account returns a one-time welcome state. The
+signed-in shell shows a short, dismissible orientation card:
+
+- play a few games first;
+- describe an idea to build a game;
+- report rough edges and surprises.
+
+The welcome is shown from the client-side sign-in response, not inferred from a browser
+cookie. That keeps it tied to the account's first successful authentication while avoiding
+another persistent personal-data field. Anonymous visit telemetry records `shown`,
+`continued`, or `dismissed` without a uid.
+
 ## Existing operator surface
 
 - Admin UI for the waitlist shipped as the operator console **Waitlist** tab


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show a polished, dismissible welcome overlay after a new beta account signs in for the first time
- orient new testers toward playing, building, and reporting feedback
- add English/Polish copy, responsive styling, keyboard dismissal, and focused tests
- record anonymous beta-welcome funnel steps (`shown`, `continued`, `dismissed`) and surface them in operator telemetry
- fix UX feedback: visible mascot, non-overlapping mobile cards, and an explicit Contact us link to `/contact`
- add modal focus trapping and restore focus to the opener for keyboard accessibility

## UX
The first successful account creation returns a transient `betaWelcome` signal. Existing accounts do not see the overlay again, and no persistent personal-data field is added. Invite sign-ins see the invite acceptance first, then the welcome when they enter the beta.

The welcome mascot uses a static proud pose. The feedback card links directly to the contact form, which also provides the published email fallback. Escape, close, and tab navigation are handled within the dialog.

### Desktop
[Final beta welcome splash desktop](https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbeta-welcome-fixed-actual.png)

### Mobile
[Final beta welcome splash mobile](https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbeta-welcome-fixed-mobile-actual.png)

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- actual Chromium desktop/mobile checks: mascot visible, no horizontal overflow, contact link present

Instrumentation impact: this improves the first-minute funnel; the admin visit-funnel view answers how many new testers saw the welcome and continued past it without joining identity to visit telemetry.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f192a10a-ac5f-48d3-91d9-dac7a9abc6a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

