### PR TITLE
Stop telling MCP self-build agents to run npm run submit

### DIFF
--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -835,8 +835,8 @@ export async function registerAgentChannelRoutes(
           : {
               mustDeliver:
                 'Nothing has been delivered for this build yet. Pushing a branch is not delivering — ' +
-                'submit_sources (or `npm run submit -- <slug>` in a shell sandbox) before you finish, ' +
-                'or this session produces nothing.',
+                'call submit_sources with mode=preview at least once (mode=publish to seal, or ' +
+                '`npm run submit -- <slug>` in a shell sandbox) before you finish, or this session produces nothing.',
             }),
       },
     };

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -826,8 +826,8 @@ export async function registerAgentChannelRoutes(
                     : `The gate ran against your delivery and refused it (${gate.version}). You are not ` +
                       'done: nothing can be published until it passes. Read `gate.report` below — it ends ' +
                       'with the check that stopped the chain — fix the cause in your game, and deliver ' +
-                      'again with `npm run submit -- <slug>` (or submit_sources mode=publish). Re-delivering ' +
-                      'without a fix just stores another version that fails the same way.',
+                      'again with submit_sources mode=publish (or `npm run submit -- <slug>` in a shell ' +
+                      'sandbox). Re-delivering without a fix just stores another version that fails the same way.',
             }
           : {}),
         ...(record.deliveredVersion
@@ -835,7 +835,8 @@ export async function registerAgentChannelRoutes(
           : {
               mustDeliver:
                 'Nothing has been delivered for this build yet. Pushing a branch is not delivering — ' +
-                'run `npm run submit -- <slug>` before you finish, or this session produces nothing.',
+                'submit_sources (or `npm run submit -- <slug>` in a shell sandbox) before you finish, ' +
+                'or this session produces nothing.',
             }),
       },
     };

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1054,8 +1054,7 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(warningCodes).toContain('inbox_pending');
     expect(warningCodes).toContain('must_deliver');
-    // must_deliver must not tell an MCP session (no shell) to run a CLI command —
-    // it should point at the submit_sources tool instead (review, confusing-npm-submit).
+    // must_deliver must point MCP (no shell) at submit_sources, not a CLI command.
     const mustDeliverMessage = (
       (examples.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? []
     ).find((w) => w.code === 'must_deliver')?.message;

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1054,6 +1054,13 @@ describe('POST /api/mcp (BY-05)', () => {
     );
     expect(warningCodes).toContain('inbox_pending');
     expect(warningCodes).toContain('must_deliver');
+    // must_deliver must not tell an MCP session (no shell) to run a CLI command —
+    // it should point at the submit_sources tool instead (review, confusing-npm-submit).
+    const mustDeliverMessage = (
+      (examples.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? []
+    ).find((w) => w.code === 'must_deliver')?.message;
+    expect(mustDeliverMessage).not.toMatch(/npm run submit/);
+    expect(mustDeliverMessage).toMatch(/submit_sources/);
   });
 
   it('refuses the retired send_screenshot base64 tool', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -512,7 +512,19 @@ function warningsFromChannel(body: ChannelControlBody): Array<{ code: string; me
   }
   const deliver = typeof body.control?.mustDeliver === 'string' ? body.control.mustDeliver.trim() : '';
   if (deliver) {
-    warnings.push({ code: 'must_deliver', message: deliver });
+    // The channel's raw copy tells a shell-sandbox agent (Copilot's build prompt) to
+    // run `npm run submit -- <slug>`. An MCP tool session has no shell — its deliver
+    // step is submit_sources — so that text is never right here. must_fix_gate above
+    // gets channel-authored copy because its remedy varies by gate status; must_deliver
+    // has one fixed remedy for every MCP session, so it's authored here instead of
+    // patched out of the channel's string.
+    warnings.push({
+      code: 'must_deliver',
+      message:
+        'Nothing has been delivered for this build yet. Staging or pushing a branch is not delivering — ' +
+        'stage your sources, then call submit_sources({ fromStaged: true, mode, kitEngineRef }) before you ' +
+        'finish, or this session produces nothing.',
+    });
   }
   return warnings;
 }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -517,8 +517,9 @@ function warningsFromChannel(body: ChannelControlBody): Array<{ code: string; me
       code: 'must_deliver',
       message:
         'Nothing has been delivered for this build yet. Staging or pushing a branch is not delivering — ' +
-        'stage your sources, then call submit_sources({ fromStaged: true, mode, kitEngineRef }) before you ' +
-        'finish, or this session produces nothing.',
+        'stage your sources, then call submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) ' +
+        '(mode: "publish" to seal instead, but that needs TRACE.json + PLAYTEST.json) before you finish, ' +
+        'or this session produces nothing.',
     });
   }
   return warnings;

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -512,12 +512,7 @@ function warningsFromChannel(body: ChannelControlBody): Array<{ code: string; me
   }
   const deliver = typeof body.control?.mustDeliver === 'string' ? body.control.mustDeliver.trim() : '';
   if (deliver) {
-    // The channel's raw copy tells a shell-sandbox agent (Copilot's build prompt) to
-    // run `npm run submit -- <slug>`. An MCP tool session has no shell — its deliver
-    // step is submit_sources — so that text is never right here. must_fix_gate above
-    // gets channel-authored copy because its remedy varies by gate status; must_deliver
-    // has one fixed remedy for every MCP session, so it's authored here instead of
-    // patched out of the channel's string.
+    // No-shell remedy, authored here rather than forwarded.
     warnings.push({
       code: 'must_deliver',
       message:


### PR DESCRIPTION
## Summary

An MCP self-build session (Claude/ChatGPT via `/api/mcp`, no shell) hit the `must_deliver` soft warning and was told:

> run `npm run submit -- <slug>` before you finish

That command doesn't exist for an MCP tool session — its deliver step is the `submit_sources` tool. The channel's `mustDeliver` / `mustFixGate` copy is shared between the raw REST channel (used by shell-sandbox agents like Copilot's build prompt) and the MCP layer (`warningsFromChannel` in `mcp-server.ts` forwards it verbatim), and it was written CLI-first with no MCP awareness.

Same pattern existed in the generic (non-`kit_outdated`/`preview_failed`) `must_fix_gate` branch, which also led with `npm run submit -- <slug>` before mentioning `submit_sources` only as a parenthetical.

## Changes

- `apps/api/src/agent-channel.ts`: reordered both messages so `submit_sources` is the lead instruction; `npm run submit -- <slug>` is now a parenthetical for agents that do have a shell sandbox. This fixes the copy for both the raw channel and (via forwarding) the MCP layer.
- `apps/api/src/mcp-server.ts`: `must_deliver`'s MCP-facing text is now authored directly (it has one fixed remedy regardless of gate status, unlike `must_fix_gate` whose remedy varies by status and stays channel-authored) rather than forwarding the raw channel string unmodified.
- `apps/api/src/mcp-server.test.ts`: regression test asserting the MCP `must_deliver` warning never mentions `npm run submit` and always points at `submit_sources`.

## Test plan

- [x] `npx vitest run src/agent-channel.test.ts src/mcp-server.test.ts src/build-prompt.test.ts src/copilot-backend.test.ts` — 180 passed
- [x] `npm run type-check` in `apps/api`

---
_Generated by [Claude Code](https://claude.ai/code/session_013AYvMn3662QyuNgrYuJgGA)_