### PR TITLE
Close the feedback gap after a red preview gate outlives its session

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -124,6 +124,54 @@ remembers. (Observed 2026-08-05: an agent treated a stale `stop: true` as a stan
 prohibition and reported a protocol violation, while the response in front of it said
 `stop: false`.)
 
+### A red gate outlives the session that triggered it
+
+The documented loop is submit → `end` (see "`end` is required after submit" below), and
+Cloud Build takes 1-3 minutes — so the session that delivered is very often gone before
+its own gate finishes. Two things close that gap, added after a round (arena-brawlers,
+2026-08-09) shipped two straight red preview gates and neither was ever seen: the first
+session correctly stopped on `gate_pending`; the second submitted a fix, called `end`
+immediately per the workflow, and the _second_ gate turned red only after the session
+that could have fixed it had already left. Nothing was watching, and nothing else picked
+it up — the job sat in `submitted` (reads as "building" to the creator) indefinitely.
+
+- **Reconciliation now covers preview, not just publish.** `reconcileGateVerdict`
+  (`apps/api/src/submissions.ts`) used to read only `manifest.gate` (the publish-mode
+  verdict) — a `mode=preview` delivery writes `manifest.previewGate` instead, so a red
+  preview never transitioned the job at all. It now also reacts to a **red**
+  `previewGate` the same way: `needs_changes` / `gate_red`, `transitionClosesRound`
+  still keeps the round open (same-session repair, no new token). A **green** preview is
+  never promoted — that would let an unpublished, unreviewed draft skip moderation
+  (BY-28a: typecheck/smoke/build only, not publish readiness).
+- **`start` now surfaces an outstanding red gate itself.** `must_fix_gate` used to only
+  ride `show_round` / `get_gate_verdict` / `report_progress` replies — a session that
+  reconnects and calls `start` first (the normal first call of any session) got no
+  signal unless it happened to call one of those three next. `start`'s response now
+  carries an optional `gate: { status, deliveryId }` (mirroring `show_round`'s shape,
+  via the shared `apps/api/src/gate-verdict.ts`) whenever the last delivery still needs
+  a fix, with `warnings.code=must_fix_gate` riding the same reply. Absent when nothing
+  is outstanding — a passing round's `start` response is unchanged.
+
+### GAME.json shape is checked at stage/patch time, not just at the gate
+
+The shared kit's `assemble.ts` reads `manifest.engine.modules` unconditionally when
+building the game — a missing/empty `engine.modules` (or `audio` selected without
+`audio.sounds`/`audio.music`) is not a validation error, it is a silent
+`Cannot read properties of undefined (reading 'modules')` crash at smoke time, with a
+stack trace that points at the test harness, not at GAME.json. That is what sank
+arena-brawlers' two deliveries: GAME.json never had an `engine` block, and the agent
+that fixed an unrelated typecheck bug in `game.ts` never looked at GAME.json again
+because nothing pointed it there until a Cloud Build log did, minutes later.
+
+`stage_source_file` and `patch_source_file` now run a shallow shape check
+(`apps/api/src/game-manifest-hint.ts`) whenever the staged/patched path is `GAME.json`,
+and emit `warnings.code=game_manifest_invalid` on the _same_ reply if it's missing
+`engine.modules` (or `audio` is selected without `audio.sounds`/`audio.music`). This is
+deliberately shallow — it does not know the kit's module catalog, canonical order, or
+duplicates (that's `validate.ts` in the games repo, which still runs as the source of
+truth in the gate) — it only catches the shapes that crash outright before any real
+validation runs.
+
 ### `kit_outdated` — do not re-upload the tree
 
 When the gate returns `kit_outdated` (or soft copy says the kit rotated):
@@ -288,16 +336,17 @@ cache), so a resume cannot keep showing “finished this round” next to live p
 
 Merged by `applySessionNudges` / submit handler. Act, then continue:
 
-| Code                | Meaning                                                                                                                                                                    |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `call_end`          | Call `end` when finished iterating this round                                                                                                                              |
-| `must_fix_gate`     | Last delivery refused (`preview_failed` / `red` / `kit_outdated`) — fix and **`submit_sources` again**; staging alone does not re-run the gate or refresh the creator card |
-| `must_deliver`      | Nothing delivered yet — submit before finishing                                                                                                                            |
-| `gate_not_started`  | Delivery ok but Cloud Build did not start — no preview yet                                                                                                                 |
-| `gate_poll_backoff` | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true`                                                                                           |
-| `progress_stale`    | Call `report_progress`                                                                                                                                                     |
-| `inbox_pending`     | `read_inbox` → apply → `ack_inbox`                                                                                                                                         |
-| `seed_unread`       | Call `get_seed` before scaffolding from the kit                                                                                                                            |
+| Code                    | Meaning                                                                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `call_end`              | Call `end` when finished iterating this round                                                                                                                              |
+| `must_fix_gate`         | Last delivery refused (`preview_failed` / `red` / `kit_outdated`) — fix and **`submit_sources` again**; staging alone does not re-run the gate or refresh the creator card |
+| `must_deliver`          | Nothing delivered yet — submit before finishing                                                                                                                            |
+| `gate_not_started`      | Delivery ok but Cloud Build did not start — no preview yet                                                                                                                 |
+| `gate_poll_backoff`     | Repeated one-shot gate check — stop checking; build/submit or honour `stop:true`                                                                                           |
+| `progress_stale`        | Call `report_progress`                                                                                                                                                     |
+| `inbox_pending`         | `read_inbox` → apply → `ack_inbox`                                                                                                                                         |
+| `seed_unread`           | Call `get_seed` before scaffolding from the kit                                                                                                                            |
+| `game_manifest_invalid` | Just-staged/patched `GAME.json` has a shape that crashes the gate before typecheck (e.g. missing `engine.modules`) — fix it now, in the same session, before submitting    |
 
 ## Builder handoff (Studio)
 
@@ -356,21 +405,24 @@ queued.
 
 ## Key code
 
-| Area                         | Path                                                                                                                                                                      |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MCP tools                    | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` / `stage_upload_url` → signed PUT; no base64 shot tool)                                                             |
-| Upload tokens                | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload` + `PUT …/sources/stage/upload`                                                      |
-| Presence pulses              | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
-| Gate milestones              | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |
-| Account-session invalidation | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |
-| Channel (`POST …/end`, …)    | `apps/api/src/agent-channel.ts`                                                                                                                                           |
-| Stall / `ended`              | `apps/api/src/job-state.ts` (`detectStall`)                                                                                                                               |
-| Handoff gate                 | `apps/api/src/builder.ts` (`allowsCreatorBuilderHandoff`)                                                                                                                 |
-| Live staged preview          | `apps/api/src/staged-preview.ts`                                                                                                                                          |
-| Studio live-preview frame    | `apps/web/src/StudioLivePreview.tsx`                                                                                                                                      |
-| Studio status poll cadence   | `apps/web/src/studioStatusPoll.ts` (tight poll on `ended` / `quiet` / `no_agent_yet` / `dispatched`)                                                                      |
-| Feedback / resume            | `apps/api/src/submissions.ts`                                                                                                                                             |
-| Studio copy / builder choice | `apps/web/src/selfBuildCopy.ts`, `BuilderModeBadge.tsx`, `SubmissionStatusView.tsx` (sticky badge + Change modal at round boundaries; full two-up stays in create wizard) |
+| Area                          | Path                                                                                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP tools                     | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` / `stage_upload_url` → signed PUT; no base64 shot tool)                                                             |
+| Upload tokens                 | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload` + `PUT …/sources/stage/upload`                                                      |
+| Presence pulses               | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
+| Gate milestones               | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |
+| Gate verdict (shared)         | `apps/api/src/gate-verdict.ts` — `readGateVerdict` / `deriveGateStatusString`, used by the channel's `/api/agent/build/gate` route and by `start`'s reconnect visibility  |
+| Preview-gate reconciliation   | `apps/api/src/submissions.ts` (`reconcileGateVerdict`) — red `previewGate` → `needs_changes`/`gate_red`; green preview never promotes                                     |
+| GAME.json staging shape check | `apps/api/src/game-manifest-hint.ts` (`gameManifestHint`) — wired into the stage/patch routes in `agent-channel.ts`                                                       |
+| Account-session invalidation  | `apps/api/src/agent-session-revocation.ts`                                                                                                                                |
+| Channel (`POST …/end`, …)     | `apps/api/src/agent-channel.ts`                                                                                                                                           |
+| Stall / `ended`               | `apps/api/src/job-state.ts` (`detectStall`)                                                                                                                               |
+| Handoff gate                  | `apps/api/src/builder.ts` (`allowsCreatorBuilderHandoff`)                                                                                                                 |
+| Live staged preview           | `apps/api/src/staged-preview.ts`                                                                                                                                          |
+| Studio live-preview frame     | `apps/web/src/StudioLivePreview.tsx`                                                                                                                                      |
+| Studio status poll cadence    | `apps/web/src/studioStatusPoll.ts` (tight poll on `ended` / `quiet` / `no_agent_yet` / `dispatched`)                                                                      |
+| Feedback / resume             | `apps/api/src/submissions.ts`                                                                                                                                             |
+| Studio copy / builder choice  | `apps/web/src/selfBuildCopy.ts`, `BuilderModeBadge.tsx`, `SubmissionStatusView.tsx` (sticky badge + Change modal at round boundaries; full two-up stays in create wizard) |
 
 ## Safety invariant (unchanged)
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -28,6 +28,7 @@ import {
 } from './agent-upload-token.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
+import { deriveGateStatusString, readGateVerdict } from './gate-verdict.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
 import {
   InvalidUploadError,
@@ -57,6 +58,7 @@ import {
 } from './kit-registry.js';
 import { seedPayload } from './seed-status.js';
 import { largeSourceFileHint } from './module-size.js';
+import { gameManifestHint } from './game-manifest-hint.js';
 import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
 import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
@@ -715,51 +717,12 @@ export async function registerAgentChannelRoutes(
    * yet", which is what the agent would have seen a moment earlier anyway.
    */
   async function gateVerdict(record: SubmissionRecord) {
-    const { slug } = record;
-    // Prefer previewVersion: publish writes both pointers to the same id, while a later
-    // mode=preview only advances previewVersion. delivered-first would keep reporting the
-    // stale publish red after the agent already fixed and re-previewed.
-    const version = record.previewVersion ?? record.deliveredVersion;
-    if (!options.gamesStore || !slug || !version) return null;
-    try {
-      const manifest = await options.gamesStore.getManifest(slug, version);
-      if (manifest?.gate) {
-        return {
-          // Named so the agent can tell a verdict about *this* delivery from a stale one
-          // about the previous round — the difference between "fix it" and "already fixed".
-          version,
-          lane: 'publish' as const,
-          green: manifest.gate.green,
-          ranAt: manifest.gate.ranAt,
-          // The tail is where the chain names the check that stopped it; the runner has
-          // already trimmed to 4000 characters for exactly this reason.
-          ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
-          // `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game.
-          ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
-        };
-      }
-      // Preview-lane check: never report as publishable green (that ends the MCP round).
-      if (manifest?.previewGate) {
-        const kitOutdated = manifest.previewGate.status === 'kit_outdated';
-        return {
-          version,
-          lane: 'preview' as const,
-          green: false,
-          previewPassed: manifest.previewGate.green,
-          ranAt: manifest.previewGate.ranAt,
-          ...(manifest.previewGate.report ? { report: manifest.previewGate.report } : {}),
-          status: kitOutdated
-            ? ('kit_outdated' as const)
-            : manifest.previewGate.green
-              ? ('preview_passed' as const)
-              : ('preview_failed' as const),
-        };
-      }
-      return null;
-    } catch (error) {
-      app.log.warn({ err: error, issueNumber: record.issueNumber, slug }, 'could not read the gate verdict');
-      return null;
-    }
+    return readGateVerdict(options.gamesStore, record, (error) =>
+      app.log.warn(
+        { err: error, issueNumber: record.issueNumber, slug: record.slug },
+        'could not read the gate verdict',
+      ),
+    );
   }
 
   /**
@@ -1192,6 +1155,7 @@ export async function registerAgentChannelRoutes(
         // After the buffer is durable, so the assembly it schedules reads this file too.
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
         const hint = largeSourceFileHint(staged.path, staged.bytes, parsed.data.content);
+        const manifestHint = gameManifestHint(staged.path, parsed.data.content);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -1203,6 +1167,7 @@ export async function registerAgentChannelRoutes(
             maxFiles: staged.maxFiles,
             updatedAt: staged.updatedAt,
           },
+          ...(manifestHint ? { manifestHint } : {}),
           ...(hint ? { hint } : {}),
           ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
         });
@@ -1281,6 +1246,7 @@ export async function registerAgentChannelRoutes(
         options.onEvent?.(issueNumber);
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
         const hint = largeSourceFileHint(staged.path, staged.bytes, content);
+        const manifestHint = gameManifestHint(staged.path, content);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -1292,6 +1258,7 @@ export async function registerAgentChannelRoutes(
             maxFiles: staged.maxFiles,
             updatedAt: staged.updatedAt,
           },
+          ...(manifestHint ? { manifestHint } : {}),
           ...(hint ? { hint } : {}),
           ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
         });
@@ -1418,6 +1385,7 @@ export async function registerAgentChannelRoutes(
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
 
         const hint = largeSourceFileHint(staged.path, staged.bytes, patched.content);
+        const manifestHint = gameManifestHint(staged.path, patched.content);
         return reply.send({
           accepted: true,
           path: staged.path,
@@ -1431,6 +1399,7 @@ export async function registerAgentChannelRoutes(
             maxFiles: staged.maxFiles,
             updatedAt: staged.updatedAt,
           },
+          ...(manifestHint ? { manifestHint } : {}),
           ...(hint ? { hint } : {}),
           ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
         });
@@ -2554,15 +2523,7 @@ export async function registerAgentChannelRoutes(
         });
       }
 
-      const status = gate.green
-        ? 'green'
-        : gate.status === 'kit_outdated'
-          ? 'kit_outdated'
-          : gate.status === 'preview_passed'
-            ? 'preview_passed'
-            : gate.status === 'preview_failed'
-              ? 'preview_failed'
-              : 'red';
+      const status = deriveGateStatusString(gate);
       return reply.send({
         status,
         deliveryId: version,

--- a/apps/api/src/game-manifest-hint.test.ts
+++ b/apps/api/src/game-manifest-hint.test.ts
@@ -16,10 +16,6 @@ describe('gameManifestHint', () => {
     expect(gameManifestHint('GAME.json', '"hi"')).toMatch(/must be a JSON object/);
   });
 
-  // This exact shape crashed two straight arena-brawlers preview deliveries with
-  // "Cannot read properties of undefined (reading 'modules')" — assemble.ts reads
-  // manifest.engine.modules unconditionally, and nothing upstream of the gate ever
-  // validated GAME.json's shape before this.
   it('flags a manifest with no engine block at all', () => {
     const content = JSON.stringify({
       title: 'Arena Brawlers',

--- a/apps/api/src/game-manifest-hint.test.ts
+++ b/apps/api/src/game-manifest-hint.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { gameManifestHint } from './game-manifest-hint.js';
+
+describe('gameManifestHint', () => {
+  it('ignores every path other than GAME.json', () => {
+    expect(gameManifestHint('game.ts', '{}')).toBeNull();
+    expect(gameManifestHint('game/model.ts', '{}')).toBeNull();
+  });
+
+  it('flags invalid JSON', () => {
+    expect(gameManifestHint('GAME.json', '{ not json')).toMatch(/not valid JSON/);
+  });
+
+  it('flags a non-object manifest', () => {
+    expect(gameManifestHint('GAME.json', '[]')).toMatch(/must be a JSON object/);
+    expect(gameManifestHint('GAME.json', '"hi"')).toMatch(/must be a JSON object/);
+  });
+
+  // This exact shape crashed two straight arena-brawlers preview deliveries with
+  // "Cannot read properties of undefined (reading 'modules')" — assemble.ts reads
+  // manifest.engine.modules unconditionally, and nothing upstream of the gate ever
+  // validated GAME.json's shape before this.
+  it('flags a manifest with no engine block at all', () => {
+    const content = JSON.stringify({
+      title: 'Arena Brawlers',
+      slug: 'arena-brawlers',
+      description: '3v3 top-down arena skirmish.',
+      orientation: 'any',
+    });
+    const hint = gameManifestHint('GAME.json', content);
+    expect(hint).toMatch(/engine\.modules/);
+    expect(hint).toMatch(/modules'/);
+  });
+
+  it('flags engine.modules that is missing, empty, or not an array', () => {
+    expect(gameManifestHint('GAME.json', JSON.stringify({ engine: {} }))).toMatch(/engine\.modules/);
+    expect(gameManifestHint('GAME.json', JSON.stringify({ engine: { modules: [] } }))).toMatch(/engine\.modules/);
+    expect(gameManifestHint('GAME.json', JSON.stringify({ engine: { modules: 'gfx' } }))).toMatch(/engine\.modules/);
+  });
+
+  it('flags non-string entries in engine.modules', () => {
+    expect(gameManifestHint('GAME.json', JSON.stringify({ engine: { modules: ['gfx', 3] } }))).toMatch(
+      /must contain only strings/,
+    );
+  });
+
+  it('flags the audio module selected without audio.sounds / audio.music', () => {
+    const noAudioBlock = JSON.stringify({ engine: { modules: ['gfx', 'audio'] } });
+    expect(gameManifestHint('GAME.json', noAudioBlock)).toMatch(/audio\.sounds/);
+
+    const soundsOnly = JSON.stringify({
+      engine: { modules: ['gfx', 'audio'] },
+      audio: { sounds: ['coin'] },
+    });
+    expect(gameManifestHint('GAME.json', soundsOnly)).toMatch(/audio\.music/);
+  });
+
+  it('accepts a minimal valid manifest with no audio module', () => {
+    const content = JSON.stringify({ engine: { modules: ['input', 'gfx'] } });
+    expect(gameManifestHint('GAME.json', content)).toBeNull();
+  });
+
+  it('accepts a valid manifest with audio wired up', () => {
+    const content = JSON.stringify({
+      engine: { modules: ['input', 'gfx', 'audio'] },
+      audio: { sounds: ['coin', 'pop'], music: 'dream-float' },
+    });
+    expect(gameManifestHint('GAME.json', content)).toBeNull();
+  });
+});

--- a/apps/api/src/game-manifest-hint.ts
+++ b/apps/api/src/game-manifest-hint.ts
@@ -1,20 +1,4 @@
-/**
- * Soft, best-effort shape check for a staged `GAME.json` — catches the crash classes the
- * shared kit's assemble step throws on *before* build/typecheck even starts, so the agent
- * hears about them at stage time instead of ~2-3 minutes later off a Cloud Build report
- * (or, if the delivering session already ended, only via the next reconnect).
- *
- * Deliberately shallow: this repo does not carry the games repo's module catalog, so it
- * cannot validate module names, canonical order, or duplicates (that is `validate.ts` in
- * www.gamedev.pl-games, which still runs as the source of truth in the gate). It only
- * catches the two shapes that crash `readSharedSources` outright — `engine.modules`
- * missing/empty, and `audio` selected without `audio.sounds` / `audio.music` — because
- * those are silent `undefined` reads, not a validation error, so nothing points at the
- * real cause until a human reads a smoke-test stack trace (arena-brawlers, 2026-08-09:
- * two straight preview deliveries died on `Cannot read properties of undefined (reading
- * 'modules')` because GAME.json never had an `engine` block, and the agent that fixed an
- * unrelated typecheck error in game.ts never looked at GAME.json again).
- */
+// Shallow shape check — catches assemble.ts crashes before the gate does.
 export function gameManifestHint(path: string, content: string): string | null {
   const normalized = path.trim().replaceAll('\\', '/');
   if (normalized !== 'GAME.json') return null;

--- a/apps/api/src/game-manifest-hint.ts
+++ b/apps/api/src/game-manifest-hint.ts
@@ -1,0 +1,73 @@
+/**
+ * Soft, best-effort shape check for a staged `GAME.json` — catches the crash classes the
+ * shared kit's assemble step throws on *before* build/typecheck even starts, so the agent
+ * hears about them at stage time instead of ~2-3 minutes later off a Cloud Build report
+ * (or, if the delivering session already ended, only via the next reconnect).
+ *
+ * Deliberately shallow: this repo does not carry the games repo's module catalog, so it
+ * cannot validate module names, canonical order, or duplicates (that is `validate.ts` in
+ * www.gamedev.pl-games, which still runs as the source of truth in the gate). It only
+ * catches the two shapes that crash `readSharedSources` outright — `engine.modules`
+ * missing/empty, and `audio` selected without `audio.sounds` / `audio.music` — because
+ * those are silent `undefined` reads, not a validation error, so nothing points at the
+ * real cause until a human reads a smoke-test stack trace (arena-brawlers, 2026-08-09:
+ * two straight preview deliveries died on `Cannot read properties of undefined (reading
+ * 'modules')` because GAME.json never had an `engine` block, and the agent that fixed an
+ * unrelated typecheck error in game.ts never looked at GAME.json again).
+ */
+export function gameManifestHint(path: string, content: string): string | null {
+  const normalized = path.trim().replaceAll('\\', '/');
+  if (normalized !== 'GAME.json') return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    return `GAME.json is not valid JSON (${error instanceof Error ? error.message : String(error)}) — the gate will fail to read it before typecheck even runs.`;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return 'GAME.json must be a JSON object.';
+  }
+  const manifest = parsed as Record<string, unknown>;
+
+  const engine = manifest.engine;
+  const modules =
+    typeof engine === 'object' && engine !== null && !Array.isArray(engine)
+      ? (engine as Record<string, unknown>).modules
+      : undefined;
+  if (!Array.isArray(modules) || modules.length === 0) {
+    return (
+      'GAME.json has no engine.modules array. The shared kit reads manifest.engine.modules unconditionally when ' +
+      'assembling the game — a missing/empty array crashes preview smoke with "Cannot read properties of ' +
+      "undefined (reading 'modules')\" before build or capture ever run, with no useful stack trace. Add " +
+      '"engine": { "modules": [...] } naming only the modules game/*.ts actually imports (e.g. "input", "gfx").'
+    );
+  }
+  if (!modules.every((m) => typeof m === 'string')) {
+    return 'GAME.json engine.modules must contain only strings.';
+  }
+
+  if (modules.includes('audio')) {
+    const audio = manifest.audio;
+    const audioObj =
+      typeof audio === 'object' && audio !== null && !Array.isArray(audio) ? (audio as Record<string, unknown>) : {};
+    const sounds = audioObj.sounds;
+    const music = audioObj.music;
+    if (!Array.isArray(sounds) || sounds.length === 0) {
+      return (
+        'GAME.json enables the "audio" engine module but has no audio.sounds array. assemble will throw ' +
+        '"<slug> enables audio but does not select audio.sounds" — add audio.sounds (from the shared catalog, ' +
+        'or your own music.json for custom tracks) or drop "audio" from engine.modules if the game is silent.'
+      );
+    }
+    if (typeof music !== 'string' || !music) {
+      return (
+        'GAME.json enables the "audio" engine module but has no audio.music string. assemble will throw ' +
+        '"<slug> enables audio but does not select audio.music" — add audio.music, or drop "audio" from ' +
+        'engine.modules if the game is silent.'
+      );
+    }
+  }
+
+  return null;
+}

--- a/apps/api/src/gate-verdict.ts
+++ b/apps/api/src/gate-verdict.ts
@@ -1,0 +1,89 @@
+import { type GamesStore } from './games-store.js';
+
+/**
+ * Read a delivered version's own-gate verdict off its manifest.
+ *
+ * Shared between the `/api/agent/build/gate` channel route (agent-channel.ts) and the
+ * MCP `start` tool (mcp-server.ts) — both need the same publish/preview distinction, and
+ * duplicating it let `start` drift out of sync with what `show_round` / `get_gate_verdict`
+ * already report (see the `start` doesn't surface a red gate on reconnect gap, #arena-brawlers).
+ */
+export interface GateVerdictSummary {
+  /** Named so a caller can tell a verdict about *this* delivery from a stale prior one. */
+  version: string;
+  lane: 'publish' | 'preview';
+  green: boolean;
+  ranAt: string;
+  report?: string;
+  previewPassed?: boolean;
+  /** `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game. */
+  status?: 'kit_outdated' | 'preview_passed' | 'preview_failed';
+}
+
+export interface GateVerdictRecordLike {
+  slug?: string | null;
+  previewVersion?: string | null;
+  deliveredVersion?: string | null;
+}
+
+/**
+ * Best effort: absent/failed reads as "no verdict yet", same as a genuinely pending gate —
+ * callers must not let this take down a hot path like session start or an inbox poll.
+ */
+export async function readGateVerdict(
+  gamesStore: GamesStore | undefined,
+  record: GateVerdictRecordLike,
+  onError?: (error: unknown) => void,
+): Promise<GateVerdictSummary | null> {
+  const { slug } = record;
+  // Prefer previewVersion: publish writes both pointers to the same id, while a later
+  // mode=preview only advances previewVersion. delivered-first would keep reporting the
+  // stale publish red after the agent already fixed and re-previewed.
+  const version = record.previewVersion ?? record.deliveredVersion;
+  if (!gamesStore || !slug || !version) return null;
+  try {
+    const manifest = await gamesStore.getManifest(slug, version);
+    if (manifest?.gate) {
+      return {
+        version,
+        lane: 'publish',
+        green: manifest.gate.green,
+        ranAt: manifest.gate.ranAt,
+        ...(manifest.gate.report ? { report: manifest.gate.report } : {}),
+        ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
+      };
+    }
+    // Preview-lane check: never report as publishable green (that would end the MCP round).
+    if (manifest?.previewGate) {
+      const kitOutdated = manifest.previewGate.status === 'kit_outdated';
+      return {
+        version,
+        lane: 'preview',
+        green: false,
+        previewPassed: manifest.previewGate.green,
+        ranAt: manifest.previewGate.ranAt,
+        ...(manifest.previewGate.report ? { report: manifest.previewGate.report } : {}),
+        status: kitOutdated
+          ? ('kit_outdated' as const)
+          : manifest.previewGate.green
+            ? ('preview_passed' as const)
+            : ('preview_failed' as const),
+      };
+    }
+    return null;
+  } catch (error) {
+    onError?.(error);
+    return null;
+  }
+}
+
+/** Same green/kit_outdated/preview_passed/preview_failed/red vocabulary the gate route replies with. */
+export function deriveGateStatusString(
+  gate: Pick<GateVerdictSummary, 'green' | 'status'>,
+): 'green' | 'kit_outdated' | 'preview_passed' | 'preview_failed' | 'red' {
+  if (gate.green) return 'green';
+  if (gate.status === 'kit_outdated') return 'kit_outdated';
+  if (gate.status === 'preview_passed') return 'preview_passed';
+  if (gate.status === 'preview_failed') return 'preview_failed';
+  return 'red';
+}

--- a/apps/api/src/gate-verdict.ts
+++ b/apps/api/src/gate-verdict.ts
@@ -1,22 +1,13 @@
 import { type GamesStore } from './games-store.js';
 
-/**
- * Read a delivered version's own-gate verdict off its manifest.
- *
- * Shared between the `/api/agent/build/gate` channel route (agent-channel.ts) and the
- * MCP `start` tool (mcp-server.ts) — both need the same publish/preview distinction, and
- * duplicating it let `start` drift out of sync with what `show_round` / `get_gate_verdict`
- * already report (see the `start` doesn't surface a red gate on reconnect gap, #arena-brawlers).
- */
+// Shared by the channel's gate route and MCP `start`.
 export interface GateVerdictSummary {
-  /** Named so a caller can tell a verdict about *this* delivery from a stale prior one. */
   version: string;
   lane: 'publish' | 'preview';
   green: boolean;
   ranAt: string;
   report?: string;
   previewPassed?: boolean;
-  /** `kit_outdated` is a distinct refusal: refresh the kit, do not chase check:game. */
   status?: 'kit_outdated' | 'preview_passed' | 'preview_failed';
 }
 
@@ -26,19 +17,14 @@ export interface GateVerdictRecordLike {
   deliveredVersion?: string | null;
 }
 
-/**
- * Best effort: absent/failed reads as "no verdict yet", same as a genuinely pending gate —
- * callers must not let this take down a hot path like session start or an inbox poll.
- */
+// Best effort: a read failure reads as "no verdict yet".
 export async function readGateVerdict(
   gamesStore: GamesStore | undefined,
   record: GateVerdictRecordLike,
   onError?: (error: unknown) => void,
 ): Promise<GateVerdictSummary | null> {
   const { slug } = record;
-  // Prefer previewVersion: publish writes both pointers to the same id, while a later
-  // mode=preview only advances previewVersion. delivered-first would keep reporting the
-  // stale publish red after the agent already fixed and re-previewed.
+  // previewVersion first: a later mode=preview only advances that pointer.
   const version = record.previewVersion ?? record.deliveredVersion;
   if (!gamesStore || !slug || !version) return null;
   try {
@@ -53,7 +39,7 @@ export async function readGateVerdict(
         ...(manifest.gate.status === 'kit_outdated' ? { status: 'kit_outdated' as const } : {}),
       };
     }
-    // Preview-lane check: never report as publishable green (that would end the MCP round).
+    // Preview lane: never green — that would end the MCP round.
     if (manifest?.previewGate) {
       const kitOutdated = manifest.previewGate.status === 'kit_outdated';
       return {
@@ -77,7 +63,7 @@ export async function readGateVerdict(
   }
 }
 
-/** Same green/kit_outdated/preview_passed/preview_failed/red vocabulary the gate route replies with. */
+// Same vocabulary the gate route replies with.
 export function deriveGateStatusString(
   gate: Pick<GateVerdictSummary, 'green' | 'status'>,
 ): 'green' | 'kit_outdated' | 'preview_passed' | 'preview_failed' | 'red' {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1504,6 +1504,55 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((shown.structured as { gate?: { status?: string } }).gate?.status).toBe('preview_failed');
   });
 
+  // Before this, `must_fix_gate` was only attached to show_round / get_gate_verdict /
+  // report_progress replies. A session that reconnects after the delivering session
+  // already called `end` — because the gate was still running Cloud Build when `end` was
+  // called, per the documented "submit then end" workflow — called `start` first and got
+  // no signal at all unless it happened to call one of those three tools next. This is the
+  // arena-brawlers gap (2026-08-09): two red preview deliveries, the second session ended
+  // right after resubmitting, and nothing surfaced the second failure to anyone.
+  it('surfaces must_fix_gate on start itself when reconnecting after a red gate', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    await store.incrementRoundDeliveryCount(ISSUE);
+    const { gamesStore } = stubGamesStore({
+      green: false,
+      lane: 'preview',
+      status: 'preview_failed',
+      report: "FAIL smoke arena-brawlers\n  - Cannot read properties of undefined (reading 'modules')",
+      ranAt: '2026-08-09T14:32:00.000Z',
+    });
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+
+    // The very first call of the new session — no show_round / get_gate_verdict yet.
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+    const structured = started.structured as {
+      gate?: { status?: string; deliveryId?: string };
+      warnings?: Array<{ code: string; message: string }>;
+    };
+    expect(structured.gate?.status).toBe('preview_failed');
+    expect(structured.gate?.deliveryId).toBe('v1');
+    expect(structured.warnings?.some((w) => w.code === 'must_fix_gate')).toBe(true);
+  });
+
+  // A passing round must not gain a `gate` field or any new warning — the response shape
+  // for the common case (no outstanding refusal) is unchanged.
+  it('start omits gate when there is nothing outstanding to fix', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const { gamesStore } = stubGamesStore();
+    app = await createApp(store, gamesStore);
+    const sessionId = await initialize(app);
+
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    expect(started.isError).toBe(false);
+    const structured = started.structured as { gate?: unknown };
+    expect(structured.gate).toBeUndefined();
+  });
+
   describe('terminal receipt (generation one behind) on all three transports', () => {
     async function closeRoundGreen(store: InMemoryStore, gamesStore: GamesStore) {
       await store.setSubmissionDeliveredVersion(ISSUE, 'v1');

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1504,13 +1504,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((shown.structured as { gate?: { status?: string } }).gate?.status).toBe('preview_failed');
   });
 
-  // Before this, `must_fix_gate` was only attached to show_round / get_gate_verdict /
-  // report_progress replies. A session that reconnects after the delivering session
-  // already called `end` — because the gate was still running Cloud Build when `end` was
-  // called, per the documented "submit then end" workflow — called `start` first and got
-  // no signal at all unless it happened to call one of those three tools next. This is the
-  // arena-brawlers gap (2026-08-09): two red preview deliveries, the second session ended
-  // right after resubmitting, and nothing surfaced the second failure to anyone.
+  // arena-brawlers gap (2026-08-09): start() alone used to say nothing.
   it('surfaces must_fix_gate on start itself when reconnecting after a red gate', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
@@ -1538,8 +1532,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(structured.warnings?.some((w) => w.code === 'must_fix_gate')).toBe(true);
   });
 
-  // A passing round must not gain a `gate` field or any new warning — the response shape
-  // for the common case (no outstanding refusal) is unchanged.
+  // A passing round's start response must not gain a gate field.
   it('start omits gate when there is nothing outstanding to fix', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -44,6 +44,8 @@ import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base6
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
 import { assertDeliverableSourcePath, InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
+import { deriveGateStatusString, readGateVerdict } from './gate-verdict.js';
+import { gameManifestHint } from './game-manifest-hint.js';
 import { detectStall, resolveJobState, toSubmissionStatus } from './job-state.js';
 import { largeSourceFileHint, moduleSizeWarnings } from './module-size.js';
 import type { GcsObjectStore } from './gcs-sign.js';
@@ -542,6 +544,28 @@ function channelControlFields(
 /** Gate statuses that mean "fix and deliver again" — not a finished round. */
 function gateNeedsResubmit(status: unknown): boolean {
   return status === 'preview_failed' || status === 'red' || status === 'kit_outdated';
+}
+
+/**
+ * `start`'s reconnect-visibility field: the last delivery's gate status, when it still
+ * needs a fix. Absent (not `null`) when nothing is amiss, so a passing round's response
+ * shape is unchanged.
+ *
+ * Without this, a session that reconnects after the delivering session already called
+ * `end` — e.g. because the gate was still running Cloud Build when `end` was called, per
+ * the documented "submit then end" workflow — got no signal at all: `must_fix_gate` was
+ * only ever attached to `show_round` / `get_gate_verdict` / `report_progress` replies, and
+ * a fresh `start()` call has no reason to make any of those next (arena-brawlers, 2026-08-09).
+ */
+async function gateFieldForStart(
+  gamesStore: GamesStore | undefined,
+  record: Pick<SubmissionRecord, 'slug' | 'previewVersion' | 'deliveredVersion'>,
+): Promise<{ gate: { status: string; deliveryId: string } } | Record<string, never>> {
+  const gate = await readGateVerdict(gamesStore, record).catch(() => null);
+  if (!gate) return {};
+  const status = deriveGateStatusString(gate);
+  if (!gateNeedsResubmit(status)) return {};
+  return { gate: { status, deliveryId: gate.version } };
 }
 
 function mustFixGateWarningForStatus(status: string, deliveryId?: string | null): NudgeWarning {
@@ -1171,7 +1195,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       !hasMustFix &&
       gateStatus &&
       gateNeedsResubmit(gateStatus) &&
-      (toolName === 'show_round' || toolName === 'get_gate_verdict' || toolName === 'report_progress')
+      (toolName === 'start' ||
+        toolName === 'show_round' ||
+        toolName === 'get_gate_verdict' ||
+        toolName === 'report_progress')
     ) {
       prior.push(mustFixGateWarningForStatus(gateStatus, gateDelivery));
     }
@@ -1256,7 +1283,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        'Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, card_unopened, must_fix_gate, must_deliver). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. card_unopened means the creator has no status card yet — call show_round once. must_fix_gate means the last delivery was refused — fix and submit_sources again; staging alone does not re-run the gate.',
+        "Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, game_manifest_invalid, card_unopened, must_fix_gate, must_deliver). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. game_manifest_invalid means the just-staged GAME.json has a shape that crashes the gate before typecheck (e.g. missing engine.modules) — fix it in the SAME stage/patch call's target, do not wait for submit_sources to find out. card_unopened means the creator has no status card yet — call show_round once. must_fix_gate means the last delivery was refused — fix and submit_sources again; staging alone does not re-run the gate.",
       items: {
         type: 'object',
         properties: {
@@ -1270,6 +1297,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'gate_not_started',
               'gate_poll_backoff',
               'module_too_large',
+              'game_manifest_invalid',
               'card_unopened',
               'must_fix_gate',
               'must_deliver',
@@ -1340,6 +1368,14 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           seedAvailable: { type: 'boolean' },
           seedStatus: { type: 'string', enum: ['pending', 'available', 'unavailable'] },
           seedNotice: { type: ['string', 'null'] },
+          gate: {
+            type: 'object',
+            description:
+              'Present only when the round already has a delivery whose gate needs a fix (preview_failed / red / ' +
+              'kit_outdated) — e.g. a prior session submitted and ended before its gate finished. Absent when ' +
+              'nothing is outstanding. warnings.code=must_fix_gate rides alongside this on the same reply.',
+            properties: { status: { type: 'string' }, deliveryId: { type: 'string' } },
+          },
         },
         required: ['sessionKey', 'jobId', 'workflow', 'seedAvailable', 'seedStatus'],
       },
@@ -1386,7 +1422,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const slugArg = typeof args.slug === 'string' ? args.slug.trim() : '';
         const bearer = ctx.bearerToken;
 
-        const bindActiveRound = (active: SubmissionRecord): ToolResult => {
+        const bindActiveRound = async (active: SubmissionRecord): Promise<ToolResult> => {
           pruneTransportSessions(now());
           pruneInvalidStartBuckets(now());
           // Prefer the client's correlator when well-formed — even if this instance
@@ -1409,6 +1445,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           const used = active.roundDeliveryCount ?? 0;
 
           const seed = seedPayload(active);
+          const gateField = await gateFieldForStart(options.gamesStore, active);
           const structured = {
             sessionKey,
             sessionId,
@@ -1424,6 +1461,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             inboxPolicy: INBOX_POLICY,
             whenRefused: RETIRED_KEY_ETIQUETTE,
             ...seed,
+            ...gateField,
           };
           const base = toolOk(structured);
           return {
@@ -1441,7 +1479,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             noteInvalidStart(ctx.request);
             return toolErr(resolved.reason);
           }
-          return bindActiveRound(resolved.record);
+          return await bindActiveRound(resolved.record);
         }
 
         if (!key && bearer && looksLikeAsAccessToken(bearer)) {
@@ -1470,7 +1508,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             return toolErr(PLATFORM_ROUND_REASON);
           }
 
-          return bindActiveRound(active);
+          return await bindActiveRound(active);
         }
 
         if (key && looksLikeAsAccessToken(key)) {
@@ -1565,6 +1603,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const used = record.roundDeliveryCount ?? 0;
 
         const seed = seedPayload(record);
+        const gateField = await gateFieldForStart(options.gamesStore, record);
         const structured = {
           sessionKey,
           sessionId,
@@ -1580,6 +1619,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           inboxPolicy: INBOX_POLICY,
           whenRefused: RETIRED_KEY_ETIQUETTE,
           ...seed,
+          ...gateField,
         };
         // Base shape via toolOk so we do not drift from other tools; append the human-
         // readable loop so an agent reading either form knows when to stop.
@@ -3454,6 +3494,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           path?: string;
           bytes?: number;
           hint?: string;
+          manifestHint?: string;
           staged?: {
             files: Array<{ path: string; bytes: number }>;
             totalBytes: number;
@@ -3469,6 +3510,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const hint =
           body.hint ??
           (typeof body.bytes === 'number' ? largeSourceFileHint(body.path ?? path, body.bytes, content) : null);
+        const manifestHint = body.manifestHint ?? gameManifestHint(body.path ?? path, content);
         return toolOk({
           ok: body.accepted !== false,
           ...(body.rejected ? { rejected: body.rejected } : {}),
@@ -3476,7 +3518,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes: body.bytes ?? 0,
           ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
-          ...channelControlFields(body, hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
+          ...channelControlFields(body, [
+            ...(manifestHint ? [{ code: 'game_manifest_invalid' as const, message: manifestHint }] : []),
+            ...(hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
+          ]),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },
@@ -3589,6 +3634,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           replacements?: number;
           baseFrom?: 'staged' | 'delivery' | 'seed';
           hint?: string;
+          manifestHint?: string;
           staged?: {
             files: Array<{ path: string; bytes: number }>;
             totalBytes: number;
@@ -3612,7 +3658,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           baseFrom: body.baseFrom ?? 'staged',
           ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
-          ...channelControlFields(body, hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
+          ...channelControlFields(body, [
+            ...(body.manifestHint ? [{ code: 'game_manifest_invalid' as const, message: body.manifestHint }] : []),
+            ...(hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
+          ]),
           pendingMessages: pendingMessagesFromChannel(body),
         });
       },

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -546,17 +546,7 @@ function gateNeedsResubmit(status: unknown): boolean {
   return status === 'preview_failed' || status === 'red' || status === 'kit_outdated';
 }
 
-/**
- * `start`'s reconnect-visibility field: the last delivery's gate status, when it still
- * needs a fix. Absent (not `null`) when nothing is amiss, so a passing round's response
- * shape is unchanged.
- *
- * Without this, a session that reconnects after the delivering session already called
- * `end` — e.g. because the gate was still running Cloud Build when `end` was called, per
- * the documented "submit then end" workflow — got no signal at all: `must_fix_gate` was
- * only ever attached to `show_round` / `get_gate_verdict` / `report_progress` replies, and
- * a fresh `start()` call has no reason to make any of those next (arena-brawlers, 2026-08-09).
- */
+// Gives `start` the same reconnect-visibility show_round/get_gate_verdict already had.
 async function gateFieldForStart(
   gamesStore: GamesStore | undefined,
   record: Pick<SubmissionRecord, 'slug' | 'previewVersion' | 'deliveredVersion'>,

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1504,6 +1504,128 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  // A preview-only delivery (mode=preview, never published) never writes manifest.gate —
+  // only manifest.previewGate. Before this, reconcileGateVerdict read manifest.gate alone,
+  // so a preview delivery that came back red never transitioned at all: the job sat in
+  // `submitted` forever, indistinguishable from a gate that was still running. This bit a
+  // real round (arena-brawlers, 2026-08-09) where the delivering session had already called
+  // `end` — the documented "submit then end" workflow — before Cloud Build finished, so
+  // nothing was left watching to notice the red preview and nothing else ever would.
+  it('acts on a red preview-only gate verdict for a job still sitting in submitted', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 197 });
+    const { backend } = createBackendStub();
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'arena-brawlers',
+        version: 'v3',
+        createdAt: '2026-08-09T14:20:00.000Z',
+        issueNumber: 197,
+        sourceFiles: [],
+        previewGate: {
+          green: false,
+          ranAt: '2026-08-09T14:22:00.000Z',
+          report: "FAIL smoke arena-brawlers\n  - Cannot read properties of undefined (reading 'modules')",
+        },
+      }),
+    } as unknown as GamesStore;
+
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about a top-down arena brawler.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+
+    await store.setSubmissionSlug(job.issueNumber, 'arena-brawlers');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v3');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-08-09T14:20:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    expect(status.statusCode).toBe(200);
+    // Never `ready_for_review` — a preview pass proves typecheck/smoke/build only, never
+    // publish readiness, and this delivery did not even pass that. It must still stop
+    // reading as "still assembling", which is what `needs_changes` buys the creator.
+    expect(status.json().phase).toBe('needs_changes');
+    expect(status.json().failure).toEqual({ reason: 'gate_red' });
+
+    await app.close();
+  });
+
+  // The mirror case: a green preview must never promote the round on its own — that would
+  // let an unpublished, unreviewed draft skip moderation the moment typecheck/smoke/build
+  // pass. It should simply leave the job where a live agent session left it.
+  it('does not promote a job on a green preview-only gate verdict', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 198 });
+    const { backend } = createBackendStub();
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'arena-brawlers',
+        version: 'v4',
+        createdAt: '2026-08-09T14:20:00.000Z',
+        issueNumber: 198,
+        sourceFiles: [],
+        previewGate: { green: true, ranAt: '2026-08-09T14:22:00.000Z' },
+      }),
+    } as unknown as GamesStore;
+
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about a top-down arena brawler.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+
+    await store.setSubmissionSlug(job.issueNumber, 'arena-brawlers');
+    await store.setSubmissionDeliveredVersion(job.issueNumber, 'v4');
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-08-09T14:20:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const status = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}`,
+      headers: authHeaders,
+    });
+
+    expect(status.statusCode).toBe(200);
+    // `phase` is the raw job state, not the public projection — `submitted` (unlike
+    // `ready_for_review` / `needs_changes` above) is where this one differs from
+    // `toSubmissionStatus`, which would read this back as `building`.
+    expect(status.json().phase).toBe('submitted');
+    expect(status.json().status).toBe('building');
+
+    await app.close();
+  });
+
   it('posts the gate capture screenshot into the build thread on reconcile', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 197 });
     const { backend } = createBackendStub();

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1504,13 +1504,7 @@ describe('submission routes', () => {
     await app.close();
   });
 
-  // A preview-only delivery (mode=preview, never published) never writes manifest.gate —
-  // only manifest.previewGate. Before this, reconcileGateVerdict read manifest.gate alone,
-  // so a preview delivery that came back red never transitioned at all: the job sat in
-  // `submitted` forever, indistinguishable from a gate that was still running. This bit a
-  // real round (arena-brawlers, 2026-08-09) where the delivering session had already called
-  // `end` — the documented "submit then end" workflow — before Cloud Build finished, so
-  // nothing was left watching to notice the red preview and nothing else ever would.
+  // mode=preview writes manifest.previewGate, not manifest.gate (arena-brawlers).
   it('acts on a red preview-only gate verdict for a job still sitting in submitted', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 197 });
     const { backend } = createBackendStub();
@@ -1560,18 +1554,14 @@ describe('submission routes', () => {
     });
 
     expect(status.statusCode).toBe(200);
-    // Never `ready_for_review` — a preview pass proves typecheck/smoke/build only, never
-    // publish readiness, and this delivery did not even pass that. It must still stop
-    // reading as "still assembling", which is what `needs_changes` buys the creator.
+    // Never `ready_for_review` — a preview pass is not publish readiness.
     expect(status.json().phase).toBe('needs_changes');
     expect(status.json().failure).toEqual({ reason: 'gate_red' });
 
     await app.close();
   });
 
-  // The mirror case: a green preview must never promote the round on its own — that would
-  // let an unpublished, unreviewed draft skip moderation the moment typecheck/smoke/build
-  // pass. It should simply leave the job where a live agent session left it.
+  // Mirror case: a green preview must never promote the round.
   it('does not promote a job on a green preview-only gate verdict', async () => {
     const { githubClient } = createGithubClientStub({ issueNumber: 198 });
     const { backend } = createBackendStub();
@@ -1617,9 +1607,7 @@ describe('submission routes', () => {
     });
 
     expect(status.statusCode).toBe(200);
-    // `phase` is the raw job state, not the public projection — `submitted` (unlike
-    // `ready_for_review` / `needs_changes` above) is where this one differs from
-    // `toSubmissionStatus`, which would read this back as `building`.
+    // `phase` is the raw job state; `status` is the public projection.
     expect(status.json().phase).toBe('submitted');
     expect(status.json().status).toBe('building');
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2416,29 +2416,64 @@ export async function registerSubmissionRoutes(
     try {
       const manifest = await gamesStore.getManifest(record.slug, record.deliveredVersion);
       const verdict = manifest?.gate;
-      if (!verdict) return null;
-      // Green means publishable, never published: the human review this waits for is the
-      // moderation boundary, and a gate that promoted past it would quietly delete it.
-      const to = verdict.green ? 'ready_for_review' : 'needs_changes';
+      if (verdict) {
+        // Green means publishable, never published: the human review this waits for is the
+        // moderation boundary, and a gate that promoted past it would quietly delete it.
+        const to = verdict.green ? 'ready_for_review' : 'needs_changes';
+        if (!canTransition(state, to)) return null;
+        const transition: JobTransition = {
+          to,
+          at: verdict.ranAt,
+          by: 'gate',
+          reason: verdict.green ? 'gate_green' : verdict.status === 'kit_outdated' ? 'kit_outdated' : 'gate_red',
+        };
+        const recorded = await store.recordJobTransition(record.issueNumber, transition);
+        if (!recorded) return null;
+        // First time we act on this verdict: post the capture frame into the thread so the
+        // creator sees what the platform check saw, on the same path as agent-sent shots.
+        if (verdict.screenshot) {
+          await postGateScreenshotToThread({
+            store,
+            gamesStore,
+            issueNumber: record.issueNumber,
+            slug: record.slug,
+            version: record.deliveredVersion,
+            screenshotPath: verdict.screenshot,
+          }).catch((error) => {
+            app.log.warn({ err: error, issueNumber: record.issueNumber }, 'could not post gate screenshot');
+          });
+        }
+        return transition;
+      }
+      // No publish gate ran — this delivery was mode=preview. A green preview proves
+      // nothing about publish readiness (typecheck/smoke/build only, BY-28a) and must
+      // never promote to review; but a RED preview still has to unstick the round the same
+      // way a red publish gate does. Without this, a session that submits and then calls
+      // `end` right after (the documented workflow) races the async Cloud Build gate: if
+      // the gate turns red after the session is already gone, nothing was ever watching to
+      // repair it in-session, and nothing else transitions the job — it sat in `submitted`
+      // indefinitely with Studio polling a "still assembling" state that never resolved
+      // (arena-brawlers, 2026-08-09).
+      const preview = manifest?.previewGate;
+      if (!preview || preview.green) return null;
+      const to = 'needs_changes' as const;
       if (!canTransition(state, to)) return null;
       const transition: JobTransition = {
         to,
-        at: verdict.ranAt,
+        at: preview.ranAt,
         by: 'gate',
-        reason: verdict.green ? 'gate_green' : verdict.status === 'kit_outdated' ? 'kit_outdated' : 'gate_red',
+        reason: preview.status === 'kit_outdated' ? 'kit_outdated' : 'gate_red',
       };
       const recorded = await store.recordJobTransition(record.issueNumber, transition);
       if (!recorded) return null;
-      // First time we act on this verdict: post the capture frame into the thread so the
-      // creator sees what the platform check saw, on the same path as agent-sent shots.
-      if (verdict.screenshot) {
+      if (preview.screenshot) {
         await postGateScreenshotToThread({
           store,
           gamesStore,
           issueNumber: record.issueNumber,
           slug: record.slug,
           version: record.deliveredVersion,
-          screenshotPath: verdict.screenshot,
+          screenshotPath: preview.screenshot,
         }).catch((error) => {
           app.log.warn({ err: error, issueNumber: record.issueNumber }, 'could not post gate screenshot');
         });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -2445,15 +2445,7 @@ export async function registerSubmissionRoutes(
         }
         return transition;
       }
-      // No publish gate ran — this delivery was mode=preview. A green preview proves
-      // nothing about publish readiness (typecheck/smoke/build only, BY-28a) and must
-      // never promote to review; but a RED preview still has to unstick the round the same
-      // way a red publish gate does. Without this, a session that submits and then calls
-      // `end` right after (the documented workflow) races the async Cloud Build gate: if
-      // the gate turns red after the session is already gone, nothing was ever watching to
-      // repair it in-session, and nothing else transitions the job — it sat in `submitted`
-      // indefinitely with Studio polling a "still assembling" state that never resolved
-      // (arena-brawlers, 2026-08-09).
+      // mode=preview never writes manifest.gate — red still needs a transition too.
       const preview = manifest?.previewGate;
       if (!preview || preview.green) return null;
       const to = 'needs_changes' as const;


### PR DESCRIPTION
## Summary

arena-brawlers (2026-08-09) shipped two straight red preview-gate deliveries that nobody was ever told about. Investigation (Cloud Build logs + Firestore + games-store manifests) found three assumptions that all quietly relied on the delivering session sticking around:

- **`reconcileGateVerdict` only read `manifest.gate`** (publish-mode). A `mode=preview` delivery writes `manifest.previewGate` instead, so a red preview never transitioned the job — it sat in `submitted` (reads as "building" to the creator) indefinitely, and the sweep that's supposed to catch stuck jobs never looked at the right field. It now also reacts to a **red** `previewGate` (`needs_changes`/`gate_red`, same-session repair preserved). A **green** preview is still never promoted — that would let an unpublished, unreviewed draft skip moderation (BY-28a: typecheck/smoke/build only, not publish readiness).
- **`start` never surfaced an outstanding gate verdict.** `warnings.code=must_fix_gate` only rode `show_round` / `get_gate_verdict` / `report_progress` replies. A session that reconnects and calls `start` first (the normal first call) got no signal at all unless it happened to call one of those three next. `start` now carries an optional `gate: { status, deliveryId }` + `must_fix_gate` when the last delivery still needs a fix, via a verdict reader (`apps/api/src/gate-verdict.ts`) shared with the channel's own `/api/agent/build/gate` route so the two can't drift.
- **Nothing pointed at the actual bug** until a human read a Cloud Build log: `GAME.json` had no `engine.modules`, which crashes the shared kit's `assemble` step with `Cannot read properties of undefined (reading 'modules')` at smoke time — a silent `undefined` read, not a validation error. `stage_source_file`/`patch_source_file` now run a shallow shape check on a staged/patched `GAME.json` (`engine.modules` present; `audio.sounds`/`audio.music` present when `audio` is selected) and emit `warnings.code=game_manifest_invalid` on the *same* reply — before the agent ever has to wait on the gate to find out.

`byoca-mcp` skill doc updated in the same change (its own mandate) with the new warning code, the new `start` field, and the preview-gate reconciliation fix.

## Test plan

- [x] `npm run type-check --workspace=apps/api`
- [x] `vitest run` on `mcp-server.test.ts`, `agent-channel.test.ts`, `submissions.test.ts`, `job-state.test.ts`, plus new `game-manifest-hint.test.ts` (9 new tests) — all passing, including two new `submissions.test.ts` cases (red preview → `needs_changes`; green preview → no promotion) and two new `mcp-server.test.ts` cases (`start` surfaces `must_fix_gate` on reconnect; `start` omits `gate` when nothing's outstanding)
- [ ] Manual: re-run the arena-brawlers round with a fixed `GAME.json` and confirm Play works end-to-end (not done in this session — happy to follow up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)