### PR TITLE
Use iframe body bounds for embedded games

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -70,7 +70,7 @@ describe('embedGameHtml', () => {
       '#game{--gdpl-canvas-ratio:1.6;--gdpl-embed-width:100%;--gdpl-embed-height:100dvh;flex:0 1 auto!important;width:min(var(--gdpl-embed-width),calc(var(--gdpl-embed-height) * var(--gdpl-canvas-ratio)))!important;',
     );
     expect(out).toContain('aspect-ratio:var(--gdpl-canvas-ratio)!important');
-    expect(out).toContain('max-width:100%!important');
+    expect(out).toContain('max-width:var(--gdpl-embed-width)!important');
     expect(out).toContain('max-height:100%!important');
     expect(out).not.toContain('#game{width:auto!important;height:auto!important');
     expect(out).not.toContain('#game{width:100%!important;height:100%!important');

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -342,8 +342,7 @@ const BRIDGE = `(function(){
   function fitGameCanvas(){
     var canvas=el('game');
     if(!canvas||!canvas.width||!canvas.height)return;
-    var wrap=canvas.closest('.wrap')||document.body;
-    var bounds=wrap.getBoundingClientRect();
+    var bounds=document.body.getBoundingClientRect();
     canvas.style.setProperty('--gdpl-canvas-ratio',String(canvas.width/canvas.height));
     canvas.style.setProperty('--gdpl-embed-width',String(bounds.width)+'px');
     canvas.style.setProperty('--gdpl-embed-height',String(bounds.height)+'px');
@@ -400,7 +399,7 @@ const HIDE_CHROME =
   `width:min(var(--gdpl-embed-width),calc(var(--gdpl-embed-height) * var(--gdpl-canvas-ratio)))!important;` +
   `height:auto!important;` +
   `aspect-ratio:var(--gdpl-canvas-ratio)!important;` +
-  `max-width:100%!important;` +
+  `max-width:var(--gdpl-embed-width)!important;` +
   `max-height:100%!important;` +
   `min-height:0!important;` +
   `box-shadow:none!important` +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix the remaining embedded canvas sizing issue when iframe viewport units differ from element bounds.
- Measure the actual iframe document body and use its width/height for aspect-ratio fitting.
- Remove the narrow wrapper max-width cap from the canvas sizing path.

## Validation
- Reproduced the Settlers case: body `1085×986`, wrapper/canvas incorrectly `646×525` because `.wrap` was narrow and `100dvh` resolved to `525px`.
- Body-bound sizing produces approximately `1085×882`, preserving Settlers’ `640×520` ratio.
- Public green gate passes on the follow-up change.

```gate-attest
sha: 9e7b162f4b22eaf3c7f78f99c20bb7544c5e1cbf
command: npm run type-check && npm run lint && npm run test && npm run build
result: pass
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b427ff4-cc51-4bff-bd87-35dfacd51096?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b427ff4-cc51-4bff-bd87-35dfacd51096&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

