### PR TITLE
chore(contract): sync grid module order (KC-04)

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -5,6 +5,7 @@
     "input",
     "collision",
     "world",
+    "grid",
     "path",
     "ai",
     "gameplay",

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -93,6 +93,7 @@ describe('games-repo-contract (website half)', () => {
       'input',
       'collision',
       'world',
+      'grid',
       'path',
       'ai',
       'gameplay',
@@ -227,7 +228,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
+        'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -42,6 +42,7 @@ export const GAME_KIT_MODULES = [
   'input',
   'collision',
   'world',
+  'grid',
   'path',
   'ai',
   'gameplay',


### PR DESCRIPTION
Paired with gamedevpl/www.gamedev.pl-games#661.

- Add `grid` and restore the already-shipped `path` entry to the website's canonical GameKit module order.
- Update the vendored games-repo assemble contract fixture.
- Update the extractor fixture test so it covers the complete order.

Verification: `npm test -w @gamedevpl/api -- src/games-repo-contract.test.ts` (28 tests passing).