### PR TITLE
Catch incomplete game manifests before preview smoke

### DIFF
--- a/apps/api/src/build-prompt.test.ts
+++ b/apps/api/src/build-prompt.test.ts
@@ -23,6 +23,8 @@ describe('buildPrompt delivery contract', () => {
     expect(prompt).toContain('do not download or browse the kit');
     expect(prompt).toContain('Stage source content directly');
     expect(prompt).toContain('audio.sounds');
+    expect(prompt).toContain('engine.modules array');
+    expect(prompt).toContain('audio.music must be one music id string');
     expect(prompt).toContain('submit_sources');
     expect(prompt).toContain('delivered rough');
     expect(prompt).not.toContain('npm run submit');

--- a/apps/api/src/build-prompt.ts
+++ b/apps/api/src/build-prompt.ts
@@ -156,6 +156,8 @@ function channelDelivery(brief: BuildBrief, fast: boolean, creating: boolean): s
       '- Skip optional polish. One screen, one loop, readable visuals.',
       '- Always call `.audio()` in GameKit.defineGame; set audio.sounds and audio.music in GAME.json.',
       "- Audio ids are a fixed catalog: copy from the digest's Audio catalog and never invent one.",
+      '- GAME.json must include an engine.modules array copied from the kit template; never omit it.',
+      '- audio.sounds must be an array of catalog ids; audio.music must be one music id string.',
       '- The publish gate requires the audio module, so removing it only defers the failure.',
       '- Stage and `submit_sources({ fromStaged: true, mode: "preview", kitEngineRef })` as soon as the',
       '  game is playable, even if you can see things you would rather improve. A delivered rough',

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -152,6 +152,12 @@ describe('validateSourceUpload — the delivery contract', () => {
     ).toThrow(/audio\.sounds/);
   });
 
+  it('rejects a preview manifest without engine.modules before smoke runs', () => {
+    expect(() =>
+      validateSourceUpload([...MINIMAL, { path: 'GAME.json', content: JSON.stringify({ howToPlay: {} }) }], 'preview'),
+    ).toThrow(/engine\.modules as an array/);
+  });
+
   it('catches an audio module with sounds but no music, as the assembler would', () => {
     expect(() =>
       validateSourceUpload(

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -275,7 +275,12 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
         engine?: { modules?: unknown };
         audio?: { sounds?: unknown; music?: unknown };
       };
-      const modules = Array.isArray(manifest.engine?.modules) ? manifest.engine.modules : [];
+      if (!Array.isArray(manifest.engine?.modules)) {
+        throw new InvalidUploadError(
+          'GAME.json must include engine.modules as an array — copy the module selection from the Creator Kit template before preview.',
+        );
+      }
+      const modules = manifest.engine.modules;
       const sounds = Array.isArray(manifest.audio?.sounds) ? manifest.audio.sounds : [];
       const music = typeof manifest.audio?.music === 'string' ? manifest.audio.music.trim() : '';
       // Same two rules the assembler enforces, one round trip earlier.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first real creation round delivered a preview candidate, but `GAME.json` omitted `engine.modules`. Preview upload accepted it; smoke then crashed with `Cannot read properties of undefined (reading 'modules')`. The agent spent the remaining round repairing other required files before the preview could even reach that failure.

This adds an earlier, actionable guard and aligns the creation prompt with the gate:

- preview uploads reject `GAME.json` when `engine.modules` is missing or not an array;
- the fast creation prompt explicitly requires `engine.modules`;
- it explicitly distinguishes `audio.sounds` as an array of legal sound ids and `audio.music` as one legal music id string;
- tests cover the preflight refusal and prompt wording.

No existing checks are weakened: this moves an already-failing runtime contract earlier in the same preview lane.

## Verification

`npm run type-check -w @gamedevpl/api`, `npm run lint`, and the focused tests pass: 52 tests across `games-store.test.ts` and `build-prompt.test.ts`.

The next retained creation probe should use the published digest via `--digest-file` so the audio catalog is present as well as the new manifest instruction.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

